### PR TITLE
fix(dockerfile): remove --link flag and use engine-agnostic chmod for Podman compat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,13 +193,12 @@ RUN cd web && npm run build && \
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.
-# --link decouples this layer from parents for cache purposes; --chmod bakes
-# the final read-only permissions at copy time so we skip the separate
-# `chmod -R` pass that previously walked ~30k files across the venv +
-# node_modules + source (21s amd64 / 222s arm64 — #49113).  `a+rX,go-w`
-# gives the non-root hermes user read + traverse but no write; root retains
-# write so the build steps below don't need chmod u+w dances.
-COPY --link --chmod=a+rX,go-w . .
+# `--link` is Docker BuildKit-only (breaks Podman/Buildah, #62849), and the
+# `a+rX,go-w` --chmod syntax is not supported by Buildah's parser either.
+# Fall back to a simple COPY + RUN chmod — slightly slower per build but
+# engine-agnostic.  The 30k-file chmod walk is ~21s amd64 / ~222s arm64.
+COPY . .
+RUN chmod -R a+rX,go-w .
 
 # ---------- Permissions ----------
 # Link hermes-agent itself (editable). Deps are already installed in the


### PR DESCRIPTION
## Description

The `COPY --link --chmod=a+rX,go-w . .` flags are Docker BuildKit-specific and break Podman/Buildah:
- `--link` is unsupported by Buildah
- `a+rX,go-w` chmod syntax causes `Error parsing chmod` on Buildah

Replace with a plain `COPY . .` + `RUN chmod -R a+rX,go-w .` that works on both engines.

Fixes #62849