### PR TITLE
fix(cli): interrupt subagents on /new and /clear to prevent orphan delegation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7024,6 +7024,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
+        # Interrupt any running subagents before resetting the session.
+        # /new and /clear without interrupting subagents leaves orphan
+        # subagents running against the old session — their results can
+        # leak back or inject stale context into the new session (#63463).
+        try:
+            from tools.async_delegation import interrupt_all
+            interrupt_all(reason="new_session")
+        except Exception:
+            pass
         old_session_id = self.session_id
         _boundary_snapshot = None
         if self.agent and self.conversation_history:


### PR DESCRIPTION
Fixes #63463

When a user issues /new or /clear while sub-agents are running via delegate_task, the old subagents continue running against the now-stale session. Their results can leak back into the new session, inject stale context, or cause the session reset to appear non-functional.

The fix calls interrupt_all() at the top of new_session() so every in-flight delegation is signalled to stop before the session is reset. This mirrors the existing pattern used by CLI shutdown (exit_handler) and /stop — applying it at the shared new_session() entry point means both /new and /clear benefit from the same guard.