### PR TITLE
feat(discord): make command approvals understandable

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -126,6 +126,7 @@ from gateway.platforms.base import (
     validate_inbound_media_size,
 )
 from tools.url_safety import is_safe_url
+from tools.approval_summary import summarize_command_approval
 
 
 def _truncate_discord_component_text(text: str, limit: int) -> str:
@@ -5603,17 +5604,22 @@ class DiscordAdapter(BasePlatformAdapter):
             if len(reason_display) > reason_budget:
                 reason_display = reason_display[: reason_budget - 15] + "... [truncated]"
 
+            summary = summarize_command_approval(command, description)
+            summary_markdown = summary.to_markdown()
             prompt_prefix = (
-                "⚠️ **Command Approval Required**\n\n"
-                "Do you want Hermes to run this command?\n\n"
-                "**Requested command:**\n```bash\n"
+                "⚠️ **Approval needed**\n\n"
+                f"{summary_markdown}\n\n"
+                "**Technical details**\n```bash\n"
             )
             if smart_denied:
-                prompt_prefix += "**Smart DENY:** owner override applies to this one operation only.\n\n"
+                prompt_prefix = (
+                    "**Smart DENY:** an owner may override this one operation only.\n\n"
+                    + prompt_prefix
+                )
             mention_content = self._approval_mention_content()
             if mention_content:
                 prompt_prefix = f"{mention_content}\n{prompt_prefix}"
-            prompt_tail = f"\n```\n**Reason:** {reason_display}"
+            prompt_tail = f"\n```\n**Why Hermes paused:** {reason_display}"
             truncated_suffix = "\n... [truncated]"
             command_budget = max(0, self.MAX_MESSAGE_LENGTH - len(prompt_prefix) - len(prompt_tail))
             content_cmd_display = str(command or "")
@@ -5628,14 +5634,21 @@ class DiscordAdapter(BasePlatformAdapter):
             # for clients where embeds render correctly.
             max_embed_desc = 4088
             embed_cmd_display = str(command or "")
-            if len(embed_cmd_display) > max_embed_desc:
-                embed_cmd_display = embed_cmd_display[: max_embed_desc - 3] + "..."
+            technical_prefix = f"{summary_markdown}\n\n**Technical details**\n```bash\n"
+            technical_tail = "\n```"
+            embed_command_budget = max(
+                0, max_embed_desc - len(technical_prefix) - len(technical_tail)
+            )
+            if len(embed_cmd_display) > embed_command_budget:
+                embed_cmd_display = (
+                    embed_cmd_display[: max(0, embed_command_budget - 3)] + "..."
+                )
             embed = discord.Embed(
-                title="⚠️ Command Approval Required",
-                description=f"```\n{embed_cmd_display}\n```",
+                title=f"⚠️ Approval needed — {summary.risk_level.upper()} risk",
+                description=f"{technical_prefix}{embed_cmd_display}{technical_tail}",
                 color=discord.Color.orange(),
             )
-            embed.add_field(name="Reason", value=reason_display, inline=False)
+            embed.add_field(name="Why Hermes paused", value=reason_display, inline=False)
 
             require_admin, admin_user_ids = _resolve_exec_approval_admin_gate(
                 getattr(self.config, "extra", None)
@@ -5646,7 +5659,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
                 require_admin=require_admin,
                 admin_user_ids=admin_user_ids,
-                allow_permanent=allow_permanent,
+                allow_session=not summary.once_only,
+                allow_permanent=allow_permanent and not summary.once_only,
                 smart_denied=smart_denied,
             )
 
@@ -6829,7 +6843,9 @@ def _define_discord_view_classes() -> None:
         """
         Interactive button view for exec approval of dangerous commands.
 
-        Shows four buttons: Allow Once, Allow Session, Always Allow, Deny.
+        Shows Allow Once and Deny for every request. Session/permanent choices
+        are shown only when the approval scope is narrow enough; broad inline,
+        destructive, or unknown operations are intentionally one-time only.
         Clicking a button calls ``resolve_gateway_approval()`` to unblock the
         waiting agent thread — the same mechanism as the text ``/approve`` flow.
         Only users in the allowed list can click.  Times out after 5 minutes.
@@ -6842,6 +6858,7 @@ def _define_discord_view_classes() -> None:
             allowed_role_ids: Optional[set] = None,
             require_admin: bool = False,
             admin_user_ids: Optional[set] = None,
+            allow_session: bool = True,
             allow_permanent: bool = True,
             smart_denied: bool = False,
         ):
@@ -6857,11 +6874,24 @@ def _define_discord_view_classes() -> None:
                 str(a).strip() for a in (admin_user_ids or set()) if str(a).strip()
             }
             self.resolved = False
+            self.allow_session_scope = allow_session
+            self.allow_permanent_scope = allow_permanent
+
+            def _remove_button(item) -> None:
+                remove_item = getattr(self, "remove_item", None)
+                if callable(remove_item):
+                    remove_item(item)
+                elif item in self.children:  # lightweight gateway test double
+                    self.children.remove(item)
+
             if smart_denied:
-                self.remove_item(self.allow_session)
-                self.remove_item(self.allow_always)
-            elif not allow_permanent:
-                self.remove_item(self.allow_always)
+                _remove_button(self.allow_session)
+                _remove_button(self.allow_always)
+            else:
+                if not allow_session:
+                    _remove_button(self.allow_session)
+                if not allow_permanent:
+                    _remove_button(self.allow_always)
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             """Verify the user clicking is authorized.

