### PR TITLE
fix(dashboard): isolate PTY attachments per tab

### DIFF
--- a/web/src/lib/pty-attach-token.test.ts
+++ b/web/src/lib/pty-attach-token.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let ptyAttachToken: (typeof import("./pty-attach-token"))["ptyAttachToken"];
+
+async function reloadTokenModule() {
+  vi.resetModules();
+  ({ ptyAttachToken } = await import("./pty-attach-token"));
+}
+
+function storage(values = new Map<string, string>()) {
+  return {
+    values,
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => void values.set(key, value)),
+  };
+}
+
+function browserPage(
+  sessionStorage = storage(),
+  navigationType: PerformanceNavigationTiming["type"] | undefined = "navigate",
+) {
+  const localStorage = storage();
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    sessionStorage,
+    localStorage,
+    opener: null as object | null,
+    performance: {
+      getEntriesByType: vi.fn(() =>
+        navigationType ? [{ type: navigationType }] : [],
+      ),
+    },
+    addEventListener: vi.fn((type: string, listener: () => void) => {
+      const handlers = listeners.get(type) ?? new Set();
+      handlers.add(listener);
+      listeners.set(type, handlers);
+    }),
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) ?? []) listener();
+    },
+  };
+}
+
+function broadcastChannel() {
+  const listeners = new Map<string, Set<(event: MessageEvent) => void>>();
+
+  class MockBroadcastChannel {
+    private readonly handlers = new Set<(event: MessageEvent) => void>();
+    private readonly name: string;
+
+    constructor(name: string) {
+      this.name = name;
+      const channels = listeners.get(name) ?? new Set();
+      channels.add(this.receive);
+      listeners.set(name, channels);
+    }
+
+    addEventListener(_: "message", listener: (event: MessageEvent) => void) {
+      this.handlers.add(listener);
+    }
+
+    removeEventListener(_: "message", listener: (event: MessageEvent) => void) {
+      this.handlers.delete(listener);
+    }
+
+    postMessage(data: unknown) {
+      for (const listener of listeners.get(this.name) ?? []) {
+        if (listener !== this.receive) {
+          queueMicrotask(() => listener({ data } as MessageEvent));
+        }
+      }
+    }
+
+    private receive = (event: MessageEvent) => {
+      for (const handler of this.handlers) handler(event);
+    };
+  }
+
+  return MockBroadcastChannel;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(async () => {
+  vi.stubGlobal("BroadcastChannel", broadcastChannel());
+  await reloadTokenModule();
+});
+
+describe("ptyAttachToken", () => {
+  it("reuses the tab-local token across reloads without touching shared localStorage", async () => {
+    const sessionStorage = storage();
+    const firstPage = browserPage(sessionStorage);
+    vi.stubGlobal("window", firstPage);
+    vi.stubGlobal("crypto", {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(7),
+    });
+
+    expect(await ptyAttachToken()).toBe("07".repeat(16));
+
+    const reloadedPage = browserPage(sessionStorage, "reload");
+    firstPage.dispatch("pagehide");
+    vi.stubGlobal("window", reloadedPage);
+    await reloadTokenModule();
+    expect(await ptyAttachToken()).toBe("07".repeat(16));
+    expect(sessionStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(firstPage.localStorage.getItem).not.toHaveBeenCalled();
+    expect(firstPage.localStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("keeps the token through same-tab history navigation", async () => {
+    const sessionStorage = storage();
+    const firstPage = browserPage(sessionStorage);
+    vi.stubGlobal("window", firstPage);
+    vi.stubGlobal("crypto", {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(7),
+    });
+
+    expect(await ptyAttachToken()).toBe("07".repeat(16));
+
+    const historyPage = browserPage(sessionStorage, "back_forward");
+    firstPage.dispatch("pagehide");
+    vi.stubGlobal("window", historyPage);
+    await reloadTokenModule();
+
+    expect(await ptyAttachToken()).toBe("07".repeat(16));
+  });
+
+  it("mints a browser-duplicated tab a fresh token after cloned back-forward navigation", async () => {
+    let nextByte = 1;
+    const parentPage = browserPage();
+    vi.stubGlobal("window", parentPage);
+    vi.stubGlobal("crypto", {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(nextByte++),
+    });
+
+    expect(await ptyAttachToken()).toBe("01".repeat(16));
+
+    const childPage = browserPage(
+      storage(new Map(parentPage.sessionStorage.values)),
+      "back_forward",
+    );
+    expect(childPage.opener).toBeNull();
+    vi.stubGlobal("window", childPage);
+    await reloadTokenModule();
+
+    expect(await ptyAttachToken()).toBe("02".repeat(16));
+    expect(await ptyAttachToken()).toBe("02".repeat(16));
+    expect(parentPage.sessionStorage.values.get("hermes.pty.token.chat")).toBe(
+      "01".repeat(16),
+    );
+
+    const reloadedChildPage = browserPage(childPage.sessionStorage, "reload");
+    childPage.dispatch("pagehide");
+    vi.stubGlobal("window", reloadedChildPage);
+    await reloadTokenModule();
+    expect(await ptyAttachToken()).toBe("02".repeat(16));
+  });
+
+  it("rotates the attachment after an explicitly fresh session", async () => {
+    const page = browserPage();
+    let nextByte = 1;
+    vi.stubGlobal("window", page);
+    vi.stubGlobal("crypto", {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(nextByte++),
+    });
+
+    expect(await ptyAttachToken()).toBe("01".repeat(16));
+    expect(await ptyAttachToken(true)).toBe("02".repeat(16));
+  });
+});

--- a/web/src/lib/pty-attach-token.ts
+++ b/web/src/lib/pty-attach-token.ts
@@ -1,0 +1,112 @@
+// A PTY attachment identifies a browser tab's live TUI process. sessionStorage
+// survives reloads in that tab, but Chromium clones it along with history when
+// duplicating a tab. A live tab confirms its ownership before another page
+// reuses a stored token, so clone detection does not depend on navigation type.
+const PTY_ATTACH_TOKEN_KEY = "hermes.pty.token.chat";
+const PTY_ATTACH_CHANNEL = "hermes.pty.attach";
+const PTY_ATTACH_CLAIM_TIMEOUT_MS = 75;
+let pageToken = "";
+let pageIsLeaving = false;
+let ownerChannel: BroadcastChannel | null = null;
+
+interface AttachMessage {
+  type: "claim" | "claimed";
+  token: string;
+}
+
+function isAttachMessage(value: unknown): value is AttachMessage {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Partial<AttachMessage>;
+  return (
+    (message.type === "claim" || message.type === "claimed") &&
+    typeof message.token === "string"
+  );
+}
+
+function attachmentChannel(): BroadcastChannel | null {
+  if (ownerChannel) return ownerChannel;
+
+  try {
+    const channel = new BroadcastChannel(PTY_ATTACH_CHANNEL);
+    channel.addEventListener("message", (event) => {
+      if (!isAttachMessage(event.data)) return;
+      if (
+        event.data.type === "claim" &&
+        event.data.token === pageToken &&
+        !pageIsLeaving
+      ) {
+        channel.postMessage({ type: "claimed", token: pageToken });
+      }
+    });
+    window.addEventListener("pagehide", () => {
+      pageIsLeaving = true;
+    });
+    window.addEventListener("pageshow", () => {
+      pageIsLeaving = false;
+    });
+    ownerChannel = channel;
+    return channel;
+  } catch {
+    return null;
+  }
+}
+
+function tokenIsOwnedByLiveTab(token: string): Promise<boolean> {
+  const channel = attachmentChannel();
+  if (!channel) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (owned: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      channel.removeEventListener("message", onMessage);
+      resolve(owned);
+    };
+    const onMessage = (event: MessageEvent<unknown>) => {
+      if (
+        isAttachMessage(event.data) &&
+        event.data.type === "claimed" &&
+        event.data.token === token
+      ) {
+        finish(true);
+      }
+    };
+    const timeout = setTimeout(
+      () => finish(false),
+      PTY_ATTACH_CLAIM_TIMEOUT_MS,
+    );
+    channel.addEventListener("message", onMessage);
+    channel.postMessage({ type: "claim", token });
+  });
+}
+
+export async function ptyAttachToken(rotate = false): Promise<string> {
+  if (!rotate && pageToken) return pageToken;
+
+  let token = "";
+  if (!rotate) {
+    try {
+      token = window.sessionStorage.getItem(PTY_ATTACH_TOKEN_KEY) ?? "";
+    } catch {
+      /* private mode / storage blocked */
+    }
+  }
+  if (token && (await tokenIsOwnedByLiveTab(token))) token = "";
+  if (!token) {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    token = Array.from(bytes, (byte) =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("");
+    try {
+      window.sessionStorage.setItem(PTY_ATTACH_TOKEN_KEY, token);
+    } catch {
+      /* ignore */
+    }
+  }
+  pageToken = token;
+  attachmentChannel();
+  return token;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -37,6 +37,7 @@ import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { latchChatActivation } from "@/lib/chat-activation";
 import { normalizeSessionTitle } from "@/lib/chat-title";
+import { ptyAttachToken } from "@/lib/pty-attach-token";
 import {
   PTY_CONNECTING_TIMEOUT_MS,
   PTY_RECONNECT_INPUT_MESSAGE,
@@ -59,34 +60,12 @@ import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
 import { useProfileScope } from "@/contexts/useProfileScope";
 
-// Stable per-browser token identifying THIS chat tab's keep-alive PTY session.
+// Stable per-tab token identifying THIS chat tab's keep-alive PTY session.
 // Sent as ?attach=; lets a refresh/disconnect reattach to the same live process
-// instead of spawning a fresh one. Per-localStorage, so other devices can't grab it.
+// instead of spawning a fresh one. Browser-duplicated sibling tabs discard a
+// cloned token before creating their own attachment.
 // ``rotate`` mints a new token — used when the user explicitly starts a fresh
 // session so the old keep-alive PTY is NOT reattached (the registry reaps it).
-const PTY_ATTACH_TOKEN_KEY = "hermes.pty.token.chat";
-function ptyAttachToken(rotate = false): string {
-  let t = "";
-  if (!rotate) {
-    try {
-      t = window.localStorage.getItem(PTY_ATTACH_TOKEN_KEY) ?? "";
-    } catch {
-      /* private mode / storage blocked */
-    }
-  }
-  if (!t) {
-    const a = new Uint8Array(16);
-    crypto.getRandomValues(a);
-    t = Array.from(a, (b) => b.toString(16).padStart(2, "0")).join("");
-    try {
-      window.localStorage.setItem(PTY_ATTACH_TOKEN_KEY, t);
-    } catch {
-      /* ignore */
-    }
-  }
-  return t;
-}
-
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar
 // (subscriber).  Generated once per mount so a tab refresh starts a fresh
 // channel — the previous PTY child terminates with the old WS, and its
@@ -925,7 +904,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Keep-alive identity: reattach to this tab's living PTY across
       // refresh/transient drops. A forced-fresh start rotates the token so
       // the previous keep-alive PTY is not reattached (registry reaps it).
-      params.attach = ptyAttachToken(forceFresh);
+      params.attach = await ptyAttachToken(forceFresh);
+      if (unmounting) return;
       // Profile-scoped chat: the PTY child gets HERMES_HOME pointed at the
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).


### PR DESCRIPTION
## What changed and why

Per the reporter's 2026-07-12 clarification, `/compress` can trigger the same dashboard hang as `/new`. The chat page used `localStorage` for its PTY reattachment token, which is shared by all same-origin browser tabs. A second tab could therefore attach to the first tab's live TUI process and render its session.

This change moves the token to `sessionStorage`: it survives reloads in the same tab, preserving transient reconnect behavior, but each sibling tab receives its own PTY process. It also adds focused regression coverage for reuse, rotation, and avoiding shared `localStorage`.

## Addressing maintainer feedback

- #59305 is the related Desktop cross-tab content-mixing report. This PR addresses the distinct dashboard WS/PTY mechanism identified by the maintainer, not the Desktop surface.
- #49106 is the closed web/WeChat session-history-leak report. This PR does not alter WeChat history handling; it prevents dashboard tabs from sharing a PTY attachment identity.

## How to test

1. Open the dashboard chat in two same-origin browser tabs.
2. Confirm each tab opens an independent conversation, then run `/new` or `/compress` in one tab.
3. Confirm the other tab remains attached to its original conversation.
4. Reload either tab and confirm it reconnects to that tab's own live PTY session.
5. From `web/`, run `npm test -- --run src/lib/pty-attach-token.test.ts`.

## What platforms tested on

- Static diff check: macOS.
- Automated web test was not run in this checkout because `web/node_modules` is absent and `vitest` is unavailable.

Fixes #62726

<!-- autocontrib:worker-id=issue-followup-6d2d414c kind=pr-open -->