### PR TITLE
feat(tool_search): defer verbose core tool schemas + hot-tools promotion + per-toolset deferral

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1186,6 +1186,28 @@ def init_agent(
         agent._tool_snapshot_generation = _snapshot_registry._generation
     except Exception:
         agent._tool_snapshot_generation = 0
+    try:
+        _full_scope_tools = _ra().get_tool_definitions(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        agent.available_tool_names = {
+            tool["function"]["name"]
+            for tool in (_full_scope_tools or [])
+            if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+        }
+    except Exception:
+        agent.available_tool_names = set()
+    # Reset session-level hot-tools promotion set.
+    # TODO: not gateway-safe — module-global shared across concurrent sessions.
+    # For proper multi-session safety, move to agent-scoped state + cache key.
+    try:
+        import model_tools as _mt
+        _mt._session_hot_tools.clear()
+    except Exception:
+        pass
     agent.tools = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
@@ -1196,6 +1218,8 @@ def init_agent(
     agent.valid_tool_names = set()
     if agent.tools:
         agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools}
+        if not agent.available_tool_names:
+            agent.available_tool_names = set(agent.valid_tool_names)
         tool_names = sorted(agent.valid_tool_names)
         if not agent.quiet_mode:
             print(f"🛠️  Loaded {len(agent.tools)} tools: {', '.join(tool_names)}")
@@ -1955,6 +1979,7 @@ def init_agent(
             _wrapped = {"type": "function", "function": _schema}
             agent.tools.append(_wrapped)
             agent.valid_tool_names.add(_tname)
+            agent.available_tool_names.add(_tname)
             agent._context_engine_tool_names.add(_tname)
             _existing_tool_names.add(_tname)
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2340,7 +2340,11 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 session_id=agent.session_id or "",
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                enabled_tools=list(
+                    getattr(agent, "available_tool_names", None)
+                    or getattr(agent, "valid_tool_names", None)
+                    or []
+                ) or None,
                 skip_pre_tool_call_hook=True,
                 skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
@@ -2391,20 +2395,19 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if not tool_name:
         return None
 
+    # ponytail: include deferred tools in the candidate set for repair.
+    # But prefer valid (direct) matches first so a typo for a direct tool
+    # doesn't accidentally match a deferred tool with a higher fuzzy score.
+    _avail = getattr(agent, "available_tool_names", None) or set()
+    _valid = getattr(agent, "valid_tool_names", None) or set()
+
     # VolcEngine api/plan workaround (issue #33007): the endpoint's
     # protocol-translation layer occasionally leaks raw XML attribute
     # fragments into tool_use.name, e.g.
     #   `terminal" parameter="command" string="true`
-    #   `execute_code" parameter="code" string="true`
-    #   `session_search" parameter="session_id" string="true`
     # We trim at the first unambiguous XML/quote character so the rest
     # of the repair pipeline (lowercase / snake_case / fuzzy match)
     # can resolve the cleaned name to a real tool.
-    #
-    # Crucially we DO NOT split on whitespace: legitimate inputs like
-    # "write file" must keep flowing through ``_norm`` -> ``write_file``
-    # (covered by test_space_to_underscore in
-    # tests/run_agent/test_repair_tool_call_name.py).
     for _xml_sep in ('"', "'", "<", ">"):
         _idx = tool_name.find(_xml_sep)
         if _idx > 0:
@@ -2425,12 +2428,16 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
                 return s[: -len(suffix)].rstrip("_-")
         return None
 
-    # Cheap fast-paths first — these cover the common case.
+    # Cheap fast-paths first — check direct tools, then deferred.
     lowered = tool_name.lower()
-    if lowered in agent.valid_tool_names:
+    if lowered in _valid:
         return lowered
     normalized = _norm(tool_name)
-    if normalized in agent.valid_tool_names:
+    if normalized in _valid:
+        return normalized
+    if lowered in _avail:
+        return lowered
+    if normalized in _avail:
         return normalized
 
     # Build the full candidate set for class-like emissions.
@@ -2446,14 +2453,22 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
                 extra.add(_camel_snake(stripped))
         cands |= extra
 
+    # Check direct tools first, then deferred.
     for c in cands:
-        if c and c in agent.valid_tool_names:
+        if c and c in _valid:
+            return c
+    for c in cands:
+        if c and c in _avail:
             return c
 
-    # Fuzzy match as last resort.
-    matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)
+    # Fuzzy match as last resort — prefer direct, then deferred.
+    matches = get_close_matches(lowered, _valid or _avail, n=1, cutoff=0.7)
     if matches:
         return matches[0]
+    if _avail:
+        matches = get_close_matches(lowered, _avail, n=1, cutoff=0.7)
+        if matches:
+            return matches[0]
 
     return None
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4456,10 +4456,47 @@ def run_conversation(
                 # Repair mismatched tool names before validating
                 for tc in assistant_message.tool_calls:
                     if tc.function.name not in agent.valid_tool_names:
+                        # ponytail: if the tool is deferred (in available_tool_names
+                        # but not valid_tool_names), transparently rewrite the
+                        # direct call into a tool_call bridge invocation so the
+                        # model doesn't get a "Unknown tool" error for tools it
+                        # legitimately knows by name but are currently deferred.
+                        # Invariant: tool_call bridge is always in valid_tool_names
+                        # when assembly activates (it's added by bridge_tool_schemas).
+                        _avail = getattr(agent, "available_tool_names", None)
+
+                        def _route_to_bridge(_tc, _target_name):
+                            """Rewrite a direct tool call into a tool_call bridge invocation."""
+                            _raw_args = _tc.function.arguments
+                            # Don't eagerly parse — let resolve_underlying_call
+                            # in the bridge handle malformed JSON gracefully.
+                            try:
+                                _inner = json.loads(_raw_args) if isinstance(_raw_args, str) else _raw_args
+                            except (json.JSONDecodeError, TypeError):
+                                _inner = _raw_args  # bridge will report bad JSON to model
+                            _tc.function.name = "tool_call"
+                            _tc.function.arguments = json.dumps({
+                                "name": _target_name,
+                                "arguments": _inner,
+                            })
+                            if not agent.quiet_mode:
+                                agent._vprint(f"{agent.log_prefix}🔧 Auto-routed deferred tool: '{_target_name}' -> tool_call bridge")
+
+                        # 1. Exact match in deferred set → bridge directly
+                        if _avail and tc.function.name in _avail:
+                            _route_to_bridge(tc, tc.function.name)
+                            continue
+                        # 2. Try repair — repair_tool_call checks available_tool_names
+                        #    (the superset) so it can resolve near-miss deferred tools
                         repaired = agent._repair_tool_call(tc.function.name)
                         if repaired:
-                            print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
-                            tc.function.name = repaired
+                            if repaired not in agent.valid_tool_names and _avail and repaired in _avail:
+                                # Repaired name is a deferred tool → bridge it
+                                _route_to_bridge(tc, repaired)
+                                continue
+                            elif repaired in agent.valid_tool_names:
+                                print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
+                                tc.function.name = repaired
                 invalid_tool_calls = [
                     tc.function.name for tc in assistant_message.tool_calls
                     if tc.function.name not in agent.valid_tool_names

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -123,6 +123,10 @@ def inject_memory_provider_tools(agent: Any) -> int:
     if valid_tool_names is None:
         valid_tool_names = set()
         agent.valid_tool_names = valid_tool_names
+    available_tool_names = getattr(agent, "available_tool_names", None)
+    if available_tool_names is None:
+        available_tool_names = set(valid_tool_names)
+        agent.available_tool_names = available_tool_names
 
     added = 0
     for raw_schema in get_schemas():
@@ -139,6 +143,7 @@ def inject_memory_provider_tools(agent: Any) -> int:
             continue
         tools.append({"type": "function", "function": schema})
         valid_tool_names.add(tool_name)
+        available_tool_names.add(tool_name)
         existing_tool_names.add(tool_name)
         added += 1
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -27,6 +27,11 @@ import json
 import os
 from typing import Any, Dict, List, Optional
 
+# ponytail: helper for tool-search deferred-tool awareness in guidance gates.
+# Falls back to valid_tool_names when available_tool_names isn't set (pre-patch).
+def _r_available_tool_names(agent: Any) -> set:
+    return getattr(agent, "available_tool_names", None) or getattr(agent, "valid_tool_names", set())
+
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
@@ -218,11 +223,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
-    if "memory" in agent.valid_tool_names:
+    if "memory" in _r_available_tool_names(agent):
         tool_guidance.append(MEMORY_GUIDANCE)
-    if "session_search" in agent.valid_tool_names:
+    if "session_search" in _r_available_tool_names(agent):
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
-    if "skill_manage" in agent.valid_tool_names:
+    if "skill_manage" in _r_available_tool_names(agent):
         tool_guidance.append(SKILLS_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
@@ -231,7 +236,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+    elif _kanban_guidance is None and "kanban_show" in _r_available_tool_names(agent):
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
@@ -246,11 +251,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # tool_guidance because the content is multi-paragraph. The guidance is
     # rendered for the host platform so Windows/Linux hosts don't see
     # macOS-only wording (Mac, Space, cmd+s).
-    if "computer_use" in agent.valid_tool_names:
+    if "computer_use" in _r_available_tool_names(agent):
         from agent.prompt_builder import computer_use_guidance
         stable_parts.append(computer_use_guidance())
 
-    nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
+    nous_subscription_prompt = _r.build_nous_subscription_prompt(_r_available_tool_names(agent))
     if nous_subscription_prompt:
         stable_parts.append(nous_subscription_prompt)
     # Tool-use enforcement: tells the model to actually call tools instead

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -263,6 +263,13 @@ def _tool_search_scoped_names(agent) -> frozenset:
     return names
 
 
+def _available_tool_names_for_dispatch(agent) -> list[str] | None:
+    names = getattr(agent, "available_tool_names", None)
+    if not names:
+        names = getattr(agent, "valid_tool_names", None)
+    return list(names) if names else None
+
+
 def _apply_tool_request_middleware_for_agent(
     agent,
     *,
@@ -1478,7 +1485,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     session_id=agent.session_id or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",
                     api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                    enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                    enabled_tools=_available_tool_names_for_dispatch(agent),
                     skip_pre_tool_call_hook=True,
                     skip_tool_request_middleware=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
@@ -1520,7 +1527,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     session_id=agent.session_id or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",
                     api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                    enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                    enabled_tools=_available_tool_names_for_dispatch(agent),
                     skip_pre_tool_call_hook=True,
                     skip_tool_request_middleware=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -306,7 +306,7 @@ def build_turn_context(
     # Track memory nudge trigger (turn-based, checked here).
     should_review_memory = False
     if (agent._memory_nudge_interval > 0
-            and "memory" in agent.valid_tool_names
+            and "memory" in (getattr(agent, "available_tool_names", None) or agent.valid_tool_names)
             and agent._memory_store):
         agent._turns_since_memory += 1
         if agent._turns_since_memory >= agent._memory_nudge_interval:

--- a/model_tools.py
+++ b/model_tools.py
@@ -276,6 +276,14 @@ def _clear_tool_defs_cache() -> None:
     _tool_defs_cache.clear()
 
 
+# ponytail: module-level hot-tools set, written when tool_call bridge
+# dispatches a deferred tool, read by get_tool_definitions → assemble_tool_defs.
+# Included in _tool_defs_cache key so promotion actually takes effect.
+# TODO: not gateway-safe — module-global shared across concurrent sessions.
+# For proper multi-session safety, move to agent-scoped state + cache key.
+_session_hot_tools: set = set()
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -323,6 +331,7 @@ def get_tool_definitions(
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
+            frozenset(_session_hot_tools),  # ponytail: hot-tools promotion
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -553,6 +562,7 @@ def _compute_tool_definitions(
                 filtered_tools,
                 context_length=context_length,
                 config=ts_cfg,
+                hot_tools=frozenset(_session_hot_tools),
             )
             if assembly.activated and not quiet_mode:
                 print(
@@ -1105,10 +1115,16 @@ def handle_function_call(
             return _ts_mod.dispatch_tool_search(function_args or {},
                                                 current_tool_defs=current_defs)
         if function_name == _ts_mod.TOOL_DESCRIBE_NAME:
+            _ts_cfg = _ts_mod.load_config()
             return _ts_mod.dispatch_tool_describe(function_args or {},
-                                                  current_tool_defs=current_defs)
+                                                  current_tool_defs=current_defs,
+                                                  config=_ts_cfg)
         if function_name == _ts_mod.TOOL_CALL_NAME:
-            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(function_args or {})
+            _ts_cfg = _ts_mod.load_config()
+            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(
+                function_args or {},
+                config=_ts_cfg,
+            )
             if err or not underlying_name:
                 return json.dumps({"error": err or "tool_call could not be resolved"},
                                   ensure_ascii=False)
@@ -1118,7 +1134,10 @@ def handle_function_call(
             # additionally rejects any tool the session was not granted, so a
             # restricted session can never invoke an out-of-scope tool through
             # the bridge even if the catalog scoping above regressed.
-            _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
+            _scoped_deferrable = _ts_mod.scoped_deferrable_names(
+                current_defs,
+                config=_ts_cfg,
+            )
             if underlying_name not in _scoped_deferrable:
                 return json.dumps({
                     "error": (
@@ -1126,6 +1145,10 @@ def handle_function_call(
                         "Use tool_search to find tools you can call."
                     ),
                 }, ensure_ascii=False)
+            # Hot-tools promotion: record this tool as hot so the next
+            # assembly re-inflates it into the direct array. Only grows.
+            global _session_hot_tools
+            _session_hot_tools.add(underlying_name)
             # Recurse with the underlying tool. All hooks fire against the
             # real tool name. The bridge is invisible to hooks by design.
             return handle_function_call(

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -45,6 +45,8 @@ class TestConfigParsing:
         cfg = ToolSearchConfig.from_raw(None)
         assert cfg.enabled == "auto"
         assert cfg.threshold_pct == 10.0
+        assert cfg.auto_token_threshold == 8_000
+        assert cfg.defer_core_tools is False  # conservative default: MCP-only
 
     def test_bool_true_maps_to_auto(self):
         from tools.tool_search import ToolSearchConfig
@@ -84,22 +86,55 @@ class TestConfigParsing:
 
 
 # ---------------------------------------------------------------------------
-# Classification — the hard invariant: core tools NEVER defer.
+# Classification — the hard invariant: deferral is explicit and scoped.
 # ---------------------------------------------------------------------------
 
 
 class TestClassification:
-    def test_core_tools_never_defer(self):
-        """The critical invariant from the OpenClaw report."""
-        from tools.tool_search import is_deferrable_tool_name
-        # Sample of core tools from _HERMES_CORE_TOOLS.
-        for core_name in ["terminal", "read_file", "write_file", "patch",
-                          "search_files", "todo", "memory", "browser_navigate",
-                          "web_search", "session_search", "clarify",
-                          "execute_code", "delegate_task", "send_message"]:
-            assert not is_deferrable_tool_name(core_name), (
-                f"Core tool '{core_name}' must NEVER be deferrable"
+    def test_only_allowlisted_core_tools_defer(self):
+        """Core deferral is allowlist-based, never an all-core blanket."""
+        from tools.tool_search import ToolSearchConfig, is_deferrable_tool_name
+        cfg = ToolSearchConfig.from_raw({"defer_core_tools": True})
+
+        for core_name in ["terminal", "patch", "memory", "browser_navigate",
+                          "session_search", "execute_code",
+                          "delegate_task"]:
+            assert is_deferrable_tool_name(core_name, config=cfg), (
+                f"Verbose core tool {core_name!r} should be eligible for deferral"
             )
+
+        for core_name in ["read_file", "write_file", "search_files", "todo",
+                          "web_search", "web_extract", "process", "clarify"]:
+            assert not is_deferrable_tool_name(core_name, config=cfg), (
+                f"Foundational core tool {core_name!r} should stay direct"
+            )
+
+    def test_core_deferral_can_be_disabled(self):
+        from tools.tool_search import ToolSearchConfig, is_deferrable_tool_name
+        cfg = ToolSearchConfig.from_raw({"defer_core_tools": False})
+        assert not is_deferrable_tool_name("terminal", config=cfg)
+
+    def test_core_deferral_disabled_by_default(self):
+        """Conservative default: auto mode defers only MCP, not core tools."""
+        from tools.tool_search import ToolSearchConfig, is_deferrable_tool_name
+        cfg = ToolSearchConfig.from_raw(None)  # default config
+        assert cfg.defer_core_tools is False
+        # Core tools should NOT be deferrable with default config
+        assert not is_deferrable_tool_name("terminal", config=cfg)
+        assert not is_deferrable_tool_name("memory", config=cfg)
+
+    def test_per_toolset_deferral_config(self):
+        """defer_toolsets config defers all tools in named toolsets."""
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({
+            "defer_toolsets": ["terminal", "browser"],
+        })
+        assert cfg.defer_toolsets == ("terminal", "browser")
+
+    def test_defer_toolsets_empty_by_default(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(None)
+        assert cfg.defer_toolsets == ()
 
     def test_bridge_tools_never_defer(self):
         from tools.tool_search import is_deferrable_tool_name, BRIDGE_TOOL_NAMES
@@ -151,8 +186,12 @@ class TestThresholdGate:
 
     def test_auto_below_threshold_does_not_activate(self):
         from tools.tool_search import ToolSearchConfig, should_activate
-        cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
-        # 5% of 200K = below 10% threshold
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "threshold_pct": 10,
+            "auto_token_threshold": 50_000,
+        })
+        # 5% of 200K = below the uncapped 10% threshold.
         assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
 
     def test_auto_at_or_above_threshold_activates(self):
@@ -165,8 +204,17 @@ class TestThresholdGate:
         """Fallback cutoff used when the active model is unknown."""
         from tools.tool_search import ToolSearchConfig, should_activate
         cfg = ToolSearchConfig.from_raw({"enabled": "auto"})
-        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=0)
-        assert should_activate(cfg, deferrable_tokens=25_000, context_length=0)
+        assert not should_activate(cfg, deferrable_tokens=7_000, context_length=0)
+        assert should_activate(cfg, deferrable_tokens=8_000, context_length=0)
+
+    def test_auto_threshold_is_capped_by_token_threshold(self):
+        from tools.tool_search import ToolSearchConfig, should_activate
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "threshold_pct": 10,
+            "auto_token_threshold": 8_000,
+        })
+        assert should_activate(cfg, deferrable_tokens=8_000, context_length=200_000)
 
     def test_token_estimate_proportional_to_schema_size(self):
         from tools.tool_search import estimate_tokens_from_schemas
@@ -241,14 +289,60 @@ class TestAssembly:
     def test_no_deferrable_returns_unchanged(self):
         """Pure-core toolset: pass-through, no bridge tools added."""
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig
-        defs = [_td("terminal", "Run shell"), _td("read_file", "Read a file")]
+        defs = [_td("read_file", "Read a file"), _td("write_file", "Write a file")]
         result = assemble_tool_defs(
             defs,
             context_length=200_000,
             config=ToolSearchConfig.from_raw({"enabled": "on"}),
         )
         assert not result.activated
-        assert {t["function"]["name"] for t in result.tool_defs} == {"terminal", "read_file"}
+        assert {t["function"]["name"] for t in result.tool_defs} == {"read_file", "write_file"}
+
+    def test_verbose_core_tools_defer_when_gate_activates(self):
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+        defs = [
+            _td("read_file", "Read a file"),
+            _td("terminal", "Run shell commands " * 200),
+            _td("memory", "Persistent memory " * 200),
+        ]
+        result = assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({
+                "enabled": "on",
+                "defer_core_tools": True,
+            }),
+        )
+        assert result.activated
+        names = {t["function"]["name"] for t in result.tool_defs}
+        assert "read_file" in names
+        assert "terminal" not in names
+        assert "memory" not in names
+        assert {"tool_search", "tool_describe", "tool_call"}.issubset(names)
+
+    def test_hot_tools_promotion_keeps_tool_direct(self):
+        """Hot-tools promotion: a deferred tool in the hot set stays direct."""
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig
+        defs = [
+            _td("read_file", "Read a file"),
+            _td("terminal", "Run shell commands " * 200),
+            _td("memory", "Persistent memory " * 200),
+        ]
+        result = assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({
+                "enabled": "on",
+                "defer_core_tools": True,
+            }),
+            hot_tools=frozenset({"terminal"}),
+        )
+        assert result.activated
+        names = {t["function"]["name"] for t in result.tool_defs}
+        assert "read_file" in names
+        assert "terminal" in names  # hot — stays direct
+        assert "memory" not in names  # still deferred
+        assert {"tool_search", "tool_describe", "tool_call"}.issubset(names)
 
     def test_below_threshold_returns_unchanged(self):
         """Tiny deferrable surface: don't bother."""
@@ -296,11 +390,11 @@ class TestBridgeDispatch:
         assert "error" in json.loads(result)
 
     def test_tool_describe_rejects_non_deferrable(self):
-        """If the model asks to describe a core tool, refuse — it's already
+        """If the model asks to describe a direct tool, refuse — it's already
         in the visible list."""
         from tools.tool_search import dispatch_tool_describe
         result = dispatch_tool_describe(
-            {"name": "terminal"}, current_tool_defs=[_td("terminal", "Run shell")],
+            {"name": "read_file"}, current_tool_defs=[_td("read_file", "Read a file")],
         )
         assert "error" in json.loads(result)
 
@@ -372,45 +466,37 @@ class TestRegression_OpenClawCron84141:
     resulted in the agent receiving only ``sessions_send`` — the catalog
     builder silently dropped the requested core tool.
 
-    Our defense: core tools are NEVER deferred. This test exercises the
-    full assembly pipeline with a mixed core+MCP toolset and asserts that
-    every core tool survives.
+    Our defense: unknown tools and direct-core tools are never deferred or
+    dropped. This test exercises the full assembly pipeline and asserts that
+    the direct core substrate survives.
     """
 
-    def test_core_tool_survives_alongside_many_mcp_tools(self):
+    def test_direct_core_tool_survives_alongside_many_mcp_tools(self):
         from tools.tool_search import (
-            assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES,
+            assemble_tool_defs, ToolSearchConfig,
             classify_tools,
         )
-        # 1 core tool + 50 unknown/MCP-shaped tools (deferrable).
-        defs = [_td("terminal", "Run shell commands")]
-        # Pad with fake "deferrable" tools — without registry registration,
-        # classify_tools puts them in 'visible'. So instead, we just verify
-        # the core-tool side: terminal stays in visible regardless.
+        defs = [_td("read_file", "Read files")]
         visible, deferrable = classify_tools(defs)
         assert any(
-            (td.get("function") or {}).get("name") == "terminal"
+            (td.get("function") or {}).get("name") == "read_file"
             for td in visible
-        ), "Core tool 'terminal' was wrongly classified as deferrable"
+        ), "Direct core tool 'read_file' was wrongly classified as deferrable"
 
-        # Now force activation and check the resulting tool-defs list.
         result = assemble_tool_defs(
             defs,
             context_length=200_000,
             config=ToolSearchConfig.from_raw({"enabled": "on"}),
         )
         names = {(t.get("function") or {}).get("name") for t in result.tool_defs}
-        # terminal must be present; bridges are only added if there are
-        # deferrable tools to put behind them.
-        assert "terminal" in names
+        assert "read_file" in names
 
-    def test_unwrap_rejects_core_tool_attempt(self):
-        """Even if the model tries to invoke a core tool through tool_call,
-        we reject the call and tell the model to use it directly."""
+    def test_unwrap_rejects_direct_core_tool_attempt(self):
+        """Direct core tools should still be called directly."""
         from tools.tool_search import resolve_underlying_call
         _, _, err = resolve_underlying_call({
-            "name": "terminal",
-            "arguments": {"command": "echo hi"},
+            "name": "read_file",
+            "arguments": {"path": "README.md"},
         })
         assert err is not None
         assert "not a deferrable" in err
@@ -533,6 +619,5 @@ class TestRegression_ToolsetScoping:
         )
         names = scoped_deferrable_names(defs)
         assert "mcp_helper_op" in names
-        # core tools are never deferrable
-        assert "terminal" not in names
+        assert "read_file" not in names
 

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1,17 +1,18 @@
 """Progressive tool disclosure ("tool search") for Hermes Agent.
 
-When enabled, MCP and non-core plugin tools are replaced in the model-visible
-tools array by three bridge tools — ``tool_search``, ``tool_describe``,
-``tool_call`` — and surfaced on demand. Core Hermes tools never defer.
+When enabled, MCP, non-core plugin tools, and selected verbose Hermes built-ins
+are replaced in the model-visible tools array by three bridge tools —
+``tool_search``, ``tool_describe``, ``tool_call`` — and surfaced on demand.
 
 Design constraints this module is built around (see ``openclaw-tool-search-report``
 for the full rationale):
 
-* Core tools defined in ``toolsets._HERMES_CORE_TOOLS`` are *never* deferred.
-  Always-load means always-load. No exceptions.
-* The threshold gate runs every assembly: when deferrable tools would consume
-  less than ``threshold_pct`` of the model's context window (default 10%),
-  tool search is a no-op and the tools array passes through unchanged.
+* Only an explicit allowlist of verbose core tools may defer. Cheap
+  foundational tools stay direct, and unknown tools are never silently dropped.
+* The threshold gate runs every assembly: when deferrable tools are below the
+  configured auto threshold (context percentage capped by a fixed token
+  ceiling), tool search is a no-op and the tools array passes through
+  unchanged.
 * The catalog is stateless across turns and tools-array assemblies. It is
   rebuilt from the current tool-defs list every time. This is the lesson
   from OpenClaw's cron regression (openclaw/openclaw#84141): a session-keyed
@@ -55,6 +56,52 @@ BRIDGE_TOOL_NAMES = frozenset({TOOL_SEARCH_NAME, TOOL_DESCRIBE_NAME, TOOL_CALL_N
 CHARS_PER_TOKEN = 4.0
 
 
+# Core tools whose schemas are large enough to justify progressive disclosure.
+# The always-direct core remains the substrate a model commonly needs without a
+# discovery hop: web search/extract, basic file reads/writes/search, process
+# inspection, todo, and GUI terminal-tab helpers. Everything here is still in
+# the session's scope; the bridge only moves its verbose schema behind
+# tool_search/tool_describe/tool_call.
+DEFAULT_DEFERRABLE_CORE_TOOLS = frozenset({
+    "terminal",
+    "patch",
+    "vision_analyze",
+    "image_generate",
+    "browser_navigate",
+    "browser_snapshot",
+    "browser_click",
+    "browser_type",
+    "browser_scroll",
+    "browser_back",
+    "browser_press",
+    "browser_get_images",
+    "browser_vision",
+    "browser_console",
+    "browser_cdp",
+    "browser_dialog",
+    "text_to_speech",
+    "memory",
+    "session_search",
+    "execute_code",
+    "delegate_task",
+    "cronjob",
+    "ha_list_entities",
+    "ha_get_state",
+    "ha_list_services",
+    "ha_call_service",
+    "kanban_show",
+    "kanban_list",
+    "kanban_complete",
+    "kanban_block",
+    "kanban_heartbeat",
+    "kanban_comment",
+    "kanban_create",
+    "kanban_link",
+    "kanban_unblock",
+    "computer_use",
+})
+
+
 # ---------------------------------------------------------------------------
 # Configuration plumbing
 # ---------------------------------------------------------------------------
@@ -66,8 +113,11 @@ class ToolSearchConfig:
 
     enabled: str  # "auto" | "on" | "off"
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
+    auto_token_threshold: int
     search_default_limit: int
     max_search_limit: int
+    defer_core_tools: bool
+    defer_toolsets: tuple  # toolset names whose tools should be deferred
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -81,13 +131,19 @@ class ToolSearchConfig:
         """
         if raw is True:
             return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       auto_token_threshold=8_000,
+                       search_default_limit=5, max_search_limit=20,
+                       defer_core_tools=False, defer_toolsets=())
         if raw is False:
             return cls(enabled="off", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       auto_token_threshold=8_000,
+                       search_default_limit=5, max_search_limit=20,
+                       defer_core_tools=False, defer_toolsets=())
         if not isinstance(raw, dict):
             return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       auto_token_threshold=8_000,
+                       search_default_limit=5, max_search_limit=20,
+                       defer_core_tools=False, defer_toolsets=())
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
         if enabled_raw in ("true", "1", "yes"):
@@ -101,16 +157,31 @@ class ToolSearchConfig:
 
         threshold_pct = _safe_float(raw.get("threshold_pct"), 10.0)
         threshold_pct = max(0.0, min(100.0, threshold_pct))
+        auto_token_threshold = max(1_000, min(
+            100_000,
+            _safe_int(raw.get("auto_token_threshold"), 8_000),
+        ))
 
         max_search_limit = max(1, min(50, _safe_int(raw.get("max_search_limit"), 20)))
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
+        defer_core_tools = _safe_bool(raw.get("defer_core_tools"), False)
+
+        # Parse defer_toolsets: a list of toolset names whose tools should defer.
+        _raw_defer_ts = raw.get("defer_toolsets")
+        if isinstance(_raw_defer_ts, (list, tuple)):
+            defer_toolsets = tuple(str(s).strip() for s in _raw_defer_ts if str(s).strip())
+        else:
+            defer_toolsets = ()
 
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
+            auto_token_threshold=auto_token_threshold,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
+            defer_core_tools=defer_core_tools,
+            defer_toolsets=defer_toolsets,
         )
 
 
@@ -126,6 +197,19 @@ def _safe_float(value: Any, fallback: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return fallback
+
+
+def _safe_bool(value: Any, fallback: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return fallback
+    raw = str(value).strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return fallback
 
 
 def load_config() -> ToolSearchConfig:
@@ -160,18 +244,30 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
-def is_deferrable_tool_name(name: str) -> bool:
+def is_deferrable_tool_name(name: str, config: Optional[ToolSearchConfig] = None) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
-    A tool is deferrable iff it is registered with an MCP toolset prefix
-    OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
-    even when their toolset is technically plugin-provided (this protects
-    against accidental shadowing).
+    A tool is deferrable iff it is registered with an MCP toolset prefix, is
+    not in ``_HERMES_CORE_TOOLS``, or is an explicitly allowed verbose core
+    tool and core deferral is enabled. Core tools outside the allowlist are
+    always direct, even when their schema is large.
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
+    if config is None:
+        config = load_config()
     if name in _core_tool_names():
-        return False
+        # Check toolset-based deferral first (per-toolset config)
+        if config.defer_toolsets:
+            try:
+                from tools.registry import registry
+                entry = registry.get_entry(name)
+                if entry is not None and entry.toolset in config.defer_toolsets:
+                    return True
+            except Exception:
+                pass
+        # Fallback to per-tool allowlist when defer_core_tools is enabled
+        return bool(config.defer_core_tools and name in DEFAULT_DEFERRABLE_CORE_TOOLS)
     # Check registry toolset for MCP prefix.
     try:
         from tools.registry import registry
@@ -186,7 +282,10 @@ def is_deferrable_tool_name(name: str) -> bool:
         return False
 
 
-def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def classify_tools(
+    tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
     ``visible`` retains every tool that must stay in the model-facing array:
@@ -195,6 +294,8 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
     """
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
+    if config is None:
+        config = load_config()
     for td in tool_defs:
         fn = td.get("function") or {}
         name = fn.get("name", "")
@@ -202,7 +303,7 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
             # Should never happen — bridge tools are added after classification —
             # but be defensive.
             continue
-        if is_deferrable_tool_name(name):
+        if is_deferrable_tool_name(name, config=config):
             deferrable.append(td)
         else:
             visible.append(td)
@@ -250,12 +351,36 @@ def should_activate(
     if config.enabled == "on":
         return True
     # auto
-    if not context_length or context_length <= 0:
-        # Without a known context size, fall back to a fixed 20K-token cutoff
-        # — the cliff above which Anthropic and OpenAI both saw quality drops.
-        return deferrable_tokens >= 20_000
-    threshold_tokens = int(context_length * (config.threshold_pct / 100.0))
+    threshold_tokens = auto_threshold_tokens(config, context_length)
     return deferrable_tokens >= threshold_tokens
+
+
+def auto_threshold_tokens(config: ToolSearchConfig, context_length: Optional[int]) -> int:
+    """Return the token threshold for ``auto`` activation.
+
+    ``auto_token_threshold`` is the primary knob — a fixed absolute token
+    budget that applies regardless of context window size. This is correct
+    because the cost of a bloated tools array is roughly context-independent:
+    it's paid every turn regardless of window size, and it poisons the prompt
+    cache prefix identically.
+
+    ``threshold_pct`` is a secondary clamp for short-context models where
+    the percentage threshold would be *lower* than the absolute threshold
+    (e.g. a 16K-context model with threshold_pct=10 = 1,600 tokens, which
+    is below the 8K default). For large-context models (1M tokens), the
+    absolute threshold dominates and the percentage is irrelevant.
+
+    When ``threshold_pct == 0``, gating is purely token-threshold-based.
+    """
+    if not context_length or context_length <= 0:
+        return config.auto_token_threshold
+    if config.threshold_pct <= 0:
+        # Pure token-threshold mode — percentage gate disabled.
+        return config.auto_token_threshold
+    pct_threshold = int(context_length * (config.threshold_pct / 100.0))
+    # Take the MIN: short-context models get the lower (percentage) gate,
+    # large-context models get capped by the absolute threshold.
+    return max(1, min(pct_threshold, config.auto_token_threshold))
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +431,13 @@ def _entry_search_text(td: Dict[str, Any]) -> str:
 
 def _classify_source(name: str) -> Tuple[str, str]:
     """Return (source_kind, source_name) for a registered tool name."""
+    if name in _core_tool_names():
+        try:
+            from tools.registry import registry
+            entry = registry.get_entry(name)
+            return ("core", entry.toolset if entry is not None else "core")
+        except Exception:
+            return ("core", "core")
     try:
         from tools.registry import registry
         entry = registry.get_entry(name)
@@ -531,6 +663,7 @@ def assemble_tool_defs(
     *,
     context_length: Optional[int] = None,
     config: Optional[ToolSearchConfig] = None,
+    hot_tools: Optional[frozenset] = None,
 ) -> AssemblyResult:
     """Return the tool-defs list the model should actually see.
 
@@ -538,6 +671,11 @@ def assemble_tool_defs(
     threshold), this is a passthrough. When active, MCP and plugin tools
     are stripped from the visible list and replaced with the three bridge
     tools. Core tools are *never* deferred regardless of config.
+
+    Hot-tools promotion: tools in ``hot_tools`` are re-inflated into the
+    direct array even if they would otherwise be deferred. This set should
+    only grow within a session (never shrink) to preserve prompt cache
+    stability — see system_prompt.py module docstring.
 
     Idempotent: calling with bridge tools already in the input is a no-op
     (they classify as non-core/non-deferrable but their names are reserved,
@@ -551,33 +689,54 @@ def assemble_tool_defs(
     incoming = [td for td in tool_defs
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
-    visible, deferrable = classify_tools(incoming)
+    visible, deferrable = classify_tools(incoming, config=config)
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 
-    deferrable_tokens = estimate_tokens_from_schemas(deferrable)
+    hidden_names: set[str] = set()
+    hidden_defs: List[Dict[str, Any]] = []
+    _hot = hot_tools or frozenset()
+    for td in deferrable:
+        name = (td.get("function") or {}).get("name", "")
+        source, _ = _classify_source(name)
+        # Keep plugin tools directly visible when tool_search activates.
+        if source == "plugin":
+            continue
+        # Hot-tools promotion: keep recently-used tools direct.
+        if name in _hot:
+            continue
+        hidden_names.add(name)
+        hidden_defs.append(td)
+
+    if not hidden_defs:
+        return AssemblyResult(tool_defs=incoming, activated=False)
+
+    deferrable_tokens = estimate_tokens_from_schemas(hidden_defs)
     if not should_activate(config, deferrable_tokens, context_length):
         return AssemblyResult(
             tool_defs=incoming,
             activated=False,
-            deferred_count=len(deferrable),
+            deferred_count=len(hidden_defs),
             deferred_tokens=deferrable_tokens,
-            threshold_tokens=int((context_length or 0) * (config.threshold_pct / 100.0)),
+            threshold_tokens=auto_threshold_tokens(config, context_length),
         )
 
     bridge = bridge_tool_schemas(len(deferrable))
-    result = visible + bridge
-    threshold_tokens = int((context_length or 0) * (config.threshold_pct / 100.0))
+    result = [
+        td for td in incoming
+        if (td.get("function") or {}).get("name") not in hidden_names
+    ] + bridge
+    threshold_tokens = auto_threshold_tokens(config, context_length)
 
     logger.info(
         "tool_search activated: %d core/visible tools kept, %d deferred (~%d tokens, threshold ~%d)",
-        len(visible), len(deferrable), deferrable_tokens, threshold_tokens,
+        len(result) - len(bridge), len(hidden_defs), deferrable_tokens, threshold_tokens,
     )
 
     return AssemblyResult(
         tool_defs=result,
         activated=True,
-        deferred_count=len(deferrable),
+        deferred_count=len(hidden_defs),
         deferred_tokens=deferrable_tokens,
         threshold_tokens=threshold_tokens,
     )
@@ -586,8 +745,6 @@ def assemble_tool_defs(
 # ---------------------------------------------------------------------------
 # Bridge tool dispatch
 # ---------------------------------------------------------------------------
-
-
 def is_bridge_tool(name: str) -> bool:
     return name in BRIDGE_TOOL_NAMES
 
@@ -619,7 +776,7 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config=config)
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
     return json.dumps({
@@ -631,19 +788,22 @@ def dispatch_tool_search(args: Dict[str, Any],
 
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
-                           current_tool_defs: List[Dict[str, Any]]) -> str:
+                           current_tool_defs: List[Dict[str, Any]],
+                           config: Optional[ToolSearchConfig] = None) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
     name = str(args.get("name") or "").strip()
     if not name:
         return json.dumps({"error": "name is required"}, ensure_ascii=False)
-    if not is_deferrable_tool_name(name):
+    if config is None:
+        config = load_config()
+    if not is_deferrable_tool_name(name, config=config):
         return json.dumps({
             "error": (
                 f"'{name}' is not a deferrable tool. If you see it in the tools list "
                 "already, call it directly; otherwise check the spelling against tool_search."
             ),
         }, ensure_ascii=False)
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config=config)
     for td in deferrable:
         fn = td.get("function") or {}
         if fn.get("name") == name:
@@ -657,7 +817,10 @@ def dispatch_tool_describe(args: Dict[str, Any],
     }, ensure_ascii=False)
 
 
-def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
+def scoped_deferrable_names(
+    tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> frozenset[str]:
     """Return the set of deferrable tool names present in ``tool_defs``.
 
     ``tool_defs`` is expected to be the *pre-assembly* tool list for the
@@ -670,14 +833,19 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     an out-of-scope tool via the bridge.
     """
     names: set[str] = set()
+    if config is None:
+        config = load_config()
     for td in tool_defs:
         name = (td.get("function") or {}).get("name", "")
-        if name and is_deferrable_tool_name(name):
+        if name and is_deferrable_tool_name(name, config=config):
             names.add(name)
     return frozenset(names)
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(
+    args: Dict[str, Any],
+    config: Optional[ToolSearchConfig] = None,
+) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -702,7 +870,9 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
+    if config is None:
+        config = load_config()
+    if not is_deferrable_tool_name(name, config=config):
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."
@@ -723,6 +893,8 @@ __all__ = [
     "classify_tools",
     "estimate_tokens_from_schemas",
     "should_activate",
+    "auto_threshold_tokens",
+    "DEFAULT_DEFERRABLE_CORE_TOOLS",
     "build_catalog",
     "search_catalog",
     "bridge_tool_schemas",


### PR DESCRIPTION
## What

Extends Tool Search (progressive tool disclosure) to allow verbose built-in Hermes tools to defer behind the `tool_search`/`tool_describe`/`tool_call` bridge — same mechanism that already works for MCP/plugin tools. Adds per-toolset deferral config, conservative MCP-only `auto` default, absolute token threshold as primary gate, and hot-tools promotion (LRU re-inflation of recently-used deferred tools).

## The Problem

Hermes injects full JSON schemas for ALL enabled tools on every API call. With 34 tools active on a typical Telegram session, that's **~58.4KB / ~14,700 tokens of tool schemas per turn** — 49% of the total context. Pure overhead for conversational turns. The model doesn't need `delegate_task`'s 1,925-token schema when the user just says "hello."

Tool Search already defers MCP/plugin tools behind the bridge, but core tools are hardcoded as **never deferrable** (`is_deferrable_tool_name` returns `False` for anything in `_HERMES_CORE_TOOLS`). This makes the feature a near no-op for MCP-light installs — exactly where the built-in schemas are the entire entry tax.

## What This PR Does

### 1. Verbose core tool deferral (the main fix)
Adds `DEFAULT_DEFERRABLE_CORE_TOOLS` — an allowlist of verbose core tools eligible for deferral. Foundational tools (`read_file`, `write_file`, `search_files`, `web_search`, `web_extract`, `process`, `todo`, `clarify`) stay always direct.

**Deferred behind the bridge:** `terminal`, `patch`, `memory`, `session_search`, `execute_code`, `delegate_task`, `cronjob`, `browser_*`, `vision_analyze`, `image_generate`, `text_to_speech`, `computer_use`, kanban tools, HA tools.

Gated by `tools.tool_search.defer_core_tools: true` (default: `false` — conservative).

### 2. Conservative `auto` default (MCP-only)
`defer_core_tools` defaults to `false`. New users get MCP-only deferral in `auto` mode — core tools stay direct unless explicitly opted in. This is safe-by-default and still captures most of the token win (MCP servers are where runaway schemas live).

### 3. Absolute token threshold as primary knob
`auto_token_threshold` (default: 8000) is the primary gate. `threshold_pct` becomes a secondary clamp for short-context models. `threshold_pct=0` means pure token-threshold mode. A 1M-context model with 15K of MCP schema still defers — the window has room, but the model doesn't need 15K of schema on a "hello" turn, and it wrecks cache reuse.

### 4. Per-toolset deferral config
New `defer_toolsets` config key: `defer_toolsets: [browser, kanban, home_assistant]` defers all tools in those toolsets. Cleaner than per-tool allowlists and auto-covers new tools added to a toolset.

### 5. Hot-tools promotion (LRU re-inflation)
When a deferred tool is invoked via `tool_call`, it's recorded as "hot" and re-inflated into the direct array on the next assembly. The set only grows within a session (never shrinks) to preserve prompt cache stability. Included in `_tool_defs_cache` key so promotion actually takes effect.

**TODO:** Not gateway-safe — module-global `_session_hot_tools` is shared across concurrent sessions. For proper multi-session safety, move to agent-scoped state.

### 6. System-prompt guidance gates fixed
Guidance gates for `memory`, `session_search`, `skill_manage`, `kanban_show`, `computer_use`, and `nous_subscription` now check `available_tool_names` (the superset including deferred tools) instead of `valid_tool_names` (which excludes them). Without this, deferred tools lose their system-prompt guidance — maximally hard to discover.

### 7. Auto-route direct calls to deferred tools
When the model calls a deferred tool by name directly (e.g. `terminal(...)`), `conversation_loop.py` transparently rewrites it to `tool_call(name="terminal", arguments={...})` instead of returning "Unknown tool." `repair_tool_call` also resolves near-miss deferred names (casing variants, suffixes) and bridges them.

## Measured Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Tool schemas | 58.4 KB (34 tools) | 27.2 KB (29 tools) | **−53%** |
| Tests | 39 | 46 + 29 = 75 | All pass |

## Config

```yaml
tools:
  tool_search:
    enabled: on                # auto, on, or off
    threshold_pct: 10           # secondary clamp for short-context models
    auto_token_threshold: 8000  # primary knob — absolute token budget
    defer_core_tools: true      # opt-in: allow verbose built-ins to defer
    defer_toolsets: [browser]   # per-toolset deferral (optional)
    search_default_limit: 5
    max_search_limit: 20
```

## Files Changed (10)

| File | What |
|------|------|
| `tools/tool_search.py` | Allowlist + config fields + config-aware classification + hot-tools + auto_threshold_tokens |
| `model_tools.py` | Config-aware bridge dispatch + _session_hot_tools + cache key |
| `agent/agent_init.py` | available_tool_names tracking + hot-tools reset |
| `agent/system_prompt.py` | Guidance gates → available_tool_names |
| `agent/turn_context.py` | Memory nudge gate → available_tool_names |
| `agent/conversation_loop.py` | Auto-route deferred tool calls through bridge |
| `agent/agent_runtime_helpers.py` | repair_tool_call valid-first matching + enabled_tools routing |
| `agent/tool_executor.py` | _available_tool_names_for_dispatch helper |
| `agent/memory_manager.py` | Sync available_tool_names with memory provider tools |
| `tests/tools/test_tool_search.py` | 7 new tests, updated classification/regression tests |

## Design Review

This patch was reviewed by Claude Opus across 3 rounds:
- **Round 1:** Found 2 ship-blocking bugs (guidance gates, direct-call hallucination) + recommended removing `clarify` from allowlist
- **Round 2:** Found 2 bugs in the fixes (repair returning deferred names that fail validation, uncaught JSON parse in auto-route)
- **Round 3:** Approved improvements 1–3, identified hot-tools promotion cache-key defect (fixed) and gateway-safety limitation (documented as TODO)

All findings addressed. 75/75 tests pass.

## Related

- Addresses #6839 (master issue, 16 👍, open since Apr 2026)
- Builds on #58838, #43521, #45147, #60182, #35457
- Refs #13983, #57044

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update (docstrings + config examples)
- [x] ✅ Tests (7 new tests, updated existing)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run pytest tests/tools/test_tool_search.py -q → 46 passed
- [x] I've run pytest tests/run_agent/test_repair_tool_call_name.py -q → 29 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu 6.8.0-134-generic)
- [x] I've updated relevant docstrings
- [x] I've considered cross-platform impact — pure Python config/logic, no OS-specific paths