### PR TITLE
fix(compression): resolve provider output-token reservation on init + provider switch (#43547) 

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -240,6 +240,41 @@ _SMALL_CTX_WINDOW_LIMIT = 512_000
 _SMALL_CTX_THRESHOLD_PERCENT = 0.75
 
 
+def _resolve_output_reservation(
+    agent_max_tokens: int | None, provider: str, model: str = "",
+) -> int | None:
+    """Return the output-token reservation the compressor should assume.
+
+    The provider carves ``max_tokens`` of output space out of the context
+    window, so the usable INPUT budget is ``context_length - max_tokens``.
+    The compressor must assume the SAME reservation the wire path sends, or
+    its threshold math disagrees with what the provider actually enforces
+    (#43547).
+
+    Priority: explicit ``agent.max_tokens`` > the provider profile's resolved
+    ``get_max_tokens(model)`` > ``None`` (no registered profile → no default,
+    which is exactly what the wire's legacy path sends for such providers).
+
+    This mirrors the wire path by construction: both call
+    ``providers.get_provider_profile(provider)`` with the same string and read
+    ``profile.get_max_tokens(model)`` (``agent/transports/chat_completions.py``).
+    Using ``get_max_tokens(model)`` — not ``default_max_tokens`` directly —
+    honors per-model overrides (e.g. opencode-go caps mimo-v2.5-pro at 131072).
+    """
+    if agent_max_tokens is not None:
+        return agent_max_tokens
+    try:
+        from providers import get_provider_profile
+        profile = get_provider_profile(provider)
+    except Exception:
+        # Mirror the wire path's defensive guard: a malformed user provider
+        # plugin can make discovery raise. Degrade to "no reservation".
+        return None
+    if profile is None:
+        return None
+    return profile.get_max_tokens(model)
+
+
 _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
 
 # MEDIA delivery directives must not reach the summarizer — if one leaks into
@@ -893,6 +928,7 @@ class ContextCompressor(ContextEngine):
         max_tokens: int | None = None,
     ) -> None:
         """Update model info after a model switch or fallback activation."""
+        _old_provider = self.provider  # capture BEFORE overwrite (re-resolve gate)
         self.model = model
         self.base_url = base_url
         self.api_key = api_key
@@ -911,11 +947,29 @@ class ContextCompressor(ContextEngine):
         self.threshold_percent = self._effective_threshold_percent(
             context_length, _configured_pct,
         )
-        # max_tokens=None here means "caller didn't specify" → keep the existing
-        # output reservation. A switch that genuinely changes the output budget
-        # passes the new value explicitly. (#43547)
+        # Output-token reservation across a model/provider switch (#43547):
+        #   1. An explicit max_tokens arg still wins and marks the reservation
+        #      user-explicit (preserves the historical contract for callers
+        #      that pass a value, and for the ctx-only sites that pass none).
+        #   2. Otherwise, if the PROVIDER genuinely changed and the current
+        #      reservation was auto-derived (not user config), re-resolve it for
+        #      the NEW provider — fallback, /model switch, and restore-primary
+        #      all land here, so a provider with a different default_max_tokens
+        #      no longer carries the old provider's reservation.
+        #   3. Otherwise (same provider, or user-explicit value) keep it.
+        # getattr guard: compressors constructed/unpickled before the flag
+        # existed treat it as "not explicit" and safely re-resolve.
         if max_tokens is not None:
             self.max_tokens = self._coerce_max_tokens(max_tokens)
+            self._max_tokens_is_explicit = True
+        elif (
+            provider
+            and provider != _old_provider
+            and not getattr(self, "_max_tokens_is_explicit", False)
+        ):
+            self.max_tokens = self._coerce_max_tokens(
+                _resolve_output_reservation(None, provider, model),
+            )
         self.threshold_tokens = self._compute_threshold_tokens(
             context_length, self.threshold_percent, self.max_tokens,
         )
