### PR TITLE
fix(dashboard): pass TUI Python env to embedded chat

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1997,6 +1997,34 @@ def _resolve_tui_heap_mb(default_mb: int = 8192) -> int:
     return max(1536, sized) if limit_mb > 2048 else sized
 
 
+def _safe_tui_cwd(env: Optional[dict] = None) -> str:
+    """Return a stable cwd value for the Node TUI child environment."""
+    try:
+        return os.getcwd()
+    except FileNotFoundError:
+        candidate = ((env or {}).get("PWD") or os.environ.get("PWD") or "").strip()
+        if candidate and Path(candidate).is_dir():
+            return candidate
+        return str(PROJECT_ROOT)
+
+
+def _apply_tui_python_env(env: dict) -> None:
+    """Seed/repair Python-related env vars shared by CLI and dashboard TUI launches."""
+    src_root = str(env.get("HERMES_PYTHON_SRC_ROOT") or "").strip()
+    if not src_root or not Path(src_root).is_dir():
+        env["HERMES_PYTHON_SRC_ROOT"] = str(PROJECT_ROOT)
+
+    python = str(env.get("HERMES_PYTHON") or "").strip()
+    if not python or not (
+        (Path(python).is_file() and os.access(python, os.X_OK)) or shutil.which(python)
+    ):
+        env["HERMES_PYTHON"] = sys.executable
+
+    cwd = str(env.get("HERMES_CWD") or "").strip()
+    if not cwd or not Path(cwd).is_dir():
+        env["HERMES_CWD"] = _safe_tui_cwd(env)
+
+
 def _launch_tui(
     resume_session_id: Optional[str] = None,
     tui_dev: bool = False,
@@ -2030,11 +2058,7 @@ def _launch_tui(
     )
     os.close(active_session_fd)
     env["HERMES_TUI_ACTIVE_SESSION_FILE"] = active_session_file
-    env["HERMES_PYTHON_SRC_ROOT"] = os.environ.get(
-        "HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT)
-    )
-    env.setdefault("HERMES_PYTHON", sys.executable)
-    env.setdefault("HERMES_CWD", os.getcwd())
+    _apply_tui_python_env(env)
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
 
     wt_info = None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14647,6 +14647,9 @@ def _resolve_chat_argv(
         apply_terminal_config_to_env(env=env)
     except Exception:
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
+    env.setdefault("HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT))
+    env.setdefault("HERMES_PYTHON", sys.executable)
+    env.setdefault("HERMES_CWD", os.getcwd())
     env.setdefault("NODE_ENV", "production")
     # Browser-embedded chat should prefer stable wheel-based scrollback over
     # native terminal mouse tracking. When mouse tracking is enabled, wheel

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14633,7 +14633,7 @@ def _resolve_chat_argv(
     dashboard's in-memory gateway runs under the dashboard's own profile,
     so a profile-scoped chat must spawn its own gateway subprocess.
     """
-    from hermes_cli.main import PROJECT_ROOT, _make_tui_argv
+    from hermes_cli.main import PROJECT_ROOT, _apply_tui_python_env, _make_tui_argv
 
     profile_dir: Optional[Path] = None
     requested = (profile or "").strip()
@@ -14647,9 +14647,7 @@ def _resolve_chat_argv(
         apply_terminal_config_to_env(env=env)
     except Exception:
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
-    env.setdefault("HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT))
-    env.setdefault("HERMES_PYTHON", sys.executable)
-    env.setdefault("HERMES_CWD", os.getcwd())
+    _apply_tui_python_env(env)
     env.setdefault("NODE_ENV", "production")
     # Browser-embedded chat should prefer stable wheel-based scrollback over
     # native terminal mouse tracking. When mouse tracking is enabled, wheel

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -6620,6 +6620,44 @@ class TestPtyWebSocket:
         assert env["HERMES_PYTHON"] == sys.executable
         assert env["HERMES_CWD"] == os.getcwd()
 
+    def test_resolve_chat_argv_replaces_invalid_tui_python_environment(self, monkeypatch):
+        """Dashboard chat does not preserve unusable inherited TUI Python env."""
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setenv("HERMES_PYTHON_SRC_ROOT", "/definitely/missing/hermes-src")
+        monkeypatch.setenv("HERMES_PYTHON", "/definitely/missing/python")
+        monkeypatch.setenv("HERMES_CWD", "/definitely/missing/cwd")
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert env is not None
+        assert env["HERMES_PYTHON_SRC_ROOT"] == str(main_mod.PROJECT_ROOT)
+        assert env["HERMES_PYTHON"] == sys.executable
+        assert env["HERMES_CWD"] == os.getcwd()
+
+    def test_resolve_chat_argv_falls_back_when_getcwd_is_missing(self, monkeypatch, tmp_path):
+        """Dashboard chat still starts if the service cwd was deleted."""
+        import hermes_cli.main as main_mod
+
+        monkeypatch.delenv("HERMES_CWD", raising=False)
+        monkeypatch.setenv("PWD", str(tmp_path))
+        monkeypatch.setattr(main_mod.os, "getcwd", lambda: (_ for _ in ()).throw(FileNotFoundError()))
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert env is not None
+        assert env["HERMES_CWD"] == str(tmp_path)
+
     def test_resolve_chat_argv_backfills_colorterm_truecolor(self, monkeypatch):
         """Headless servers (cloud/systemd) have no COLORTERM, which made
         chalk in the TUI child degrade skin hex colors to the xterm 256

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -6600,6 +6600,26 @@ class TestPtyWebSocket:
         assert env["HERMES_TUI_INLINE"] == "1"
         assert env["HERMES_TUI_DISABLE_MOUSE"] == "1"
 
+    def test_resolve_chat_argv_sets_tui_python_environment(self, monkeypatch):
+        """Dashboard chat gives the Node TUI the same Python env as CLI launches."""
+        import hermes_cli.main as main_mod
+
+        monkeypatch.delenv("HERMES_PYTHON_SRC_ROOT", raising=False)
+        monkeypatch.delenv("HERMES_PYTHON", raising=False)
+        monkeypatch.delenv("HERMES_CWD", raising=False)
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert env is not None
+        assert env["HERMES_PYTHON_SRC_ROOT"] == str(main_mod.PROJECT_ROOT)
+        assert env["HERMES_PYTHON"] == sys.executable
+        assert env["HERMES_CWD"] == os.getcwd()
+
     def test_resolve_chat_argv_backfills_colorterm_truecolor(self, monkeypatch):
         """Headless servers (cloud/systemd) have no COLORTERM, which made
         chalk in the TUI child degrade skin hex colors to the xterm 256

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -6640,6 +6640,29 @@ class TestPtyWebSocket:
         assert env["HERMES_PYTHON"] == sys.executable
         assert env["HERMES_CWD"] == os.getcwd()
 
+    def test_resolve_chat_argv_preserves_valid_tui_python_environment(self, monkeypatch, tmp_path):
+        """Explicit usable TUI paths still take precedence over launcher defaults."""
+        import hermes_cli.main as main_mod
+
+        python = tmp_path / "python"
+        python.write_text("#!/bin/sh\n", encoding="utf-8")
+        python.chmod(0o755)
+        monkeypatch.setenv("HERMES_PYTHON_SRC_ROOT", str(tmp_path))
+        monkeypatch.setenv("HERMES_PYTHON", str(python))
+        monkeypatch.setenv("HERMES_CWD", str(tmp_path))
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert env is not None
+        assert env["HERMES_PYTHON_SRC_ROOT"] == str(tmp_path)
+        assert env["HERMES_PYTHON"] == str(python)
+        assert env["HERMES_CWD"] == str(tmp_path)
+
     def test_resolve_chat_argv_falls_back_when_getcwd_is_missing(self, monkeypatch, tmp_path):
         """Dashboard chat still starts if the service cwd was deleted."""
         import hermes_cli.main as main_mod


### PR DESCRIPTION
Fixes #63754

Salvages the launcher-environment work from #44797 by @alvarosanchez. The original two commits and their authorship are retained, with conflicts resolved against current `main`.

## Root cause

Dashboard Chat starts the Node TUI through `_resolve_chat_argv()`, bypassing the Python/source-root setup used by `hermes --tui`. `GatewayClient.start()` eagerly computes its Python source root with `resolve(import.meta.dirname, '../../')` before selecting WebSocket attach mode. When `import.meta.dirname` is unavailable, that becomes `resolve(undefined, '../../')` and the PTY child exits before its first WebSocket handshake. Setting `HERMES_PYTHON` alone cannot bypass that earlier expression.

## Summary

- share one TUI Python-environment helper between CLI and dashboard launches
- seed or repair `HERMES_PYTHON_SRC_ROOT`, `HERMES_PYTHON`, and `HERMES_CWD` before the embedded TUI starts
- preserve usable explicit overrides and fall back through `PWD` when a service's original cwd was deleted
- cover missing, invalid, explicitly valid, and deleted-cwd launch environments

This fixes the reported undefined-path crash. It does not lower the repository's declared Node.js >=20 requirement; Node version discovery/validation remains separate work in #21769.

## Validation

- `python -m pytest -q tests/hermes_cli/test_web_server.py -k 'resolve_chat_argv and (tui_python_environment or getcwd_is_missing or dashboard_scroll_env or colorterm_truecolor or operator_colorterm or terminal_backend_config)'` — 8 passed
- `python -m pytest -q tests/hermes_cli/test_tui_resume_flow.py` — 48 passed
- `python -m pytest -q tests/hermes_cli/test_web_server_profile_unification.py::TestProfileScopedChatPty` — 3 passed
- `python -m pytest -q tests/hermes_cli/test_tui_npm_install.py` — 29 passed
- `ruff check hermes_cli/main.py hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
