### PR TITLE
docs(memory): list Nexusyn standalone memory provider plugin

### DIFF
--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -613,6 +613,31 @@ Base URL precedence is `supermemory.json` → `SUPERMEMORY_BASE_URL` → `https:
 
 **Support:** [Discord](https://supermemory.link/discord) · [support@supermemory.com](mailto:support@supermemory.com)
 
+### Nexusyn
+
+Multi-agent memory engine with hybrid retrieval (vector + full-text + reranking), per-agent attribution, and project scoping. A server-side compile pipeline automatically distills raw memories into wiki articles, lessons, decisions and error reports — visible in the Nexusyn dashboard. Built for teams running several agents (Hermes, IDEs, CLIs) against one shared memory.
+
+| | |
+|---|---|
+| **Best for** | Multi-agent teams sharing one memory with per-agent attribution and project scoping |
+| **Requires** | `pip install hermes-nexusyn` + `hermes-nexusyn install` + [API token](https://app.nexusyn.ai) (cloud) or a self-hosted Nexusyn engine |
+| **Data storage** | Nexusyn Cloud or self-hosted |
+| **Cost** | Free tier; paid plans by monthly query volume / free (self-hosted) |
+
+**Tools (4):** `nexusyn_search` (hybrid search), `nexusyn_query` (grounded answer with sources), `nexusyn_remember` (persist a fact), `nexusyn_forget` (delete by id)
+
+**Architecture:** Prefetch runs a hybrid search on the user message in the background and injects a `[Nexusyn Memory]` block on the next turn. Turn persistence is configurable: `session` (default — one digest ingested at session end/compression), `turn` (every turn), or `off`. Built-in memory writes are mirrored. Ingested content is distilled server-side, so the plugin needs no client-side extraction. Recall with a project set returns that project's memories plus globals.
+
+**Setup:**
+```bash
+pip install hermes-nexusyn
+hermes-nexusyn install     # copies the plugin into $HERMES_HOME/plugins/nexusyn/
+hermes config set memory.provider nexusyn
+hermes memory setup        # or: echo "NEXUSYN_API_KEY=your-token" >> ~/.hermes/.env
+```
+
+**Config reference:** [nexusyn/hermes-nexusyn](https://github.com/nexusyn/hermes-nexusyn) (standalone plugin repo)
+
 ### Memori
 
 Structured long-term memory using Memori Cloud, with background completed-turn capture, tool-aware turn context, and explicit recall tools for facts, summaries, quota, signup, and feedback.
@@ -648,6 +673,7 @@ hermes memory setup
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud/Self-hosted | Free/Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
+| **Nexusyn** | Cloud/Self-hosted | Free/Paid | 4 | `hermes-nexusyn` | Per-agent attribution + project scoping + server-side distillation |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
 
 ## Profile Isolation

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -633,7 +633,7 @@ Multi-agent memory engine with hybrid retrieval (vector + full-text + reranking)
 pip install hermes-nexusyn
 hermes-nexusyn install     # copies the plugin into $HERMES_HOME/plugins/nexusyn/
 hermes config set memory.provider nexusyn
-hermes memory setup        # or: echo "NEXUSYN_API_KEY=your-token" >> ~/.hermes/.env
+hermes memory setup
 ```
 
 **Config reference:** [nexusyn/hermes-nexusyn](https://github.com/nexusyn/hermes-nexusyn) (standalone plugin repo)


### PR DESCRIPTION
## What does this PR do?

Documents **[Nexusyn](https://nexusyn.ai)** on the memory-providers page, following the **Memori precedent** for out-of-tree providers.

Per [CONTRIBUTING.md — Memory Providers: Ship as a Standalone Plugin](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md), the provider itself lives in its own repo — [nexusyn/hermes-nexusyn](https://github.com/nexusyn/hermes-nexusyn), installable today with `pip install hermes-nexusyn` + `hermes-nexusyn install` (copies into `$HERMES_HOME/plugins/nexusyn/`, picked up by the existing user-dir discovery).

> ℹ️ Earlier revisions of this PR added the provider in-tree under `plugins/memory/nexusyn/`; that was against the contribution policy (thanks, review bot) and has been removed. The implementation, tests and setup docs moved to the standalone repo. This PR is now **docs-only** — no core code changes.

Nexusyn in one line: multi-tenant memory engine with hybrid retrieval (vector + FTS + reranking), per-agent attribution, project scoping, and server-side distillation of raw memories into wiki/lessons/decisions. The plugin implements the `MemoryProvider` ABC: background prefetch, session-digest or per-turn sync, built-in memory mirroring, 4 tools, read-only in cron/subagent contexts.

## Related Issue

No existing issue — searched open/closed issues and PRs for "nexusyn" (no duplicates).

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/memory-providers.md` — Nexusyn section (Memori-style: pip setup, tools, architecture, standalone repo link) + comparison table row

## How to Test

1. Docs render: the new section follows the exact structure of the existing provider sections.
2. End-to-end (optional): `pip install hermes-nexusyn && hermes-nexusyn install && hermes config set memory.provider nexusyn` with a free-tier token from app.nexusyn.ai — all four tools were validated against the production API.

## Checklist

- [x] I've read the Contributing Guide (including the standalone-plugin policy for memory providers)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (single docs file)
- [x] `pytest tests/ -q` — N/A, docs-only change (no code touched)
- [x] Tests — live in the standalone plugin repo
- [x] Tested on my platform: macOS 15 (Darwin 25.5.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)