### PR TITLE
fix(agent): raise on failed Copilot ACP prompt turns so quota exhaustion triggers fallback

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -59,6 +59,44 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
     return any(marker in lower for marker in _DEPRECATION_MARKERS)
 
 
+# The Copilot ACP server reports backend failures (monthly quota exhaustion,
+# entitlement problems) as a *successful* ``session/prompt`` turn: the error
+# text is streamed like a normal agent_message_chunk and the turn ends with
+# ``stopReason: "refusal"`` — not with a JSON-RPC error response.  GitHub's
+# own ACP integration example treats any ``stopReason`` other than
+# ``end_turn`` as the failure path.  If Hermes returns that text as an
+# ordinary assistant message, the conversation loop never sees an exception,
+# ``classify_api_error()`` never runs, and ``fallback_providers`` never
+# activate — the raw quota error is delivered to the user as the agent's
+# reply.  ``max_tokens`` / ``max_turn_requests`` / ``cancelled`` still carry
+# legitimate partial output and are NOT treated as failures.  (issue #63815)
+_REFUSAL_STOP_REASON = "refusal"
+
+# Copilot backend error lines have a stable shape:
+#   Error: You have exceeded your monthly quota (Request ID: A540:22A007:...)
+# Matched against the ENTIRE stripped response, so a legitimate answer that
+# merely quotes such a line inside longer prose can never trip it.  This
+# catches CLI builds that stream the backend error but still end the turn
+# with ``end_turn`` instead of ``refusal``.
+_BACKEND_ERROR_RESPONSE_RE = re.compile(
+    r"error:\s+\S.{0,2000}\(request id:\s*[0-9a-f:]+\)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _failed_prompt_turn_detail(stop_reason: str, response_text: str) -> str | None:
+    """Return error detail for a failed prompt turn, or ``None`` on success."""
+
+    text = (response_text or "").strip()
+    if stop_reason == _REFUSAL_STOP_REASON:
+        if text:
+            return f"turn ended with stopReason={stop_reason!r}: {text[:2000]}"
+        return f"turn ended with stopReason={stop_reason!r} and no content"
+    if text and _BACKEND_ERROR_RESPONSE_RE.fullmatch(text):
+        return text
+    return None
+
+
 def _resolve_command() -> str:
     return (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
@@ -643,7 +681,7 @@ class CopilotACPClient:
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []
-            _request(
+            prompt_result = _request(
                 "session/prompt",
                 {
                     "sessionId": session_id,
@@ -657,7 +695,19 @@ class CopilotACPClient:
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
             )
-            return "".join(text_parts), "".join(reasoning_parts)
+            stop_reason = ""
+            if isinstance(prompt_result, dict):
+                stop_reason = str(prompt_result.get("stopReason") or "").strip()
+            response_text = "".join(text_parts)
+            failure_detail = _failed_prompt_turn_detail(stop_reason, response_text)
+            if failure_detail is not None:
+                # Raise instead of returning the error text as the answer so
+                # the conversation loop's classifier can route it (billing /
+                # rate-limit) and activate fallback_providers.  (issue #63815)
+                raise RuntimeError(
+                    f"Copilot ACP session/prompt failed: {failure_detail}"
+                )
+            return response_text, "".join(reasoning_parts)
         finally:
             self.close()
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -312,3 +312,137 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+# ── Failed prompt-turn detection (issue #63815) ──────────────────────
+#
+# The Copilot ACP server reports quota exhaustion by streaming the backend
+# error text as a normal agent_message_chunk and ending the turn with
+# stopReason "refusal" — not with a JSON-RPC error.  Before the fix the
+# client returned that text as the assistant's answer, so the conversation
+# loop never classified the failure and fallback_providers never activated.
+
+from agent.copilot_acp_client import _failed_prompt_turn_detail
+
+_QUOTA_LINE = (
+    "Error: You have exceeded your monthly quota "
+    "(Request ID: A540:22A007:3849658:44F52D9:6A541F53)"
+)
+
+
+class _ScriptedACPProcess:
+    """Fake `copilot --acp` subprocess with a pre-scripted stdout dialogue."""
+
+    def __init__(self, script: list[dict]) -> None:
+        self.stdin = io.StringIO()
+        self.stdout = io.StringIO(
+            "".join(json.dumps(msg) + "\n" for msg in script)
+        )
+        self.stderr = io.StringIO()
+        self.pid = 4242
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+def _scripted_prompt_turn(*, chunks: list[str], stop_reason: str) -> list[dict]:
+    """JSON-RPC script for initialize → session/new → session/prompt."""
+    script = [
+        {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": 1}},
+        {"jsonrpc": "2.0", "id": 2, "result": {"sessionId": "sess-1"}},
+    ]
+    for chunk in chunks:
+        script.append(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": chunk},
+                    }
+                },
+            }
+        )
+    script.append({"jsonrpc": "2.0", "id": 3, "result": {"stopReason": stop_reason}})
+    return script
+
+
+def _run_scripted_completion(tmp_path, script: list[dict]):
+    client = _make_home_client(tmp_path)
+    with _patch(
+        "agent.copilot_acp_client.subprocess.Popen",
+        return_value=_ScriptedACPProcess(script),
+    ):
+        return client._create_chat_completion(
+            model="copilot-acp",
+            messages=[{"role": "user", "content": "hello"}],
+            timeout=5,
+        )
+
+
+def test_refusal_turn_with_quota_error_raises(tmp_path):
+    script = _scripted_prompt_turn(chunks=[_QUOTA_LINE], stop_reason="refusal")
+    with pytest.raises(RuntimeError, match="exceeded your monthly quota"):
+        _run_scripted_completion(tmp_path, script)
+
+
+def test_end_turn_with_bare_backend_error_raises(tmp_path):
+    """CLI builds that end the error turn with end_turn are still caught."""
+    script = _scripted_prompt_turn(chunks=[_QUOTA_LINE], stop_reason="end_turn")
+    with pytest.raises(RuntimeError, match="exceeded your monthly quota"):
+        _run_scripted_completion(tmp_path, script)
+
+
+def test_refusal_turn_without_content_raises(tmp_path):
+    script = _scripted_prompt_turn(chunks=[], stop_reason="refusal")
+    with pytest.raises(RuntimeError, match="stopReason='refusal' and no content"):
+        _run_scripted_completion(tmp_path, script)
+
+
+def test_normal_turn_still_returns_text(tmp_path):
+    script = _scripted_prompt_turn(chunks=["Hello ", "from ACP"], stop_reason="end_turn")
+    response = _run_scripted_completion(tmp_path, script)
+    assert response.choices[0].message.content == "Hello from ACP"
+    assert response.choices[0].finish_reason == "stop"
+
+
+def test_error_line_quoted_inside_longer_answer_is_not_flagged(tmp_path):
+    """A legitimate answer that merely quotes an error line must pass through."""
+    answer = (
+        "That message — "
+        f"{_QUOTA_LINE} — means your Copilot plan ran out for the month."
+    )
+    script = _scripted_prompt_turn(chunks=[answer], stop_reason="end_turn")
+    response = _run_scripted_completion(tmp_path, script)
+    assert response.choices[0].message.content == answer
+
+
+def test_failed_turn_detail_ignores_partial_output_stop_reasons():
+    # max_tokens / max_turn_requests / cancelled carry legitimate partial
+    # output and must not be converted into errors.
+    assert _failed_prompt_turn_detail("max_tokens", "partial answer") is None
+    assert _failed_prompt_turn_detail("max_turn_requests", "partial") is None
+    assert _failed_prompt_turn_detail("cancelled", "partial") is None
+    assert _failed_prompt_turn_detail("end_turn", "normal answer") is None
+
+
+def test_quota_refusal_classifies_as_billing_with_fallback():
+    """Contract with the error classifier: the raised message must route to
+    billing/should_fallback so the conversation loop activates the chain."""
+    from agent.error_classifier import FailoverReason, classify_api_error
+
+    detail = _failed_prompt_turn_detail("refusal", _QUOTA_LINE)
+    err = RuntimeError(f"Copilot ACP session/prompt failed: {detail}")
+    classified = classify_api_error(err, provider="copilot-acp", model="auto")
+    assert classified.reason == FailoverReason.billing
+    assert classified.should_fallback is True

--- a/tests/run_agent/test_copilot_acp_quota_fallback.py
+++ b/tests/run_agent/test_copilot_acp_quota_fallback.py
@@ -1,0 +1,109 @@
+"""Regression test for #63815: copilot-acp quota exhaustion must activate
+the fallback provider chain.
+
+The Copilot ACP server reports monthly-quota exhaustion by streaming the
+backend error text as a normal message chunk and ending the turn with
+stopReason "refusal".  agent/copilot_acp_client.py converts such turns into
+a RuntimeError; this test pins the rest of the chain — classification as
+billing and eager fallback activation in the conversation loop — so the
+configured fallback provider answers instead of the raw error being
+returned to the user.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+_QUOTA_ERROR = RuntimeError(
+    "Copilot ACP session/prompt failed: turn ended with stopReason='refusal': "
+    "Error: You have exceeded your monthly quota "
+    "(Request ID: A540:22A007:3849658:44F52D9:6A541F53)"
+)
+
+
+def _make_copilot_acp_agent(fb_chain):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key="copilot-acp",
+            base_url="acp://copilot",
+            provider="copilot-acp",
+            model="auto",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fb_chain,
+        )
+        return agent
+
+
+def _mock_response(content: str):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="fallback/model", usage=None)
+
+
+class TestCopilotACPQuotaFallback:
+    def test_quota_refusal_activates_fallback_chain(self):
+        fb_chain = [
+            {
+                "provider": "openrouter",
+                "model": "deepseek/deepseek-v4-flash",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        ]
+        agent = _make_copilot_acp_agent(fb_chain)
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = _QUOTA_ERROR
+        agent.client = primary_client
+
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://openrouter.ai/api/v1"
+        fallback_client.api_key = "fb-key"
+        fallback_client.chat.completions.create.return_value = _mock_response(
+            "hello from fallback"
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "deepseek/deepseek-v4-flash"),
+        ):
+            result = agent.chat("hi there")
+
+        assert agent._fallback_activated is True
+        assert agent.provider == "openrouter"
+        # The user gets the fallback provider's answer — not the raw
+        # Copilot quota error surfaced as if it were the agent's reply.
+        assert result == "hello from fallback"
+        assert fallback_client.chat.completions.create.call_count == 1
+        # Billing errors are non-retryable: the primary must not be
+        # hammered again once the quota error is classified.
+        assert primary_client.chat.completions.create.call_count == 1
+
+    def test_quota_refusal_without_fallback_surfaces_error(self):
+        """Without a chain the turn still terminates with an error result
+        (no infinite retry loop) and mentions the quota problem."""
+        agent = _make_copilot_acp_agent(None)
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = _QUOTA_ERROR
+        agent.client = primary_client
+
+        result = agent.chat("hi there")
+
+        assert agent._fallback_activated is False
+        assert primary_client.chat.completions.create.call_count == 1
+        assert "quota" in str(result).lower()


### PR DESCRIPTION
## What does this PR do?

Fixes the fallback provider chain never activating when GitHub Copilot (`copilot-acp`) exhausts its monthly quota. Instead of failing over, Hermes delivered the raw backend error to the user as if it were the model's answer:

```
Error: You have exceeded your monthly quota (Request ID: A540:22A007:3849658:44F52D9:6A541F53)
```

It's not a missing classifier pattern. On current `main`, `classify_api_error()` already classifies this exact message as `billing` with `should_fallback=True` — the `"quota"` entry in `_USAGE_LIMIT_PATTERNS` catches it, and driving the conversation loop with a client that raises the presumed `RuntimeError` activates the fallback chain correctly. The loop and the classifier are innocent.

The real bug is one layer down. The Copilot ACP server doesn't send a JSON-RPC error for backend failures — it streams the error text as a regular `agent_message_chunk` and ends the turn with `stopReason: "refusal"`. That's the [ACP spec's](https://agentclientprotocol.com/protocol/prompt-turn) blessed way to report it, and GitHub's own [ACP server docs](https://docs.github.com/en/copilot/reference/copilot-cli-reference/acp-server) check `stopReason !== "end_turn"` as the failure idiom. Meanwhile `CopilotACPClient._run_prompt()` threw the `session/prompt` result away without looking at it, so a quota-exhausted turn looked like a perfectly successful completion whose "answer" happened to be the error text. No exception → classifier never runs → fallback never activates → the user gets the error as a chat reply. That's also why the reported error has none of the usual error ceremony around it (no `Copilot ACP session/prompt failed:` prefix, no `❌ Non-retryable error` trace) — Hermes never treated it as an error at all.

This PR converts failed prompt turns into a `RuntimeError` so the *existing* classifier and fallback machinery take over. The JSON-RPC error path and the process-died path already classified and fell back fine; this closes the one remaining route.

**Relationship to #63830:** that PR adds `"exceeded your monthly quota"` to `_BILLING_PATTERNS`. Harmless as belt-and-suspenders, but it can't fix #63815 on its own — in the reported scenario no exception ever reaches the classifier, and the classifier already handles the message anyway (pinned by a contract test here). No conflict between the two PRs.

## Related Issue

Fixes #63815

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/copilot_acp_client.py` — `_run_prompt()` now reads the `session/prompt` result's `stopReason`. A `refusal` turn raises `RuntimeError("Copilot ACP session/prompt failed: ...")` carrying the streamed error text so the existing classifier routes it (billing → fallback). A whole-response match on the stable Copilot backend error shape (`Error: ... (Request ID: <hex>)`) also raises, covering CLI builds that end error turns with `end_turn`; the match is anchored to the entire stripped response, so an answer that merely quotes an error line can't trip it. `max_tokens` / `max_turn_requests` / `cancelled` still return partial output unchanged.
- `tests/agent/test_copilot_acp_client.py` — scripted fake ACP subprocess harness plus tests: refusal turn with quota text raises; `end_turn` with a bare backend error line raises; refusal with no content raises; normal turns and answers that merely quote an error line pass through untouched; partial-output stop reasons unaffected; classifier contract test (raised message → `billing` + `should_fallback=True`).
- `tests/run_agent/test_copilot_acp_quota_fallback.py` — end-to-end conversation-loop regression: a `copilot-acp` agent with a fallback chain gets the fallback's answer (primary called exactly once, since billing is non-retryable); with no chain the turn ends in a proper error result instead of looping.

## How to Test

1. Run the targeted suites (hermetic — scripted fake ACP subprocess, no network): `scripts/run_tests.sh tests/agent/test_copilot_acp_client.py tests/run_agent/test_copilot_acp_quota_fallback.py` — 20 passed.
2. Regression sweep: full `tests/run_agent/` (1969 tests), `tests/acp/` (306), and `tests/agent/` pass via `scripts/run_tests.sh`, plus a full `tests/` sweep — the only failures are macOS-local environment ones (e.g. `/tmp` → `/private/tmp` realpath assertions) that reproduce identically on untouched `main`. `scripts/check-windows-footguns.py` is clean on the diff.
3. Optional manual repro (needs a drained Copilot quota): set `copilot-acp` as primary with any `fallback_providers`, send a message via CLI or Telegram. Before this fix: the raw quota error comes back as the reply. After: `⚠️ Billing or credits exhausted — switching to fallback provider...` and an answer from the fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (found #63830 — relationship explained above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full test suite via `scripts/run_tests.sh` (the CI-parity wrapper for `pytest tests/`) — the only failures are macOS-local environment ones that reproduce identically on untouched `main`; zero regressions from this diff
- [x] I've added tests for my changes (9 unit tests + 2 end-to-end regressions)
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior fix; inline comments document the ACP failure shape)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure-Python message handling; `scripts/check-windows-footguns.py` clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool changes)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_copilot_acp_client.py tests/run_agent/test_copilot_acp_quota_fallback.py
...
tests/run_agent/test_copilot_acp_quota_fallback.py::TestCopilotACPQuotaFallback::test_quota_refusal_activates_fallback_chain PASSED
tests/run_agent/test_copilot_acp_quota_fallback.py::TestCopilotACPQuotaFallback::test_quota_refusal_without_fallback_surfaces_error PASSED
============================== 20 passed in 5.66s ==============================
```

Classifier contract on the raised message (unmodified classifier):

```
>>> classify_api_error(RuntimeError("Copilot ACP session/prompt failed: turn ended with stopReason='refusal': Error: You have exceeded your monthly quota (Request ID: ...)"), provider="copilot-acp", model="auto")
reason=billing  retryable=False  should_fallback=True
```
