### PR TITLE
fix(cron): detach manual gateway runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -489,6 +489,107 @@ def _get_sequential_pool() -> concurrent.futures.ThreadPoolExecutor:
     return _sequential_pool
 
 
+def _resolve_max_parallel_workers() -> Optional[int]:
+    """Resolve the shared cron parallelism limit from env/config."""
+    try:
+        env_value = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
+        if env_value:
+            return int(env_value) or None
+    except (ValueError, TypeError):
+        logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to config/unbounded")
+
+    try:
+        config = load_config() or {}
+        configured = (
+            config.get("cron", {}) if isinstance(config, dict) else {}
+        ).get("max_parallel_jobs")
+        if configured is not None:
+            return int(configured) or None
+    except (ValueError, TypeError):
+        logger.warning("Invalid cron.max_parallel_jobs value; defaulting to unbounded")
+    except Exception:
+        pass
+    return None
+
+
+def _submit_with_guard(
+    job: dict,
+    pool: concurrent.futures.ThreadPoolExecutor,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+) -> Optional[concurrent.futures.Future]:
+    """Submit one job while tracking it for deduplication and shutdown drain."""
+    job_id = job["id"]
+    if _interpreter_shutting_down():
+        logger.warning(
+            "Job '%s' not dispatched — interpreter is shutting down",
+            job.get("name", job_id),
+        )
+        return None
+
+    with _running_lock:
+        if job_id in _running_job_ids:
+            logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+            return None
+        _running_job_ids.add(job_id)
+
+    context = contextvars.copy_context()
+
+    def _run_and_release() -> bool:
+        try:
+            return context.run(
+                run_one_job,
+                job,
+                adapters=adapters,
+                loop=loop,
+                verbose=verbose,
+            )
+        finally:
+            with _running_lock:
+                _running_job_ids.discard(job_id)
+
+    try:
+        return pool.submit(_run_and_release)
+    except RuntimeError as submit_error:
+        with _running_lock:
+            _running_job_ids.discard(job_id)
+        if _interpreter_shutting_down(submit_error):
+            logger.warning(
+                "Job '%s' not dispatched — interpreter is shutting down",
+                job.get("name", job_id),
+            )
+            return None
+        raise
+
+
+def submit_claimed_job(
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+) -> Optional[concurrent.futures.Future]:
+    """Dispatch an already-claimed job without blocking the caller.
+
+    Manual gateway runs use the same persistent pools, in-flight tracking, and
+    shutdown-drain visibility as scheduler ticks. The caller remains
+    responsible for claiming/advancing the job before dispatch.
+    """
+    if (job.get("workdir") or "").strip():
+        pool = _get_sequential_pool()
+    else:
+        pool = _get_parallel_pool(_resolve_max_parallel_workers())
+    return _submit_with_guard(
+        job,
+        pool,
+        adapters=adapters,
+        loop=loop,
+        verbose=verbose,
+    )
+
+
 def _shutdown_parallel_pool() -> None:
     """Shut down the persistent pools on process exit."""
     global _parallel_pool, _parallel_pool_max_workers, _sequential_pool
@@ -3609,23 +3710,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
-        _max_workers: Optional[int] = None
-        try:
-            _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
-            if _env_par:
-                _max_workers = int(_env_par) or None
-        except (ValueError, TypeError):
-            logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
-        if _max_workers is None:
-            try:
-                _ucfg = load_config() or {}
-                _cfg_par = (
-                    _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
-                ).get("max_parallel_jobs")
-                if _cfg_par is not None:
-                    _max_workers = int(_cfg_par) or None
-            except Exception:
-                pass
+        _max_workers = _resolve_max_parallel_workers()
 
         if verbose:
             logger.info(
@@ -3633,13 +3718,6 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 len(due_jobs),
                 _max_workers if _max_workers else "unbounded",
             )
