### PR TITLE
chore(security-guidance): sync forked patterns

### DIFF
--- a/plugins/security-guidance/NOTICE
+++ b/plugins/security-guidance/NOTICE
@@ -7,7 +7,7 @@ licensed under the Apache License, Version 2.0.
 
     Source:    https://github.com/anthropics/claude-plugins-official
     Subpath:   plugins/security-guidance/hooks/patterns.py
-    Commit:    0bde168 (2026-05-26)
+    Commit:    12a5376 (2026-05-29)
     License:   Apache License 2.0 (see LICENSE in this directory)
 
 Forked content

--- a/plugins/security-guidance/README.md
+++ b/plugins/security-guidance/README.md
@@ -81,7 +81,7 @@ not a substitute for code review, SAST, dependency scanning, or pen testing.
 
 * `patterns.py` is a verbatim fork from
   [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/security-guidance/hooks)
-  (commit `0bde168`, 2026-05-26), licensed under the
+  (commit `12a5376`, 2026-05-29), licensed under the
   [Apache License 2.0](./LICENSE). See [NOTICE](./NOTICE) for the full
   attribution.
 * `__init__.py`, `plugin.yaml`, `README.md`, and tests are original work by

--- a/plugins/security-guidance/patterns.py
+++ b/plugins/security-guidance/patterns.py
@@ -24,7 +24,7 @@ Forked verbatim from Anthropic's claude-plugins-official repository
 
 Modifications by NousResearch for the Hermes Agent plugin port:
   - none to the pattern data itself; this file is byte-for-byte the upstream
-    patterns.py at commit 0bde168 (2026-05-26). Hermes-side wiring lives in
+    patterns.py at commit 12a5376 (2026-05-29). Hermes-side wiring lives in
     __init__.py.
 """
 from enum import IntEnum
@@ -117,6 +117,9 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "new_function_injection",
+        # JS-only construct: gate to JS/TS files so docs/.md and other prose
+        # mentioning "new Function" don't trip the warning.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["new Function"],
         "reminder": "\u26a0\ufe0f Security Warning: Using new Function() with string interpolation is a CODE INJECTION vulnerability. If any variable is concatenated or interpolated into the function body string, an attacker controlling that variable can execute arbitrary code. Use safe alternatives: for property access use obj[key] or array.reduce((o, k) => o[k], root); for computation use a safe expression parser. NEVER interpolate untrusted strings into new Function() bodies.",
     },
@@ -130,16 +133,24 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "react_dangerously_set_html",
+        # JS/TS-only (React); gate so .md docs / .py / .go files don't trip.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["dangerouslySetInnerHTML"],
         "reminder": "⚠️ Security Warning: dangerouslySetInnerHTML can lead to XSS vulnerabilities if used with untrusted content. Ensure all content is properly sanitized using an HTML sanitizer library like DOMPurify, or use safe alternatives.",
     },
     {
         "ruleName": "document_write_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["document.write"],
         "reminder": "⚠️ Security Warning: document.write() can be exploited for XSS attacks and has performance issues. Use DOM manipulation methods like createElement() and appendChild() instead.",
     },
     {
         "ruleName": "innerHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source. Closes FPs like
+        # docs/example HTML, playground/self-contained skills that hardcode
+        # innerHTML strings with zero user input (#410).
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".innerHTML =", ".innerHTML="],
         "reminder": "⚠️ Security Warning: Setting innerHTML with untrusted content can lead to XSS vulnerabilities. Use textContent for plain text or safe DOM methods for HTML content. If you need HTML support, consider using an HTML sanitizer library such as DOMPurify.",
     },
@@ -240,11 +251,15 @@ Additionally, validate user inputs:
     },
     {
         "ruleName": "outerHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".outerHTML =", ".outerHTML="],
         "reminder": "⚠️ Security Warning: Use textContent or sanitize with DOMPurify. outerHTML assignment is an XSS sink equivalent to innerHTML.",
     },
     {
         "ruleName": "insertAdjacentHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".insertAdjacentHTML("],
         "reminder": "⚠️ Security Warning: Use insertAdjacentText() or sanitize with DOMPurify. insertAdjacentHTML is an XSS sink.",
     },

--- a/tests/plugins/test_security_guidance_plugin.py
+++ b/tests/plugins/test_security_guidance_plugin.py
@@ -157,6 +157,20 @@ class TestScanContent:
         )
         assert "react_dangerously_set_html" in [n for n, _ in findings]
 
+    def test_new_function_in_markdown_is_skipped(self):
+        mod = _load_plugin_init()
+        findings = mod._scan_content(
+            "/tmp/foo.md", "Avoid new Function('return x') in browser code."
+        )
+        assert "new_function_injection" not in [n for n, _ in findings]
+
+    def test_inner_html_in_markdown_is_skipped(self):
+        mod = _load_plugin_init()
+        findings = mod._scan_content(
+            "/tmp/foo.md", "Example: el.innerHTML = '<b>demo</b>'"
+        )
+        assert "innerHTML_xss" not in [n for n, _ in findings]
+
     def test_github_workflow_path_check_fires_on_path_alone(self):
         """github_actions_workflow has no regex/substring — fires on path."""
         mod = _load_plugin_init()


### PR DESCRIPTION
## Summary
- sync `plugins/security-guidance/patterns.py` to Anthropic upstream commit `12a5376` (2026-05-29)
- gate JS-only `new Function` and browser-DOM XSS rules to JS-family paths to avoid false positives in Markdown/prose files
- update vendored provenance docs (`README.md`, `NOTICE`) and add regression tests for the new path gating

## Upstream sources checked
- `anthropics/claude-plugins-official`
  - path: `plugins/security-guidance/hooks/patterns.py`
  - compared local vendored copy against upstream path history (`0bde168` -> `12a5376`)
- `PCinkusz/hermes-achievements`
  - checked upstream `main` (`9ad096f`); saw follow-up commits (`46a3e52`, `12b4477`) but deferred because Hermes carries a locally modified vendored dashboard bundle and that sync should be its own focused PR
- `photon-hq/spectrum-ts`
  - checked npm releases; Hermes sidecar is pinned to `8.0.0`, latest is `10.0.0`; deferred because the sidecar carries a version-sensitive postinstall patch and adapter validation is required
- `trycua/cua`
  - checked tags / release lineage; no repo-side update here because Hermes does not vendor or pin `cua-driver` in-tree

## Before / after refs
- before: Hermes metadata claimed `patterns.py` matched upstream `0bde168` (2026-05-26)
- after: Hermes metadata now points to upstream `12a5376` (2026-05-29)
- upstream delta applied: Anthropic's JS-family path filters for `new Function`, `dangerouslySetInnerHTML`, `document.write`, `innerHTML`, `outerHTML`, and `insertAdjacentHTML`

## Validation
- `scripts/run_tests.sh tests/plugins/test_security_guidance_plugin.py`
  - passed: `29 tests passed, 0 failed` in `0.9s`

## Risks / follow-ups
- deferred: `plugins/hermes-achievements/` upstream drift (`46a3e52`, `12b4477`) should land in a separate PR because the vendored dashboard bundle in Hermes has local modifications
- deferred: Photon `spectrum-ts` bump requires updating and re-validating `patch-spectrum-mixed-attachments.mjs`
