### PR TITLE
fix(gateway): discover SYSTEM-session gateways via psutil on Windows (#63743)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -333,6 +333,39 @@ def _append_unique_pid(
     pids.append(pid)
 
 
+def _is_install_venv_python_exe(exe: str | None) -> bool:
+    """Return True when ``exe`` is this install's ``venv\\Scripts\\python(w).exe``."""
+    if not exe:
+        return False
+    try:
+        exe_path = Path(exe).resolve()
+    except (OSError, ValueError):
+        exe_path = Path(str(exe))
+    if exe_path.name.lower() not in {"python.exe", "pythonw.exe"}:
+        return False
+    try:
+        venv_scripts = (PROJECT_ROOT / "venv" / "Scripts").resolve()
+    except OSError:
+        venv_scripts = PROJECT_ROOT / "venv" / "Scripts"
+    try:
+        return exe_path.parent == venv_scripts or venv_scripts in exe_path.parents
+    except Exception:
+        return str(exe_path).lower().startswith(str(venv_scripts).lower() + os.sep)
+
+
+def _psutil_username_is_system(username: str | None) -> bool:
+    """True for Windows SYSTEM / LocalSystem process owners."""
+    if not username:
+        return False
+    normalized = username.strip().upper().replace("/", "\\")
+    return (
+        normalized == "SYSTEM"
+        or normalized.endswith("\\SYSTEM")
+        or normalized == "NT AUTHORITY\\SYSTEM"
+        or normalized.endswith("\\LOCALSYSTEM")
+    )
+
+
 def _scan_gateway_pids_windows_psutil(
     pids: list[int],
     exclude_pids: set[int],
@@ -340,15 +373,21 @@ def _scan_gateway_pids_windows_psutil(
     all_profiles: bool,
     matches_gateway_runtime,
     matches_current_profile,
+    known_pids: set[int] | None = None,
 ) -> None:
     """Supplement wmic/CIM with psutil for cross-session gateways (#63743).
 
     ``Get-CimInstance Win32_Process`` often returns an empty ``CommandLine``
     for processes in another session (e.g. a Scheduled Task gateway running as
-    SYSTEM) when queried from a non-elevated user. psutil can still read their
-    argv — the same API ``_detect_venv_python_processes`` uses to block
-    ``hermes update``. Without this pass the update flow fails to pause the
+    SYSTEM) when queried from a non-elevated user. psutil can still often read
+    ``exe`` across that boundary even when ``cmdline`` is empty or
+    ``AccessDenied``. Without this pass the update flow fails to pause the
     gateway but still refuses with "Other Hermes processes are running".
+
+    Strict identity when cmdline is unavailable:
+    - install ``venv\\Scripts\\python(w).exe`` **and** SYSTEM owner, or
+    - install venv python whose parent/child is already a known gateway PID
+      (PID-file / prior scan hit) so launcher stubs join the tree.
     """
     try:
         import psutil  # type: ignore
@@ -356,9 +395,13 @@ def _scan_gateway_pids_windows_psutil(
         return
 
     try:
-        proc_iter = psutil.process_iter(["pid", "cmdline"])
+        proc_iter = psutil.process_iter(["pid", "cmdline", "exe", "username", "ppid"])
     except Exception:
         return
+
+    known = {int(pid) for pid in pids}
+    if known_pids:
+        known.update(int(pid) for pid in known_pids)
 
     try:
         for proc in proc_iter:
@@ -369,19 +412,65 @@ def _scan_gateway_pids_windows_psutil(
             pid = info.get("pid")
             if pid is None:
                 continue
+            pid_i = int(pid)
+
             cmdline_parts = info.get("cmdline") or []
             if not cmdline_parts:
                 try:
                     cmdline_parts = list(proc.cmdline() or [])
                 except Exception:
-                    continue
-            if not cmdline_parts:
+                    # AccessDenied / empty across the SYSTEM session boundary.
+                    cmdline_parts = []
+
+            if cmdline_parts:
+                command = " ".join(str(part) for part in cmdline_parts)
+                if matches_gateway_runtime(command) and (
+                    all_profiles or matches_current_profile(command)
+                ):
+                    _append_unique_pid(pids, pid_i, exclude_pids)
+                    known.add(pid_i)
                 continue
-            command = " ".join(str(part) for part in cmdline_parts)
-            if matches_gateway_runtime(command) and (
-                all_profiles or matches_current_profile(command)
-            ):
-                _append_unique_pid(pids, int(pid), exclude_pids)
+
+            # No readable cmdline: require exe + a strict corroborating signal.
+            exe = info.get("exe")
+            if not exe:
+                try:
+                    exe = proc.exe()
+                except Exception:
+                    continue
+            if not _is_install_venv_python_exe(exe):
+                continue
+
+            username = info.get("username")
+            if not username:
+                try:
+                    username = proc.username()
+                except Exception:
+                    username = None
+
+            ppid = info.get("ppid")
+            if ppid is None:
+                try:
+                    ppid = proc.ppid()
+                except Exception:
+                    ppid = None
+            try:
+                ppid_i = int(ppid) if ppid is not None else None
+            except (TypeError, ValueError):
+                ppid_i = None
+
+            system_owned = _psutil_username_is_system(username)
+            tree_hit = pid_i in known or (ppid_i is not None and ppid_i in known)
+            if not system_owned and not tree_hit:
+                continue
+            # SYSTEM-owned install python is only safe as a gateway candidate
+            # for the update-wide (all_profiles) sweep — profile scoping needs
+            # cmdline or a PID-file hit collected elsewhere.
+            if system_owned and not all_profiles and not tree_hit:
+                continue
+
+            _append_unique_pid(pids, pid_i, exclude_pids)
+            known.add(pid_i)
     except Exception:
         return
 
@@ -390,18 +479,25 @@ def _scan_gateway_pids(
     exclude_pids: set[int],
     all_profiles: bool = False,
     include_restart_managers: bool = False,
+    seed_pids: list[int] | None = None,
 ) -> list[int]:
     """Best-effort process-table scan for gateway PIDs.
 
     This supplements the profile-scoped PID file so status views can still spot
     a live gateway when the PID file is stale/missing, and ``--all`` sweeps can
     discover gateways outside the current profile.
+
+    ``seed_pids`` carries PIDs already established by PID-file / service
+    discovery so the Windows psutil pass can attach launcher-stub parents when
+    cmdline is unreadable across the SYSTEM session boundary. Seeds are not
+    re-emitted in the return value — callers already hold them.
     """
     # Exclude the entire ancestor chain so the CLI process that invoked this
     # scan (e.g. ``hermes gateway status``) is never mistaken for a running
     # gateway.  See #13242.
     exclude_pids = exclude_pids | _get_ancestor_pids()
     pids: list[int] = []
+    known_seeds = {int(pid) for pid in (seed_pids or ()) if pid is not None}
     # Strict command-line matcher shared with gateway.status: requires the
     # actual ``gateway run`` subcommand (or the dedicated entrypoints), so this
     # scan no longer false-matches ``gateway status``/``dashboard`` siblings or
@@ -532,6 +628,7 @@ def _scan_gateway_pids(
                 all_profiles=all_profiles,
                 matches_gateway_runtime=_matches_gateway_runtime,
                 matches_current_profile=_matches_current_profile,
+                known_pids=known_seeds,
             )
         else:
             # Try /proc first (works in Docker without procps installed),
@@ -661,6 +758,11 @@ def find_gateway_pids(
             needs this because a code update affects every profile.
             When ``False`` (default), only PIDs belonging to the current
             Hermes profile are returned.
+
+    When ``all_profiles`` is set, profile ``gateway.pid`` records are included
+    first. Cross-session SYSTEM gateways often have an empty CIM command line
+    and a denied psutil cmdline, but the PID file + lock still identify them
+    (#63743) — process-table scans alone are not enough.
     """
     _exclude = set(exclude_pids or set())
     pids: list[int] = []
@@ -669,6 +771,13 @@ def find_gateway_pids(
             from gateway.status import get_running_pid
 
             _append_unique_pid(pids, get_running_pid(), _exclude)
+        except Exception:
+            pass
+    else:
+        # PID-file-aware discovery for update / multi-profile sweeps.
+        try:
+            for proc in find_profile_gateway_processes(exclude_pids=_exclude):
+                _append_unique_pid(pids, proc.pid, _exclude)
         except Exception:
             pass
     for pid in _get_service_pids():
@@ -681,6 +790,7 @@ def find_gateway_pids(
         _exclude,
         all_profiles=all_profiles,
         include_restart_managers=include_restart_managers,
+        seed_pids=pids,
     ):
         _append_unique_pid(pids, pid, _exclude)
     return pids

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -333,6 +333,59 @@ def _append_unique_pid(
     pids.append(pid)
 
 
+def _scan_gateway_pids_windows_psutil(
+    pids: list[int],
+    exclude_pids: set[int],
+    *,
+    all_profiles: bool,
+    matches_gateway_runtime,
+    matches_current_profile,
+) -> None:
+    """Supplement wmic/CIM with psutil for cross-session gateways (#63743).
+
+    ``Get-CimInstance Win32_Process`` often returns an empty ``CommandLine``
+    for processes in another session (e.g. a Scheduled Task gateway running as
+    SYSTEM) when queried from a non-elevated user. psutil can still read their
+    argv — the same API ``_detect_venv_python_processes`` uses to block
+    ``hermes update``. Without this pass the update flow fails to pause the
+    gateway but still refuses with "Other Hermes processes are running".
+    """
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return
+
+    try:
+        proc_iter = psutil.process_iter(["pid", "cmdline"])
+    except Exception:
+        return
+
+    try:
+        for proc in proc_iter:
+            try:
+                info = proc.info
+            except Exception:
+                continue
+            pid = info.get("pid")
+            if pid is None:
+                continue
+            cmdline_parts = info.get("cmdline") or []
+            if not cmdline_parts:
+                try:
+                    cmdline_parts = list(proc.cmdline() or [])
+                except Exception:
+                    continue
+            if not cmdline_parts:
+                continue
+            command = " ".join(str(part) for part in cmdline_parts)
+            if matches_gateway_runtime(command) and (
+                all_profiles or matches_current_profile(command)
+            ):
+                _append_unique_pid(pids, int(pid), exclude_pids)
+    except Exception:
+        return
+
+
 def _scan_gateway_pids(
     exclude_pids: set[int],
     all_profiles: bool = False,
@@ -408,7 +461,6 @@ def _scan_gateway_pids(
 
             _no_window = {"creationflags": windows_hide_flags()}
             wmic_path = shutil.which("wmic")
-            used_fallback = False
             result = None
             if wmic_path is not None:
                 try:
@@ -433,46 +485,54 @@ def _scan_gateway_pids(
                 # Fallback: PowerShell Get-CimInstance, emit LIST-style output
                 # so the downstream parser below doesn't need to branch.
                 powershell = shutil.which("powershell") or shutil.which("pwsh")
-                if powershell is None:
-                    return []
-                ps_cmd = (
-                    "Get-CimInstance Win32_Process | "
-                    "ForEach-Object { "
-                    "  'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); "
-                    "  'ProcessId=' + $_.ProcessId; "
-                    "  '' "
-                    "}"
-                )
-                try:
-                    result = subprocess.run(
-                        [powershell, "-NoProfile", "-Command", ps_cmd],
-                        capture_output=True,
-                        text=True,
-                        encoding="utf-8",
-                        errors="ignore",
-                        timeout=15,
-                        **_no_window,
+                if powershell is not None:
+                    ps_cmd = (
+                        "Get-CimInstance Win32_Process | "
+                        "ForEach-Object { "
+                        "  'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); "
+                        "  'ProcessId=' + $_.ProcessId; "
+                        "  '' "
+                        "}"
                     )
-                except (OSError, subprocess.TimeoutExpired):
-                    return []
-                used_fallback = True
-            if result.returncode != 0 or result.stdout is None:
-                return []
-            current_cmd = ""
-            for line in result.stdout.split("\n"):
-                line = line.strip()
-                if line.startswith("CommandLine="):
-                    current_cmd = line[len("CommandLine=") :]
-                elif line.startswith("ProcessId="):
-                    pid_str = line[len("ProcessId=") :]
-                    if _matches_gateway_runtime(current_cmd) and (
-                        all_profiles or _matches_current_profile(current_cmd)
-                    ):
-                        try:
-                            _append_unique_pid(pids, int(pid_str), exclude_pids)
-                        except ValueError:
-                            pass
-                    current_cmd = ""
+                    try:
+                        result = subprocess.run(
+                            [powershell, "-NoProfile", "-Command", ps_cmd],
+                            capture_output=True,
+                            text=True,
+                            encoding="utf-8",
+                            errors="ignore",
+                            timeout=15,
+                            **_no_window,
+                        )
+                    except (OSError, subprocess.TimeoutExpired):
+                        result = None
+            if (
+                result is not None
+                and result.returncode == 0
+                and result.stdout is not None
+            ):
+                current_cmd = ""
+                for line in result.stdout.split("\n"):
+                    line = line.strip()
+                    if line.startswith("CommandLine="):
+                        current_cmd = line[len("CommandLine=") :]
+                    elif line.startswith("ProcessId="):
+                        pid_str = line[len("ProcessId=") :]
+                        if _matches_gateway_runtime(current_cmd) and (
+                            all_profiles or _matches_current_profile(current_cmd)
+                        ):
+                            try:
+                                _append_unique_pid(pids, int(pid_str), exclude_pids)
+                            except ValueError:
+                                pass
+                        current_cmd = ""
+            _scan_gateway_pids_windows_psutil(
+                pids,
+                exclude_pids,
+                all_profiles=all_profiles,
+                matches_gateway_runtime=_matches_gateway_runtime,
+                matches_current_profile=_matches_current_profile,
+            )
         else:
             # Try /proc first (works in Docker without procps installed),
             # fall back to ps -A eww.
@@ -538,7 +598,8 @@ def _scan_gateway_pids(
                     ):
                         _append_unique_pid(pids, pid, exclude_pids)
     except (OSError, subprocess.TimeoutExpired):
-        return []
+        if not pids:
+            return []
 
     # Windows-specific: collapse venv launcher stubs.  A venv-built
     # ``pythonw.exe`` in ``<venv>/Scripts/`` is a ~100 KB launcher exe

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9933,18 +9933,57 @@ def _pause_windows_gateways_for_update() -> dict | None:
             logger.debug("Could not capture argv for unmapped gateway %s: %s", pid, exc)
         unmapped.append({"pid": int(pid), "argv": argv})
 
+    # Task-aware stop first (#63743): a non-elevated ``taskkill`` against a
+    # SYSTEM-owned Scheduled Task gateway is often Access Denied. ``schtasks
+    # /End`` uses the task ACL the installer created and can stop Session-0
+    # gateways the raw PID kill cannot.
+    task_ended = False
+    try:
+        from hermes_cli import gateway_windows
+
+        if gateway_windows.is_task_registered():
+            code, _out, err = gateway_windows._exec_schtasks(
+                ["/End", "/TN", gateway_windows.get_task_name()]
+            )
+            if code == 0:
+                task_ended = True
+            elif "not running" not in (err or "").lower():
+                logger.debug(
+                    "schtasks /End before update returned %s: %s", code, (err or "").strip()
+                )
+    except Exception as exc:
+        logger.debug("Could not end Windows gateway Scheduled Task before update: %s", exc)
+
     force_killed = []
+    kill_denied = []
     for pid in sorted(set(survivors).union(unmapped_pids)):
         try:
             terminate_pid(int(pid), force=True)
             force_killed.append(int(pid))
-        except (ProcessLookupError, PermissionError, OSError):
+        except ProcessLookupError:
             pass
+        except PermissionError:
+            kill_denied.append(int(pid))
+        except OSError as exc:
+            # taskkill surfaces access-denied as OSError with stderr text.
+            details = str(exc).lower()
+            if "access is denied" in details or "denied" in details:
+                kill_denied.append(int(pid))
+            else:
+                logger.debug("taskkill failed for gateway PID %s: %s", pid, exc)
 
     if profiles:
         print(f"  ✓ Paused gateway profile(s): {', '.join(sorted(profiles))}")
+    if task_ended:
+        print("  → Ended Windows gateway Scheduled Task")
     if force_killed:
         print(f"  → Force-stopped {len(force_killed)} gateway process(es)")
+    if kill_denied:
+        print(
+            f"  ⚠ Could not force-stop gateway PID(s) {', '.join(str(p) for p in kill_denied)} "
+            "(access denied — SYSTEM session?). If update still blocks, run an elevated "
+            "`hermes gateway stop` or end the Hermes_Gateway Scheduled Task, then retry."
+        )
 
     if unmapped_pids:
         respawnable = sum(1 for u in unmapped if u.get("argv"))

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1142,6 +1142,90 @@ def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch)
     assert gateway._scan_gateway_pids(set(), all_profiles=True) == [2468]
 
 
+def _fake_psutil_process_iter(records):
+    """Build a minimal psutil.process_iter stand-in for gateway scan tests."""
+
+    class _Proc:
+        def __init__(self, info):
+            self.info = info
+
+        def cmdline(self):
+            return self.info.get("cmdline") or []
+
+    class _Psutil:
+        @staticmethod
+        def process_iter(attrs):
+            for record in records:
+                yield _Proc(record)
+
+    return _Psutil()
+
+
+def test_scan_gateway_pids_windows_psutil_when_cim_hides_cmdline(monkeypatch):
+    """CIM often returns empty CommandLine for SYSTEM gateways (#63743)."""
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(
+        gateway.shutil,
+        "which",
+        lambda name: "powershell.exe" if name == "powershell" else None,
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "powershell.exe":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "CommandLine=\n"
+                    "ProcessId=4242\n\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 4242,
+                "cmdline": [
+                    "pythonw.exe",
+                    "-m",
+                    "hermes_cli.main",
+                    "gateway",
+                    "run",
+                ],
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [4242]
+
+
+def test_scan_gateway_pids_windows_psutil_only_when_no_wmic_or_powershell(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 5150,
+                "cmdline": [
+                    "C:\\Hermes\\venv\\Scripts\\pythonw.exe",
+                    "-m",
+                    "hermes_cli.main",
+                    "gateway",
+                    "run",
+                ],
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [5150]
+
+
 # ---------------------------------------------------------------------------
 # _wait_for_gateway_exit
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1062,15 +1062,23 @@ def test_find_gateway_pids_includes_restart_managers_without_systemd(monkeypatch
     monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
     monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "find_profile_gateway_processes", lambda **_k: [])
 
-    def fake_scan(exclude_pids, all_profiles=False, include_restart_managers=False):
-        calls.append((set(exclude_pids), all_profiles, include_restart_managers))
+    def fake_scan(
+        exclude_pids,
+        all_profiles=False,
+        include_restart_managers=False,
+        seed_pids=None,
+    ):
+        calls.append(
+            (set(exclude_pids), all_profiles, include_restart_managers, list(seed_pids or []))
+        )
         return [708] if include_restart_managers else []
 
     monkeypatch.setattr(gateway, "_scan_gateway_pids", fake_scan)
 
     assert gateway.find_gateway_pids(all_profiles=True) == [708]
-    assert calls == [(set(), True, True)]
+    assert calls == [(set(), True, True, [])]
 
 
 def test_reap_unsupervised_orphans_noop_on_systemd_hosts(monkeypatch):
@@ -1145,14 +1153,34 @@ def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch)
 def _fake_psutil_process_iter(records):
     """Build a minimal psutil.process_iter stand-in for gateway scan tests."""
 
+    class _AccessDenied(Exception):
+        pass
+
     class _Proc:
         def __init__(self, info):
             self.info = info
 
         def cmdline(self):
-            return self.info.get("cmdline") or []
+            if self.info.get("cmdline_raises"):
+                raise _AccessDenied("AccessDenied")
+            return list(self.info.get("cmdline") or [])
+
+        def exe(self):
+            if self.info.get("exe_raises"):
+                raise _AccessDenied("AccessDenied")
+            return self.info.get("exe")
+
+        def username(self):
+            if self.info.get("username_raises"):
+                raise _AccessDenied("AccessDenied")
+            return self.info.get("username")
+
+        def ppid(self):
+            return self.info.get("ppid")
 
     class _Psutil:
+        AccessDenied = _AccessDenied
+
         @staticmethod
         def process_iter(attrs):
             for record in records:
@@ -1224,6 +1252,84 @@ def test_scan_gateway_pids_windows_psutil_only_when_no_wmic_or_powershell(monkey
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     assert gateway._scan_gateway_pids(set(), all_profiles=True) == [5150]
+
+
+def test_scan_gateway_pids_windows_psutil_exe_when_cmdline_access_denied(monkeypatch, tmp_path):
+    """SYSTEM boundary: cmdline denied, but exe under install venv is readable."""
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", tmp_path)
+
+    scripts = tmp_path / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    exe = scripts / "pythonw.exe"
+    exe.write_bytes(b"")
+
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 7777,
+                "cmdline": [],
+                "cmdline_raises": True,
+                "exe": str(exe),
+                "username": r"NT AUTHORITY\SYSTEM",
+                "ppid": 4,
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [7777]
+
+
+def test_scan_gateway_pids_windows_psutil_empty_cmdline_needs_system_or_seed(
+    monkeypatch, tmp_path
+):
+    """User-owned venv python with empty cmdline must not match without a seed."""
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", tmp_path)
+
+    scripts = tmp_path / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    exe = scripts / "python.exe"
+    exe.write_bytes(b"")
+
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 8888,
+                "cmdline": [],
+                "exe": str(exe),
+                "username": "Alice",
+                "ppid": 1,
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == []
+    # Parent already known via PID file → attach the launcher stub.
+    assert gateway._scan_gateway_pids(set(), all_profiles=True, seed_pids=[1]) == [8888]
+
+
+def test_find_gateway_pids_all_profiles_includes_pid_files(monkeypatch, tmp_path):
+    """Update sweep must see SYSTEM gateways via gateway.pid when scan is blind."""
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(
+        gateway,
+        "find_profile_gateway_processes",
+        lambda exclude_pids=None: [
+            gateway.ProfileGatewayProcess(
+                profile="default", path=tmp_path, pid=4242
+            )
+        ],
+    )
+
+    assert gateway.find_gateway_pids(all_profiles=True) == [4242]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -494,6 +494,9 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
         "terminate_pid",
         lambda pid, force=False: terminated.append((pid, force)),
     )
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
 
     token = cli_main._pause_windows_gateways_for_update()
 
@@ -521,6 +524,50 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     # An unmapped PID whose argv we captured is respawnable, so we must NOT
     # tell the user to restart it manually.
     assert "Restart manually after update" not in captured
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_pause_windows_gateways_ends_scheduled_task_before_taskkill(
+    _winp,
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    """SYSTEM Scheduled Task gateways need schtasks /End; taskkill often denies."""
+    import gateway.status as status_mod
+    import hermes_cli.gateway as gateway_mod
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **_k: [303])
+    monkeypatch.setattr(gateway_mod, "find_profile_gateway_processes", lambda **_k: [])
+    monkeypatch.setattr(gateway_mod, "_get_restart_drain_timeout", lambda: 0.1)
+    monkeypatch.setattr(
+        cli_main, "_wait_for_windows_update_gateway_exit", lambda pids, *, timeout: set()
+    )
+    monkeypatch.setattr(gateway_mod, "_capture_gateway_argv", lambda pid: None)
+
+    schtasks_calls = []
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: schtasks_calls.append(list(args)) or (0, "", ""),
+    )
+
+    terminated = []
+    monkeypatch.setattr(
+        status_mod,
+        "terminate_pid",
+        lambda pid, force=False: terminated.append((pid, force)),
+    )
+
+    token = cli_main._pause_windows_gateways_for_update()
+
+    assert token["unmapped_pids"] == [303]
+    assert schtasks_calls == [["/End", "/TN", "Hermes_Gateway"]]
+    assert terminated == [(303, True)]
+    assert "Ended Windows gateway Scheduled Task" in capsys.readouterr().out
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)


### PR DESCRIPTION
## Summary
- Supplement the Windows `wmic`/Get-CimInstance gateway scan with a psutil pass so Scheduled Task gateways running as SYSTEM are found before `hermes update` mutates the venv
- Preserve partial CIM hits when the psutil enumeration pass fails (sandbox/permission errors no longer wipe already-discovered PIDs)

Fixes #63743

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_gateway.py -k scan_gateway_pids`
- [ ] On Windows with gateway installed as a Scheduled Task (SYSTEM): `hermes update` pauses the gateway instead of blocking with "Other Hermes processes are running"