### PR TITLE
fix(sms): support Twilio Messaging Service sender

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -7,6 +7,7 @@ Shares credentials with the optional telephony skill — same env vars:
   - TWILIO_ACCOUNT_SID
   - TWILIO_AUTH_TOKEN
   - TWILIO_PHONE_NUMBER  (E.164 from-number, e.g. +15551234567)
+  - TWILIO_MESSAGING_SERVICE_SID  (optional outbound Messaging Service)
 
 Gateway-specific env vars:
   - SMS_WEBHOOK_PORT     (default 8080)
@@ -24,6 +25,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import urllib.parse
 from typing import Any, Dict, Optional
 
@@ -45,6 +47,15 @@ DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 _TWILIO_WEBHOOK_MAX_BODY_BYTES = 65_536  # 64 KiB — Twilio payloads are small
 
 
+def _add_twilio_sender_field(form_data: Any, from_number: str) -> None:
+    """Add the mutually exclusive Twilio outbound sender field."""
+    messaging_service_sid = os.getenv("TWILIO_MESSAGING_SERVICE_SID", "").strip()
+    if messaging_service_sid:
+        form_data.add_field("MessagingServiceSid", messaging_service_sid)
+    else:
+        form_data.add_field("From", from_number)
+
+
 def check_sms_requirements() -> bool:
     """Check if SMS adapter dependencies are available."""
     try:
@@ -59,7 +70,8 @@ class SmsAdapter(BasePlatformAdapter):
     Twilio SMS <-> Hermes gateway adapter.
 
     Each inbound phone number gets its own Hermes session (multi-tenant).
