### PR TITLE
fix(cron): add recurring-job governance gate

### DIFF
--- a/cron/governance.py
+++ b/cron/governance.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from croniter import croniter
+
 
 @dataclass(frozen=True)
 class CronGovernanceDecision:
@@ -16,6 +18,24 @@ class CronGovernanceDecision:
 
 def _blocked(code: str, reason: str) -> CronGovernanceDecision:
     return CronGovernanceDecision(False, code, reason)
+
+
+def _schedule_period_minutes(schedule: dict[str, Any]) -> int | None:
+    """Return the recurring schedule period in whole minutes when determinable."""
+    kind = schedule.get("kind")
+    if kind == "interval":
+        minutes = schedule.get("minutes")
+        return minutes if isinstance(minutes, int) else None
+    if kind == "cron":
+        expr = schedule.get("expr")
+        if not isinstance(expr, str) or not expr.strip():
+            return None
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        iterator = croniter(expr, base)
+        first = iterator.get_next(datetime)
+        second = iterator.get_next(datetime)
+        return max(1, int((second - first).total_seconds() // 60))
+    return None
 
 
 def evaluate_cron_governance_policy(job: dict[str, Any]) -> CronGovernanceDecision:
@@ -36,10 +56,12 @@ def evaluate_cron_governance_policy(job: dict[str, Any]) -> CronGovernanceDecisi
     schedule = job.get("schedule")
     if not isinstance(minimum, int) or minimum < 1:
         return _blocked("missing_cadence_policy", "cadence minimum must be a positive integer")
-    if not isinstance(schedule, dict) or schedule.get("kind") != "interval":
-        return _blocked("unknown_cadence", "only declared interval schedules are governable")
-    minutes = schedule.get("minutes")
-    if not isinstance(minutes, int) or minutes < minimum:
+    if not isinstance(schedule, dict):
+        return _blocked("unknown_cadence", "job schedule is not governable")
+    minutes = _schedule_period_minutes(schedule)
+    if minutes is None:
+        return _blocked("unknown_cadence", "schedule period could not be determined")
+    if minutes < minimum:
         return _blocked("over_cadence", "schedule is more frequent than its policy permits")
 
     if not job.get("no_agent", False):

--- a/cron/governance.py
+++ b/cron/governance.py
@@ -1,0 +1,81 @@
+"""Deterministic pre-execution policy for Hermes recurring jobs."""
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CronGovernanceDecision:
+    allow: bool
+    code: str
+    reason: str
+
+
+def _blocked(code: str, reason: str) -> CronGovernanceDecision:
+    return CronGovernanceDecision(False, code, reason)
+
+
+def evaluate_cron_governance_policy(job: dict[str, Any]) -> CronGovernanceDecision:
+    """Return an allow/block decision without running, advancing, or delivering a job."""
+    if job.get("enabled") is not True:
+        return _blocked("disabled", "job is disabled")
+    if job.get("state") != "scheduled":
+        return _blocked("paused_state", "job state must be scheduled")
+
+    governance = job.get("governance")
+    if not isinstance(governance, dict) or not governance.get("owner_issue"):
+        return _blocked("missing_owner_issue", "job requires an accountable owner issue")
+
+    cadence = governance.get("cadence")
+    if not isinstance(cadence, dict):
+        return _blocked("missing_cadence_policy", "job requires a cadence policy")
+    minimum = cadence.get("min_minutes")
+    schedule = job.get("schedule")
+    if not isinstance(minimum, int) or minimum < 1:
+        return _blocked("missing_cadence_policy", "cadence minimum must be a positive integer")
+    if not isinstance(schedule, dict) or schedule.get("kind") != "interval":
+        return _blocked("unknown_cadence", "only declared interval schedules are governable")
+    minutes = schedule.get("minutes")
+    if not isinstance(minutes, int) or minutes < minimum:
+        return _blocked("over_cadence", "schedule is more frequent than its policy permits")
+
+    if not job.get("no_agent", False):
+        model_policy = governance.get("model_policy")
+        budget_policy = governance.get("budget_policy")
+        if not isinstance(model_policy, dict) or not isinstance(budget_policy, dict):
+            return _blocked("missing_model_budget_policy", "agent jobs require model and budget policies")
+        if not model_policy.get("provider") or not model_policy.get("model"):
+            return _blocked("missing_model_budget_policy", "agent model policy requires provider and model")
+        if "max_usd_per_run" not in budget_policy:
+            return _blocked("missing_model_budget_policy", "agent budget policy requires a per-run limit")
+
+    if job.get("deliver", "local") != "local" and governance.get("allow_nonlocal_delivery") is not True:
+        return _blocked("nonlocal_delivery_not_authorized", "nonlocal delivery requires explicit authorization")
+
+    return CronGovernanceDecision(True, "allowed", "job passed governance policy")
+
+
+def append_governance_audit(
+    audit_path: Path, job: dict[str, Any], decision: CronGovernanceDecision
+) -> None:
+    """Append a bounded, secret-free decision record for operational visibility."""
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    if audit_path.exists() and audit_path.stat().st_size >= 5 * 1024 * 1024:
+        audit_path.replace(audit_path.with_suffix(audit_path.suffix + ".1"))
+    event = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "job_id": job.get("id"),
+        "name": job.get("name"),
+        "decision": "allow" if decision.allow else "block",
+        "code": decision.code,
+        "enabled": job.get("enabled") is True,
+        "state": job.get("state"),
+        "schedule": job.get("schedule"),
+        "deliver": job.get("deliver", "local"),
+        "owner_issue_present": bool((job.get("governance") or {}).get("owner_issue")),
+    }
+    with audit_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1011,7 +1011,8 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     needs_save = False
 
     for job in jobs:
-        if not job.get("enabled", True):
+        # OPS-1308: paused state must not run even if enabled drifted true.
+        if not job.get("enabled", True) or job.get("state") == "paused":
             continue
 
         next_run = job.get("next_run_at")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -40,6 +40,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
+from cron.governance import append_governance_audit, evaluate_cron_governance_policy
 
 logger = logging.getLogger(__name__)
 
@@ -1854,6 +1855,17 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _cron_governance_enforced() -> bool:
+    """Return whether the migrated cron governance policy is active."""
+    try:
+        cfg = load_config() or {}
+    except Exception:
+        return False
+    cron_cfg = cfg.get("cron") if isinstance(cfg, dict) else None
+    governance_cfg = cron_cfg.get("governance") if isinstance(cron_cfg, dict) else None
+    return bool(governance_cfg and governance_cfg.get("enforce") is True)
+
+
 def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     """
     Check and run all due jobs.
@@ -1888,6 +1900,21 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
     try:
         due_jobs = get_due_jobs()
+        if _cron_governance_enforced():
+            governed_due_jobs = []
+            governance_audit_path = get_hermes_home() / "cron" / "governance_audit.jsonl"
+            for job in due_jobs:
+                decision = evaluate_cron_governance_policy(job)
+                append_governance_audit(governance_audit_path, job, decision)
+                if decision.allow:
+                    governed_due_jobs.append(job)
+                else:
+                    logger.warning(
+                        "Cron job '%s' blocked by governance policy: %s",
+                        job.get("id", "unknown"),
+                        decision.code,
+                    )
+            due_jobs = governed_due_jobs
 
         if verbose and not due_jobs:
             logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,7 @@ AUTHOR_MAP = {
     "wangpuv@hotmail.com": "wangpuv",
     "202622897+ticketclosed-wontfix@users.noreply.github.com": "ticketclosed-wontfix",
     "wuxuebin1993@gmail.com": "victorGPT",
+    "mike@michaelcourtney.com": "mkc909",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "kenyon1977@gmail.com": "kenyonxu",

--- a/tests/cron/test_governance.py
+++ b/tests/cron/test_governance.py
@@ -1,0 +1,136 @@
+"""Deterministic policy tests for recurring-job governance (OPS-1308)."""
+
+import json
+from unittest.mock import Mock
+
+from cron import scheduler
+from cron.governance import append_governance_audit, evaluate_cron_governance_policy
+
+
+def authorized_job(**overrides):
+    job = {
+        "id": "cron-1",
+        "name": "Governed local script",
+        "enabled": True,
+        "state": "scheduled",
+        "deliver": "local",
+        "no_agent": True,
+        "schedule": {"kind": "interval", "minutes": 120},
+        "governance": {
+            "owner_issue": "OPS-1308",
+            "cadence": {"min_minutes": 60},
+        },
+    }
+    job.update(overrides)
+    return job
+
+
+def test_paused_job_is_blocked_even_if_enabled():
+    decision = evaluate_cron_governance_policy(
+        authorized_job(state="paused", enabled=True)
+    )
+
+    assert decision.allow is False
+    assert decision.code == "paused_state"
+
+
+def test_job_without_accountable_issue_is_blocked():
+    job = authorized_job(governance={"cadence": {"min_minutes": 60}})
+
+    decision = evaluate_cron_governance_policy(job)
+
+    assert decision.allow is False
+    assert decision.code == "missing_owner_issue"
+
+
+def test_agent_job_without_model_budget_policy_is_blocked():
+    job = authorized_job(
+        no_agent=False,
+        governance={
+            "owner_issue": "OPS-1308",
+            "cadence": {"min_minutes": 60},
+        },
+    )
+
+    decision = evaluate_cron_governance_policy(job)
+
+    assert decision.allow is False
+    assert decision.code == "missing_model_budget_policy"
+
+
+def test_short_interval_is_blocked_before_execution():
+    job = authorized_job(schedule={"kind": "interval", "minutes": 30})
+
+    decision = evaluate_cron_governance_policy(job)
+
+    assert decision.allow is False
+    assert decision.code == "over_cadence"
+
+
+def test_nonlocal_delivery_requires_explicit_authorization():
+    job = authorized_job(deliver="origin")
+
+    decision = evaluate_cron_governance_policy(job)
+
+    assert decision.allow is False
+    assert decision.code == "nonlocal_delivery_not_authorized"
+
+
+def test_governed_agent_with_authorized_delivery_and_budget_is_allowed():
+    job = authorized_job(
+        no_agent=False,
+        governance={
+            "owner_issue": "OPS-1308",
+            "cadence": {"min_minutes": 60},
+            "model_policy": {
+                "provider": "openai-codex",
+                "model": "gpt-5.5",
+                "max_runs_per_day": 1,
+            },
+            "budget_policy": {"max_usd_per_run": 0},
+            "allow_nonlocal_delivery": True,
+        },
+        deliver="origin",
+    )
+
+    decision = evaluate_cron_governance_policy(job)
+
+    assert decision.allow is True
+    assert decision.code == "allowed"
+
+
+def test_tick_does_not_advance_or_run_a_paused_due_job(monkeypatch, tmp_path):
+    job = authorized_job(state="paused", enabled=True)
+    advance = Mock()
+    run = Mock(return_value=(True, "", "[SILENT]", None))
+    audit = Mock()
+
+    monkeypatch.setattr(scheduler, "_get_lock_paths", lambda: (tmp_path, tmp_path / "tick.lock"))
+    monkeypatch.setattr(scheduler, "_cron_governance_enforced", lambda: True)
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(scheduler, "advance_next_run", advance)
+    monkeypatch.setattr(scheduler, "run_job", run)
+    monkeypatch.setattr(scheduler, "save_job_output", Mock())
+    monkeypatch.setattr(scheduler, "append_governance_audit", audit)
+    monkeypatch.setattr(scheduler, "_kill_orphaned_mcp_children", Mock(), raising=False)
+
+    scheduler.tick(verbose=False)
+
+    advance.assert_not_called()
+    run.assert_not_called()
+    audit.assert_called_once()
+
+
+def test_governance_audit_is_secret_free_and_bounded(tmp_path):
+    job = authorized_job(name="Governed job", prompt="do not persist this")
+    decision = evaluate_cron_governance_policy(job)
+    audit_path = tmp_path / "governance.jsonl"
+
+    append_governance_audit(audit_path, job, decision)
+
+    event = json.loads(audit_path.read_text().strip())
+    assert event["job_id"] == "cron-1"
+    assert event["decision"] == "allow"
+    assert event["code"] == "allowed"
+    assert "prompt" not in event
+    assert event["name"] == "Governed job"

--- a/tests/cron/test_governance.py
+++ b/tests/cron/test_governance.py
@@ -67,6 +67,24 @@ def test_short_interval_is_blocked_before_execution():
     assert decision.code == "over_cadence"
 
 
+def test_daily_cron_schedule_can_satisfy_cadence_policy():
+    job = authorized_job(schedule={"kind": "cron", "expr": "0 13 * * *"})
+
+    decision = evaluate_cron_governance_policy(job)
+
+    assert decision.allow is True
+    assert decision.code == "allowed"
+
+
+def test_cron_expression_that_runs_too_frequently_is_blocked():
+    job = authorized_job(schedule={"kind": "cron", "expr": "*/5 * * * *"})
+
+    decision = evaluate_cron_governance_policy(job)
+
+    assert decision.allow is False
+    assert decision.code == "over_cadence"
+
+
 def test_nonlocal_delivery_requires_explicit_authorization():
     job = authorized_job(deliver="origin")
 


### PR DESCRIPTION
## Summary\n- add deterministic cron governance policy for scheduled/paused state, owner issue, cadence, model/budget policy, and nonlocal delivery authorization\n- block paused jobs even when enabled drifted true before due-job selection advances or runs them\n- support cadence checks for both interval and cron expression schedules\n- append bounded, secret-free governance audit events when enforcement is enabled\n\n## OPS-1308 evidence\n- local jobs registry classified all 8 currently enabled Hermes cron jobs with owner/cadence/delivery metadata\n- generated governance status snapshot: /root/.hermes/cron/governance-status-2026-07-13.json\n- Notion Daily Workspace page updated with managed OPS-1308 governance surface\n\n## Tests\n- /root/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron -q\n- 396 passed, 1 warning in 13.01s\n\n## Activation note\nRuntime enforcement remains config-gated behind cron.governance.enforce=true; no gateway restart or config activation is performed by this PR.