### PR TITLE
fix(qq): accept GROUP_MESSAGE_CREATE events from updated QQ Bot API

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -849,6 +849,7 @@ class QQAdapter(BasePlatformAdapter):
                 logger.info("[%s] Session resumed", self._log_tag)
             elif t in {
                     "C2C_MESSAGE_CREATE",
+                    "GROUP_MESSAGE_CREATE",
                     "GROUP_AT_MESSAGE_CREATE",
                     "DIRECT_MESSAGE_CREATE",
                     "GUILD_MESSAGE_CREATE",
@@ -949,7 +950,7 @@ class QQAdapter(BasePlatformAdapter):
         # Route by event type
         if event_type == "C2C_MESSAGE_CREATE":
             await self._handle_c2c_message(d, msg_id, content, author, timestamp)
-        elif event_type in {"GROUP_AT_MESSAGE_CREATE",}:
+        elif event_type in {"GROUP_MESSAGE_CREATE", "GROUP_AT_MESSAGE_CREATE",}:
             await self._handle_group_message(d, msg_id, content, author, timestamp)
         elif event_type in {"GUILD_MESSAGE_CREATE", "GUILD_AT_MESSAGE_CREATE"}:
             await self._handle_guild_message(d, msg_id, content, author, timestamp)


### PR DESCRIPTION
Fixes #63761

QQ Bot API changed the group message event type from `GROUP_AT_MESSAGE_CREATE` to `GROUP_MESSAGE_CREATE` (the old `@`-mention-only event type was replaced with a unified group message event).

This PR adds `GROUP_MESSAGE_CREATE` to both the dispatch routing table and the `_on_message` handler, while keeping `GROUP_AT_MESSAGE_CREATE` for backward compatibility with older QQ Bot API versions.

```
[QQBot:102929556] Unhandled dispatch: GROUP_MESSAGE_CREATE
```