--- a/tests/gateway/test_discord_approval_mentions.py
+++ b/tests/gateway/test_discord_approval_mentions.py
@@ -46,11 +46,12 @@ async def test_exec_approval_mentions_allowed_users_when_enabled(monkeypatch):
     )
 
     assert result.success is True
+    assert channel.sent_kwargs is not None
     # Mentions are prepended to the (always present) content mirror.
     assert channel.sent_kwargs["content"].startswith("<@111> <@222>\n")
     assert "make check" in channel.sent_kwargs["content"]
     assert "allowed_mentions" in channel.sent_kwargs
-    assert channel.sent_kwargs["embed"].title.endswith("Command Approval Required")
+    assert "Approval needed" in channel.sent_kwargs["embed"].title
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_exec_approval_content.py
+++ b/tests/gateway/test_discord_exec_approval_content.py
@@ -40,12 +40,18 @@ async def test_exec_approval_prompt_uses_visible_content_with_command_and_reason
     assert sent["embed"] is not None
 
     prompt_text = sent["content"]
-    assert "Command Approval Required" in prompt_text
-    assert "Do you want Hermes to run this command?" in prompt_text
-    assert "Requested command" in prompt_text
+    assert "Approval needed" in prompt_text
+    assert "What Hermes wants to do" in prompt_text
+    assert "deployment" in prompt_text
+    assert "Risk: 🔴 HIGH" in prompt_text
+    assert "Approval scope" in prompt_text
+    assert "Technical details" in prompt_text
     assert command in prompt_text
-    assert "Reason" in prompt_text
+    assert "Why Hermes paused" in prompt_text
     assert "script execution via -c flag" in prompt_text
+
+    assert sent["view"].allow_session_scope is False
+    assert sent["view"].allow_permanent_scope is False
 
 
 @pytest.mark.asyncio
@@ -65,4 +71,4 @@ async def test_exec_approval_prompt_truncates_long_command_in_content():
     assert len(sent["content"]) <= adapter.MAX_MESSAGE_LENGTH
     assert "... [truncated]" in sent["content"]
     assert "long generated shell command" in sent["content"]
-    assert len(sent["embed"].description) > len(sent["content"])
+    assert "What Hermes wants to do" in sent["embed"].description

--- a/tests/tools/test_approval_summary.py
+++ b/tests/tools/test_approval_summary.py
@@ -1,0 +1,46 @@
+from tools.approval_summary import summarize_command_approval
+
+
+ODOO_EXPORT_COMMAND = r'''python3 -c '
+import zipfile, json, sys, collections
+p=sys.argv[1]
+with zipfile.ZipFile(p) as z:
+    names=z.namelist()
+    print(json.dumps(names[:20]))
+    print(z.read("manifest.json").decode("utf-8", "replace")[:12000])
+' /Users/example/.hermes/cache/documents/odoo-export.zip'''
+
+
+def test_inline_zip_inspection_explains_data_access_and_model_exposure():
+    summary = summarize_command_approval(
+        ODOO_EXPORT_COMMAND,
+        "script execution via -e/-c flag",
+    )
+
+    assert summary.risk_level == "medium"
+    assert "ZIP archive" in summary.purpose
+    assert any("Reads" in item and "odoo-export.zip" in item for item in summary.effects)
+    assert any("not modify or delete" in item for item in summary.effects)
+    assert any("model context" in item for item in summary.effects)
+    assert "later inline scripts" in summary.session_scope
+    assert summary.once_only is True
+
+
+def test_recursive_delete_is_high_risk_and_does_not_claim_reversibility():
+    summary = summarize_command_approval(
+        "rm -rf /Users/example/project/build",
+        "recursive delete",
+    )
+
+    assert summary.risk_level == "high"
+    assert "Delete" in summary.purpose
+    assert any("permanently" in item for item in summary.effects)
+    assert summary.once_only is True
+
+
+def test_unknown_command_uses_cautious_language():
+    summary = summarize_command_approval("custom-tool --flag", "dangerous command")
+
+    assert summary.risk_level == "medium"
+    assert "could not be determined" in summary.effects[0]
+    assert "matching this safety rule" in summary.session_scope

