### PR TITLE
fix(cli): persist model.base_url on /model switch to prevent stale endpoint

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7954,6 +7954,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            # Persist base_url so switching back from a provider with a
+            # custom endpoint (e.g. openai-codex) doesn't leave a stale
+            # base_url in config.yaml that routes the next provider's
+            # API key to the wrong host (#51507).
+            if result.base_url:
+                save_config_value("model.base_url", result.base_url)
+            else:
+                save_config_value("model.base_url", None)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
@@ -8266,6 +8274,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            # Persist base_url so switching back from a provider with a
+            # custom endpoint (e.g. openai-codex) doesn't leave a stale
+            # base_url in config.yaml that routes the next provider's
+            # API key to the wrong host (#51507).
+            if result.base_url:
+                save_config_value("model.base_url", result.base_url)
+            else:
+                save_config_value("model.base_url", None)
             _cprint("    Saved to config.yaml")
         else:
             _cprint("    (session only — add --global to persist)")


### PR DESCRIPTION
## Problem

When switching models via `/model` in the CLI, the persistence code saves `model.default` and `model.provider` to `config.yaml` but **never saves `model.base_url`**.

This causes a bug when:
1. User switches from deepseek → openai-codex (base_url becomes `https://chatgpt.com/backend-api/codex`)
2. User switches back from openai-codex → deepseek (session works, but `model.base_url` is NOT reset)
3. User exits and restarts Hermes
4. `model.base_url` still points to `https://chatgpt.com/backend-api/codex`
5. `resolve_runtime_provider` honors `model.base_url` from config (see `_resolve_runtime_from_pool_entry` L488-491 in `runtime_provider.py`)
6. DeepSeek API key gets sent to OpenAI's endpoint → **HTTP 403**

Symptom:
```
Provider: deepseek  Model: deepseek-v4-pro
Endpoint: https://chatgpt.com/backend-api/codex
💡 Your API key was rejected by the provider.
```

## Root Cause

The TUI gateway (`tui_gateway/server.py:2813-2823`) already handles this correctly:
```python
save_config_value("model.base_url", result.base_url)   # save when set
save_config_value("model.base_url", None)              # clear when empty
```

But the CLI (`cli.py`) at both model-switch persistence sites (hidden switch L7954 + main /model L8266) only saves `model.default` and `model.provider`.

## Fix

Apply the same base_url persistence pattern to both CLI sites. This is consistent with the TUI gateway implementation.