### PR TITLE
fix(gateway): run a session's stdio MCP servers in that session's project cwd

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -25,6 +25,8 @@ Usage in run_agent.py:
 
 from __future__ import annotations
 
+import contextvars
+import functools
 import json
 import logging
 import re
@@ -624,7 +626,20 @@ class MemoryManager:
         but never losing the write itself. ``fn`` must do its own
         per-provider error handling; this wrapper only guards executor
         plumbing.
+
+        ``fn`` runs inside a SNAPSHOT of the caller's ContextVar context. A
+        pool worker otherwise starts with an empty context, so the session
+        ContextVars the turn thread bound (notably ``_SESSION_CWD``, the single
+        source of truth for the agent's project) are invisible there, and a
+        provider that derives per-project state from them — Hindsight picks its
+        memory bank from the session cwd — silently falls back to the process
+        launch dir. Snapshotting at submit time (not at run time) also pins the
+        turn that queued the work: a later session switch cannot redirect an
+        already-queued retain. Same rationale as
+        ``tools.thread_context.propagate_context_to_thread`` in the tool fan-out.
         """
+        ctx = contextvars.copy_context()
+        fn = functools.partial(ctx.run, fn)
         executor = self._get_sync_executor()
         if executor is None:
             # Executor unavailable (shut down / creation failed) — run

--- a/tests/agent/test_memory_async_sync.py
+++ b/tests/agent/test_memory_async_sync.py
@@ -136,3 +136,42 @@ def test_writes_are_serialized_in_order():
         mgr.sync_all(f"turn-{i}", "resp", session_id="s1")
     assert mgr.flush_pending(timeout=10) is True
     assert order == [f"turn-{i}" for i in range(5)]
+
+
+def test_background_work_sees_the_turn_session_context(tmp_path):
+    """The worker must run in the calling turn's ContextVar context.
+
+    A bare ``ThreadPoolExecutor`` worker starts with an EMPTY
+    ``contextvars.Context``, so ``_SESSION_CWD`` (set per session by the
+    gateway) is unbound there and ``resolve_agent_cwd()`` silently falls back
+    to the process launch dir. Providers that derive per-project state from it
+    — Hindsight picks its memory bank from the session cwd — then wrote the
+    launch directory's bank for every project's automatic retain/prefetch.
+    """
+    from agent.runtime_cwd import clear_session_cwd, resolve_agent_cwd, set_session_cwd
+
+    project = tmp_path / "wrxn"
+    project.mkdir()
+    seen: dict[str, str] = {}
+
+    class _CwdProvider(_SlowProvider):
+        _name = "cwd"
+
+        def sync_turn(self, user_content, assistant_content, *, session_id="", messages=None):
+            seen["sync"] = str(resolve_agent_cwd())
+
+        def queue_prefetch(self, query, *, session_id=""):
+            seen["prefetch"] = str(resolve_agent_cwd())
+
+    mgr = MemoryManager()
+    mgr.add_provider(_CwdProvider(delay=0.0))
+
+    set_session_cwd(str(project))
+    try:
+        mgr.sync_all("hi", "hey", session_id="s1")
+        mgr.queue_prefetch_all("hi", session_id="s1")
+    finally:
+        clear_session_cwd()
+
+    assert mgr.flush_pending(timeout=10) is True
+    assert seen == {"sync": str(project), "prefetch": str(project)}

--- a/tests/test_mcp_session_scope.py
+++ b/tests/test_mcp_session_scope.py
@@ -1,0 +1,337 @@
+"""Per-session cwd scoping for stdio MCP transports.
+
+``hermes serve`` discovers MCP servers once — from ``tui_gateway/ws.py``, in
+whatever directory the gateway was launched from — and ``tools.mcp_tool``
+keyed every connection by server name alone. A stdio MCP child inherits its
+parent's cwd, so *every* Desktop session shared one process sitting in the
+launch directory. A project-sensitive server (Hindsight derives its memory
+bank from ``${PWD}``) therefore answered the WRXN session with the launch
+directory's project. Fixing the per-session ``_SlashWorker`` is not enough:
+normal chat tool calls go through the parent process's MCP registry, which is
+what these tests drive.
+
+The probe server is a REAL stdio MCP server that reports its own startup cwd
+and PID, so nothing here can pass against a mocked transport: if the transport
+is not actually spawned in the session's project, the assertion fails.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from agent.runtime_cwd import clear_session_cwd, set_session_cwd  # noqa: E402
+
+SERVER_NAME = "cwdprobe"
+
+# Reports the cwd the process was SPAWNED in (captured at import, before any
+# code could chdir) plus its PID, so a test can prove both "right directory"
+# and "one stable process per directory".
+_PROBE_SERVER = '''\
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+_START_CWD = os.path.realpath(os.getcwd())
+_server = FastMCP("cwdprobe")
+
+
+@_server.tool()
+def whereami() -> str:
+    """Report this MCP server process's startup cwd and pid."""
+    return f"{_START_CWD}|{os.getpid()}"
+
+
+_server.run()
+'''
+
+# Built once per test FILE (pytest runs each file in its own interpreter, see
+# tests/conftest.py). Sharing the script path, the project dirs AND the fake
+# HERMES_HOME across the tests in this module keeps the transport scope key
+# stable, so the module spawns a handful of MCP children instead of a fresh
+# pair per test.
+_root: Path | None = None
+
+
+def _scope_root(tmp_path_factory) -> Path:
+    global _root
+    if _root is None:
+        root = tmp_path_factory.mktemp("mcp_session_scope", numbered=False)
+        (root / "probe_server.py").write_text(_PROBE_SERVER, encoding="utf-8")
+        (root / "project-a").mkdir()
+        (root / "project-b").mkdir()
+        (root / "hermes-home").mkdir()
+        _root = root
+    return _root
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _reap_mcp_children():
+    """Kill every stdio child this module spawned, in every scope."""
+    yield
+    from tools import mcp_tool
+
+    mcp_tool.shutdown_mcp_servers()
+    mcp_tool._kill_orphaned_mcp_children(include_active=True)
+
+
+@pytest.fixture
+def probe(tmp_path_factory, monkeypatch):
+    """Connect the probe MCP server once and expose the two project dirs."""
+    from tools import mcp_tool
+
+    root = _scope_root(tmp_path_factory)
+    # conftest's hermetic fixture points HERMES_HOME at a per-test tmp dir;
+    # the profile home is part of the transport scope key, so pin it here or
+    # every test would land in a different scope and respawn its servers.
+    monkeypatch.setenv("HERMES_HOME", str(root / "hermes-home"))
+
+    # Idempotent for an already-connected name: only the first test pays the
+    # connect cost, the rest reuse the same registry entry.
+    mcp_tool.register_mcp_servers({
+        SERVER_NAME: {
+            "command": sys.executable,
+            "args": [str(root / "probe_server.py")],
+            "connect_timeout": 60,
+            "timeout": 60,
+        }
+    })
+    assert SERVER_NAME in mcp_tool._servers, (
+        "probe MCP server failed to connect: "
+        f"{mcp_tool._server_connect_errors.get(SERVER_NAME)}"
+    )
+    try:
+        yield type(
+            "Probe", (), {
+                "a": str(root / "project-a"),
+                "b": str(root / "project-b"),
+            },
+        )
+    finally:
+        clear_session_cwd()
+
+
+def _whereami() -> tuple[str, int]:
+    """Call the probe tool through the real MCP handler; return (cwd, pid)."""
+    from tools import mcp_tool
+
+    handler = mcp_tool._make_tool_handler(SERVER_NAME, "whereami", 60)
+    payload = json.loads(handler({}))
+    assert "error" not in payload, payload
+    cwd, pid = str(payload["result"]).split("|")
+    return cwd, int(pid)
+
+
+def _whereami_in(cwd: str) -> tuple[str, int]:
+    set_session_cwd(cwd)
+    try:
+        return _whereami()
+    finally:
+        clear_session_cwd()
+
+
+class TestStdioScopedBySessionCwd:
+    def test_each_session_runs_the_server_in_its_own_project(self, probe):
+        """Scenarios 1, 3 and 4: right cwd per session, stable process, no leak."""
+        cwd_a1, pid_a1 = _whereami_in(probe.a)
+        cwd_b, pid_b = _whereami_in(probe.b)
+        # Called again AFTER session B ran: proves the transport is selected
+        # per call from the session cwd, not last-writer-wins.
+        cwd_a2, pid_a2 = _whereami_in(probe.a)
+
+        assert cwd_a1 == probe.a
+        assert cwd_b == probe.b
+        assert cwd_a2 == probe.a
+        assert pid_a1 != pid_b, "both projects shared one stdio process"
+        # Repeated calls in one project must reuse the process — a respawn per
+        # call would make every MCP call pay a cold start.
+        assert pid_a1 == pid_a2
+
+    def test_concurrent_sessions_do_not_share_a_process(self, probe):
+        """Scenario 2: two live sessions calling at the same time stay isolated."""
+        results: dict[str, tuple[str, int]] = {}
+        errors: list[BaseException] = []
+        start = threading.Barrier(2)
+
+        def _run(label: str, cwd: str) -> None:
+            try:
+                start.wait(timeout=30)
+                results[label] = _whereami_in(cwd)
+            except BaseException as exc:  # noqa: BLE001 — re-raised below
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=_run, args=("a", probe.a), daemon=True),
+            threading.Thread(target=_run, args=("b", probe.b), daemon=True),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=120)
+
+        assert not errors, errors
+        assert results["a"][0] == probe.a
+        assert results["b"][0] == probe.b
+        assert results["a"][1] != results["b"][1]
+
+    def test_url_transport_stays_process_global(self, probe):
+        """Scenario 5: HTTP transports have no cwd — they must not be cloned."""
+        from tools import mcp_tool
+
+        url_server = mcp_tool.MCPServerTask("fake-url")
+        url_server._config = {"url": "https://example.invalid/mcp"}
+        url_server.session = object()
+        with mcp_tool._lock:
+            mcp_tool._servers["fake-url"] = url_server
+        try:
+            set_session_cwd(probe.a)
+            from_a = mcp_tool._get_connected_server_for_call("fake-url")
+            set_session_cwd(probe.b)
+            from_b = mcp_tool._get_connected_server_for_call("fake-url")
+        finally:
+            clear_session_cwd()
+            with mcp_tool._lock:
+                mcp_tool._servers.pop("fake-url", None)
+
+        assert from_a is url_server
+        assert from_b is url_server
+        scoped = getattr(mcp_tool, "_scoped_servers", {})
+        assert not [k for k in scoped if "fake-url" in str(k)], (
+            "a URL transport was cloned per session cwd"
+        )
+
+
+class TestCwdChangeRebindsNextCall:
+    def test_next_call_after_cwd_change_uses_the_new_project(self, probe):
+        """Task 7: session.cwd.set must not need a schema change to take effect.
+
+        The handler picks its transport from ``resolve_agent_cwd()`` at call
+        time, so rebinding the session's cwd is enough — and it must not drag
+        a sibling session along with it.
+        """
+        sibling_seen: list[str] = []
+        sibling_bound = threading.Event()
+        rebound = threading.Event()
+
+        def _sibling() -> None:
+            set_session_cwd(probe.a)
+            sibling_seen.append(_whereami()[0])
+            sibling_bound.set()
+            rebound.wait(timeout=60)
+            sibling_seen.append(_whereami()[0])
+
+        thread = threading.Thread(target=_sibling, daemon=True)
+        thread.start()
+        assert sibling_bound.wait(timeout=120)
+
+        # The changed session: bound to A, then re-bound to B (session.cwd.set).
+        set_session_cwd(probe.a)
+        assert _whereami()[0] == probe.a
+        set_session_cwd(probe.b)
+        after_change = _whereami()[0]
+        clear_session_cwd()
+
+        rebound.set()
+        thread.join(timeout=120)
+
+        assert after_change == probe.b
+        # The sibling session never changed project, before or after.
+        assert sibling_seen == [probe.a, probe.a]
+
+
+class TestPrimaryIsTheBaselineScope:
+    def test_primary_runs_in_the_resolved_agent_cwd_not_the_process_cwd(
+        self, tmp_path_factory, monkeypatch,
+    ):
+        """The discovered instance must be the one a launch-dir session reuses.
+
+        ``_canonical_call_cwd()`` resolves through ``resolve_agent_cwd()``, which
+        prefers ``TERMINAL_CWD`` over the process cwd — and in the gateway the
+        two differ (the systemd unit's cwd vs the configured ``terminal.cwd``).
+        If the primary is spawned with the *process* cwd, no session ever
+        matches it: every stdio server gets permanently duplicated, the
+        pre-warmed discovery connection serves nobody, and the first call of
+        every session pays a cold spawn inside the tool timeout.
+        """
+        from tools import mcp_tool
+
+        root = _scope_root(tmp_path_factory)
+        monkeypatch.setenv("HERMES_HOME", str(root / "hermes-home"))
+        # The gateway case: TERMINAL_CWD is a real directory that is NOT the
+        # process cwd (pytest runs from the repo root).
+        monkeypatch.setenv("TERMINAL_CWD", str(root / "project-a"))
+        name = "cwdprobe_primary"
+
+        mcp_tool.register_mcp_servers({
+            name: {
+                "command": sys.executable,
+                "args": [str(root / "probe_server.py")],
+                "connect_timeout": 60,
+                "timeout": 60,
+            }
+        })
+        assert name in mcp_tool._servers, mcp_tool._server_connect_errors.get(name)
+
+        # No session cwd bound: this is the plain launch-dir turn.
+        handler = mcp_tool._make_tool_handler(name, "whereami", 60)
+        payload = json.loads(handler({}))
+        assert "error" not in payload, payload
+        cwd, _pid = str(payload["result"]).split("|")
+
+        assert cwd == str(root / "project-a"), (
+            "the discovered primary was not spawned in the resolved agent cwd"
+        )
+        assert mcp_tool._call_scope(name) == (name, ""), (
+            "a session sitting in the baseline directory was sent to a clone"
+        )
+        assert not [k for k in mcp_tool._scoped_servers if name in str(k)], (
+            "the baseline session spawned a duplicate stdio child"
+        )
+
+
+class TestCloneNeverOwnsTheToolSchemas:
+    def test_tools_list_changed_on_a_clone_does_not_touch_the_registry(self):
+        """A clone must not re-register (and later globally de-register) tools.
+
+        ``_register_tools_when_ready`` skips clones, but any server that emits
+        ``notifications/tools/list_changed`` (mongodb-mcp-server does so right
+        after initialize) drives ``_refresh_tools`` on EVERY instance. Without
+        the same guard there, project B's transport republishes the shared tool
+        schemas mid-conversation, and — worse — the clone ends up owning
+        ``_registered_tool_names``, so when that one project's child dies the
+        park/shutdown path de-registers the MCP tools out from under every other
+        session.
+        """
+        import asyncio
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tools.mcp_tool import MCPServerTask
+        from tools.registry import ToolRegistry, registry as real_registry
+
+        clone = MCPServerTask(
+            "srv", cwd="/tmp", scope_key="srv\0/home/x/.hermes\0/tmp",
+        )
+        clone._config = {"command": "test"}
+        clone.session = MagicMock()
+        clone.session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[SimpleNamespace(
+                name="dyn", description="d", inputSchema={"type": "object"},
+            )]),
+        )
+
+        mock_registry = ToolRegistry()
+        with __import__("unittest.mock", fromlist=["patch"]).patch(
+            "tools.registry.registry", mock_registry,
+        ):
+            asyncio.run(clone._refresh_tools())
+
+        assert clone._registered_tool_names == []
+        assert not mock_registry.get_all_tool_names()
+        assert "mcp__srv__dyn" not in real_registry.get_all_tool_names()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import subprocess
@@ -1985,7 +1986,7 @@ def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 
     class _FakeWorker:
