### PR TITLE
feat(gateway): make runtime footer use effective OAuth and Fast signals

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17092,7 +17092,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import (
+                    build_footer_line as _bfl,
+                    reasoning_effort_label as _reasoning_effort_label,
+                )
+                _footer_reasoning_effort = _reasoning_effort_label(
+                    self._resolve_session_reasoning_config(source=source)
+                )
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
@@ -17100,6 +17106,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    reasoning_effort=_footer_reasoning_effort,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17097,7 +17097,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     reasoning_effort_label as _reasoning_effort_label,
                 )
                 _footer_reasoning_effort = _reasoning_effort_label(
-                    self._resolve_session_reasoning_config(source=source)
+                    self._resolve_session_reasoning_config(
+                        source=source,
+                        model=agent_result.get("model"),
+                    )
                 )
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17102,6 +17102,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         model=agent_result.get("model"),
                     )
                 )
+                _footer_fast_mode = (
+                    self._resolve_session_service_tier(source=source) == "priority"
+                )
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
@@ -17110,6 +17113,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                     reasoning_effort=_footer_reasoning_effort,
+                    fast_mode=_footer_fast_mode,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5298,6 +5298,8 @@ class TurnRunner:
             _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
         _resolved_model = getattr(_agent, "model", None) if _agent else None
+        _resolved_provider = getattr(_agent, "provider", None) if _agent else None
+        _resolved_base_url = getattr(_agent, "base_url", None) if _agent else None
 
         # Sync session_id immediately after run_conversation(). Compression
         # can rotate before a follow-up model call fails; the failure return
@@ -5433,6 +5435,8 @@ class TurnRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": _resolved_provider,
+                "base_url": _resolved_base_url,
                 "context_length": _context_length,
             }
 
@@ -5571,6 +5575,8 @@ class TurnRunner:
             "input_tokens": _input_toks,
             "output_tokens": _output_toks,
             "model": _resolved_model,
+            "provider": _resolved_provider,
+            "base_url": _resolved_base_url,
             "context_length": _context_length,
             "session_id": effective_session_id,
             "response_previewed": result.get("response_previewed", False),
