### PR TITLE
fix(computer_use): pin subprocess text-mode encoding to utf-8

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -164,6 +164,7 @@ def _resolve_mcp_invocation(
         proc = subprocess.run(
             [driver_cmd, "manifest"],
             capture_output=True, text=True, timeout=timeout,
+            encoding="utf-8", errors="replace",
             stdin=subprocess.DEVNULL,
             # cua-driver is a third-party binary — never hand it provider
             # API keys via inherited env (same policy as the MCP and CLI
@@ -255,6 +256,7 @@ def cua_driver_update_check(*, timeout: float = 8.0) -> Optional[Dict[str, Any]]
         proc = subprocess.run(
             [_CUA_DRIVER_CMD, "check-update", "--json"],
             capture_output=True, text=True, timeout=timeout,
+            encoding="utf-8", errors="replace",
             # Some older drivers don't have the verb and fall through to a
             # stdin-reading mode rather than erroring — DEVNULL gives them EOF
             # so they exit fast instead of blocking until the timeout.
@@ -921,6 +923,7 @@ class _CuaDriverSession:
                 try:
                     proc = _subprocess.run(
                         cmd, capture_output=True, text=True, timeout=max(15.0, timeout),
+                        encoding="utf-8", errors="replace",
                         env=_sanitize_subprocess_env(cua_driver_child_env()),
                     )
                 except Exception as e:  # pragma: no cover - subprocess spawn failure

--- a/tools/computer_use/permissions.py
+++ b/tools/computer_use/permissions.py
@@ -72,6 +72,8 @@ def _run(binary: str, *args: str, timeout: float) -> subprocess.CompletedProcess
         [binary, *args],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=timeout,
         env=_child_env(),
         stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Problem

On non-UTF-8 locales (e.g. Chinese Windows where the ANSI codepage is GBK/CP936), `subprocess.run(..., text=True)` without an explicit `encoding=` defaults to the system locale for decoding the child's stdout/stderr. `cua-driver` emits UTF-8 (emoji, Chinese paths, non-ASCII status), so the subprocess module's internal `_readerthread` blows up with a cascade like:

```
Exception in thread Thread-N (_readerthread):
Traceback (most recent call last):
  File ".../threading.py", line 1045, in _bootstrap_inner
    self.run()
  File ".../threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File ".../subprocess.py", line 1599, in _readerthread
    buffer.append(fh.read())
                  ^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 1711: illegal multibyte sequence
```

The main return path still works (partial stdout is captured up to the failure point), but the tracebacks spam stderr on every `computer_use` capture, mask real errors, and unsettle users on zh-CN Windows.

## Fix

Pin `encoding='utf-8', errors='replace'` on every text-mode subprocess call in the `computer_use` tool:

- `tools/computer_use/cua_backend.py`
  - `_resolve_mcp_invocation` (manifest discovery)
  - `cua_driver_update_check` (`check-update --json`)
  - `_CuaDriverSession` CLI fallback spawn
- `tools/computer_use/permissions.py` — the `_run` helper

`tools/computer_use/doctor.py` already had `encoding='utf-8'` on its `Popen`; this PR brings the rest in line.

## Verification

Before: on zh-CN Windows, `computer_use(action='capture', app='screen', mode='vision')` returns a valid result but stderr fills with 3+ `UnicodeDecodeError` tracebacks.

After (same host, same command): the capture returns cleanly, no background thread exceptions.

## Notes

- `errors='replace'` (not `strict`) is deliberate: cua-driver's output is authoritative UTF-8, but on the unlikely chance of a mixed-encoding byte we prefer a replacement char over crashing a reader thread.
- No behaviour change on POSIX / UTF-8 locales — `encoding='utf-8'` matches the default there.