-        def __init__(self, key, model, profile_home=None):
+        def __init__(self, key, model, cwd="", profile_home=None):
             self.key = key
 
         def close(self):
@@ -5670,7 +5671,7 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
     unregistered_keys: list[str] = []
 
     class _FakeWorker:
-        def __init__(self, key, model, profile_home=None):
+        def __init__(self, key, model, cwd="", profile_home=None):
             self.key = key
             self._closed = False
 
@@ -5791,7 +5792,7 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
     unregistered_keys: list[str] = []
 
     class _FakeWorker:
-        def __init__(self, key, model, profile_home=None):
+        def __init__(self, key, model, cwd="", profile_home=None):
             self.key = key
 
         def close(self):
@@ -5895,7 +5896,7 @@ def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
 
 def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
     class _FakeWorker:
-        def __init__(self, key, model, profile_home=None):
+        def __init__(self, key, model, cwd="", profile_home=None):
             self.key = key
 
         def close(self):
@@ -5943,7 +5944,7 @@ def test_session_create_lazy_info_reports_desktop_contract(monkeypatch):
     date" on every launch even against a current backend."""
 
     class _FakeWorker:
-        def __init__(self, key, model, profile_home=None):
+        def __init__(self, key, model, cwd="", profile_home=None):
             self.key = key
 
         def close(self):
