### PR TITLE
fix(desktop): keep draft fallback rows across config autosave

### DIFF
--- a/apps/desktop/src/app/settings/fallback-models-field.test.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.test.tsx
@@ -110,4 +110,18 @@ describe('FallbackModelsField', () => {
 
     await waitFor(() => expect(screen.getAllByLabelText('Remove')).toHaveLength(1))
   })
+
+  it('keeps a draft row visible after autosave re-renders the same persisted chain', async () => {
+    const onChange = vi.fn()
+    const rerender = await renderFieldWithRerender([], onChange)
+
+    fireEvent.click(screen.getByText('Add fallback'))
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([])
+    expect(screen.getAllByLabelText('Remove')).toHaveLength(1)
+
+    rerender([])
+
+    await waitFor(() => expect(screen.getAllByLabelText('Remove')).toHaveLength(1))
+  })
 })

--- a/apps/desktop/src/app/settings/fallback-models-field.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.tsx
@@ -40,6 +40,14 @@ function normalizeEntries(value: unknown): FallbackEntry[] {
   })
 }
 
+function completeEntries(rows: FallbackEntry[]): FallbackEntry[] {
+  return rows.filter(entry => entry.provider && entry.model)
+}
+
+function entriesEqual(a: FallbackEntry[], b: FallbackEntry[]): boolean {
+  return a.length === b.length && a.every((entry, index) => entry.provider === b[index]?.provider && entry.model === b[index]?.model)
+}
+
 /**
  * Structured editor for the top-level `fallback_providers` config list — a
  * chain of `{provider, model}` pairs tried in order when the default model
@@ -72,13 +80,26 @@ export function FallbackModelsField({
 
   // Settings can reload after a profile/config change while this component
   // stays mounted. Avoid displaying or saving the previous profile's chain.
+  // Keep in-progress draft rows (provider/model not both set) unless the
+  // persisted chain actually changed — autosave re-renders with the filtered
+  // value and would otherwise wipe a freshly added blank row.
   useEffect(() => {
-    setRows(normalizeEntries(value))
+    const persisted = normalizeEntries(value)
+
+    setRows(current => {
+      const drafts = current.filter(entry => !entry.provider || !entry.model)
+
+      if (entriesEqual(persisted, completeEntries(current))) {
+        return drafts.length > 0 ? [...persisted, ...drafts] : current
+      }
+
+      return persisted
+    })
   }, [value])
 
   const commit = (next: FallbackEntry[]) => {
     setRows(next)
-    onChange(next.filter(entry => entry.provider && entry.model))
+    onChange(completeEntries(next))
   }
 
   const updateRow = (index: number, patch: Partial<FallbackEntry>) =>


### PR DESCRIPTION
## Summary
- Clicking **Add fallback** in Desktop Settings → Model added a draft row locally, but autosave immediately re-rendered with the unchanged persisted `fallback_providers` list and the resync effect wiped the draft — so the button looked dead.
- Preserve in-progress draft rows when the persisted chain is unchanged; still resync on profile switch / external config edits.

## Test plan
- [x] `cd apps/desktop && npx vitest run src/app/settings/fallback-models-field.test.tsx --environment jsdom`
- [ ] Open Desktop → Settings → Model → click **Add fallback** → provider/model pickers appear
- [ ] Pick provider + model → entry saves to `fallback_providers`