### PR TITLE
fix(desktop): clear OAuth partition before Settings -> Gateway sign-in

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { DesktopConnectionConfig, DesktopConnectionProbeResult } from '@/global'
 import type { ProfileInfo } from '@/types/hermes'
 
 const getConnectionConfig = vi.fn()
@@ -117,5 +118,104 @@ describe('GatewaySettings', () => {
         })
       )
     )
+  })
+})
+
+// The dedicated boot-failure reauth button (65712bf78) clears the OAuth
+// partition before opening the login window so a stale identity-provider
+// cookie can't bounce a fresh sign-in back into the same broken session. The
+// routine Settings -> Gateway "Sign in" button is the OTHER door into the
+// exact same oauth-login IPC call and was left doing a bare login with no
+// logout first — this proves it now clears the partition first too.
+
+const OAUTH_URL = 'https://gateway.example.com'
+
+function oauthBaseConfig(patch: Partial<DesktopConnectionConfig> = {}): DesktopConnectionConfig {
+  return {
+    envOverride: false,
+    mode: 'remote',
+    profile: null,
+    remoteAuthMode: 'oauth',
+    remoteOauthConnected: false,
+    remoteTokenPreview: null,
+    remoteTokenSet: true, // lets authResolved settle without waiting on the debounced probe
+    remoteUrl: OAUTH_URL,
+    cloudOrg: '',
+    ...patch
+  }
+}
+
+function oauthProbeResult(): DesktopConnectionProbeResult {
+  return {
+    baseUrl: OAUTH_URL,
+    reachable: true,
+    authMode: 'oauth',
+    providers: [{ name: 'nous', displayName: 'Nous', supportsPassword: false }],
+    version: null,
+    error: null
+  }
+}
+
+function stubOauthDesktop(config: DesktopConnectionConfig) {
+  const calls: string[] = []
+
+  const oauthLogoutConnectionConfig = vi.fn(async () => {
+    calls.push('logout')
+
+    return { ok: true, connected: false }
+  })
+
+  const oauthLoginConnectionConfig = vi.fn(async () => {
+    calls.push('login')
+
+    return { ok: true, baseUrl: OAUTH_URL, connected: true }
+  })
+
+  const original = window.hermesDesktop
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      getConnectionConfig: async () => config,
+      saveConnectionConfig: async (payload: unknown) => ({ ...config, ...(payload as object) }),
+      probeConnectionConfig: async () => oauthProbeResult(),
+      oauthLoginConnectionConfig,
+      oauthLogoutConnectionConfig
+    }
+  })
+
+  return {
+    calls,
+    oauthLoginConnectionConfig,
+    oauthLogoutConnectionConfig,
+    restore: () => Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: original })
+  }
+}
+
+describe('GatewaySettings sign-in', () => {
+  it('clears the OAuth partition before opening the login window', async () => {
+    const desktop = stubOauthDesktop(oauthBaseConfig())
+
+    try {
+      const { GatewaySettings } = await import('./gateway-settings')
+
+      render(<GatewaySettings embedded />)
+
+      // The auth-mode probe is debounced 500ms; the button only renders once
+      // it resolves. Its label is "Sign in with <provider>" (the probe's
+      // single non-password provider, "Nous") — an exact match, since "Sign
+      // in to Hermes Cloud" (the cloud-mode panel, always rendered alongside
+      // the mode picker) also contains the substring "sign in".
+      const signInButton = await screen.findByRole('button', { name: 'Sign in with Nous' }, { timeout: 3000 })
+      fireEvent.click(signInButton)
+
+      await waitFor(() => expect(desktop.oauthLoginConnectionConfig).toHaveBeenCalled(), { timeout: 2000 })
+
+      expect(desktop.oauthLogoutConnectionConfig).toHaveBeenCalledWith(OAUTH_URL)
+      expect(desktop.oauthLoginConnectionConfig).toHaveBeenCalledWith(OAUTH_URL)
+      // Logout must complete before the login window opens, not just both fire.
+      expect(desktop.calls).toEqual(['logout', 'login'])
+    } finally {
+      desktop.restore()
+    }
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -550,6 +550,13 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
 
       acceptSavedConfig(saved)
 
+      // Clear any stale identity-provider cookie for this gateway before
+      // opening the login window — otherwise a lapsed remote/cloud session
+      // (the same connected-but-expired shape the boot-failure recovery
+      // screen's dedicated reauth button already guards against) can bounce
+      // this sign-in attempt straight back into the broken session.
+      await window.hermesDesktop.oauthLogoutConnectionConfig(trimmedUrl || undefined)
+
       const result = await window.hermesDesktop.oauthLoginConnectionConfig(trimmedUrl)
 
       if (seq !== signingSeq.current) {


### PR DESCRIPTION
## Summary
- `65712bf78` ("fix(desktop): clear the OAuth partition before remote sign-in") added a logout-before-login sequence to the boot-failure recovery screen's dedicated reauth button (`signInRemote()` in `boot-failure-overlay.tsx`), fixing a lapsed remote/cloud session bouncing a fresh sign-in attempt back into the same broken session.
- The routine Settings -> Gateway "Sign in" button (`signIn()` in `apps/desktop/src/app/settings/gateway-settings.tsx`) is the *other* door into the exact same `oauthLoginConnectionConfig()` IPC call, and was left calling it directly with no logout first — so a stale identity-provider cookie in the shared `persist:hermes-remote-oauth` partition can still silently bounce a sign-in attempt started from this button.
- Notably, the original closed PR this shipped from (#61279) itself described the Settings -> Gateway sign-out/sign-in flow as the manual workaround for this exact bug — the workaround button had the same bug the dedicated fix was built to avoid.
- Fix: call `oauthLogoutConnectionConfig(trimmedUrl || undefined)` before `oauthLoginConnectionConfig(trimmedUrl)` in `signIn()`, mirroring `signOut()` in the same file, which already scopes the logout call to the URL being signed into.

## Test plan
- [x] Added `apps/desktop/src/app/settings/gateway-settings.test.tsx` (first test file for this component), rendering the real `<GatewaySettings embedded />` against a stubbed `window.hermesDesktop`, clicking the OAuth sign-in button, and asserting `oauthLogoutConnectionConfig` is called (scoped to the gateway URL) before `oauthLoginConnectionConfig`.
- [x] Mutation-verify: reverted the fix locally, confirmed the new test fails (`oauthLogoutConnectionConfig` never called), then restored the fix and confirmed it passes.
- [x] `npx vitest run --environment jsdom src/app/settings/gateway-settings.test.tsx src/components/boot-failure-overlay.test.tsx src/components/boot-failure-reauth.test.ts` — 25 passed (no regression in the sibling reauth flow).
- [x] `npm run typecheck` — clean.
- [x] `npx eslint src/app/settings/gateway-settings.tsx src/app/settings/gateway-settings.test.tsx` — clean.