### PR TITLE
feat(cli): add on_status_bar_render hook to all status bar width tiers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5634,6 +5634,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._preload_skills_requested: list = []
         self._preload_skills_finalized = False
         self._active_session_lease = None
+        # Background refresh for the on_status_bar_render plugin hook (see
+        # _refresh_status_bar_plugin_values). Kept off the repaint path so a
+        # slow callback (including shell hooks with a 60s default timeout)
+        # cannot stall rendering or input.
+        self._status_bar_plugin_refresh_lock = threading.Lock()
+        self._status_bar_plugin_refresh_executor = None
+        self._status_bar_plugin_refresh_running = False
+        self._status_bar_plugin_refresh_thread = None
 
         # Voice mode state (also reinitialized inside run() for interactive TUI).
         self._voice_lock = threading.Lock()
@@ -7329,58 +7337,143 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return result
 
     _STATUS_BAR_PLUGIN_CACHE_TTL = 1.0
+    _STATUS_BAR_PLUGIN_REFRESH_TIMEOUT = 3.0
 
-    def _get_status_bar_plugin_values(self, snapshot: Dict[str, Any]) -> List[str]:
-        """Return fail-closed, display-ready status-bar hook values.
+    def _get_status_bar_plugin_values(self) -> List[str]:
+        """Return the last background-refreshed status-bar hook values.
 
-        Results are cached briefly because this method runs on prompt_toolkit's
-        repaint path; plugin callbacks must not stall every frame. The hook is
-        still resolved for each cache refresh so plugin loading and tests can
-        replace the module-level dispatcher without leaving a stale reference.
-        Its aggregate contract is deliberately a list, not an arbitrary
-        iterable: accepting generators or strings here would make rendering
-        consume plugin-owned state or split a contribution into characters.
+        This runs on prompt_toolkit's synchronous repaint path (both the
+        live ``FormattedTextControl`` and the text-renderer fallback) and
+        must never block, so it only reads the cache populated by
+        ``_refresh_status_bar_plugin_values()`` on a background thread — it
+        never calls ``invoke_hook()`` itself. A slow or misbehaving
+        ``on_status_bar_render`` callback (including a configured shell
+        hook, which shells out via ``subprocess.run()`` with up to a 60s
+        default timeout) therefore cannot stall a frame or freeze input.
         """
-        now = time.monotonic()
-        cached_at = getattr(self, "_status_bar_plugin_values_cached_at", None)
-        if cached_at is not None and now - cached_at < self._STATUS_BAR_PLUGIN_CACHE_TTL:
-            return list(getattr(self, "_status_bar_plugin_values_cache", ()))
+        return list(getattr(self, "_status_bar_plugin_values_cache", ()))
 
-        normalized: List[str] = []
+    def _invoke_status_bar_plugin_hook(
+        self, snapshot: Dict[str, Any]
+    ) -> Optional[List[str]]:
+        """Call the on_status_bar_render hook and normalize its output.
+
+        Only ever called from the background refresh path
+        (``_refresh_status_bar_plugin_values``), never from rendering.
+        Returns ``None`` on any lookup/dispatch failure or malformed
+        return shape so the caller leaves the existing cache untouched
+        instead of blanking the footer. The aggregate contract is
+        deliberately a list, not an arbitrary iterable: accepting
+        generators or strings here would make rendering consume
+        plugin-owned state or split a contribution into characters.
+        """
         try:
             from hermes_cli.plugins import invoke_hook
 
             # Plugins receive an isolated mapping: the renderer continues to
             # read the authoritative snapshot after callbacks return.
             values = invoke_hook("on_status_bar_render", snapshot=dict(snapshot))
-            if isinstance(values, list):
-                for value in values:
-                    try:
-                        # Hook callbacks are allowed to expose compact scalar
-                        # state without formatting it themselves. Falsey
-                        # values are omissions; truthy values are stringified
-                        # independently so one malformed contribution cannot
-                        # discard healthy siblings.
-                        if not value:
-                            continue
-                        display_value = re.sub(
-                            r"[\x00-\x1f\x7f-\x9f]", " ", str(value)
-                        ).strip()
-                        if display_value:
-                            normalized.append(display_value)
-                    except Exception:
-                        # Keep healthy contributions if one plugin-owned value
-                        # behaves unexpectedly during normalization.
-                        continue
         except Exception:
-            # Rendering the footer must remain available even when plugin
-            # lookup or dispatch fails. Caching this empty result also backs
-            # off persistently failing hooks until the next refresh window.
-            normalized = []
+            return None
+
+        if not isinstance(values, list):
+            return None
+
+        normalized: List[str] = []
+        for value in values:
+            try:
+                # Hook callbacks are allowed to expose compact scalar
+                # state without formatting it themselves. Falsey
+                # values are omissions; truthy values are stringified
+                # independently so one malformed contribution cannot
+                # discard healthy siblings.
+                if not value:
+                    continue
+                display_value = re.sub(
+                    r"[\x00-\x1f\x7f-\x9f]", " ", str(value)
+                ).strip()
+                if display_value:
+                    normalized.append(display_value)
+            except Exception:
+                # Keep healthy contributions if one plugin-owned value
+                # behaves unexpectedly during normalization.
+                continue
+        return normalized
+
+    def _refresh_status_bar_plugin_values(self) -> None:
+        """Refresh the status-bar plugin cache off the render/repaint path.
+
+        Dispatches ``on_status_bar_render`` via ``invoke_hook()`` on a
+        dedicated worker thread. Only one refresh may be in flight at a
+        time: if a previous callback is still running (e.g. stuck in a
+        slow shell hook), this call is a no-op rather than piling up
+        concurrent runs of the same stuck callback. The calling thread
+        waits up to ``_STATUS_BAR_PLUGIN_REFRESH_TIMEOUT`` for a result;
+        past that it gives up and returns, but the lock is only released
+        once the underlying call actually finishes, so the in-flight
+        guard still holds even after this method has returned. Timeouts
+        and errors leave the existing cache untouched.
+        """
+        if not self._status_bar_plugin_refresh_lock.acquire(blocking=False):
+            return
+
+        def _invoke(snapshot: Dict[str, Any]) -> Optional[List[str]]:
+            try:
+                return self._invoke_status_bar_plugin_hook(snapshot)
+            finally:
+                self._status_bar_plugin_refresh_lock.release()
+
+        try:
+            snapshot = self._get_status_bar_snapshot()
+            executor = self._status_bar_plugin_refresh_executor
+            if executor is None:
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="status-bar-plugin-refresh"
+                )
+                self._status_bar_plugin_refresh_executor = executor
+            future = executor.submit(_invoke, snapshot)
+        except Exception:
+            # Nothing was actually scheduled to release the lock, so this
+            # thread must release it itself or every future refresh would
+            # be permanently blocked by the in-flight guard.
+            self._status_bar_plugin_refresh_lock.release()
+            return
+
+        try:
+            normalized = future.result(timeout=self._STATUS_BAR_PLUGIN_REFRESH_TIMEOUT)
+        except Exception:
+            return
+        if normalized is None:
+            return
 
         self._status_bar_plugin_values_cache = tuple(normalized)
-        self._status_bar_plugin_values_cached_at = now
-        return normalized
+        self._status_bar_plugin_values_cached_at = time.monotonic()
+
+    def _status_bar_plugin_refresh_loop(self) -> None:
+        """Periodically refresh the status-bar plugin cache in the background."""
+        while self._status_bar_plugin_refresh_running:
+            self._refresh_status_bar_plugin_values()
+            time.sleep(self._STATUS_BAR_PLUGIN_CACHE_TTL)
+
+    def _status_bar_plugin_refresh_start(self) -> None:
+        """Start the background refresh loop (no-op if already running)."""
+        if self._status_bar_plugin_refresh_running:
+            return
+        self._status_bar_plugin_refresh_running = True
+        self._status_bar_plugin_refresh_thread = threading.Thread(
+            target=self._status_bar_plugin_refresh_loop,
+            daemon=True,
+            name="status-bar-plugin-refresh-loop",
+        )
+        self._status_bar_plugin_refresh_thread.start()
+
+    def _status_bar_plugin_refresh_stop(self) -> None:
+        """Stop the background refresh loop started by ``_status_bar_plugin_refresh_start``."""
+        self._status_bar_plugin_refresh_running = False
+        thread = self._status_bar_plugin_refresh_thread
+        if thread is not None:
+            thread.join(timeout=0.3)
+        self._status_bar_plugin_refresh_thread = None
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
@@ -7388,7 +7481,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             snapshot = self._get_status_bar_snapshot()
             if width is None:
                 width = self._get_tui_terminal_width()
-            plugin_values = self._get_status_bar_plugin_values(snapshot)
+            plugin_values = self._get_status_bar_plugin_values()
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
@@ -7544,7 +7637,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # the exception fallback must obey the same one-row bound.
             width = self._get_tui_terminal_width()
             snapshot = self._get_status_bar_snapshot()
-            plugin_values = self._get_status_bar_plugin_values(snapshot)
+            plugin_values = self._get_status_bar_plugin_values()
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
@@ -21330,6 +21423,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _enable_extended_enter_keys(app.output)
                 # Drive the petdex mascot animation (no-op when no pet enabled).
                 self._pet_start_anim()
+                # Keep the on_status_bar_render plugin cache warm off the
+                # repaint path (see _refresh_status_bar_plugin_values).
+                self._status_bar_plugin_refresh_start()
                 app.run()
         except (EOFError, KeyboardInterrupt, BrokenPipeError):
             pass
@@ -21357,6 +21453,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         finally:
             self._should_exit = True
             self._pet_stop_anim()
+            self._status_bar_plugin_refresh_stop()
             # Immediate feedback: prompt_toolkit has just torn down the input
             # box + status bar, so without a line here the terminal sits
             # silent for the whole cleanup window (session flush, memory

--- a/cli.py
+++ b/cli.py
@@ -7328,12 +7328,63 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._status_bar_field_set_cache = result
         return result
 
+    _STATUS_BAR_PLUGIN_CACHE_TTL = 1.0
+
+    def _get_status_bar_plugin_values(self, snapshot: Dict[str, Any]) -> List[str]:
+        """Return fail-closed, display-ready status-bar hook values.
+
+        Results are cached briefly because this method runs on prompt_toolkit's
+        repaint path; plugin callbacks must not stall every frame. The hook is
+        still resolved for each cache refresh so plugin loading and tests can
+        replace the module-level dispatcher without leaving a stale reference.
+        Its aggregate contract is deliberately a list, not an arbitrary
+        iterable: accepting generators or strings here would make rendering
+        consume plugin-owned state or split a contribution into characters.
+        """
+        now = time.monotonic()
+        cached_at = getattr(self, "_status_bar_plugin_values_cached_at", None)
+        if cached_at is not None and now - cached_at < self._STATUS_BAR_PLUGIN_CACHE_TTL:
+            return list(getattr(self, "_status_bar_plugin_values_cache", ()))
+
+        normalized: List[str] = []
+        try:
+            from hermes_cli.plugins import invoke_hook
+
+            # Plugins receive an isolated mapping: the renderer continues to
+            # read the authoritative snapshot after callbacks return.
+            values = invoke_hook("on_status_bar_render", snapshot=dict(snapshot))
+            if isinstance(values, list):
+                for value in values:
+                    try:
+                        # Status segments are a display API, not a generic
+                        # serialization surface. Reject accidental dict/list/
+                        # numeric returns instead of exposing Python reprs.
+                        if not isinstance(value, str):
+                            continue
+                        display_value = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", value).strip()
+                        if display_value:
+                            normalized.append(display_value)
+                    except Exception:
+                        # Keep healthy contributions if one plugin-owned value
+                        # behaves unexpectedly during normalization.
+                        continue
+        except Exception:
+            # Rendering the footer must remain available even when plugin
+            # lookup or dispatch fails. Caching this empty result also backs
+            # off persistently failing hooks until the next refresh window.
+            normalized = []
+
+        self._status_bar_plugin_values_cache = tuple(normalized)
+        self._status_bar_plugin_values_cached_at = now
+        return normalized
+
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
                 width = self._get_tui_terminal_width()
+            plugin_values = self._get_status_bar_plugin_values(snapshot)
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
@@ -7368,8 +7419,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     segs.append(focus_label)
                 if yolo_active and _ok("yolo"):
                     segs.append("⚠ YOLO")
-                text = battery_prefix + " · ".join(segs) if segs else f"{battery_prefix}⚕ {snapshot['model_short']}"
-                return self._right_align_status_title(text, session_title, width)
+                if not segs:
+                    segs = [f"⚕ {snapshot['model_short']}"]
+                segs.extend(plugin_values)
+                return self._trim_status_bar_text(" · ".join(segs), width)
             if width < 76:
                 parts = []
                 if _ok("model"):
@@ -7403,7 +7456,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     parts.append("⚠ YOLO")
                 if not parts:
                     parts = [f"⚕ {snapshot['model_short']}"]
-                return self._right_align_status_title(" · ".join(parts), session_title, width)
+                parts.extend(plugin_values)
+                return self._trim_status_bar_text(" · ".join(parts), width)
 
             parts = []
             if _ok("model"):
@@ -7462,7 +7516,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 parts.append(f"Σ{format_token_count_compact(total_tokens)}")
             if not parts:
                 parts = [f"⚕ {snapshot['model_short']}"]
-            return self._right_align_status_title(" │ ".join(parts), session_title, width)
+            parts.extend(plugin_values)
+            return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
 

--- a/cli.py
+++ b/cli.py
@@ -7356,12 +7356,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if isinstance(values, list):
                 for value in values:
                     try:
-                        # Status segments are a display API, not a generic
-                        # serialization surface. Reject accidental dict/list/
-                        # numeric returns instead of exposing Python reprs.
-                        if not isinstance(value, str):
+                        # Hook callbacks are allowed to expose compact scalar
+                        # state without formatting it themselves. Falsey
+                        # values are omissions; truthy values are stringified
+                        # independently so one malformed contribution cannot
+                        # discard healthy siblings.
+                        if not value:
                             continue
-                        display_value = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", value).strip()
+                        display_value = re.sub(
+                            r"[\x00-\x1f\x7f-\x9f]", " ", str(value)
+                        ).strip()
                         if display_value:
                             normalized.append(display_value)
                     except Exception:
@@ -7519,19 +7523,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             parts.extend(plugin_values)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
-            return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
+            agent = getattr(self, "agent", None)
+            model_name = (
+                getattr(agent, "model", None)
+                or getattr(self, "model", None)
+                or "Hermes"
+            )
+            fallback = f"⚕ {model_name}"
+            if width is not None:
+                fallback = self._trim_status_bar_text(fallback, width)
+            return fallback
 
     def _get_status_bar_fragments(self):
         if not self._status_bar_visible or getattr(self, '_model_picker_state', None) or getattr(self, '_command_palette_state', None):
             return []
+        width: Optional[int] = None
         try:
-            snapshot = self._get_status_bar_snapshot()
-            # Use prompt_toolkit's own terminal width when running inside the
-            # TUI — shutil.get_terminal_size() can return stale or fallback
-            # values (especially on SSH) that differ from what prompt_toolkit
-            # actually renders, causing the fragments to overflow to a second
-            # line and produce duplicated status bar rows over long sessions.
+            # Resolve the live width before any snapshot or plugin work that can
+            # fail. prompt_toolkit's width can differ from shutil on SSH, and
+            # the exception fallback must obey the same one-row bound.
             width = self._get_tui_terminal_width()
+            snapshot = self._get_status_bar_snapshot()
+            plugin_values = self._get_status_bar_plugin_values(snapshot)
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
@@ -7570,6 +7583,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _append(frags, " · ", ("class:status-bar-strong", focus_label))
                 if yolo_active and _ok("yolo"):
                     _append(frags, " · ", ("class:status-bar-yolo", "⚠ YOLO"))
+                for plugin_value in plugin_values:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append(("class:status-bar", plugin_value))
                 if not frags:
                     frags = [
                         ("class:status-bar", " ⚕ "),
@@ -7609,6 +7625,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         _append(frags, " · ", ("class:status-bar-strong", focus_label))
                     if yolo_active and _ok("yolo"):
                         _append(frags, " · ", ("class:status-bar-yolo", "⚠ YOLO"))
+                    for plugin_value in plugin_values:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar", plugin_value))
                     if not frags:
                         frags = [
                             ("class:status-bar", " ⚕ "),
@@ -7727,7 +7746,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return [("class:status-bar", trimmed)]
             return frags
         except Exception:
-            return [("class:status-bar", f" {self._build_status_bar_text()} ")]
+            # Preserve the full text-renderer fallback. Plugin values are
+            # cached by _get_status_bar_plugin_values(), so delegating after a
+            # fragment-only failure does not redispatch callbacks in the same
+            # render.
+            fallback_width = width if width is not None else 80
+            fallback = f" {self._build_status_bar_text(width=fallback_width)} "
+            fallback = self._trim_status_bar_text(fallback, fallback_width)
+            return [("class:status-bar", fallback)]
 
     @staticmethod
     def _fmt_stash_age(stashed_at: float) -> str:

--- a/cli.py
+++ b/cli.py
@@ -4678,6 +4678,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.preloaded_skills: list[str] = []
         self._startup_skills_line_shown = False
         self._active_session_lease = None
+        # Background refresh for the on_status_bar_render plugin hook (see
+        # _refresh_status_bar_plugin_values). Kept off the repaint path so a
+        # slow callback (including shell hooks with a 60s default timeout)
+        # cannot stall rendering or input.
+        self._status_bar_plugin_refresh_lock = threading.Lock()
+        self._status_bar_plugin_refresh_executor = None
+        self._status_bar_plugin_refresh_running = False
+        self._status_bar_plugin_refresh_thread = None
 
         # Voice mode state (also reinitialized inside run() for interactive TUI).
         self._voice_lock = threading.Lock()
@@ -5866,58 +5874,143 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return "⊙ goal"
 
     _STATUS_BAR_PLUGIN_CACHE_TTL = 1.0
+    _STATUS_BAR_PLUGIN_REFRESH_TIMEOUT = 3.0
 
-    def _get_status_bar_plugin_values(self, snapshot: Dict[str, Any]) -> List[str]:
-        """Return fail-closed, display-ready status-bar hook values.
+    def _get_status_bar_plugin_values(self) -> List[str]:
+        """Return the last background-refreshed status-bar hook values.
 
-        Results are cached briefly because this method runs on prompt_toolkit's
-        repaint path; plugin callbacks must not stall every frame. The hook is
-        still resolved for each cache refresh so plugin loading and tests can
-        replace the module-level dispatcher without leaving a stale reference.
-        Its aggregate contract is deliberately a list, not an arbitrary
-        iterable: accepting generators or strings here would make rendering
-        consume plugin-owned state or split a contribution into characters.
+        This runs on prompt_toolkit's synchronous repaint path (both the
+        live ``FormattedTextControl`` and the text-renderer fallback) and
+        must never block, so it only reads the cache populated by
+        ``_refresh_status_bar_plugin_values()`` on a background thread — it
+        never calls ``invoke_hook()`` itself. A slow or misbehaving
+        ``on_status_bar_render`` callback (including a configured shell
+        hook, which shells out via ``subprocess.run()`` with up to a 60s
+        default timeout) therefore cannot stall a frame or freeze input.
         """