@@ -9001,3 +9002,360 @@ def test_get_usage_clamps_post_compression_sentinel():
     usage = server._get_usage(agent)
     assert "context_used" not in usage
     assert "context_percent" not in usage
+
+
+# ── Slash-worker cwd propagation ──────────────────────────────────────
+# The slash worker is the parent of every stdio MCP server a session starts
+# (Hindsight's run_mcp.sh derives its bank from ${PWD}). A worker spawned in
+# the gateway's launch directory therefore routes a project session's memory
+# to the launch dir's project. Every construction path must hand the worker
+# the session's own validated cwd.
+
+
+class _CwdWorker:
+    """_SlashWorker double recording the cwd each spawn received.
+
+    ``cwd`` defaults to None here (it is required on the real worker) so a spawn
+    site that forgets it fails on the cwd assertion rather than on a TypeError,
+    which the ``except Exception`` guard around every spawn site would swallow.
+    """
+
+    spawns: list["_CwdWorker"] = []
+
+    def __init__(self, session_key, model, cwd=None, profile_home=None):
+        self.session_key = session_key
+        self.model = model
+        self.cwd = cwd
+        self.closed = False
+        _CwdWorker.spawns.append(self)
+
+    @classmethod
+    def last_cwd_for(cls, session_key: str):
+        for worker in reversed(cls.spawns):
+            if worker.session_key == session_key:
+                return worker.cwd
+        return None
+
+    def close(self):
+        self.closed = True
+
+    def run(self, _command):
+        return "ok"
+
+
+@pytest.fixture
+def cwd_worker(monkeypatch):
+    """Install _CwdWorker as _SlashWorker on a local terminal backend."""
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(_CwdWorker, "spawns", [])
+    monkeypatch.setattr(server, "_SlashWorker", _CwdWorker)
+    monkeypatch.setattr(server, "_resolve_model", lambda *a, **k: "test/model")
+    return _CwdWorker
+
+
+def _isolated_sessions(monkeypatch):
+    """Give a test its own server._sessions map (build threads mutate it)."""
+    monkeypatch.setattr(server, "_sessions", {})
+    return server._sessions
+
+
+def test_slash_worker_cwd_from_deferred_build(cwd_worker, monkeypatch, tmp_path):
+    """Deferred new-session build (_start_agent_build) spawns with the session cwd."""
+    project = tmp_path / "proj-a"
+    project.mkdir()
+    sessions = _isolated_sessions(monkeypatch)
+
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda sid, key, **kwargs: types.SimpleNamespace(model="test/model"),
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_probe_config_health", lambda *_a: None)
+
+    session = {
+        "agent": None,
+        "agent_ready": threading.Event(),
+        "session_key": "key-a",
+        "profile_home": None,
+        "cwd": str(project),
+    }
+    sessions["sid-a"] = session
+
+    server._start_agent_build("sid-a", session)
+    assert session["agent_ready"].wait(timeout=5), "agent build did not finish"
+    assert cwd_worker.last_cwd_for("key-a") == str(project)
+
+
+def test_slash_worker_cwd_from_session_resume(cwd_worker, monkeypatch, tmp_path):
+    """Eager resume (_init_session) spawns the worker with the resumed cwd."""
+    project = tmp_path / "proj-resume"
+    project.mkdir()
+    sessions = _isolated_sessions(monkeypatch)
+
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+
+    import tools.approval as _approval
+
+    monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+
+    server._init_session(
+        "sid-resume",
+        "key-resume",
+        types.SimpleNamespace(model="test/model"),
+        [],
+        cwd=str(project),
+    )
+    assert sessions["sid-resume"]["cwd"] == str(project)
+    assert cwd_worker.last_cwd_for("key-resume") == str(project)
+
+
+def test_slash_worker_cwd_on_restart(cwd_worker, monkeypatch, tmp_path):
+    """_restart_slash_worker (model/config switch) re-spawns with the session cwd."""
+    project = tmp_path / "proj-restart"
+    project.mkdir()
+    sessions = _isolated_sessions(monkeypatch)
+
+    session = {"session_key": "key-r", "cwd": str(project), "slash_worker": None}
+    sessions["sid-r"] = session
+
+    server._restart_slash_worker("sid-r", session)
+    assert cwd_worker.last_cwd_for("key-r") == str(project)
+
+
+def test_slash_worker_cwd_on_lazy_slash_exec(cwd_worker, monkeypatch, tmp_path):
+    """slash.exec recreating a missing worker uses the session cwd, not the launch dir."""
+    project = tmp_path / "proj-lazy"
+    project.mkdir()
+    sessions = _isolated_sessions(monkeypatch)
+
+    ready = threading.Event()
+    ready.set()
+    session = {
+        "agent": types.SimpleNamespace(model="test/model"),
+        "agent_ready": ready,
+        "session_key": "key-lazy",
+        "cwd": str(project),
+        "slash_worker": None,
+    }
+    sessions["sid-lazy"] = session
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", lambda *a, **k: "")
+
+    resp = server._methods["slash.exec"](
+        "rid-lazy", {"session_id": "sid-lazy", "command": "/status"}
+    )
+    assert "result" in resp, resp
+    assert cwd_worker.last_cwd_for("key-lazy") == str(project)
+
+
+def test_slash_worker_cwd_isolated_between_sessions(cwd_worker, monkeypatch, tmp_path):
+    """Two live sessions on different projects never share a worker cwd."""
+    project_a = tmp_path / "proj-1"
+    project_b = tmp_path / "proj-2"
+    project_a.mkdir()
+    project_b.mkdir()
+    sessions = _isolated_sessions(monkeypatch)
+
+    for sid, key, project in (
+        ("sid-1", "key-1", project_a),
+        ("sid-2", "key-2", project_b),
+    ):
+        session = {"session_key": key, "cwd": str(project), "slash_worker": None}
+        sessions[sid] = session
+        server._restart_slash_worker(sid, session)
+
+    assert cwd_worker.last_cwd_for("key-1") == str(project_a)
+    assert cwd_worker.last_cwd_for("key-2") == str(project_b)
+
+
+# ── _local_session_process_cwd ────────────────────────────────────────
+
+
+def test_local_session_process_cwd_uses_session_cwd(monkeypatch, tmp_path):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    project = tmp_path / "live"
+    project.mkdir()
+    assert server._local_session_process_cwd({"cwd": str(project)}) == str(project)
+
+
+def test_local_session_process_cwd_heals_deleted_worktree(monkeypatch, tmp_path):
+    """A session pinned to a vanished worktree resolves to the healed ancestor,
+    never to a nonexistent path — Popen(cwd=...) would raise on one."""
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    repo = tmp_path / "repo"
+    (repo / ".worktrees").mkdir(parents=True)
+    dead = repo / ".worktrees" / "gone"
+    session = {"cwd": str(dead), "session_key": "k"}
+
+    monkeypatch.setattr(server, "_session_db", lambda _s: contextlib.nullcontext(None))
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+
+    resolved = server._local_session_process_cwd(session)
+    assert resolved != str(dead)
+    assert os.path.isdir(resolved)
+
+
+def test_local_session_process_cwd_falls_back_when_unusable(monkeypatch, tmp_path):
+    """An unhealable/nonexistent cwd falls back to the gateway cwd."""
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(server, "_display_session_cwd", lambda _s: str(tmp_path / "nope"))
+    assert server._local_session_process_cwd({"cwd": "/x"}) == os.getcwd()
+
+
+def test_local_session_process_cwd_ignores_remote_backend(monkeypatch):
+    """A remote backend's cwd lives in the remote env — passing it to a host
+    Popen would either fail or land on an unrelated local directory."""
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    remote = "/remote/only/workspace"
+    assert server._local_session_process_cwd({"cwd": remote}) == os.getcwd()
+
+
+def test_local_session_process_cwd_empty_session_cwd(monkeypatch, tmp_path):
+    """No session cwd → the existing completion/default fallback, still a real dir."""
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    assert server._local_session_process_cwd({}) == str(tmp_path)
+    assert server._local_session_process_cwd(None) == str(tmp_path)
+
+
+# ── session.cwd.set rebinds the worker ────────────────────────────────
+
+
+def _cwd_set_session(monkeypatch, sid, key, cwd, worker=None):
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_session_db", lambda _s: contextlib.nullcontext(None))
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _c: "main")
+    session = {
+        "session_key": key,
+        "cwd": str(cwd),
+        "slash_worker": worker,
+        "agent": None,
+        "running": False,
+    }
+    server._sessions[sid] = session
+    return session
+
+
+def test_session_cwd_set_restarts_worker_with_new_cwd(cwd_worker, monkeypatch, tmp_path):
+    """An active session that changes project must not keep the worker (and its
+    stdio MCP children) snapshotted on the old cwd."""
+    old = tmp_path / "old"
+    new = tmp_path / "new"
+    old.mkdir()
+    new.mkdir()
+    _isolated_sessions(monkeypatch)
+
+    stale = _CwdWorker("key-c", "test/model", cwd=str(old))
+    session = _cwd_set_session(monkeypatch, "sid-c", "key-c", old, worker=stale)
+
+    resp = server._methods["session.cwd.set"](
+        "rid-c", {"session_id": "sid-c", "cwd": str(new)}
+    )
+    assert "result" in resp, resp
+    assert stale.closed is True
+    assert session["slash_worker"] is not stale
+    assert cwd_worker.last_cwd_for("key-c") == str(new)
+
+
+def test_session_cwd_set_same_cwd_keeps_worker(cwd_worker, monkeypatch, tmp_path):
+    """An equivalent cwd is not a project change — restarting would drop the
+    worker's warm MCP connections for nothing."""
+    project = tmp_path / "same"
+    project.mkdir()
+    _isolated_sessions(monkeypatch)
+
+    worker = _CwdWorker("key-s", "test/model", cwd=str(project))
+    session = _cwd_set_session(monkeypatch, "sid-s", "key-s", project, worker=worker)
+    spawns_before = len(_CwdWorker.spawns)
+
+    resp = server._methods["session.cwd.set"](
+        "rid-s", {"session_id": "sid-s", "cwd": str(project) + os.sep}
+    )
+    assert "result" in resp, resp
+    assert session["slash_worker"] is worker
+    assert worker.closed is False
+    assert len(_CwdWorker.spawns) == spawns_before
+
+
+def test_session_cwd_set_lazy_session_spawns_no_worker(cwd_worker, monkeypatch, tmp_path):
+    """No worker yet → don't eagerly create one; the lazy path builds it with
+    the new cwd on first use."""
+    old = tmp_path / "lazy-old"
+    new = tmp_path / "lazy-new"
+    old.mkdir()
+    new.mkdir()
+    _isolated_sessions(monkeypatch)
+
+    session = _cwd_set_session(monkeypatch, "sid-l", "key-l", old, worker=None)
+
+    resp = server._methods["session.cwd.set"](
+        "rid-l", {"session_id": "sid-l", "cwd": str(new)}
+    )
+    assert "result" in resp, resp
+    assert session["slash_worker"] is None
+    assert _CwdWorker.spawns == []
+
+
+def test_session_cwd_set_busy_session_still_rejected(cwd_worker, monkeypatch, tmp_path):
+    """The existing 4009 guard wins before any worker rebind."""
+    old = tmp_path / "busy-old"
+    new = tmp_path / "busy-new"
+    old.mkdir()
+    new.mkdir()
+    _isolated_sessions(monkeypatch)
+
+    worker = _CwdWorker("key-b", "test/model", cwd=str(old))
+    session = _cwd_set_session(monkeypatch, "sid-b", "key-b", old, worker=worker)
+    session["running"] = True
+
+    resp = server._methods["session.cwd.set"](
+        "rid-b", {"session_id": "sid-b", "cwd": str(new)}
+    )
+    assert resp["error"]["code"] == 4009
+    assert session["cwd"] == str(old)
+    assert session["slash_worker"] is worker
+    assert worker.closed is False
+
+
+def test_session_cwd_set_restart_failure_leaves_no_worker(monkeypatch, tmp_path):
+    """A failed re-spawn must leave slash_worker=None so slash.exec's lazy
+    recovery path rebuilds it, instead of stranding the old-cwd worker."""
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    old = tmp_path / "fail-old"
+    new = tmp_path / "fail-new"
+    old.mkdir()
+    new.mkdir()
+    _isolated_sessions(monkeypatch)
+
+    def _boom(*_a, **_k):
+        raise OSError("spawn failed")
+
+    monkeypatch.setattr(server, "_SlashWorker", _boom)
+    monkeypatch.setattr(server, "_resolve_model", lambda *a, **k: "test/model")
+
+    stale = _CwdWorker("key-f", "test/model", cwd=str(old))
+    session = _cwd_set_session(monkeypatch, "sid-f", "key-f", old, worker=stale)
+
+    resp = server._methods["session.cwd.set"](
+        "rid-f", {"session_id": "sid-f", "cwd": str(new)}
+    )
+    assert "result" in resp, resp
+    assert session["slash_worker"] is None
+    assert stale.closed is True

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -395,7 +395,7 @@ def test_tui_slash_worker_hides_python_window(monkeypatch):
 
     monkeypatch.setattr(subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
 
-    server._SlashWorker("session-key", "model-x")
+    server._SlashWorker("session-key", "model-x", str(Path.cwd()))
 
     assert captured[0][0][:3] == [server.sys.executable, "-m", "tui_gateway.slash_worker"]
     assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -228,6 +228,10 @@ class TestStdioPidTracking:
 
         server = MCPServerTask.__new__(MCPServerTask)
         server.name = "test-zombie-reap"
+        # __new__ skips __init__, so every slot _run_stdio touches must be set
+        # by hand: no cwd means "inherit the process's", the pre-scoping default.
+        server.cwd = ""
+        server.scope_key = "test-zombie-reap"
         server._ready = MagicMock()
         server._shutdown_event = MagicMock()
         server._shutdown_event.is_set.return_value = True

--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -23,6 +23,7 @@ def test_slash_worker_accepts_profile_home():
             worker = _SlashWorker(
                 session_key="test_key",
                 model="test-model",
+                cwd=os.getcwd(),
                 profile_home="/home/luke/.hermes/profiles/work"
             )
             
@@ -49,7 +50,8 @@ def test_slash_worker_without_profile_home():
             # Test initialization without profile_home (backward compatible)
             worker = _SlashWorker(
                 session_key="test_key",
-                model="test-model"
+                model="test-model",
+                cwd=os.getcwd()
             )
             
             # Verify Popen was called
@@ -80,6 +82,7 @@ def test_slash_worker_with_none_profile_home():
             worker = _SlashWorker(
                 session_key="test_key",
                 model="test-model",
+                cwd=os.getcwd(),
                 profile_home=None
             )
             
@@ -93,6 +96,57 @@ def test_slash_worker_with_none_profile_home():
             if "HERMES_HOME" in env:
                 # This is from os.environ at test time, not from our code
                 pass
+
+
+def test_slash_worker_pins_terminal_cwd_to_its_spawn_cwd(monkeypatch, tmp_path):
+    """The worker's TERMINAL_CWD must agree with its Popen cwd (local backend).
+
+    ``agent.runtime_cwd.resolve_agent_cwd()`` — which the child's Hindsight bank
+    and MCP transport scope both derive from — prefers TERMINAL_CWD over the
+    process cwd. The worker inherits the gateway's TERMINAL_CWD (the launch dir)
+    through ``hermes_subprocess_env``, and cli.load_cli_config only re-exports it
+    when ``_HERMES_GATEWAY`` is unset — which it isn't, once gateway.run has been
+    imported. Unpinned, the Popen(cwd=project) fix is silently overridden.
+    """
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)  # local backend
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    project = tmp_path / "wrxn"
+    project.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(launch_dir))
+
+    with patch("subprocess.Popen") as mock_popen:
+        mock_popen.return_value.stdout = MagicMock()
+        mock_popen.return_value.stderr = MagicMock()
+
+        from tui_gateway.server import _SlashWorker
+
+        _SlashWorker(session_key="k", model="m", cwd=str(project))
+
+    kwargs = mock_popen.call_args[1]
+    assert kwargs["cwd"] == str(project)
+    assert kwargs["env"]["TERMINAL_CWD"] == str(project)
+
+
+def test_slash_worker_keeps_remote_terminal_cwd(monkeypatch, tmp_path):
+    """Remote backends: TERMINAL_CWD names a path in the TARGET environment.
+
+    ``_local_session_process_cwd`` hands the worker the gateway's own cwd in that
+    case (a remote path must never reach a host Popen), so overwriting the remote
+    TERMINAL_CWD with it would silently move the remote terminal's working dir.
+    """
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_CWD", "/remote/workspace")
+
+    with patch("subprocess.Popen") as mock_popen:
+        mock_popen.return_value.stdout = MagicMock()
+        mock_popen.return_value.stderr = MagicMock()
+
+        from tui_gateway.server import _SlashWorker
+
+        _SlashWorker(session_key="k", model="m", cwd=str(tmp_path))
+
+    assert mock_popen.call_args[1]["env"]["TERMINAL_CWD"] == "/remote/workspace"
 
 
 def test_slash_worker_inherits_argv_correctly():
