### PR TITLE
fix(auxiliary): omit temperature for GPT-5 Responses

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -857,14 +857,23 @@ def _fixed_temperature_for_model(
 
     Returns:
         ``OMIT_TEMPERATURE`` — caller must remove the ``temperature`` key so the
-            provider chooses its own default.  Used for all Kimi / Moonshot
-            models whose gateway selects temperature server-side.
+        provider chooses its own default.  Used for models whose gateway
+            selects temperature server-side, including Kimi / Moonshot and
+            OpenAI GPT-5 Responses routes.
         ``float`` — a specific value the caller must use (reserved for future
             models with fixed-temperature contracts).
         ``None`` — no override; caller should use its own default.
     """
     if _is_kimi_model(model):
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
+        return OMIT_TEMPERATURE
+    # LiteLLM sends this model family through OpenAI's Responses API. That
+    # route rejects non-default temperature values, so auxiliary callers must
+    # use the same request contract as the main route instead of relying on a
+    # title-specific retry/fallback.
+    bare_model = (model or "").strip().lower().rsplit("/", 1)[-1]
+    if bare_model == "gpt-5" or bare_model.startswith("gpt-5-") or bare_model.startswith("gpt-5."):
+        logger.debug("Omitting temperature for GPT-5 Responses model %r", model)
         return OMIT_TEMPERATURE
     if _is_arcee_trinity_thinking(model):
         return 0.5

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -852,12 +852,13 @@ def _is_codex_spark(model: Optional[str], provider: Optional[str] = None) -> boo
 def _fixed_temperature_for_model(
     model: Optional[str],
     base_url: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> "Optional[float] | object":
     """Return a temperature directive for models with strict contracts.
 
     Returns:
         ``OMIT_TEMPERATURE`` — caller must remove the ``temperature`` key so the
-        provider chooses its own default.  Used for models whose gateway
+            provider chooses its own default.  Used for models whose gateway
             selects temperature server-side, including Kimi / Moonshot and
             OpenAI GPT-5 Responses routes.
         ``float`` — a specific value the caller must use (reserved for future
@@ -867,12 +868,18 @@ def _fixed_temperature_for_model(
     if _is_kimi_model(model):
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
         return OMIT_TEMPERATURE
-    # LiteLLM sends this model family through OpenAI's Responses API. That
-    # route rejects non-default temperature values, so auxiliary callers must
-    # use the same request contract as the main route instead of relying on a
-    # title-specific retry/fallback.
+    # GPT-5 only rejects this on the Responses route.  The same model can be
+    # deliberately kept on chat completions by Nous and custom providers, so
+    # a model-only check would silently change those requests.
     bare_model = (model or "").strip().lower().rsplit("/", 1)[-1]
-    if bare_model == "gpt-5" or bare_model.startswith("gpt-5-") or bare_model.startswith("gpt-5."):
+    if (
+        api_mode == "codex_responses"
+        and (
+            bare_model == "gpt-5"
+            or bare_model.startswith("gpt-5-")
+            or bare_model.startswith("gpt-5.")
+        )
+    ):
         logger.debug("Omitting temperature for GPT-5 Responses model %r", model)
         return OMIT_TEMPERATURE
     if _is_arcee_trinity_thinking(model):
@@ -5118,6 +5125,7 @@ def _retry_same_provider_sync(
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
         task=task,
+        api_mode=resolved_api_mode,
     )
     # Preserve per-request attribution headers (e.g. Copilot's
     # ``x-initiator: user``) across the rebuilt-client retry — dropping them
@@ -5193,6 +5201,7 @@ async def _retry_same_provider_async(
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
         task=task,
+        api_mode=resolved_api_mode,
     )
     # Preserve per-request attribution headers across the rebuilt-client
     # retry — see the sync variant above (#60293).
@@ -9070,6 +9079,7 @@ def _build_call_kwargs(
     reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None,
     task: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -9078,7 +9088,7 @@ def _build_call_kwargs(
         "timeout": timeout,
     }
 
-    fixed_temperature = _fixed_temperature_for_model(model, base_url)
+    fixed_temperature = _fixed_temperature_for_model(model, base_url, api_mode)
     if fixed_temperature is OMIT_TEMPERATURE:
         temperature = None  # strip — let server choose
     elif fixed_temperature is not None:
@@ -10217,7 +10227,10 @@ def _call_llm_impl(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_base_info or resolved_base_url, task=task)
+        base_url=_base_info or resolved_base_url,
+        task=task,
+        api_mode=resolved_api_mode,
+    )
     if fast_compression_cap is not None and max_tokens is None:
         # Normal auxiliary calls intentionally omit a cap on most
         # OpenAI-compatible/local providers.  This is the narrow exception:
@@ -11099,7 +11112,10 @@ async def _async_call_llm_impl(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_client_base or resolved_base_url, task=task)
+        base_url=_client_base or resolved_base_url,
+        task=task,
+        api_mode=resolved_api_mode,
+    )
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(request_provider, _client_base):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -637,12 +637,13 @@ def _is_codex_spark(model: Optional[str], provider: Optional[str] = None) -> boo
 def _fixed_temperature_for_model(
     model: Optional[str],
     base_url: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> "Optional[float] | object":
     """Return a temperature directive for models with strict contracts.
 
     Returns:
         ``OMIT_TEMPERATURE`` — caller must remove the ``temperature`` key so the
-        provider chooses its own default.  Used for models whose gateway
+            provider chooses its own default.  Used for models whose gateway
             selects temperature server-side, including Kimi / Moonshot and
             OpenAI GPT-5 Responses routes.
         ``float`` — a specific value the caller must use (reserved for future
@@ -652,12 +653,18 @@ def _fixed_temperature_for_model(
     if _is_kimi_model(model):
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
         return OMIT_TEMPERATURE
-    # LiteLLM sends this model family through OpenAI's Responses API. That
-    # route rejects non-default temperature values, so auxiliary callers must
-    # use the same request contract as the main route instead of relying on a
-    # title-specific retry/fallback.
+    # GPT-5 only rejects this on the Responses route.  The same model can be
+    # deliberately kept on chat completions by Nous and custom providers, so
+    # a model-only check would silently change those requests.
     bare_model = (model or "").strip().lower().rsplit("/", 1)[-1]
-    if bare_model == "gpt-5" or bare_model.startswith("gpt-5-") or bare_model.startswith("gpt-5."):
+    if (
+        api_mode == "codex_responses"
+        and (
+            bare_model == "gpt-5"
+            or bare_model.startswith("gpt-5-")
+            or bare_model.startswith("gpt-5.")
+        )
+    ):
         logger.debug("Omitting temperature for GPT-5 Responses model %r", model)
         return OMIT_TEMPERATURE
     if _is_arcee_trinity_thinking(model):
@@ -4307,6 +4314,7 @@ def _retry_same_provider_sync(
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
         task=task,
+        api_mode=resolved_api_mode,
     )
     # Preserve per-request attribution headers (e.g. Copilot's
     # ``x-initiator: user``) across the rebuilt-client retry — dropping them
@@ -4379,6 +4387,7 @@ async def _retry_same_provider_async(
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
         task=task,
+        api_mode=resolved_api_mode,
     )
     # Preserve per-request attribution headers across the rebuilt-client
     # retry — see the sync variant above (#60293).
@@ -7754,6 +7763,7 @@ def _build_call_kwargs(
     reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None,
     task: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -7762,7 +7772,7 @@ def _build_call_kwargs(
         "timeout": timeout,
     }
 
-    fixed_temperature = _fixed_temperature_for_model(model, base_url)
+    fixed_temperature = _fixed_temperature_for_model(model, base_url, api_mode)
     if fixed_temperature is OMIT_TEMPERATURE:
         temperature = None  # strip — let server choose
     elif fixed_temperature is not None:
@@ -8606,7 +8616,10 @@ def call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_base_info or resolved_base_url, task=task)
+        base_url=_base_info or resolved_base_url,
+        task=task,
+        api_mode=resolved_api_mode,
+    )
     if extra_headers:
         kwargs["extra_headers"] = dict(extra_headers)
 
@@ -9318,7 +9331,10 @@ async def async_call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_client_base or resolved_base_url, task=task)
+        base_url=_client_base or resolved_base_url,
+        task=task,
+        api_mode=resolved_api_mode,
+    )
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -642,14 +642,23 @@ def _fixed_temperature_for_model(
 
     Returns:
         ``OMIT_TEMPERATURE`` — caller must remove the ``temperature`` key so the
-            provider chooses its own default.  Used for all Kimi / Moonshot
-            models whose gateway selects temperature server-side.
+        provider chooses its own default.  Used for models whose gateway
+            selects temperature server-side, including Kimi / Moonshot and
+            OpenAI GPT-5 Responses routes.
         ``float`` — a specific value the caller must use (reserved for future
             models with fixed-temperature contracts).
         ``None`` — no override; caller should use its own default.
     """
     if _is_kimi_model(model):
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
+        return OMIT_TEMPERATURE
+    # LiteLLM sends this model family through OpenAI's Responses API. That
+    # route rejects non-default temperature values, so auxiliary callers must
+    # use the same request contract as the main route instead of relying on a
+    # title-specific retry/fallback.
+    bare_model = (model or "").strip().lower().rsplit("/", 1)[-1]
+    if bare_model == "gpt-5" or bare_model.startswith("gpt-5-") or bare_model.startswith("gpt-5."):
+        logger.debug("Omitting temperature for GPT-5 Responses model %r", model)
         return OMIT_TEMPERATURE
     if _is_arcee_trinity_thinking(model):
         return 0.5

--- a/contributors/emails/axegggl@gmail.com
+++ b/contributors/emails/axegggl@gmail.com
@@ -1,0 +1,2 @@
+AXEG0
+# PR #63800 contributor attribution

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2214,7 +2214,6 @@ class TestKimiTemperatureOmitted:
 
 
 
-
     @pytest.mark.asyncio
     async def test_async_call_omits_temperature(self):
         client = MagicMock()
@@ -2265,6 +2264,30 @@ class TestKimiTemperatureOmitted:
 # ---------------------------------------------------------------------------
 # async_call_llm payment / connection fallback (#7512 bug 2)
 # ---------------------------------------------------------------------------
+
+
+class TestGpt5TemperatureOmitted:
+    """GPT-5 Responses models must not receive a chat temperature override."""
+
+    @pytest.mark.parametrize("model", [
+        "gpt-5",
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "openai/gpt-5.6-terra",
+    ])
+    def test_gpt5_models_omit_temperature(self, model):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model=model,
+            messages=[{"role": "user", "content": "Generate a title"}],
+            temperature=0.2,
+            base_url="http://litellm.example/v1",
+        )
+
+        assert "temperature" not in kwargs
 
 
 class TestStaleBaseUrlWarning:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2219,16 +2219,19 @@ class TestKimiTemperatureOmitted:
 
 
 class TestGpt5TemperatureOmitted:
-    """GPT-5 Responses models must not receive a chat temperature override."""
+    """GPT-5 Responses requests must not receive a chat temperature override."""
 
-    @pytest.mark.parametrize("model", [
-        "gpt-5",
-        "gpt-5.5",
-        "gpt-5.6-sol",
-        "gpt-5.6-terra",
-        "openai/gpt-5.6-terra",
-    ])
-    def test_gpt5_models_omit_temperature(self, model):
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5",
+            "gpt-5.5",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "openai/gpt-5.6-terra",
+        ],
+    )
+    def test_gpt5_responses_models_omit_temperature(self, model):
         from agent.auxiliary_client import _build_call_kwargs
 
         kwargs = _build_call_kwargs(
@@ -2237,9 +2240,66 @@ class TestGpt5TemperatureOmitted:
             messages=[{"role": "user", "content": "Generate a title"}],
             temperature=0.2,
             base_url="http://litellm.example/v1",
+            api_mode="codex_responses",
         )
 
         assert "temperature" not in kwargs
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            ("nous", "https://inference-api.nousresearch.com/v1"),
+            ("custom", "https://relay.example/v1"),
+        ],
+    )
+    def test_gpt5_chat_completions_requests_preserve_temperature(
+        self, provider, base_url
+    ):
+        """The same model keeps temperature when its route is chat completions."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Generate a title"}],
+            temperature=0.2,
+            base_url=base_url,
+            api_mode="chat_completions",
+        )
+
+        assert kwargs["temperature"] == 0.2
+
+    @pytest.mark.parametrize(
+        "api_mode,expects_temperature",
+        [("codex_responses", False), ("chat_completions", True)],
+    )
+    def test_request_uses_temperature_contract_of_selected_route(
+        self, api_mode, expects_temperature
+    ):
+        """Route metadata, not the GPT-5 name, controls the outgoing request."""
+        from agent.auxiliary_client import call_llm
+
+        client = MagicMock()
+        client.base_url = "http://litellm.example/v1"
+        response = MagicMock()
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("custom", "gpt-5.4", client.base_url, "test-key", api_mode),
+            ),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, "gpt-5.4")),
+            patch("agent.auxiliary_client._validate_llm_response", return_value=response),
+        ):
+            assert call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "Generate a title"}],
+                temperature=0.2,
+            ) is response
+
+        request = client.chat.completions.create.call_args.kwargs
+        assert ("temperature" in request) is expects_temperature
+        if expects_temperature:
+            assert request["temperature"] == 0.2
 
 
 class TestStaleBaseUrlWarning:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2267,16 +2267,19 @@ class TestKimiTemperatureOmitted:
 
 
 class TestGpt5TemperatureOmitted:
-    """GPT-5 Responses models must not receive a chat temperature override."""
+    """GPT-5 Responses requests must not receive a chat temperature override."""
 
-    @pytest.mark.parametrize("model", [
-        "gpt-5",
-        "gpt-5.5",
-        "gpt-5.6-sol",
-        "gpt-5.6-terra",
-        "openai/gpt-5.6-terra",
-    ])
-    def test_gpt5_models_omit_temperature(self, model):
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5",
+            "gpt-5.5",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "openai/gpt-5.6-terra",
+        ],
+    )
+    def test_gpt5_responses_models_omit_temperature(self, model):
         from agent.auxiliary_client import _build_call_kwargs
 
         kwargs = _build_call_kwargs(
@@ -2285,9 +2288,66 @@ class TestGpt5TemperatureOmitted:
             messages=[{"role": "user", "content": "Generate a title"}],
             temperature=0.2,
             base_url="http://litellm.example/v1",
+            api_mode="codex_responses",
         )
 
         assert "temperature" not in kwargs
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            ("nous", "https://inference-api.nousresearch.com/v1"),
+            ("custom", "https://relay.example/v1"),
+        ],
+    )
+    def test_gpt5_chat_completions_requests_preserve_temperature(
+        self, provider, base_url
+    ):
+        """The same model keeps temperature when its route is chat completions."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Generate a title"}],
+            temperature=0.2,
+            base_url=base_url,
+            api_mode="chat_completions",
+        )
+
+        assert kwargs["temperature"] == 0.2
+
+    @pytest.mark.parametrize(
+        "api_mode,expects_temperature",
+        [("codex_responses", False), ("chat_completions", True)],
+    )
+    def test_request_uses_temperature_contract_of_selected_route(
+        self, api_mode, expects_temperature
+    ):
+        """Route metadata, not the GPT-5 name, controls the outgoing request."""
+        from agent.auxiliary_client import call_llm
+
+        client = MagicMock()
+        client.base_url = "http://litellm.example/v1"
+        response = MagicMock()
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("custom", "gpt-5.4", client.base_url, "test-key", api_mode),
+            ),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, "gpt-5.4")),
+            patch("agent.auxiliary_client._validate_llm_response", return_value=response),
+        ):
+            assert call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "Generate a title"}],
+                temperature=0.2,
+            ) is response
+
+        request = client.chat.completions.create.call_args.kwargs
+        assert ("temperature" in request) is expects_temperature
+        if expects_temperature:
+            assert request["temperature"] == 0.2
 
 
 class TestStaleBaseUrlWarning:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2166,7 +2166,6 @@ class TestKimiTemperatureOmitted:
 
 
 
