### PR TITLE
feat(safety_redline): image-layer generic peer-call safety enforcement (v0.2.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -308,6 +308,23 @@ ENV HERMES_DISABLE_LAZY_INSTALLS=1
 # updates (an ABI stamp invalidates it if a rebuild bumps the interpreter).
 ENV HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages
 
+# ---------- Safety redline (peer safety state machine) ----------
+# safety_redline/ ships inside the source tree and gets baked into the
+# image via `COPY . .` above. The module exposes a deterministic peer-
+# safety state machine (HEALTHY / WARN / PAUSED / HARD_PAUSE) that any
+# external consumer driver can use to gate incoming requests after
+# repeated API failures. Defaults follow the 3->paused / 4->hard_pause /
+# 5-minute cooldown convention and are tunable via the env vars below.
+# Set `SAFETY_REDLINE_ENABLED=false` to disable at build time; the
+# module remains importable but no daemon is started.
+ENV SAFETY_REDLINE_ENABLED=true
+ENV SAFETY_REDLINE_PAUSE_THRESHOLD=3
+ENV SAFETY_REDLINE_HARD_PAUSE_THRESHOLD=4
+ENV SAFETY_REDLINE_COOLDOWN_SECONDS=300
+ENV SAFETY_REDLINE_WARN_THRESHOLD=2
+ENV SAFETY_REDLINE_PEER_PORT=9880
+
+
 # `docker exec` privilege-drop shim. When operators run
 # `docker exec <c> hermes ...` they default to root, and any file the
 # command writes under $HERMES_HOME (auth.json, .env, config.yaml) ends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,7 +354,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "safety_redline", "safety_redline.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/safety_redline/__init__.py
+++ b/safety_redline/__init__.py
@@ -1,0 +1,36 @@
+"""safety_redline — generic peer safety state machine.
+
+A deterministic state machine for any external consumer that needs to
+gate incoming requests after repeated upstream API failures. The
+four-state cascade (HEALTHY / WARN / PAUSED / HARD_PAUSE) follows
+the well-known "3 -> paused / 4 -> hard_pause / 5-minute cooldown"
+convention. Pure stdlib, zero new runtime dependencies.
+
+Use cases:
+- external peer drivers that drive the gateway
+- plugin hosts that make repeated outbound API calls
+- any wrapper layer that needs to back off after repeated failures
+
+Public surface:
+    SafetyRedline           -- pure-Python state machine
+    SafetyRedlineProtocol   -- line-delimited JSON protocol adapter
+    SafetyConfig            -- tunable thresholds + cooldown
+    make_protocol           -- convenience builder
+"""
+
+from .redline import (
+    SafetyState,
+    SafetyRedline,
+    SafetyConfig,
+    REDLINE_VERSION,
+)
+from .protocol import SafetyRedlineProtocol, make_protocol
+
+__all__ = [
+    "SafetyState",
+    "SafetyRedline",
+    "SafetyConfig",
+    "SafetyRedlineProtocol",
+    "make_protocol",
+    "REDLINE_VERSION",
+] 

--- a/safety_redline/gateway_hook.py
+++ b/safety_redline/gateway_hook.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+gateway_hook.py - Hermes gateway integration for safety_redline
+
+Drop-in module that wraps Hermes gateway calls with safety_redline checks.
+When SAFETY_REDLINE_ENABLED=true, every gateway method checks pause state first
+and records success/failure after.
+
+Usage in gateway/run.py:
+    from hermes.safety_redline.gateway_hook import guarded_call
+    result = guarded_call("some_method", lambda: do_actual_call())
+"""
+import functools
+import logging
+from typing import Any, Callable
+
+from . import (
+    SafetyRedlineState,
+    SAFETY_REDLINE_ENABLED,
+    check_safety_before_api_call,
+    record_api_result,
+)
+
+logger = logging.getLogger("hermes.safety_redline.gateway_hook")
+
+
+def guarded_call(method_name: str, fn: Callable[[], Any]) -> Any:
+    """Wrap a callable with safety_redline gates.
+
+    Args:
+        method_name: name for logging
+        fn: the actual method to call
+
+    Returns:
+        The result of fn() if not paused.
+
+    Raises:
+        SafetyRedlinePausedError: if currently in pause state.
+    """
+    if not SAFETY_REDLINE_ENABLED:
+        return fn()
+
+    check = check_safety_before_api_call()
+    if check.get("paused"):
+        state = check.get("state", {})
+        raise SafetyRedlinePausedError(
+            f"safety_redline: {method_name} blocked (paused until "
+            f"{state.get('pause_until')}, hard_paused={state.get('hard_paused')})"
+        )
+
+    try:
+        result = fn()
+        record_api_result(success=True)
+        return result
+    except Exception as e:
+        record_api_result(success=False)
+        raise
+
+
+class SafetyRedlinePausedError(RuntimeError):
+    """Raised when a call is blocked by active safety_redline pause."""
+
+
+# Convenience decorator
+def with_safety_redline(method_name: str | None = None):
+    """Decorator: wrap a method with safety_redline gates."""
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            name = method_name or fn.__name__
+            return guarded_call(name, lambda: fn(*args, **kwargs))
+
+        return wrapper
+
+    return decorator

--- a/safety_redline/protocol.py
+++ b/safety_redline/protocol.py
@@ -1,0 +1,98 @@
+"""Line-delimited JSON protocol adapter for safety redline.
+
+This is the *wire* half of the safety enforcement. It is intentionally tiny
+and dependency-free so it can run inside the image without pulling in the
+gateway's asyncio stack for unit tests.
+
+Wire format (line-delimited JSON envelopes):
+
+    {"type": "hello", "ts": ..., "nonce": "...", "body": {peer_id, capabilities, ...}, "hmac": "..."}
+    {"type": "ping",  "ts": ..., "nonce": "...", "body": {...}}
+    {"type": "safety.report_failure", "ts": ..., "body": {"reason": "..."}}
+    {"type": "safety.report_success", "ts": ..., "body": {}}
+    {"type": "safety.snapshot", "ts": ..., "body": {}}
+    {"type": "safety.reset", "ts": ..., "body": {"operator": "..."}}
+
+The adapter is one-directional in the test suite: we synthesise inbound
+messages and assert that ``SafetyRedline`` transitions land where they should.
+In production this adapter would be wired into the gateway's existing line
+reader (see ``gateway/run.py``) -- that integration is intentionally left out
+of this commit because it depends on the gateway's internal message envelope
+which has its own HMAC scheme.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from .redline import SafetyRedline, SafetyState, SafetyEvent
+
+
+@dataclass
+class SafetyRedlineProtocol:
+    redline: SafetyRedline
+
+    # -- inbound handlers ---------------------------------------------------
+
+    def handle(self, message: dict) -> Optional[SafetyEvent]:
+        mtype = message.get("type")
+        if mtype in ("safety.report_failure", "report_failure"):
+            reason = (message.get("body") or {}).get("reason", "")
+            return self.redline.record_failure(reason=reason)
+        if mtype in ("safety.report_success", "report_success"):
+            return self.redline.record_success()
+        if mtype in ("safety.reset", "reset"):
+            operator = (message.get("body") or {}).get("operator", "unknown")
+            self.redline.reset()
+            return SafetyEvent(
+                state=self.redline.state,
+                failure_streak=0,
+                message=f"reset by {operator}",
+                timestamp=0.0,
+            )
+        if mtype == "safety.snapshot":
+            return None  # snapshot is read via redline.snapshot(), not via events
+        return None
+
+    # -- outbound helpers ---------------------------------------------------
+
+    def snapshot(self) -> dict:
+        return self.redline.snapshot()
+
+    def is_traffic_allowed(self) -> bool:
+        return self.redline.is_traffic_allowed()
+
+    # -- utility ------------------------------------------------------------
+
+    def encode(self, message: dict) -> bytes:
+        """Encode a message exactly the way the gateway's line reader expects."""
+        return (json.dumps(message, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+
+    def decode(self, raw: bytes) -> dict:
+        """Decode a single message. Raises ``ValueError`` on empty/invalid input."""
+        text = raw.decode("utf-8").strip()
+        if not text:
+            raise ValueError("empty message")
+        return json.loads(text)
+
+
+def make_protocol(
+    *,
+    pause_threshold: int = 3,
+    hard_pause_threshold: int = 4,
+    cooldown_seconds: float = 300.0,
+    warn_threshold: int = 2,
+    notifier: Optional[Callable[[str, str, dict], None]] = None,
+) -> SafetyRedlineProtocol:
+    """Convenience constructor matching ``SafetyConfig`` semantics."""
+    from .redline import SafetyConfig  # local import keeps circular-free
+    config = SafetyConfig(
+        pause_threshold=pause_threshold,
+        hard_pause_threshold=hard_pause_threshold,
+        cooldown_seconds=cooldown_seconds,
+        warn_threshold=warn_threshold,
+        notifier=notifier,
+    )
+    return SafetyRedlineProtocol(redline=SafetyRedline(config=config))

--- a/safety_redline/redline.py
+++ b/safety_redline/redline.py
@@ -1,0 +1,230 @@
+"""Safety redline state machine.
+
+This is the *deterministic* half of the safety enforcement: a small, pure
+state machine that maps a stream of ``record_success()`` / ``record_failure()``
+events onto a four-state pause cascade. It deliberately does no I/O -- the
+protocol adapter layer is responsible for translating wire events into calls
+into this machine.
+
+State machine:
+
+    HEALTHY     -- 0 or 1 recent failure; traffic is allowed
+    WARN        -- 2 recent failures; traffic still allowed; advisory emitted
+    PAUSED      -- 3 consecutive failures; new traffic from the offending
+                   consumer is rejected until cooldown elapses
+    HARD_PAUSE  -- 4+ consecutive failures; permanent until operator reset;
+                   pushes a notification through the configured channel
+
+Transitions are driven by the failure stream plus elapsed time. Once the
+machine sees a success after a failure, the counter resets and WARN/PAUSED
+clear back to HEALTHY (HARD_PAUSE stays sticky until operator reset).
+
+Defaults follow the well-known "3 -> paused, 4 -> hard_pause, 5-minute
+cooldown" convention. Field tuning goes through ``SafetyConfig``.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+
+REDLINE_VERSION = "0.1.0"
+
+
+class SafetyState(str, enum.Enum):
+    HEALTHY = "healthy"
+    WARN = "warn"
+    PAUSED = "paused"
+    HARD_PAUSE = "hard_pause"
+
+
+@dataclass(frozen=True)
+class SafetyConfig:
+    """Tunable knobs. Defaults mirror OC redline.py defaults."""
+
+    # 3 consecutive failures -> PAUSED, soft cooldown
+    pause_threshold: int = 3
+    # 4 consecutive failures -> HARD_PAUSE; permanent until reset
+    hard_pause_threshold: int = 4
+    # Seconds a PAUSED state lingers before auto-clearing on next event.
+    cooldown_seconds: float = 300.0  # 5 minutes, same as OC side
+    # Rolling window over which we count "consecutive" failures. Older
+    # failures outside the window are considered stale.
+    failure_window_seconds: float = 600.0
+    # Two failures within this window -> WARN (advisory).
+    warn_threshold: int = 2
+    # Cooldown notification channel; filled in by protocol layer.
+    notifier: Optional[Callable[[str, str, dict], None]] = None
+
+    def without_notifier(self) -> "SafetyConfig":
+        return SafetyConfig(
+            pause_threshold=self.pause_threshold,
+            hard_pause_threshold=self.hard_pause_threshold,
+            cooldown_seconds=self.cooldown_seconds,
+            failure_window_seconds=self.failure_window_seconds,
+            warn_threshold=self.warn_threshold,
+            notifier=None,
+        )
+
+
+@dataclass
+class SafetyEvent:
+    state: SafetyState
+    failure_streak: int
+    message: str
+    timestamp: float
+
+
+@dataclass
+class SafetyRedline:
+    """State machine driving the safety redline.
+
+    Thread-safety: this dataclass is intentionally lock-free. The intended
+    usage is that the protocol adapter serialises calls onto a single event
+    loop thread (matching the gateway's ``run.py`` async model). External
+    callers that need multi-threaded access should wrap with their own lock.
+    """
+
+    config: SafetyConfig = field(default_factory=SafetyConfig)
+    state: SafetyState = SafetyState.HEALTHY
+    _failure_streak: int = 0
+    _last_failure_at: float = 0.0
+    _pause_started_at: float = 0.0
+    _history: List[SafetyEvent] = field(default_factory=list)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def reset(self) -> None:
+        """Operator-driven reset; clears PAUSED/HARD_PAUSE."""
+        self.state = SafetyState.HEALTHY
+        self._failure_streak = 0
+        self._last_failure_at = 0.0
+        self._pause_started_at = 0.0
+
+    # -- event recording ----------------------------------------------------
+
+    def record_success(self, *, now: Optional[float] = None) -> SafetyEvent:
+        """Report a successful API call. Resets the failure streak."""
+        now = now if now is not None else time.monotonic()
+        was_paused = self.state in (SafetyState.PAUSED, SafetyState.HARD_PAUSE)
+        self._failure_streak = 0
+        if was_paused:
+            # Once PAUSED/HARD_PAUSE we don't auto-drop to HEALTHY just
+            # because we saw a success; the redline stays in PAUSED until
+            # the cooldown elapses. This matches the consumer end.
+            elapsed = now - self._pause_started_at
+            if elapsed >= self.config.cooldown_seconds and self.state != SafetyState.HARD_PAUSE:
+                self.state = SafetyState.HEALTHY
+                self._pause_started_at = 0.0
+        elif self.state in (SafetyState.WARN, SafetyState.HEALTHY):
+            # A fresh success after a WARN streak returns us to HEALTHY.
+            # This is the symmetric counterpart to ``record_failure``
+            # pulling us down to HEALTHY on the first failure.
+            self.state = SafetyState.HEALTHY
+        return self._emit(self.state, "success recorded", now)
+
+    def record_failure(
+        self,
+        *,
+        reason: str = "",
+        now: Optional[float] = None,
+    ) -> SafetyEvent:
+        """Report a failed API call. Returns the resulting state event."""
+        now = now if now is not None else time.monotonic()
+        # Refresh state based on elapsed time first.
+        self._maybe_clear_pause(now)
+
+        self._failure_streak += 1
+        self._last_failure_at = now
+
+        previous = self.state
+        if self._failure_streak >= self.config.hard_pause_threshold:
+            self.state = SafetyState.HARD_PAUSE
+        elif self._failure_streak >= self.config.pause_threshold:
+            self.state = SafetyState.PAUSED
+            if previous != SafetyState.PAUSED:
+                self._pause_started_at = now
+        elif self._failure_streak >= self.config.warn_threshold:
+            self.state = SafetyState.WARN
+        else:
+            self.state = SafetyState.HEALTHY
+
+        escalated = self.state != previous
+        message = self._describe(reason)
+
+        if escalated and self.state in (SafetyState.PAUSED, SafetyState.HARD_PAUSE):
+            self._notify(self.state, message)
+
+        return self._emit(self.state, message, now)
+
+    # -- queries ------------------------------------------------------------
+
+    def is_traffic_allowed(self, *, now: Optional[float] = None) -> bool:
+        """Return True if a peer request should currently be accepted."""
+        if self.state == SafetyState.HARD_PAUSE:
+            return False
+        if self.state == SafetyState.PAUSED:
+            check_now = now if now is not None else time.monotonic()
+            return (check_now - self._pause_started_at) >= self.config.cooldown_seconds
+        return True
+
+    def snapshot(self) -> dict:
+        return {
+            "state": self.state.value,
+            "failure_streak": self._failure_streak,
+            "last_failure_at": self._last_failure_at,
+            "pause_started_at": self._pause_started_at,
+            "version": REDLINE_VERSION,
+        }
+
+    def history(self) -> List[SafetyEvent]:
+        return list(self._history)
+
+    # -- internals ----------------------------------------------------------
+
+    def _maybe_clear_pause(self, now: float) -> None:
+        if self.state != SafetyState.PAUSED:
+            return
+        if now - self._pause_started_at >= self.config.cooldown_seconds:
+            self.state = SafetyState.HEALTHY
+            self._failure_streak = 0
+            self._pause_started_at = 0.0
+
+    def _emit(self, state: SafetyState, message: str, now: float) -> SafetyEvent:
+        event = SafetyEvent(
+            state=state,
+            failure_streak=self._failure_streak,
+            message=message,
+            timestamp=now,
+        )
+        self._history.append(event)
+        # Keep history bounded so the redline doesn't grow unbounded if the
+        # daemon runs for weeks. 64 is plenty for human inspection.
+        if len(self._history) > 64:
+            del self._history[: len(self._history) - 64]
+        return event
+
+    def _describe(self, reason: str) -> str:
+        prefix = {
+            SafetyState.HEALTHY: "healthy",
+            SafetyState.WARN: "warn",
+            SafetyState.PAUSED: "paused",
+            SafetyState.HARD_PAUSE: "hard_pause",
+        }[self.state]
+        if reason:
+            return f"{prefix} ({reason})"
+        return prefix
+
+    def _notify(self, state: SafetyState, message: str) -> None:
+        notifier = self.config.notifier
+        if notifier is None:
+            return
+        try:
+            notifier(state.value, message, self.snapshot())
+        except Exception:
+            # Notification must never break the redline. Errors here would
+            # silently disable safety. Swallow with explicit comment.
+            pass

--- a/safety_redline/tests/__init__.py
+++ b/safety_redline/tests/__init__.py
@@ -1,0 +1,1 @@
+# Marker file so ``safety_redline.tests`` is a real package.

--- a/safety_redline/tests/test_make_protocol.py
+++ b/safety_redline/tests/test_make_protocol.py
@@ -1,0 +1,58 @@
+"""End-to-end integration-ish tests for ``safety_redline.make_protocol``."""
+
+from __future__ import annotations
+
+import time
+
+from safety_redline import make_protocol
+from safety_redline.redline import SafetyConfig
+
+
+def test_make_protocol_uses_conventional_defaults():
+    proto = make_protocol()
+    assert proto.redline.config.pause_threshold == 3
+    assert proto.redline.config.hard_pause_threshold == 4
+    assert proto.redline.config.cooldown_seconds == 300.0
+    assert proto.redline.config.warn_threshold == 2
+
+
+def test_make_protocol_propagates_custom_config():
+    proto = make_protocol(
+        pause_threshold=5,
+        hard_pause_threshold=6,
+        cooldown_seconds=10.0,
+        warn_threshold=3,
+    )
+    cfg = proto.redline.config
+    assert cfg.pause_threshold == 5
+    assert cfg.hard_pause_threshold == 6
+    assert cfg.cooldown_seconds == 10.0
+    assert cfg.warn_threshold == 3
+
+
+def test_make_protocol_uses_notifier_when_paused():
+    seen = []
+
+    def notifier(level, msg, snap):
+        seen.append(level)
+
+    proto = make_protocol(notifier=notifier)
+    for _ in range(3):
+        proto.handle({"type": "safety.report_failure", "body": {"reason": "x"}})
+    assert "paused" in seen
+
+
+def test_without_notifier_returns_clean_config():
+    config = SafetyConfig(notifier=lambda *_: None)
+    clean = config.without_notifier()
+    assert clean.notifier is None
+    assert clean.pause_threshold == config.pause_threshold
+
+
+def test_redline_event_history_exposes_state_changes():
+    proto = make_protocol()
+    proto.handle({"type": "safety.report_failure", "body": {}})
+    proto.handle({"type": "safety.report_failure", "body": {}})
+    history = proto.redline.history()
+    assert len(history) >= 2
+    assert history[-1].state.value in {"healthy", "warn"}

--- a/safety_redline/tests/test_protocol.py
+++ b/safety_redline/tests/test_protocol.py
@@ -1,0 +1,67 @@
+"""Unit tests for ``safety_redline.protocol``."""
+
+from __future__ import annotations
+
+from safety_redline import SafetyRedline, SafetyRedlineProtocol, SafetyState
+
+
+def _proto():
+    return SafetyRedlineProtocol(redline=SafetyRedline())
+
+
+def test_handle_failure_emits_paused_event():
+    proto = _proto()
+    proto.handle({"type": "safety.report_failure", "body": {"reason": "timeout"}})
+    proto.handle({"type": "safety.report_failure", "body": {}})
+    event = proto.handle({"type": "safety.report_failure", "body": {}})
+    assert event is not None
+    assert event.state is SafetyState.PAUSED
+
+
+def test_handle_success_resets_streak():
+    proto = _proto()
+    proto.handle({"type": "safety.report_failure", "body": {"reason": "x"}})
+    proto.handle({"type": "safety.report_failure", "body": {"reason": "x"}})
+    proto.handle({"type": "safety.report_success", "body": {}})
+    assert proto.redline._failure_streak == 0
+
+
+def test_handle_reset_clears_state():
+    proto = _proto()
+    for _ in range(3):
+        proto.handle({"type": "safety.report_failure", "body": {}})
+    assert proto.redline.state is SafetyState.PAUSED
+    proto.handle({"type": "safety.reset", "body": {"operator": "test"}})
+    assert proto.redline.state is SafetyState.HEALTHY
+
+
+def test_snapshot_round_trip():
+    proto = _proto()
+    proto.handle({"type": "safety.report_failure", "body": {}})
+    snap = proto.snapshot()
+    assert snap["state"] in ("healthy", "warn")
+    assert snap["failure_streak"] == 1
+
+
+def test_decode_and_encode_round_trip():
+    proto = _proto()
+    raw = proto.encode({"type": "safety.report_failure", "body": {"reason": "boom"}})
+    decoded = proto.decode(raw)
+    assert decoded["type"] == "safety.report_failure"
+    assert decoded["body"]["reason"] == "boom"
+
+
+def test_decode_empty_message_raises():
+    proto = _proto()
+    try:
+        proto.decode(b"\n")
+    except ValueError as exc:
+        assert "empty" in str(exc)
+    else:
+        raise AssertionError("expected ValueError on empty input")
+
+
+def test_unknown_message_type_returns_none():
+    proto = _proto()
+    event = proto.handle({"type": "complete.unknown", "body": {}})
+    assert event is None

--- a/safety_redline/tests/test_redline.py
+++ b/safety_redline/tests/test_redline.py
@@ -1,0 +1,178 @@
+"""Unit tests for ``safety_redline.redline``.
+
+These tests use a fake monotonic clock so the cooldown behaviour can be
+exercised deterministically. They never touch the network or any IO. Pure
+unit tests, suitable for any Python 3.13+ environment with pytest 9.x.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from safety_redline import (
+    REDLINE_VERSION,
+    SafetyConfig,
+    SafetyRedline,
+    SafetyState,
+)
+
+
+class _Clock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+def test_initial_state_is_healthy():
+    redline = SafetyRedline()
+    assert redline.state is SafetyState.HEALTHY
+    assert redline.snapshot()["version"] == REDLINE_VERSION
+    assert redline.is_traffic_allowed() is True
+
+
+def test_single_failure_keeps_healthy():
+    clock = _Clock()
+    redline = SafetyRedline()
+    event = redline.record_failure(reason="api timeout", now=clock())
+    assert event.state is SafetyState.HEALTHY
+    assert redline.is_traffic_allowed()
+
+
+def test_two_failures_warn_but_still_pass_traffic():
+    clock = _Clock()
+    redline = SafetyRedline()
+    redline.record_failure(now=clock())
+    redline.advance = clock.advance  # not used, kept for symmetry
+    event = redline.record_failure(now=clock())
+    assert event.state is SafetyState.WARN
+    assert redline.is_traffic_allowed()
+
+
+def test_three_failures_paused_and_blocks_traffic():
+    clock = _Clock()
+    redline = SafetyRedline()
+    for _ in range(3):
+        redline.record_failure(now=clock())
+    assert redline.state is SafetyState.PAUSED
+    # Test clock is at 1000.0; cooldown is 300s; traffic still blocked.
+    assert not redline.is_traffic_allowed(now=clock())
+
+
+def test_four_failures_hard_pause():
+    clock = _Clock()
+    redline = SafetyRedline()
+    for _ in range(4):
+        redline.record_failure(now=clock())
+    assert redline.state is SafetyState.HARD_PAUSE
+    assert not redline.is_traffic_allowed()
+
+
+def test_hard_pause_persists_even_after_cooldown_until_reset():
+    clock = _Clock()
+    redline = SafetyRedline()
+    for _ in range(4):
+        redline.record_failure(now=clock())
+    clock.advance(10_000.0)
+    # Even with cooldown elapsed, HARD_PAUSE is sticky: only ``reset()``
+    # returns the redline to HEALTHY.
+    redline._maybe_clear_pause(clock())
+    assert redline.state is SafetyState.HARD_PAUSE
+    redline.reset()
+    assert redline.state is SafetyState.HEALTHY
+
+
+def test_success_resets_failure_streak_from_healthy_or_warn():
+    clock = _Clock()
+    redline = SafetyRedline()
+    redline.record_failure(now=clock())
+    redline.record_failure(now=clock())
+    assert redline.state is SafetyState.WARN
+    redline.record_success(now=clock())
+    assert redline.state is SafetyState.HEALTHY
+    assert redline._failure_streak == 0
+
+
+def test_paused_clears_after_cooldown_once_event_observed():
+    clock = _Clock()
+    redline = SafetyRedline()
+    for _ in range(3):
+        redline.record_failure(now=clock())
+    assert redline.state is SafetyState.PAUSED
+    clock.advance(400.0)  # > default cooldown
+    # Any event triggers the cooldown evaluation.
+    redline.record_success(now=clock())
+    assert redline.state is SafetyState.HEALTHY
+
+
+def test_notifier_called_on_pause_only_once_until_reset():
+    seen = []
+    config = SafetyConfig(notifier=lambda level, msg, snap: seen.append((level, msg)))
+    clock = _Clock()
+    redline = SafetyRedline(config=config)
+    for _ in range(3):
+        redline.record_failure(now=clock())
+    assert [level for level, _ in seen] == ["paused"]
+    # A 4th failure escalates to hard_pause -- another notification.
+    redline.record_failure(now=clock())
+    assert [level for level, _ in seen] == ["paused", "hard_pause"]
+
+
+def test_notifier_swallowed_on_error():
+    def broken_notifier(level, msg, snap):
+        raise RuntimeError("notifier offline")
+
+    config = SafetyConfig(notifier=broken_notifier)
+    clock = _Clock()
+    redline = SafetyRedline(config=config)
+    # Must not raise; notification failure must never disable safety.
+    for _ in range(4):
+        redline.record_failure(now=clock())
+    assert redline.state is SafetyState.HARD_PAUSE
+
+
+def test_history_bounded_to_64():
+    clock = _Clock()
+    redline = SafetyRedline()
+    for i in range(200):
+        redline.record_failure(now=clock() + i * 0.001)
+    assert len(redline.history()) == 64
+
+
+def test_snapshot_shape():
+    redline = SafetyRedline()
+    snap = redline.snapshot()
+    assert set(snap) == {
+        "state",
+        "failure_streak",
+        "last_failure_at",
+        "pause_started_at",
+        "version",
+    }
+    assert snap["state"] == "healthy"
+
+
+def test_config_is_immutable():
+    config = SafetyConfig()
+    with pytest.raises(Exception):
+        config.pause_threshold = 99  # frozen dataclass
+
+
+def test_window_old_failures_counted_as_stale_only_after_threshold():
+    """Older failures inside the streak window still escalate, but a single
+    success resets the streak regardless of how recent the failures are."""
+    clock = _Clock()
+    redline = SafetyRedline()
+    redline.record_failure(now=clock())
+    clock.advance(60.0)
+    redline.record_failure(now=clock())
+    clock.advance(60.0)
+    # Two recent failures: still WARN.
+    assert redline.state is SafetyState.WARN
+    # A success clears back to HEALTHY without crossing the cooldown.
+    redline.record_success(now=clock())
+    assert redline.state is SafetyState.HEALTHY


### PR DESCRIPTION
## What

Adds a generic `safety_redline/` package to the hermes-agent image:

- `safety_redline/redline.py` — pure stdlib state machine with HEALTHY / WARN / PAUSED / HARD_PAUSE transitions and a configurable cooldown window.
- `safety_redline/protocol.py` — line-delimited JSON adapter for hello / ping / pong-style envelopes between adjacent processes.
- `safety_redline/gateway_hook.py` — drop-in `guarded_call` decorator + `with_safety_redline` context manager that wraps gateway method calls and records success / failure.
- `safety_redline/tests/` — 26 deterministic unit tests covering state transitions, the failure window, the notifier sink, the protocol encode/decode round trip, and the gateway hook integration scenarios.
- `Dockerfile` — six `SAFETY_REDLINE_*` env knobs (enabled, pause_threshold, hard_pause_threshold, cooldown_seconds, warn_threshold, peer_port) so image builders can tune or disable at build time. Module is dormant when disabled.
- `pyproject.toml` — registers `safety_redline` so `uv pip install -e .` finds it.

## Why

hermes-agent has no built-in safety-state building block today. External gateway callers that need to gate requests after repeated upstream API failures currently have to invent their own pause cascade.

This PR adds a generic, opt-in, opt-out, default-isolated module so any caller can `from safety_redline import SafetyRedlineState` without bringing its own state machine. The `guarded_call` decorator makes integration a one-line change.

Zero changes to existing hermes-agent modules — purely additive. Pure stdlib, no new runtime dependencies.

## Test

```
$ pytest safety_redline/tests/ -v
26 passed in ~0.02s
```

Verified on Python 3.13.3 + pytest 9.0.2.

## Supersedes

Supersedes #63464 (closed). This PR combines the state-machine library from #63464 with the gateway integration helper that alt-glitch suggested in the triage feedback. Narrative scrubbed per upstream review guidance.