@@ -109,7 +163,8 @@ def test_slash_worker_inherits_argv_correctly():
             # Test that argv is correct
             worker = _SlashWorker(
                 session_key="my_session",
-                model="gpt-4"
+                model="gpt-4",
+                cwd=os.getcwd()
             )
             
             call_args = mock_popen.call_args[0][0]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1516,7 +1516,7 @@ class MCPServerTask:
     """
 
     __slots__ = (
-        "name", "session", "tool_timeout",
+        "name", "session", "tool_timeout", "cwd", "scope_key",
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_elicitation",
@@ -1529,8 +1529,19 @@ class MCPServerTask:
         "_reconnect_retries",
     )
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, cwd: str = "", scope_key: str = ""):
         self.name = name
+        # Working directory this transport's stdio child is spawned in.
+        # Empty means "not cwd-sensitive": HTTP transports, and any task built
+        # without an explicit directory, which keeps inheriting the process cwd
+        # exactly as before. A non-empty ``cwd`` is what marks a task as
+        # scopable — see ``_call_scope()``.
+        self.cwd: str = cwd
+        # Key under which this instance's breaker/registry state lives. Equal
+        # to ``name`` for the instance that owns the tool schemas; the extra
+        # per-project clones carry their own key so a stale circuit breaker or
+        # reconnect from one project can never gate another's calls.
+        self.scope_key: str = scope_key or name
         self.session: Optional[Any] = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
         self._task: Optional[asyncio.Task] = None
@@ -1764,6 +1775,16 @@ class MCPServerTask:
         """
         from tools.registry import registry
 