-        now = time.monotonic()
-        cached_at = getattr(self, "_status_bar_plugin_values_cached_at", None)
-        if cached_at is not None and now - cached_at < self._STATUS_BAR_PLUGIN_CACHE_TTL:
-            return list(getattr(self, "_status_bar_plugin_values_cache", ()))
+        return list(getattr(self, "_status_bar_plugin_values_cache", ()))
 
-        normalized: List[str] = []
+    def _invoke_status_bar_plugin_hook(
+        self, snapshot: Dict[str, Any]
+    ) -> Optional[List[str]]:
+        """Call the on_status_bar_render hook and normalize its output.
+
+        Only ever called from the background refresh path
+        (``_refresh_status_bar_plugin_values``), never from rendering.
+        Returns ``None`` on any lookup/dispatch failure or malformed
+        return shape so the caller leaves the existing cache untouched
+        instead of blanking the footer. The aggregate contract is
+        deliberately a list, not an arbitrary iterable: accepting
+        generators or strings here would make rendering consume
+        plugin-owned state or split a contribution into characters.
+        """
         try:
             from hermes_cli.plugins import invoke_hook
 
             # Plugins receive an isolated mapping: the renderer continues to
             # read the authoritative snapshot after callbacks return.
             values = invoke_hook("on_status_bar_render", snapshot=dict(snapshot))
-            if isinstance(values, list):
-                for value in values:
-                    try:
-                        # Hook callbacks are allowed to expose compact scalar
-                        # state without formatting it themselves. Falsey
-                        # values are omissions; truthy values are stringified
-                        # independently so one malformed contribution cannot
-                        # discard healthy siblings.
-                        if not value:
-                            continue
-                        display_value = re.sub(
-                            r"[\x00-\x1f\x7f-\x9f]", " ", str(value)
-                        ).strip()
-                        if display_value:
-                            normalized.append(display_value)
-                    except Exception:
-                        # Keep healthy contributions if one plugin-owned value
-                        # behaves unexpectedly during normalization.
-                        continue
         except Exception:
-            # Rendering the footer must remain available even when plugin
-            # lookup or dispatch fails. Caching this empty result also backs
-            # off persistently failing hooks until the next refresh window.
-            normalized = []
+            return None
+
+        if not isinstance(values, list):
+            return None
+
+        normalized: List[str] = []
+        for value in values:
+            try:
+                # Hook callbacks are allowed to expose compact scalar
+                # state without formatting it themselves. Falsey
+                # values are omissions; truthy values are stringified
+                # independently so one malformed contribution cannot
+                # discard healthy siblings.
+                if not value:
+                    continue
+                display_value = re.sub(
+                    r"[\x00-\x1f\x7f-\x9f]", " ", str(value)
+                ).strip()
+                if display_value:
+                    normalized.append(display_value)
+            except Exception:
+                # Keep healthy contributions if one plugin-owned value
+                # behaves unexpectedly during normalization.
+                continue
+        return normalized
+
+    def _refresh_status_bar_plugin_values(self) -> None:
+        """Refresh the status-bar plugin cache off the render/repaint path.
+
+        Dispatches ``on_status_bar_render`` via ``invoke_hook()`` on a
+        dedicated worker thread. Only one refresh may be in flight at a
+        time: if a previous callback is still running (e.g. stuck in a
+        slow shell hook), this call is a no-op rather than piling up
+        concurrent runs of the same stuck callback. The calling thread
+        waits up to ``_STATUS_BAR_PLUGIN_REFRESH_TIMEOUT`` for a result;
+        past that it gives up and returns, but the lock is only released
+        once the underlying call actually finishes, so the in-flight
+        guard still holds even after this method has returned. Timeouts
+        and errors leave the existing cache untouched.
+        """
+        if not self._status_bar_plugin_refresh_lock.acquire(blocking=False):
+            return
+
+        def _invoke(snapshot: Dict[str, Any]) -> Optional[List[str]]:
+            try:
+                return self._invoke_status_bar_plugin_hook(snapshot)
+            finally:
+                self._status_bar_plugin_refresh_lock.release()
+
+        try:
+            snapshot = self._get_status_bar_snapshot()
+            executor = self._status_bar_plugin_refresh_executor
+            if executor is None:
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="status-bar-plugin-refresh"
+                )
+                self._status_bar_plugin_refresh_executor = executor
+            future = executor.submit(_invoke, snapshot)
+        except Exception:
+            # Nothing was actually scheduled to release the lock, so this
+            # thread must release it itself or every future refresh would
+            # be permanently blocked by the in-flight guard.
+            self._status_bar_plugin_refresh_lock.release()
+            return
+
+        try:
+            normalized = future.result(timeout=self._STATUS_BAR_PLUGIN_REFRESH_TIMEOUT)
+        except Exception:
+            return
+        if normalized is None:
+            return
 
         self._status_bar_plugin_values_cache = tuple(normalized)
-        self._status_bar_plugin_values_cached_at = now
-        return normalized
+        self._status_bar_plugin_values_cached_at = time.monotonic()
+
+    def _status_bar_plugin_refresh_loop(self) -> None:
+        """Periodically refresh the status-bar plugin cache in the background."""
+        while self._status_bar_plugin_refresh_running:
+            self._refresh_status_bar_plugin_values()
+            time.sleep(self._STATUS_BAR_PLUGIN_CACHE_TTL)
+
+    def _status_bar_plugin_refresh_start(self) -> None:
+        """Start the background refresh loop (no-op if already running)."""
+        if self._status_bar_plugin_refresh_running:
+            return
+        self._status_bar_plugin_refresh_running = True
+        self._status_bar_plugin_refresh_thread = threading.Thread(
+            target=self._status_bar_plugin_refresh_loop,
+            daemon=True,
+            name="status-bar-plugin-refresh-loop",
+        )
+        self._status_bar_plugin_refresh_thread.start()
+
+    def _status_bar_plugin_refresh_stop(self) -> None:
+        """Stop the background refresh loop started by ``_status_bar_plugin_refresh_start``."""
+        self._status_bar_plugin_refresh_running = False
+        thread = self._status_bar_plugin_refresh_thread
+        if thread is not None:
+            thread.join(timeout=0.3)
+        self._status_bar_plugin_refresh_thread = None
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
@@ -5925,7 +6018,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             snapshot = self._get_status_bar_snapshot()
             if width is None:
                 width = self._get_tui_terminal_width()
-            plugin_values = self._get_status_bar_plugin_values(snapshot)
+            plugin_values = self._get_status_bar_plugin_values()
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
@@ -6032,7 +6125,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # the exception fallback must obey the same one-row bound.
             width = self._get_tui_terminal_width()
             snapshot = self._get_status_bar_snapshot()
-            plugin_values = self._get_status_bar_plugin_values(snapshot)
+            plugin_values = self._get_status_bar_plugin_values()
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
@@ -17308,6 +17401,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _mark_tui_input_modes_active()
                 # Drive the petdex mascot animation (no-op when no pet enabled).
                 self._pet_start_anim()
+                # Keep the on_status_bar_render plugin cache warm off the
+                # repaint path (see _refresh_status_bar_plugin_values).
+                self._status_bar_plugin_refresh_start()
                 app.run()
         except (EOFError, KeyboardInterrupt, BrokenPipeError):
             pass
@@ -17335,6 +17431,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         finally:
             self._should_exit = True
             self._pet_stop_anim()
+            self._status_bar_plugin_refresh_stop()
             # Immediate feedback: prompt_toolkit has just torn down the input
             # box + status bar, so without a line here the terminal sits
             # silent for the whole cleanup window (session flush, memory

--- a/cli.py
+++ b/cli.py
@@ -5893,12 +5893,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if isinstance(values, list):
                 for value in values:
                     try:
-                        # Status segments are a display API, not a generic
-                        # serialization surface. Reject accidental dict/list/
-                        # numeric returns instead of exposing Python reprs.
-                        if not isinstance(value, str):
+                        # Hook callbacks are allowed to expose compact scalar
+                        # state without formatting it themselves. Falsey
+                        # values are omissions; truthy values are stringified
+                        # independently so one malformed contribution cannot
+                        # discard healthy siblings.
+                        if not value:
                             continue
-                        display_value = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", value).strip()
+                        display_value = re.sub(
+                            r"[\x00-\x1f\x7f-\x9f]", " ", str(value)
+                        ).strip()
                         if display_value:
                             normalized.append(display_value)
                     except Exception:
@@ -6007,19 +6011,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             parts.extend(plugin_values)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
-            return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
+            agent = getattr(self, "agent", None)
+            model_name = (
+                getattr(agent, "model", None)
+                or getattr(self, "model", None)
+                or "Hermes"
+            )
+            fallback = f"⚕ {model_name}"
+            if width is not None:
+                fallback = self._trim_status_bar_text(fallback, width)
+            return fallback
 
     def _get_status_bar_fragments(self):
         if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
             return []
+        width: Optional[int] = None
         try:
-            snapshot = self._get_status_bar_snapshot()
-            # Use prompt_toolkit's own terminal width when running inside the
-            # TUI — shutil.get_terminal_size() can return stale or fallback
-            # values (especially on SSH) that differ from what prompt_toolkit
-            # actually renders, causing the fragments to overflow to a second
-            # line and produce duplicated status bar rows over long sessions.
+            # Resolve the live width before any snapshot or plugin work that can
+            # fail. prompt_toolkit's width can differ from shutil on SSH, and
+            # the exception fallback must obey the same one-row bound.
             width = self._get_tui_terminal_width()
+            snapshot = self._get_status_bar_snapshot()
+            plugin_values = self._get_status_bar_plugin_values(snapshot)
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
@@ -6043,7 +6056,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 if yolo_active:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-yolo", "⚠ YOLO"))
-                frags.append(("class:status-bar", " "))
             else:
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
@@ -6083,7 +6095,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
-                    frags.append(("class:status-bar", " "))
                 else:
                     if snapshot["context_length"]:
                         ctx_total = _format_context_length(snapshot["context_length"])
@@ -6144,7 +6155,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
-                    frags.append(("class:status-bar", " "))
+
+            plugin_separator = " · " if width < 76 else " │ "
+            for plugin_value in plugin_values:
+                frags.append(("class:status-bar-dim", plugin_separator))
+                frags.append(("class:status-bar", plugin_value))
+            frags.append(("class:status-bar", " "))
 
             # Battery is the first status-bar element when enabled: prepend it
             # ahead of the leading ⚕ marker in whichever width tier ran above.