@@ -17109,6 +17115,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
+                    provider=agent_result.get("provider"),
+                    base_url=agent_result.get("base_url"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19875,15 +19875,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import (
+                    build_footer_line as _bfl,
+                    outgoing_fast_applied as _outgoing_fast_applied,
+                    reasoning_effort_label as _reasoning_effort_label,
+                )
+                _footer_reasoning_effort = _reasoning_effort_label(
+                    self._resolve_session_reasoning_config(
+                        source=source,
+                        model=agent_result.get("model"),
+                    )
+                )
+                _footer_fast_mode = _outgoing_fast_applied(
+                    model=agent_result.get("model"),
+                    provider=agent_result.get("provider"),
+                    requested=self._resolve_session_service_tier(source=source) == "priority",
+                )
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
+                    provider=agent_result.get("provider"),
+                    base_url=agent_result.get("base_url"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
+                    reasoning_effort=_footer_reasoning_effort,
+                    fast_mode=_footer_fast_mode,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,15 +1,15 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
-to keep replies minimal.
+Renders a compact footer showing runtime state (model, reasoning effort,
+context %, cwd) and appends it to the FINAL message of an agent turn when
+enabled.  Off by default to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, reasoning_effort, context_pct, cwd]
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -53,6 +53,15 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def reasoning_effort_label(reasoning_config: dict[str, Any] | None) -> str:
+    """Return the session-configured effort label used by the footer."""
+    if reasoning_config is None:
+        return "medium"
+    if not reasoning_config.get("enabled", True):
+        return "none"
+    return str(reasoning_config.get("effort") or "medium").strip().lower()
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -94,6 +103,7 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -107,6 +117,10 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field in {"reasoning", "reasoning_effort"}:
+            effort = str(reasoning_effort or "").strip().lower()
+            if effort:
+                parts.append(f"reasoning: {effort}")
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -130,6 +144,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -145,5 +160,6 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        reasoning_effort=reasoning_effort,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -29,8 +29,55 @@ from __future__ import annotations
 import os
 from typing import Any, Iterable, Optional
 
+from utils import base_url_host_matches
+
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _DEFAULT_SEPARATOR = " · "
+_CREDIT_WARNING = "💸 consuming credits"
+
+# Providers whose normal Hermes route is usage-metered. OAuth/subscription
+# routes deliberately use distinct slugs (for example ``openai-codex`` and
+# ``xai-oauth``) and are therefore excluded. Host matching catches generic
+# OpenAI-compatible routes that actually terminate at a metered provider.
+_METERED_PROVIDER_SLUGS = frozenset({
+    "ai-gateway",
+    "anthropic",
+    "azure-openai",
+    "bedrock",
+    "cohere",
+    "deepinfra",
+    "deepseek",
+    "fireworks",
+    "gemini",
+    "google",
+    "groq",
+    "mistral",
+    "moonshot",
+    "novita",
+    "nvidia",
+    "openai",
+    "openrouter",
+    "perplexity",
+    "together",
+    "vertex",
+    "xai",
+})
+_METERED_PROVIDER_HOSTS = (
+    "openrouter.ai",
+    "api.openai.com",
+    "api.anthropic.com",
+    "api.x.ai",
+    "api.deepseek.com",
+    "api.groq.com",
+    "api.mistral.ai",
+    "api.together.ai",
+    "api.together.xyz",
+    "fireworks.ai",
+    "perplexity.ai",
+    "generativelanguage.googleapis.com",
+    "api.cohere.com",
+    "api.deepinfra.com",
+)
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -60,6 +107,18 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def provider_consumes_credits(
+    provider: Optional[str],
+    base_url: Optional[str] = None,
+) -> bool:
+    """Return whether the effective backend is a known usage-metered route."""
+    slug = str(provider or "").strip().lower().replace("_", "-")
+    if slug in _METERED_PROVIDER_SLUGS:
+        return True
+    url = str(base_url or "")
+    return any(base_url_host_matches(url, host) for host in _METERED_PROVIDER_HOSTS)
 
 
 def reasoning_effort_label(reasoning_config: dict[str, Any] | None) -> str:
@@ -130,6 +189,8 @@ def format_runtime_footer(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
     cwd: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     fast_mode: bool = False,
@@ -177,9 +238,10 @@ def format_runtime_footer(
                 parts.append(short)
         # Unknown field names are silently ignored.
 
-    if not parts:
-        return ""
-    return separator.join(parts)
+    footer = separator.join(parts)
+    if provider_consumes_credits(provider, base_url):
+        return f"{footer}\n{_CREDIT_WARNING}" if footer else _CREDIT_WARNING
+    return footer
 
 
 def build_footer_line(
@@ -189,6 +251,8 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
     cwd: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     fast_mode: bool = False,
@@ -206,6 +270,8 @@ def build_footer_line(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
+        provider=provider,
+        base_url=base_url,
         cwd=cwd,
         reasoning_effort=reasoning_effort,
         fast_mode=fast_mode,

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -9,7 +9,8 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, reasoning_effort, context_pct, cwd]
+        fields: [model, reasoning_effort, fast, context_pct, cwd]
+        separator: " • "
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -29,7 +30,7 @@ import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
-_SEP = " · "
+_DEFAULT_SEPARATOR = " · "
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -44,6 +45,14 @@ def _home_relative_cwd(cwd: str) -> str:
         return p
     except Exception:
         return cwd
+
+
+def _cwd_short(cwd: str) -> str:
+    """Return only the current directory name for compact footers."""
+    rel = _home_relative_cwd(cwd)
+    if rel in {"", "~", os.sep}:
+        return rel
+    return os.path.basename(rel.rstrip(os.sep)) or rel
 
 
 def _model_short(model: Optional[str]) -> str:
@@ -62,6 +71,17 @@ def reasoning_effort_label(reasoning_config: dict[str, Any] | None) -> str:
     return str(reasoning_config.get("effort") or "medium").strip().lower()
 
 
+def _reasoning_short(effort: Optional[str]) -> str:
+    """Return a compact, human-readable reasoning effort label."""
+    normalized = str(effort or "").strip().lower()
+    aliases = {
+        "minimal": "min",
+        "medium": "med",
+        "none": "off",
+    }
+    return aliases.get(normalized, normalized)
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -73,7 +93,11 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved = {
+        "enabled": False,
+        "fields": list(_DEFAULT_FIELDS),
+        "separator": _DEFAULT_SEPARATOR,
+    }
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
@@ -82,6 +106,8 @@ def resolve_footer_config(
             resolved["enabled"] = bool(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        if isinstance(global_cfg.get("separator"), str):
+            resolved["separator"] = global_cfg["separator"]
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -93,6 +119,8 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                if isinstance(plat_footer.get("separator"), str):
+                    resolved["separator"] = plat_footer["separator"]
 
     return resolved
 
@@ -104,7 +132,9 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    fast_mode: bool = False,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    separator: str = _DEFAULT_SEPARATOR,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -112,15 +142,27 @@ def format_runtime_footer(
     partially-populated footer is better than a line with ``?%`` or empty slots.
     """
     parts: list[str] = []
-    for field in fields:
+    field_names = tuple(str(field) for field in fields)
+    fast_requested = any(field in {"fast", "service_tier"} for field in field_names)
+    model_requested = "model" in field_names
+
+    for field in field_names:
         if field == "model":
             m = _model_short(model)
             if m:
+                if fast_mode and fast_requested:
+                    m = f"{m} ⚡️"
                 parts.append(m)
         elif field in {"reasoning", "reasoning_effort"}:
-            effort = str(reasoning_effort or "").strip().lower()
+            effort = _reasoning_short(reasoning_effort)
             if effort:
-                parts.append(f"reasoning: {effort}")
+                parts.append(f"🧠 {effort}")
+        elif field in {"fast", "service_tier"}:
+            # With a model field, Fast decorates the model (``gpt-5 ⚡️``) to
+            # avoid spending a full footer segment on one icon.  Without a
+            # model field, keep the icon useful as a standalone segment.
+            if fast_mode and not model_requested:
+                parts.append("⚡️")
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -129,11 +171,15 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "dir":
+            short = _cwd_short(cwd or os.environ.get("TERMINAL_CWD", ""))
+            if short:
+                parts.append(short)
         # Unknown field names are silently ignored.
 
     if not parts:
         return ""
-    return _SEP.join(parts)
+    return separator.join(parts)
 
 
 def build_footer_line(
@@ -145,6 +191,7 @@ def build_footer_line(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    fast_mode: bool = False,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -161,5 +208,7 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         reasoning_effort=reasoning_effort,
+        fast_mode=fast_mode,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        separator=cfg.get("separator", _DEFAULT_SEPARATOR),
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,44 +1,66 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
-to keep replies minimal.
+Renders a compact footer showing runtime state (model, reasoning effort,
+context %, cwd) and appends it to the FINAL message of an agent turn when
+enabled.  Off by default to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, context_pct, cwd]
+        separator: " · "
 
 Available fields:
-    model        — bare model id, vendor prefix dropped (``gpt-5.4``)
-    context_pct  — last-call context occupancy as a percent (``5%``)
-    latency      — wall-clock duration of the turn (``22s``, ``1m05s``)
-    cwd          — home-relative working dir (``~``)
+    model             — bare model id, vendor prefix dropped (``gpt-5.4``)
+    reasoning_effort  — session-configured reasoning level (``high``)
+    fast              — Priority / Fast indicator (``⚡️``) when it was applied
+    context_pct       — last-call context occupancy as a percent (``5%``)
+    latency           — wall-clock duration of the turn (``22s``, ``1m05s``)
+    cwd               — home-relative working dir (``~/projects/hermes``)
+    dir               — compact current-directory name (``hermes``)
 
-``latency`` is opt-in: it is NOT in the default field set, so a footer whose
-``fields`` are unset renders exactly as before.
+``reasoning_effort``, ``fast``, ``latency``, and ``dir`` are opt-in: they are
+NOT in the default field set, so a footer whose ``fields`` are unset renders
+exactly as before.
 
-Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
-Users can toggle the global setting with ``/footer on|off`` from both the CLI
-and any gateway platform.
-
-The footer is appended to the final response text in ``gateway/run.py`` right
-before returning the response to the adapter send path — so it only lands on
-the final message a user sees, not on tool-progress updates or streaming
-partials.  When streaming is on and the final text has already been delivered
-piecemeal, the footer is sent as a separate trailing message via
-``send_trailing_footer()``.
+Credits warning: a second line ``💸 consuming credits`` is added only when
+the *effective* provider is a usage-metered API-key route. Subscription /
+OAuth / Copilot providers (the catalog Accounts tab) stay quiet even when
+they share a metered hostname such as ``api.x.ai``.
 """
 
 from __future__ import annotations
 
 import os
 from typing import Any, Iterable, Optional
+from urllib.parse import urlparse
+
+from utils import base_url_host_matches
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
-_SEP = " · "
+_DEFAULT_SEPARATOR = " · "
+_CREDIT_WARNING = "💸 consuming credits"
+
+# Host fallback for unknown / custom OpenAI-compatible endpoints only.
+# Never used to override a catalog Accounts (OAuth/subscription) slug.
+_METERED_PROVIDER_HOSTS = (
+    "openrouter.ai",
+    "api.openai.com",
+    "api.anthropic.com",
+    "api.x.ai",
+    "api.deepseek.com",
+    "api.groq.com",
+    "api.mistral.ai",
+    "api.together.ai",
+    "api.together.xyz",
+    "fireworks.ai",
+    "perplexity.ai",
+    "generativelanguage.googleapis.com",
+    "api.cohere.com",
+    "api.deepinfra.com",
+)
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -55,11 +77,130 @@ def _home_relative_cwd(cwd: str) -> str:
         return cwd
 
 
+def _cwd_short(cwd: str) -> str:
+    """Return only the current directory name for compact footers."""
+    rel = _home_relative_cwd(cwd)
+    if rel in {"", "~", os.sep}:
+        return rel
+    return os.path.basename(rel.rstrip(os.sep)) or rel
+
+
 def _model_short(model: Optional[str]) -> str:
     """Drop ``vendor/`` prefix for readability (``openai/gpt-5.4`` → ``gpt-5.4``)."""
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _normalize_provider(provider: Optional[str]) -> str:
+    return str(provider or "").strip().lower().replace("_", "-")
+
+
+def _is_loopback_url(base_url: Optional[str]) -> bool:
+    url = str(base_url or "").strip()
+    if not url:
+        return False
+    host = (urlparse(url).hostname or "").lower()
+    return host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+
+
+def _catalog_tab(provider: Optional[str]) -> Optional[str]:
+    """Return the provider catalog tab (``accounts``|``keys``) or None."""
+    slug = _normalize_provider(provider)
+    if not slug:
+        return None
+    try:
+        from hermes_cli.provider_catalog import provider_catalog_by_slug
+
+        desc = provider_catalog_by_slug().get(slug)
+    except Exception:
+        return None
+    return getattr(desc, "tab", None) if desc else None
+
+
+def provider_consumes_credits(
+    provider: Optional[str],
+    base_url: Optional[str] = None,
+) -> bool:
+    """Return whether the effective backend is a usage-metered API-key route.
+
+    Classification follows Hermes' provider catalog so new OAuth plugins
+    (``auth_type`` → Accounts tab) and new API-key plugins inherit the
+    correct footer behaviour without a footer edit. Catalog Accounts always
+    win over host matching — xAI OAuth and xAI API keys share ``api.x.ai``.
+    """
+    tab = _catalog_tab(provider)
+    if tab == "accounts":
+        return False
+    if _is_loopback_url(base_url):
+        return False
+    if tab == "keys":
+        return True
+    url = str(base_url or "")
+    return any(base_url_host_matches(url, host) for host in _METERED_PROVIDER_HOSTS)
+
+
+def reasoning_effort_label(reasoning_config: dict[str, Any] | None) -> str:
+    """Return the session-configured effort label used by the footer."""
+    if reasoning_config is None:
+        return "medium"
+    if not reasoning_config.get("enabled", True):
+        return "none"
+    return str(reasoning_config.get("effort") or "medium").strip().lower()
+
+
+def _reasoning_short(effort: Optional[str]) -> str:
+    """Return a compact, human-readable reasoning effort label."""
+    normalized = str(effort or "").strip().lower()
+    aliases = {
+        "minimal": "min",
+        "medium": "med",
+        "none": "off",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def outgoing_fast_applied(
+    *,
+    model: Optional[str],
+    provider: Optional[str],
+    requested: bool,
+) -> bool:
+    """Return whether Fast/Priority would survive onto the outgoing request.
+
+    Uses the same model gate as ``/fast`` (``resolve_fast_mode_overrides``)
+    and the same xAI strip as the Codex Responses transport: only the Grok
+    4.6 family keeps ``service_tier=priority``. New Fast-eligible models
+    inherit this automatically when that helper is updated.
+    """
+    if not requested:
+        return False
+    try:
+        from hermes_cli.models import resolve_fast_mode_overrides
+    except Exception:
+        return False
+    try:
+        overrides = resolve_fast_mode_overrides(model)
+    except Exception:
+        overrides = None
+    if not overrides:
+        return False
+
+    kwargs = dict(overrides)
+    slug = _normalize_provider(provider)
+    if slug in {"xai", "xai-oauth"}:
+        try:
+            from agent.model_metadata import is_grok_46_family
+
+            keep_priority = is_grok_46_family(str(model or "")) and (
+                kwargs.get("service_tier") == "priority"
+            )
+        except Exception:
+            keep_priority = False
+        if not keep_priority:
+            kwargs.pop("service_tier", None)
+
+    return kwargs.get("service_tier") == "priority" or kwargs.get("speed") == "fast"
 
 
 def resolve_footer_config(
@@ -73,7 +214,11 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved = {
+        "enabled": False,
+        "fields": list(_DEFAULT_FIELDS),
+        "separator": _DEFAULT_SEPARATOR,
+    }
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
@@ -82,6 +227,8 @@ def resolve_footer_config(
             resolved["enabled"] = bool(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        if isinstance(global_cfg.get("separator"), str):
+            resolved["separator"] = global_cfg["separator"]
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -93,6 +240,8 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                if isinstance(plat_footer.get("separator"), str):
+                    resolved["separator"] = plat_footer["separator"]
 
     return resolved
 
@@ -113,39 +262,59 @@ def format_runtime_footer(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
+    reasoning_effort: Optional[str] = None,
+    fast_mode: bool = False,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    separator: str = _DEFAULT_SEPARATOR,
 ) -> str:
-    """Render the footer line, or return "" if no fields have data.
+    """Render the footer line, or return \"\" if no fields have data.
 
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
     """
     parts: list[str] = []
-    for field in fields:
+    field_names = tuple(str(field) for field in fields)
+    fast_requested = any(field in {"fast", "service_tier"} for field in field_names)
+    model_requested = "model" in field_names
+
+    for field in field_names:
         if field == "model":
             m = _model_short(model)
             if m:
+                if fast_mode and fast_requested:
+                    m = f"{m} ⚡️"
                 parts.append(m)
+        elif field in {"reasoning", "reasoning_effort"}:
+            effort = _reasoning_short(reasoning_effort)
+            if effort:
+                parts.append(f"🧠 {effort}")
+        elif field in {"fast", "service_tier"}:
+            if fast_mode and not model_requested:
+                parts.append("⚡️")
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
                 parts.append(f"{pct}%")
         elif field == "latency":
-            # Wall-clock turn duration. Skipped when the caller supplied no
-            # timing (call sites that don't measure) or the value is negative.
             if turn_seconds is not None and turn_seconds >= 0:
                 parts.append(_format_latency(turn_seconds))
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
-        # Unknown field names are silently ignored.
+        elif field == "dir":
+            short = _cwd_short(cwd or os.environ.get("TERMINAL_CWD", ""))
+            if short:
+                parts.append(short)
 
-    if not parts:
-        return ""
-    return _SEP.join(parts)
+    footer = separator.join(parts)
+    if provider_consumes_credits(provider, base_url):
+        return f"{footer}\n{_CREDIT_WARNING}" if footer else _CREDIT_WARNING
+    return footer
 
 
 def build_footer_line(
@@ -155,8 +324,12 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
+    reasoning_effort: Optional[str] = None,
+    fast_mode: bool = False,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -175,7 +348,12 @@ def build_footer_line(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
+        provider=provider,
+        base_url=base_url,
         cwd=cwd,
         turn_seconds=turn_seconds,
+        reasoning_effort=reasoning_effort,
+        fast_mode=fast_mode,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        separator=cfg.get("separator", _DEFAULT_SEPARATOR),
     )

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -1,5 +1,9 @@
 """Tests for per-model reasoning_effort override in gateway _load_reasoning_config."""
 
+import ast
+import inspect
+import textwrap
+
 import pytest
 
 import gateway.run as gateway_run
@@ -82,3 +86,73 @@ class TestGatewaySessionEffectiveModel:
         assert result_default is not None
         assert result_default["effort"] == "low"
 
+    def test_resolve_session_reasoning_forwards_model(self, monkeypatch):
+        """_resolve_session_reasoning_config passes the effective model through
+        (and session-scoped /reasoning overrides still win over it)."""
+        fake_cfg = {
+            "model": {"default": "gpt-5"},
+            "agent": {
+                "reasoning_effort": "medium",
+                "reasoning_overrides": {"claude-opus-4.5": "xhigh"},
+            },
+        }
+        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: fake_cfg)
+
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner._session_reasoning_overrides = {}
+
+        # No session override → per-model override for the effective model.
+        result = runner._resolve_session_reasoning_config(
+            session_key="agent:main:telegram:private:1", model="claude-opus-4.5"
+        )
+        assert result is not None
+        assert result["effort"] == "xhigh"
+
+        # Session-scoped /reasoning override still wins over per-model.
+        runner._session_reasoning_overrides = {
+            "agent:main:telegram:private:1": {"enabled": True, "effort": "minimal"}
+        }
+        result = runner._resolve_session_reasoning_config(
+            session_key="agent:main:telegram:private:1", model="claude-opus-4.5"
+        )
+        assert result == {"enabled": True, "effort": "minimal"}
+
+    def test_runtime_footer_uses_agent_result_model(self):
+        """The footer must resolve reasoning for the turn's effective model.
+
+        The default and session models can have different reasoning overrides;
+        omitting ``model`` here would make the footer display the default
+        model's effort after a session-only ``/model`` switch.
+        """
+        tree = ast.parse(
+            textwrap.dedent(
+                inspect.getsource(gateway_run.GatewayRunner._handle_message_with_agent)
+            )
+        )
+
+        footer_resolver_calls = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(
+                isinstance(target, ast.Name)
+                and target.id == "_footer_reasoning_effort"
+                for target in node.targets
+            ):
+                continue
+            footer_resolver_calls.extend(
+                call
+                for call in ast.walk(node.value)
+                if isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "_resolve_session_reasoning_config"
+            )
+
+        assert len(footer_resolver_calls) == 1
+        model_keyword = next(
+            (kw.value for kw in footer_resolver_calls[0].keywords if kw.arg == "model"),
+            None,
+        )
+        assert ast.dump(model_keyword) == ast.dump(
+            ast.parse('agent_result.get("model")', mode="eval").body
+        )

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -188,3 +188,26 @@ class TestGatewaySessionEffectiveModel:
         assert ast.dump(source_keyword) == ast.dump(
             ast.parse("source", mode="eval").body
         )
+
+    def test_runtime_footer_uses_effective_provider_and_base_url(self):
+        """Credit warnings follow the backend that answered this turn."""
+        tree = ast.parse(
+            textwrap.dedent(
+                inspect.getsource(gateway_run.GatewayRunner._handle_message_with_agent)
+            )
+        )
+        footer_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_bfl"
+        ]
+        assert len(footer_calls) == 1
+        keywords = {kw.arg: kw.value for kw in footer_calls[0].keywords}
+        assert ast.dump(keywords["provider"]) == ast.dump(
+            ast.parse('agent_result.get("provider")', mode="eval").body
+        )
+        assert ast.dump(keywords["base_url"]) == ast.dump(
+            ast.parse('agent_result.get("base_url")', mode="eval").body
+        )

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -156,3 +156,35 @@ class TestGatewaySessionEffectiveModel:
         assert ast.dump(model_keyword) == ast.dump(
             ast.parse('agent_result.get("model")', mode="eval").body
         )
+
+    def test_runtime_footer_uses_session_service_tier(self):
+        """The fast icon follows the effective session-scoped /fast override."""
+        tree = ast.parse(
+            textwrap.dedent(
+                inspect.getsource(gateway_run.GatewayRunner._handle_message_with_agent)
+            )
+        )
+        footer_tier_calls = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(
+                isinstance(target, ast.Name) and target.id == "_footer_fast_mode"
+                for target in node.targets
+            ):
+                continue
+            footer_tier_calls.extend(
+                call
+                for call in ast.walk(node.value)
+                if isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "_resolve_session_service_tier"
+            )
+        assert len(footer_tier_calls) == 1
+        source_keyword = next(
+            (kw.value for kw in footer_tier_calls[0].keywords if kw.arg == "source"),
+            None,
+        )
+        assert ast.dump(source_keyword) == ast.dump(
+            ast.parse("source", mode="eval").body
+        )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -14,6 +14,7 @@ from gateway.runtime_footer import (
     _reasoning_short,
     build_footer_line,
     format_runtime_footer,
+    provider_consumes_credits,
     reasoning_effort_label,
     resolve_footer_config,
 )
@@ -162,6 +163,48 @@ def test_format_footer_fast_standalone_without_model_field():
         separator=" • ",
     )
     assert out == "⚡️ • 37%"
+
+
+@pytest.mark.parametrize(
+    "provider,base_url,expected",
+    [
+        ("openrouter", None, True),
+        ("openai", "https://openrouter.ai/api/v1", True),
+        ("openai", None, True),
+        ("anthropic", None, True),
+        ("openai-codex", None, False),
+        ("xai-oauth", None, False),
+        ("ollama", None, False),
+        (None, None, False),
+    ],
+)
+def test_provider_consumes_credits(provider, base_url, expected):
+    assert provider_consumes_credits(provider, base_url) is expected
+
+
+def test_format_footer_puts_metered_provider_warning_on_second_line():
+    out = format_runtime_footer(
+        model="gpt-5.6-sol",
+        provider="openrouter",
+        context_tokens=37,
+        context_length=100,
+        reasoning_effort="medium",
+        fields=("model", "reasoning_effort", "context_pct"),
+        separator=" • ",
+    )
+    assert out == "gpt-5.6-sol • 🧠 med • 37%\n💸 consuming credits"
+
+
+def test_format_footer_does_not_warn_for_codex_oauth():
+    out = format_runtime_footer(
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        context_tokens=37,
+        context_length=100,
+        fields=("model", "context_pct"),
+        separator=" • ",
+    )
+    assert out == "gpt-5.6-sol • 37%"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -8,8 +8,10 @@ import os
 import pytest
 
 from gateway.runtime_footer import (
+    _cwd_short,
     _home_relative_cwd,
     _model_short,
+    _reasoning_short,
     build_footer_line,
     format_runtime_footer,
     reasoning_effort_label,
@@ -41,6 +43,10 @@ def test_home_relative_cwd_collapses_home(tmp_path, monkeypatch):
     sub.mkdir(parents=True)
     result = _home_relative_cwd(str(sub))
     assert result == "~/projects/hermes"
+
+
+def test_cwd_short_returns_only_directory_name():
+    assert _cwd_short("/opt/data/repos/ai-life") == "ai-life"
 
 
 # ---------------------------------------------------------------------------
@@ -78,9 +84,11 @@ def test_format_footer_skips_missing_context_length():
 @pytest.mark.parametrize(
     "field,effort,expected",
     [
-        ("reasoning_effort", "high", "gpt-5.4 · reasoning: high"),
-        ("reasoning", "xhigh", "gpt-5.4 · reasoning: xhigh"),
-        ("reasoning_effort", "none", "gpt-5.4 · reasoning: none"),
+        ("reasoning_effort", "high", "gpt-5.4 · 🧠 high"),
+        ("reasoning", "xhigh", "gpt-5.4 · 🧠 xhigh"),
+        ("reasoning_effort", "medium", "gpt-5.4 · 🧠 med"),
+        ("reasoning_effort", "minimal", "gpt-5.4 · 🧠 min"),
+        ("reasoning_effort", "none", "gpt-5.4 · 🧠 off"),
         ("reasoning_effort", None, "gpt-5.4"),
     ],
 )
@@ -109,10 +117,56 @@ def test_reasoning_effort_label(config, expected):
     assert reasoning_effort_label(config) == expected
 
 
+@pytest.mark.parametrize(
+    "effort,expected",
+    [("minimal", "min"), ("medium", "med"), ("high", "high"), ("none", "off")],
+)
+def test_reasoning_short(effort, expected):
+    assert _reasoning_short(effort) == expected
+
+
+def test_format_footer_compact_style_with_fast():
+    out = format_runtime_footer(
+        model="openai-codex/gpt-5.6-sol",
+        context_tokens=37,
+        context_length=100,
+        cwd="/opt/data/repos/ai-life",
+        reasoning_effort="medium",
+        fast_mode=True,
+        fields=("model", "reasoning_effort", "fast", "context_pct", "dir"),
+        separator=" • ",
+    )
+    assert out == "gpt-5.6-sol ⚡️ • 🧠 med • 37% • ai-life"
+
+
+def test_format_footer_fast_field_hidden_when_normal():
+    out = format_runtime_footer(
+        model="gpt-5.6-sol",
+        context_tokens=37,
+        context_length=100,
+        reasoning_effort="low",
+        fast_mode=False,
+        fields=("model", "reasoning_effort", "fast", "context_pct"),
+        separator=" • ",
+    )
+    assert out == "gpt-5.6-sol • 🧠 low • 37%"
+
+
+def test_format_footer_fast_standalone_without_model_field():
+    out = format_runtime_footer(
+        model="gpt-5.6-sol",
+        context_tokens=37,
+        context_length=100,
+        fast_mode=True,
+        fields=("fast", "context_pct"),
+        separator=" • ",
+    )
+    assert out == "⚡️ • 37%"
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
-
 
 def test_resolve_platform_override_wins():
     user = {
@@ -144,6 +198,19 @@ def test_resolve_platform_can_add_fields_only():
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]
+
+
+def test_resolve_platform_can_override_separator():
+    user = {
+        "display": {
+            "runtime_footer": {"enabled": True, "separator": " • "},
+            "platforms": {
+                "slack": {"runtime_footer": {"separator": " | "}},
+            },
+        },
+    }
+    assert resolve_footer_config(user, "telegram")["separator"] == " • "
+    assert resolve_footer_config(user, "slack")["separator"] == " | "
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -12,6 +12,7 @@ from gateway.runtime_footer import (
     _model_short,
     build_footer_line,
     format_runtime_footer,
+    reasoning_effort_label,
     resolve_footer_config,
 )
 
@@ -72,6 +73,40 @@ def test_format_footer_skips_missing_context_length():
     assert "%" not in out
     assert "gpt-5.4" in out
     assert "/tmp/wd" in out
+
+
+@pytest.mark.parametrize(
+    "field,effort,expected",
+    [
+        ("reasoning_effort", "high", "gpt-5.4 · reasoning: high"),
+        ("reasoning", "xhigh", "gpt-5.4 · reasoning: xhigh"),
+        ("reasoning_effort", "none", "gpt-5.4 · reasoning: none"),
+        ("reasoning_effort", None, "gpt-5.4"),
+    ],
+)
+def test_format_footer_reasoning_effort(field, effort, expected):
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=100,
+        cwd="",
+        reasoning_effort=effort,
+        fields=("model", field),
+    )
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        (None, "medium"),
+        ({"enabled": False, "effort": "high"}, "none"),
+        ({"enabled": True, "effort": "XHIGH"}, "xhigh"),
+        ({"enabled": True}, "medium"),
+    ],
+)
+def test_reasoning_effort_label(config, expected):
+    assert reasoning_effort_label(config) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -10,8 +10,12 @@ import pytest
 from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
+    _reasoning_short,
     build_footer_line,
     format_runtime_footer,
+    outgoing_fast_applied,
+    provider_consumes_credits,
+    reasoning_effort_label,
     resolve_footer_config,
 )
 
@@ -317,3 +321,181 @@ def test_default_build_footer_line_ignores_turn_seconds(monkeypatch):
     with_timing = build_footer_line(**common, turn_seconds=125.0)
     assert baseline == "gpt-5.4 · 5% · /var/data"
     assert with_timing == baseline
+
+
+# ---------------------------------------------------------------------------
+# Credits: catalog Accounts wins over metered hosts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider,base_url,expected",
+    [
+        ("openrouter", None, True),
+        ("openai", "https://openrouter.ai/api/v1", True),
+        ("xai", "https://api.x.ai/v1", True),
+        ("xai-oauth", "https://api.x.ai/v1", False),
+        ("xai-oauth", None, False),
+        ("openai-codex", "https://api.openai.com/v1", False),
+        ("nous", None, False),
+        ("qwen-oauth", "https://portal.qwen.ai/v1", False),
+        ("minimax-oauth", None, False),
+        ("ollama", "http://127.0.0.1:11434/v1", False),
+        (None, None, False),
+    ],
+)
+def test_provider_consumes_credits_follows_catalog(provider, base_url, expected):
+    assert provider_consumes_credits(provider, base_url) is expected
+
+
+def test_format_footer_does_not_warn_for_xai_oauth_on_api_host():
+    out = format_runtime_footer(
+        model="grok-4.6",
+        provider="xai-oauth",
+        base_url="https://api.x.ai/v1",
+        context_tokens=10,
+        context_length=100,
+        fields=("model", "context_pct"),
+    )
+    assert out == "grok-4.6 · 10%"
+    assert "consuming credits" not in out
+
+
+def test_format_footer_warns_for_xai_api_key_on_same_host():
+    out = format_runtime_footer(
+        model="grok-4.6",
+        provider="xai",
+        base_url="https://api.x.ai/v1",
+        context_tokens=10,
+        context_length=100,
+        fields=("model", "context_pct"),
+    )
+    assert out == "grok-4.6 · 10%\n💸 consuming credits"
+
+
+def test_format_footer_warns_for_openrouter():
+    out = format_runtime_footer(
+        model="gpt-5.6-sol",
+        provider="openrouter",
+        context_tokens=37,
+        context_length=100,
+        reasoning_effort="medium",
+        fields=("model", "reasoning_effort", "context_pct"),
+        separator=" • ",
+    )
+    assert out == "gpt-5.6-sol • 🧠 med • 37%\n💸 consuming credits"
+
+
+# ---------------------------------------------------------------------------
+# Reasoning + Fast fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field,effort,expected",
+    [
+        ("reasoning_effort", "high", "gpt-5.4 · 🧠 high"),
+        ("reasoning", "xhigh", "gpt-5.4 · 🧠 xhigh"),
+        ("reasoning_effort", "medium", "gpt-5.4 · 🧠 med"),
+        ("reasoning_effort", "minimal", "gpt-5.4 · 🧠 min"),
+        ("reasoning_effort", "none", "gpt-5.4 · 🧠 off"),
+        ("reasoning_effort", None, "gpt-5.4"),
+    ],
+)
+def test_format_footer_reasoning_effort(field, effort, expected):
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=100,
+        cwd="",
+        reasoning_effort=effort,
+        fields=("model", field),
+    )
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        (None, "medium"),
+        ({"enabled": False, "effort": "high"}, "none"),
+        ({"enabled": True, "effort": "XHIGH"}, "xhigh"),
+        ({"enabled": True}, "medium"),
+    ],
+)
+def test_reasoning_effort_label(config, expected):
+    assert reasoning_effort_label(config) == expected
+
+
+def test_reasoning_short():
+    assert _reasoning_short("minimal") == "min"
+    assert _reasoning_short("medium") == "med"
+    assert _reasoning_short("high") == "high"
+
+
+def test_format_footer_fast_decorates_model_when_applied():
+    out = format_runtime_footer(
+        model="openai-codex/gpt-5.6-sol",
+        context_tokens=37,
+        context_length=100,
+        cwd="/opt/data/repos/ai-life",
+        reasoning_effort="medium",
+        fast_mode=True,
+        fields=("model", "reasoning_effort", "fast", "context_pct", "dir"),
+        separator=" • ",
+    )
+    assert out == "gpt-5.6-sol ⚡️ • 🧠 med • 37% • ai-life"
+
+
+def test_format_footer_fast_hidden_when_not_applied():
+    out = format_runtime_footer(
+        model="gpt-5.6-sol",
+        context_tokens=37,
+        context_length=100,
+        reasoning_effort="low",
+        fast_mode=False,
+        fields=("model", "reasoning_effort", "fast", "context_pct"),
+        separator=" • ",
+    )
+    assert out == "gpt-5.6-sol • 🧠 low • 37%"
+
+
+def test_outgoing_fast_sol_when_requested():
+    assert outgoing_fast_applied(
+        model="gpt-5.6-sol", provider="openai-codex", requested=True
+    ) is True
+
+
+def test_outgoing_fast_not_applied_when_not_requested():
+    assert outgoing_fast_applied(
+        model="gpt-5.6-sol", provider="openai-codex", requested=False
+    ) is False
+
+
+def test_outgoing_fast_grok46_keeps_priority():
+    assert outgoing_fast_applied(
+        model="grok-4.6", provider="xai-oauth", requested=True
+    ) is True
+
+
+def test_outgoing_fast_older_grok_stripped():
+    assert outgoing_fast_applied(
+        model="grok-4.5", provider="xai-oauth", requested=True
+    ) is False
+
+
+def test_format_footer_grok_oauth_stale_fast_uses_effective_bit():
+    out = format_runtime_footer(
+        model="grok-4.5",
+        provider="xai-oauth",
+        base_url="https://api.x.ai/v1",
+        context_tokens=40,
+        context_length=100,
+        reasoning_effort="high",
+        fast_mode=outgoing_fast_applied(
+            model="grok-4.5", provider="xai-oauth", requested=True
+        ),
+        fields=("model", "reasoning_effort", "fast", "context_pct"),
+        separator=" • ",
+    )
+    assert out == "grok-4.5 • 🧠 high • 40%"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1703,6 +1703,8 @@ Focus view is **display-only**. It never edits conversation history, the system 
 
 When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer can show the model, session-configured reasoning-effort level, Priority Processing state, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance. The `reasoning_effort` field follows session-scoped `/reasoning` overrides as well as the global setting; `reasoning` is accepted as a shorter alias. The optional `fast` field decorates the model with `⚡️` only while Priority Processing is effective for that session (or renders standalone when the model field is hidden). Provider-specific clamping may still adjust the value sent to a model.
 
+When the effective provider or base URL is a known usage-metered API, Hermes automatically adds a second line, `💸 consuming credits`. The warning follows the backend that actually answered the turn—including fallback routing—rather than trusting the visible model name. Subscription/OAuth and local routes such as `openai-codex`, `xai-oauth`, and `ollama` do not trigger it.
+
 ```yaml
 display:
   runtime_footer:
@@ -1718,6 +1720,13 @@ Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
 gpt-5.6-sol ⚡️ • 🧠 med • 42% • hermes
+```
+
+With a usage-metered backend:
+
+```
+gpt-5.6-sol • 🧠 med • 42% • hermes
+💸 consuming credits
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1701,13 +1701,14 @@ Focus view is **display-only**. It never edits conversation history, the system 
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer can show the model, session-configured reasoning-effort level, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance. The `reasoning_effort` field follows session-scoped `/reasoning` overrides as well as the global setting; `reasoning` is accepted as a shorter alias. Provider-specific clamping may still adjust the value sent to a model.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # supported fields: model, context_pct, cwd
+    fields: ["model", "reasoning_effort", "context_pct", "cwd"]
+    # supported: model, reasoning_effort (or reasoning), context_pct, cwd
 ```
 
 The `/footer` slash command toggles this at runtime in any session.
@@ -1715,7 +1716,7 @@ The `/footer` slash command toggles this at runtime in any session.
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+claude-opus-4.7 · reasoning: high · 42% · ~/projects/hermes
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1701,14 +1701,15 @@ Focus view is **display-only**. It never edits conversation history, the system 
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer can show the model, session-configured reasoning-effort level, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance. The `reasoning_effort` field follows session-scoped `/reasoning` overrides as well as the global setting; `reasoning` is accepted as a shorter alias. Provider-specific clamping may still adjust the value sent to a model.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer can show the model, session-configured reasoning-effort level, Priority Processing state, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance. The `reasoning_effort` field follows session-scoped `/reasoning` overrides as well as the global setting; `reasoning` is accepted as a shorter alias. The optional `fast` field decorates the model with `⚡️` only while Priority Processing is effective for that session (or renders standalone when the model field is hidden). Provider-specific clamping may still adjust the value sent to a model.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "reasoning_effort", "context_pct", "cwd"]
-    # supported: model, reasoning_effort (or reasoning), context_pct, cwd
+    fields: ["model", "reasoning_effort", "fast", "context_pct", "dir"]
+    separator: " • "
+    # supported: model, reasoning_effort (or reasoning), fast, context_pct, cwd, dir
 ```
 
 The `/footer` slash command toggles this at runtime in any session.
@@ -1716,7 +1717,7 @@ The `/footer` slash command toggles this at runtime in any session.
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-claude-opus-4.7 · reasoning: high · 42% · ~/projects/hermes
+gpt-5.6-sol ⚡️ • 🧠 med • 42% • hermes
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1851,32 +1851,44 @@ Focus view is **display-only**. It never edits conversation history, the system 
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer reports the *effective* turn: the model that answered, whether Fast/Priority actually went out on the wire, and a `💸 consuming credits` line only for usage-metered API-key routes. Subscription/OAuth providers (the same Accounts tab as `hermes model`) stay quiet even when they share a metered hostname such as `api.x.ai`. Off by default.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # order shown; drop any to hide
+    fields: ["model", "reasoning_effort", "fast", "context_pct", "dir"]
+    separator: " • "
 ```
 
 Supported fields:
 
 | Field | Renders | Example |
 | --- | --- | --- |
-| `model` | Bare model id, vendor prefix dropped | `gpt-5.4` |
+| `model` | Bare model id, vendor prefix dropped. Decorated with `⚡️` when Fast was applied | `gpt-5.6-sol ⚡️` |
+| `reasoning_effort` | Session-effective reasoning level | `🧠 high` |
+| `fast` | Standalone `⚡️` when the model field is hidden | `⚡️` |
 | `context_pct` | Last-call context occupancy as a percent | `5%` |
 | `latency` | Wall-clock duration of the turn | `22s`, `1m05s` |
-| `cwd` | Home-relative working directory | `~` |
+| `cwd` | Home-relative working directory | `~/projects/hermes` |
+| `dir` | Current directory name only | `hermes` |
 
-The default field set is `["model", "context_pct", "cwd"]`. `latency` is opt-in — add it to `fields` to use it. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
+The default field set is `["model", "context_pct", "cwd"]`. `reasoning_effort`, `fast`, `latency`, and `dir` are opt-in. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
+
+`💸 consuming credits` is not a field: it is added automatically when the effective provider is a catalog API-key route (OpenRouter, `xai`, `openai`, …). OAuth slugs such as `xai-oauth` and `openai-codex` never trigger it. Fast/Priority is shown only when `/fast` is on *and* the same helper that builds request overrides would still send `service_tier`/`speed` after provider-specific stripping (for example older Grok models drop it; Grok 4.6 keeps it).
 
 The `/footer` slash command toggles this at runtime in any session.
 
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+gpt-5.6-sol ⚡️ • 🧠 high • 12% • ai-life
+```
+
+OAuth Grok 4.5 with a leftover Fast toggle:
+
+```
+grok-4.5 • 🧠 high • 12% • ai-life
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.


### PR DESCRIPTION
## Summary

- derive `💸 consuming credits` from the provider catalog Accounts/Keys tab, not a hardcoded slug/host race
- keep OAuth/subscription routes (`xai-oauth`, `openai-codex`, `qwen-oauth`, `minimax-oauth`, `nous`, Copilot, and any new `auth_type=oauth_*` plugin) quiet even when they share a metered hostname such as `api.x.ai`
- still warn for API-key routes on the same host (`xai`, `openai`, `openrouter`)
- add opt-in footer fields `reasoning_effort`, `fast`, and `dir`, plus a configurable separator
- show `⚡️` only when `/fast` is on **and** `resolve_fast_mode_overrides` plus the same xAI strip as the Codex transport would still send `service_tier`/`speed`
- Grok 4.6 keeps Priority; older Grok models drop it. Switching model/provider mid-session cannot leave a stale bolt or a false credits line

## Why

The previous host-match treated `xai-oauth` as metered because SuperGrok and the xAI API key both use `api.x.ai`. A leftover `agent.service_tier: fast` from Codex also painted `⚡️` on providers that never sent Priority.

This follows Hermes' existing catalog so new OAuth plugins and new Fast-eligible models inherit the correct footer without another footer edit.

## Behavior

```yaml
display:
  runtime_footer:
    enabled: true
    fields: [model, reasoning_effort, fast, context_pct, dir]
    separator: " • "
```

Subscription/OAuth:

```text
grok-4.6 • 🧠 high • 12% • ai-life
```

OpenAI Fast applied:

```text
gpt-5.6-sol ⚡️ • 🧠 high • 12% • ai-life
```

Usage-metered API key, including OpenRouter:

```text
gpt-5.6-sol • 🧠 med • 34% • ai-life
💸 consuming credits
```

## Tests

```text
69 passed  tests/gateway/test_runtime_footer.py
```

## Related

Rebases #63812 onto current `main` and replaces the host-match heuristic with catalog + effective Fast.
