### PR TITLE
fix(error_classifier): add Copilot monthly quota exhaustion pattern to billing classification

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -114,6 +114,7 @@ _BILLING_PATTERNS = [
     "billing hard limit",
     "exceeded your current quota",
     "account is deactivated",
+    "exceeded your monthly quota",  # GitHub Copilot monthly quota exhaustion
     "plan does not include",
     "out of extra usage",  # Anthropic OAuth Pro/Max overage bucket depleted (HTTP 400)
     "out of funds",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -224,6 +224,13 @@ class TestClassify402:
         )
         assert result.reason == FailoverReason.billing
 
+    def test_copilot_monthly_quota(self):
+        """Copilot 'exceeded your monthly quota' is billing, should fallback."""
+        error = RuntimeError("You have exceeded your monthly quota (Request ID: A540:22A007:3849658:44F52D9:6A541F53)")
+        result = classify_api_error(error, provider="copilot-acp", model="auto")
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
+
 
 # ── Test: Full classification pipeline ─────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Fixes the fallback provider chain not activating when GitHub Copilot ACP returns a monthly quota exhaustion error.

The Copilot ACP subprocess raises a `RuntimeError` with the message "You have exceeded your monthly quota (Request ID: ...)" when the monthly quota is exhausted. This error should trigger the fallback chain to switch to the next configured provider, but it was being surfaced directly to the user instead.

The root cause: `_BILLING_PATTERNS` in `agent/error_classifier.py` contained `"exceeded your current quota"` but Copilot's actual message is `"exceeded your monthly quota"`. The substring `"exceeded your current quota"` does not match `"exceeded your monthly quota"`, so the error was not classified as a billing issue and `should_fallback=True` was never set.

This PR adds the missing pattern `"exceeded your monthly quota"` to `_BILLING_PATTERNS`. Now when Copilot returns this error, `classify_api_error()` returns `FailoverReason.billing` with `should_fallback=True`, and the conversation loop correctly activates the fallback chain.

## Related Issue

Fixes #63815

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: Added `"exceeded your monthly quota"` pattern to `_BILLING_PATTERNS` to classify GitHub Copilot monthly quota exhaustion as a billing error.

## How to Test

The fix is a simple string pattern addition that can be verified by:

1. **Manual pattern verification**: Run `python3 -c "from agent.error_classifier import _BILLING_PATTERNS; print('monthly quota' in str(_BILLING_PATTERNS))"` — should return `True`.

2. **Classification verification**: Import and run the classifier on a Copilot monthly quota error message:
   ```python
   from agent.error_classifier import classify_api_error, FailoverReason
   error = RuntimeError("You have exceeded your monthly quota (Request ID: A540:22A007:3849658:44F52D9:6A541F53)")
   classified = classify_api_error(error, provider="copilot-acp", model="auto")
   assert classified.reason == FailoverReason.billing
   assert classified.should_fallback == True
   ```

3. **End-to-end reproduction** (requires active Copilot quota exhaustion):
   - Configure `copilot-acp` as the primary provider with `fallback_providers` set to at least one other provider (e.g., `opencode-zen`).
   - Exhaust the Copilot monthly quota.
   - Send a message via Telegram or CLI.
   - **Expected behavior**: The agent falls back to the next provider and returns a response.
   - **Observed result (before fix)**: The raw error message "You have exceeded your monthly quota (Request ID: ...)" is surfaced to the user.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md).
- [x] I've run `python -m pytest tests/agent/test_error_classifier.py -q` locally to verify no regressions.
- [x] My changes follow the project's style guidelines.
- [x] I've updated documentation if needed.

### Tests

- [x] I've added tests for the new pattern in `tests/agent/test_error_classifier.py`.

### Platform

- [x] macOS
- [ ] Linux
- [ ] Windows