### PR TITLE
fix(daemon_pool): support Python 3.14 ThreadPoolExecutor WorkerContext signature

### DIFF
--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -5,6 +5,11 @@ batches, wedged memory-provider syncs) can never block interpreter exit:
 stdlib ThreadPoolExecutor workers are non-daemon AND registered in
 concurrent.futures.thread._threads_queues, whose atexit hook joins every
 worker unconditionally — even after shutdown(wait=False).
+
+Additional Python 3.14+ coverage: the stdlib ``ThreadPoolExecutor`` changed
+its internal ``_worker`` signature and dropped ``self._initializer`` /
+``self._initargs`` in favor of a WorkerContext (issue #63769). The daemon
+pool must keep working on both layouts.
 """
 
 import subprocess
@@ -14,7 +19,7 @@ import time
 
 from concurrent.futures.thread import _threads_queues
 
-from tools.daemon_pool import DaemonThreadPoolExecutor
+from tools.daemon_pool import DaemonThreadPoolExecutor, _PY314_PLUS
 
 
 def test_workers_are_daemon_threads():
@@ -81,6 +86,79 @@ def test_wedged_worker_does_not_block_interpreter_exit():
     )
     assert proc.returncode == 0
     assert "main-done" in proc.stdout
+
+
+def test_python_314_worker_context_signature_does_not_crash():
+    """Regression test for issue #63769.
+
+    On Python 3.14+, stdlib ``ThreadPoolExecutor`` drops ``self._initializer``
+    / ``self._initargs`` and switches ``_worker`` to a ``(ref, ctx, q)``
+    signature with a ``WorkerContext``. The daemon pool must:
+
+      1. submit without raising ``AttributeError: ... _initializer``.
+      2. still produce daemon workers that are not registered with
+         ``concurrent.futures.thread._threads_queues``.
+      3. still honor ``initializer`` / ``initargs`` semantics via the new
+         WorkerContext path.
+    """
+    if not _supports_worker_context():
+        # On 3.11–3.13 the legacy path is exercised by the other tests; this
+        # assertion is a 3.14+ guard, so skip rather than duplicate work.
+        import pytest
+
+        pytest.skip("WorkerContext path only exists on Python 3.14+")
+
+    init_seen = []
+
+    def _init(tag):
+        init_seen.append(tag)
+
+    pool = DaemonThreadPoolExecutor(max_workers=1, initializer=_init, initargs=("ctx",))
+    try:
+        # Submit must not raise AttributeError: '_initializer'
+        result = pool.submit(lambda: 21 * 2).result(timeout=10)
+        assert result == 42
+        # Initializer ran exactly once per worker spawn.
+        assert init_seen == ["ctx"]
+
+        # Worker is still daemon and unregistered with the atexit join hook.
+        worker_id = pool.submit(threading.get_ident).result(timeout=10)
+        worker = next(
+            (t for t in pool._threads if t.ident == worker_id),
+            None,
+        )
+        assert worker is not None
+        assert worker.daemon is True
+        assert worker not in _threads_queues
+    finally:
+        pool.shutdown(wait=True)
+
+
+def test_python_314_submit_many_tasks_exercises_reused_workers():
+    """Submit several sequential tasks on a single-worker pool.
+
+    On 3.14+ this exercises both _adjust_thread_count branches: the first
+    submit spawns the worker, subsequent submits reuse it via the idle
+    semaphore. This guards against any silent ctx/state mismatch where a
+    second task would fail to run because the worker context was tied to
+    the first submit only.
+    """
+    pool = DaemonThreadPoolExecutor(max_workers=1)
+    try:
+        results = [pool.submit(lambda i=i: i * i).result(timeout=10) for i in range(5)]
+        assert results == [0, 1, 4, 9, 16]
+    finally:
+        pool.shutdown(wait=True)
+
+
+def _supports_worker_context() -> bool:
+    """True if the active Python ships the 3.14+ ThreadPoolExecutor layout.
+
+    Reuses ``tools.daemon_pool._PY314_PLUS`` so the test gate and the
+    dispatch logic stay in lockstep — a future Python release that changes
+    ``_worker``'s signature again only needs to be updated in one place.
+    """
+    return _PY314_PLUS
 
 
 def _repo_root():

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -22,24 +22,61 @@ concurrent tool execution, background memory sync, catalog fan-out,
 subagent timeout wrappers.  Do NOT use it for work that must complete
 before exit (durable writes) — those belong on foreground threads with
 explicit bounded joins.
+
+Python 3.14+ note
+-----------------
+CPython 3.14 changed ``ThreadPoolExecutor`` internals: ``_worker`` now
+takes ``(executor_ref, ctx, work_queue)`` where ``ctx`` is a
+``WorkerContext`` produced by ``self._create_worker_context()``, replacing
+the old ``_worker(executor_ref, work_queue, initializer, initargs)``
+signature and the ``self._initializer`` / ``self._initargs`` attributes
+(they no longer exist on 3.14).  This module detects which layout the
+active interpreter exposes and dispatches accordingly; the 3.8–3.13 path
+is unchanged.
 """
 
 from __future__ import annotations
 
+import sys
 import threading
 import weakref
+import inspect as _inspect
+
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures.thread import _worker
 
 __all__ = ["DaemonThreadPoolExecutor"]
 
 
+# Python 3.14 refactored ThreadPoolExecutor: the per-executor initializer
+# state moved from `self._initializer` / `self._initargs` into a WorkerContext
+# produced by `self._create_worker_context()` (an instance attribute assigned
+# in `__init__`), and the `_worker` target now takes `(ref, ctx, work_queue)`
+# instead of the legacy `(ref, work_queue, initializer, initargs)`.
+#
+# Detect which layout the active interpreter exposes by inspecting `_worker`'s
+# signature once at import time.  The check is robust against:
+#   - instance-vs-class attribute pitfalls (3.11 sets `_initializer` only on
+#     instances, so `hasattr(ThreadPoolExecutor, "_initializer")` is False);
+#   - patched distributions that backport `_create_worker_context` without
+#     switching the `_worker` signature;
+#   - any future micro release that re-adds legacy attributes for compat.
+# The `_worker` signature is the load-bearing contract.
+try:
+    _WORKER_PARAM_COUNT = len(_inspect.signature(_worker).parameters)
+except (TypeError, ValueError):  # extremely defensive: built-in unavailable
+    _WORKER_PARAM_COUNT = 4  # legacy 3.8–3.13 layout
+_PY314_PLUS = _WORKER_PARAM_COUNT == 3
+
+
 class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
-        # daemon=True and no _threads_queues registration.
+        # Mirrors CPython's implementation with two changes:
+        # daemon=True and no _threads_queues registration. Two code paths
+        # cover Python 3.8–3.13 (legacy `_worker(ref, q, init, initargs)`)
+        # and Python 3.14+ (`_worker(ref, ctx, q)` with WorkerContext).
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -47,8 +84,27 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
             q.put(None)
 
         num_threads = len(self._threads)
-        if num_threads < self._max_workers:
-            thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+        if num_threads >= self._max_workers:
+            return
+
+        thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+
+        if _PY314_PLUS:
+            # 3.14+: WorkerContext encapsulates initializer/initargs. The
+            # ``weakref.ref`` callback wakes a parked worker; the ctx carries
+            # per-executor init state. Worker is daemon so it won't block exit.
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=(
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                ),
+                daemon=True,
+            )
+        else:
+            # 3.8–3.13: initializer/initargs live on the executor instance.
             t = threading.Thread(
                 name=thread_name,
                 target=_worker,
@@ -60,5 +116,6 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
                 ),
                 daemon=True,
             )