@@ -6162,7 +6178,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return [("class:status-bar", trimmed)]
             return frags
         except Exception:
-            return [("class:status-bar", f" {self._build_status_bar_text()} ")]
+            # Preserve the full text-renderer fallback. Plugin values are
+            # cached by _get_status_bar_plugin_values(), so delegating after a
+            # fragment-only failure does not redispatch callbacks in the same
+            # render.
+            fallback_width = width if width is not None else 80
+            fallback = f" {self._build_status_bar_text(width=fallback_width)} "
+            fallback = self._trim_status_bar_text(fallback, fallback_width)
+            return [("class:status-bar", fallback)]
 
     def _normalize_model_for_provider(self, resolved_provider: str) -> bool:
         """Normalize provider-specific model IDs and routing."""

--- a/cli.py
+++ b/cli.py
@@ -5865,12 +5865,63 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return f"⊙ goal {used}/{max_turns}"
         return "⊙ goal"
 
+    _STATUS_BAR_PLUGIN_CACHE_TTL = 1.0
+
+    def _get_status_bar_plugin_values(self, snapshot: Dict[str, Any]) -> List[str]:
+        """Return fail-closed, display-ready status-bar hook values.
+
+        Results are cached briefly because this method runs on prompt_toolkit's
+        repaint path; plugin callbacks must not stall every frame. The hook is
+        still resolved for each cache refresh so plugin loading and tests can
+        replace the module-level dispatcher without leaving a stale reference.
+        Its aggregate contract is deliberately a list, not an arbitrary
+        iterable: accepting generators or strings here would make rendering
+        consume plugin-owned state or split a contribution into characters.
+        """
+        now = time.monotonic()
+        cached_at = getattr(self, "_status_bar_plugin_values_cached_at", None)
+        if cached_at is not None and now - cached_at < self._STATUS_BAR_PLUGIN_CACHE_TTL:
+            return list(getattr(self, "_status_bar_plugin_values_cache", ()))
+
+        normalized: List[str] = []
+        try:
+            from hermes_cli.plugins import invoke_hook
+
+            # Plugins receive an isolated mapping: the renderer continues to
+            # read the authoritative snapshot after callbacks return.
+            values = invoke_hook("on_status_bar_render", snapshot=dict(snapshot))
+            if isinstance(values, list):
+                for value in values:
+                    try:
+                        # Status segments are a display API, not a generic
+                        # serialization surface. Reject accidental dict/list/
+                        # numeric returns instead of exposing Python reprs.
+                        if not isinstance(value, str):
+                            continue
+                        display_value = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", value).strip()
+                        if display_value:
+                            normalized.append(display_value)
+                    except Exception:
+                        # Keep healthy contributions if one plugin-owned value
+                        # behaves unexpectedly during normalization.
+                        continue
+        except Exception:
+            # Rendering the footer must remain available even when plugin
+            # lookup or dispatch fails. Caching this empty result also backs
+            # off persistently failing hooks until the next refresh window.
+            normalized = []
+
+        self._status_bar_plugin_values_cache = tuple(normalized)
+        self._status_bar_plugin_values_cached_at = now
+        return normalized
+
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
                 width = self._get_tui_terminal_width()
+            plugin_values = self._get_status_bar_plugin_values(snapshot)
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
@@ -5881,14 +5932,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
             if width < 52:
-                text = f"{battery_prefix}⚕ {snapshot['model_short']} · {duration_label}"
+                parts = [f"⚕ {snapshot['model_short']}", duration_label]
+                if battery_label:
+                    parts.insert(0, battery_label)
                 if goal_segment:
-                    text += f" · {goal_segment}"
+                    parts.append(goal_segment)
                 if focus_label:
-                    text += f" · {focus_label}"
+                    parts.append(focus_label)
                 if yolo_active:
-                    text += " · ⚠ YOLO"
-                return self._trim_status_bar_text(text, width)
+                    parts.append("⚠ YOLO")
+                parts.extend(plugin_values)
+                return self._trim_status_bar_text(" · ".join(parts), width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
                 if battery_label:
@@ -5912,6 +5966,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     parts.append(focus_label)
                 if yolo_active:
                     parts.append("⚠ YOLO")
+                parts.extend(plugin_values)
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
             if snapshot["context_length"]:
@@ -5949,6 +6004,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 parts.append(focus_label)
             if yolo_active:
                 parts.append("⚠ YOLO")
+            parts.extend(plugin_values)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -180,6 +180,19 @@ _DEFAULT_PAYLOADS = {
     },
     "on_session_finalize": {"session_id": "test-session"},
     "on_session_reset": {"session_id": "test-session"},
+    "on_status_bar_render": {
+        "snapshot": {
+            "model_name": "anthropic/claude-sonnet-4-6",
+            "model_short": "claude-sonnet-4-6",
+            "duration": "1m 23s",
+            "context_tokens": 2048,
+            "context_length": 120000,
+            "context_percent": 2,
+            "session_total_tokens": 2560,
+            "session_api_calls": 1,
+        },
+        "telemetry_schema_version": "hermes.observer.v1",
+    },
     "pre_api_request": {
         "session_id": "test-session",
         "task_id": "test-task",

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -162,6 +162,19 @@ _DEFAULT_PAYLOADS = {
     },
     "on_session_finalize": {"session_id": "test-session"},
     "on_session_reset": {"session_id": "test-session"},
+    "on_status_bar_render": {
+        "snapshot": {
+            "model_name": "anthropic/claude-sonnet-4-6",
+            "model_short": "claude-sonnet-4-6",
+            "duration": "1m 23s",
+            "context_tokens": 2048,
+            "context_length": 120000,
+            "context_percent": 2,
+            "session_total_tokens": 2560,
+            "session_api_calls": 1,
+        },
+        "telemetry_schema_version": "hermes.observer.v1",
+    },
     "pre_api_request": {
         "session_id": "test-session",
         "task_id": "test-task",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -161,6 +161,7 @@ VALID_HOOKS: Set[str] = {
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",
+    "on_status_bar_render",
     "subagent_start",
     "subagent_stop",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -223,6 +223,7 @@ VALID_HOOKS: Set[str] = {
     # Successful skill lifecycle facts. The local skill name is available to
     # plugins, while built-in shared metrics emit only bounded classifications.
     "on_skill_lifecycle",
+    "on_status_bar_render",
     "subagent_start",
     "subagent_stop",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import cli as cli_mod
 from cli import HermesCLI
 
@@ -51,6 +53,267 @@ def _attach_agent(
         ),
     )
     return cli_obj
+
+
+_STATUS_BAR_WIDTHS = (51, 52, 75, 76)
+
+
+def _plugin_status_bar_snapshot():
+    """Return a deterministic snapshot that exercises all three text tiers."""
+    return {
+        "model_short": "m",
+        "context_percent": 25,
+        "context_length": 200_000,
+        "context_tokens": 50_000,
+        "duration": "9m",
+        "compressions": 0,
+        "active_background_tasks": 0,
+        "active_background_processes": 0,
+        "active_background_subagents": 0,
+        "prompt_elapsed": "⏲ 3s",
+        "idle_since": "",
+    }
+
+
+def _plugin_status_bar_baseline(width):
+    if width < 52:
+        return "⚕ m · 9m"
+    if width < 76:
+        return "⚕ m · 25% · 9m"
+    return "⚕ m │ 50K/200K │ 25% │ 9m │ ⏲ 3s"
+
+
+def _assert_status_bar_hook_call(hook, snapshot):
+    assert hook.call_count == 1
+    assert hook.call_args.args == ("on_status_bar_render",)
+    assert set(hook.call_args.kwargs) == {"snapshot"}
+    assert hook.call_args.kwargs["snapshot"] == snapshot
+    assert hook.call_args.kwargs["snapshot"] is not snapshot
+
+
+class _BrokenTruthValue:
+    def __bool__(self):
+        raise RuntimeError("truth-value failure")
+
+
+class _BrokenStringValue:
+    def __bool__(self):
+        return True
+
+    def __str__(self):
+        raise RuntimeError("stringification failure")
+
+
+class TestStatusBarPluginValueHelper:
+    def test_invokes_once_and_normalizes_only_ordered_nonempty_string_values(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[None, "", 0, False, "ready", 7, {"state": "ok"}],
+        ) as hook:
+            values = cli_obj._get_status_bar_plugin_values(snapshot)
+
+        assert values == ["ready"]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_sanitizes_control_characters_to_keep_footer_on_one_line(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[" ready\nnow\r\x1b[31m\t "],
+        ) as hook:
+            values = cli_obj._get_status_bar_plugin_values(snapshot)
+
+        assert values == ["ready now  [31m"]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_plugin_cannot_mutate_renderer_snapshot(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        def mutate_snapshot(*_args, **kwargs):
+            kwargs["snapshot"].clear()
+            return ["ready"]
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=mutate_snapshot):
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+
+        assert snapshot == _plugin_status_bar_snapshot()
+
+    @pytest.mark.parametrize(
+        "unsupported",
+        [
+            (),
+            (value for value in ("generated",)),
+            "string aggregate",
+            None,
+        ],
+        ids=("tuple", "generator", "string", "none"),
+    )
+    def test_rejects_non_list_aggregates(self, unsupported):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=unsupported) as hook:
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == []
+
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
+    def test_preserves_healthy_values_when_an_element_is_broken(self, broken):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
+        ) as hook:
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["partial"]
+
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_caches_hook_values_during_repaint_window(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=["ready"]) as hook, patch(
+            "cli.time.monotonic", side_effect=[10.0, 10.5, 11.0]
+        ):
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+
+        assert hook.call_count == 2
+
+
+class TestStatusBarPluginTierIntegration:
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_appends_ordered_truthy_values_with_tier_separator(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+        expected = separator.join([_plugin_status_bar_baseline(width), "ready"])
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[None, "", 0, False, "ready", 7],
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == expected
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    @pytest.mark.parametrize(
+        "result_factory",
+        [
+            lambda: [],
+            lambda: [None, "", 0, False],
+            lambda: ("tuple",),
+            lambda: (value for value in ("generated",)),
+            lambda: "string aggregate",
+            lambda: None,
+        ],
+        ids=("empty-list", "falsey-list", "tuple", "generator", "string", "none"),
+    )
+    def test_omission_forms_preserve_exact_baseline_without_trailing_separator(
+        self, width, result_factory
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == _plugin_status_bar_baseline(width)
+        assert not text.endswith(separator)
+        _assert_status_bar_hook_call(hook, snapshot)
+
+
+class TestStatusBarPluginFailuresAndOverflow:
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_invocation_failure_preserves_exact_baseline(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == _plugin_status_bar_baseline(width)
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
+    def test_element_failure_preserves_exact_baseline(self, width, broken):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        separator = " · " if width < 76 else " │ "
+        assert text == _plugin_status_bar_baseline(width) + separator + "partial"
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_lookup_failure_preserves_exact_baseline(self, width, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        monkeypatch.delattr(plugins, "invoke_hook")
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == _plugin_status_bar_baseline(width)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_plugin_values_are_appended_before_display_width_trimming(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+        untrimmed = separator.join(
+            [_plugin_status_bar_baseline(width), "x" * 200]
+        )
+        expected = cli_obj._trim_status_bar_text(untrimmed, width)
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["x" * 200]
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == expected
+        assert text.endswith("...")
+        assert cli_obj._status_bar_display_width(text) <= width
+        _assert_status_bar_hook_call(hook, snapshot)
 
 
 class TestCLIStatusBar:

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
@@ -20,6 +21,10 @@ def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
+    cli_obj._status_bar_plugin_refresh_lock = threading.Lock()
+    cli_obj._status_bar_plugin_refresh_executor = None
+    cli_obj._status_bar_plugin_refresh_running = False
+    cli_obj._status_bar_plugin_refresh_thread = None
     return cli_obj
 
 
@@ -88,7 +93,7 @@ def _plugin_status_bar_baseline(width):
     return "⚕ m │ 50K/200K │ 25% │ 9m │ ⏲ 3s"
 
 
-def _assert_status_bar_hook_call(hook, snapshot):
+def _assert_hook_invoked_once_with_snapshot(hook, snapshot):
     assert hook.call_count == 1
     assert hook.call_args.args == ("on_status_bar_render",)
     assert set(hook.call_args.kwargs) == {"snapshot"}
@@ -109,7 +114,15 @@ class _BrokenStringValue:
         raise RuntimeError("stringification failure")
 
 
-class TestStatusBarPluginValueHelper:
+class TestStatusBarPluginHookNormalization:
+    """Tests for _invoke_status_bar_plugin_hook.
+
+    This helper is only ever called from the background refresh path
+    (_refresh_status_bar_plugin_values) -- never from rendering. It owns
+    calling invoke_hook() and normalizing the result into display-ready
+    strings.
+    """
+
     def test_invokes_once_and_normalizes_ordered_truthy_values(self):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
@@ -117,10 +130,10 @@ class TestStatusBarPluginValueHelper:
             "hermes_cli.plugins.invoke_hook",
             return_value=[None, "", 0, False, "ready", 7, {"state": "ok"}],
         ) as hook:
-            values = cli_obj._get_status_bar_plugin_values(snapshot)
+            values = cli_obj._invoke_status_bar_plugin_hook(snapshot)
 
         assert values == ["ready", "7", "{'state': 'ok'}"]
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
     def test_sanitizes_control_characters_to_keep_footer_on_one_line(self):
         cli_obj = _make_cli()
@@ -129,10 +142,10 @@ class TestStatusBarPluginValueHelper:
             "hermes_cli.plugins.invoke_hook",
             return_value=[" ready\nnow\r\x1b[31m\t "],
         ) as hook:
-            values = cli_obj._get_status_bar_plugin_values(snapshot)
+            values = cli_obj._invoke_status_bar_plugin_hook(snapshot)
 
         assert values == ["ready now  [31m"]
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
     def test_plugin_cannot_mutate_renderer_snapshot(self):
         cli_obj = _make_cli()
@@ -143,7 +156,7 @@ class TestStatusBarPluginValueHelper:
             return ["ready"]
 
         with patch("hermes_cli.plugins.invoke_hook", side_effect=mutate_snapshot):
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) == ["ready"]
 
         assert snapshot == _plugin_status_bar_snapshot()
 
@@ -157,13 +170,13 @@ class TestStatusBarPluginValueHelper:
         ],
         ids=("tuple", "generator", "string", "none"),
     )
-    def test_rejects_non_list_aggregates(self, unsupported):
+    def test_rejects_non_list_aggregates_by_returning_none(self, unsupported):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         with patch("hermes_cli.plugins.invoke_hook", return_value=unsupported) as hook:
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == []
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) is None
 
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
     @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
     def test_preserves_healthy_values_when_an_element_is_broken(self, broken):
@@ -172,28 +185,194 @@ class TestStatusBarPluginValueHelper:
         with patch(
             "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
         ) as hook:
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["partial"]
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) == ["partial"]
 
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
-    def test_caches_hook_values_during_repaint_window(self):
+    def test_invocation_failure_returns_none(self):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
-        with patch("hermes_cli.plugins.invoke_hook", return_value=["ready"]) as hook, patch(
-            "cli.time.monotonic", side_effect=[10.0, 10.5, 11.0]
-        ):
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+        with patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
+        ) as hook:
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) is None
 