@@ -1017,8 +1071,12 @@ class ContextCompressor(ContextEngine):
         budget is materially smaller than the raw window, and a threshold based
         on the full window lets the session hit a provider 400 before compaction
         fires (#43547). The percentage and the degenerate-window check below both
-        operate on the effective input budget. ``max_tokens=None`` (provider
-        default) conservatively assumes no reservation (full window).
+        operate on the effective input budget. ``max_tokens=None`` means "no
+        reservation known" (the provider has no registered profile / no default,
+        so the wire path likewise sends none) and falls back to the full window.
+        Callers resolve the provider default via ``_resolve_output_reservation``
+        before reaching here, so ``None`` is genuinely "no reservation," not
+        merely "unset."
         """
         effective_window = context_length - (max_tokens or 0)
         if effective_window <= 0:
@@ -1067,7 +1125,18 @@ class ContextCompressor(ContextEngine):
         # Coerce defensively: only a positive int is a real reservation; any
         # other value (None, non-numeric, <=0) means "no reservation" so the
         # threshold arithmetic never sees a non-int (e.g. a test MagicMock).
-        self.max_tokens = self._coerce_max_tokens(max_tokens)
+        #
+        # _max_tokens_is_explicit tracks USER intent (was max_tokens set in
+        # config?) BEFORE we resolve a provider default — so a later provider
+        # switch knows whether to preserve the value (user-explicit) or
+        # re-resolve it for the new provider (auto-derived). Must be computed
+        # from the raw argument, NOT the resolved value, or an auto-derived
+        # default would masquerade as explicit and get frozen across switches.
+        self._max_tokens_is_explicit = max_tokens is not None
+        _resolved_max_tokens = _resolve_output_reservation(
+            max_tokens, provider, model,
+        )
+        self.max_tokens = self._coerce_max_tokens(_resolved_max_tokens)
         # When True, summary-generation failure aborts compression entirely
         # (returns messages unchanged, sets _last_compress_aborted=True).
         # When False (default = historical behavior), insert a

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3439,3 +3439,145 @@ class TestDoubleCompactionSummaryRole:
             "summary of earlier turns" in (m.get("content") or "")
             for m in result
         )
+
+
+class TestResolveOutputReservation:
+    """#43547: the compressor's output-token reservation must match what the
+    wire path sends (providers.get_provider_profile().get_max_tokens(model)),
+    so threshold math sees the same effective input budget the provider does.
+
+    These exercise the REAL provider registry (the thing under test); only the
+    context-length HTTP probe is mocked, matching the rest of this suite.
+    """
+
+    def test_none_custom_returns_provider_default(self):
+        from agent.context_compressor import _resolve_output_reservation
+        # custom profile default_max_tokens=65536
+        assert _resolve_output_reservation(None, "custom") == 65536
+
+    def test_none_registered_alias_returns_provider_default(self):
+        from agent.context_compressor import _resolve_output_reservation
+        # "vllm"/"local"/"ollama" are aliases of the custom profile
+        assert _resolve_output_reservation(None, "vllm") == 65536
+        assert _resolve_output_reservation(None, "local") == 65536
+
+    def test_explicit_wins_over_provider_default(self):
+        from agent.context_compressor import _resolve_output_reservation
+        assert _resolve_output_reservation(8192, "custom") == 8192
+
+    def test_none_nvidia_returns_nvidia_default(self):
+        from agent.context_compressor import _resolve_output_reservation
+        assert _resolve_output_reservation(None, "nvidia") == 16384
+
+    def test_unknown_provider_returns_none(self):
+        from agent.context_compressor import _resolve_output_reservation
+        assert _resolve_output_reservation(None, "unknown-provider-xyz") is None
+
+    def test_per_model_override_honored(self):
+        from agent.context_compressor import _resolve_output_reservation
+        # opencode-go caps mimo-v2.5-pro at 131072 via get_max_tokens() override
+        assert _resolve_output_reservation(
+            None, "opencode-go", model="mimo-v2.5-pro"
+        ) == 131072
+
+    def test_user_slug_forms_return_none(self):
+        """vllm-5090 / custom:vllm-5090 do NOT resolve to a registered profile
+        → None (wire's legacy path also sends no default → agree)."""
+        from agent.context_compressor import _resolve_output_reservation
+        assert _resolve_output_reservation(None, "vllm-5090") is None
+        assert _resolve_output_reservation(None, "custom:vllm-5090") is None
+
+
+class TestOutputReservationConstruction:
+    """#43547: constructor must resolve the provider default when max_tokens is
+    unset, and record whether the reservation was user-explicit."""
+
+    def test_custom_implicit_reserves_provider_default(self):
+        with patch("agent.context_compressor.get_model_context_length",
+                   return_value=200_000):
+            comp = ContextCompressor(
+                model="Qwen3.6-27B", provider="custom",
+                max_tokens=None, threshold_percent=0.50, quiet_mode=True,
+            )
+        assert comp.max_tokens == 65536
+        # effective_window = 200000 - 65536 = 134464; threshold = 50% of that
+        assert comp.threshold_tokens <= 200_000 - 65536
+
+    def test_explicit_max_tokens_marks_explicit(self):
+        with patch("agent.context_compressor.get_model_context_length",
+                   return_value=200_000):
+            comp = ContextCompressor(
+                model="Qwen3.6-27B", provider="custom",
+                max_tokens=8192, threshold_percent=0.50, quiet_mode=True,
+            )
+        assert comp.max_tokens == 8192
+        assert comp._max_tokens_is_explicit is True
+
+    def test_unknown_provider_no_reservation(self):
+        with patch("agent.context_compressor.get_model_context_length",
+                   return_value=200_000):
+            comp = ContextCompressor(
+                model="m", provider="unknown-provider-xyz",
+                max_tokens=None, threshold_percent=0.50, quiet_mode=True,
+            )
+        assert comp.max_tokens is None
+        assert comp._max_tokens_is_explicit is False
+
+
+class TestOutputReservationProviderSwitch:
+    """#43547: update_model() must re-resolve the reservation on a provider
+    change when it was auto-derived — but preserve an explicit user value."""
+
+    def _comp(self, provider, max_tokens):
+        with patch("agent.context_compressor.get_model_context_length",
+                   return_value=200_000):
+            return ContextCompressor(
+                model="Qwen3.6-27B", provider=provider,
+                max_tokens=max_tokens, threshold_percent=0.50, quiet_mode=True,
+            )
+
+    def test_switch_flips_implicit_reservation(self):
+        """custom(65536) -> nvidia(16384): reservation must follow the new
+        provider, not stay stuck at the old one."""
+        comp = self._comp("custom", None)
+        assert comp.max_tokens == 65536
+        comp.update_model("Qwen3.6-27B", context_length=200_000, provider="nvidia")
+        assert comp.max_tokens == 16384
+
+    def test_switch_preserves_explicit_reservation(self):
+        """Explicit user max_tokens survives a provider switch unchanged."""
+        comp = self._comp("custom", 8192)
+        comp.update_model("Qwen3.6-27B", context_length=200_000, provider="nvidia")
+        assert comp.max_tokens == 8192
+
+    def test_restore_primary_is_a_switch(self):
+        """primary(custom,65536) -> fallback(nvidia,16384) -> restore(custom):
+        must return to 65536, not stay stuck at the fallback's 16384.
+        (rev1 missed this site: agent_runtime_helpers.py:1202.)"""
+        comp = self._comp("custom", None)
+        comp.update_model("Qwen3.6-27B", context_length=200_000, provider="nvidia")
+        assert comp.max_tokens == 16384
+        comp.update_model("Qwen3.6-27B", context_length=200_000, provider="custom")
+        assert comp.max_tokens == 65536
+
+    def test_same_provider_ctx_change_keeps_reservation(self):
+        """Ctx-only update (same provider) must NOT touch the reservation —
+        guards the 4 non-switch call sites (LM Studio, ctx-probe, 1M downgrade)."""
+        comp = self._comp("custom", None)
+        assert comp.max_tokens == 65536
+        comp.update_model("Qwen3.6-27B", context_length=32_000, provider="custom")
+        assert comp.max_tokens == 65536
+
+    def test_switch_to_unknown_provider_drops_to_no_reservation(self):
+        comp = self._comp("custom", None)
+        comp.update_model("m", context_length=200_000, provider="unknown-xyz")
+        assert comp.max_tokens is None
+
+    def test_old_instance_without_flag_survives_switch(self):
+        """A compressor constructed before _max_tokens_is_explicit existed
+        (unpickled/legacy) must not AttributeError on provider switch."""
+        comp = self._comp("custom", None)
+        del comp._max_tokens_is_explicit
+        # Should treat missing flag as "not explicit" and re-resolve, no crash.
+        comp.update_model("Qwen3.6-27B", context_length=200_000, provider="nvidia")
+        assert comp.max_tokens == 16384


### PR DESCRIPTION
# PR: fix(compression): resolve provider output-token reservation on init + provider switch

**Ref issue:** #43547
**Head:** `jcjc81:fix/compressor-output-reservation-43547`  ->  **Base:** `NousResearch:main`
**Open PR:** https://github.com/NousResearch/hermes-agent/compare/main...jcjc81:fix/compressor-output-reservation-43547?expand=1

---

## Title
```
fix(compression): resolve provider output-token reservation on init + provider switch (#43547)
```

## Summary

The context compressor budgets usable input as `context_length - max_tokens`
(the provider reserves `max_tokens` of the window for output). When a profile
leaves `model.max_tokens` **unset**, the compressor assumed **no** reservation
while the wire path actually sent the provider profile's `default_max_tokens`
(e.g. `custom` = 65536). The compressor therefore believed it had the full
window and set its compaction threshold too high -- the session could hit a
provider 400 (input+output > window) *before* auto-compaction ever fired.

The threshold arithmetic in `_compute_threshold_tokens` was already correct
(it subtracts `max_tokens` from the window). The bug was purely in **what
reservation value reached it**:

1. **On construction** (`ContextCompressor.__init__`) the reservation was taken
   verbatim from `agent.max_tokens` with no provider-default fallback, so
   `None` meant "assume 0 reserved" -- disagreeing with the wire.
2. **On a provider switch** (`update_model`, reached by fallback activation,
   `/model`, and restore-primary) an auto-derived reservation was carried over
   from the **old** provider, so e.g. custom(65536) -> nvidia(16384) kept the
   stale 65536 (or vice-versa).

## Fix

One helper, resolution kept inside the compressor (no new public surface):

- **`_resolve_output_reservation(agent_max_tokens, provider, model)`** --
  priority: explicit `agent.max_tokens` > `get_provider_profile(provider).get_max_tokens(model)` > `None`.
  This mirrors the wire path **by construction**: both call
  `providers.get_provider_profile(provider)` with the same string and read
  `profile.get_max_tokens(model)` (see `agent/transports/chat_completions.py`,
  the `profile.get_max_tokens(model)` branch). Uses `get_max_tokens(model)`, not
  `default_max_tokens` directly, so per-model overrides are honored (e.g.
  opencode-go caps `mimo-v2.5-pro` at 131072).
- **`__init__`** resolves the reservation when `max_tokens` is unset and records
  `self._max_tokens_is_explicit` from the **raw** argument (user intent), not the
  resolved value.
- **`update_model()`** captures the old provider before overwrite; when the
  provider genuinely changes **and** the reservation was auto-derived (not
  user-explicit), it re-resolves for the new provider. An explicit user value is
  always preserved. A `getattr` guard makes compressors constructed/unpickled
  before the flag existed safely re-resolve rather than `AttributeError`.

This covers **all three** provider-switch call sites (fallback activation,
`/model` switch, and -- importantly -- `restore_primary`, which is itself a
provider switch back to the primary) without editing any call site, because the
logic lives inside `update_model()`.

## Behavior -- what changes / what doesn't

- **No profile registered for the provider** (unknown provider, or a
  user-config `custom_providers:` slug like `vllm-5090` / `custom:vllm-5090`
  that doesn't resolve via `get_provider_profile`) -> resolves to `None`, i.e.
  **no reservation** -- which is exactly what the wire's legacy path sends for
  those providers. Compressor and wire still agree; this is a deliberate no-op,
  not a gap.
- **Explicit `model.max_tokens` set** -> identical to today; the value is
  preserved across provider switches.
- **Only behavior change:** the previously-unhandled "`max_tokens` unset +
  provider has a registered profile" case now assumes the provider's real
  reservation on both construction and provider switches.

## Scope boundary (intentional)

Making the *compressor* assume a reservation for user-config custom-provider
slugs that take the wire's **legacy** path (which sends no default) would break
the compressor<->wire agreement -- the compressor would over-reserve and compress
prematurely. Aligning those would require a provider-resolution-layer change so
the wire sends the default too; that is out of scope for this fix and noted for a
possible follow-up.

## Tests

`tests/agent/test_context_compressor.py` -- 16 new tests across 3 classes,
exercising the **real** provider registry (only the context-length HTTP probe is
mocked), per the repo's "E2E validation, not just green unit mocks" guidance:

- `_resolve_output_reservation`: custom->65536, alias(vllm/local)->65536,
  explicit-wins, nvidia->16384, unknown->None, per-model override
  (opencode-go/mimo-v2.5-pro->131072), user-slug forms->None.
- Construction: implicit-reserves-provider-default, explicit-marks-explicit,
  unknown-no-reservation.
- Provider switch: switch flips implicit reservation (custom->nvidia),
  switch preserves explicit reservation, **restore-primary is a switch**
  (custom->nvidia->custom returns to 65536), same-provider ctx-change keeps
  reservation (guards the ctx-only call sites), switch-to-unknown drops to none,
  old-instance-without-flag survives switch (getattr guard).

**Verification run:** 16/16 new tests pass; full regression on
`test_context_compressor.py` + `test_compression_small_ctx_threshold_floor.py` +
`tests/providers/test_transport_parity.py` + `tests/providers/test_e2e_wiring.py`
= **209 passed**. Rebased onto current `origin/main` and re-verified.

## Files

```
agent/context_compressor.py            |  81 +++++++++++++++++--  (helper + __init__ + update_model + docstring)
tests/agent/test_context_compressor.py | 142 +++++++++++++++++++++  (16 new tests)
2 files changed, 217 insertions(+), 6 deletions(-)
```

## Risk / review notes

- A provider without a registered profile must degrade to today's behavior
  (`None` -> no reservation), never crash -- covered by the unknown-provider and
  user-slug tests plus the `try/except` around discovery in the helper.
- `_max_tokens_is_explicit` tracks **user config intent**, computed from the raw
  argument before resolution -- so an auto-derived default never masquerades as
  explicit and get frozen across a switch (guarded by the explicit-preserved and
  switch-flips tests).
- Ties to #43547, already referenced in the surrounding code comments.
- Scope stays inside `agent/` -- no new core tool, no config-surface change.
  Consistent with "keep the core narrow" / "extend, don't duplicate."