-
     @pytest.mark.asyncio
     async def test_async_call_omits_temperature(self):
         client = MagicMock()
@@ -2217,6 +2216,30 @@ class TestKimiTemperatureOmitted:
 # ---------------------------------------------------------------------------
 # async_call_llm payment / connection fallback (#7512 bug 2)
 # ---------------------------------------------------------------------------
+
+
+class TestGpt5TemperatureOmitted:
+    """GPT-5 Responses models must not receive a chat temperature override."""
+
+    @pytest.mark.parametrize("model", [
+        "gpt-5",
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "openai/gpt-5.6-terra",
+    ])
+    def test_gpt5_models_omit_temperature(self, model):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model=model,
+            messages=[{"role": "user", "content": "Generate a title"}],
+            temperature=0.2,
+            base_url="http://litellm.example/v1",
+        )
+
+        assert "temperature" not in kwargs
 
 
 class TestStaleBaseUrlWarning:


### PR DESCRIPTION
## What does this PR do?

Makes auxiliary-request temperature handling route-aware for GPT-5 models.

When the resolved auxiliary route uses the Responses API (`codex_responses`), the request omits `temperature`, which that route rejects for affected GPT-5 models. Chat-completions routes—including custom providers and OpenRouter—continue to receive the caller's configured temperature. This keeps the fix aligned with the actual transport contract instead of applying a model-name-only rule.

