### PR TITLE
fix(cli): honor -s/--skills in oneshot (-z) mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -171,6 +171,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    skills: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -181,6 +182,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            skills=skills,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -10764,6 +10766,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            skills=getattr(args, "skills", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12368,6 +12371,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            skills=getattr(args, "skills", None),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -50,6 +50,68 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     return [item for item in normalized if item] or None
 
 
+def _build_oneshot_skills_prompt(skills: object = None) -> tuple[str, str | None]:
+    """Build the preloaded-skills system-prompt block for a oneshot run.
+
+    Mirrors the interactive CLI contract (cli.py main()): when at least one
+    requested skill loads, unknown entries are skipped with a stderr warning;
+    only when EVERY requested skill is missing does the run hard-fail, so a
+    fully-misconfigured caller fails loudly instead of running blind.
+
+    Returns (skills_prompt, fatal_error). fatal_error is a ready-to-print
+    stderr message; when set the caller should exit 2 without running.
+    """
+    try:
+        from cli import _parse_skills_argument
+    except Exception:
+        _parse_skills_argument = None
+
+    if _parse_skills_argument is not None:
+        parsed = _parse_skills_argument(skills)
+    else:  # very early bootstrap failure — fall back to a minimal parse
+        raw_items = [skills] if isinstance(skills, str) else (skills or [])
+        if not isinstance(raw_items, (list, tuple)):
+            raw_items = [raw_items]
+        parsed = []
+        seen: set[str] = set()
+        for item in raw_items:
+            for part in str(item).split(","):
+                name = part.strip()
+                if name and name not in seen:
+                    seen.add(name)
+                    parsed.append(name)
+
+    if not parsed:
+        return "", None
+
+    try:
+        from agent.skill_commands import build_preloaded_skills_prompt
+    except Exception as exc:
+        return "", f"hermes -z: failed to load --skills: {exc}\n"
+
+    skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
+        parsed,
+        task_id=None,
+    )
+    if missing_skills:
+        missing_display = ", ".join(missing_skills)
+        if loaded_skills:
+            # Same graceful degradation as interactive chat: a typo'd skill
+            # name must not kill the worker. Warn on stderr (pre-redirect)
+            # and continue with what loaded.
+            sys.stderr.write(
+                f"hermes -z: unknown --skills entries skipped: {missing_display}. "
+                f"Continuing with: {', '.join(loaded_skills)}.\n"
+            )
+        else:
+            return "", (
+                f"hermes -z: unknown --skills entries: {missing_display}. "
+                "List available skills with `hermes skills list`.\n"
+            )
+
+    return skills_prompt or "", None
+
+
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
@@ -173,6 +235,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    skills: object = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +250,9 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        skills: Optional comma-separated string or iterable of skills to
+            preload into the system prompt (same semantics as `hermes -s`
+            in interactive chat).
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -215,6 +281,14 @@ def run_oneshot(
         sys.stderr.write(toolsets_error)
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
+
+    # Resolve --skills BEFORE the stderr redirect so both the fatal
+    # "every skill missing" error and the partial-miss warning actually
+    # reach the terminal.
+    skills_prompt, skills_error = _build_oneshot_skills_prompt(skills)
+    if skills_error:
+        sys.stderr.write(skills_error)
+        return 2
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
     # definition — a prompt would hang forever.
@@ -248,6 +322,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    skills_prompt=skills_prompt,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -316,6 +391,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    skills_prompt: Optional[str] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -420,6 +496,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            ephemeral_system_prompt=skills_prompt or None,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -61,6 +61,9 @@ def _build_oneshot_skills_prompt(skills: object = None) -> tuple[str, str | None
     Returns (skills_prompt, fatal_error). fatal_error is a ready-to-print
     stderr message; when set the caller should exit 2 without running.
     """
+    if not skills:
+        return "", None
+
     try:
         from cli import _parse_skills_argument
     except Exception:

--- a/tests/hermes_cli/test_oneshot_skills.py
+++ b/tests/hermes_cli/test_oneshot_skills.py
@@ -1,0 +1,135 @@
+"""Tests for hermes -z --skills preloading (issue #31548).
+
+The oneshot path must honor -s/--skills with the same contract as
+interactive chat (cli.py main()):
+  - all requested skills load        -> prompt built, run proceeds
+  - SOME skills missing              -> warn on stderr, continue with loaded
+  - ALL requested skills missing     -> fatal error on stderr, exit 2
+  - no skills requested              -> no-op
+"""
+
+from unittest import mock
+
+import pytest
+
+from hermes_cli.oneshot import _build_oneshot_skills_prompt, run_oneshot
+
+
+def _patch_builder(monkeypatch, prompt, loaded, missing):
+    """Route the agent.skill_commands import to a stub module."""
+    import sys
+    import types
+
+    stub = types.ModuleType("agent.skill_commands")
+    calls = {}
+
+    def build_preloaded_skills_prompt(identifiers, task_id=None):
+        calls["identifiers"] = list(identifiers)
+        calls["task_id"] = task_id
+        return prompt, loaded, missing
+
+    stub.build_preloaded_skills_prompt = build_preloaded_skills_prompt
+    agent_pkg = sys.modules.get("agent") or types.ModuleType("agent")
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.skill_commands", stub)
+    return calls
+
+
+class TestBuildOneshotSkillsPrompt:
+    def test_no_skills_is_noop(self):
+        prompt, err = _build_oneshot_skills_prompt(None)
+        assert prompt == ""
+        assert err is None
+
+    def test_empty_entries_are_noop(self):
+        prompt, err = _build_oneshot_skills_prompt(" , ,")
+        assert prompt == ""
+        assert err is None
+
+    def test_all_loaded_returns_prompt(self, monkeypatch):
+        calls = _patch_builder(
+            monkeypatch, "SKILL PROMPT", ["github-operations"], []
+        )
+        prompt, err = _build_oneshot_skills_prompt("github-operations")
+        assert prompt == "SKILL PROMPT"
+        assert err is None
+        assert calls["identifiers"] == ["github-operations"]
+
+    def test_comma_and_repeat_flags_deduplicate(self, monkeypatch):
+        calls = _patch_builder(monkeypatch, "P", ["a", "b"], [])
+        prompt, err = _build_oneshot_skills_prompt(["a,b", "a"])
+        assert err is None
+        assert calls["identifiers"] == ["a", "b"]
+
+    def test_partial_missing_warns_and_continues(self, monkeypatch, capsys):
+        _patch_builder(monkeypatch, "PARTIAL PROMPT", ["real-skill"], ["typo-skill"])
+        prompt, err = _build_oneshot_skills_prompt("real-skill,typo-skill")
+        assert prompt == "PARTIAL PROMPT"
+        assert err is None  # NOT fatal — mirrors interactive chat
+        stderr = capsys.readouterr().err
+        assert "typo-skill" in stderr
+        assert "real-skill" in stderr
+
+    def test_all_missing_is_fatal(self, monkeypatch):
+        _patch_builder(monkeypatch, "", [], ["nope-1", "nope-2"])
+        prompt, err = _build_oneshot_skills_prompt("nope-1,nope-2")
+        assert prompt == ""
+        assert err is not None
+        assert "nope-1" in err
+        assert "nope-2" in err
+
+    def test_import_failure_is_fatal_not_silent(self, monkeypatch):
+        import sys
+
+        monkeypatch.setitem(sys.modules, "agent", None)
+        monkeypatch.setitem(sys.modules, "agent.skill_commands", None)
+        prompt, err = _build_oneshot_skills_prompt("anything")
+        assert prompt == ""
+        assert err is not None
+
+
+class TestRunOneshotSkillsWiring:
+    def test_all_missing_exits_2_before_agent(self, monkeypatch, capsys):
+        _patch_builder(monkeypatch, "", [], ["ghost"])
+        with mock.patch("hermes_cli.oneshot._run_agent") as agent:
+            rc = run_oneshot("hi", skills="ghost")
+        assert rc == 2
+        agent.assert_not_called()
+        assert "ghost" in capsys.readouterr().err
+
+    def test_skills_prompt_forwarded_to_run_agent(self, monkeypatch):
+        _patch_builder(monkeypatch, "THE PROMPT", ["real"], [])
+        with mock.patch(
+            "hermes_cli.oneshot._run_agent", return_value=("ok", {})
+        ) as agent:
+            rc = run_oneshot("hi", skills="real")
+        assert rc == 0
+        assert agent.call_args.kwargs["skills_prompt"] == "THE PROMPT"
+
+    def test_no_skills_forwards_empty_prompt(self):
+        with mock.patch(
+            "hermes_cli.oneshot._run_agent", return_value=("ok", {})
+        ) as agent:
+            rc = run_oneshot("hi")
+        assert rc == 0
+        assert agent.call_args.kwargs["skills_prompt"] == ""
+
+    def test_partial_missing_still_runs(self, monkeypatch, capsys):
+        _patch_builder(monkeypatch, "PARTIAL", ["real"], ["typo"])
+        with mock.patch(
+            "hermes_cli.oneshot._run_agent", return_value=("ok", {})
+        ) as agent:
+            rc = run_oneshot("hi", skills="real,typo")
+        assert rc == 0
+        assert agent.call_args.kwargs["skills_prompt"] == "PARTIAL"
+        assert "typo" in capsys.readouterr().err
+
+    def test_current_run_agent_contract_tuple(self):
+        # Guard the (response, result) return contract this fix relies on —
+        # a fake agent asserting the old str-only contract regressed PR #31591.
+        with mock.patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=("final text", {"api_calls": 1}),
+        ):
+            rc = run_oneshot("hi")
+        assert rc == 0

--- a/tests/hermes_cli/test_oneshot_skills.py
+++ b/tests/hermes_cli/test_oneshot_skills.py
@@ -133,3 +133,105 @@ class TestRunOneshotSkillsWiring:
         ):
             rc = run_oneshot("hi")
         assert rc == 0
+
+
+SENTINEL = "ONESHOT-SKILLS-E2E-SENTINEL-31548 use the frobnicate protocol"
+
+
+def _make_real_skill(hermes_home, name, body_sentinel=SENTINEL):
+    """Write a real SKILL.md under <hermes_home>/skills/<name>/."""
+    skill_dir = hermes_home / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""\
+---
+name: {name}
+description: Integration regression fixture for issue #31548.
+---
+
+# {name}
+
+{body_sentinel}
+""",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _fake_runtime(**overrides):
+    """Minimal resolve_runtime_provider() shape for a mocked-agent run."""
+    runtime = {
+        "api_key": "test-key",
+        "base_url": "http://127.0.0.1:1",
+        "provider": "openai",
+        "api_mode": "chat_completions",
+        "credential_pool": None,
+    }
+    runtime.update(overrides)
+    return runtime
+
+
+class TestOneshotSkillsEndToEnd:
+    """Integration regression (review feedback on #63814): no skill-loader
+    stubs. A REAL skill on disk under a temp HERMES_HOME must be discovered
+    by the actual agent.skill_commands loader and its body must reach the
+    ``ephemeral_system_prompt`` handed to AIAgent. Only the external
+    boundaries (provider resolution, the agent itself) are mocked."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_logging(self):
+        # run_oneshot() calls logging.disable(CRITICAL) globally; undo it so
+        # this test can't degrade later files in shared-process runs.
+        import logging
+
+        yield
+        logging.disable(logging.NOTSET)
+
+    def _run(self, tmp_path, monkeypatch, skills):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+
+        agent_cls = mock.MagicMock()
+        agent_cls.return_value.run_conversation.return_value = {
+            "final_response": "done",
+            "api_calls": 1,
+        }
+        with mock.patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=_fake_runtime(),
+        ), mock.patch("run_agent.AIAgent", agent_cls):
+            rc = run_oneshot("hi", skills=skills)
+        return rc, agent_cls
+
+    def test_real_skill_body_reaches_agent_ephemeral_prompt(
+        self, tmp_path, monkeypatch
+    ):
+        _make_real_skill(tmp_path, "oneshot-e2e-skill")
+
+        rc, agent_cls = self._run(tmp_path, monkeypatch, "oneshot-e2e-skill")
+
+        assert rc == 0
+        agent_cls.assert_called_once()
+        prompt = agent_cls.call_args.kwargs["ephemeral_system_prompt"]
+        # The actual on-disk skill body — not a stub — must arrive verbatim.
+        assert SENTINEL in prompt
+        assert "oneshot-e2e-skill" in prompt
+
+    def test_missing_skill_with_real_loader_exits_2_before_agent(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        (tmp_path / "skills").mkdir(parents=True)  # empty skills dir
+
+        rc, agent_cls = self._run(tmp_path, monkeypatch, "no-such-skill")
+
+        assert rc == 2
+        agent_cls.assert_not_called()
+        assert "no-such-skill" in capsys.readouterr().err
+
+    def test_no_skills_requested_passes_none_ephemeral_prompt(
+        self, tmp_path, monkeypatch
+    ):
+        rc, agent_cls = self._run(tmp_path, monkeypatch, None)
+
+        assert rc == 0
+        assert agent_cls.call_args.kwargs["ephemeral_system_prompt"] is None

--- a/tests/hermes_cli/test_oneshot_skills.py
+++ b/tests/hermes_cli/test_oneshot_skills.py
@@ -37,7 +37,8 @@ def _patch_builder(monkeypatch, prompt, loaded, missing):
 
 class TestBuildOneshotSkillsPrompt:
     def test_no_skills_is_noop(self):
-        prompt, err = _build_oneshot_skills_prompt(None)
+        with mock.patch("builtins.__import__", side_effect=AssertionError):
+            prompt, err = _build_oneshot_skills_prompt(None)
         assert prompt == ""
         assert err is None
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -254,6 +254,95 @@ def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     assert env["NODE_ENV"] == "production"
 
 
+def test_main_top_level_oneshot_forwards_skills(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "hello",
+            "--skills",
+            "demo-skill",
+            "--usage-file",
+            "usage.json",
+        ],
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(main_mod, "_exit_after_oneshot", _raise_exit)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured["prompt"] == "hello"
+    assert captured["skills"] == ["demo-skill"]
+    assert captured["usage_file"] == "usage.json"
+
+
+def test_termux_fast_oneshot_forwards_skills(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "-z", "hello", "--skills", "demo-skill"],
+    )
+    monkeypatch.setattr(main_mod, "_prepare_agent_startup", lambda _args: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(main_mod, "_exit_after_oneshot", _raise_exit)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._try_termux_fast_cli_launch()
+
+    assert exc.value.code == 0
+    assert captured["prompt"] == "hello"
+    assert captured["skills"] == ["demo-skill"]
+
+
 
 
 def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path):
@@ -282,7 +371,5 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert argv == [str(tsx), "src/entry.tsx"]
     assert cwd == tui_dir
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
-
-
 
 


### PR DESCRIPTION
# Summary

`hermes -z` (oneshot) accepts `-s/--skills` at the parser level but silently discards it: both `-z` dispatch sites in `hermes_cli/main.py` drop `args.skills` before calling `run_oneshot()`, and `hermes_cli/oneshot.py` has no skills path at all — even though its own module docstring promises "Rules / memory / AGENTS.md / preloaded skills = same as a normal chat turn."

This matters for scripted workers: a `hermes -z "<task>" -s <skill>` invocation runs blind with no error, which is exactly the silent-failure mode oneshot is supposed to avoid.

Fixes #31548.

# What this does

- Forwards `skills=getattr(args, "skills", None)` at both `-z` dispatch sites (`main.py`).
- Adds `_build_oneshot_skills_prompt()` in `oneshot.py`: normalizes the flag via the existing `cli._parse_skills_argument` (comma/repeat/dedupe parity with interactive chat), loads via `agent.skill_commands.build_preloaded_skills_prompt`, and injects the result through `AIAgent`'s existing `ephemeral_system_prompt` seam — no new agent surface.
- **Mirrors the interactive CLI contract** (`cli.py` `main()`): when at least one requested skill loads, unknown entries are skipped with a stderr warning and the run continues; only when *every* requested skill is missing does it hard-fail (exit 2, before the agent runs). A typo'd skill name must not kill a scripted worker.
- Skills resolution happens **before** the oneshot stderr redirect, so both the fatal error and the partial-miss warning actually reach the terminal.

# Reproduced

On current `main` (af250d849):

```
$ hermes -z "say hi" -s github-operations   # runs, skill never loaded, no warning
```

After this change:

```
$ hermes -z "say hi" -s definitely-not-a-skill
hermes -z: unknown --skills entries: definitely-not-a-skill. List available skills with `hermes skills list`.   # exit 2
$ hermes -z "say hi" -s real-skill,typo-skill
hermes -z: unknown --skills entries skipped: typo-skill. Continuing with: real-skill.   # runs with real-skill loaded
```

# Tests

- New `tests/hermes_cli/test_oneshot_skills.py` (12 tests): normalization/dedupe, all-loaded, **mixed valid/missing continues**, all-missing exits 2 before the agent is built, prompt forwarded into `_run_agent(skills_prompt=...)`, import-failure is loud, and a guard for the current `_run_agent` `(response, result)` tuple contract.
- Updated the two `run_oneshot` forwarding expectation dicts in `test_tui_resume_flow.py` (they assert the exact kwargs both dispatch sites pass).
- `66 passed` across `test_oneshot_skills.py` + `test_oneshot_usage_file.py` + `test_tui_resume_flow.py`.
- E2E (no mocks): real skill dir under a temp `HERMES_HOME` — skill body lands in the built prompt; mixed valid/missing warns and continues; all-missing is fatal.

# Relationship to #31591

This builds on the approach from #31591 (credit: @GarlicGo) — same seam (`ephemeral_system_prompt`), same dispatch-site forwarding. It addresses the two blockers from the sweeper review there:

1. #31591 fails when *any* skill is missing; the interactive CLI contract (`cli.py`) degrades gracefully on partial misses and only hard-fails when all are missing. This PR mirrors that.
2. #31591 predates the current oneshot path (`usage_file` forwarding, `_run_agent` returning `(response, result)`); this PR is built against current `main` and keeps `usage_file` intact.

If you'd rather land this as an update to #31591, I'm happy to close this one — I'll defer to your call.