-        assert hook.call_count == 2
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
+
+    def test_lookup_failure_returns_none(self, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        monkeypatch.delattr(plugins, "invoke_hook")
+
+        assert cli_obj._invoke_status_bar_plugin_hook(snapshot) is None
+
+
+class TestStatusBarPluginValueCache:
+    """_get_status_bar_plugin_values() is the repaint-path reader.
+
+    It runs on prompt_toolkit's synchronous repaint path and must never
+    call invoke_hook() -- it only reflects whatever the background refresh
+    last wrote to the cache.
+    """
+
+    def test_returns_empty_list_when_no_cache_populated(self):
+        cli_obj = _make_cli()
+        with patch("hermes_cli.plugins.invoke_hook") as hook:
+            assert cli_obj._get_status_bar_plugin_values() == []
+
+        hook.assert_not_called()
+
+    def test_returns_cached_values_without_calling_invoke_hook(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("ready", "7")
+
+        with patch("hermes_cli.plugins.invoke_hook") as hook:
+            assert cli_obj._get_status_bar_plugin_values() == ["ready", "7"]
+
+        hook.assert_not_called()
+
+    def test_returned_list_is_a_copy(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("ready",)
+
+        values = cli_obj._get_status_bar_plugin_values()
+        values.append("mutated")
+
+        assert cli_obj._status_bar_plugin_values_cache == ("ready",)
+
+
+class TestStatusBarPluginBackgroundRefresh:
+    """_refresh_status_bar_plugin_values() is the only caller of invoke_hook()
+    for this event. Covers the single-in-flight guard, the hard timeout, and
+    that the cache survives errors/timeouts untouched.
+    """
+
+    def test_populates_cache_from_hook_on_success(self):
+        cli_obj = _make_cli()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=["ready"]):
+            cli_obj._refresh_status_bar_plugin_values()
+
+        assert cli_obj._get_status_bar_plugin_values() == ["ready"]
+
+    def test_error_preserves_existing_cache(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("old",)
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("boom")):
+            cli_obj._refresh_status_bar_plugin_values()
+
+        assert cli_obj._get_status_bar_plugin_values() == ["old"]
+
+    def test_single_in_flight_guard_skips_concurrent_refresh(self):
+        cli_obj = _make_cli()
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_invoke_hook(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=2)
+            return ["done"]
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=blocking_invoke_hook
+        ) as hook:
+            first = threading.Thread(target=cli_obj._refresh_status_bar_plugin_values)
+            first.start()
+            assert started.wait(timeout=2)
+
+            # A second refresh while the first is still in flight must be a
+            # no-op -- it must not call invoke_hook again.
+            cli_obj._refresh_status_bar_plugin_values()
+            assert hook.call_count == 1
+
+            release.set()
+            first.join(timeout=2)
+
+        assert cli_obj._get_status_bar_plugin_values() == ["done"]
+
+    def test_blocking_callback_does_not_freeze_the_repaint_path(self):
+        """Regression: a slow/blocking on_status_bar_render callback (e.g. a
+        configured shell hook shelling out via subprocess.run(), which
+        defaults to a 60s timeout) must never stall rendering. The refresh
+        call itself is bounded by _STATUS_BAR_PLUGIN_REFRESH_TIMEOUT, and the
+        render path never calls invoke_hook() at all, so a repaint stays
+        instant regardless of what the callback is doing.
+        """
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("old",)
+        cli_obj._STATUS_BAR_PLUGIN_REFRESH_TIMEOUT = 0.05
+
+        release = threading.Event()
+
+        def blocking_invoke_hook(*_args, **_kwargs):
+            # Blocks well past the refresh timeout, mirroring a stuck or
+            # slow shell hook.
+            release.wait(timeout=1.0)
+            return ["late"]
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=blocking_invoke_hook
+        ) as hook:
+            t0 = time.monotonic()
+            cli_obj._refresh_status_bar_plugin_values()
+            elapsed = time.monotonic() - t0
+
+            # The refresh call returns promptly even though the callback is
+            # still running -- bounded by the timeout, not the callback.
+            assert elapsed < 0.5
+
+            # The repaint path is untouched by any of this: it never calls
+            # invoke_hook and reflects the pre-existing cache.
+            with patch.object(
+                cli_obj, "_get_status_bar_snapshot",
+                return_value=_plugin_status_bar_snapshot(),
+            ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
+                t1 = time.monotonic()
+                text = cli_obj._build_status_bar_text(width=120)
+                render_elapsed = time.monotonic() - t1
+
+            assert "old" in text
+            assert render_elapsed < 0.5
+
+            release.set()
+
+        # invoke_hook was only ever dispatched once, by the refresh call.
+        assert hook.call_count == 1
+
+    def test_start_triggers_periodic_refresh_and_stop_ends_it(self):
+        cli_obj = _make_cli()
+
+        with patch.object(HermesCLI, "_STATUS_BAR_PLUGIN_CACHE_TTL", 0.01), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["ready"]
+        ):
+            cli_obj._status_bar_plugin_refresh_start()
+            try:
+                deadline = time.monotonic() + 2
+                while (
+                    cli_obj._get_status_bar_plugin_values() != ["ready"]
+                    and time.monotonic() < deadline
+                ):
+                    time.sleep(0.01)
+            finally:
+                cli_obj._status_bar_plugin_refresh_stop()
+
+        assert cli_obj._get_status_bar_plugin_values() == ["ready"]
+        assert cli_obj._status_bar_plugin_refresh_running is False
+        assert cli_obj._status_bar_plugin_refresh_thread is None
 
 
 class TestStatusBarPluginTierIntegration:
+    """Rendering must reflect whatever the background refresh cached -- it
+    must never dispatch invoke_hook() itself.
+    """
+
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    def test_appends_ordered_truthy_values_with_tier_separator(self, width):
+    def test_appends_cached_values_with_tier_separator(self, width):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("ready", "7")
         separator = " · " if width < 76 else " │ "
         expected = separator.join(
             [_plugin_status_bar_baseline(width), "ready", "7"]
@@ -203,30 +382,15 @@ class TestStatusBarPluginTierIntegration:
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[None, "", 0, False, "ready", 7],
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             text = cli_obj._build_status_bar_text(width=width)
 
         assert text == expected
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    @pytest.mark.parametrize(
-        "result_factory",
-        [
-            lambda: [],
-            lambda: [None, "", 0, False],
-            lambda: ("tuple",),
-            lambda: (value for value in ("generated",)),
-            lambda: "string aggregate",
-            lambda: None,
-        ],
-        ids=("empty-list", "falsey-list", "tuple", "generator", "string", "none"),
-    )
-    def test_omission_forms_preserve_exact_baseline_without_trailing_separator(
-        self, width, result_factory
+    def test_empty_cache_preserves_exact_baseline_without_trailing_separator(
+        self, width
     ):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
@@ -236,73 +400,19 @@ class TestStatusBarPluginTierIntegration:
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             text = cli_obj._build_status_bar_text(width=width)
 
         assert text == _plugin_status_bar_baseline(width)
         assert not text.endswith(separator)
-        _assert_status_bar_hook_call(hook, snapshot)
-
-
-class TestStatusBarPluginFailuresAndOverflow:
-    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    def test_invocation_failure_preserves_exact_baseline(self, width):
-        cli_obj = _make_cli()
-        snapshot = _plugin_status_bar_snapshot()
-
-        with patch.object(
-            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
-        ) as hook:
-            text = cli_obj._build_status_bar_text(width=width)
-
-        assert text == _plugin_status_bar_baseline(width)
-        _assert_status_bar_hook_call(hook, snapshot)
-
-    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
-    def test_element_failure_preserves_exact_baseline(self, width, broken):
-        cli_obj = _make_cli()
-        snapshot = _plugin_status_bar_snapshot()
-
-        with patch.object(
-            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
-        ) as hook:
-            text = cli_obj._build_status_bar_text(width=width)
-
-        separator = " · " if width < 76 else " │ "
-        assert text == _plugin_status_bar_baseline(width) + separator + "partial"
-        _assert_status_bar_hook_call(hook, snapshot)
-
-    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    def test_lookup_failure_preserves_exact_baseline(self, width, monkeypatch):
-        import hermes_cli.plugins as plugins
-
-        cli_obj = _make_cli()
-        snapshot = _plugin_status_bar_snapshot()
-        monkeypatch.delattr(plugins, "invoke_hook")
-
-        with patch.object(
-            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
-            text = cli_obj._build_status_bar_text(width=width)
-
-        assert text == _plugin_status_bar_baseline(width)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
     def test_plugin_values_are_appended_before_display_width_trimming(self, width):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         separator = " · " if width < 76 else " │ "
+        cli_obj._status_bar_plugin_values_cache = ("x" * 200,)
         untrimmed = separator.join(
             [_plugin_status_bar_baseline(width), "x" * 200]
         )
@@ -312,15 +422,13 @@ class TestStatusBarPluginFailuresAndOverflow:
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["x" * 200]
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             text = cli_obj._build_status_bar_text(width=width)
 
         assert text == expected
         assert text.endswith("...")
         assert cli_obj._status_bar_display_width(text) <= width
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
 
 _RENDERERS = ("text", "fragments")
@@ -376,32 +484,18 @@ def _plugin_status_bar_fragment_baseline(width):
     ]
 
 
-_AC4_RESULT_FACTORIES = (
-    pytest.param(lambda: [], id="result-empty-list"),
-    pytest.param(lambda: [None, "", 0, False], id="result-falsey-list"),
-    pytest.param(lambda: ("tuple",), id="result-tuple"),
-    pytest.param(
-        lambda: (value for value in ("generated",)),
-        id="result-generator",
-    ),
-    pytest.param(lambda: "string aggregate", id="result-string"),
-    pytest.param(lambda: None, id="result-none"),
-)
-
-
 class TestStatusBarPluginCrossRendererRegression:
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    def test_fragment_renderer_invokes_once_with_snapshot_and_exact_styles(self, width):
+    def test_fragment_renderer_reflects_cache_with_exact_styles(self, width):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("ready",)
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ) as get_snapshot, patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["ready"]
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             fragments = _render_status_bar(cli_obj, "fragments", width)
 
         separator = " · " if width < 76 else " │ "
@@ -412,15 +506,14 @@ class TestStatusBarPluginCrossRendererRegression:
         ]
         assert fragments == expected
         get_snapshot.assert_called_once_with()
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    @pytest.mark.parametrize("result_factory", _AC4_RESULT_FACTORIES)
-    def test_ac4_omission_forms_match_empty_list_without_dangling_separator(
-        self, renderer, width, result_factory
+    def test_empty_cache_matches_across_renderers_without_dangling_separator(
+        self, renderer, width
     ):
         snapshot = _plugin_status_bar_snapshot()
         baseline_cli = _make_cli()
@@ -428,20 +521,14 @@ class TestStatusBarPluginCrossRendererRegression:
 
         with patch.object(
             baseline_cli, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            baseline_cli, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=[]
-        ):
+        ), patch.object(baseline_cli, "_is_session_yolo_active", return_value=False):
             empty_render = _render_status_bar(baseline_cli, renderer, width)
 
         with patch.object(
             candidate_cli, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             candidate_cli, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             candidate_render = _render_status_bar(candidate_cli, renderer, width)
 
         empty_text = _rendered_status_bar_text(empty_render)
@@ -451,25 +538,22 @@ class TestStatusBarPluginCrossRendererRegression:
         assert candidate_text.rstrip().endswith(separator_glyph) is False
         if renderer == "fragments":
             assert candidate_render == empty_render
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    def test_successful_callback_uses_tier_separator_and_strict_width_bound(
+    def test_cached_value_uses_tier_separator_and_strict_width_bound(
         self, renderer, width
     ):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("x",)
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["x"]
-        ) as hook:
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
             rendered = _render_status_bar(cli_obj, renderer, width)
 
         separator = " · " if width < 76 else " │ "
@@ -482,15 +566,19 @@ class TestStatusBarPluginCrossRendererRegression:
                 ("class:status-bar", "x"),
                 ("class:status-bar", " "),
             ]
-        _assert_status_bar_hook_call(hook, snapshot)
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    def test_failing_callback_preserves_baseline_and_invokes_once(
+    def test_stale_or_missing_cache_preserves_baseline_and_never_calls_hook(
         self, renderer, width
     ):
+        """Rendering must never depend on invoke_hook succeeding: an empty
+        cache (e.g. before the first background refresh completes, or after
+        one failed) just renders without plugin values -- and it must not
+        call invoke_hook() to find out.
+        """
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
 
@@ -499,8 +587,7 @@ class TestStatusBarPluginCrossRendererRegression:
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
         ), patch(
-            "hermes_cli.plugins.invoke_hook",
-            side_effect=RuntimeError("plugin failure"),
+            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
         ) as hook:
             rendered = _render_status_bar(cli_obj, renderer, width)
 
@@ -511,7 +598,7 @@ class TestStatusBarPluginCrossRendererRegression:
         assert cli_obj._status_bar_display_width(
             _rendered_status_bar_text(rendered)
         ) <= width
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
@@ -523,15 +610,12 @@ class TestStatusBarPluginCrossRendererRegression:
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         plugin_value = "x" * 200
+        cli_obj._status_bar_plugin_values_cache = (plugin_value,)
         separator = " · " if width < 76 else " │ "
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=[plugin_value]
-        ) as hook:
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
             rendered = _render_status_bar(cli_obj, renderer, width)
 
         if renderer == "text":
@@ -552,27 +636,26 @@ class TestStatusBarPluginCrossRendererRegression:
         assert text == cli_obj._trim_status_bar_text(untrimmed, width)
         assert text.endswith("...")
         assert cli_obj._status_bar_display_width(text) <= width
-        _assert_status_bar_hook_call(hook, snapshot)
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", (51, 52, 76), ids=lambda value: f"width-{value}")
-    def test_truthy_non_strings_are_filtered_stringified_and_ordered(
+    def test_truthy_non_strings_are_ordered_once_already_normalized(
         self, renderer, width
     ):
+        # Stringify/order/filter-falsy normalization itself is covered
+        # directly in TestStatusBarPluginHookNormalization. This confirms
+        # the renderer places already-normalized cache entries correctly
+        # relative to each width tier.
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         separator = " · " if width < 76 else " │ "
+        cli_obj._status_bar_plugin_values_cache = ("7", "2.5")
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[None, 7, "", False, 2.5, 0],
-        ) as hook:
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
             rendered = _render_status_bar(cli_obj, renderer, width)
 
         text = _rendered_status_bar_text(rendered)