-            t.start()
-            self._threads.add(t)
+
+        t.start()
+        self._threads.add(t)


### PR DESCRIPTION
## Problem

Python 3.14 refactored `concurrent.futures.ThreadPoolExecutor`: the `_worker` target now takes `(executor_ref, ctx, work_queue)` where `ctx` is a `WorkerContext` produced by `self._create_worker_context()`, replacing the legacy `(executor_ref, work_queue, initializer, initargs)` signature. `__init__` also no longer sets `self._initializer` / `self._initargs`.

`DaemonThreadPoolExecutor._adjust_thread_count` still passed the legacy 4-arg shape, so on Python 3.14 every spawn raised:

```
AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

This breaks every daemon-pool consumer on 3.14+:
- `tools/delegate_tool.py` (subagent batch execution + timeout wrappers)
- `tools/async_delegation.py` (background delegate_task dispatch)
- `tools/skills_hub.py` (catalog fan-out)

When the daemon pool cannot spawn, `delegate_task`'s batch path collapses to a synchronous inline run, destroying parallelism and silently wedging subagent fan-out.

Fixes #63769.

## Fix

Detect the new layout once at import time by inspecting `_worker`'s signature (param count **3** = 3.14+, **4** = 3.8–3.13). The `_worker` signature is the load-bearing contract: stable across patch releases and immune to the instance-vs-class attribute pitfall that breaks `hasattr(ThreadPoolExecutor, '_initializer')` (3.11 only sets it on instances, so the class check is `False` on every version).

The 3.14+ branch passes `self._create_worker_context()` as `ctx`; the 3.8–3.13 branch is unchanged. Daemon behavior (`daemon=True`, no `_threads_queues` registration) is preserved on both paths.

## Testing

`tests/tools/test_daemon_pool.py`:
- Existing 4 tests still pass on 3.8–3.13 (unchanged behavior)
- **New**: `test_python_314_worker_context_signature_does_not_crash` — guards the regression: submit must not raise `AttributeError`, worker must be daemon, must not be in `_threads_queues`, initializer must run via WorkerContext. Skips on 3.11–3.13.
- **New**: `test_python_314_submit_many_tasks_exercises_reused_workers` — guards against worker-context-tied-to-first-submit regression on the idle-semaphore reuse path. Runs on all versions.

### Verified on both runtimes

| Python | daemon_pool tests | delegate + async_delegation tests |
|--------|------------------|----------------------------------|
| 3.11.15 | 5 passed, 1 skipped | 27 passed (no regressions) |
| 3.14.4  | **6 passed** (regression test now executes) | — |

## Notes

- The detector uses `_worker`'s function signatur e via `inspect.signature`, not class-level attribute probes — this is the only reliable cross-version check.
- `_PY314_PLUS` is a module-level constant computed once at import time, so the hot path (`_adjust_thread_count`) stays branch-lite.
- Test helper `_supports_worker_context()` re-uses `_PY314_PLUS` so the gate and dispatch logic stay in lockstep.