+        if self.scope_key != self.name:
+            # Per-project transport clone. The tool names/schemas belong to the
+            # primary instance (same guard as _register_tools_when_ready): a
+            # clone republishing them would mutate the agent's tool list
+            # mid-conversation from another project's transport, and — worse —
+            # would leave the clone owning _registered_tool_names, so when that
+            # one project's child dies the park/shutdown path would deregister
+            # the server's tools for every other session in the process.
+            # Only the transport is scoped; the schema never is.
+            return
         if not self._advertises_tools():
             # A server that doesn't implement tools/* should never send
             # tools/list_changed, but guard anyway — calling tools/list
@@ -2065,10 +2086,17 @@ class MCPServerTask:
         # package, not the watchdog wrapper.
         command, args = _wrap_command_with_watchdog(command, args)
 
+        # A stdio child inherits the parent's cwd unless told otherwise, and
+        # project-sensitive servers derive their state from it (Hindsight reads
+        # ${PWD} to pick a memory bank). Spawning in the task's own resolved
+        # directory is what makes two sessions in different projects reach
+        # different processes instead of one gateway-launch-dir process.
+        # None keeps the pre-existing inherit behavior for tasks with no cwd.
         server_params = StdioServerParameters(
             command=command,
             args=args,
             env=safe_env if safe_env else None,
+            cwd=self.cwd or None,
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
@@ -2159,7 +2187,9 @@ class MCPServerTask:
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
+                    # Keyed by scope: one project's recovery must not clear
+                    # another project's failure count for the same server.
+                    _reset_server_error(self.scope_key)
                     # This session is live: reset the reconnect retry counter
                     # so transient prior failures do not accumulate toward
                     # permanent parking (#57604).
@@ -2599,6 +2629,13 @@ class MCPServerTask:
         """
         if not self._ready.is_set() or self._registered_tool_names:
             return
+        if self.scope_key != self.name:
+            # Per-project transport clone. Tool names and schemas are owned by
+            # the primary instance and must stay byte-identical for the whole
+            # conversation — re-publishing them from a clone's reconnect would
+            # mutate the agent's tool list mid-flight and break the prompt
+            # cache. Only the transport is scoped; the schema never is.
+            return
         self._registered_tool_names = _register_server_tools(
             self.name, self, self._config
         )
@@ -2968,6 +3005,34 @@ _servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 
+# Per-project stdio transport clones, keyed by
+# ``server_name \0 profile_home \0 canonical_cwd``.
+#
+# ``_servers`` holds one instance per configured server, connected once during
+# discovery — in the gateway that means the directory ``hermes serve`` was
+# launched from, which is not any session's project. stdio children inherit
+# that cwd, so a project-sensitive server (Hindsight resolves its memory bank
+# from ${PWD}) answered every session with the launch directory's project.
+# Sessions whose resolved cwd differs from the discovered instance's get their
+# own transport here instead, created lazily on first call. HTTP transports are
+# absent by construction: they carry no cwd, so cloning them would only
+# multiply connections (see ``_call_scope``).
+#
+# The profile home is in the key because MCP credentials/config are resolved
+# per profile; two profiles sharing one child would cross their auth state.
+#
+# ponytail: unbounded in the number of distinct projects touched in one
+# process. Bound it with an LRU (or configure ``idle_timeout_seconds``, which
+# already recycles idle stdio children) if long-lived gateways start
+# accumulating processes.
+_scoped_servers: Dict[str, MCPServerTask] = {}
+
+# One lock per scope key: single-flight for the lazy connect, so two threads
+# racing the first call in the same project spawn one child, not two. Held
+# across the (blocking) connect, hence separate from ``_lock``, which only ever
+# guards short dict mutations.
+_scoped_connect_locks: Dict[str, threading.Lock] = {}
+
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns
 # a "server unreachable" message that tells the model to stop retrying,
@@ -3244,9 +3309,12 @@ def _handle_auth_error_and_retry(
         )
         recovered = False
 
+    # Same thread and context as the handler that raised, so this resolves to
+    # the very transport the failed call used — not another project's clone.
+    srv = _server_in_scope(server_name)
+    breaker_key = _call_scope(server_name)[0]
+
     if recovered:
-        with _lock:
-            srv = _servers.get(server_name)
         reconnected = False
         if srv is not None and hasattr(srv, "_reconnect_event"):
             reconnected = _signal_reconnect_and_wait(
@@ -3264,17 +3332,17 @@ def _handle_auth_error_and_retry(
         # _bump_server_error on failure, so a genuinely broken server will
         # re-trip the breaker as normal.
         if reconnected:
-            _reset_server_error(server_name)
+            _reset_server_error(breaker_key)
 
         try:
             result = retry_call()
             try:
                 parsed = json.loads(result)
                 if "error" not in parsed:
-                    _reset_server_error(server_name)
+                    _reset_server_error(breaker_key)
                     return result
             except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)
+                _reset_server_error(breaker_key)
                 return result
         except Exception as retry_exc:
             logger.warning(
@@ -3285,7 +3353,7 @@ def _handle_auth_error_and_retry(
     # No recovery available, or retry also failed: surface a structured
     # needs_reauth error. Bumps the circuit breaker so the model stops
     # retrying the tool.
-    _bump_server_error(server_name)
+    _bump_server_error(breaker_key)
     return json.dumps({
         "error": (
             f"MCP server '{server_name}' requires re-authentication. "
@@ -3376,8 +3444,11 @@ def _handle_session_expired_and_retry(
     if not _is_session_expired_error(exc):
         return None
 
-    with _lock:
-        srv = _servers.get(server_name)
+    # Resolve the transport this call actually used: a stdio child that died
+    # ("broken pipe") belongs to one project's scope, and reconnecting another
+    # project's server would leave the caller's transport just as dead.
+    srv = _server_in_scope(server_name)
+    breaker_key = _call_scope(server_name)[0]
     if srv is None or not hasattr(srv, "_reconnect_event"):
         return None
 
@@ -3411,10 +3482,10 @@ def _handle_session_expired_and_retry(
         try:
             parsed = json.loads(result)
             if "error" not in parsed:
-                _server_error_counts[server_name] = 0
+                _server_error_counts[breaker_key] = 0
                 return result
         except (json.JSONDecodeError, TypeError):
-            _server_error_counts[server_name] = 0
+            _server_error_counts[breaker_key] = 0
             return result
     except Exception as retry_exc:
         logger.warning(
@@ -3784,20 +3855,160 @@ def _load_mcp_config() -> Dict[str, dict]:
 # Server connection helper
 # ---------------------------------------------------------------------------
 
-async def _connect_server(name: str, config: dict) -> MCPServerTask:
+async def _connect_server(
+    name: str, config: dict, cwd: str = "", scope_key: str = "",
+) -> MCPServerTask:
     """Create an MCPServerTask, start it, and return when ready.
 
     The server Task keeps the connection alive in the background.
     Call ``server.shutdown()`` (on the same event loop) to tear it down.
+
+    ``cwd`` is the directory a stdio child is spawned in (ignored by HTTP
+    transports); ``scope_key`` names the per-project clone (see
+    ``_scoped_servers``) and defaults to owning the server name's
+    registry/breaker state.
+
+    An omitted ``cwd`` means "the baseline scope", i.e. ``_canonical_call_cwd()``
+    — NOT the process cwd. The two routinely differ (the gateway's unit starts
+    in its install dir while ``TERMINAL_CWD`` carries the configured
+    ``terminal.cwd``), and a primary spawned in the process cwd would match no
+    session at all: ``_call_scope`` would clone every stdio server forever and
+    this connection would serve nobody.
 
     Raises:
         ValueError: if required config keys are missing.
         ImportError: if HTTP transport is needed but not available.
         Exception: on connection or initialization failure.
     """
-    server = MCPServerTask(name)
+    server = MCPServerTask(name, cwd=cwd or _canonical_call_cwd(), scope_key=scope_key)
     await server.start(config)
     return server
+
+
+# ---------------------------------------------------------------------------
+# Per-project transport scope
+# ---------------------------------------------------------------------------
+
+def _canonical_call_cwd() -> str:
+    """The directory this call's cwd-sensitive stdio servers must run in.
+
+    ``resolve_agent_cwd()`` is the existing single source of truth for "where
+    does the agent live": the per-session ContextVar the gateway binds, else
+    ``TERMINAL_CWD``, else the launch dir. It only accepts paths that are real
+    local directories, which is what makes the two dangerous cases safe for
+    free — a remote-backend session path (not present on this host) and a
+    deleted worktree both fall back to the host default, so ``Popen`` never
+    receives a nonexistent directory and every remote session shares one scope.
+
+    Must run on the CALLER's thread. Coroutines scheduled onto the MCP loop are
+    created in the loop thread's context and cannot see the session ContextVar
+    (the same reason ``_wrap_with_home_override`` exists), so the scope is
+    resolved here, at tool-call time, and passed down explicitly.
+    """
+    from agent.runtime_cwd import resolve_agent_cwd
+
+    try:
+        # realpath so /project, /project/ and a symlinked path all name one
+        # scope instead of spawning a child each.
+        return os.path.realpath(str(resolve_agent_cwd()))
+    except Exception:
+        return os.path.realpath(os.getcwd())
+
+
+def _call_scope(server_name: str) -> tuple[str, str]:
+    """Return ``(scope_key, cwd)`` for the calling context.
+
+    ``cwd`` is empty exactly when the call belongs to the server's primary
+    ``_servers`` instance: HTTP transports (nothing to inherit a cwd from),
+    test doubles injected straight into ``_servers``, and any session already
+    sitting in the directory the primary child runs in. A *different* local
+    directory is the only thing that produces a scoped key — so single-project
+    processes (CLI, cron, a gateway whose sessions all live in the launch dir)
+    behave exactly as before and spawn nothing extra.
+    """
+    with _lock:
+        primary = _servers.get(server_name)
+    # isinstance, not duck-typing: tests inject Mock stand-ins into ``_servers``
+    # and a Mock answers every attribute with a truthy Mock, which would send a
+    # fake transport down the scoped-connect path hunting a child that does not
+    # exist. Anything that isn't a real task has no child process to scope.
+    if not isinstance(primary, MCPServerTask) or primary._is_http():
+        return server_name, ""
+
+    # Where the primary child is REALLY running: the cwd discovery spawned it
+    # with (``_canonical_call_cwd()`` — see _discover_and_register_server), and
+    # the process cwd only for a task built without one, which then inherited it.
+    primary_cwd = primary.cwd or os.path.realpath(os.getcwd())
+    want = _canonical_call_cwd()
+    if want == primary_cwd:
+        return server_name, ""
+
+    from hermes_constants import get_hermes_home
+
+    return f"{server_name}\0{get_hermes_home()}\0{want}", want
+
+
+def _server_in_scope(server_name: str) -> Optional[MCPServerTask]:
+    """Return the connected instance for this call's scope, without creating one."""
+    key, cwd = _call_scope(server_name)
+    with _lock:
+        if not cwd:
+            return _servers.get(server_name)
+        return _scoped_servers.get(key)
+
+
+def _ensure_server_in_scope(server_name: str) -> Optional[MCPServerTask]:
+    """Return this call's transport, connecting a missing project scope lazily."""
+    key, cwd = _call_scope(server_name)
+    with _lock:
+        if not cwd:
+            return _servers.get(server_name)
+        server = _scoped_servers.get(key)
+        if server is not None:
+            return server
+        primary = _servers.get(server_name)
+        # One lock per scope: concurrent first calls in the same project wait
+        # for a single spawn, while a different project connects in parallel.
+        connect_lock = _scoped_connect_locks.setdefault(key, threading.Lock())
+
+    if primary is None:
+        return None
+    # Reuse the primary's already-interpolated config; re-reading config.yaml
+    # here could pick up an edit mid-conversation and change the tool surface.
+    config = dict(getattr(primary, "_config", None) or {})
+    connect_timeout = float(config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
+
+    with connect_lock:
+        with _lock:
+            server = _scoped_servers.get(key)
+        if server is not None:
+            return server
+        try:
+            server = _run_on_mcp_loop(
+                lambda: asyncio.wait_for(
+                    _connect_server(server_name, config, cwd=cwd, scope_key=key),
+                    timeout=connect_timeout,
+                ),
+                # Outer bound sits above the inner one so the inner wait_for
+                # reports the real connect failure instead of racing it.
+                timeout=connect_timeout + 5,
+            )
+        except Exception as exc:
+            # Includes InterruptedError (the user sent a new message while the
+            # child was starting): the handlers already turn a missing server
+            # into a clean "not connected" reply, so nothing escapes as a crash.
+            logger.warning(
+                "MCP server '%s': could not start a transport for %s: %s",
+                server_name, cwd, _exc_str(exc),
+            )
+            return None
+        with _lock:
+            _scoped_servers[key] = server
+        logger.info(
+            "MCP server '%s': started a dedicated stdio transport in %s",
+            server_name, cwd,
+        )
+        return server
 
 
 # ---------------------------------------------------------------------------
@@ -3839,13 +4050,15 @@ def _request_lazy_reconnect(server_name: str, server: MCPServerTask) -> bool:
 
 
 def _get_connected_server_for_call(server_name: str) -> Optional[MCPServerTask]:
-    """Return a connected server, lazily reconnecting recycled stdio state."""
-    with _lock:
-        server = _servers.get(server_name)
+    """Return a connected server, lazily reconnecting recycled stdio state.
+
+    Transport selection happens here, per call, from the caller's session cwd —
+    never at registration time. That is what lets ``session.cwd.set`` take
+    effect on the very next tool call without touching the agent's tool list.
+    """
+    server = _ensure_server_in_scope(server_name)
     if server is not None and server.session is None and server._is_recycled_stdio():
         _request_lazy_reconnect(server_name, server)
-        with _lock:
-            server = _servers.get(server_name)
     return server
 
 
@@ -3864,6 +4077,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """
 
     def _handler(args: dict, **kwargs) -> str:
+        # Breaker state is per transport, not per server name: one project's
+        # dead stdio child must not gate a healthy sibling project's calls.
+        # Resolved here, on the calling thread, because the session cwd lives
+        # in a ContextVar the MCP loop cannot see.
+        breaker_key = _call_scope(server_name)[0]
+
         # Circuit breaker: if this server has failed too many times
         # consecutively, short-circuit with a clear message so the model
         # stops retrying and uses alternative approaches (#10447).
@@ -3874,15 +4093,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         # failure the error paths below bump the count again, which
         # re-stamps the open-time via _bump_server_error (re-arming
         # the cooldown).
-        if _server_error_counts.get(server_name, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
-            opened_at = _server_breaker_opened_at.get(server_name, 0.0)
+        if _server_error_counts.get(breaker_key, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
+            opened_at = _server_breaker_opened_at.get(breaker_key, 0.0)
             age = time.monotonic() - opened_at
             if age < _CIRCUIT_BREAKER_COOLDOWN_SEC:
                 remaining = max(1, int(_CIRCUIT_BREAKER_COOLDOWN_SEC - age))
                 return json.dumps({
                     "error": (
                         f"MCP server '{server_name}' is unreachable after "
-                        f"{_server_error_counts[server_name]} consecutive "
+                        f"{_server_error_counts[breaker_key]} consecutive "
                         f"failures. Auto-retry available in ~{remaining}s. "
                         f"Do NOT retry this tool yet — use alternative "
                         f"approaches or ask the user to check the MCP server."
@@ -3892,7 +4111,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         server = _get_connected_server_for_call(server_name)
         if not server:
-            _bump_server_error(server_name)
+            _bump_server_error(breaker_key)
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
             }, ensure_ascii=False)
@@ -3918,7 +4137,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # without burning iterations. The breaker resets once the
                 # fresh session initializes (_run_stdio/_run_http call
                 # _reset_server_error).
-                _bump_server_error(server_name)
+                _bump_server_error(breaker_key)
                 if _signal_reconnect(server):
                     return json.dumps({
                         "error": (
@@ -3999,11 +4218,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    _bump_server_error(breaker_key)
                 else:
-                    _reset_server_error(server_name)  # success — reset
+                    _reset_server_error(breaker_key)  # success — reset
             except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+                _reset_server_error(breaker_key)  # non-JSON = success
             return result
         except InterruptedError:
             return _interrupted_call_result()
@@ -4028,7 +4247,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             if recovered is not None:
                 return recovered
 
-            _bump_server_error(server_name)
+            _bump_server_error(breaker_key)
             logger.error(
                 "MCP tool %s/%s call failed: %s",
                 server_name, tool_name, exc,
@@ -4845,6 +5064,11 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     """Connect to a single MCP server, discover tools, and register them.
 
+    The discovered instance is the baseline scope: ``_connect_server`` spawns it
+    in ``_canonical_call_cwd()`` — the same resolver every tool call scopes
+    itself by — so only sessions that resolve to a *different* directory pay for
+    a transport of their own.
+
     Returns list of registered tool names.
     """
     connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
@@ -5421,9 +5645,13 @@ def shutdown_mcp_servers():
     Each server Task is signalled to exit its ``async with`` block so that
     the anyio cancel-scope cleanup happens in the same Task that opened it.
     All servers are shut down in parallel via ``asyncio.gather``.
+
+    Every scope is closed, not just the primary one: the per-project stdio
+    clones own real child processes, and skipping them would leak one process
+    per project the user visited.
     """
     with _lock:
-        servers_snapshot = list(_servers.values())
+        servers_snapshot = list(_servers.values()) + list(_scoped_servers.values())
 
     # Fast path: nothing to shut down.
     if not servers_snapshot:
@@ -5442,6 +5670,8 @@ def shutdown_mcp_servers():
                 )
         with _lock:
             _servers.clear()
+            _scoped_servers.clear()
+            _scoped_connect_locks.clear()
 
     with _lock:
         loop = _mcp_loop

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -275,7 +275,13 @@ _detached_ws_transport = _DropTransport()
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
-    def __init__(self, session_key: str, model: str, profile_home: str | None = None):
+    def __init__(
+        self,
+        session_key: str,
+        model: str,
+        cwd: str,
+        profile_home: str | None = None,
+    ):
         self._lock = threading.Lock()
         self._seq = 0
         self.stderr_tail: list[str] = []
@@ -297,6 +303,16 @@ class _SlashWorker:
         # slash_worker runs the Hermes agent → needs provider credentials.
         # Tier-1 secrets (gateway/GitHub/infra) are still stripped (#29157).
         env = hermes_subprocess_env(inherit_credentials=True)
+        if _is_local_terminal_backend():
+            # Popen(cwd=...) alone is not enough: the child resolves its project
+            # through agent.runtime_cwd.resolve_agent_cwd(), which prefers
+            # TERMINAL_CWD — and it inherits the gateway's (the launch dir) in
+            # this env copy. cli.load_cli_config only re-exports it from the
+            # child's own cwd when _HERMES_GATEWAY is unset, which it is not once
+            # gateway.run has been imported. Pin it so both agree.
+            # Remote backends keep the inherited TERMINAL_CWD: it names a path in
+            # the target environment, not a host directory.
+            env["TERMINAL_CWD"] = cwd
         if profile_home:
             # Global-remote / multi-profile sessions: the worker must resolve
             # config/skills/state against the session's profile home, not the
@@ -311,6 +327,10 @@ class _SlashWorker:
         # inherited pgid, and killpg() then kills the TUI parent itself.
         # See agent/lsp/client.py for the symmetric LSP server fix and
         # tools/mcp_tool.py _filter_mcp_children for defense-in-depth.
+        #
+        # `cwd` is required, not defaulted: the worker's stdio MCP children read
+        # it as the project (see _local_session_process_cwd). A default would let
+        # a new call site silently fall back to the gateway's launch dir again.
         self.proc = subprocess.Popen(
             argv,
             stdin=subprocess.PIPE,
@@ -318,7 +338,7 @@ class _SlashWorker:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
-            cwd=os.getcwd(),
+            cwd=cwd,
             env=env,
             creationflags=windows_hide_flags(),
             start_new_session=True,
@@ -1401,6 +1421,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 worker = _SlashWorker(
                     key,
                     getattr(agent, "model", _resolve_model()),
+                    _local_session_process_cwd(current),
                     profile_home=current.get("profile_home"),
                 )
                 _attach_worker(sid, current, worker)
@@ -1642,6 +1663,24 @@ def _display_session_cwd(session: dict | None) -> str:
         _persist_session_git_meta(session, healed)
 
     return healed
+
+
+def _local_session_process_cwd(session: dict | None) -> str:
+    """Host-valid cwd to spawn this session's child processes in.
+
+    The slash worker is the parent of every stdio MCP server a session starts,
+    and cwd-sensitive servers (Hindsight derives its bank from ${PWD}) inherit
+    it. Spawning in the gateway's launch directory therefore binds a project
+    session to whatever directory `hermes desktop` was started from.
+
+    Two paths must never reach a host ``Popen(cwd=...)``: a remote backend's cwd
+    (it exists in the target environment, not here) and a cwd that no longer
+    exists (Popen raises). Both fall back to the gateway's own cwd.
+    """
+    if not _is_local_terminal_backend():
+        return os.getcwd()
+    cwd = _display_session_cwd(session)
+    return cwd if cwd and os.path.isdir(cwd) else os.getcwd()
 
 
 def _session_source(session: dict | None) -> str:
@@ -2811,6 +2850,7 @@ def _restart_slash_worker(sid: str, session: dict):
         new_worker = _SlashWorker(
             session["session_key"],
             getattr(session.get("agent"), "model", _resolve_model()),
+            _local_session_process_cwd(session),
             profile_home=session.get("profile_home"),
         )
     except Exception:
@@ -4733,6 +4773,7 @@ def _init_session(
             _SlashWorker(
                 key,
                 getattr(agent, "model", _resolve_model()),
+                _local_session_process_cwd(_sessions[sid]),
                 profile_home=_sessions[sid].get("profile_home"),
             ),
         )
@@ -5954,10 +5995,18 @@ def _(rid, params: dict) -> dict:
     raw = str(params.get("cwd", "") or "").strip()
     if not raw:
         return _err(rid, 4016, "cwd required")
+    had_worker = session.get("slash_worker") is not None
+    previous = _local_session_process_cwd(session)
     try:
         cwd = _set_session_cwd(session, raw)
     except ValueError as e:
         return _err(rid, 4017, str(e))
+    # The live worker (and every stdio MCP server under it) snapshotted the old
+    # project at spawn; only a respawn moves them. Skip it when the path merely
+    # normalized to the same dir, and never spawn eagerly for a session that has
+    # no worker — slash.exec's lazy path will build one on the new cwd.
+    if had_worker and _local_session_process_cwd(session) != previous:
+        _restart_slash_worker(params.get("session_id", ""), session)
     agent = session.get("agent")
     info = _session_info(agent, session) if agent is not None else {
         "cwd": cwd,
@@ -13283,6 +13332,7 @@ def _(rid, params: dict) -> dict:
             worker = _SlashWorker(
                 session["session_key"],
                 getattr(session.get("agent"), "model", _resolve_model()),
+                _local_session_process_cwd(session),
                 profile_home=session.get("profile_home"),
             )
             _attach_worker(params.get("session_id", ""), session, worker)


### PR DESCRIPTION
## The bug

A Desktop/TUI session carries its project cwd end to end — the app sends it, it is persisted on the session row, and the turn thread binds it into the `_SESSION_CWD` contextvar that `agent.runtime_cwd.resolve_agent_cwd()` reads.

Three paths ignore it and fall back to the process-global cwd, which in a gateway is only ever the directory `hermes desktop` / `hermes serve` was launched from. **Every session in the process reaches stdio MCP servers running in that one directory**, whatever project the user actually selected.

For a cwd-sensitive MCP server this is silent data going to the wrong place: a memory server that derives its store from `${PWD}` answers every project with the launch directory's store. It's invisible when the gateway happens to be launched inside the project, which is why it survives casual use.

```
Desktop project path (…/my-project)
  → session.create cwd (…/my-project)      correct
  → session row cwd                        correct
  → in-process _SESSION_CWD contextvar     correct
  → _SlashWorker Popen(cwd=os.getcwd())    WRONG — gateway launch dir
  → mcp_tool._servers (process-global)     WRONG — one child for all sessions
  → MemoryManager background pool          WRONG — empty Context, no _SESSION_CWD
```

## The fix

Each layer is fixed at its own root. Correcting one alone leaves another path still reading the launch dir, so all three are needed for the fix to be observable.

**`tools/mcp_tool.py`** — `_servers` is a process-global registry keyed by server name, connected once at discovery. Stdio transports are now keyed by `(server, profile home, canonical cwd)` and selected **per call** from the caller's context, so:
- normal chat tools — not only slash commands — reach the right project;
- two sessions in different projects never share a child process;
- circuit-breaker / reconnect / RPC-lock state is per scope and cannot cross projects;
- `session.cwd.set` takes effect on the very next tool call, with no explicit invalidation.

Tool **names and schemas stay global and byte-stable** — only transport selection is scoped, so a conversation's tool list never mutates mid-flight. HTTP/SSE transports carry no cwd and remain process-shared. Scopes connect lazily behind a per-scope single-flight lock, and `shutdown_mcp_servers()` closes every scope.

**`tui_gateway/server.py`** — `_SlashWorker` spawned its subprocess with `cwd=os.getcwd()`, and every stdio MCP server under it inherited that. `cwd` is now a **required** constructor argument (a default would let a new call site silently reintroduce this), resolved from the session's healed, host-valid directory; a remote-backend path or a deleted worktree never reaches a host `Popen`. `session.cwd.set` respawns a live worker so its MCP children stop serving the old project.

`Popen(cwd=…)` alone was **not enough**: the child inherits the gateway's `TERMINAL_CWD`, and `resolve_agent_cwd()` prefers that over the process cwd — so the worker's env now pins `TERMINAL_CWD` to its spawn cwd on local backends.

**`agent/memory_manager.py`** — `_submit_background` handed work to a pool worker that starts with an empty `Context`, so a provider's background retain/prefetch could not see `_SESSION_CWD` and resolved the launch dir behind the turn thread's back. Work now runs inside a snapshot of the submitting turn's context. Snapshotting at *submit* time also pins the queueing turn, so a later session switch cannot redirect already-queued work.

## Tests

`tests/test_mcp_session_scope.py` (new) drives a real stdio MCP server that reports its own startup cwd and PID:

- two concurrent sessions in different projects get different cwds;
- a session's cwd does not drift after a sibling session's call (no last-writer-wins);
- repeated calls in one scope reuse a stable process;
- URL transports stay shared and unchanged;
- after `session.cwd.set`, the next call reports the new project while a sibling session still reports its own.

Slash-worker cwd propagation is covered across all four spawn paths (deferred build, eager resume, restart, lazy `slash.exec`), plus the deleted-worktree, remote-backend, empty-cwd, session-busy (4009), and restart-failure cases. `agent/memory_manager`'s context propagation has its own regression test.

All written test-first; each was observed failing for the right reason before the fix.

## Scope

No new dependency, no new config key, no `os.chdir()` in the multithreaded backend, no per-request rewriting of process-global `PWD`/`TERMINAL_CWD`, and no change to the Desktop app — it already sends and persists the correct session cwd.