--- a/tools/approval_summary.py
+++ b/tools/approval_summary.py
@@ -1,0 +1,195 @@
+"""Plain-language explanations for command approval prompts.
+
+The approval guard's regex description explains *why the guard fired*, not what
+running the command means for a person.  This module adds a conservative,
+deterministic explanation without asking another model to judge the command.
+It deliberately says "visible"/"detected" instead of promising safety: shell
+commands and inline programs can compute behavior dynamically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import shlex
+
+
+_INLINE_SCRIPT_RE = re.compile(r"\b(?:python[23]?|node|ruby|perl)\s+-[^\s]*[ec](?:\s|$)", re.I)
+_DELETE_RE = re.compile(
+    r"(?:\brm\s+[^\n]*(?:-[^\s]*r[^\s]*f|-[^\s]*f[^\s]*r)|"
+    r"\b(?:unlink|rmdir)\b|shutil\.rmtree\s*\(|\.unlink\s*\()",
+    re.I,
+)
+_WRITE_RE = re.compile(
+    r"(?:\.write(?:_text|_bytes)?\s*\(|\bwritelines?\s*\(|"
+    r"open\s*\([^\n]{0,240},\s*['\"](?:w|a|x|r\+)|"
+    r"\b(?:mv|cp|install)\s+|(?:^|\s)>{1,2}\s*\S)",
+    re.I,
+)
+_READ_RE = re.compile(
+    r"(?:\.read(?:_text|_bytes)?\s*\(|\bopen\s*\(|\bcat\s+|"
+    r"zipfile|namelist\s*\(|json\.loads?\s*\()",
+    re.I,
+)
+_NETWORK_RE = re.compile(
+    r"(?:\b(?:curl|wget|ssh|scp|rsync)\b|https?://|"
+    r"\b(?:requests|httpx|urllib|socket)\s*\.|urlopen\s*\()",
+    re.I,
+)
+_OUTPUT_RE = re.compile(r"(?:\bprint\s*\(|\bcat\s+|\b(?:head|tail)\s+)", re.I)
+_PRIVILEGED_RE = re.compile(r"(?:^|\s)sudo(?:\s|$)|\bchmod\s+777\b", re.I)
+_DEPLOY_RE = re.compile(r"\b(?:deploy|publish|release|kubectl\s+apply|terraform\s+apply)\b", re.I)
+
+
+@dataclass(frozen=True)
+class ApprovalSummary:
+    purpose: str
+    effects: tuple[str, ...]
+    risk_level: str
+    risk_reason: str
+    session_scope: str
+    recommendation: str
+    once_only: bool = False
+
+    def to_markdown(self) -> str:
+        """Render a compact explanation suitable for chat surfaces."""
+        icon = {"low": "🟢", "medium": "🟡", "high": "🔴"}.get(
+            self.risk_level, "🟡"
+        )
+        effects = "\n".join(f"- {effect}" for effect in self.effects)
+        return (
+            f"**What Hermes wants to do**\n{self.purpose}\n\n"
+            f"**Access and effects**\n{effects}\n\n"
+            f"**Risk: {icon} {self.risk_level.upper()}** — {self.risk_reason}\n\n"
+            f"**Approval scope**\n{self.session_scope}\n\n"
+            f"**Recommendation**\n{self.recommendation}"
+        )
+
+
+def _shell_paths(command: str) -> list[str]:
+    """Extract path-like shell arguments without treating code literals as paths."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = command.split()
+
+    paths: list[str] = []
+    for token in tokens:
+        candidate = token.strip()
+        if not (candidate.startswith("/") or candidate.startswith("~/")):
+            continue
+        # Inline program bodies are one large token and may contain newlines.
+        if "\n" in candidate or len(candidate) > 300:
+            continue
+        candidate = candidate.rstrip(",;)")
+        if candidate not in paths:
+            paths.append(candidate)
+    return paths[:3]
+
+
+def _session_scope(description: str, inline_script: bool) -> str:
+    description_lower = (description or "").lower()
+    if inline_script or "script execution via -e/-c" in description_lower:
+        return (
+            "“Allow for Session” would also pre-approve later inline scripts "
+            "(Python, Node, Ruby, or Perl) that match this rule—not just this command."
+        )
+    if "recursive delete" in description_lower:
+        return (
+            "“Allow for Session” would also pre-approve later recursive-delete "
+            "commands that match this rule—not just this path."
+        )
+    return (
+        "“Allow for Session” pre-approves later commands matching this safety "
+        "rule; it is broader than approving this exact command once."
+    )
+
+
+def summarize_command_approval(command: str, description: str = "dangerous command") -> ApprovalSummary:
+    """Return a cautious, non-technical explanation of a guarded command."""
+    command = str(command or "")
+    lower = command.lower()
+    inline_script = bool(_INLINE_SCRIPT_RE.search(command))
+    deletes = bool(_DELETE_RE.search(command))
+    writes = deletes or bool(_WRITE_RE.search(command))
+    reads = bool(_READ_RE.search(command))
+    network = bool(_NETWORK_RE.search(command))
+    privileged = bool(_PRIVILEGED_RE.search(command))
+    deploys = bool(_DEPLOY_RE.search(command))
+    emits_output = bool(_OUTPUT_RE.search(command))
+    zip_inspection = "zipfile" in lower and ("namelist(" in lower or ".read(" in lower)
+    paths = _shell_paths(command)
+
+    if zip_inspection:
+        purpose = "Inspect a ZIP archive and print selected file names and contents."
+    elif deletes:
+        purpose = "Delete files or directories on the execution environment."
+    elif deploys:
+        purpose = "Run a deployment, publishing, or release operation."
+    elif network:
+        purpose = "Contact another computer or network service."
+    elif inline_script:
+        purpose = "Run an inline program with the same system access as Hermes."
+    else:
+        purpose = "Run a command on Hermes’ configured execution environment."
+
+    effects: list[str] = []
+    shown_paths = ", ".join(f"`{path}`" for path in paths)
+    if deletes:
+        target = f" ({shown_paths})" if shown_paths else ""
+        effects.append(f"Can permanently delete data{target}; this may not be reversible.")
+    elif writes:
+        target = f" at {shown_paths}" if shown_paths else ""
+        effects.append(f"Can create or change files{target}.")
+    elif reads:
+        target = shown_paths or "files referenced by the program"
+        effects.append(f"Reads data from {target}.")
+        effects.append("The visible command does not modify or delete files.")
+    else:
+        effects.append(
+            "The concrete data access and side effects could not be determined from the visible command."
+        )
+
+    if reads and emits_output:
+        effects.append(
+            "Content written to command output can enter Hermes’ model context and session logs."
+        )
+    if network:
+        effects.append("The visible command can communicate over the network.")
+    elif inline_script:
+        effects.append("No network operation is visible, but inline code has broad capabilities.")
+    if privileged:
+        effects.append("It requests elevated system privileges.")
+
+    unknown = not any((reads, writes, network, deploys, privileged))
+    high = deletes or privileged or deploys
+    if high:
+        risk_level = "high"
+        risk_reason = "It can cause external, privileged, or hard-to-reverse changes."
+    elif reads and emits_output:
+        risk_level = "medium"
+        risk_reason = "No destructive change is visible, but file contents may be exposed to the AI context."
+    elif network or writes or inline_script or unknown:
+        risk_level = "medium"
+        risk_reason = "The operation has broad or incompletely determined effects."
+    else:
+        risk_level = "low"
+        risk_reason = "Only limited read-only effects are visible."
+
+    once_only = inline_script or high or unknown
+    recommendation = (
+        "Use “Allow Once” only if this purpose and data access are expected. "
+        "Otherwise deny it and ask Hermes for a safer or more limited approach."
+        if once_only or risk_level != "low"
+        else "Allow once if the described read-only access is expected."
+    )
+
+    return ApprovalSummary(
+        purpose=purpose,
+        effects=tuple(effects),
+        risk_level=risk_level,
+        risk_reason=risk_reason,
+        session_scope=_session_scope(description, inline_script),
+        recommendation=recommendation,
+        once_only=once_only,
+    )


### PR DESCRIPTION
## Problem

Discord command approvals currently present raw shell/Python code plus the guard's technical regex reason. Non-technical users cannot tell what data is accessed, what changes, or what “Allow Session” will authorize, so the prompt encourages blind approval rather than informed consent.

## Changes

- add a deterministic plain-language command explainer (no extra LLM/network call)
- show purpose, detected data access/effects, risk level, approval scope, and a recommendation before the raw command
- explicitly warn that printed file contents can enter model context and session logs
- keep the command available under **Technical details** for audit/technical review
- make broad inline, destructive, and unknown operations one-time-only in Discord by hiding session/permanent approval buttons
- preserve redaction, mention routing, smart-deny behavior, and Discord message limits

Example inline ZIP inspection is summarized as read-only but medium confidentiality risk, with `Allow Once` and `Deny` as the only choices.

## Verification

- `51 passed` across the new summary tests and Discord approval/component/lazy-install tests
- `ruff check` passes for all changed Python files
- standalone real-discord.py render verified a 1,163-character prompt with only `Allow Once` and `Deny`