-
-        def _process_job(job: dict) -> bool:
-            """Run one due job end-to-end. Thin wrapper around the shared
-            module-level ``run_one_job`` so ``tick`` and external providers
-            (Chronos ``fire_due``) use the identical execute→save→deliver→mark
-            body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
@@ -3653,54 +3731,6 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         _results: list = []
         _all_futures: list = []
 
-        def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor):
-            """Submit a job fire-and-forget with the in-flight dedup guard.
-
-            Returns the future, or None if the job was skipped because a prior
-            tick's run of the same job is still in flight.  The running-set
-            membership is released in the worker's finally block.
-            """
-            job_id = job["id"]
-            # A tick can race gateway teardown: once the interpreter is
-            # finalizing, ``pool.submit`` raises "cannot schedule new futures
-            # after interpreter shutdown" and crashes the tick. Skip cleanly —
-            # the job stays due and will fire on the next healthy tick
-            # (#58720, #55924).
-            if _interpreter_shutting_down():
-                logger.warning(
-                    "Job '%s' not dispatched — interpreter is shutting down",
-                    job.get("name", job_id),
-                )
-                return None
-            with _running_lock:
-                if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
-                    return None
-                _running_job_ids.add(job_id)
-            _ctx = contextvars.copy_context()
-
-            def _run_and_release(j=job, ctx=_ctx):
-                try:
-                    return ctx.run(_process_job, j)
-                finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
-
-            try:
-                return pool.submit(_run_and_release)
-            except RuntimeError as submit_err:
-                # Interpreter began finalizing between the guard above and the
-                # submit — release the in-flight claim we just took and skip.
-                if _interpreter_shutting_down(submit_err):
-                    with _running_lock:
-                        _running_job_ids.discard(job_id)
-                    logger.warning(
-                        "Job '%s' not dispatched — interpreter is shutting down",
-                        job.get("name", job_id),
-                    )
-                    return None
-                raise
-
         # Sequential pass for env-mutating (workdir) jobs.
         # Queued to a persistent single-thread pool so they run one at a time
         # WITHOUT blocking the ticker thread — a long workdir job no
@@ -3710,7 +3740,13 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         if sequential_jobs:
             seq_pool = _get_sequential_pool()
             for job in sequential_jobs:
-                fut = _submit_with_guard(job, seq_pool)
+                fut = _submit_with_guard(
+                    job,
+                    seq_pool,
+                    adapters=adapters,
+                    loop=loop,
+                    verbose=verbose,
+                )
                 if fut is None:
                     continue
                 _all_futures.append(fut)
@@ -3725,7 +3761,13 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         if parallel_jobs:
             pool = _get_parallel_pool(_max_workers)
             for job in parallel_jobs:
-                fut = _submit_with_guard(job, pool)
+                fut = _submit_with_guard(
+                    job,
+                    pool,
+                    adapters=adapters,
+                    loop=loop,
+                    verbose=verbose,
+                )
                 if fut is None:
                     continue
                 _all_futures.append(fut)

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -59,6 +59,33 @@ class TestPersistentPool:
 class TestRunningJobGuard:
     """_running_job_ids prevents double-dispatch of active jobs."""
 
+    def test_submit_claimed_job_returns_before_completion_and_tracks_run(self, monkeypatch):
+        """Manual gateway dispatch uses the persistent pool and running set."""
+        import cron.scheduler as sched
+
+        sched._parallel_pool = None
+        sched._parallel_pool_max_workers = None
+        sched._running_job_ids.clear()
+        job = {"id": "manual-job", "name": "manual", "prompt": "test"}
+        barrier = threading.Barrier(2, timeout=5)
+
+        def slow_run(_job, **_kwargs):
+            barrier.wait()
+            return True
+
+        monkeypatch.setattr(sched, "run_one_job", slow_run)
+
+        future = sched.submit_claimed_job(job)
+
+        assert future is not None
+        assert "manual-job" in sched.get_running_job_ids()
+        assert future.done() is False
+
+        barrier.wait()
+        assert future.result(timeout=5) is True
+        assert "manual-job" not in sched.get_running_job_ids()
+        sched._shutdown_parallel_pool()
+
     def test_running_set_prevents_double_dispatch(self, tmp_path, monkeypatch):
         """A job already in _running_job_ids is skipped on the next tick."""
         import cron.scheduler as sched

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -4,12 +4,14 @@ Before this fix, `cronjob(action='run')` only set next_run_at=now and returned
 success, relying on the scheduler ticker to actually run the job. With no
 gateway/ticker active (e.g. a CLI-only Windows setup) the job never executed and
 last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
-blocking a concurrent tick) and fires it inline via the shared run_one_job body.
+blocking a concurrent tick). CLI callers fire inline; persistent gateway
+sessions dispatch through the scheduler pool so a long run cannot consume the
+chat turn's idle timeout.
 """
 import json
 from unittest.mock import patch
 
-from tools.cronjob_tools import cronjob, _execute_job_now
+from tools.cronjob_tools import cronjob, _execute_job_now, _manual_run_should_detach
 
 
 _JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
@@ -17,6 +19,52 @@ _JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
 
 
 class TestCronjobRunExecutesImmediately:
