### PR TITLE
feat(photon): add mobile supervisor cards

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2613,6 +2613,17 @@ class BasePlatformAdapter(ABC):
             if event.text:
                 sink.on_commentary(event.text)
 
+    @property
+    def send_progress_without_edit(self) -> bool:
+        """Whether gateway tool progress may be sent as separate messages.
+
+        The default is fail-closed for adapters that inherit the base
+        ``edit_message`` implementation: draining progress avoids turning every
+        tool call into a separate chat bubble on platforms that cannot edit in
+        place. Adapters with intentionally compact progress UX may opt in.
+        """
+        return False
+
     def format_tool_event(self, event: Any, *, mode: str = "all",
                           preview_max_len: int = 40) -> Optional[str]:
         """Return the rendered chrome for a ToolCallChunk, or None to eat it.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1813,6 +1813,55 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _should_drain_progress_for_no_edit_adapter(adapter: Any) -> bool:
+    """Return True when gateway progress must stay silent for no-edit adapters.
+
+    Platforms that inherit ``BasePlatformAdapter.edit_message`` cannot update a
+    single progress bubble, so the gateway historically drains their progress
+    queue to avoid one chat message per tool call. A platform may opt into
+    separate sends only by explicitly setting ``send_progress_without_edit``.
+    """
+    if type(adapter).edit_message is not BasePlatformAdapter.edit_message:
+        return False
+    return not bool(getattr(adapter, "send_progress_without_edit", False))
+
+
+def _format_adapter_tool_progress(
+    adapter: Any,
+    *,
+    tool_name: Optional[str],
+    preview: Optional[str],
+    args: Optional[dict],
+    mode: str,
+    preview_max_len: int,
+    index: int = 0,
+) -> Optional[str]:
+    """Render a tool-start line through an adapter override when present.
+
+    The legacy gateway progress callback remains the production source of tool
+    progress events. This helper is the bridge that lets adapter-level
+    ``format_tool_event`` implementations participate in that active path while
+    leaving the historical gateway formatting untouched for adapters that do not
+    override the hook.
+    """
+    if not adapter or not tool_name:
+        return None
+    if type(adapter).format_tool_event is BasePlatformAdapter.format_tool_event:
+        return None
+    from gateway.stream_events import ToolCallChunk
+
+    return adapter.format_tool_event(
+        ToolCallChunk(
+            tool_name=tool_name,
+            preview=preview,
+            args=args,
+            index=index,
+        ),
+        mode=mode,
+        preview_max_len=preview_max_len,
+    )
+
+
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
     Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
@@ -17309,9 +17358,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if needs_progress_queue else None
-        last_tool = [None]  # Mutable container for tracking in closure
-        last_progress_msg = [None]  # Track last message for dedup
+        last_tool: List[Optional[str]] = [None]  # Mutable container for tracking in closure
+        last_progress_msg: List[Optional[Any]] = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
+        progress_tool_index = [0]  # Tool-start ordinal for adapter render hooks
         # True when the previously enqueued progress line was a terminal
         # fenced code block — consecutive terminal calls then drop the
         # repeated "💻 terminal" header and render back-to-back blocks.
@@ -17467,6 +17517,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
+            current_tool_index = progress_tool_index[0]
+            progress_tool_index[0] += 1
+
+            # Let platform adapters with explicit structured render hooks own
+            # their presentation on the active legacy gateway progress path.
+            try:
+                _progress_adapter = self._adapter_for_source(source)
+            except Exception:
+                _progress_adapter = None
+            from agent.display import get_tool_preview_max_len
+            _pl = get_tool_preview_max_len()
+            _adapter_msg = _format_adapter_tool_progress(
+                _progress_adapter,
+                tool_name=tool_name,
+                preview=preview,
+                args=args,
+                mode=progress_mode,
+                preview_max_len=_pl if _pl > 0 or progress_mode == "verbose" else 40,
+                index=current_tool_index,
+            )
+            if _adapter_msg:
+                last_was_terminal_block[0] = False
+                if _adapter_msg == last_progress_msg[0]:
+                    repeat_count[0] += 1
+                    progress_queue.put(("__dedup__", _adapter_msg, repeat_count[0]))
+                    return
+                last_progress_msg[0] = _adapter_msg
+                repeat_count[0] = 0
+                progress_queue.put(_adapter_msg)
+                return
 
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
@@ -17683,9 +17763,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
 
             # Skip tool progress for platforms that don't support message
-            # editing (e.g. iMessage/BlueBubbles) — each progress update
-            # would become a separate message bubble, which is noisy.
-            if type(adapter).edit_message is BasePlatformAdapter.edit_message:
+            # editing unless the adapter explicitly opts into compact separate
+            # sends. This preserves the no-edit anti-spam guard for generic
+            # SMS/iMessage-like platforms while allowing native card UIs such as
+            # Photon mobile supervisor cards.
+            adapter_can_edit = type(adapter).edit_message is not BasePlatformAdapter.edit_message
+            if not adapter_can_edit and _should_drain_progress_for_no_edit_adapter(adapter):
                 while not progress_queue.empty():
                     try:
                         progress_queue.get_nowait()
@@ -17695,7 +17778,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
             progress_msg_id = None   # ID of the current progress message to edit
-            can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
+            can_edit = adapter_can_edit and progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -541,7 +541,7 @@ def build_session_context_prompt(
                 "Do not promise to perform these actions. If the user asks, explain "
                 "that you can only read messages sent directly to you and respond."
             )
-    elif context.source.platform == Platform.BLUEBUBBLES:
+    elif context.source.platform in {Platform.BLUEBUBBLES, Platform("photon")}:
         lines.append("")
         lines.append(
             "**Platform notes:** You are responding via iMessage. "
@@ -553,6 +553,17 @@ def build_session_context_prompt(
             "If the user needs a detailed answer, give the short version first "
             "and offer to elaborate."
         )
+        if context.source.platform == Platform("photon"):
+            lines.append(
+                "For multi-step or long-running work over Photon/iMessage, use "
+                "compact supervisor-card language: start with a short status or "
+                "decision heading, then include only the current phase, boundary "
+                "(for example read-only/status-only/no production action), key "
+                "evidence, blockers, and the safest next action. Do not present "
+                "iMessage as an approval or production-execution surface; when "
+                "action is needed, provide a paste-ready prompt or instruction for "
+                "the governed execution surface instead."
+            )
     elif context.source.platform == Platform.YUANBAO:
         lines.append("")
         lines.append(

--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -146,6 +146,11 @@ All env vars are documented in `plugin.yaml`. The most important:
   builder; iMessage renders bold/italics/lists/code natively and other
   Spectrum platforms degrade to readable plain text. `PHOTON_MARKDOWN=false`
   reverts to stripped plain text.
+- **Mobile supervisor cards are enabled by default.** Tool-progress events are
+  rendered as compact status cards (`Hermes status`, iteration, tool, current
+  target, and an explicit `status only — no approval/action taken` boundary)
+  instead of raw debug-style tool chrome. Disable with
+  `platforms.photon.extra.mobile_cards: false` or `PHOTON_MOBILE_CARDS=false`.
 - **Reactions (tapbacks) are supported** behind `PHOTON_REACTIONS` (default
   off): the adapter tapbacks 👀 while processing and swaps it for 👍/👎 on
   completion, and a user tapback on a bot-sent message is routed to the agent

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -261,6 +261,32 @@ def _markdown_enabled() -> bool:
     }
 
 
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    """Coerce config bool-ish values for Photon plugin extras."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in {"true", "1", "yes", "on"}:
+            return True
+        if token in {"false", "0", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def _truncate_one_line(text: Optional[str], max_len: int) -> str:
+    """Return a compact single-line preview safe for an iMessage status card."""
+    if not text:
+        return ""
+    collapsed = " ".join(str(text).split())
+    if max_len > 0 and len(collapsed) > max_len:
+        return collapsed[: max_len - 1].rstrip() + "…"
+    return collapsed
+
+
 # ---------------------------------------------------------------------------
 # Adapter
 
@@ -311,6 +337,16 @@ class PhotonAdapter(BasePlatformAdapter):
         # With markdown on, format_message preserves fences and the sidecar's
         # markdown() builder renders them (or degrades them readably).
         self.supports_code_blocks = _markdown_enabled()
+        # Compact status cards make Photon/iMessage usable as a supervisor
+        # surface: instead of raw tool chrome, users see one glanceable
+        # progress bubble. This is presentation-only and can be disabled per
+        # platform config with platforms.photon.extra.mobile_cards: false.
+        self.mobile_cards = _coerce_bool(
+            extra.get("mobile_cards")
+            if "mobile_cards" in extra
+            else os.getenv("PHOTON_MOBILE_CARDS"),
+            True,
+        )
 
         # Runtime state
         self._sidecar_proc: Optional[subprocess.Popen] = None
@@ -1388,6 +1424,42 @@ class PhotonAdapter(BasePlatformAdapter):
         if _markdown_enabled():
             return content
         return strip_markdown(content)
+
+    def format_tool_event(
+        self,
+        event: Any,
+        *,
+        mode: str = "all",
+        preview_max_len: int = 40,
+    ) -> Optional[str]:
+        """Render tool progress as a compact iMessage-native status card.
+
+        Photon is usually a personal mobile channel. The base tool chrome
+        (``🔧 tool_name: preview``) is technically correct but reads like raw
+        debug output in Messages. A tiny card keeps the useful telemetry — what
+        is running, iteration, and the current target — without implying that
+        iMessage is an execution approval surface.
+        """
+        from gateway.stream_events import ToolCallChunk
+
+        if not isinstance(event, ToolCallChunk):
+            return None
+        if not self.mobile_cards:
+            return super().format_tool_event(
+                event, mode=mode, preview_max_len=preview_max_len,
+            )
+
+        preview = _truncate_one_line(event.preview, preview_max_len or 80)
+        iteration = event.index + 1 if event.index >= 0 else 1
+        lines = [
+            "⏳ **Hermes status**",
+            f"Working — iteration {iteration}",
+            f"Tool: `{event.tool_name}`",
+        ]
+        if preview:
+            lines.append(f"Current: {preview}")
+        lines.append("Boundary: status only — no approval/action taken")
+        return "\n".join(lines)
 
     @staticmethod
     def _is_retryable_error(error: Optional[str]) -> bool:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1425,6 +1425,11 @@ class PhotonAdapter(BasePlatformAdapter):
             return content
         return strip_markdown(content)
 
+    @property
+    def send_progress_without_edit(self) -> bool:
+        """Photon opts into separate progress sends only for compact cards."""
+        return bool(self.mobile_cards)
+
     def format_tool_event(
         self,
         event: Any,

--- a/plugins/platforms/photon/plugin.yaml
+++ b/plugins/platforms/photon/plugin.yaml
@@ -82,6 +82,10 @@ optional_env:
     description: "Send agent replies as markdown — iMessage renders it natively, other Spectrum platforms degrade to plain text (true/false, default true)"
     prompt: "Render replies as markdown? (true/false)"
     password: false
+  - name: PHOTON_MOBILE_CARDS
+    description: "Render tool progress as compact supervisor status cards in iMessage (true/false, default true)"
+    prompt: "Render mobile supervisor cards? (true/false)"
+    password: false
   - name: PHOTON_REACTIONS
     description: "Tapback 👀/👍/👎 on messages as processing status and route tapbacks on bot messages to the agent (true/false, default false)"
     prompt: "Enable reaction tapbacks? (true/false)"

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -213,6 +213,27 @@ class TestBuildSessionContextPrompt:
         assert "short and conversational" in prompt
         assert "blank line" in prompt
 
+    def test_photon_prompt_adds_supervisor_card_boundary_guidance(self):
+        photon = Platform("photon")
+        config = GatewayConfig(
+            platforms={
+                photon: PlatformConfig(enabled=True, extra={"project_id": "pid", "project_secret": "sec"}),
+            },
+        )
+        source = SessionSource(
+            platform=photon,
+            chat_id="any;-;+155****4567",
+            chat_name="Jeff",
+            chat_type="dm",
+        )
+        ctx = build_session_context(source, config)
+        prompt = build_session_context_prompt(ctx)
+
+        assert "responding via iMessage" in prompt
+        assert "compact supervisor-card language" in prompt
+        assert "Do not present iMessage as an approval" in prompt
+        assert "paste-ready prompt" in prompt
+
     def test_discord_prompt(self):
         config = GatewayConfig(
             platforms={

--- a/tests/plugins/platforms/photon/test_mobile_cards.py
+++ b/tests/plugins/platforms/photon/test_mobile_cards.py
@@ -1,0 +1,87 @@
+"""Mobile supervisor-card formatting for Photon/iMessage progress."""
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.stream_events import ToolCallChunk
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch, *, mobile_cards=True) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(
+        enabled=True,
+        token="",
+        extra={"mobile_cards": mobile_cards},
+    )
+    return PhotonAdapter(cfg)
+
+
+def test_tool_progress_renders_compact_supervisor_card(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    rendered = adapter.format_tool_event(
+        ToolCallChunk(
+            tool_name="mcp_google_multi_gmail_search",
+            preview="checking all NYU open items and inbox state",
+            index=5,
+        ),
+        preview_max_len=80,
+    )
+
+    assert rendered is not None
+    assert "**Hermes status**" in rendered
+    assert "Working — iteration 6" in rendered
+    assert "Tool: `mcp_google_multi_gmail_search`" in rendered
+    assert "Current: checking all NYU open items" in rendered
+    assert "Boundary: status only" in rendered
+
+
+def test_tool_progress_preview_is_single_line_and_truncated(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    rendered = adapter.format_tool_event(
+        ToolCallChunk(
+            tool_name="terminal",
+            preview="first line\nsecond line with extra detail",
+            index=0,
+        ),
+        preview_max_len=18,
+    )
+
+    assert rendered is not None
+    assert "first line second…" in rendered
+    assert "\nsecond line" not in rendered
+
+
+def test_mobile_cards_can_fall_back_to_base_tool_chrome(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch, mobile_cards=False)
+
+    rendered = adapter.format_tool_event(
+        ToolCallChunk(tool_name="terminal", preview="date", index=0),
+        preview_max_len=40,
+    )
+
+    assert rendered is not None
+    assert "terminal" in rendered
+    assert "Hermes status" not in rendered
+    assert "Boundary: status only" not in rendered
+
+
+def test_mobile_cards_can_be_disabled_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    monkeypatch.setenv("PHOTON_MOBILE_CARDS", "false")
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+    rendered = adapter.format_tool_event(
+        ToolCallChunk(tool_name="terminal", preview="date", index=0),
+        preview_max_len=40,
+    )
+
+    assert rendered is not None
+    assert "terminal" in rendered
+    assert "Hermes status" not in rendered
+    assert "Boundary: status only" not in rendered

--- a/tests/plugins/platforms/photon/test_mobile_cards.py
+++ b/tests/plugins/platforms/photon/test_mobile_cards.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.run import (
+    _format_adapter_tool_progress,
+    _should_drain_progress_for_no_edit_adapter,
+)
 from gateway.stream_events import ToolCallChunk
 from plugins.platforms.photon.adapter import PhotonAdapter
 
@@ -56,6 +60,37 @@ def test_tool_progress_preview_is_single_line_and_truncated(monkeypatch: pytest.
     assert "\nsecond line" not in rendered
 
 
+def test_active_gateway_progress_path_uses_photon_mobile_card_formatter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    rendered = _format_adapter_tool_progress(
+        adapter,
+        tool_name="mcp_google_multi_gmail_search",
+        preview="checking all NYU open items and inbox state",
+        args={"query": "NYU"},
+        mode="all",
+        preview_max_len=80,
+        index=5,
+    )
+
+    assert rendered is not None
+    assert "**Hermes status**" in rendered
+    assert "Working — iteration 6" in rendered
+    assert "Tool: `mcp_google_multi_gmail_search`" in rendered
+    assert "Current: checking all NYU open items" in rendered
+    assert "Boundary: status only" in rendered
+
+
+def test_no_edit_progress_guard_allows_photon_cards_without_opening_all_no_edit_adapters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    assert _should_drain_progress_for_no_edit_adapter(adapter) is False
+
+
 def test_mobile_cards_can_fall_back_to_base_tool_chrome(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch, mobile_cards=False)
 
@@ -68,6 +103,7 @@ def test_mobile_cards_can_fall_back_to_base_tool_chrome(monkeypatch: pytest.Monk
     assert "terminal" in rendered
     assert "Hermes status" not in rendered
     assert "Boundary: status only" not in rendered
+    assert _should_drain_progress_for_no_edit_adapter(adapter) is True
 
 
 def test_mobile_cards_can_be_disabled_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -85,3 +121,4 @@ def test_mobile_cards_can_be_disabled_by_env(monkeypatch: pytest.MonkeyPatch) ->
     assert "terminal" in rendered
     assert "Hermes status" not in rendered
     assert "Boundary: status only" not in rendered
+    assert _should_drain_progress_for_no_edit_adapter(adapter) is True

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -633,6 +633,7 @@ Connect Hermes to [Photon](https://photon.codes/) / Spectrum (iMessage and other
 | `PHOTON_HOME_CHANNEL_NAME` | Human label for the home channel. |
 | `PHOTON_MARKDOWN` | Send agent replies as markdown — iMessage renders it natively, other Spectrum platforms degrade to plain text (`true`/`false`, default `true`). |
 | `PHOTON_REACTIONS` | Tapback 👀/👍/👎 on messages as processing status and route tapbacks on bot messages to the agent (`true`/`false`, default `false`). |
+| `PHOTON_MOBILE_CARDS` | Render tool progress as compact mobile supervisor cards (`true`/`false`, default `true`). When enabled, Photon explicitly opts into separate progress-card sends even though iMessage cannot edit messages; other no-edit platforms remain protected by the generic anti-spam drain. |
 | `PHOTON_TELEMETRY` | Enable Spectrum SDK telemetry in the sidecar (`true`/`false`, default `false`; toggle with `hermes photon telemetry on|off`). |
 | `PHOTON_SIDECAR_PORT` | Loopback port for the Node sidecar control + inbound channel (default `8789`). |
 | `PHOTON_SIDECAR_AUTOSTART` | Spawn the Node sidecar on connect (`true`/`false`, default `true`). |

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -221,6 +221,8 @@ Common issues:
 | `PHOTON_ALLOW_ALL_USERS`  | `false`            | Dev only — accept any sender               |
 | `PHOTON_REQUIRE_MENTION`  | `false`            | Require a wake word before responding in groups |
 | `PHOTON_MENTION_PATTERNS` | Hermes wake words  | JSON list / comma / newline regex patterns for group mentions |
+| `PHOTON_MARKDOWN`       | `true`             | Send replies as markdown so iMessage renders native formatting |
+| `PHOTON_MOBILE_CARDS`   | `true`             | Render tool progress as compact mobile supervisor cards; also opts Photon into separate progress sends despite lacking edit support |
 | `PHOTON_DASHBOARD_HOST`   | `app.photon.codes` | Override the dashboard / device-login host |
 | `PHOTON_SPECTRUM_HOST`    | `spectrum.photon.codes` | Override the Spectrum API host |
 


### PR DESCRIPTION
## Summary
- Render Photon/iMessage tool progress as compact supervisor status cards
- Add Photon session guidance for status/recommendation/paste-ready-prompt behavior
- Add `PHOTON_MOBILE_CARDS` / `platforms.photon.extra.mobile_cards` disable switches
- Document the behavior and add tests

## Test Plan
- [x] `scripts/run_tests.sh tests/plugins/platforms/photon/test_mobile_cards.py tests/gateway/test_session.py -q`

## Governance boundary
This is presentation-only. It does not add approval or production execution from iMessage. The intended product pattern is mobile supervision/status, with any actual action routed back to the governed execution surface via paste-ready prompts or instructions.
