### PR TITLE
feat(desktop): titlebar local/remote/cloud gateway switch menu

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -259,6 +259,58 @@ describe('useRouteResume', () => {
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
   })
+
+  it('does not resume a previous-host session on reconnect while a fresh draft is armed', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: null }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map() }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    // Seed lastPathname while the gateway is down so the next open is a
+    // reconnect (gatewayBecameOpen), not a pathname-driven user navigation.
+    const { rerender } = render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady
+        gatewayState="closed"
+        locationPathname="/old-session"
+        resumeSession={resumeSession}
+        routedSessionId="old-session"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    rerender(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady
+        gatewayState="open"
+        locationPathname="/old-session"
+        resumeSession={resumeSession}
+        routedSessionId="old-session"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    // Reconnect with a fresh draft still armed must not resume the dead id.
+    expect(resumeSession).not.toHaveBeenCalled()
+  })
 })
 
 describe('useRouteResume bounded auto-retry after a failed resume', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -1,6 +1,8 @@
+import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useEffect, useRef } from 'react'
 
 import { isNewChatRoute } from '@/app/routes'
+import { $gatewaySwitching } from '@/store/gateway-switch'
 import { setResumeExhaustedSessionId } from '@/store/session'
 
 interface RouteResumeOptions {
@@ -82,6 +84,7 @@ export function useRouteResume({
   selectedStoredSessionIdRef,
   startFreshSessionDraft
 }: RouteResumeOptions) {
+  const gatewaySwitching = useStore($gatewaySwitching)
   const lastPathnameRef = useRef<string | null>(null)
   const seenGatewayStateRef = useRef(false)
   const wasGatewayOpenRef = useRef(false)
@@ -108,7 +111,10 @@ export function useRouteResume({
     seenGatewayStateRef.current = true
     wasGatewayOpenRef.current = gatewayOpen
 
-    if (currentView !== 'chat' || !gatewayOpen) {
+    // Soft gateway-mode switch re-homes the backend. Session ids in the URL /
+    // cache belong to the previous host and 404 if we resume them here — wipe
+    // + requestFreshSession own the chat reset; skip until the switch settles.
+    if (currentView !== 'chat' || !gatewayOpen || gatewaySwitching) {
       return
     }
 
@@ -140,7 +146,13 @@ export function useRouteResume({
       // we're stranded on a routed session that never loaded. The first two
       // guard against a transient /:sid re-resume during "new chat" state clears
       // before the pathname updates from /:sid -> /.
-      const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+      //
+      // Gateway reconnect (gatewayBecameOpen) must NOT re-open a previous-host
+      // session while a blank draft is armed (gateway switch / new chat) — even
+      // if the hash still reads /:sid for one more frame. Pathname changes still
+      // resume so clicking a session from a fresh draft works.
+      const shouldResume =
+        pathnameChanged || stuckOnRoutedSession || (gatewayBecameOpen && !freshDraftReady)
 
       // On a reconnect (gatewayBecameOpen) re-resume even when the route looks
       // `alreadyActive`: the cached runtime id can be stale once the gateway
@@ -168,6 +180,7 @@ export function useRouteResume({
     currentView,
     freshDraftReady,
     gatewayState,
+    gatewaySwitching,
     locationPathname,
     resumeSession,
     routedSessionId,
@@ -206,7 +219,7 @@ export function useRouteResume({
       retryAttemptRef.current = 0
     }
 
-    if (currentView !== 'chat' || gatewayState !== 'open') {
+    if (currentView !== 'chat' || gatewayState !== 'open' || gatewaySwitching) {
       return
     }
 
@@ -276,6 +289,7 @@ export function useRouteResume({
     creatingSessionRef,
     currentView,
     gatewayState,
+    gatewaySwitching,
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -1,15 +1,32 @@
 import { useStore } from '@nanostores/react'
-import { type ComponentProps, type MouseEvent, type ReactNode, useEffect, useState } from 'react'
+import {
+  type ComponentProps,
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useState
+} from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
 import { resetLayoutTree } from '@/components/pane-shell/tree/store'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
+import type { DesktopConnectionConfig } from '@/global'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
+import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import {
   $fileBrowserOpen,
@@ -18,6 +35,8 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
+import { notify, notifyError } from '@/store/notifications'
+import { $connection } from '@/store/session'
 
 import { appViewForPath, isOverlayView, SETTINGS_ROUTE } from '../routes'
 
@@ -42,11 +61,23 @@ export interface TitlebarTool {
 export type TitlebarToolSide = 'left' | 'right'
 export type SetTitlebarToolGroup = (id: string, tools: readonly TitlebarTool[], side?: TitlebarToolSide) => void
 
+type GatewayMode = 'local' | 'remote' | 'cloud'
+
+interface GatewayTarget {
+  mode: 'remote' | 'cloud'
+  remoteUrl: string
+  remoteAuthMode: 'oauth' | 'token'
+  cloudOrg?: string
+}
+
 interface TitlebarControlsProps extends ComponentProps<'div'> {
   leftTools?: readonly TitlebarTool[]
   tools?: readonly TitlebarTool[]
   onOpenSettings: () => void
 }
+
+const LAST_REMOTE_KEY = 'hermes.desktop.gateway-last-remote'
+const LAST_CLOUD_KEY = 'hermes.desktop.gateway-last-cloud'
 
 /**
  * The layout button's glyph. Morphs into its composite reset form — the
@@ -94,6 +125,124 @@ function useModifierHeld(): boolean {
   return held
 }
 
+function modeIcon(mode: GatewayMode, busy = false): string {
+  if (busy) {
+    return 'loading'
+  }
+
+  if (mode === 'cloud') {
+    return 'cloud'
+  }
+
+  if (mode === 'remote') {
+    return 'globe'
+  }
+
+  return 'home'
+}
+
+function canUseRemoteLike(config: DesktopConnectionConfig | null | undefined): boolean {
+  if (!config?.remoteUrl) {
+    return false
+  }
+
+  return config.remoteAuthMode === 'oauth' ? config.remoteOauthConnected : config.remoteTokenSet
+}
+
+function readLastTarget(key: string): GatewayTarget | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const raw = window.localStorage.getItem(key)
+
+    if (!raw) {
+      return null
+    }
+
+    const parsed = JSON.parse(raw) as Partial<GatewayTarget>
+    const remoteUrl = String(parsed.remoteUrl || '').trim()
+    const mode = parsed.mode === 'cloud' ? 'cloud' : parsed.mode === 'remote' ? 'remote' : null
+    const remoteAuthMode = parsed.remoteAuthMode === 'oauth' ? 'oauth' : 'token'
+
+    if (!mode || !remoteUrl) {
+      return null
+    }
+
+    return {
+      mode,
+      remoteUrl,
+      remoteAuthMode,
+      cloudOrg: mode === 'cloud' ? String(parsed.cloudOrg || '').trim() || undefined : undefined
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeLastTarget(key: string, target: GatewayTarget): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(target))
+  } catch {
+    // Quota / private mode — menu still works from the live saved config.
+  }
+}
+
+function targetFromConfig(config: DesktopConnectionConfig): GatewayTarget | null {
+  const remoteUrl = String(config.remoteUrl || '').trim()
+
+  if (!remoteUrl) {
+    return null
+  }
+
+  if (config.mode === 'cloud') {
+    return {
+      mode: 'cloud',
+      remoteUrl,
+      remoteAuthMode: config.remoteAuthMode === 'oauth' ? 'oauth' : 'token',
+      cloudOrg: String(config.cloudOrg || '').trim() || undefined
+    }
+  }
+
+  // A remote-shaped block (or residual url after local hop) is a remote target.
+  return {
+    mode: 'remote',
+    remoteUrl,
+    remoteAuthMode: config.remoteAuthMode === 'oauth' ? 'oauth' : 'token'
+  }
+}
+
+function rememberTargetFromConfig(config: DesktopConnectionConfig | null | undefined): void {
+  if (!config) {
+    return
+  }
+
+  const target = targetFromConfig(config)
+
+  if (!target) {
+    return
+  }
+
+  // Only cache targets that still authenticate — a dead OAuth session should
+  // not keep advertising a one-click hop that will just bounce to Settings.
+  if (!canUseRemoteLike(config) && config.mode !== 'local') {
+    return
+  }
+
+  if (target.mode === 'cloud' || config.mode === 'cloud') {
+    writeLastTarget(LAST_CLOUD_KEY, { ...target, mode: 'cloud' })
+  }
+
+  if (target.mode === 'remote' || config.mode === 'remote') {
+    writeLastTarget(LAST_REMOTE_KEY, { ...target, mode: 'remote' })
+  }
+}
+
 export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }: TitlebarControlsProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
@@ -102,6 +251,51 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const hapticsMuted = useStore($hapticsMuted)
   const fileBrowserOpen = useStore($fileBrowserOpen)
   const sidebarOpen = useStore($sidebarOpen)
+  const connection = useStore($connection)
+  const gatewaySwitching = useStore($gatewaySwitching)
+  const [gatewayBusy, setGatewayBusy] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [savedConfig, setSavedConfig] = useState<DesktopConnectionConfig | null>(null)
+  const [lastRemote, setLastRemote] = useState<GatewayTarget | null>(() => readLastTarget(LAST_REMOTE_KEY))
+  const [lastCloud, setLastCloud] = useState<GatewayTarget | null>(() => readLastTarget(LAST_CLOUD_KEY))
+
+  const busy = gatewayBusy || gatewaySwitching
+  // Saved provenance (cloud/remote/local) for the checkmarks; live connection is
+  // only ever local|remote so cloud needs the saved config to show correctly.
+  const selectedMode: GatewayMode =
+    savedConfig?.mode === 'cloud' || savedConfig?.mode === 'remote' || savedConfig?.mode === 'local'
+      ? savedConfig.mode
+      : connection?.mode === 'remote'
+        ? 'remote'
+        : 'local'
+
+  const refreshSavedConfig = useCallback(async () => {
+    const desktop = window.hermesDesktop
+
+    if (!desktop?.getConnectionConfig) {
+      return
+    }
+
+    try {
+      const next = await desktop.getConnectionConfig()
+      setSavedConfig(next)
+      rememberTargetFromConfig(next)
+      setLastRemote(readLastTarget(LAST_REMOTE_KEY))
+      setLastCloud(readLastTarget(LAST_CLOUD_KEY))
+    } catch {
+      // Keep last known config; a transient IPC miss shouldn't blank the menu.
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshSavedConfig()
+  }, [connection?.mode, connection?.baseUrl, refreshSavedConfig])
+
+  useEffect(() => {
+    if (menuOpen) {
+      void refreshSavedConfig()
+    }
+  }, [menuOpen, refreshSavedConfig])
 
   const toggleHaptics = () => {
     if (!hapticsMuted) {
@@ -114,6 +308,118 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       window.requestAnimationFrame(() => triggerHaptic('success'))
     }
   }
+
+  // Soft-switch the saved connection mode. Remote and cloud targets are cached
+  // separately so Cloud → Local → Cloud still works even though the persisted
+  // connection config intentionally drops cloud provenance on a local hop.
+  const selectGatewayMode = useCallback(
+    async (mode: GatewayMode) => {
+      const desktop = window.hermesDesktop
+      const copy = t.titlebar
+
+      if (!desktop?.applyConnectionConfig || !desktop.getConnectionConfig || busy) {
+        return
+      }
+
+      if (selectedMode === mode && !busy) {
+        // Already on this mode — still open settings for remote/cloud so the
+        // user can re-auth / re-pick without hunting the nav.
+        if (mode !== 'local') {
+          navigate(`${SETTINGS_ROUTE}?tab=gateway`)
+        }
+
+        return
+      }
+
+      setGatewayBusy(true)
+      triggerHaptic('tap')
+
+      try {
+        if (mode === 'local') {
+          // Snapshot the live target BEFORE local apply. Cloud→local clears
+          // cloud provenance in coerceDesktopConnectionConfig; without this
+          // cache the menu loses Cloud entirely.
+          const live = await desktop.getConnectionConfig().catch(() => null)
+          rememberTargetFromConfig(live)
+
+          const next = await desktop.applyConnectionConfig({ mode: 'local' })
+          setSavedConfig(next)
+          setLastRemote(readLastTarget(LAST_REMOTE_KEY))
+          setLastCloud(readLastTarget(LAST_CLOUD_KEY))
+          notify({ kind: 'success', message: copy.gatewaySwitchLocalMessage, title: copy.gatewayModeLocal })
+
+          return
+        }
+
+        const config = await desktop.getConnectionConfig()
+        const cached = mode === 'cloud' ? readLastTarget(LAST_CLOUD_KEY) : readLastTarget(LAST_REMOTE_KEY)
+        const liveMatches =
+          config.mode === mode && canUseRemoteLike(config)
+            ? targetFromConfig(config)
+            : config.mode !== 'local' && canUseRemoteLike(config) && mode === 'remote' && config.mode === 'remote'
+              ? targetFromConfig(config)
+              : null
+
+        // Prefer a still-authenticated live match; else the last successful
+        // target of that mode. Cached OAuth targets still need a live cookie.
+        let target = liveMatches || cached
+
+        if (target && target.mode !== mode) {
+          target = { ...target, mode }
+        }
+
+        if (!target?.remoteUrl) {
+          navigate(`${SETTINGS_ROUTE}?tab=gateway`)
+          notify({
+            kind: 'info',
+            message: mode === 'cloud' ? copy.gatewaySwitchNeedsCloudMessage : copy.gatewaySwitchNeedsSetupMessage,
+            title: mode === 'cloud' ? copy.gatewaySwitchNeedsCloudTitle : copy.gatewaySwitchNeedsSetupTitle
+          })
+
+          return
+        }
+
+        // For OAuth, the live cookie jar must still be signed in for this URL.
+        // If the saved config points at the same URL and reports disconnected,
+        // bounce to Settings instead of a doomed apply.
+        if (
+          target.remoteAuthMode === 'oauth' &&
+          config.remoteUrl === target.remoteUrl &&
+          !config.remoteOauthConnected
+        ) {
+          navigate(`${SETTINGS_ROUTE}?tab=gateway`)
+          notify({
+            kind: 'info',
+            message: mode === 'cloud' ? copy.gatewaySwitchNeedsCloudMessage : copy.gatewaySwitchNeedsSetupMessage,
+            title: mode === 'cloud' ? copy.gatewaySwitchNeedsCloudTitle : copy.gatewaySwitchNeedsSetupTitle
+          })
+
+          return
+        }
+
+        const next = await desktop.applyConnectionConfig({
+          mode,
+          remoteAuthMode: target.remoteAuthMode,
+          remoteUrl: target.remoteUrl,
+          cloudOrg: mode === 'cloud' ? target.cloudOrg : undefined
+        })
+        setSavedConfig(next)
+        rememberTargetFromConfig(next)
+        setLastRemote(readLastTarget(LAST_REMOTE_KEY))
+        setLastCloud(readLastTarget(LAST_CLOUD_KEY))
+        notify({
+          kind: 'success',
+          message: mode === 'cloud' ? copy.gatewaySwitchCloudMessage : copy.gatewaySwitchRemoteMessage,
+          title: mode === 'cloud' ? copy.gatewayModeCloud : copy.gatewayModeRemote
+        })
+      } catch (err) {
+        notifyError(err, t.titlebar.gatewaySwitchFailed)
+      } finally {
+        setGatewayBusy(false)
+      }
+    },
+    [busy, navigate, selectedMode, t.titlebar]
+  )
 
   // POSITIONAL toggles: each button shows/hides everything on its physical
   // side of the main zone (the layout tree collapses the whole side), so they
@@ -159,7 +465,9 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     }
   }
 
-  // Static system tools — always pinned to the screen's right edge.
+  // Static system tools — always pinned to the screen's right edge. Gateway
+  // mode is rendered separately as a dropdown so the click opens Local /
+  // Remote / Cloud instead of toggling.
   const systemTools: TitlebarTool[] = [
     {
       className: 'group/tool',
@@ -219,7 +527,57 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   }
 
   const visibleSystemTools = systemTools.filter(tool => !tool.hidden)
+  const settingsTool = visibleSystemTools.find(tool => tool.id === 'settings')
+  const visibleSystemToolsBeforeSettings = visibleSystemTools.filter(tool => tool.id !== 'settings')
   const visiblePaneTools = tools.filter(tool => !tool.hidden)
+
+  const gatewayTriggerClass = cn(
+    titlebarButtonClass,
+    'bg-transparent select-none',
+    selectedMode !== 'local' && 'text-foreground'
+  )
+
+  // Only list gateways the user can actually switch to. Unconfigured remote /
+  // cloud stay out of the menu — use "Gateway settings" to add them. Last
+  // successful targets survive Cloud/Remote → Local so the round-trip stays
+  // one click. The currently-selected mode always stays visible.
+  const remoteConfigured =
+    Boolean(lastRemote?.remoteUrl) ||
+    (canUseRemoteLike(savedConfig) && savedConfig?.mode === 'remote') ||
+    (canUseRemoteLike(savedConfig) && savedConfig?.mode !== 'cloud' && Boolean(savedConfig?.remoteUrl))
+  const cloudConfigured =
+    Boolean(lastCloud?.remoteUrl) || (canUseRemoteLike(savedConfig) && savedConfig?.mode === 'cloud')
+  const showRemote = selectedMode === 'remote' || remoteConfigured
+  const showCloud = selectedMode === 'cloud' || cloudConfigured
+
+  const modeItems: { mode: GatewayMode; icon: string; label: string; hint: string }[] = [
+    {
+      mode: 'local',
+      icon: 'home',
+      label: t.titlebar.gatewayModeLocal,
+      hint: t.titlebar.gatewayModeLocalHint
+    },
+    ...(showRemote
+      ? [
+          {
+            mode: 'remote' as const,
+            icon: 'globe',
+            label: t.titlebar.gatewayModeRemote,
+            hint: t.titlebar.gatewayModeRemoteHint
+          }
+        ]
+      : []),
+    ...(showCloud
+      ? [
+          {
+            mode: 'cloud' as const,
+            icon: 'cloud',
+            label: t.titlebar.gatewayModeCloud,
+            hint: t.titlebar.gatewayModeCloudHint
+          }
+        ]
+      : [])
+  ]
 
   return (
     <>
@@ -257,9 +615,65 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         aria-label={t.shell.appControls}
         className="fixed right-(--titlebar-tools-right) top-(--titlebar-controls-top) z-70 flex flex-row items-center justify-end gap-x-1 pointer-events-auto select-none [-webkit-app-region:no-drag]"
       >
-        {visibleSystemTools.map(tool => (
+        {visibleSystemToolsBeforeSettings.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
         ))}
+
+        <DropdownMenu onOpenChange={setMenuOpen} open={menuOpen}>
+          <Tip label={t.titlebar.gatewayModeMenuTitle}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label={t.titlebar.gatewayModeMenuTitle}
+                aria-pressed={selectedMode !== 'local' || undefined}
+                className={gatewayTriggerClass}
+                disabled={busy}
+                onPointerDown={event => event.stopPropagation()}
+                size="icon-titlebar"
+                type="button"
+                variant="ghost"
+              >
+                <Codicon name={modeIcon(selectedMode, busy)} spinning={busy} />
+              </Button>
+            </DropdownMenuTrigger>
+          </Tip>
+          <DropdownMenuContent align="end" className="min-w-52" side="bottom" sideOffset={6}>
+            <DropdownMenuLabel>{t.titlebar.gatewayModeMenuTitle}</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {modeItems.map(item => {
+              const active = selectedMode === item.mode
+
+              return (
+                <DropdownMenuItem
+                  className="gap-2"
+                  disabled={busy}
+                  key={item.mode}
+                  onSelect={() => {
+                    void selectGatewayMode(item.mode)
+                  }}
+                >
+                  <Codicon name={item.icon} size="0.875rem" />
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate font-medium">{item.label}</span>
+                    <span className="truncate text-[0.65rem] text-muted-foreground">{item.hint}</span>
+                  </span>
+                  {active ? <Codicon className="text-foreground" name="check" size="0.75rem" /> : null}
+                </DropdownMenuItem>
+              )
+            })}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="gap-2"
+              onSelect={() => {
+                navigate(`${SETTINGS_ROUTE}?tab=gateway`)
+              }}
+            >
+              <Codicon name="settings-gear" size="0.875rem" />
+              <span className="truncate">{t.titlebar.gatewayModeOpenSettings}</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {settingsTool && <TitlebarToolButton navigate={navigate} tool={settingsTool} />}
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
       </div>
     </>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -192,7 +192,23 @@ export const en: Translations = {
     openStarmap: 'Open memory graph',
     openKeybinds: 'Keyboard shortcuts',
     layoutEditor: 'Layout editor',
-    layoutEditorTitle: 'Layout editor — ⌘-click resets the layout'
+    layoutEditorTitle: 'Layout editor — ⌘-click resets the layout',
+    gatewayModeMenuTitle: 'Gateway connection',
+    gatewayModeLocal: 'Local',
+    gatewayModeLocalHint: 'Private backend on this machine',
+    gatewayModeRemote: 'Remote',
+    gatewayModeRemoteHint: 'Saved remote Hermes backend',
+    gatewayModeCloud: 'Cloud',
+    gatewayModeCloudHint: 'Hermes Cloud agent',
+    gatewayModeOpenSettings: 'Gateway settings…',
+    gatewaySwitchLocalMessage: 'Reconnecting to the local Hermes gateway…',
+    gatewaySwitchRemoteMessage: 'Reconnecting to the remote Hermes gateway…',
+    gatewaySwitchCloudMessage: 'Reconnecting to Hermes Cloud…',
+    gatewaySwitchNeedsSetupTitle: 'Remote gateway not ready',
+    gatewaySwitchNeedsSetupMessage: 'Configure and sign in under Settings → Gateway first.',
+    gatewaySwitchNeedsCloudTitle: 'Cloud gateway not ready',
+    gatewaySwitchNeedsCloudMessage: 'Sign in and pick an agent under Settings → Gateway first.',
+    gatewaySwitchFailed: 'Could not switch gateway'
   },
 
   keybinds: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -190,7 +190,26 @@ export const ja = defineLocale({
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',
-    openStarmap: 'メモリグラフを開く'
+    openStarmap: 'メモリグラフを開く',
+    openKeybinds: 'キーボードショートカット',
+    layoutEditor: 'レイアウト編集',
+    layoutEditorTitle: 'レイアウト編集 — ⌘クリックでリセット',
+    gatewayModeMenuTitle: 'ゲートウェイ接続',
+    gatewayModeLocal: 'ローカル',
+    gatewayModeLocalHint: 'このマシンのプライベートバックエンド',
+    gatewayModeRemote: 'リモート',
+    gatewayModeRemoteHint: '保存済みのリモート Hermes バックエンド',
+    gatewayModeCloud: 'クラウド',
+    gatewayModeCloudHint: 'Hermes Cloud エージェント',
+    gatewayModeOpenSettings: 'ゲートウェイ設定…',
+    gatewaySwitchLocalMessage: 'ローカル Hermes ゲートウェイに再接続中…',
+    gatewaySwitchRemoteMessage: 'リモート Hermes ゲートウェイに再接続中…',
+    gatewaySwitchCloudMessage: 'Hermes Cloud に再接続中…',
+    gatewaySwitchNeedsSetupTitle: 'リモートゲートウェイ未設定',
+    gatewaySwitchNeedsSetupMessage: '先に 設定 → ゲートウェイ で構成してサインインしてください。',
+    gatewaySwitchNeedsCloudTitle: 'クラウドゲートウェイ未設定',
+    gatewaySwitchNeedsCloudMessage: '先に 設定 → ゲートウェイ でサインインし、エージェントを選んでください。',
+    gatewaySwitchFailed: 'ゲートウェイを切り替えられませんでした'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -234,6 +234,22 @@ export interface Translations {
     openKeybinds: string
     layoutEditor: string
     layoutEditorTitle: string
+    gatewayModeMenuTitle: string
+    gatewayModeLocal: string
+    gatewayModeLocalHint: string
+    gatewayModeRemote: string
+    gatewayModeRemoteHint: string
+    gatewayModeCloud: string
+    gatewayModeCloudHint: string
+    gatewayModeOpenSettings: string
+    gatewaySwitchLocalMessage: string
+    gatewaySwitchRemoteMessage: string
+    gatewaySwitchCloudMessage: string
+    gatewaySwitchNeedsSetupTitle: string
+    gatewaySwitchNeedsSetupMessage: string
+    gatewaySwitchNeedsCloudTitle: string
+    gatewaySwitchNeedsCloudMessage: string
+    gatewaySwitchFailed: string
   }
 
   keybinds: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -184,7 +184,26 @@ export const zhHant = defineLocale({
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
     openSettings: '開啟設定',
-    openStarmap: '開啟記憶圖譜'
+    openStarmap: '開啟記憶圖譜',
+    openKeybinds: '鍵盤快捷鍵',
+    layoutEditor: '版面編輯器',
+    layoutEditorTitle: '版面編輯器 — ⌘ 點擊重設版面',
+    gatewayModeMenuTitle: '閘道連線',
+    gatewayModeLocal: '本機',
+    gatewayModeLocalHint: '本機私有後端',
+    gatewayModeRemote: '遠端',
+    gatewayModeRemoteHint: '已儲存的遠端 Hermes 後端',
+    gatewayModeCloud: '雲端',
+    gatewayModeCloudHint: 'Hermes Cloud 智能體',
+    gatewayModeOpenSettings: '閘道設定…',
+    gatewaySwitchLocalMessage: '正在重新連線本機 Hermes 閘道…',
+    gatewaySwitchRemoteMessage: '正在重新連線遠端 Hermes 閘道…',
+    gatewaySwitchCloudMessage: '正在重新連線 Hermes Cloud…',
+    gatewaySwitchNeedsSetupTitle: '遠端閘道尚未就緒',
+    gatewaySwitchNeedsSetupMessage: '請先在 設定 → 閘道 中完成設定並登入。',
+    gatewaySwitchNeedsCloudTitle: '雲端閘道尚未就緒',
+    gatewaySwitchNeedsCloudMessage: '請先在 設定 → 閘道 中登入並選擇智能體。',
+    gatewaySwitchFailed: '無法切換閘道'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -187,7 +187,23 @@ export const zh: Translations = {
     openStarmap: '打开记忆图谱',
     openKeybinds: '键盘快捷键',
     layoutEditor: '布局编辑器',
-    layoutEditorTitle: '布局编辑器 — ⌘ 点击重置布局'
+    layoutEditorTitle: '布局编辑器 — ⌘ 点击重置布局',
+    gatewayModeMenuTitle: '网关连接',
+    gatewayModeLocal: '本地',
+    gatewayModeLocalHint: '本机私有后端',
+    gatewayModeRemote: '远程',
+    gatewayModeRemoteHint: '已保存的远程 Hermes 后端',
+    gatewayModeCloud: '云端',
+    gatewayModeCloudHint: 'Hermes Cloud 智能体',
+    gatewayModeOpenSettings: '网关设置…',
+    gatewaySwitchLocalMessage: '正在重连本地 Hermes 网关…',
+    gatewaySwitchRemoteMessage: '正在重连远程 Hermes 网关…',
+    gatewaySwitchCloudMessage: '正在重连 Hermes Cloud…',
+    gatewaySwitchNeedsSetupTitle: '远程网关未就绪',
+    gatewaySwitchNeedsSetupMessage: '请先在 设置 → 网关 中配置并登录。',
+    gatewaySwitchNeedsCloudTitle: '云端网关未就绪',
+    gatewaySwitchNeedsCloudMessage: '请先在 设置 → 网关 中登录并选择智能体。',
+    gatewaySwitchFailed: '无法切换网关'
   },
 
   keybinds: {

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -18,13 +18,38 @@ import {
 
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from './gateway-switch'
 
+const requestFreshSession = vi.fn()
+
 vi.mock('@/lib/query-client', () => ({
   invalidateProfileScopedQueries: vi.fn()
+}))
+
+vi.mock('@/store/profile', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/profile')>()
+
+  return {
+    ...actual,
+    requestFreshSession: (...args: unknown[]) => requestFreshSession(...args)
+  }
+})
+
+vi.mock('@/app/routes', () => ({
+  routeSessionId: (pathname: string) => {
+    if (!pathname || pathname === '/' || pathname.startsWith('/settings')) {
+      return null
+    }
+
+    const id = pathname.replace(/^\//, '')
+
+    return id && !id.includes('/') ? id : null
+  }
 }))
 
 describe('wipeSessionListsForGatewaySwitch', () => {
   beforeEach(() => {
     $gatewaySwitching.set(false)
+    requestFreshSession.mockReset()
+    window.location.hash = ''
     setSessions([{ id: 's1', title: 'old', profile: 'default' } as never])
     setSessionsTotal(1)
     setCronSessions([{ id: 'c1', title: 'cron', profile: 'default' } as never])
@@ -41,6 +66,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setMessagingSessions([])
     setSessionsLoading(true)
     $gatewaySwitching.set(false)
+    window.location.hash = ''
   })
 
   it('clears lists and arms loading so sidebar skeletons retrigger', () => {
@@ -53,5 +79,22 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessionsLoading.get()).toBe(true)
     expect($sessionsLimit.get()).toBe(SIDEBAR_SESSIONS_PAGE_SIZE)
     expect($freshDraftReady.get()).toBe(true)
+    expect(requestFreshSession).not.toHaveBeenCalled()
+  })
+
+  it('requests a blank draft when the URL still points at a previous-gateway session', () => {
+    window.location.hash = '#/old-session-id'
+
+    wipeSessionListsForGatewaySwitch()
+
+    expect(requestFreshSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close Settings / overlay routes during a soft switch', () => {
+    window.location.hash = '#/settings?tab=gateway'
+
+    wipeSessionListsForGatewaySwitch()
+
+    expect(requestFreshSession).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -1,7 +1,9 @@
 import { atom } from 'nanostores'
 
+import { routeSessionId } from '@/app/routes'
 import { invalidateProfileScopedQueries } from '@/lib/query-client'
 import { resetSessionsLimit } from '@/store/layout'
+import { requestFreshSession } from '@/store/profile'
 import {
   $unreadFinishedSessionIds,
   setActiveSessionId,
@@ -11,6 +13,9 @@ import {
   setMessagingPlatformTotals,
   setMessagingSessions,
   setMessagingTruncated,
+  setRememberedSessionId,
+  setResumeExhaustedSessionId,
+  setResumeFailedSessionId,
   setSelectedStoredSessionId,
   setSessionProfileTotals,
   setSessions,
@@ -21,8 +26,24 @@ import { clearAllSessionStates } from '@/store/session-states'
 
 // True while a soft gateway-mode apply is mid-flight (wipe → re-dial). Lets the
 // boot hook suppress the backend-exit toast and keeps the cold-boot CONNECTING
-// overlay from resurrecting when startHermes re-emits boot progress.
+// overlay from resurrecting when startHermes re-emits boot progress. Also
+// blocks useRouteResume from re-opening a previous-gateway session id.
 export const $gatewaySwitching = atom(false)
+
+/** HashRouter path (`#/session-id` → `/session-id`), with a pathname fallback. */
+function currentAppPathname(): string {
+  if (typeof window === 'undefined') {
+    return '/'
+  }
+
+  const hash = window.location.hash.replace(/^#/, '')
+
+  if (hash) {
+    return hash.startsWith('/') ? hash : `/${hash}`
+  }
+
+  return window.location.pathname || '/'
+}
 
 /**
  * Clear gateway-bound session UI so sidebar skeletons retrigger.
@@ -32,9 +53,10 @@ export const $gatewaySwitching = atom(false)
  * painting the previous gateway's rows. RQ caches (settings/config/skills) are
  * invalidated separately; the live session list is this path.
  *
- * Does NOT call requestFreshSession() — that navigates to NEW_CHAT and would
- * close route overlays (Settings). Clear chat state in place; leave the URL
- * alone so the user stays where they were (e.g. mid-Gateway settings).
+ * Chat session routes (`#/:sessionId`) are reset to a blank draft — those ids
+ * belong to the previous backend and would 404-spam resume after reconnect.
+ * Overlay routes (Settings / Command Center / …) keep their URL so a mid-edit
+ * Gateway settings page is not closed by the soft switch.
  */
 export function wipeSessionListsForGatewaySwitch(): void {
   setSessions([])
@@ -56,8 +78,19 @@ export function wipeSessionListsForGatewaySwitch(): void {
   setSelectedStoredSessionId(null)
   setMessages([])
   setFreshDraftReady(true)
+  // Stop the bounded resume retry + "last session" boot restore from chasing
+  // an id that only existed on the previous backend.
+  setResumeFailedSessionId(null)
+  setResumeExhaustedSessionId(null)
+  setRememberedSessionId(null)
 
   // Narrowed: account/marketplace/onboarding caches are global, not gateway-
   // scoped, so a mode swap must not refetch them.
   invalidateProfileScopedQueries()
+
+  if (routeSessionId(currentAppPathname())) {
+    // Navigate via the shared fresh-session request so the chat controller
+    // owns the route flip (HashRouter) instead of us reaching into history.
+    requestFreshSession()
+  }
 }


### PR DESCRIPTION
## Summary

- Add a Desktop titlebar menu for one-click soft-switch between **Local**, **Remote**, and **Cloud** gateways
- Open Settings → Gateway when remote/cloud is not configured instead of failing mid-switch
- Clear previous-gateway session state / chat session routes so reconnect does not spam `Session not found` 404s

## Motivation

Switching gateways currently requires Settings → Gateway → select → apply every time. Users who hop between local and remote backends need a faster path.

Closes #62878

## Changes

- `titlebar-controls.tsx`: gateway connection dropdown (Local / Remote / Cloud + Gateway settings)
- Soft-apply via existing `applyConnectionConfig` / `saveConnectionConfig` IPC
- Preserve remote credentials across local hops; snapshot cloud→remote so round-trips stay one click
- `gateway-switch.ts`: wipe session lists, clear resume latches, request a blank draft only on chat session routes (keep Settings overlays open)
- `use-route-resume.ts`: skip resume while `$gatewaySwitching`, and do not re-open previous-host sessions on reconnect when a fresh draft is armed
- i18n: en / zh / ja / zh-hant

## Test Plan

- [x] `npx vitest run src/store/gateway-switch.test.ts src/app/session/hooks/use-route-resume.test.tsx --environment jsdom` (15 passed)
- [ ] Manual: Desktop titlebar gateway icon opens Local / Remote / Cloud menu
- [ ] Manual: switch Local ↔ Remote with a saved remote config
- [ ] Manual: unconfigured Remote/Cloud opens Settings → Gateway
- [ ] Manual: after switch, no repeated `Session not found` 404 spam for the previous host session URL

## Notes for Reviewers

- Soft switch only; no new backend RPC
- Cloud vs remote checkmarks use saved connection provenance (`getConnectionConfig`) because the live connection mode is only `local|remote`
- Multiple named remotes are left for a follow-up; this PR uses the existing single saved remote/cloud target