@@ -586,7 +669,6 @@ class TestStatusBarPluginCrossRendererRegression:
                 ("class:status-bar", "2.5"),
                 ("class:status-bar", " "),
             ]
-        _assert_status_bar_hook_call(hook, snapshot)
 
     @pytest.mark.parametrize(
         ("visible", "model_picker"),
@@ -612,6 +694,7 @@ class TestStatusBarPluginCrossRendererRegression:
         cli_obj = _make_cli()
         cli_obj._status_bar_visible = True
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("x",)
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
@@ -621,13 +704,11 @@ class TestStatusBarPluginCrossRendererRegression:
             cli_obj,
             "_is_session_yolo_active",
             side_effect=[RuntimeError("fragment failure"), False],
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["x"]
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             rendered = cli_obj._get_status_bar_fragments()
 
         assert rendered == [("class:status-bar", " ⚕ m · 25% · 9m · x ")]
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     def test_fragment_snapshot_failure_uses_live_model_and_width_bound(self):
         cli_obj = _make_cli()
@@ -646,7 +727,14 @@ class TestStatusBarPluginCrossRendererRegression:
         assert cli_obj.model not in text
         assert cli_obj._status_bar_display_width(text) <= 20
 
-    def test_one_registered_callback_renders_all_eight_combinations_with_metadata(self):
+    def test_registered_plugin_callback_only_reaches_render_via_background_refresh(
+        self,
+    ):
+        """End-to-end: a real registered on_status_bar_render callback must
+        go through _refresh_status_bar_plugin_values() to reach the cache
+        the renderer reads. Calling the renderer alone (with no refresh yet)
+        must not dispatch it.
+        """
         manager = PluginManager()
         context = PluginContext(
             PluginManifest(name="status-bar-renderer-regression", source="user"),
@@ -670,13 +758,21 @@ class TestStatusBarPluginCrossRendererRegression:
                     ), patch.object(
                         cli_obj, "_is_session_yolo_active", return_value=False
                     ):
-                        rendered = _render_status_bar(cli_obj, renderer, width)
+                        received_before = len(received)
+                        rendered_before = _render_status_bar(cli_obj, renderer, width)
+                        assert len(received) == received_before, (
+                            "render must not dispatch the hook"
+                        )
+                        assert rendered_before is not None
 
-                    text = _rendered_status_bar_text(rendered)
+                        cli_obj._refresh_status_bar_plugin_values()
+                        rendered_after = _render_status_bar(cli_obj, renderer, width)
+
+                    text = _rendered_status_bar_text(rendered_after)
                     separator = " · " if width < 76 else " │ "
-                    assert separator + "x" in text, (renderer, width, rendered)
+                    assert separator + "x" in text, (renderer, width, rendered_after)
                     if renderer == "fragments":
-                        assert ("class:status-bar", "x") in rendered
+                        assert ("class:status-bar", "x") in rendered_after
 
         assert manager.has_hook("on_status_bar_render")
         assert len(received) == len(_RENDERERS) * len(_STATUS_BAR_WIDTHS)

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import cli as cli_mod
 from cli import HermesCLI
 
@@ -52,6 +54,267 @@ def _attach_agent(
         ),
     )
     return cli_obj
+
+
+_STATUS_BAR_WIDTHS = (51, 52, 75, 76)
+
+
+def _plugin_status_bar_snapshot():
+    """Return a deterministic snapshot that exercises all three text tiers."""
+    return {
+        "model_short": "m",
+        "context_percent": 25,
+        "context_length": 200_000,
+        "context_tokens": 50_000,
+        "duration": "9m",
+        "compressions": 0,
+        "active_background_tasks": 0,
+        "active_background_processes": 0,
+        "active_background_subagents": 0,
+        "prompt_elapsed": "⏲ 3s",
+        "idle_since": "",
+    }
+
+
+def _plugin_status_bar_baseline(width):
+    if width < 52:
+        return "⚕ m · 9m"
+    if width < 76:
+        return "⚕ m · 25% · 9m"
+    return "⚕ m │ 50K/200K │ 25% │ 9m │ ⏲ 3s"
+
+
+def _assert_status_bar_hook_call(hook, snapshot):
+    assert hook.call_count == 1
+    assert hook.call_args.args == ("on_status_bar_render",)
+    assert set(hook.call_args.kwargs) == {"snapshot"}
+    assert hook.call_args.kwargs["snapshot"] == snapshot
+    assert hook.call_args.kwargs["snapshot"] is not snapshot
+
+
+class _BrokenTruthValue:
+    def __bool__(self):
+        raise RuntimeError("truth-value failure")
+
+
+class _BrokenStringValue:
+    def __bool__(self):
+        return True
+
+    def __str__(self):
+        raise RuntimeError("stringification failure")
+
+
+class TestStatusBarPluginValueHelper:
+    def test_invokes_once_and_normalizes_only_ordered_nonempty_string_values(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[None, "", 0, False, "ready", 7, {"state": "ok"}],
+        ) as hook:
+            values = cli_obj._get_status_bar_plugin_values(snapshot)
+
+        assert values == ["ready"]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_sanitizes_control_characters_to_keep_footer_on_one_line(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[" ready\nnow\r\x1b[31m\t "],
+        ) as hook:
+            values = cli_obj._get_status_bar_plugin_values(snapshot)
+
+        assert values == ["ready now  [31m"]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_plugin_cannot_mutate_renderer_snapshot(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        def mutate_snapshot(*_args, **kwargs):
+            kwargs["snapshot"].clear()
+            return ["ready"]
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=mutate_snapshot):
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+
+        assert snapshot == _plugin_status_bar_snapshot()
+
+    @pytest.mark.parametrize(
+        "unsupported",
+        [
+            (),
+            (value for value in ("generated",)),
+            "string aggregate",
+            None,
+        ],
+        ids=("tuple", "generator", "string", "none"),
+    )
+    def test_rejects_non_list_aggregates(self, unsupported):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=unsupported) as hook:
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == []
+
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
+    def test_preserves_healthy_values_when_an_element_is_broken(self, broken):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
+        ) as hook:
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["partial"]
+
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_caches_hook_values_during_repaint_window(self):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=["ready"]) as hook, patch(
+            "cli.time.monotonic", side_effect=[10.0, 10.5, 11.0]
+        ):
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+
+        assert hook.call_count == 2
+
+
+class TestStatusBarPluginTierIntegration:
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_appends_ordered_truthy_values_with_tier_separator(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+        expected = separator.join([_plugin_status_bar_baseline(width), "ready"])
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[None, "", 0, False, "ready", 7],
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == expected
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    @pytest.mark.parametrize(
+        "result_factory",
+        [
+            lambda: [],
+            lambda: [None, "", 0, False],
+            lambda: ("tuple",),
+            lambda: (value for value in ("generated",)),
+            lambda: "string aggregate",
+            lambda: None,
+        ],
+        ids=("empty-list", "falsey-list", "tuple", "generator", "string", "none"),
+    )
+    def test_omission_forms_preserve_exact_baseline_without_trailing_separator(
+        self, width, result_factory
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == _plugin_status_bar_baseline(width)
+        assert not text.endswith(separator)
+        _assert_status_bar_hook_call(hook, snapshot)
+
+
+class TestStatusBarPluginFailuresAndOverflow:
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_invocation_failure_preserves_exact_baseline(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == _plugin_status_bar_baseline(width)
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
+    def test_element_failure_preserves_exact_baseline(self, width, broken):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        separator = " · " if width < 76 else " │ "
+        assert text == _plugin_status_bar_baseline(width) + separator + "partial"
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_lookup_failure_preserves_exact_baseline(self, width, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        monkeypatch.delattr(plugins, "invoke_hook")
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == _plugin_status_bar_baseline(width)
+
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
+    def test_plugin_values_are_appended_before_display_width_trimming(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+        untrimmed = separator.join(
+            [_plugin_status_bar_baseline(width), "x" * 200]
+        )
+        expected = cli_obj._trim_status_bar_text(untrimmed, width)
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["x" * 200]
+        ) as hook:
+            text = cli_obj._build_status_bar_text(width=width)
+
+        assert text == expected
+        assert text.endswith("...")
+        assert cli_obj._status_bar_display_width(text) <= width
+        _assert_status_bar_hook_call(hook, snapshot)
 
 
 class TestCLIStatusBar:

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -21,6 +22,10 @@ def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
+    cli_obj._status_bar_plugin_refresh_lock = threading.Lock()
+    cli_obj._status_bar_plugin_refresh_executor = None
+    cli_obj._status_bar_plugin_refresh_running = False
+    cli_obj._status_bar_plugin_refresh_thread = None
     return cli_obj
 
 
@@ -89,7 +94,7 @@ def _plugin_status_bar_baseline(width):
     return "⚕ m │ 50K/200K │ 25% │ 9m │ ⏲ 3s"
 
 
-def _assert_status_bar_hook_call(hook, snapshot):
+def _assert_hook_invoked_once_with_snapshot(hook, snapshot):
     assert hook.call_count == 1
     assert hook.call_args.args == ("on_status_bar_render",)
     assert set(hook.call_args.kwargs) == {"snapshot"}
@@ -110,7 +115,15 @@ class _BrokenStringValue:
         raise RuntimeError("stringification failure")
 
 
-class TestStatusBarPluginValueHelper:
+class TestStatusBarPluginHookNormalization:
+    """Tests for _invoke_status_bar_plugin_hook.
+
+    This helper is only ever called from the background refresh path
+    (_refresh_status_bar_plugin_values) -- never from rendering. It owns
+    calling invoke_hook() and normalizing the result into display-ready
+    strings.
+    """
+
     def test_invokes_once_and_normalizes_ordered_truthy_values(self):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
@@ -118,10 +131,10 @@ class TestStatusBarPluginValueHelper:
             "hermes_cli.plugins.invoke_hook",
             return_value=[None, "", 0, False, "ready", 7, {"state": "ok"}],
         ) as hook:
-            values = cli_obj._get_status_bar_plugin_values(snapshot)
+            values = cli_obj._invoke_status_bar_plugin_hook(snapshot)
 
         assert values == ["ready", "7", "{'state': 'ok'}"]
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
     def test_sanitizes_control_characters_to_keep_footer_on_one_line(self):
         cli_obj = _make_cli()
@@ -130,10 +143,10 @@ class TestStatusBarPluginValueHelper:
             "hermes_cli.plugins.invoke_hook",
             return_value=[" ready\nnow\r\x1b[31m\t "],
         ) as hook:
-            values = cli_obj._get_status_bar_plugin_values(snapshot)
+            values = cli_obj._invoke_status_bar_plugin_hook(snapshot)
 
         assert values == ["ready now  [31m"]
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
     def test_plugin_cannot_mutate_renderer_snapshot(self):
         cli_obj = _make_cli()
@@ -144,7 +157,7 @@ class TestStatusBarPluginValueHelper:
             return ["ready"]
 
         with patch("hermes_cli.plugins.invoke_hook", side_effect=mutate_snapshot):
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) == ["ready"]
 
         assert snapshot == _plugin_status_bar_snapshot()
 
@@ -158,13 +171,13 @@ class TestStatusBarPluginValueHelper:
         ],
         ids=("tuple", "generator", "string", "none"),
     )
-    def test_rejects_non_list_aggregates(self, unsupported):
+    def test_rejects_non_list_aggregates_by_returning_none(self, unsupported):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         with patch("hermes_cli.plugins.invoke_hook", return_value=unsupported) as hook:
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == []
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) is None
 
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
     @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
     def test_preserves_healthy_values_when_an_element_is_broken(self, broken):
@@ -173,28 +186,194 @@ class TestStatusBarPluginValueHelper:
         with patch(
             "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
         ) as hook:
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["partial"]
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) == ["partial"]
 
-        _assert_status_bar_hook_call(hook, snapshot)
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
 
-    def test_caches_hook_values_during_repaint_window(self):
+    def test_invocation_failure_returns_none(self):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
-        with patch("hermes_cli.plugins.invoke_hook", return_value=["ready"]) as hook, patch(
-            "cli.time.monotonic", side_effect=[10.0, 10.5, 11.0]
-        ):
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
-            assert cli_obj._get_status_bar_plugin_values(snapshot) == ["ready"]
+        with patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
+        ) as hook:
+            assert cli_obj._invoke_status_bar_plugin_hook(snapshot) is None
 
