### PR TITLE
fix(gateway): report missing post-stream media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1342,6 +1342,45 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     return None
 
 
+def is_missing_media_delivery_path(path: str) -> bool:
+    """Return whether an absent file would otherwise pass delivery policy."""
+    if not path:
+        return False
+
+    candidate = str(path).strip()
+    if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in "`\"'":
+        candidate = candidate[1:-1].strip()
+    candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    if not candidate:
+        return False
+
+    try:
+        expanded = Path(os.path.expanduser(candidate))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if not expanded.is_absolute():
+        return False
+
+    try:
+        resolved = expanded.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if resolved.exists():
+        return False
+
+    for root in _media_delivery_allowed_roots():
+        try:
+            resolved_root = root.expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if _path_is_within(resolved, resolved_root):
+            return True
+
+    if _media_delivery_strict_mode():
+        return False
+    return not _path_under_denied_prefix(resolved)
+
+
 # Neutralise control chars and the Unicode line separators (NEL, LS, PS) that
 # str.splitlines() / log aggregators treat as breaks, so a model-emitted path
 # can't forge a second log line. Truncated to keep records bounded.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13273,10 +13273,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # send_multiple_images (Telegram sendPhoto recompresses to ~1280px).
             force_document_attachments = "[[as_document]]" in response
 
-            from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
+            from gateway.platforms.base import (
+                BasePlatformAdapter,
+                is_missing_media_delivery_path,
+                should_send_media_as_audio,
+            )
 
-            media_files, cleaned = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            media_candidates, cleaned = adapter.extract_media(response)
+            media_files = []
+            missing_media_paths = []
+            for candidate in media_candidates:
+                media_path, _ = candidate
+                if is_missing_media_delivery_path(media_path):
+                    missing_media_paths.append(media_path)
+                    continue
+                media_files.extend(BasePlatformAdapter.filter_media_delivery_paths([candidate]))
             # Chain the cleaned text through each extractor (extract_media →
             # extract_images → extract_local_files) so MEDIA: tags and image URLs
             # are removed before the bare-path auto-detect runs. Previously the
@@ -13292,6 +13303,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+
+            for missing_path in dict.fromkeys(missing_media_paths):
+                display_name = Path(missing_path).name or "attachment"
+                logger.warning(
+                    "[%s] Missing post-stream MEDIA attachment: %s",
+                    adapter.name,
+                    display_name,
+                )
+                try:
+                    await adapter.send(
+                        chat_id=event.source.chat_id,
+                        content=f"Media attachment unavailable: `{display_name}`",
+                        metadata=_thread_meta,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[%s] Missing post-stream media notice failed: %s",
+                        adapter.name,
+                        e,
+                    )
 
             # Partition out images so they can be sent as a single batch
             # (e.g. Signal's multi-attachment RPC). When [[as_document]] was

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -140,6 +140,7 @@ async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sen
         extract_media=BasePlatformAdapter.extract_media,
         extract_images=BasePlatformAdapter.extract_images,
         extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="notice")),
         send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
         send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
         send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
@@ -158,7 +159,51 @@ async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sen
         file_path=str(media_file),
         metadata={"thread_id": "topic-1"},
     )
+    adapter.send.assert_not_awaited()
     adapter.send_voice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_reports_missing_explicit_media_without_file_send(tmp_path, monkeypatch):
+    event = _event(thread_id="topic-1")
+    allowed_root = tmp_path / "media-cache"
+    allowed_root.mkdir()
+    missing_file = allowed_root / "missing.png"
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (allowed_root,),
+    )
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="notice")),
+        send_multiple_images=AsyncMock(
+            return_value=SendResult(success=True, message_id="images")
+        ),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}),
+        f"MEDIA:{missing_file}",
+        event,
+        adapter,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        chat_id="chat-1",
+        content="Media attachment unavailable: `missing.png`",
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -246,6 +291,7 @@ async def test_streaming_delivery_blocks_media_path_outside_allowed_roots(tmp_pa
         extract_media=BasePlatformAdapter.extract_media,
         extract_images=BasePlatformAdapter.extract_images,
         extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="notice")),
         send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
         send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
         send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
