### PR TITLE
fix(mcp): bound reconnect transport setup

### DIFF
--- a/tests/tools/test_mcp_reconnect_signal.py
+++ b/tests/tools/test_mcp_reconnect_signal.py
@@ -55,3 +55,46 @@ async def test_wait_for_lifecycle_event_shutdown_wins_when_both_set():
     task._reconnect_event.set()
     reason = await task._wait_for_lifecycle_event()
     assert reason == "shutdown"
+
+
+@pytest.mark.asyncio
+async def test_transport_connect_attempt_times_out_before_session_is_published():
+    """A wedged OAuth reconnect must not block the server task forever.
+
+    A production OAuth failure left ``_run_http`` stuck inside the SDK transport
+    before it published ``server.session``. Without an outer setup watchdog,
+    the retry loop never reached attempt 2 and reconnect signals could not be
+    serviced until the gateway restarted.
+    """
+    from tools.mcp_tool import MCPServerTask
+
+    task = MCPServerTask("oauth")
+    blocker = asyncio.Event()
+
+    async def _wedged_transport():
+        await blocker.wait()
+
+    with pytest.raises(TimeoutError, match="timed out before publishing a session"):
+        await task._run_transport_with_connect_timeout(
+            _wedged_transport,
+            connect_timeout=0.01,
+        )
+
+
+@pytest.mark.asyncio
+async def test_transport_connect_watchdog_preserves_lifecycle_result():
+    """The setup watchdog must stay transparent after session publication."""
+    from tools.mcp_tool import MCPServerTask
+
+    task = MCPServerTask("test")
+
+    async def _published_transport():
+        task.session = object()
+        return "recycle"
+
+    reason = await task._run_transport_with_connect_timeout(
+        _published_transport,
+        connect_timeout=0.1,
+    )
+
+    assert reason == "recycle"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2603,6 +2603,50 @@ class MCPServerTask:
             self.name, self, self._config
         )
 
+    async def _run_transport_with_connect_timeout(
+        self,
+        transport_factory: Callable[[], Coroutine[Any, Any, Any]],
+        connect_timeout: float,
+    ) -> Any:
+        """Run a long-lived transport with a bounded session setup phase.
+
+        Bound only the interval before the transport publishes ``self.session``;
+        the transport itself intentionally remains alive until reconnect or
+        shutdown. Keeping it in one owning task also preserves anyio's
+        same-task cleanup requirement.
+        """
+        transport_task = asyncio.create_task(transport_factory())
+        deadline = asyncio.get_running_loop().time() + max(float(connect_timeout), 0.01)
+        try:
+            while self.session is None and not transport_task.done():
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    transport_task.cancel()
+                    try:
+                        await transport_task
+                    except asyncio.CancelledError:
+                        pass
+                    raise TimeoutError(
+                        f"MCP server '{self.name}' transport timed out before "
+                        f"publishing a session ({connect_timeout}s)"
+                    )
+                # ``asyncio.wait`` yields to the transport task without relying
+                # on ``asyncio.sleep`` (which several lifecycle tests patch).
+                await asyncio.wait(
+                    {transport_task},
+                    timeout=min(0.05, remaining),
+                )
+
+            return await transport_task
+        except asyncio.CancelledError:
+            if not transport_task.done():
+                transport_task.cancel()
+                try:
+                    await transport_task
+                except asyncio.CancelledError:
+                    pass
+            raise
+
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
 
@@ -2689,9 +2733,15 @@ class MCPServerTask:
         while True:
             try:
                 if self._is_http():
-                    lifecycle_reason = await self._run_http(config)
+                    lifecycle_reason = await self._run_transport_with_connect_timeout(
+                        lambda: self._run_http(config),
+                        config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT),
+                    )
                 else:
-                    lifecycle_reason = await self._run_stdio(config)
+                    lifecycle_reason = await self._run_transport_with_connect_timeout(
+                        lambda: self._run_stdio(config),
+                        config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT),
+                    )
                 # Transport returned cleanly. Two cases:
                 #  - _shutdown_event was set: exit the run loop entirely.
                 #  - _reconnect_event was set (auth recovery): loop back and


### PR DESCRIPTION
## What does this PR do?

Prevents a long-lived MCP server task from hanging forever when a fresh transport wedges before publishing `server.session`.

The reconnect loop previously awaited `_run_http()` / `_run_stdio()` directly. If SDK, OAuth, or transport setup blocked without returning or raising, the loop never advanced past reconnect attempt 1; later reconnect signals had no effect and only a gateway restart recovered the server.

This change adds a setup-only watchdog:

- the transport still runs in one owning task, preserving AnyIO's same-task cleanup requirement;
- only the interval before `self.session` is published is bounded by `connect_timeout`;
- after publication, the transport remains long-lived exactly as before;
- timeout cancellation is awaited before the outer retry loop continues;
- upstream lifecycle results such as `"recycle"` pass through unchanged.

This is complementary to #63495, which fixes the known OAuth inner-generator leak behind #38193. That root fix prevents one concrete deadlock; this PR keeps any future SDK/OAuth/transport setup wedge from freezing Hermes' entire reconnect state machine.

## Related Issue

Related: #38193, #31987, #49543  
Complementary to: #63495

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`
  - add `_run_transport_with_connect_timeout()`;
  - bound only pre-session transport setup;
  - preserve transport lifecycle return values;
  - route both HTTP and stdio setup through the watchdog.
- `tests/tools/test_mcp_reconnect_signal.py`
  - prove a transport that never publishes a session times out;
  - prove lifecycle results remain transparent after session publication.

## How to Test

1. Run the MCP tool suite:

   ```bash
   python -m pytest tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp*.py -q
   ```

   Result: **582 passed, 4 pre-existing unknown-mark warnings**.

2. Run static and cross-platform checks:

   ```bash
   ruff check tools/mcp_tool.py tests/tools/test_mcp_reconnect_signal.py
   python scripts/check-windows-footguns.py --diff origin/main
   python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_reconnect_signal.py
   git diff origin/main...HEAD --check
   ```

   Result: all pass.

3. Production validation: on macOS arm64 / Python 3.11.15, an OAuth-backed MCP transport emitted the AnyIO lock-cleanup error and then logged only reconnect attempt 1 indefinitely. With the setup watchdog loaded, the gateway restarted cleanly and the live Discord session completed MCP format-guide, search, and memo-by-ID calls directly without a fresh-process fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched open and closed issues/PRs; this PR is explicitly complementary to #63495
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite — the complete MCP tool suite passes
- [x] I've added tests for the bug
- [x] I've tested on macOS 26.1 arm64 with Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior is internal and documented in code
- [x] `cli-config.yaml.example` update — N/A; no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; Windows footgun scan passes
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Observed failure signature:

```text
RuntimeError: The current task is not holding this lock
MCP server '<oauth-server>' connection lost (attempt 1/5), reconnecting in 1s
```

No attempt 2 or fresh-session registration followed until gateway restart.