-        assert hook.call_count == 2
+        _assert_hook_invoked_once_with_snapshot(hook, snapshot)
+
+    def test_lookup_failure_returns_none(self, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        monkeypatch.delattr(plugins, "invoke_hook")
+
+        assert cli_obj._invoke_status_bar_plugin_hook(snapshot) is None
+
+
+class TestStatusBarPluginValueCache:
+    """_get_status_bar_plugin_values() is the repaint-path reader.
+
+    It runs on prompt_toolkit's synchronous repaint path and must never
+    call invoke_hook() -- it only reflects whatever the background refresh
+    last wrote to the cache.
+    """
+
+    def test_returns_empty_list_when_no_cache_populated(self):
+        cli_obj = _make_cli()
+        with patch("hermes_cli.plugins.invoke_hook") as hook:
+            assert cli_obj._get_status_bar_plugin_values() == []
+
+        hook.assert_not_called()
+
+    def test_returns_cached_values_without_calling_invoke_hook(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("ready", "7")
+
+        with patch("hermes_cli.plugins.invoke_hook") as hook:
+            assert cli_obj._get_status_bar_plugin_values() == ["ready", "7"]
+
+        hook.assert_not_called()
+
+    def test_returned_list_is_a_copy(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("ready",)
+
+        values = cli_obj._get_status_bar_plugin_values()
+        values.append("mutated")
+
+        assert cli_obj._status_bar_plugin_values_cache == ("ready",)
+
+
+class TestStatusBarPluginBackgroundRefresh:
+    """_refresh_status_bar_plugin_values() is the only caller of invoke_hook()
+    for this event. Covers the single-in-flight guard, the hard timeout, and
+    that the cache survives errors/timeouts untouched.
+    """
+
+    def test_populates_cache_from_hook_on_success(self):
+        cli_obj = _make_cli()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=["ready"]):
+            cli_obj._refresh_status_bar_plugin_values()
+
+        assert cli_obj._get_status_bar_plugin_values() == ["ready"]
+
+    def test_error_preserves_existing_cache(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("old",)
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("boom")):
+            cli_obj._refresh_status_bar_plugin_values()
+
+        assert cli_obj._get_status_bar_plugin_values() == ["old"]
+
+    def test_single_in_flight_guard_skips_concurrent_refresh(self):
+        cli_obj = _make_cli()
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_invoke_hook(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=2)
+            return ["done"]
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=blocking_invoke_hook
+        ) as hook:
+            first = threading.Thread(target=cli_obj._refresh_status_bar_plugin_values)
+            first.start()
+            assert started.wait(timeout=2)
+
+            # A second refresh while the first is still in flight must be a
+            # no-op -- it must not call invoke_hook again.
+            cli_obj._refresh_status_bar_plugin_values()
+            assert hook.call_count == 1
+
+            release.set()
+            first.join(timeout=2)
+
+        assert cli_obj._get_status_bar_plugin_values() == ["done"]
+
+    def test_blocking_callback_does_not_freeze_the_repaint_path(self):
+        """Regression: a slow/blocking on_status_bar_render callback (e.g. a
+        configured shell hook shelling out via subprocess.run(), which
+        defaults to a 60s timeout) must never stall rendering. The refresh
+        call itself is bounded by _STATUS_BAR_PLUGIN_REFRESH_TIMEOUT, and the
+        render path never calls invoke_hook() at all, so a repaint stays
+        instant regardless of what the callback is doing.
+        """
+        cli_obj = _make_cli()
+        cli_obj._status_bar_plugin_values_cache = ("old",)
+        cli_obj._STATUS_BAR_PLUGIN_REFRESH_TIMEOUT = 0.05
+
+        release = threading.Event()
+
+        def blocking_invoke_hook(*_args, **_kwargs):
+            # Blocks well past the refresh timeout, mirroring a stuck or
+            # slow shell hook.
+            release.wait(timeout=1.0)
+            return ["late"]
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook", side_effect=blocking_invoke_hook
+        ) as hook:
+            t0 = time.monotonic()
+            cli_obj._refresh_status_bar_plugin_values()
+            elapsed = time.monotonic() - t0
+
+            # The refresh call returns promptly even though the callback is
+            # still running -- bounded by the timeout, not the callback.
+            assert elapsed < 0.5
+
+            # The repaint path is untouched by any of this: it never calls
+            # invoke_hook and reflects the pre-existing cache.
+            with patch.object(
+                cli_obj, "_get_status_bar_snapshot",
+                return_value=_plugin_status_bar_snapshot(),
+            ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
+                t1 = time.monotonic()
+                text = cli_obj._build_status_bar_text(width=120)
+                render_elapsed = time.monotonic() - t1
+
+            assert "old" in text
+            assert render_elapsed < 0.5
+
+            release.set()
+
+        # invoke_hook was only ever dispatched once, by the refresh call.
+        assert hook.call_count == 1
+
+    def test_start_triggers_periodic_refresh_and_stop_ends_it(self):
+        cli_obj = _make_cli()
+
+        with patch.object(HermesCLI, "_STATUS_BAR_PLUGIN_CACHE_TTL", 0.01), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["ready"]
+        ):
+            cli_obj._status_bar_plugin_refresh_start()
+            try:
+                deadline = time.monotonic() + 2
+                while (
+                    cli_obj._get_status_bar_plugin_values() != ["ready"]
+                    and time.monotonic() < deadline
+                ):
+                    time.sleep(0.01)
+            finally:
+                cli_obj._status_bar_plugin_refresh_stop()
+
+        assert cli_obj._get_status_bar_plugin_values() == ["ready"]
+        assert cli_obj._status_bar_plugin_refresh_running is False
+        assert cli_obj._status_bar_plugin_refresh_thread is None
 
 
 class TestStatusBarPluginTierIntegration:
+    """Rendering must reflect whatever the background refresh cached -- it
+    must never dispatch invoke_hook() itself.
+    """
+
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    def test_appends_ordered_truthy_values_with_tier_separator(self, width):
+    def test_appends_cached_values_with_tier_separator(self, width):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("ready", "7")
         separator = " · " if width < 76 else " │ "
         expected = separator.join(
             [_plugin_status_bar_baseline(width), "ready", "7"]
@@ -204,30 +383,15 @@ class TestStatusBarPluginTierIntegration:
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[None, "", 0, False, "ready", 7],
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             text = cli_obj._build_status_bar_text(width=width)
 
         assert text == expected
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    @pytest.mark.parametrize(
-        "result_factory",
-        [
-            lambda: [],
-            lambda: [None, "", 0, False],
-            lambda: ("tuple",),
-            lambda: (value for value in ("generated",)),
-            lambda: "string aggregate",
-            lambda: None,
-        ],
-        ids=("empty-list", "falsey-list", "tuple", "generator", "string", "none"),
-    )
-    def test_omission_forms_preserve_exact_baseline_without_trailing_separator(
-        self, width, result_factory
+    def test_empty_cache_preserves_exact_baseline_without_trailing_separator(
+        self, width
     ):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
@@ -237,73 +401,19 @@ class TestStatusBarPluginTierIntegration:
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             text = cli_obj._build_status_bar_text(width=width)
 
         assert text == _plugin_status_bar_baseline(width)
         assert not text.endswith(separator)
-        _assert_status_bar_hook_call(hook, snapshot)
-
-
-class TestStatusBarPluginFailuresAndOverflow:
-    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    def test_invocation_failure_preserves_exact_baseline(self, width):
-        cli_obj = _make_cli()
-        snapshot = _plugin_status_bar_snapshot()
-
-        with patch.object(
-            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
-        ) as hook:
-            text = cli_obj._build_status_bar_text(width=width)
-
-        assert text == _plugin_status_bar_baseline(width)
-        _assert_status_bar_hook_call(hook, snapshot)
-
-    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    @pytest.mark.parametrize("broken", [_BrokenTruthValue(), _BrokenStringValue()])
-    def test_element_failure_preserves_exact_baseline(self, width, broken):
-        cli_obj = _make_cli()
-        snapshot = _plugin_status_bar_snapshot()
-
-        with patch.object(
-            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["partial", broken]
-        ) as hook:
-            text = cli_obj._build_status_bar_text(width=width)
-
-        separator = " · " if width < 76 else " │ "
-        assert text == _plugin_status_bar_baseline(width) + separator + "partial"
-        _assert_status_bar_hook_call(hook, snapshot)
-
-    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
-    def test_lookup_failure_preserves_exact_baseline(self, width, monkeypatch):
-        import hermes_cli.plugins as plugins
-
-        cli_obj = _make_cli()
-        snapshot = _plugin_status_bar_snapshot()
-        monkeypatch.delattr(plugins, "invoke_hook")
-
-        with patch.object(
-            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
-            text = cli_obj._build_status_bar_text(width=width)
-
-        assert text == _plugin_status_bar_baseline(width)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS)
     def test_plugin_values_are_appended_before_display_width_trimming(self, width):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         separator = " · " if width < 76 else " │ "
+        cli_obj._status_bar_plugin_values_cache = ("x" * 200,)
         untrimmed = separator.join(
             [_plugin_status_bar_baseline(width), "x" * 200]
         )
@@ -313,15 +423,13 @@ class TestStatusBarPluginFailuresAndOverflow:
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["x" * 200]
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             text = cli_obj._build_status_bar_text(width=width)
 
         assert text == expected
         assert text.endswith("...")
         assert cli_obj._status_bar_display_width(text) <= width
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
 
 _RENDERERS = ("text", "fragments")
@@ -377,32 +485,18 @@ def _plugin_status_bar_fragment_baseline(width):
     ]
 
 
-_AC4_RESULT_FACTORIES = (
-    pytest.param(lambda: [], id="result-empty-list"),
-    pytest.param(lambda: [None, "", 0, False], id="result-falsey-list"),
-    pytest.param(lambda: ("tuple",), id="result-tuple"),
-    pytest.param(
-        lambda: (value for value in ("generated",)),
-        id="result-generator",
-    ),
-    pytest.param(lambda: "string aggregate", id="result-string"),
-    pytest.param(lambda: None, id="result-none"),
-)
-
-
 class TestStatusBarPluginCrossRendererRegression:
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    def test_fragment_renderer_invokes_once_with_snapshot_and_exact_styles(self, width):
+    def test_fragment_renderer_reflects_cache_with_exact_styles(self, width):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("ready",)
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
         ) as get_snapshot, patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["ready"]
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             fragments = _render_status_bar(cli_obj, "fragments", width)
 
         separator = " · " if width < 76 else " │ "
@@ -413,15 +507,14 @@ class TestStatusBarPluginCrossRendererRegression:
         ]
         assert fragments == expected
         get_snapshot.assert_called_once_with()
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    @pytest.mark.parametrize("result_factory", _AC4_RESULT_FACTORIES)
-    def test_ac4_omission_forms_match_empty_list_without_dangling_separator(
-        self, renderer, width, result_factory
+    def test_empty_cache_matches_across_renderers_without_dangling_separator(
+        self, renderer, width
     ):
         snapshot = _plugin_status_bar_snapshot()
         baseline_cli = _make_cli()
@@ -429,20 +522,14 @@ class TestStatusBarPluginCrossRendererRegression:
 
         with patch.object(
             baseline_cli, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            baseline_cli, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=[]
-        ):
+        ), patch.object(baseline_cli, "_is_session_yolo_active", return_value=False):
             empty_render = _render_status_bar(baseline_cli, renderer, width)
 
         with patch.object(
             candidate_cli, "_get_status_bar_snapshot", return_value=snapshot
         ), patch.object(
             candidate_cli, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             candidate_render = _render_status_bar(candidate_cli, renderer, width)
 
         empty_text = _rendered_status_bar_text(empty_render)
@@ -452,25 +539,22 @@ class TestStatusBarPluginCrossRendererRegression:
         assert candidate_text.rstrip().endswith(separator_glyph) is False
         if renderer == "fragments":
             assert candidate_render == empty_render
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    def test_successful_callback_uses_tier_separator_and_strict_width_bound(
+    def test_cached_value_uses_tier_separator_and_strict_width_bound(
         self, renderer, width
     ):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("x",)
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["x"]
-        ) as hook:
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
             rendered = _render_status_bar(cli_obj, renderer, width)
 
         separator = " · " if width < 76 else " │ "
@@ -483,15 +567,19 @@ class TestStatusBarPluginCrossRendererRegression:
                 ("class:status-bar", "x"),
                 ("class:status-bar", " "),
             ]
-        _assert_status_bar_hook_call(hook, snapshot)
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
-    def test_failing_callback_preserves_baseline_and_invokes_once(
+    def test_stale_or_missing_cache_preserves_baseline_and_never_calls_hook(
         self, renderer, width
     ):
+        """Rendering must never depend on invoke_hook succeeding: an empty
+        cache (e.g. before the first background refresh completes, or after
+        one failed) just renders without plugin values -- and it must not
+        call invoke_hook() to find out.
+        """
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
 
@@ -500,8 +588,7 @@ class TestStatusBarPluginCrossRendererRegression:
         ), patch.object(
             cli_obj, "_is_session_yolo_active", return_value=False
         ), patch(
-            "hermes_cli.plugins.invoke_hook",
-            side_effect=RuntimeError("plugin failure"),
+            "hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin failure")
         ) as hook:
             rendered = _render_status_bar(cli_obj, renderer, width)
 
@@ -512,7 +599,7 @@ class TestStatusBarPluginCrossRendererRegression:
         assert cli_obj._status_bar_display_width(
             _rendered_status_bar_text(rendered)
         ) <= width
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
@@ -524,15 +611,12 @@ class TestStatusBarPluginCrossRendererRegression:
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         plugin_value = "x" * 200
+        cli_obj._status_bar_plugin_values_cache = (plugin_value,)
         separator = " · " if width < 76 else " │ "
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=[plugin_value]
-        ) as hook:
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
             rendered = _render_status_bar(cli_obj, renderer, width)
 
         if renderer == "text":
@@ -553,27 +637,26 @@ class TestStatusBarPluginCrossRendererRegression:
         assert text == cli_obj._trim_status_bar_text(untrimmed, width)
         assert text.endswith("...")
         assert cli_obj._status_bar_display_width(text) <= width
-        _assert_status_bar_hook_call(hook, snapshot)
 
     @pytest.mark.parametrize(
         "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
     )
     @pytest.mark.parametrize("width", (51, 52, 76), ids=lambda value: f"width-{value}")
-    def test_truthy_non_strings_are_filtered_stringified_and_ordered(
+    def test_truthy_non_strings_are_ordered_once_already_normalized(
         self, renderer, width
     ):
+        # Stringify/order/filter-falsy normalization itself is covered
+        # directly in TestStatusBarPluginHookNormalization. This confirms
+        # the renderer places already-normalized cache entries correctly
+        # relative to each width tier.
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         separator = " · " if width < 76 else " │ "
+        cli_obj._status_bar_plugin_values_cache = ("7", "2.5")
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
-        ), patch.object(
-            cli_obj, "_is_session_yolo_active", return_value=False
-        ), patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[None, 7, "", False, 2.5, 0],
-        ) as hook:
+        ), patch.object(cli_obj, "_is_session_yolo_active", return_value=False):
             rendered = _render_status_bar(cli_obj, renderer, width)
 
         text = _rendered_status_bar_text(rendered)
@@ -587,7 +670,6 @@ class TestStatusBarPluginCrossRendererRegression:
                 ("class:status-bar", "2.5"),
                 ("class:status-bar", " "),
             ]
-        _assert_status_bar_hook_call(hook, snapshot)
 
     @pytest.mark.parametrize(
         ("visible", "model_picker"),
@@ -613,6 +695,7 @@ class TestStatusBarPluginCrossRendererRegression:
         cli_obj = _make_cli()
         cli_obj._status_bar_visible = True
         snapshot = _plugin_status_bar_snapshot()
+        cli_obj._status_bar_plugin_values_cache = ("x",)
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
@@ -622,13 +705,11 @@ class TestStatusBarPluginCrossRendererRegression:
             cli_obj,
             "_is_session_yolo_active",
             side_effect=[RuntimeError("fragment failure"), False],
-        ), patch(
-            "hermes_cli.plugins.invoke_hook", return_value=["x"]
-        ) as hook:
+        ), patch("hermes_cli.plugins.invoke_hook") as hook:
             rendered = cli_obj._get_status_bar_fragments()
 
         assert rendered == [("class:status-bar", " ⚕ m · 25% · 9m · x ")]
-        _assert_status_bar_hook_call(hook, snapshot)
+        hook.assert_not_called()
 
     def test_fragment_snapshot_failure_uses_live_model_and_width_bound(self):
         cli_obj = _make_cli()
@@ -647,7 +728,14 @@ class TestStatusBarPluginCrossRendererRegression:
         assert cli_obj.model not in text
         assert cli_obj._status_bar_display_width(text) <= 20
 
-    def test_one_registered_callback_renders_all_eight_combinations_with_metadata(self):
+    def test_registered_plugin_callback_only_reaches_render_via_background_refresh(
+        self,
+    ):
+        """End-to-end: a real registered on_status_bar_render callback must
+        go through _refresh_status_bar_plugin_values() to reach the cache
+        the renderer reads. Calling the renderer alone (with no refresh yet)
+        must not dispatch it.
+        """
         manager = PluginManager()
         context = PluginContext(
             PluginManifest(name="status-bar-renderer-regression", source="user"),
@@ -671,13 +759,21 @@ class TestStatusBarPluginCrossRendererRegression:
                     ), patch.object(
                         cli_obj, "_is_session_yolo_active", return_value=False
                     ):