@@ -261,3 +307,4 @@ async def test_streaming_delivery_blocks_media_path_outside_allowed_roots(tmp_pa
 
     adapter.send_document.assert_not_awaited()
     adapter.send_voice.assert_not_awaited()
+    adapter.send.assert_not_awaited()

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -131,6 +131,32 @@ def _fake_runner(thread_meta):
     return runner
 
 
+def _streaming_delivery_adapter():
+    return SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="notice")),
+        send_multiple_images=AsyncMock(
+            return_value=SendResult(success=True, message_id="images")
+        ),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+
+def _assert_no_streaming_delivery(adapter):
+    adapter.send.assert_not_awaited()
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sender(tmp_path, monkeypatch):
     event = _event(thread_id="topic-1")
@@ -204,6 +230,62 @@ async def test_streaming_delivery_reports_missing_explicit_media_without_file_se
     adapter.send_voice.assert_not_awaited()
     adapter.send_document.assert_not_awaited()
     adapter.send_video.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_silences_missing_media_outside_strict_allowlist(
+    tmp_path, monkeypatch
+):
+    event = _event(thread_id="topic-1")
+    allowed_root = tmp_path / "media-cache"
+    allowed_root.mkdir()
+    missing_file = tmp_path / "outside" / "missing.pdf"
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (allowed_root,),
+    )
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+    monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+    adapter = _streaming_delivery_adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}),
+        f"MEDIA:{missing_file}",
+        event,
+        adapter,
+    )
+
+    _assert_no_streaming_delivery(adapter)
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_silences_missing_media_under_non_strict_denylist(
+    tmp_path, monkeypatch
+):
+    event = _event(thread_id="topic-1")
+    allowed_root = tmp_path / "media-cache"
+    allowed_root.mkdir()
+    denied_root = tmp_path / "denied"
+    missing_file = denied_root / "missing.pdf"
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (allowed_root,),
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
+        (denied_root,),
+    )
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "0")
+    adapter = _streaming_delivery_adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}),
+        f"MEDIA:{missing_file}",
+        event,
+        adapter,
+    )
+
+    _assert_no_streaming_delivery(adapter)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve raw explicit `MEDIA:` candidates until missing files can be distinguished from policy-rejected paths
- send a thread-aware text notice for a missing, otherwise delivery-eligible attachment
- keep validated existing files on the native sender path and keep security-rejected paths silent
- leave bare `local_files` extraction and delivery behavior unchanged

This replaces #18925 on current `main` and addresses the automated review at https://github.com/NousResearch/hermes-agent/pull/18925#pullrequestreview-4680791749.

## Root cause

The post-stream path called `filter_media_delivery_paths()` immediately after extraction. That filter correctly collapses missing and policy-rejected paths to no native attachment, but it also discarded the information needed to give the user a recovery notice. The old patch checked `Path.is_file()` after this filter, so it could not observe missing candidates on current `main`.

## Security and compatibility

- Missing-path classification reuses the current allowlist, strict-mode, and denylist policy boundaries.
- Only a basename is shown to the user; the host path is not included in the notice.
- Native senders still receive only paths accepted by `validate_media_delivery_path()`.
- Existing bare-path fallback for small-model streaming responses is unchanged, avoiding the compatibility concern discussed in #20843.

## Validation

- TDD red: the missing explicit-media regression failed because the notice sender was awaited 0 times.
- TDD green: the same regression passed after the fix.
- `python -m pytest tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py tests/gateway/test_tts_media_routing.py tests/gateway/test_tool_response_drop_recovery.py tests/gateway/test_media_extraction.py -q` — `259 passed, 2 skipped`
- `python -m ruff check gateway/platforms/base.py gateway/run.py tests/gateway/test_tts_media_routing.py` — passed
- `git diff --check` — passed

## Duplicate audit

The only open PR matching this missing post-stream attachment fallback was #18925. Adjacent routing work in #20843 and #43332 does not implement this behavior.
