### PR TITLE
feat(install): allow overriding the uv installer script URL via UV_INSTALL_SCRIPT_URL

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -570,11 +570,16 @@ install_uv() {
     # Two-stage: download the installer, then run it.  Piping
     # `curl | sh` masks curl failures (sh exits 0 on empty stdin)
     # and conflates network errors with installer errors.
-    local _uv_install_log _uv_installer
+    local _uv_install_log _uv_installer _uv_install_script_url
     _uv_install_log="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-install.$$.log")"
     _uv_installer="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-installer.$$.sh")"
-    if ! curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>"$_uv_install_log"; then
-        log_error "Failed to download uv installer from https://astral.sh/uv/install.sh"
+    # UV_INSTALL_SCRIPT_URL: optional override for the uv installer script
+    # location (mirrored / air-gapped / proxied environments). The binary
+    # download inside the script separately honors astral's
+    # UV_INSTALLER_GITHUB_BASE_URL.
+    _uv_install_script_url="${UV_INSTALL_SCRIPT_URL:-https://astral.sh/uv/install.sh}"
+    if ! curl -LsSf "$_uv_install_script_url" -o "$_uv_installer" 2>"$_uv_install_log"; then
+        log_error "Failed to download uv installer from $_uv_install_script_url"
         log_info "curl output:"
         sed 's/^/    /' "$_uv_install_log" >&2
         log_info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `UV_INSTALL_SCRIPT_URL` environment variable that lets `scripts/install.sh` fetch the uv installer *script* from an alternate location instead of the hardcoded `https://astral.sh/uv/install.sh`. Default behavior is unchanged — if the variable is unset, the script downloads from `astral.sh` exactly as before.

**Why:** `install_uv()` already lets the astral installer's *binary* download be redirected via `UV_INSTALLER_GITHUB_BASE_URL` (set when invoking the downloaded script), but the fetch of the installer *script itself* had no equivalent override. Air-gapped, mirrored, and corporate-proxy environments that need to serve all outbound fetches from an internal location currently can't install Hermes's managed uv without patching `install.sh` locally. This closes that gap for the script-fetch step, complementing the existing binary-level override.

## Related Issue

No existing issue — happy to open one if maintainers prefer that workflow.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `scripts/install.sh`: in `install_uv()`, the uv installer script URL is now resolved as `"${UV_INSTALL_SCRIPT_URL:-https://astral.sh/uv/install.sh}"` before the `curl -LsSf ... -o "$_uv_installer"` call, and the adjacent error-log line uses the resolved URL instead of the hardcoded string. Added a short comment explaining the variable and noting it's distinct from `UV_INSTALLER_GITHUB_BASE_URL` (which only covers the binary). The `docs.astral.sh` manual-install hint on failure is untouched.

## How to Test

1. `bash -n scripts/install.sh` — passes, no syntax errors.
2. `shellcheck scripts/install.sh` — diffed against the pre-change output; the change introduces zero new findings (only line numbers shift for later warnings, from the inserted lines).
3. Manually exercised just the URL-resolution + curl logic in isolation (not the full installer, to avoid mutating a real environment):
   - With `UV_INSTALL_SCRIPT_URL` unset: resolves to `https://astral.sh/uv/install.sh` and downloads it successfully (matches current behavior).
   - With `UV_INSTALL_SCRIPT_URL=http://127.0.0.1:<port>/fake-installer.sh` pointed at a local `python3 -m http.server`: the script correctly fetches from the override URL instead of astral.sh.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(install): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a pure shell installer script with no associated Python test suite exercising it
- [ ] I've added tests for my changes — N/A for the same reason; verified manually as described above
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A; grepped the repo for how the existing `UV_INSTALLER_GITHUB_BASE_URL`/`UV_UNMANAGED_INSTALL` install-time env vars are documented and found no dedicated docs page listing them (they're only referenced inline in `scripts/install.sh` comments), so I followed the same pattern rather than inventing a new docs location.
- [ ] `cli-config.yaml.example` — N/A, not a runtime config key
- [ ] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture/workflow change
- [x] Cross-platform impact considered — this only affects the POSIX `sh`-compatible uv-install branch already gated for non-Termux platforms; no new platform-specific behavior introduced
- [ ] Tool descriptions/schemas — N/A

## Screenshots / Logs

n/a (shell script change)

---

Naming is flexible — happy to rename to something more Hermes-specific (e.g. `HERMES_UV_INSTALL_SCRIPT_URL`) if maintainers would rather avoid a `UV_`-prefixed name that isn't actually read by upstream `uv`/astral tooling itself.
