### PR TITLE
fix(yuanbao): resolve real chat name/member-count in get_chat_info

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -5354,16 +5354,35 @@ class YuanbaoAdapter(BasePlatformAdapter):
         return await self._outbound.send_text(chat_id, content, reply_to, group_code=group_code)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
-        """Return basic chat metadata derived from the chat_id prefix.
+        """Return chat metadata, resolving real name/member-count where possible.
 
         chat_id conventions:
           "group:<group_code>"  → group chat
           "direct:<account>"   → C2C / direct message (default)
 
-        TODO (T06): fetch real chat name/member-count from Yuanbao API.
+        Groups: queried live via the WS QueryGroupInfo call. DMs: resolved
+        from the member-list cache (populated by prior group member queries)
+        since Yuanbao exposes no standalone C2C user-info API; falls back to
+        the raw chat_id when no live/cached data is available.
         """
         if chat_id.startswith("group:"):
+            group_code = chat_id[len("group:"):]
+            info = await self._group_query.query_group_info_raw(group_code)
+            if info and info.get("group_name"):
+                return {
+                    "name": info["group_name"],
+                    "type": "group",
+                    "member_count": info.get("member_count", 0),
+                }
             return {"name": chat_id, "type": "group"}
+
+        account = chat_id[len("direct:"):] if chat_id.startswith("direct:") else chat_id
+        for _, members in self._member_cache.values():
+            for member in members:
+                if member.get("user_id") == account:
+                    nickname = member.get("nickname")
+                    if nickname:
+                        return {"name": nickname, "type": "dm"}
         return {"name": chat_id, "type": "dm"}
 
     async def send_typing(self, chat_id: str, metadata: Optional[dict] = None) -> None:

--- a/tests/test_yuanbao_integration.py
+++ b/tests/test_yuanbao_integration.py
@@ -20,7 +20,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from gateway.config import Platform, PlatformConfig, GatewayConfig
 from gateway.platforms.yuanbao import YuanbaoAdapter
 
@@ -407,6 +407,43 @@ class TestP0PlatformScopedLock:
         adapter = YuanbaoAdapter(make_config())
         assert hasattr(adapter, '_acquire_platform_lock')
         assert hasattr(adapter, '_release_platform_lock')
+
+
+class TestGetChatInfo:
+    """get_chat_info resolves real group name/member-count and DM nicknames
+    where available, falling back to the raw chat_id otherwise."""
+
+    @pytest.mark.asyncio
+    async def test_group_resolves_real_name_and_member_count(self):
+        adapter = YuanbaoAdapter(make_config())
+        adapter._group_query.query_group_info_raw = AsyncMock(
+            return_value={"group_name": "Engineering", "member_count": 42}
+        )
+        info = await adapter.get_chat_info("group:12345")
+        assert info == {"name": "Engineering", "type": "group", "member_count": 42}
+
+    @pytest.mark.asyncio
+    async def test_group_falls_back_when_query_fails(self):
+        adapter = YuanbaoAdapter(make_config())
+        adapter._group_query.query_group_info_raw = AsyncMock(return_value=None)
+        info = await adapter.get_chat_info("group:12345")
+        assert info == {"name": "group:12345", "type": "group"}
+
+    @pytest.mark.asyncio
+    async def test_dm_resolves_nickname_from_member_cache(self):
+        adapter = YuanbaoAdapter(make_config())
+        adapter._member_cache["12345"] = (
+            0.0,
+            [{"user_id": "u1", "nickname": "Alice"}],
+        )
+        info = await adapter.get_chat_info("direct:u1")
+        assert info == {"name": "Alice", "type": "dm"}
+
+    @pytest.mark.asyncio
+    async def test_dm_falls_back_when_not_cached(self):
+        adapter = YuanbaoAdapter(make_config())
+        info = await adapter.get_chat_info("direct:unknown")
+        assert info == {"name": "direct:unknown", "type": "dm"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `get_chat_info` previously returned a placeholder (`{"name": chat_id, ...}`) for every chat, per the `TODO (T06)` comment.
- Groups now resolve the real name and member count via the existing WS `QueryGroupInfo` call (`GroupQueryService.query_group_info_raw`), already used elsewhere in the adapter.
- DMs resolve the sender's nickname from the member-list cache (`_member_cache`, populated by prior group member queries) when available. Yuanbao has no standalone C2C user-info API, so this is a best-effort lookup; falls back to the raw `chat_id` when nothing is cached or the live query fails.

## Test plan
- [x] Added `TestGetChatInfo` in `tests/test_yuanbao_integration.py` covering: group resolved via live query, group falls back on query failure, DM resolved from member cache, DM falls back when uncached.
- [x] `uv run --extra dev pytest tests/test_yuanbao_integration.py tests/test_yuanbao_pipeline.py tests/test_yuanbao_proto.py -q` → 194 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177yMzoPztzWSv8QgtAKRy7