### PR TITLE
fix(acp): match WSL UNC cwd paths in list_sessions filter

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -46,11 +46,16 @@ def _normalize_cwd_for_compare(cwd: str | None) -> str:
         raw = "."
     expanded = os.path.expanduser(raw)
 
-    # Normalize Windows drive paths into the equivalent WSL mount form so
-    # ACP history filters match the same workspace across Windows and WSL.
-    from hermes_constants import windows_path_to_wsl
+    # Normalize Windows drive paths and WSL UNC spellings (\\wsl.localhost\...,
+    # \\wsl$\...) into the equivalent WSL mount/POSIX form so ACP history
+    # filters match the same workspace across Windows and WSL — same
+    # translator order _translate_acp_cwd uses to store the cwd in the first
+    # place, so a session created from a UNC path is still found by it.
+    from hermes_constants import wsl_unc_path_to_posix, windows_path_to_wsl
 
-    translated = windows_path_to_wsl(expanded)
+    translated = wsl_unc_path_to_posix(expanded)
+    if translated is None:
+        translated = windows_path_to_wsl(expanded)
     if translated is not None:
         expanded = translated
     elif re.match(r"^/mnt/[A-Za-z]/", expanded):

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -232,6 +232,20 @@ class TestPersistence:
 
 
 
+    def test_list_sessions_matches_wsl_unc_paths(self, manager):
+        """A session created from a \\\\wsl.localhost\\ UNC workspace — the form
+        _translate_acp_cwd stores after translate_cwd_for_wsl_backend's UNC
+        translator runs — must still be found when an editor later filters
+        list_sessions() by that same UNC spelling. _normalize_cwd_for_compare
+        used to only try the drive-letter translator, so this filter silently
+        returned zero results for UNC-created sessions."""
+        state = manager.create_session(cwd="/home/user/project")
+        state.history.append({"role": "user", "content": "same project via WSL UNC"})
+
+        listing = manager.list_sessions(cwd=r"\\wsl.localhost\Ubuntu\home\user\project")
+        ids = {s["session_id"] for s in listing}
+        assert state.session_id in ids
+
 
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""


### PR DESCRIPTION
## Summary
- `_translate_acp_cwd()` (`acp_adapter/session.py`, used at session create/fork/update-cwd time) routes through `translate_cwd_for_wsl_backend()`, which tries the WSL UNC translator (`wsl_unc_path_to_posix`, for `\\wsl.localhost\<distro>\...` / `\\wsl$\...` paths) before the drive-letter translator (`windows_path_to_wsl`) — added today by `3c7b9f2e9d0` ("feat(gateway,acp): translate cross-boundary cwd when running in WSL").
- `_normalize_cwd_for_compare()` (used by `list_sessions()`'s `cwd` filter, 3 call sites) was never extended to match — it only ever tries the drive-letter translator.
- A session created from a UNC workspace path is stored as a POSIX path (via `_translate_acp_cwd`), but filtering `list_sessions(cwd=<same UNC path>)` never matches it, since the comparison side leaves the UNC form untranslated. An editor (e.g. Zed on Windows talking to `hermes acp` inside WSL) that scopes its session list to the current UNC workspace sees zero sessions for it.
- Fix: try the same UNC translator first in `_normalize_cwd_for_compare`, mirroring the store-side order. Drive-letter paths were already fine (both sides agreed).

## Test plan
- [x] Added `test_list_sessions_matches_wsl_unc_paths` in `tests/acp/test_session.py`, mirroring the existing `test_list_sessions_matches_windows_and_wsl_paths` drive-letter test.
- [x] Mutation-verify: reverted the fix locally, confirmed the new test fails (`AssertionError: assert '...' in set()`), then restored the fix and confirmed it passes.
- [x] `uv run --frozen --extra dev python -m pytest tests/acp/test_session.py` — 46 passed.
- [x] `uv run --frozen --extra dev python -m pytest tests/test_hermes_constants.py -k "wsl or windows_path"` — 8 passed (no regression in the shared translators).
- [x] `ruff check` on both changed files — clean.