### PR TITLE
fix(vision): cap browser_vision native embeds (full-page screenshots OOM local models, wedge Anthropic sessions)

### DIFF
--- a/tests/tools/test_browser_vision_embed_caps.py
+++ b/tests/tools/test_browser_vision_embed_caps.py
@@ -1,0 +1,100 @@
+"""browser_vision must apply the proactive embed caps on the native fast path.
+
+The native fast path bakes the screenshot into conversation history, where it
+is re-sent on every subsequent turn. vision_analyze has capped its embeds
+since the wedged-session incident (Anthropic rejects >5 MB / >8000 px per side
+with a non-retryable 400), but browser_vision embedded full-page screenshots
+at full resolution — arbitrarily tall pages OOM local vision models during
+prefill (observed: repeated Metal kIOGPUCommandBufferCallbackErrorOutOfMemory
+on an MLX VLM) and wedge Anthropic sessions.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover - exercised on minimal CI images
+    Image = None
+
+from tools.vision_tools import _EMBED_TARGET_BYTES
+
+
+# Minimal valid 1x1 PNG bytes.
+_TINY_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+
+
+def _run_browser_vision_with_screenshot(png_writer):
+    """Drive the real browser_vision with the browser daemon faked out.
+
+    ``png_writer(path)`` writes the test PNG to the screenshot path the tool
+    chose; the fake _run_browser_command reports success with that path, so
+    everything downstream (encode, embed caps, envelope build) is real code.
+    """
+    from tools import browser_tool
+
+    def _fake_run_browser_command(task_id, command, args, **kwargs):
+        assert command == "screenshot"
+        shot_path = args[-1]
+        png_writer(shot_path)
+        return {"success": True, "data": {"path": shot_path}}
+
+    with (
+        patch.object(browser_tool, "_is_camofox_mode", return_value=False),
+        patch.object(browser_tool, "_is_local_backend", return_value=True),
+        patch.object(browser_tool, "_get_browser_engine", return_value="chrome"),
+        patch.object(
+            browser_tool, "_run_browser_command",
+            side_effect=_fake_run_browser_command,
+        ),
+        patch(
+            "tools.vision_tools._should_use_native_vision_fast_path",
+            return_value=True,
+        ),
+    ):
+        return browser_tool.browser_vision("what is on the page?")
+
+
+@pytest.mark.skipif(Image is None, reason="Pillow not installed — resize is a no-op")
+def test_oversized_screenshot_embeds_under_cap(tmp_path):
+    def _write_big(path):
+        Image.effect_noise((2600, 2600), 80).convert("RGB").save(path, format="PNG")
+
+    result = _run_browser_vision_with_screenshot(_write_big)
+
+    assert isinstance(result, dict), f"expected multimodal envelope, got: {str(result)[:200]}"
+    assert result.get("_multimodal") is True
+    url = next(
+        p["image_url"]["url"] for p in result["content"] if p.get("type") == "image_url"
+    )
+    assert len(url) <= _EMBED_TARGET_BYTES, (
+        f"embedded screenshot {len(url) / 1024 / 1024:.1f} MB exceeds embed cap "
+        f"{_EMBED_TARGET_BYTES / 1024 / 1024:.0f} MB — re-sent every turn, this "
+        f"wedges Anthropic sessions and OOMs local vision models"
+    )
+    assert result.get("meta", {}).get("screenshot_path")
+
+
+def test_small_screenshot_embeds_at_full_resolution(tmp_path):
+    """Guard against over-eager capping: an under-cap screenshot must embed
+    as its full-resolution encoding, byte for byte."""
+
+    def _write_tiny(path):
+        with open(path, "wb") as fh:
+            fh.write(_TINY_PNG)
+
+    result = _run_browser_vision_with_screenshot(_write_tiny)
+
+    assert isinstance(result, dict), f"expected multimodal envelope, got: {str(result)[:200]}"
+    assert result.get("_multimodal") is True
+    url = next(
+        p["image_url"]["url"] for p in result["content"] if p.get("type") == "image_url"
+    )
+    expected_b64 = base64.b64encode(_TINY_PNG).decode("ascii")
+    assert url == f"data:image/png;base64,{expected_b64}"

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -180,6 +180,84 @@ class TestVisionAnalyzeNative:
         )
 
 
+# ─── _apply_embed_caps ───────────────────────────────────────────────────────
+
+
+class TestApplyEmbedCaps:
+    """The shared embed-cap gate used by every native-vision embed site
+    (vision_analyze and browser_vision). Oversized embeds are re-sent every
+    turn: they wedge Anthropic sessions with non-retryable 400s and OOM
+    local vision models during prefill."""
+
+    @staticmethod
+    def _pil_or_skip():
+        pytest = __import__("pytest")
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed — proactive resize is a no-op")
+        return Image
+
+    def test_under_cap_image_is_identity(self, tmp_path):
+        """Small images must pass through as the SAME string — no
+        recompression, no re-encode (byte-stable embeds)."""
+        from tools.vision_tools import _apply_embed_caps, _image_to_base64_data_url
+
+        img = tmp_path / "tiny.png"
+        img.write_bytes(_TINY_PNG)
+        data_url = _image_to_base64_data_url(img, mime_type="image/png")
+
+        capped, err = _apply_embed_caps(img, data_url, mime_type="image/png")
+
+        assert err is None
+        assert capped is data_url
+
+    def test_oversized_by_bytes_resized_under_cap(self, tmp_path):
+        Image = self._pil_or_skip()
+        from tools.vision_tools import (
+            _EMBED_TARGET_BYTES,
+            _apply_embed_caps,
+            _image_to_base64_data_url,
+        )
+
+        big = tmp_path / "big.png"
+        Image.effect_noise((2600, 2600), 80).convert("RGB").save(big, format="PNG")
+        data_url = _image_to_base64_data_url(big, mime_type="image/png")
+        assert len(data_url) > _EMBED_TARGET_BYTES, "test image not big enough"
+
+        capped, err = _apply_embed_caps(big, data_url, mime_type="image/png")
+
+        assert err is None
+        assert len(capped) <= _EMBED_TARGET_BYTES
+
+    def test_oversized_by_dimension_resized_under_cap(self, tmp_path):
+        """A tall full-page screenshot can be tiny in bytes yet far over the
+        per-side pixel ceiling — the dimension check must force the resize
+        even when the byte check passes."""
+        Image = self._pil_or_skip()
+        import io
+
+        from tools.vision_tools import (
+            _EMBED_MAX_DIMENSION,
+            _EMBED_TARGET_BYTES,
+            _apply_embed_caps,
+            _image_to_base64_data_url,
+        )
+
+        tall = tmp_path / "tall.png"
+        Image.new("RGB", (200, 9000), color=(255, 255, 255)).save(tall, format="PNG")
+        data_url = _image_to_base64_data_url(tall, mime_type="image/png")
+        assert len(data_url) <= _EMBED_TARGET_BYTES, "flat PNG should be small in bytes"
+
+        capped, err = _apply_embed_caps(tall, data_url, mime_type="image/png")
+
+        assert err is None
+        header, _, b64 = capped.partition(",")
+        assert header.startswith("data:image/")
+        with Image.open(io.BytesIO(base64.b64decode(b64))) as out:
+            assert max(out.size) <= _EMBED_MAX_DIMENSION
+
+
 # ─── _handle_vision_analyze fast-path gating ─────────────────────────────────
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4067,15 +4067,32 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         # an auxiliary vision LLM. The model inspects the pixels on its next
         # turn — no aux call, no information loss. Consistent with vision_analyze.
         from tools.vision_tools import (
+            _apply_embed_caps,
             _build_native_vision_tool_result,
             _should_use_native_vision_fast_path,
         )
 
         if _should_use_native_vision_fast_path():
+            # Proactive embed caps (4 MB / 7900 px): this screenshot gets
+            # baked into conversation history and re-sent every turn. A
+            # full-page capture can be arbitrarily tall — uncapped embeds
+            # wedge Anthropic sessions with non-retryable 400s and OOM
+            # local vision models during prefill. The aux path below is
+            # unaffected: it sends the full-resolution image once, outside
+            # history, and already has its own reactive resize-and-retry.
+            embed_data_url, _embed_err = _apply_embed_caps(
+                screenshot_path, data_url, mime_type="image/png",
+            )
+            if _embed_err:
+                return json.dumps({
+                    "success": False,
+                    "error": _embed_err,
+                    "screenshot_path": str(screenshot_path),
+                }, ensure_ascii=False)
             native_result = _build_native_vision_tool_result(
                 image_url=str(screenshot_path),
                 question=question,
-                image_data_url=data_url,
+                image_data_url=embed_data_url,
                 image_size_bytes=len(_screenshot_bytes),
             )
             meta = native_result.setdefault("meta", {})

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -37,7 +37,7 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Awaitable, Dict, Optional
+from typing import Any, Awaitable, Dict, Optional, Tuple
 from urllib.parse import urlparse
 import httpx
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
@@ -745,6 +745,46 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
     return data_url or _image_to_base64_data_url(image_path, mime_type=mime_type)
 
 
+def _apply_embed_caps(
+    image_path: Path,
+    image_data_url: str,
+    mime_type: Optional[str] = None,
+) -> Tuple[str, Optional[str]]:
+    """Enforce the proactive embed caps on a data URL bound for history.
+
+    Every image embedded into conversation history is re-sent on every
+    subsequent turn, so an oversized payload permanently wedges the session
+    (Anthropic rejects >5 MB or >8000 px per side with a non-retryable 400)
+    or OOMs local vision models during prefill.  Resize DOWN to the embed
+    target (4 MB / 7900 px) whenever the payload exceeds either limit.
+
+    Returns ``(data_url, None)`` — the input unmodified when already under
+    both caps, else the resized encoding — or ``(data_url, error)`` when even
+    resizing cannot get under the 20 MB hard ceiling; callers surface
+    ``error`` through their own error convention and must not embed.
+    """
+    over_bytes = len(image_data_url) > _EMBED_TARGET_BYTES
+    over_dims = _image_exceeds_dimension(image_path, _EMBED_MAX_DIMENSION)
+    if not over_bytes and not over_dims:
+        return image_data_url, None
+
+    image_data_url = _resize_image_for_vision(
+        image_path, mime_type=mime_type,
+        max_base64_bytes=_EMBED_TARGET_BYTES,
+        max_dimension=_EMBED_MAX_DIMENSION,
+    )
+    if len(image_data_url) > _MAX_BASE64_BYTES:
+        return image_data_url, (
+            f"Image too large for vision API: base64 payload is "
+            f"{len(image_data_url) / (1024 * 1024):.1f} MB "
+            f"(limit {_MAX_BASE64_BYTES / (1024 * 1024):.0f} MB) "
+            f"even after resizing. Install Pillow "
+            f"(`pip install Pillow`) for better auto-resize, "
+            f"or compress the image manually."
+        )
+    return image_data_url, None
+
+
 # ---------------------------------------------------------------------------
 # Native fast path: short-circuit the auxiliary LLM when the active main model
 # supports native vision. Instead of asking a separate LLM to describe the
@@ -1007,38 +1047,14 @@ async def _vision_analyze_native(
             temp_image_path, mime_type=detected_mime_type,
         )
 
-        # Proactive embed cap: this image gets baked into conversation
-        # history and re-sent on every subsequent turn.  Anthropic rejects
-        # any single base64 image over 5 MB OR over 8000px per side with a
-        # 400, and because history is immutable, an oversized embed
-        # permanently wedges the session — retries can't clear bytes (or
-        # pixels) that are already in the request.  Resize DOWN to the embed
-        # target (4 MB / 7900px, headroom under both ceilings) whenever the
-        # payload exceeds either limit, not just at the 20 MB hard ceiling.
-        _over_bytes = len(image_data_url) > _EMBED_TARGET_BYTES
-        _over_dims = await _run_encode_on_cpu_executor(
-            _image_exceeds_dimension, temp_image_path, _EMBED_MAX_DIMENSION,
+        # Proactive embed cap — see _apply_embed_caps for why (oversized
+        # embeds wedge the session or OOM local models).
+        image_data_url, _embed_err = await _run_encode_on_cpu_executor(
+            _apply_embed_caps,
+            temp_image_path, image_data_url, mime_type=detected_mime_type,
         )
-        if _over_bytes or _over_dims:
-            image_data_url = await _run_encode_on_cpu_executor(
-                _resize_image_for_vision,
-                temp_image_path, mime_type=detected_mime_type,
-                max_base64_bytes=_EMBED_TARGET_BYTES,
-                max_dimension=_EMBED_MAX_DIMENSION,
-            )
-            # If even resizing can't get under the absolute hard ceiling,
-            # there's nothing more we can do — reject rather than embed a
-            # session-wedging payload.
-            if len(image_data_url) > _MAX_BASE64_BYTES:
-                return tool_error(
-                    f"Image too large for vision API: base64 payload is "
-                    f"{len(image_data_url) / (1024 * 1024):.1f} MB "
-                    f"(limit {_MAX_BASE64_BYTES / (1024 * 1024):.0f} MB) "
-                    f"even after resizing. Install Pillow "
-                    f"(`pip install Pillow`) for better auto-resize, "
-                    f"or compress the image manually.",
-                    success=False,
-                )
+        if _embed_err:
+            return tool_error(_embed_err, success=False)
 
         return _build_native_vision_tool_result(
             image_url=image_url,


### PR DESCRIPTION
## What does this PR do?

Applies the proactive embed caps (4 MB / 7900 px) to `browser_vision`'s native vision fast path. When the main model supports vision, `browser_vision` embeds its **full-page** screenshot into conversation history at **full resolution** — despite the code comment claiming "Consistent with vision_analyze", which has capped its embeds since the wedged-session incident (`tools/vision_tools.py:548-566` explains why: history-embedded images are re-sent every turn, so an oversized embed permanently wedges Anthropic sessions with non-retryable 400s). A full-page capture is arbitrarily tall, making this the worst-case producer of oversized embeds.

Real-world evidence: on a 36 GB Apple Silicon machine running an MLX VLM (qwen3.6-27b via LM Studio), accumulated `browser_vision` screenshots at ~50k-token context crashed the model four consecutive times as retries re-sent the same context:

```
[METAL] Command buffer execution failed: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory)
Fatal Python error: Aborted
```

## Related Issue

Related: #63849 (the remaining accumulation half of the problem — capped screenshots still pile up on the OpenAI-compatible path; filed as a design question because eviction interacts with the prompt-caching invariant).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py` — extract the cap logic into a shared `_apply_embed_caps(image_path, image_data_url, mime_type)` helper (identity passthrough under both caps; resize via the existing `_resize_image_for_vision`; returns an error string instead of embedding when even resizing can't get under the 20 MB hard ceiling). `_vision_analyze_native` rewires to the helper — semantics-preserving, net-negative diff, guarded by the existing `test_oversized_image_resized_under_embed_cap` regression test.
- `tools/browser_tool.py` — the native fast path now caps the screenshot before embedding, scoped strictly inside the `_should_use_native_vision_fast_path()` branch. The auxiliary path is byte-identical: it sends the full-resolution image once, outside history, and keeps its existing reactive resize-and-retry.
- `tests/tools/test_vision_native_fast_path.py` — new `TestApplyEmbedCaps`: oversized-by-bytes → resized under 4 MB; oversized-by-dimension (200×9000 tall page, tiny bytes) → longest side ≤ 7900 px; under-cap image → identity passthrough (no recompression).
- `tests/tools/test_browser_vision_embed_caps.py` (new) — integration through the real `browser_vision` with only the browser daemon faked: oversized screenshot embeds under the cap; tiny screenshot embeds byte-for-byte at full resolution (guards over-eager capping).

## How to Test

1. On a vision-capable main model, call `browser_vision` on a long page (full-page screenshot > 4 MB or > 7900 px tall).
2. Before: the multimodal tool result carries the full-resolution PNG (arbitrarily large). After: the embedded data URL is ≤ 4 MB and ≤ 7900 px per side; small screenshots are untouched byte-for-byte.
3. `scripts/run_tests.sh tests/tools/test_vision_native_fast_path.py tests/tools/test_browser_vision_embed_caps.py tests/tools/test_vision_tools.py` → 115 passed.
4. Full browser suite: `scripts/run_tests.sh tests/tools/test_browser*` → 488 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(vision): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all pass (via `scripts/run_tests.sh`, the CI-parity wrapper)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 / Darwin 25.4 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal behavior; no doc describes the uncapped embed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure image-processing logic; Pillow-absent behavior unchanged (resize is a best-effort no-op, same as vision_analyze today)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool schema unchanged; only payload size)

## Screenshots / Logs

```text
scripts/run_tests.sh tests/tools/test_vision_native_fast_path.py tests/tools/test_browser_vision_embed_caps.py tests/tools/test_vision_tools.py
=== Summary: 3 files, 115 tests passed, 0 failed (100% complete) in 3.4s (20 workers) ===

scripts/run_tests.sh tests/tools/test_browser*  (35 files)
=== Summary: 35 files, 488 tests passed, 0 failed (100% complete) in 35.8s (20 workers) ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