-                        rendered = _render_status_bar(cli_obj, renderer, width)
+                        received_before = len(received)
+                        rendered_before = _render_status_bar(cli_obj, renderer, width)
+                        assert len(received) == received_before, (
+                            "render must not dispatch the hook"
+                        )
+                        assert rendered_before is not None
 
-                    text = _rendered_status_bar_text(rendered)
+                        cli_obj._refresh_status_bar_plugin_values()
+                        rendered_after = _render_status_bar(cli_obj, renderer, width)
+
+                    text = _rendered_status_bar_text(rendered_after)
                     separator = " · " if width < 76 else " │ "
-                    assert separator + "x" in text, (renderer, width, rendered)
+                    assert separator + "x" in text, (renderer, width, rendered_after)
                     if renderer == "fragments":
-                        assert ("class:status-bar", "x") in rendered
+                        assert ("class:status-bar", "x") in rendered_after
 
         assert manager.has_hook("on_status_bar_render")
         assert len(received) == len(_RENDERERS) * len(_STATUS_BAR_WIDTHS)

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -8,6 +8,11 @@ import pytest
 
 import cli as cli_mod
 from cli import HermesCLI
+from hermes_cli.plugins import (
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+)
 
 
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
@@ -106,7 +111,7 @@ class _BrokenStringValue:
 
 
 class TestStatusBarPluginValueHelper:
-    def test_invokes_once_and_normalizes_only_ordered_nonempty_string_values(self):
+    def test_invokes_once_and_normalizes_ordered_truthy_values(self):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         with patch(
@@ -115,7 +120,7 @@ class TestStatusBarPluginValueHelper:
         ) as hook:
             values = cli_obj._get_status_bar_plugin_values(snapshot)
 
-        assert values == ["ready"]
+        assert values == ["ready", "7", "{'state': 'ok'}"]
         _assert_status_bar_hook_call(hook, snapshot)
 
     def test_sanitizes_control_characters_to_keep_footer_on_one_line(self):
@@ -191,7 +196,9 @@ class TestStatusBarPluginTierIntegration:
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         separator = " · " if width < 76 else " │ "
-        expected = separator.join([_plugin_status_bar_baseline(width), "ready"])
+        expected = separator.join(
+            [_plugin_status_bar_baseline(width), "ready", "7"]
+        )
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
@@ -315,6 +322,370 @@ class TestStatusBarPluginFailuresAndOverflow:
         assert text.endswith("...")
         assert cli_obj._status_bar_display_width(text) <= width
         _assert_status_bar_hook_call(hook, snapshot)