-    Replies are always sent from the configured TWILIO_PHONE_NUMBER.
+    Replies use TWILIO_MESSAGING_SERVICE_SID when configured, otherwise they
+    are sent from TWILIO_PHONE_NUMBER.
     """
 
     MAX_MESSAGE_LENGTH = MAX_SMS_LENGTH
@@ -179,7 +191,7 @@ class SmsAdapter(BasePlatformAdapter):
         try:
             for chunk in chunks:
                 form_data = aiohttp.FormData()
-                form_data.add_field("From", self._from_number)
+                _add_twilio_sender_field(form_data, self._from_number)
                 form_data.add_field("To", chat_id)
                 form_data.add_field("Body", chunk)
 
@@ -464,7 +476,7 @@ async def _standalone_send(
         headers = {"Authorization": f"Basic {encoded}"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             form_data = aiohttp.FormData()
-            form_data.add_field("From", from_number)
+            _add_twilio_sender_field(form_data, from_number)
             form_data.add_field("To", chat_id)
             form_data.add_field("Body", message)
             async with session.post(url, data=form_data, headers=headers, **_req_kw) as resp:

--- a/plugins/platforms/sms/plugin.yaml
+++ b/plugins/platforms/sms/plugin.yaml
@@ -22,6 +22,10 @@ requires_env:
     prompt: "Twilio phone number"
     password: false
 optional_env:
+  - name: TWILIO_MESSAGING_SERVICE_SID
+    description: "Optional Twilio Messaging Service SID for outbound SMS (starts with MG)"
+    prompt: "Twilio Messaging Service SID (optional)"
+    password: false
   - name: SMS_ALLOWED_USERS
     description: "Comma-separated phone numbers allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -128,6 +128,99 @@ class TestSmsEchoPrevention:
             assert adapter._from_number == "+15550001111"
 
 
+class TestSmsOutboundSender:
+    @staticmethod
+    def _mock_session():
+        response = MagicMock(status=200)
+        response.json = AsyncMock(return_value={"sid": "SM123"})
+
+        response_context = MagicMock()
+        response_context.__aenter__ = AsyncMock(return_value=response)
+        response_context.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.post.return_value = response_context
+        return session
+
+    @staticmethod
+    def _form_fields(session):
+        form_data = session.post.call_args.kwargs["data"]
+        return {field[0]["name"]: field[2] for field in form_data._fields}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("messaging_service_sid", "expected_sender"),
+        [
+            (None, {"From": "+15550001111"}),
+            ("  MG123  ", {"MessagingServiceSid": "MG123"}),
+        ],
+    )
+    async def test_adapter_send_uses_configured_sender(
+        self, messaging_service_sid, expected_sender
+    ):
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+        }
+        if messaging_service_sid is not None:
+            env["TWILIO_MESSAGING_SERVICE_SID"] = messaging_service_sid
+
+        session = self._mock_session()
+        with patch.dict(os.environ, env, clear=True):
+            adapter = SmsAdapter(PlatformConfig(enabled=True, api_key="tok"))
+            adapter._http_session = session
+            result = await adapter.send("+15550009999", "Hello")
+
+        assert result.success is True
+        fields = self._form_fields(session)
+        assert fields == {**expected_sender, "To": "+15550009999", "Body": "Hello"}
+        assert ("From" in fields) != ("MessagingServiceSid" in fields)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("messaging_service_sid", "expected_sender"),
+        [
+            (None, {"From": "+15550001111"}),
+            ("MG123", {"MessagingServiceSid": "MG123"}),
+        ],
+    )
+    async def test_standalone_send_uses_configured_sender(
+        self, messaging_service_sid, expected_sender
+    ):
+        from plugins.platforms.sms.adapter import _standalone_send
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+        }
+        if messaging_service_sid is not None:
+            env["TWILIO_MESSAGING_SERVICE_SID"] = messaging_service_sid
+
+        session = self._mock_session()
+        session_context = MagicMock()
+        session_context.__aenter__ = AsyncMock(return_value=session)
+        session_context.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("aiohttp.ClientSession", return_value=session_context),
+        ):
+            result = await _standalone_send(
+                PlatformConfig(enabled=True, api_key="tok"),
+                "+15550009999",
+                "Hello",
+            )
+
+        assert result["success"] is True
+        fields = self._form_fields(session)
+        assert fields == {**expected_sender, "To": "+15550009999", "Body": "Hello"}
+        assert ("From" in fields) != ("MessagingServiceSid" in fields)
+
+
 # ── Requirements check ─────────────────────────────────────────────
 
 class TestSmsRequirements:

--- a/website/docs/user-guide/messaging/sms.md
+++ b/website/docs/user-guide/messaging/sms.md
@@ -51,6 +51,9 @@ TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your_auth_token_here
 TWILIO_PHONE_NUMBER=+15551234567
 
+# Optional: route outbound messages through a Twilio Messaging Service
+TWILIO_MESSAGING_SERVICE_SID=MGxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 # Security: restrict to specific phone numbers (recommended)
 SMS_ALLOWED_USERS=+15559876543,+15551112222
 
@@ -124,6 +127,7 @@ Text your Twilio number — Hermes will respond via SMS.
 | `TWILIO_ACCOUNT_SID` | Yes | Twilio Account SID (starts with `AC`) |
 | `TWILIO_AUTH_TOKEN` | Yes | Twilio Auth Token (also used for webhook signature validation) |
 | `TWILIO_PHONE_NUMBER` | Yes | Your Twilio phone number (E.164 format) |
+| `TWILIO_MESSAGING_SERVICE_SID` | No | Twilio Messaging Service SID (starts with `MG`). When set, outbound requests use `MessagingServiceSid` instead of `From` |
 | `SMS_WEBHOOK_URL` | Yes | Public URL for Twilio signature validation — must match the webhook URL in your Twilio Console |
 | `SMS_WEBHOOK_PORT` | No | Webhook listener port (default: `8080`) |
 | `SMS_WEBHOOK_HOST` | No | Webhook bind address (default: `127.0.0.1`) |
@@ -189,8 +193,9 @@ SMS has no built-in encryption. Don't use SMS for sensitive operations unless yo
 ### Replies not sending
 
 1. Check `TWILIO_PHONE_NUMBER` is set correctly (E.164 format with `+`)
-2. Verify your Twilio account has SMS-capable numbers
-3. Check Hermes gateway logs for Twilio API errors
+2. If using a Messaging Service, verify `TWILIO_MESSAGING_SERVICE_SID` starts with `MG` and contains the configured phone number
+3. Verify your Twilio account has SMS-capable numbers
+4. Check Hermes gateway logs for Twilio API errors
 
 ### Webhook port conflicts
 


### PR DESCRIPTION
## What does this PR do?

This PR makes the SMS plugin honor `TWILIO_MESSAGING_SERVICE_SID` for outbound Twilio requests.

When the variable is set to a non-empty value, Hermes submits `MessagingServiceSid` and omits `From`. When it is unset or blank, Hermes preserves the existing behavior and submits `From=TWILIO_PHONE_NUMBER`. Twilio requires these sender fields to be mutually exclusive; using `From` for an A2P 10DLC Messaging Service can produce error 30034.

### Root cause

The SMS plugin has two outbound entry points:

1. `SmsAdapter.send()`, used by the gateway adapter.
2. `_standalone_send()`, used by standalone/cron delivery.

Both paths hard-coded the `From` form field. Fixing only the adapter path would leave scheduled and standalone sends unchanged.

### Approach

A small shared helper selects exactly one Twilio sender field for both outbound paths. The selection is evaluated when the request is built, whitespace-only SIDs fall back to `From`, and existing phone-number behavior remains backward compatible.

The regression tests inspect the actual `aiohttp.FormData` passed to `session.post()` for both paths. They verify both configurations and assert that `From` and `MessagingServiceSid` never appear together.

Related work: #62279 overlaps with the adapter path. This PR additionally covers the standalone sender, the plugin manifest, user documentation, and exact submitted form data for both outbound paths.

## Related Issue

Fixes #62276

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/platforms/sms/adapter.py`
  - add one shared sender-field selector
  - use it in both `SmsAdapter.send()` and `_standalone_send()`
  - restore the missing `re` import required by the standalone markdown cleanup before it reaches Twilio
- `plugins/platforms/sms/plugin.yaml`
  - expose `TWILIO_MESSAGING_SERVICE_SID` as an optional SMS plugin setting
- `tests/gateway/test_sms.py`
  - cover configured and fallback behavior for both outbound entry points
  - assert the exact request form and sender-field mutual exclusion
- `website/docs/user-guide/messaging/sms.md`
  - document setup, environment-variable behavior, and troubleshooting

## How to Test

1. Run the canonical full suite: `scripts/run_tests.sh`.
2. Run the focused suite: `python -m pytest tests/gateway/test_sms.py -q`.
3. Confirm all 45 SMS tests pass, including the four sender-selection cases.
4. Run `python -m ruff check plugins/platforms/sms/adapter.py tests/gateway/test_sms.py`.
5. With `TWILIO_MESSAGING_SERVICE_SID=MG123`, confirm each outbound path submits `MessagingServiceSid=MG123` and no `From` field.
6. Without the setting (or with whitespace only), confirm each path submits `From=TWILIO_PHONE_NUMBER` and no `MessagingServiceSid` field.

A live Twilio request was not run because local Twilio credentials were not available. The request boundary is covered with mocked HTTP sessions that inspect the real `aiohttp.FormData` object.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't an accidental duplicate; overlapping PR #62279 is acknowledged above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the canonical full test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.12.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (SMS user guide and adapter docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A: this is a plugin-owned environment setting declared in `plugin.yaml`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - the change uses existing `os.getenv` and `aiohttp.FormData` behavior with no platform-specific paths or processes
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

No UI changes.

```text
scripts/run_tests.sh
All tests passed

python -m pytest tests/gateway/test_sms.py -q
45 passed, 6 warnings

python -m ruff check plugins/platforms/sms/adapter.py tests/gateway/test_sms.py
All checks passed
```

Additional local validation:

- parsed `plugins/platforms/sms/plugin.yaml` with `yaml.safe_load`
- `git diff --check` passed
