### PR TITLE
docs(tui): correct status-tail priority comment

### DIFF
--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -511,10 +511,10 @@ export function StatusRule({
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel, essentialWidth)
 
   // Whole-segment progressive disclosure for the tail: a segment renders only
-  // if it fits in the space left after the pinned essentials, evaluated in
-  // descending priority order — bar, duration, compressions, voice, session
-  // count, bg, cost. Lower-priority segments drop first and nothing truncates
-  // mid-segment, so status/model/context are never crushed.
+  // if it fits after the pinned essentials. Priority is activity bar, session/
+  // idle timers, compression, voice, session/background/subagent activity,
+  // parked-work resume guidance, then the dev-credit readout. Lower-priority
+  // segments drop first without mid-segment truncation.
   const SEP = stringWidth(' │ ')
   let tailBudget = Math.max(0, leftWidth - essentialWidth)
 


### PR DESCRIPTION
## What does this PR do?

Corrects the stale progressive-disclosure priority comment in `ui-tui/src/components/appChrome.tsx` so it matches the segments' actual evaluation order.

Runtime behavior is unchanged. After rebasing, the branch contains only this inline documentation correction; earlier test-formatting and bundle-guard changes are already present on `main`.

## Related Issue

Follow-up to #52717.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/appChrome.tsx`
  - Update the status-tail priority comment to match the activity bar, duration, compression, voice, session count, background/subagent activity, parked-work resume guidance, and dev-credit segments in their current evaluation order.

## How to Test

1. From `ui-tui/`, run `npm run typecheck`.
2. Confirm the branch changes only the inline priority comment.
3. Confirm no rendered behavior changes.

Final verification after rebasing onto current `main`:

```text
npm run typecheck
passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this documentation correction
- [x] Python suite — N/A; this is a TypeScript comment-only change
- [x] Tests — N/A; runtime behavior is unchanged; TUI typecheck passes
- [x] I've tested on my platform: Fedora Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline status-tail documentation only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — comment-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
npm run typecheck
> tsc --noEmit -p tsconfig.json
```
