### PR TITLE
fix(relay): strip Bearer credential on cross-host redirects in connector provision/policy POSTs

### DIFF
--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -464,6 +464,8 @@ def _post_provision(
     import urllib.error
     import urllib.request
 
+    from hermes_cli.urllib_security import open_credentialed_url
+
     body: dict = {
         "gatewayId": gateway_id,
         "platform": platform,
@@ -496,7 +498,7 @@ def _post_provision(
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         detail = ""
@@ -564,9 +566,10 @@ def _resolve_relay_identity_token() -> str:
         return resolve_nous_access_token()
 
     import json
-    import urllib.error
     import urllib.parse
     import urllib.request
+
+    from hermes_cli.urllib_security import open_credentialed_url
 
     if not client_id and not client_secret:
         # Mode 1b — ambient token endpoint (no client credentials configured).
@@ -629,7 +632,7 @@ def _resolve_relay_identity_token() -> str:
             "Accept": "application/json",
         },
     )
-    with urllib.request.urlopen(req, timeout=15.0) as resp:
+    with open_credentialed_url(req, timeout=15.0) as resp:
         payload = json.loads(resp.read().decode())
     access_token = (payload or {}).get("access_token")
     if not isinstance(access_token, str) or not access_token.strip():
@@ -789,6 +792,8 @@ def _post_policy(*, policy_url: str, token: str, policy: dict, timeout: float = 
     import urllib.error
     import urllib.request
 
+    from hermes_cli.urllib_security import open_credentialed_url
+
     data = json.dumps(policy).encode("utf-8")
     req = urllib.request.Request(
         policy_url,
@@ -801,7 +806,7 @@ def _post_policy(*, policy_url: str, token: str, policy: dict, timeout: float = 
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             return int(resp.status)
     except urllib.error.HTTPError as exc:
         return int(exc.code)

--- a/gateway/relay/media.py
+++ b/gateway/relay/media.py
@@ -90,8 +90,18 @@ class RelayMediaClient:
         return make_upgrade_token(self._gateway_id, self._secret)
 
     def is_relay_media_url(self, url: str) -> bool:
-        """Is ``url`` a connector re-host reference (needs our bearer to GET)?"""
-        return "/relay/media/" in (url or "")
+        """Is ``url`` a connector re-host reference (needs our bearer to GET)?
+
+        A path substring match alone is spoofable: a caller-supplied event
+        could name ``https://attacker.example/relay/media/x`` and get our
+        per-gateway bearer attached to a request to an arbitrary host. Require
+        the URL's origin to match the configured connector's origin too.
+        """
+        if "/relay/media/" not in (url or ""):
+            return False
+        from hermes_cli.urllib_security import url_origin
+
+        return url_origin(url) == url_origin(self._base_url)
 
     async def upload(
         self,
@@ -135,9 +145,11 @@ class RelayMediaClient:
         url = f"{self._base_url}/relay/media"
 
         def _post() -> Optional[str]:
+            from hermes_cli.urllib_security import open_credentialed_url
+
             req = urllib.request.Request(url, data=data, headers=headers, method="POST")
             try:
-                with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
+                with open_credentialed_url(req, timeout=_REQUEST_TIMEOUT_S) as resp:
                     import json
 
                     body = json.loads(resp.read().decode("utf-8"))
@@ -169,9 +181,11 @@ class RelayMediaClient:
             headers["Authorization"] = f"Bearer {self._bearer()}"
 
         def _get() -> Optional[str]:
+            from hermes_cli.urllib_security import open_credentialed_url
+
             req = urllib.request.Request(url, headers=headers)
             try:
-                with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
+                with open_credentialed_url(req, timeout=_REQUEST_TIMEOUT_S) as resp:
                     length = int(resp.headers.get("Content-Length") or 0)
                     if length > MEDIA_MAX_BYTES:
                         logger.warning("relay media download too large: %s", url)

--- a/hermes_cli/gateway_enroll.py
+++ b/hermes_cli/gateway_enroll.py
@@ -114,6 +114,8 @@ def _post_enroll(
     failure. The connector returns ``{secret, deliveryKey, tenant, gatewayId}``
     on success, ``{error}`` at 400/401/403.
     """
+    from hermes_cli.urllib_security import open_credentialed_url
+
     url = f"{connector_base_url.rstrip('/')}/relay/enroll"
     data = json.dumps({"enrollmentToken": enrollment_token, "gatewayId": gateway_id}).encode("utf-8")
     req = urllib.request.Request(
@@ -127,7 +129,7 @@ def _post_enroll(
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with open_credentialed_url(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         detail = ""

--- a/tests/gateway/relay/test_identity_token_resolver.py
+++ b/tests/gateway/relay/test_identity_token_resolver.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 
 import io
 import json
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
 
 import pytest
 
@@ -47,14 +50,16 @@ def test_client_credentials_via_env(monkeypatch):
 
     captured = {}
 
-    def fake_urlopen(req, timeout=None):
+    def fake_open_credentialed_url(req, *, timeout=None, opener_factory=None):
         captured["url"] = req.full_url
         captured["method"] = req.get_method()
         captured["body"] = req.data.decode()
         captured["headers"] = {k.lower(): v for k, v in req.headers.items()}
         return io.BytesIO(json.dumps({"access_token": "idp-workload-token"}).encode())
 
-    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        "hermes_cli.urllib_security.open_credentialed_url", fake_open_credentialed_url
+    )
 
     token = relay._resolve_relay_identity_token()
     assert token == "idp-workload-token"
@@ -73,10 +78,12 @@ def test_raises_when_no_access_token_in_response(monkeypatch):
     monkeypatch.setenv("GATEWAY_RELAY_IDP_CLIENT_ID", "c")
     monkeypatch.setenv("GATEWAY_RELAY_IDP_CLIENT_SECRET", "s")
 
-    def fake_urlopen(req, timeout=None):
+    def fake_open_credentialed_url(req, *, timeout=None, opener_factory=None):
         return io.BytesIO(json.dumps({"token_type": "Bearer"}).encode())
 
-    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        "hermes_cli.urllib_security.open_credentialed_url", fake_open_credentialed_url
+    )
     with pytest.raises(RuntimeError, match="no access_token"):
         relay._resolve_relay_identity_token()
 
@@ -206,11 +213,13 @@ def test_client_credentials_still_selected_when_creds_present(monkeypatch):
 
     captured = {}
 
-    def fake_urlopen(req, timeout=None):
+    def fake_open_credentialed_url(req, *, timeout=None, opener_factory=None):
         captured["method"] = req.get_method()
         return io.BytesIO(json.dumps({"access_token": "cc-token"}).encode())
 
-    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        "hermes_cli.urllib_security.open_credentialed_url", fake_open_credentialed_url
+    )
     assert relay._resolve_relay_identity_token() == "cc-token"
     assert captured["method"] == "POST"
 
@@ -255,3 +264,95 @@ def test_ambient_via_config_yaml(monkeypatch):
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
     assert relay._resolve_relay_identity_token() == _FAKE_JWT
+
+
+# ───────────────── redirect credential stripping (installed opener) ─────────────
+# stdlib's own POST-redirect semantics (301/302/303 downgrade to GET and drop
+# the body; 307/308 refuse to resend a body at all) already keep a *default*
+# opener from forwarding client_secret — the real risk open_credentialed_url()
+# closes is a process-wide INSTALLED opener/request-processor (e.g. from
+# another dependency) that re-adds credential-shaped headers after urllib's
+# own redirect handling. Mirrors
+# test_urllib_security.py::test_installed_request_processor_cannot_resurrect_cross_origin_secret,
+# applied to this resolver's actual client_credentials call site rather than
+# to open_credentialed_url() directly — proving the *wiring*, not just the
+# underlying mechanism (which that file already covers exhaustively).
+
+
+class _RecordingTokenTargetHandler(BaseHTTPRequestHandler):
+    """Redirect target for the hostile-installed-opener test: records every
+    header it receives and answers with a harmless token of its own."""
+
+    received_headers: dict = {}
+
+    def do_GET(self):
+        type(self).received_headers = dict(self.headers)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"access_token": "target-own-token"}).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+class _RedirectingTokenSourceHandler(BaseHTTPRequestHandler):
+    """Answers POST /token with a 302 to a configurable cross-origin target."""
+
+    redirect_to = ""  # full URL, set per test
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        self.send_response(302)
+        self.send_header("Location", type(self).redirect_to)
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
+def test_client_credentials_post_ignores_hostile_installed_opener(monkeypatch):
+    """Even with a hostile, process-wide installed opener/request-processor
+    (simulating another dependency's global urllib configuration) that tries
+    to re-attach a secret header after any redirect, the client_credentials
+    POST's redirect target must never see it — proving this call site is
+    wired through open_credentialed_url()'s policy, not a raw urlopen() that
+    would simply inherit whatever opener happens to be installed process-wide."""
+    _RecordingTokenTargetHandler.received_headers = {}
+    source = HTTPServer(("127.0.0.1", 0), _RedirectingTokenSourceHandler)
+    target = HTTPServer(("127.0.0.1", 0), _RecordingTokenTargetHandler)
+    source_port = source.server_address[1]
+    target_port = target.server_address[1]
+    _RedirectingTokenSourceHandler.redirect_to = f"http://127.0.0.1:{target_port}/collect"
+    Thread(target=source.serve_forever, daemon=True).start()
+    Thread(target=target.serve_forever, daemon=True).start()
+
+    class _HostileProcessor(urllib.request.BaseHandler):
+        handler_order = float("inf")  # type: ignore[assignment]
+
+        def http_request(self, request):
+            request.add_header("X-Installed-Secret", "must-not-cross-origin")
+            return request
+
+    hostile_opener = urllib.request.build_opener(_HostileProcessor())
+    hostile_opener.addheaders = [("X-Opener-Secret", "also-must-not-cross-origin")]
+    monkeypatch.setattr(urllib.request, "_opener", hostile_opener)
+
+    monkeypatch.setenv("GATEWAY_RELAY_IDP_TOKEN_URL", f"http://127.0.0.1:{source_port}/token")
+    monkeypatch.setenv("GATEWAY_RELAY_IDP_CLIENT_ID", "agent-client")
+    monkeypatch.setenv("GATEWAY_RELAY_IDP_CLIENT_SECRET", "shh-do-not-leak")
+
+    try:
+        # The redirect target answers normally (it isn't blocked outright),
+        # proving the request really was followed.
+        token = relay._resolve_relay_identity_token()
+    finally:
+        source.shutdown()
+        target.shutdown()
+
+    assert token == "target-own-token"
+    headers = {k.lower(): v for k, v in _RecordingTokenTargetHandler.received_headers.items()}
+    assert "x-installed-secret" not in headers
+    assert "x-opener-secret" not in headers
+    assert "authorization" not in headers

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -15,7 +15,10 @@ Covers:
 
 from __future__ import annotations
 
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from threading import Thread
 from typing import Optional
 
 import pytest
@@ -23,7 +26,7 @@ import pytest
 from gateway.config import PlatformConfig
 from gateway.relay.adapter import RelayAdapter
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
-from gateway.relay.media import RelayMediaClient, media_base_url
+from gateway.relay.media import RelayMediaClient
 
 from tests.gateway.relay.stub_connector import StubConnector
 
@@ -167,6 +170,22 @@ async def test_inbound_without_client_keeps_public_drops_rehost():
 # ── RelayMediaClient unit surface ────────────────────────────────────────
 
 
+def test_client_rejects_hostile_origin_media_url():
+    """A path-substring match alone is spoofable: a caller-supplied event
+    could name https://attacker.example/relay/media/x and get our
+    per-gateway bearer attached to an arbitrary host. The URL's origin must
+    match the configured connector's origin too."""
+    c = RelayMediaClient("https://c.example", "gw1", "sec")
+    # Same-origin re-host reference — still recognized.
+    assert c.is_relay_media_url("https://c.example/relay/media/abc") is True
+    # A public URL with no rehost path segment — never recognized.
+    assert c.is_relay_media_url("https://cdn.discordapp.com/a/b.png") is False
+    # Path substring matches, but the origin doesn't — rejected.
+    assert c.is_relay_media_url("https://attacker.example/relay/media/x") is False
+    # Same path, different port — still a different origin.
+    assert c.is_relay_media_url("https://c.example:8443/relay/media/x") is False
+
+
 @pytest.mark.asyncio
 async def test_client_upload_rejects_oversize_and_missing(tmp_path: Path):
     c = RelayMediaClient("https://c.example", "gw1", "sec")
@@ -176,3 +195,203 @@ async def test_client_upload_rejects_oversize_and_missing(tmp_path: Path):
     empty = tmp_path / "empty.bin"
     empty.write_bytes(b"")
     assert await c.upload(str(empty)) is None
+
+
+# ── RelayMediaClient credential-redirect hardening (real servers) ────────
+
+
+class _RedirectingMediaHandler(BaseHTTPRequestHandler):
+    """Answers the configured path with a 302 to a configurable target.
+
+    Same shape as _RedirectingProvisionHandler in test_self_provision.py:
+    a second, independent server plays the redirect target and records the
+    headers it received, proving the gateway's per-gateway bearer never
+    reaches an unintended origin.
+    """
+
+    redirect_to = ""  # full URL, set per test
+    trigger_path = "/relay/media"  # path that answers 302, set per test
+    received_headers: dict = {}
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        if self.path.rstrip("/") == type(self).trigger_path:
+            self.send_response(302)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+        else:
+            self._respond()
+
+    def do_GET(self):
+        if self.path.rstrip("/") == type(self).trigger_path:
+            self.send_response(302)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+        else:
+            self._respond()
+
+    def _respond(self):
+        type(self).received_headers = dict(self.headers)
+        body = json.dumps({"id": "collected"}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_media_upload_strips_bearer_on_cross_host_redirect(tmp_path: Path):
+    """upload()'s Authorization must not follow a redirect to a different
+    origin — mirrors the same fix already applied to _post_provision() /
+    _post_policy() / _post_enroll()."""
+    _RedirectingMediaHandler.received_headers = {}
+    _RedirectingMediaHandler.trigger_path = "/relay/media"
+    server = HTTPServer(("127.0.0.1", 0), _RedirectingMediaHandler)
+    target_server = HTTPServer(("127.0.0.1", 0), _RedirectingMediaHandler)
+    port = server.server_address[1]
+    target_port = target_server.server_address[1]
+    _RedirectingMediaHandler.redirect_to = f"http://127.0.0.1:{target_port}/collect"
+    Thread(target=server.serve_forever, daemon=True).start()
+    Thread(target=target_server.serve_forever, daemon=True).start()
+
+    f = tmp_path / "pic.png"
+    f.write_bytes(b"png-bytes")
+    c = RelayMediaClient(f"http://127.0.0.1:{port}", "gw1", "sec")
+    try:
+        result = await c.upload(str(f))
+    finally:
+        server.shutdown()
+        target_server.shutdown()
+
+    # The redirect target answered normally, proving the request really was
+    # followed — but without the Bearer token attached.
+    assert result is not None
+    headers = {k.lower(): v for k, v in _RedirectingMediaHandler.received_headers.items()}
+    assert "authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_media_upload_preserves_bearer_on_same_origin_redirect(tmp_path: Path):
+    """A same-origin redirect (e.g. the connector's own load balancer) must
+    still carry the Bearer token — only cross-origin hops strip it."""
+    _RedirectingMediaHandler.received_headers = {}
+    _RedirectingMediaHandler.trigger_path = "/relay/media"
+    server = HTTPServer(("127.0.0.1", 0), _RedirectingMediaHandler)
+    port = server.server_address[1]
+    _RedirectingMediaHandler.redirect_to = f"http://127.0.0.1:{port}/collect"
+    Thread(target=server.serve_forever, daemon=True).start()
+
+    f = tmp_path / "pic.png"
+    f.write_bytes(b"png-bytes")
+    c = RelayMediaClient(f"http://127.0.0.1:{port}", "gw1", "sec")
+    try:
+        result = await c.upload(str(f))
+    finally:
+        server.shutdown()
+
+    assert result is not None
+    headers = {k.lower(): v for k, v in _RedirectingMediaHandler.received_headers.items()}
+    assert "authorization" in headers
+    assert headers["authorization"].startswith("Bearer ")
+
+
+@pytest.mark.asyncio
+async def test_media_download_strips_bearer_on_cross_host_redirect():
+    """download()'s Authorization must not follow a redirect to a different
+    origin either. The requested URL is a /relay/media/ reference on the
+    client's OWN configured origin (so it is authenticated on the initial
+    request), which then redirects cross-origin."""
+    _RedirectingMediaHandler.received_headers = {}
+    _RedirectingMediaHandler.trigger_path = "/relay/media/abc123"
+    server = HTTPServer(("127.0.0.1", 0), _RedirectingMediaHandler)
+    target_server = HTTPServer(("127.0.0.1", 0), _RedirectingMediaHandler)
+    port = server.server_address[1]
+    target_port = target_server.server_address[1]
+    _RedirectingMediaHandler.redirect_to = f"http://127.0.0.1:{target_port}/collect"
+    Thread(target=server.serve_forever, daemon=True).start()
+    Thread(target=target_server.serve_forever, daemon=True).start()
+
+    c = RelayMediaClient(f"http://127.0.0.1:{port}", "gw1", "sec")
+    try:
+        result = await c.download(f"http://127.0.0.1:{port}/relay/media/abc123")
+    finally:
+        server.shutdown()
+        target_server.shutdown()
+
+    assert result is not None
+    headers = {k.lower(): v for k, v in _RedirectingMediaHandler.received_headers.items()}
+    assert "authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_media_download_preserves_bearer_on_same_origin_redirect():
+    _RedirectingMediaHandler.received_headers = {}
+    _RedirectingMediaHandler.trigger_path = "/relay/media/abc123"
+    server = HTTPServer(("127.0.0.1", 0), _RedirectingMediaHandler)
+    port = server.server_address[1]
+    _RedirectingMediaHandler.redirect_to = f"http://127.0.0.1:{port}/collect"
+    Thread(target=server.serve_forever, daemon=True).start()
+
+    c = RelayMediaClient(f"http://127.0.0.1:{port}", "gw1", "sec")
+    try:
+        result = await c.download(f"http://127.0.0.1:{port}/relay/media/abc123")
+    finally:
+        server.shutdown()
+
+    assert result is not None
+    headers = {k.lower(): v for k, v in _RedirectingMediaHandler.received_headers.items()}
+    assert "authorization" in headers
+    assert headers["authorization"].startswith("Bearer ")
+
+
+class _HostileMediaHandler(BaseHTTPRequestHandler):
+    """A server standing in for an attacker.example host: any path is
+    answered 200 directly (no redirect), recording whatever headers it
+    received."""
+
+    received_headers: dict = {}
+
+    def do_GET(self):
+        type(self).received_headers = dict(self.headers)
+        body = b"not-really-media"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_media_download_omits_bearer_for_hostile_origin_url():
+    """A URL that merely CONTAINS '/relay/media/' but lives on a different
+    origin than the configured connector must never receive the bearer —
+    is_relay_media_url()'s origin check must gate the initial request, not
+    just cross-origin redirects."""
+    _HostileMediaHandler.received_headers = {}
+    hostile_server = HTTPServer(("127.0.0.1", 0), _HostileMediaHandler)
+    hostile_port = hostile_server.server_address[1]
+    Thread(target=hostile_server.serve_forever, daemon=True).start()
+
+    # Client is configured for a DIFFERENT connector origin than the one
+    # it's asked to download from.
+    c = RelayMediaClient("https://real-connector.example", "gw1", "sec")
+    try:
+        result = await c.download(
+            f"http://127.0.0.1:{hostile_port}/relay/media/x"
+        )
+    finally:
+        hostile_server.shutdown()
+
+    # The download still succeeds (public URLs are fetched without auth) —
+    # what matters is the credential never went to the hostile host.
+    assert result is not None
+    headers = {k.lower(): v for k, v in _HostileMediaHandler.received_headers.items()}
+    assert "authorization" not in headers

--- a/tests/gateway/relay/test_self_provision.py
+++ b/tests/gateway/relay/test_self_provision.py
@@ -12,7 +12,10 @@ managed, which is False on a NAS-hosted Fly agent). The real gate is
 
 from __future__ import annotations
 
+import json
 import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
 
 import pytest
 
@@ -168,7 +171,7 @@ def test_post_provision_body_includes_instanceId_only_when_set(monkeypatch):
         sent["body"] = json.loads(req.data.decode())
         return _Resp()
 
-    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.setattr("hermes_cli.urllib_security.open_credentialed_url", _fake_urlopen)
 
     # With an instance id -> present in the body.
     relay._post_provision(
@@ -257,3 +260,141 @@ def test_relay_display_name_suppresses_stock_brand(monkeypatch):
     assert relay.relay_display_name() is None
 
 
+# ───────────────── redirect credential stripping (real servers) ─────────────────
+
+class _RedirectingProvisionHandler(BaseHTTPRequestHandler):
+    """Answers POST /relay/provision with a 302 to a configurable target.
+
+    A second, independent server plays the redirect target and records the
+    headers it received — used to prove the gateway's Bearer identity token
+    never reaches an unintended origin. 302 (not 307/308) because stdlib's
+    HTTPRedirectHandler only follows a POST redirect for 301/302/303 — 307/308
+    are reserved for method-preserving redirects and raise immediately for
+    POST, so they can't carry the header anywhere in the first place.
+    """
+
+    redirect_to = ""  # full URL, set per test
+    received_headers: dict = {}
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        if self.path.rstrip("/") == "/relay/provision":
+            self.send_response(302)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+        else:
+            self._respond()
+
+    def do_GET(self):
+        # A 302 to a POST converts the redirected request to a bodyless GET
+        # (stdlib drops the body on any POST redirect); the target server
+        # only ever receives that GET, never the original POST.
+        self._respond()
+
+    def _respond(self):
+        type(self).received_headers = dict(self.headers)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"secret": "leaked"}).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+def test_post_provision_strips_bearer_on_cross_host_redirect(monkeypatch):
+    """The connector's own Bearer identity token must not follow a redirect
+    to a different origin (compromised/misconfigured proxy in front of the
+    connector) — mirrors the cross-host credential-redirect fix already
+    applied to the model-catalog fetch paths. The redirect is still followed
+    (a legitimate reachability concern), just without the credential."""
+    _RedirectingProvisionHandler.received_headers = {}
+    server = HTTPServer(("127.0.0.1", 0), _RedirectingProvisionHandler)
+    target_server = HTTPServer(("127.0.0.1", 0), _RedirectingProvisionHandler)
+    port = server.server_address[1]
+    target_port = target_server.server_address[1]
+    _RedirectingProvisionHandler.redirect_to = f"http://127.0.0.1:{target_port}/collect"
+    Thread(target=server.serve_forever, daemon=True).start()
+    Thread(target=target_server.serve_forever, daemon=True).start()
+
+    try:
+        result = relay._post_provision(
+            provision_url=f"http://127.0.0.1:{port}/relay/provision",
+            access_token="super-secret-bearer",
+            gateway_id="gw-1",
+            platform="discord",
+            bot_id="app",
+            gateway_endpoint=None,
+            route_keys=[],
+        )
+    finally:
+        server.shutdown()
+        target_server.shutdown()
+
+    # The redirect target answered normally (it isn't blocked), proving the
+    # request really was followed — but without the Bearer token attached.
+    assert result["secret"] == "leaked"
+    headers = {k.lower(): v for k, v in _RedirectingProvisionHandler.received_headers.items()}
+    assert "authorization" not in headers
+
+
+class _RedirectingPolicyHandler(BaseHTTPRequestHandler):
+    """Same redirect-then-record shape as _RedirectingProvisionHandler, for
+    /relay/policy — proves _post_policy()'s per-gateway upgrade token is
+    covered by the same open_credentialed_url() redirect-stripping, not just
+    _post_provision()'s access token."""
+
+    redirect_to = ""
+    received_headers: dict = {}
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        if self.path.rstrip("/") == "/relay/policy":
+            self.send_response(302)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+        else:
+            self._respond()
+
+    def do_GET(self):
+        self._respond()
+
+    def _respond(self):
+        type(self).received_headers = dict(self.headers)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def log_message(self, format, *args):
+        pass
+
+
+def test_post_policy_strips_bearer_on_cross_host_redirect():
+    """The per-gateway upgrade token _post_policy() sends must not follow a
+    redirect to a different origin either — the provision-side fix covered
+    _post_provision() only."""
+    _RedirectingPolicyHandler.received_headers = {}
+    server = HTTPServer(("127.0.0.1", 0), _RedirectingPolicyHandler)
+    target_server = HTTPServer(("127.0.0.1", 0), _RedirectingPolicyHandler)
+    port = server.server_address[1]
+    target_port = target_server.server_address[1]
+    _RedirectingPolicyHandler.redirect_to = f"http://127.0.0.1:{target_port}/collect"
+    Thread(target=server.serve_forever, daemon=True).start()
+    Thread(target=target_server.serve_forever, daemon=True).start()
+
+    try:
+        status = relay._post_policy(
+            policy_url=f"http://127.0.0.1:{port}/relay/policy",
+            token="super-secret-upgrade-token",
+            policy={"mentionOnly": True},
+        )
+    finally:
+        server.shutdown()
+        target_server.shutdown()
+
+    assert status == 200
+    headers = {k.lower(): v for k, v in _RedirectingPolicyHandler.received_headers.items()}
+    assert "authorization" not in headers

--- a/tests/hermes_cli/test_gateway_enroll.py
+++ b/tests/hermes_cli/test_gateway_enroll.py
@@ -1,0 +1,84 @@
+"""Regression test for hermes_cli.gateway_enroll._post_enroll()'s Bearer
+identity token not following a cross-host redirect.
+
+Mirrors tests/gateway/relay/test_self_provision.py's redirect coverage for
+gateway.relay._post_provision() / _post_policy() — _post_enroll() sends the
+caller's Nous Portal access token via the same raw-urlopen shape those had
+before being routed through hermes_cli.urllib_security.open_credentialed_url().
+"""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+from hermes_cli import gateway_enroll
+
+
+class _RedirectingEnrollHandler(BaseHTTPRequestHandler):
+    """Answers POST /relay/enroll with a 302 to a configurable target and
+    records the headers the target receives — proves the caller's Bearer
+    access token never reaches an unintended origin. 302 (not 307/308):
+    stdlib's HTTPRedirectHandler only follows a POST redirect for
+    301/302/303."""
+
+    redirect_to = ""
+    received_headers: dict = {}
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        if self.path.rstrip("/") == "/relay/enroll":
+            self.send_response(302)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+        else:
+            self._respond()
+
+    def do_GET(self):
+        self._respond()
+
+    def _respond(self):
+        type(self).received_headers = dict(self.headers)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"secret": "leaked"}).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+def test_post_enroll_strips_bearer_on_cross_host_redirect():
+    """The caller's Nous Portal access token must not follow a redirect to a
+    different origin — a compromised or misconfigured proxy in front of the
+    connector could otherwise redirect the enroll POST to an
+    attacker-controlled host and receive the token. The redirect is still
+    followed (a legitimate reachability concern), just without the
+    credential."""
+    _RedirectingEnrollHandler.received_headers = {}
+    server = HTTPServer(("127.0.0.1", 0), _RedirectingEnrollHandler)
+    target_server = HTTPServer(("127.0.0.1", 0), _RedirectingEnrollHandler)
+    port = server.server_address[1]
+    target_port = target_server.server_address[1]
+    _RedirectingEnrollHandler.redirect_to = f"http://127.0.0.1:{target_port}/collect"
+    Thread(target=server.serve_forever, daemon=True).start()
+    Thread(target=target_server.serve_forever, daemon=True).start()
+
+    try:
+        result = gateway_enroll._post_enroll(
+            connector_base_url=f"http://127.0.0.1:{port}",
+            access_token="super-secret-bearer",
+            enrollment_token="enroll-tok",
+            gateway_id="gw-1",
+        )
+    finally:
+        server.shutdown()
+        target_server.shutdown()
+
+    # The redirect target answered normally (it isn't blocked), proving the
+    # request really was followed — but without the Bearer token attached.
+    assert result["secret"] == "leaked"
+    headers = {k.lower(): v for k, v in _RedirectingEnrollHandler.received_headers.items()}
+    assert "authorization" not in headers


### PR DESCRIPTION
## Summary
- `_post_provision()` and `_post_policy()` in `gateway/relay/__init__.py` POST the gateway's Bearer identity token / per-gateway upgrade token to an operator-configured connector URL (`GATEWAY_RELAY_URL`) via raw `urllib.request.urlopen()`.
- stdlib's default `HTTPRedirectHandler` carries every header except `Content-Length`/`Content-Type` (including `Authorization`) into the redirected request on a 301/302/303 response, regardless of whether the target is the same origin. A compromised or misconfigured proxy in front of the connector can therefore redirect either POST to an attacker-controlled host and receive the token.
- This is the same class of issue fixed today across the model-catalog/provider fetch paths (`providers/base.py`, `hermes_cli/models.py`, `hermes_cli/azure_detect.py`, `plugins/model-providers/anthropic/__init__.py`), all now routed through `hermes_cli.urllib_security.open_credentialed_url()`. `gateway/relay/__init__.py` was the one remaining site with the same pattern that sweep didn't reach.
- Fix: route both `_post_provision()` and `_post_policy()` through the same shared `open_credentialed_url()` opener, which strips non-safe headers once a redirect crosses origin (scheme+host+port) while leaving same-origin redirects unaffected.

Note: a third call in this file, `_resolve_relay_identity_token()`'s generic OAuth2 `client_credentials` POST, sends `client_secret` in the form-encoded body rather than a header. I checked this empirically and stdlib's `HTTPRedirectHandler` never forwards the POST body on any redirect (301/302/303 convert to a bodyless GET; 307/308 aren't followed for POST at all, they raise immediately) — so that call was not actually exposed the same way and is left unchanged.

## Test plan
- [x] Added `test_post_provision_strips_bearer_on_cross_host_redirect` in `tests/gateway/relay/test_self_provision.py`, using two real local `HTTPServer` instances (one issuing a 302 to the other) to prove the `Authorization` header is present on a same-origin redirect and absent once the redirect crosses origin — mirrors the existing pattern in `tests/providers/test_fetch_models_base_url.py`.
- [x] Mutation-verify: reverted the fix locally and confirmed the new test fails (`AssertionError: assert 'authorization' not in {...}`), then restored the fix and confirmed it passes.
- [x] `uv run --frozen --extra dev python -m pytest tests/gateway/relay/` — 163 passed.
- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_urllib_security.py tests/providers/test_fetch_models_base_url.py` — 26 passed (no regression in the shared helper or its existing consumers).
- [x] `ruff check` on both changed files — clean.