## Related Issue

N/A — no public issue is linked.

Related/overlapping work:

- #51157 also changes GPT-5 temperature handling, but applies a provider-agnostic model predicate. This PR instead gates omission on the resolved API mode so chat-completions routes keep their supported temperature value.
- #15620 and #15627 are earlier fallback-oriented fixes for unsupported temperature parameters; this change prevents the invalid field on the verified Responses route before a request is sent.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: carry the resolved API mode through sync, async, and retry request builders; omit GPT-5 temperature only for `codex_responses`; preserve existing Kimi and Arcee handling.
- `tests/agent/test_auxiliary_client.py`: add route-specific builder and request coverage proving Responses requests omit temperature while chat-completions requests preserve it.
- `contributors/emails/axegggl@gmail.com`: map the commit email to the GitHub contributor identity required by the repository.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -k 'gpt5_responses_models_omit_temperature or gpt5_chat_completions_requests_preserve_temperature or request_uses_temperature_contract_of_selected_route' -q`.
2. Verify GPT-5 auxiliary requests resolved to `codex_responses` omit `temperature`.
3. Verify the same model on `chat_completions` preserves the configured `temperature`.

Exact-head verification at `4bfba95d8a74a6bec3679d3276d196f1630119cc` against base `18a76be124d7c16ed98b629a358b23fef76a7f46`:

- Required repository runner, route-focused affected tests: **9 passed, 0 failed**.
- Required repository runner, complete suite: **42,257 passed, 149 failed, 414 skipped** across 3,519 files.
- The complete run's failures are unrelated current-repository/host failures dominated by the macOS restricted process environment (live-system signal guard, process/port permissions, unavailable platform binaries). The only failure in the affected file is the pre-existing `TestAuxiliaryAuthRefreshRetry::test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache`, reproduced unchanged on the exact base.
- `scripts/check-windows-footguns.py --all`: passed (1,054 files).
- Contributor mapping audit: passed.
- `git diff --check`: passed.

No paid or live external-provider request was made. The request-boundary regression tests verify the exact payload sent by each resolved route.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the required full runner completed, but unrelated current-repository/host failures remain as documented above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing interface or behavior documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent Python change; Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

N/A — regression coverage and exact-head command results are listed above.

## AI Assistance

OpenAI — GPT-5 via Codex CLI (implementation assistance, test execution, and PR-description drafting).