### PR TITLE
fix(gateway): unwrap AsyncSessionDB before sync read in model-switch warning

### DIFF
--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -153,7 +153,13 @@ def enrich_model_switch_warnings_for_gateway(
     custom_providers: list | None = None,
     load_gateway_config: Callable[[], dict] | None = None,
 ) -> None:
-    """Gateway helper: cached agent + session DB messages."""
+    """Gateway helper: cached agent + session DB messages.
+
+    Gateway callers run this helper through ``asyncio.to_thread`` because
+    context-length resolution can block.  Use the synchronous handle while
+    already off-loop; calling the ``AsyncSessionDB`` facade here would only
+    create an un-awaited coroutine.
+    """
     lock = getattr(runner, "_agent_cache_lock", None)
     cache = getattr(runner, "_agent_cache", None)
     agent = None
@@ -187,7 +193,8 @@ def enrich_model_switch_warnings_for_gateway(
     if db is not None and store is not None:
         try:
             entry = store.get_or_create_session(source)
-            messages = db.get_messages_as_conversation(entry.session_id)
+            sync_db = getattr(db, "_db", db)
+            messages = sync_db.get_messages_as_conversation(entry.session_id)
         except Exception:
             pass
 

--- a/tests/hermes_cli/test_context_switch_guard.py
+++ b/tests/hermes_cli/test_context_switch_guard.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from types import SimpleNamespace
 
-from hermes_cli.context_switch_guard import merge_preflight_compression_warning
+from hermes_cli.context_switch_guard import (
+    enrich_model_switch_warnings_for_gateway,
+    merge_preflight_compression_warning,
+)
 from hermes_cli.model_switch import ModelSwitchResult
 
 
@@ -171,3 +176,56 @@ def test_custom_provider_context_avoids_false_shrink_warning(monkeypatch):
     assert "shrinks" in result3.warning_message
     # Must not honor the unused 1M custom override when no providers were passed.
     assert "1,048,576" not in result3.warning_message
+
+
+class _RecordingSessionDB:
+    def __init__(self, messages):
+        self.messages = messages
+        self.read_thread_id = None
+
+    def get_messages_as_conversation(self, session_id):
+        self.read_thread_id = threading.get_ident()
+        return self.messages
+
+
+def test_enrich_uses_sync_db_handle_from_off_loop_worker(monkeypatch):
+    """The gateway offloads this whole helper, so its DB read must stay sync."""
+    from hermes_state import AsyncSessionDB
+
+    captured = {}
+    real_messages = [{"role": "user", "content": "hi"}]
+    sync_db = _RecordingSessionDB(real_messages)
+    runner = SimpleNamespace(
+        _agent_cache_lock=threading.Lock(),
+        _agent_cache={"session-key": (SimpleNamespace(), None)},
+        _session_db=AsyncSessionDB(sync_db),
+        session_store=SimpleNamespace(
+            get_or_create_session=lambda source: SimpleNamespace(session_id="s1"),
+        ),
+    )
+
+    def _capture_merge(result, *, messages=None, **kwargs):
+        captured["messages"] = messages
+
+    monkeypatch.setattr(
+        "hermes_cli.context_switch_guard.merge_preflight_compression_warning",
+        _capture_merge,
+    )
+
+    async def _run_like_gateway():
+        loop_thread_id = threading.get_ident()
+        await asyncio.to_thread(
+            enrich_model_switch_warnings_for_gateway,
+            _result(),
+            runner,
+            session_key="session-key",
+            source=SimpleNamespace(),
+        )
+        return loop_thread_id
+
+    loop_thread_id = asyncio.run(_run_like_gateway())
+    if asyncio.iscoroutine(captured["messages"]):
+        captured["messages"].close()
+
+    assert captured["messages"] == real_messages
+    assert sync_db.read_thread_id != loop_thread_id


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway model-switch preflight warning reading session history through the wrong side of `AsyncSessionDB`.

Current `main` runs `enrich_model_switch_warnings_for_gateway()` through `await asyncio.to_thread(...)` at both gateway call sites because context-length resolution can block. Inside that worker thread, the helper still calls `runner._session_db.get_messages_as_conversation(...)` synchronously. The gateway DB object is an `AsyncSessionDB` facade, so that call returns an un-awaited coroutine instead of messages; the broad exception path then silently drops the warning.

The helper now unwraps the facade to its synchronous `_db` handle. This is safe here specifically because the entire helper is already off the event loop. It also preserves the caller's existing offload for provider/context-length probes rather than moving those synchronous probes back onto the event loop.

## Related Issue

Fixes #70966. Related to #63712.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/context_switch_guard.py`: use the sync DB handle while the helper is already running in the gateway worker thread.
- `tests/hermes_cli/test_context_switch_guard.py`: exercise the real `AsyncSessionDB` facade through the same `asyncio.to_thread` boundary and assert both the real message list and a non-event-loop read thread.

## How to Test

```bash
pytest tests/hermes_cli/test_context_switch_guard.py \
  tests/gateway/test_async_session_db.py \
  tests/gateway/test_model_command_async_offload.py \
  tests/gateway/test_model_command_context_offload.py \
  tests/gateway/test_model_command_custom_providers.py \
  tests/gateway/test_model_command_expensive_confirm.py \
  tests/gateway/test_model_command_flat_string_config.py \
  tests/gateway/test_model_switch_persistence.py \
  tests/gateway/test_48031_model_switch_after_auto_reset.py -q
```

Result: 22 passed. Ruff and `git diff --check` pass.

## Checklist

- [x] Read the contributing guide and current `AGENTS.md`
- [x] Scope is limited to the dropped session-history read
- [x] Added a behavior-level regression test; no source-reading assertions
- [x] Verified the DB read stays off the gateway event loop
- [x] Relevant tests, Ruff, and `git diff --check` pass
- [x] Commit message follows Conventional Commits

## AI Disclosure

This bug was identified and fixed with AI assistance.