+    def test_only_persistent_gateway_sessions_detach(self):
+        with patch("gateway.session_context.get_session_env", return_value="telegram"), \
+             patch("gateway.session_context.async_delivery_supported", return_value=True):
+            assert _manual_run_should_detach() is True
+
+        with patch("gateway.session_context.get_session_env", return_value=""), \
+             patch("gateway.session_context.async_delivery_supported", return_value=True):
+            assert _manual_run_should_detach() is False
+
+        with patch("gateway.session_context.get_session_env", return_value="api"), \
+             patch("gateway.session_context.async_delivery_supported", return_value=False):
+            assert _manual_run_should_detach() is False
+
+    def test_gateway_run_dispatches_without_waiting_for_completion(self):
+        """Persistent gateway sessions must not block on a long cron run."""
+        started = {"claimed": True, "started": True, "success": None, "error": None}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools._manual_run_should_detach", return_value=True), \
+             patch("tools.cronjob_tools._execute_job_now", return_value=started) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["success"] is True
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_started"] is True
+        assert out["job"]["execution_pending"] is True
+        assert "execution_success" not in out["job"]
+        m_run.assert_called_once_with(dict(_JOB), wait=False)
+
+    def test_detached_execute_submits_without_running_inline(self):
+        """wait=False must return after scheduler dispatch, before completion."""
+        future = object()
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.submit_claimed_job", return_value=future) as m_submit, \
+             patch("cron.scheduler.run_one_job") as m_inline:
+            result = _execute_job_now(dict(_JOB), wait=False)
+
+        assert result == {
+            "claimed": True,
+            "started": True,
+            "success": None,
+            "error": None,
+        }
+        m_submit.assert_called_once_with(dict(_JOB))
+        m_inline.assert_not_called()
+
     def test_run_action_claims_and_fires_via_run_one_job(self):
         """action='run' must claim the job then fire it through run_one_job."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -601,7 +601,18 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
+def _manual_run_should_detach() -> bool:
+    """True for persistent gateway sessions that can receive async delivery."""
+    try:
+        from gateway.session_context import async_delivery_supported, get_session_env
+
+        platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip()
+        return bool(platform and async_delivery_supported())
+    except Exception:
+        return False
+
+
+def _execute_job_now(job: Dict[str, Any], *, wait: bool = True) -> Dict[str, Any]:
     """Execute a cron job immediately, outside the scheduler tick.
 
     Atomically claims the job first via ``claim_job_for_fire`` — the same
@@ -615,11 +626,16 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
     identical across paths and can't drift.
 
-    Returns {"claimed": bool, "success": bool, "error": str|None}.
+    When ``wait`` is false, dispatches through the scheduler's persistent pool
+    and returns as soon as the job has started. CLI/standalone callers keep the
+    historical synchronous behavior by using the default ``wait=True``.
+
+    Returns {"claimed": bool, "started": bool, "success": bool|None,
+    "error": str|None}.
     """
     job_id = job["id"]
     try:
-        from cron.scheduler import run_one_job
+        from cron.scheduler import run_one_job, submit_claimed_job
 
         # At-most-once claim: bail without running if a tick/other fire owns it.
         if not claim_job_for_fire(job_id):
@@ -634,7 +650,15 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
                 reason = "Job is paused/disabled; resume it before running."
             else:
                 reason = "Job is already being fired by the scheduler; not run again."
-            return {"claimed": False, "success": False, "error": reason}
+            return {"claimed": False, "started": False, "success": False, "error": reason}
+
+        if not wait:
+            future = submit_claimed_job(job)
+            if future is None:
+                error = "Cron scheduler could not start the claimed job."
+                mark_job_run(job_id, False, error)
+                return {"claimed": True, "started": False, "success": False, "error": error}
+            return {"claimed": True, "started": True, "success": None, "error": None}
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
@@ -643,6 +667,7 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
         ok = refreshed.get("last_status") == "ok"
         return {
             "claimed": True,
+            "started": True,
             "success": bool(processed and ok),
             "error": refreshed.get("last_error"),
         }
@@ -653,7 +678,7 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
             mark_job_run(job_id, False, str(e))
         except Exception:
             pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        return {"claimed": True, "started": True, "success": False, "error": str(e)}
 
 
 def cronjob(
@@ -841,11 +866,16 @@ def cronjob(
             # no gateway/ticker is active (the #41037 case). The claim inside
             # _execute_job_now advances next_run_at and blocks a concurrent tick
             # from double-firing.
-            exec_result = _execute_job_now(job)
+            detached = _manual_run_should_detach()
+            exec_result = _execute_job_now(job, wait=not detached)
             # Re-read so the response reflects the post-run last_run_at/last_status.
             result = _format_job(get_job(job_id) or {"id": job_id})
             result["executed"] = exec_result.get("claimed", False)
-            result["execution_success"] = exec_result.get("success", False)
+            result["execution_started"] = exec_result.get("started", False)
+            if exec_result.get("success") is None:
+                result["execution_pending"] = True
+            else:
+                result["execution_success"] = exec_result.get("success", False)
             if not exec_result.get("claimed", False):
                 result["execution_skipped"] = exec_result.get("error") or (
                     "Already being fired by the scheduler; not run again."


### PR DESCRIPTION
## Summary

Manual cron runs triggered from Telegram and other persistent gateway sessions now return immediately instead of holding the chat turn open until the job finishes. Long-running jobs can outlive the gateway's 300-second outer idle timeout without producing a false failure, while CLI and stateless API callers retain synchronous behavior.

Detached runs reuse the scheduler's persistent pools and in-flight guard, preserving at-most-once dispatch, duplicate prevention, and shutdown visibility.

## Validation

- 43 focused cron dispatch, shutdown, and immediate-run tests passed.
- Full-project Ruff check passed.
- Broader cron suite reached 759 passes; its 3 Photon home-channel failures reproduce unchanged against the base commit and are unrelated to this change.
- Restarted the live gateway and verified Telegram polling connected, the API health endpoint returned OK, and the response watchdog reported no pending or slow turns.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
