### PR TITLE
fix(desktop): sync UI Scale setting after zoom restore on window load

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4793,6 +4793,7 @@ function restorePersistedZoomLevel(window) {
       }
       const level = clampZoomLevel(Number(stored))
       window.webContents.setZoomLevel(level)
+	  window.webContents.send('hermes:zoom:changed', { level, percent: zoomLevelToPercent(level) })
     })
     .catch(error => rememberLog(`[zoom] restore failed: ${error?.message || error}`))
 }

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -123,3 +123,31 @@ test('pet overlay opts out of global UI zoom; chat windows keep it', () => {
   const snippet = source.slice(finishLoad, finishLoad + 300)
   assert.doesNotMatch(snippet, /restorePersistedZoomLevel\(mainWindow\)/)
 })
+// Source assertion, same pattern as the pet-overlay test above: verifies the
+// fix for the UI Scale settings control drifting out of sync after a restart.
+// restorePersistedZoomLevel correctly re-applies the persisted zoom level to
+// the window, but must also notify the renderer — otherwise the renderer's
+// $zoomPercent store (see store/zoom.ts), which only updates from zoom.get()
+// (called once on load) and 'hermes:zoom:changed' events, can be left with a
+// stale value if zoom.get() resolves before the restore finishes, leaving the
+// Appearance settings UI Scale control showing the wrong preset even though
+// the window's actual zoom level was correctly restored.
+test('restorePersistedZoomLevel notifies the renderer, same as setAndPersistZoomLevel', () => {
+  const electronDir = path.dirname(fileURLToPath(import.meta.url))
+  const source = fs.readFileSync(path.join(electronDir, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+  const restoreStart = source.indexOf('function restorePersistedZoomLevel(window)')
+  assert.notEqual(restoreStart, -1, 'missing restorePersistedZoomLevel')
+
+  const snippet = source.slice(restoreStart, restoreStart + 600)
+  const setZoomIndex = snippet.indexOf('window.webContents.setZoomLevel(level)')
+  const sendIndex = snippet.indexOf("window.webContents.send('hermes:zoom:changed'")
+
+  assert.notEqual(setZoomIndex, -1, 'restorePersistedZoomLevel must apply the restored zoom level')
+  assert.notEqual(
+    sendIndex,
+    -1,
+    'restorePersistedZoomLevel must notify the renderer after restoring zoom, or the UI Scale control can show a stale preset'
+  )
+  assert.ok(sendIndex > setZoomIndex, 'the renderer notification must happen after the zoom level is applied')
+})


### PR DESCRIPTION
## What does this PR do?
Fixes a bug where the **UI Scale** setting in Appearance settings visually resets to 100% after restarting the app or reopening a window, even though the actual window zoom level is correctly restored (e.g. 150%).

Root cause: `restorePersistedZoomLevel` (in `apps/desktop/electron/main.ts`) correctly reads the persisted zoom level from `localStorage` and applies it via `window.webContents.setZoomLevel(level)`, but unlike its sibling function `setAndPersistZoomLevel`, it never emitted the `hermes:zoom:changed` IPC event afterward. The renderer's `$zoomPercent` store (in `apps/desktop/src/store/zoom.ts`) only updates from `zoom.get()` (called once on renderer load) and from `onChanged` events so if `zoom.get()` resolves before `restorePersistedZoomLevel` finishes applying the restored level, the store is left with the stale/default value, and the Appearance settings UI never learns the real, restored zoom percentage.

The fix sends the same `hermes:zoom:changed` event after applying the restored level, so the renderer always ends up in sync regardless of the race between `zoom.get()` and the restore flow this mirrors exactly what `setAndPersistZoomLevel` already does for user-initiated zoom changes.

## Related Issue
Fixes #63846

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/electron/main.ts`: in `restorePersistedZoomLevel`, emit `hermes:zoom:changed` with the restored `level`/`percent` after calling `window.webContents.setZoomLevel(level)`, so the renderer's UI Scale control always reflects the actually-applied zoom level.
- `apps/desktop/electron/zoom.test.ts`: added a source-assertion test (`restorePersistedZoomLevel notifies the renderer, same as setAndPersistZoomLevel`) that verifies `restorePersistedZoomLevel` both applies the restored zoom level and sends `hermes:zoom:changed` afterward, and that the notification happens after the level is applied following the same source-assertion pattern already used by the neighboring `pet overlay opts out of global UI zoom` test in this file.

## How to Test
1. Open the desktop app, go to Appearance settings, and set **UI Scale** to something other than the default (e.g. 150%).
2. Close the app/window (or reopen the terminal/settings panel) and relaunch it.
3. Before this fix: the window visually renders at 150%, but the UI Scale control in Appearance settings shows 100% as selected. After this fix: the control correctly shows 150% as selected, matching the actual applied zoom.
4. Run `npx tsx --test electron/zoom.test.ts` from `apps/desktop` all 11 tests pass, including the new regression test.

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs
<!-- add your before/after screenshots of the UI Scale control here -->