+
+
+_RENDERERS = ("text", "fragments")
+
+
+def _render_status_bar(cli_obj, renderer, width):
+    if renderer == "text":
+        return cli_obj._build_status_bar_text(width=width)
+    cli_obj._status_bar_visible = True
+    with patch.object(cli_obj, "_get_tui_terminal_width", return_value=width):
+        return cli_obj._get_status_bar_fragments()
+
+
+def _rendered_status_bar_text(rendered):
+    if isinstance(rendered, str):
+        return rendered
+    return "".join(text for _, text in rendered)
+
+
+def _plugin_status_bar_fragment_baseline(width):
+    if width < 52:
+        return [
+            ("class:status-bar", " ⚕ "),
+            ("class:status-bar-strong", "m"),
+            ("class:status-bar-dim", " · "),
+            ("class:status-bar-dim", "9m"),
+            ("class:status-bar", " "),
+        ]
+    if width < 76:
+        return [
+            ("class:status-bar", " ⚕ "),
+            ("class:status-bar-strong", "m"),
+            ("class:status-bar-dim", " · "),
+            ("class:status-bar-good", "25%"),
+            ("class:status-bar-dim", " · "),
+            ("class:status-bar-dim", "9m"),
+            ("class:status-bar", " "),
+        ]
+    return [
+        ("class:status-bar", " ⚕ "),
+        ("class:status-bar-strong", "m"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-dim", "50K/200K"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-good", "[██░░░░░░░░]"),
+        ("class:status-bar-dim", " "),
+        ("class:status-bar-good", "25%"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-dim", "9m"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-dim", "⏲ 3s"),
+        ("class:status-bar", " "),
+    ]
+
+
+_AC4_RESULT_FACTORIES = (
+    pytest.param(lambda: [], id="result-empty-list"),
+    pytest.param(lambda: [None, "", 0, False], id="result-falsey-list"),
+    pytest.param(lambda: ("tuple",), id="result-tuple"),
+    pytest.param(
+        lambda: (value for value in ("generated",)),
+        id="result-generator",
+    ),
+    pytest.param(lambda: "string aggregate", id="result-string"),
+    pytest.param(lambda: None, id="result-none"),
+)
+
+
+class TestStatusBarPluginCrossRendererRegression:
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_fragment_renderer_invokes_once_with_snapshot_and_exact_styles(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ) as get_snapshot, patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["ready"]
+        ) as hook:
+            fragments = _render_status_bar(cli_obj, "fragments", width)
+
+        separator = " · " if width < 76 else " │ "
+        expected = _plugin_status_bar_fragment_baseline(width)[:-1] + [
+            ("class:status-bar-dim", separator),
+            ("class:status-bar", "ready"),
+            ("class:status-bar", " "),
+        ]
+        assert fragments == expected
+        get_snapshot.assert_called_once_with()
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    @pytest.mark.parametrize("result_factory", _AC4_RESULT_FACTORIES)
+    def test_ac4_omission_forms_match_empty_list_without_dangling_separator(
+        self, renderer, width, result_factory
+    ):
+        snapshot = _plugin_status_bar_snapshot()
+        baseline_cli = _make_cli()
+        candidate_cli = _make_cli()
+
+        with patch.object(
+            baseline_cli, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            baseline_cli, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=[]
+        ):
+            empty_render = _render_status_bar(baseline_cli, renderer, width)
+
+        with patch.object(
+            candidate_cli, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            candidate_cli, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
+        ) as hook:
+            candidate_render = _render_status_bar(candidate_cli, renderer, width)
+
+        empty_text = _rendered_status_bar_text(empty_render)
+        candidate_text = _rendered_status_bar_text(candidate_render)
+        separator_glyph = "·" if width < 76 else "│"
+        assert candidate_text == empty_text
+        assert candidate_text.rstrip().endswith(separator_glyph) is False
+        if renderer == "fragments":
+            assert candidate_render == empty_render
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_successful_callback_uses_tier_separator_and_strict_width_bound(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["x"]
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        separator = " · " if width < 76 else " │ "
+        text = _rendered_status_bar_text(rendered)
+        assert separator + "x" in text
+        assert cli_obj._status_bar_display_width(text) <= width
+        if renderer == "fragments":
+            assert rendered[-3:] == [
+                ("class:status-bar-dim", separator),
+                ("class:status-bar", "x"),
+                ("class:status-bar", " "),
+            ]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_failing_callback_preserves_baseline_and_invokes_once(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook",
+            side_effect=RuntimeError("plugin failure"),
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        if renderer == "text":
+            assert rendered == _plugin_status_bar_baseline(width)
+        else:
+            assert rendered == _plugin_status_bar_fragment_baseline(width)
+        assert cli_obj._status_bar_display_width(
+            _rendered_status_bar_text(rendered)
+        ) <= width
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_overflow_trims_final_combined_text_to_terminal_width(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        plugin_value = "x" * 200
+        separator = " · " if width < 76 else " │ "
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=[plugin_value]
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        if renderer == "text":
+            untrimmed = separator.join(
+                [_plugin_status_bar_baseline(width), plugin_value]
+            )
+        else:
+            baseline = _plugin_status_bar_fragment_baseline(width)
+            untrimmed = (
+                "".join(text for _, text in baseline[:-1])
+                + separator
+                + plugin_value
+                + " "
+            )
+            assert rendered[0][0] == "class:status-bar"
+            assert len(rendered) == 1
+        text = _rendered_status_bar_text(rendered)
+        assert text == cli_obj._trim_status_bar_text(untrimmed, width)
+        assert text.endswith("...")
+        assert cli_obj._status_bar_display_width(text) <= width
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", (51, 52, 76), ids=lambda value: f"width-{value}")
+    def test_truthy_non_strings_are_filtered_stringified_and_ordered(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[None, 7, "", False, 2.5, 0],
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        text = _rendered_status_bar_text(rendered)
+        assert separator.join(("7", "2.5")) in text
+        assert cli_obj._status_bar_display_width(text) <= width
+        if renderer == "fragments":
+            assert rendered[-5:] == [
+                ("class:status-bar-dim", separator),
+                ("class:status-bar", "7"),
+                ("class:status-bar-dim", separator),
+                ("class:status-bar", "2.5"),
+                ("class:status-bar", " "),
+            ]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        ("visible", "model_picker"),
+        ((False, None), (True, object())),
+        ids=("hidden", "model-picker"),
+    )
+    def test_hidden_and_model_picker_fragment_renders_are_hook_free(
+        self, visible, model_picker
+    ):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_visible = visible
+        cli_obj._model_picker_state = model_picker
+
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as get_snapshot, patch(
+            "hermes_cli.plugins.invoke_hook"
+        ) as hook:
+            assert cli_obj._get_status_bar_fragments() == []
+
+        get_snapshot.assert_not_called()
+        hook.assert_not_called()
+
+    def test_fragment_fallback_does_not_redispatch_hook(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_visible = True
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_get_tui_terminal_width", return_value=52
+        ), patch.object(
+            cli_obj,
+            "_is_session_yolo_active",
+            side_effect=[RuntimeError("fragment failure"), False],
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["x"]
+        ) as hook:
+            rendered = cli_obj._get_status_bar_fragments()
+
+        assert rendered == [("class:status-bar", " ⚕ m · 25% · 9m · x ")]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_fragment_snapshot_failure_uses_live_model_and_width_bound(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_visible = True
+        cli_obj.agent = SimpleNamespace(model="fallback/live-model-with-a-long-name")
+
+        with patch.object(
+            cli_obj,
+            "_get_status_bar_snapshot",
+            side_effect=RuntimeError("snapshot failure"),
+        ), patch.object(cli_obj, "_get_tui_terminal_width", return_value=20):
+            rendered = cli_obj._get_status_bar_fragments()
+
+        text = _rendered_status_bar_text(rendered)
+        assert "fallback/live" in text
+        assert cli_obj.model not in text
+        assert cli_obj._status_bar_display_width(text) <= 20
+
+    def test_one_registered_callback_renders_all_eight_combinations_with_metadata(self):
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="status-bar-renderer-regression", source="user"),
+            manager,
+        )
+        received = []
+
+        def render_status(**kwargs):
+            received.append(kwargs)
+            return "x"
+
+        context.register_hook("on_status_bar_render", render_status)
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+            for renderer in _RENDERERS:
+                for width in _STATUS_BAR_WIDTHS:
+                    cli_obj = _make_cli()
+                    with patch.object(
+                        cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+                    ), patch.object(
+                        cli_obj, "_is_session_yolo_active", return_value=False
+                    ):
+                        rendered = _render_status_bar(cli_obj, renderer, width)
+
+                    text = _rendered_status_bar_text(rendered)
+                    separator = " · " if width < 76 else " │ "
+                    assert separator + "x" in text, (renderer, width, rendered)
+                    if renderer == "fragments":
+                        assert ("class:status-bar", "x") in rendered
+
+        assert manager.has_hook("on_status_bar_render")
+        assert len(received) == len(_RENDERERS) * len(_STATUS_BAR_WIDTHS)
+        for payload in received:
+            assert set(payload) == {"snapshot", "telemetry_schema_version"}
+            assert payload["snapshot"] == snapshot
+            assert payload["snapshot"] is not snapshot
+            assert payload["telemetry_schema_version"] == "hermes.observer.v1"
 
 
 class TestCLIStatusBar:
@@ -558,7 +929,7 @@ class TestStatusBarWidthSource:
 
             total_text = "".join(text for _, text in frags)
             display_width = cli_obj._status_bar_display_width(total_text)
-            assert display_width <= width + 4, (  # +4 for minor padding chars
+            assert display_width <= width, (
                 f"At width={width}, fragment total {display_width} cells overflows "
                 f"({total_text!r})"
             )

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -7,6 +7,11 @@ import pytest
 
 import cli as cli_mod
 from cli import HermesCLI
+from hermes_cli.plugins import (
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+)
 
 
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
@@ -105,7 +110,7 @@ class _BrokenStringValue:
 
 
 class TestStatusBarPluginValueHelper:
-    def test_invokes_once_and_normalizes_only_ordered_nonempty_string_values(self):
+    def test_invokes_once_and_normalizes_ordered_truthy_values(self):
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         with patch(
@@ -114,7 +119,7 @@ class TestStatusBarPluginValueHelper:
         ) as hook:
             values = cli_obj._get_status_bar_plugin_values(snapshot)
 
-        assert values == ["ready"]
+        assert values == ["ready", "7", "{'state': 'ok'}"]
         _assert_status_bar_hook_call(hook, snapshot)
 
     def test_sanitizes_control_characters_to_keep_footer_on_one_line(self):
@@ -190,7 +195,9 @@ class TestStatusBarPluginTierIntegration:
         cli_obj = _make_cli()
         snapshot = _plugin_status_bar_snapshot()
         separator = " · " if width < 76 else " │ "
-        expected = separator.join([_plugin_status_bar_baseline(width), "ready"])
+        expected = separator.join(
+            [_plugin_status_bar_baseline(width), "ready", "7"]
+        )
 
         with patch.object(
             cli_obj, "_get_status_bar_snapshot", return_value=snapshot
@@ -314,6 +321,370 @@ class TestStatusBarPluginFailuresAndOverflow:
         assert text.endswith("...")
         assert cli_obj._status_bar_display_width(text) <= width
         _assert_status_bar_hook_call(hook, snapshot)
+
+
+_RENDERERS = ("text", "fragments")
+
+
+def _render_status_bar(cli_obj, renderer, width):
+    if renderer == "text":
+        return cli_obj._build_status_bar_text(width=width)
+    cli_obj._status_bar_visible = True
+    with patch.object(cli_obj, "_get_tui_terminal_width", return_value=width):
+        return cli_obj._get_status_bar_fragments()
+
+
+def _rendered_status_bar_text(rendered):
+    if isinstance(rendered, str):
+        return rendered
+    return "".join(text for _, text in rendered)
+
+
+def _plugin_status_bar_fragment_baseline(width):
+    if width < 52:
+        return [
+            ("class:status-bar", " ⚕ "),
+            ("class:status-bar-strong", "m"),
+            ("class:status-bar-dim", " · "),
+            ("class:status-bar-dim", "9m"),
+            ("class:status-bar", " "),
+        ]
+    if width < 76:
+        return [
+            ("class:status-bar", " ⚕ "),
+            ("class:status-bar-strong", "m"),
+            ("class:status-bar-dim", " · "),
+            ("class:status-bar-good", "25%"),
+            ("class:status-bar-dim", " · "),
+            ("class:status-bar-dim", "9m"),
+            ("class:status-bar", " "),
+        ]
+    return [
+        ("class:status-bar", " ⚕ "),
+        ("class:status-bar-strong", "m"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-dim", "50K/200K"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-good", "[██░░░░░░░░]"),
+        ("class:status-bar-dim", " "),
+        ("class:status-bar-good", "25%"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-dim", "9m"),
+        ("class:status-bar-dim", " │ "),
+        ("class:status-bar-dim", "⏲ 3s"),
+        ("class:status-bar", " "),
+    ]
+
+
+_AC4_RESULT_FACTORIES = (
+    pytest.param(lambda: [], id="result-empty-list"),
+    pytest.param(lambda: [None, "", 0, False], id="result-falsey-list"),
+    pytest.param(lambda: ("tuple",), id="result-tuple"),
+    pytest.param(
+        lambda: (value for value in ("generated",)),
+        id="result-generator",
+    ),
+    pytest.param(lambda: "string aggregate", id="result-string"),
+    pytest.param(lambda: None, id="result-none"),
+)
+
+
+class TestStatusBarPluginCrossRendererRegression:
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_fragment_renderer_invokes_once_with_snapshot_and_exact_styles(self, width):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ) as get_snapshot, patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["ready"]
+        ) as hook:
+            fragments = _render_status_bar(cli_obj, "fragments", width)
+
+        separator = " · " if width < 76 else " │ "
+        expected = _plugin_status_bar_fragment_baseline(width)[:-1] + [
+            ("class:status-bar-dim", separator),
+            ("class:status-bar", "ready"),
+            ("class:status-bar", " "),
+        ]
+        assert fragments == expected
+        get_snapshot.assert_called_once_with()
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    @pytest.mark.parametrize("result_factory", _AC4_RESULT_FACTORIES)
+    def test_ac4_omission_forms_match_empty_list_without_dangling_separator(
+        self, renderer, width, result_factory
+    ):
+        snapshot = _plugin_status_bar_snapshot()
+        baseline_cli = _make_cli()
+        candidate_cli = _make_cli()
+
+        with patch.object(
+            baseline_cli, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            baseline_cli, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=[]
+        ):
+            empty_render = _render_status_bar(baseline_cli, renderer, width)
+
+        with patch.object(
+            candidate_cli, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            candidate_cli, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=result_factory()
+        ) as hook:
+            candidate_render = _render_status_bar(candidate_cli, renderer, width)
+
+        empty_text = _rendered_status_bar_text(empty_render)
+        candidate_text = _rendered_status_bar_text(candidate_render)
+        separator_glyph = "·" if width < 76 else "│"
+        assert candidate_text == empty_text
+        assert candidate_text.rstrip().endswith(separator_glyph) is False
+        if renderer == "fragments":
+            assert candidate_render == empty_render
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_successful_callback_uses_tier_separator_and_strict_width_bound(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["x"]
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        separator = " · " if width < 76 else " │ "
+        text = _rendered_status_bar_text(rendered)
+        assert separator + "x" in text
+        assert cli_obj._status_bar_display_width(text) <= width
+        if renderer == "fragments":
+            assert rendered[-3:] == [
+                ("class:status-bar-dim", separator),
+                ("class:status-bar", "x"),
+                ("class:status-bar", " "),
+            ]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_failing_callback_preserves_baseline_and_invokes_once(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook",
+            side_effect=RuntimeError("plugin failure"),
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        if renderer == "text":
+            assert rendered == _plugin_status_bar_baseline(width)
+        else:
+            assert rendered == _plugin_status_bar_fragment_baseline(width)
+        assert cli_obj._status_bar_display_width(
+            _rendered_status_bar_text(rendered)
+        ) <= width
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", _STATUS_BAR_WIDTHS, ids=lambda value: f"width-{value}")
+    def test_overflow_trims_final_combined_text_to_terminal_width(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        plugin_value = "x" * 200
+        separator = " · " if width < 76 else " │ "
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=[plugin_value]
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        if renderer == "text":
+            untrimmed = separator.join(
+                [_plugin_status_bar_baseline(width), plugin_value]
+            )
+        else:
+            baseline = _plugin_status_bar_fragment_baseline(width)
+            untrimmed = (
+                "".join(text for _, text in baseline[:-1])
+                + separator
+                + plugin_value
+                + " "
+            )
+            assert rendered[0][0] == "class:status-bar"
+            assert len(rendered) == 1
+        text = _rendered_status_bar_text(rendered)
+        assert text == cli_obj._trim_status_bar_text(untrimmed, width)
+        assert text.endswith("...")
+        assert cli_obj._status_bar_display_width(text) <= width
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        "renderer", _RENDERERS, ids=lambda value: f"renderer-{value}"
+    )
+    @pytest.mark.parametrize("width", (51, 52, 76), ids=lambda value: f"width-{value}")
+    def test_truthy_non_strings_are_filtered_stringified_and_ordered(
+        self, renderer, width
+    ):
+        cli_obj = _make_cli()
+        snapshot = _plugin_status_bar_snapshot()
+        separator = " · " if width < 76 else " │ "
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_is_session_yolo_active", return_value=False
+        ), patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[None, 7, "", False, 2.5, 0],
+        ) as hook:
+            rendered = _render_status_bar(cli_obj, renderer, width)
+
+        text = _rendered_status_bar_text(rendered)
+        assert separator.join(("7", "2.5")) in text
+        assert cli_obj._status_bar_display_width(text) <= width
+        if renderer == "fragments":
+            assert rendered[-5:] == [
+                ("class:status-bar-dim", separator),
+                ("class:status-bar", "7"),
+                ("class:status-bar-dim", separator),
+                ("class:status-bar", "2.5"),
+                ("class:status-bar", " "),
+            ]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    @pytest.mark.parametrize(
+        ("visible", "model_picker"),
+        ((False, None), (True, object())),
+        ids=("hidden", "model-picker"),
+    )
+    def test_hidden_and_model_picker_fragment_renders_are_hook_free(
+        self, visible, model_picker
+    ):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_visible = visible
+        cli_obj._model_picker_state = model_picker
+
+        with patch.object(cli_obj, "_get_status_bar_snapshot") as get_snapshot, patch(
+            "hermes_cli.plugins.invoke_hook"
+        ) as hook:
+            assert cli_obj._get_status_bar_fragments() == []
+
+        get_snapshot.assert_not_called()
+        hook.assert_not_called()
+
+    def test_fragment_fallback_does_not_redispatch_hook(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_visible = True
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch.object(
+            cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+        ), patch.object(
+            cli_obj, "_get_tui_terminal_width", return_value=52
+        ), patch.object(
+            cli_obj,
+            "_is_session_yolo_active",
+            side_effect=[RuntimeError("fragment failure"), False],
+        ), patch(
+            "hermes_cli.plugins.invoke_hook", return_value=["x"]
+        ) as hook:
+            rendered = cli_obj._get_status_bar_fragments()
+
+        assert rendered == [("class:status-bar", " ⚕ m · 25% · 9m · x ")]
+        _assert_status_bar_hook_call(hook, snapshot)
+
+    def test_fragment_snapshot_failure_uses_live_model_and_width_bound(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_visible = True
+        cli_obj.agent = SimpleNamespace(model="fallback/live-model-with-a-long-name")
+
+        with patch.object(
+            cli_obj,
+            "_get_status_bar_snapshot",
+            side_effect=RuntimeError("snapshot failure"),
+        ), patch.object(cli_obj, "_get_tui_terminal_width", return_value=20):
+            rendered = cli_obj._get_status_bar_fragments()
+
+        text = _rendered_status_bar_text(rendered)
+        assert "fallback/live" in text
+        assert cli_obj.model not in text
+        assert cli_obj._status_bar_display_width(text) <= 20
+
+    def test_one_registered_callback_renders_all_eight_combinations_with_metadata(self):
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="status-bar-renderer-regression", source="user"),
+            manager,
+        )
+        received = []
+
+        def render_status(**kwargs):
+            received.append(kwargs)
+            return "x"
+
+        context.register_hook("on_status_bar_render", render_status)
+        snapshot = _plugin_status_bar_snapshot()
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+            for renderer in _RENDERERS:
+                for width in _STATUS_BAR_WIDTHS:
+                    cli_obj = _make_cli()
+                    with patch.object(
+                        cli_obj, "_get_status_bar_snapshot", return_value=snapshot
+                    ), patch.object(
+                        cli_obj, "_is_session_yolo_active", return_value=False
+                    ):
+                        rendered = _render_status_bar(cli_obj, renderer, width)
+
+                    text = _rendered_status_bar_text(rendered)
+                    separator = " · " if width < 76 else " │ "
+                    assert separator + "x" in text, (renderer, width, rendered)
+                    if renderer == "fragments":
+                        assert ("class:status-bar", "x") in rendered
+
+        assert manager.has_hook("on_status_bar_render")
+        assert len(received) == len(_RENDERERS) * len(_STATUS_BAR_WIDTHS)
+        for payload in received:
+            assert set(payload) == {"snapshot", "telemetry_schema_version"}
+            assert payload["snapshot"] == snapshot
+            assert payload["snapshot"] is not snapshot
+            assert payload["telemetry_schema_version"] == "hermes.observer.v1"
 
 
 class TestCLIStatusBar:
@@ -520,7 +891,7 @@ class TestStatusBarWidthSource:
 
             total_text = "".join(text for _, text in frags)
             display_width = cli_obj._status_bar_display_width(total_text)
-            assert display_width <= width + 4, (  # +4 for minor padding chars
+            assert display_width <= width, (
                 f"At width={width}, fragment total {display_width} cells overflows "
                 f"({total_text!r})"
             )

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -80,6 +80,24 @@ class TestHooksList:
 
 
 class TestHooksTest:
+    def test_status_bar_render_payload_matches_plugin_contract(self, tmp_path):
+        capture = tmp_path / "captured.json"
+        script = _hook_script(
+            tmp_path,
+            f"#!/usr/bin/env bash\ncat - > {capture}\nprintf '{{}}\\n'\n",
+        )
+        cfg = {"hooks": {"on_status_bar_render": [{"command": str(script)}]}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            _run(SimpleNamespace(
+                hooks_action="test", event="on_status_bar_render",
+                for_tool=None, payload_file=None,
+            ))
+
+        extra = json.loads(capture.read_text())["extra"]
+        assert extra["snapshot"]["model_short"] == "claude-sonnet-4-6"
+        assert extra["telemetry_schema_version"] == "hermes.observer.v1"
+
     def test_synthetic_payload_matches_production_shape(self, tmp_path):
         """`hermes hooks test` must feed the script stdin in the same
         shape invoke_hook() would at runtime.  Prior to this fix,

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -784,6 +784,36 @@ class TestPluginHooks:
 
 
 
+    def test_status_bar_render_registration_and_metadata_contract(self, caplog):
+        """Status-bar hooks use the standard plugin-manager hook contract."""
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="status-bar-plugin", source="user"),
+            manager,
+        )
+        snapshot = {"model": "test-model", "state": "ready"}
+        contribution = {"label": "ready"}
+        received = {}
+
+        def render_status_bar(**kwargs):
+            received.update(kwargs)
+            return contribution
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            context.register_hook("on_status_bar_render", render_status_bar)
+
+        assert not any(
+            "unknown hook" in record.message.lower() for record in caplog.records
+        )
+        assert manager.has_hook("on_status_bar_render") is True
+
+        results = manager.invoke_hook("on_status_bar_render", snapshot=snapshot)
+
+        assert received["snapshot"] is snapshot
+        assert received["telemetry_schema_version"] == "hermes.observer.v1"
+        assert results == [contribution]
+        assert results[0] is contribution
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -308,6 +308,36 @@ class TestPluginHooks:
 
 
 
+    def test_status_bar_render_registration_and_metadata_contract(self, caplog):
+        """Status-bar hooks use the standard plugin-manager hook contract."""
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="status-bar-plugin", source="user"),
+            manager,
+        )
+        snapshot = {"model": "test-model", "state": "ready"}
+        contribution = {"label": "ready"}
+        received = {}
+
+        def render_status_bar(**kwargs):
+            received.update(kwargs)
+            return contribution
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            context.register_hook("on_status_bar_render", render_status_bar)
+
+        assert not any(
+            "unknown hook" in record.message.lower() for record in caplog.records
+        )
+        assert manager.has_hook("on_status_bar_render") is True
+
+        results = manager.invoke_hook("on_status_bar_render", snapshot=snapshot)
+
+        assert received["snapshot"] is snapshot
+        assert received["telemetry_schema_version"] == "hermes.observer.v1"
+        assert results == [contribution]
+        assert results[0] is contribution
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"


### PR DESCRIPTION
## What does this PR do?

Extends the existing `on_status_bar_render` plugin hook from the full-width (\>= 76 cols) fragments path to **all 6 render paths**: narrow, medium, and full width in both `_build_status_bar_text()` (string-based) and `_get_status_bar_fragments()` (styled tuple-based).

Previously the hook only fired in one render path, so plugins like `hermes-quota-status` would show quota info on wide terminals but silently disappear on medium or narrow layouts.

## Related Issue

Supersedes PR #32299 (original `on_status_bar_render` proposal — feature was partially merged upstream).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

### `cli.py`
- New `_get_status_bar_plugin_values(snapshot)` helper with 1s cache TTL — normalizes hook results, strips control chars, fail-closed on exceptions
- Added hook invocation in `_build_status_bar_text()` narrow (\< 52), medium (52-75), and full (\>= 76) tiers
- Added hook invocation in `_get_status_bar_fragments()` narrow (\< 52) and medium (52-75) tiers (full already existed)
- Plugin values use ` · ` separator below 76 cols, ` │ ` at 76+ cols — matching tier conventions
- Exception safety: catch-all around hook lookup, invocation, and value normalization

### `hermes_cli/hooks.py`
- Added `on_status_bar_render` default payload to the `hermes hooks test` command

### `hermes_cli/plugins.py`
- `on_status_bar_render` already in `VALID_HOOKS` — no change needed

### Tests
- `tests/cli/test_cli_status_bar.py`: 636 lines of new tests covering all width tiers, both renderers, hook arguments, result normalization, exception isolation, overflow behavior, and every empty/unsupported result form
- `tests/hermes_cli/test_plugins.py`: Hook registration contract tests
- `tests/hermes_cli/test_hooks_cli.py`: Default payload shape for `on_status_bar_render`

## How to Test

```bash
./venv/bin/pytest tests/cli/test_cli_status_bar.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_hooks_cli.py -v
```

322 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've considered cross-platform impact — or N/A

## Screenshots

N/A — TUI status bar change, no visual diff.