### PR TITLE
fix(installer): preserve macOS entitlements during ad-hoc re-signing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6070,11 +6070,13 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     bundle also inherits the com.apple.quarantine flag from the downloaded
     installer process chain. Both make the relaunch fail.
 
-    Clearing the quarantine xattrs and re-applying a clean deep ad-hoc signature
+    Clearing the quarantine xattrs and re-applying clean ad-hoc signatures
     (omitting the hardened-runtime flag, which is meaningless without a real
-    Developer ID) lets the rebuilt app relaunch. No-op when a real signing
-    identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a properly
-    signed/notarized build is never clobbered. Best-effort: never raises.
+    Developer ID) lets the rebuilt app relaunch. Preserve the electron-builder
+    entitlements on the main bundle and Helper apps when their plists are
+    available; otherwise retain the legacy deep-sign fallback. No-op when a real
+    signing identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a
+    properly signed/notarized build is never clobbered. Best-effort: never raises.
     """
     if sys.platform != "darwin":
         return
@@ -6092,7 +6094,27 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
         return
     try:
         subprocess.run(["xattr", "-cr", str(app)], check=False)
-        subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
+        main_entitlements = desktop_dir / "electron" / "entitlements.mac.plist"
+        helper_entitlements = desktop_dir / "electron" / "entitlements.mac.inherit.plist"
+        if main_entitlements.is_file() and helper_entitlements.is_file():
+            frameworks_dir = app / "Contents" / "Frameworks"
+            for helper_app in sorted(frameworks_dir.glob("Hermes Helper*.app")):
+                if helper_app.is_dir():
+                    subprocess.run(
+                        [codesign, "--force", "--sign", "-", "--entitlements",
+                         str(helper_entitlements), str(helper_app)],
+                        check=False,
+                    )
+            subprocess.run(
+                [codesign, "--force", "--sign", "-", "--entitlements",
+                 str(main_entitlements), str(app)],
+                check=False,
+            )
+        else:
+            subprocess.run(
+                [codesign, "--force", "--deep", "--sign", "-", str(app)],
+                check=False,
+            )
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6070,13 +6070,15 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     bundle also inherits the com.apple.quarantine flag from the downloaded
     installer process chain. Both make the relaunch fail.
 
-    Clearing the quarantine xattrs and re-applying clean ad-hoc signatures
-    (omitting the hardened-runtime flag, which is meaningless without a real
-    Developer ID) lets the rebuilt app relaunch. Preserve the electron-builder
-    entitlements on the main bundle and Helper apps when their plists are
-    available; otherwise retain the legacy deep-sign fallback. No-op when a real
-    signing identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a
-    properly signed/notarized build is never clobbered. Best-effort: never raises.
+    Clearing the quarantine xattrs and re-applying clean ad-hoc signatures with
+    ``--options runtime`` lets the rebuilt app relaunch. Hardened Runtime
+    exception entitlements (allow-jit, etc.) only take effect when CS_RUNTIME
+    is set; ad-hoc + runtime does not require a Developer ID and matches the
+    release signature flags. Preserve the electron-builder entitlements on the
+    main bundle and Helper apps when their plists are available; otherwise
+    retain the legacy deep-sign fallback. No-op when a real signing identity is
+    configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a properly
+    signed/notarized build is never clobbered. Best-effort: never raises.
     """
     if sys.platform != "darwin":
         return
@@ -6101,18 +6103,19 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
             for helper_app in sorted(frameworks_dir.glob("Hermes Helper*.app")):
                 if helper_app.is_dir():
                     subprocess.run(
-                        [codesign, "--force", "--sign", "-", "--entitlements",
-                         str(helper_entitlements), str(helper_app)],
+                        [codesign, "--force", "--options", "runtime", "--sign", "-",
+                         "--entitlements", str(helper_entitlements), str(helper_app)],
                         check=False,
                     )
             subprocess.run(
-                [codesign, "--force", "--sign", "-", "--entitlements",
-                 str(main_entitlements), str(app)],
+                [codesign, "--force", "--options", "runtime", "--sign", "-",
+                 "--entitlements", str(main_entitlements), str(app)],
                 check=False,
             )
         else:
             subprocess.run(
-                [codesign, "--force", "--deep", "--sign", "-", str(app)],
+                [codesign, "--force", "--deep", "--options", "runtime", "--sign", "-",
+                 str(app)],
                 check=False,
             )
     except Exception as exc:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2738,12 +2738,15 @@ _desktop_macos_adhoc_resign() {
 
     xattr -cr "$app" 2>/dev/null || true
     if [ -f "$main_entitlements" ] && [ -f "$helper_entitlements" ]; then
+        # Hardened Runtime exception entitlements (allow-jit, etc.) only take
+        # effect when CS_RUNTIME is set. Ad-hoc + --options runtime is valid
+        # without a Developer ID and matches the release signature flags.
         while IFS= read -r -d '' helper_app; do
-            codesign --force --sign - --entitlements "$helper_entitlements" "$helper_app" >/dev/null 2>&1 || true
+            codesign --force --options runtime --sign - --entitlements "$helper_entitlements" "$helper_app" >/dev/null 2>&1 || true
         done < <(find "$app/Contents/Frameworks" -maxdepth 1 -name 'Hermes Helper*.app' -type d -print0 2>/dev/null)
-        codesign --force --sign - --entitlements "$main_entitlements" "$app" >/dev/null 2>&1 || true
+        codesign --force --options runtime --sign - --entitlements "$main_entitlements" "$app" >/dev/null 2>&1 || true
     else
-        codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        codesign --force --deep --options runtime --sign - "$app" >/dev/null 2>&1 || true
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2730,6 +2730,23 @@ _restore_electron_dist_with_fallback() {
         || { [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$install_dir" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; }
 }
 
+_desktop_macos_adhoc_resign() {
+    local app="$1"
+    local desktop_dir="$2"
+    local main_entitlements="$desktop_dir/electron/entitlements.mac.plist"
+    local helper_entitlements="$desktop_dir/electron/entitlements.mac.inherit.plist"
+
+    xattr -cr "$app" 2>/dev/null || true
+    if [ -f "$main_entitlements" ] && [ -f "$helper_entitlements" ]; then
+        while IFS= read -r -d '' helper_app; do
+            codesign --force --sign - --entitlements "$helper_entitlements" "$helper_app" >/dev/null 2>&1 || true
+        done < <(find "$app/Contents/Frameworks" -maxdepth 1 -name 'Hermes Helper*.app' -type d -print0 2>/dev/null)
+        codesign --force --sign - --entitlements "$main_entitlements" "$app" >/dev/null 2>&1 || true
+    else
+        codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+    fi
+}
+
 # Build apps/desktop into a launchable native app. Mirrors install.ps1's
 # Install-Desktop: a root-level npm install so the apps/* workspace resolves
 # the desktop's own deps (Electron ~150MB), then `npm run pack`
@@ -2920,17 +2937,7 @@ install_desktop() {
     # usable access. Skipped when a real signing identity is configured so a
     # signed build isn't clobbered.
     if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${APPLE_SIGNING_IDENTITY:-}" ] && command -v codesign >/dev/null 2>&1; then
-        xattr -cr "$app" 2>/dev/null || true
-        local main_entitlements="$desktop_dir/electron/entitlements.mac.plist"
-        local helper_entitlements="$desktop_dir/electron/entitlements.mac.inherit.plist"
-        if [ -f "$main_entitlements" ] && [ -f "$helper_entitlements" ]; then
-            while IFS= read -r -d '' helper_app; do
-                codesign --force --sign - --entitlements "$helper_entitlements" "$helper_app" >/dev/null 2>&1 || true
-            done < <(find "$app/Contents/Frameworks" -maxdepth 1 -name 'Hermes Helper*.app' -type d -print0 2>/dev/null)
-            codesign --force --sign - --entitlements "$main_entitlements" "$app" >/dev/null 2>&1 || true
-        else
-            codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
-        fi
+        _desktop_macos_adhoc_resign "$app" "$desktop_dir"
     fi
 
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2913,12 +2913,24 @@ install_desktop() {
     # self-update. An ad-hoc bundle has no stable Designated Requirement, so a
     # later in-place rebuild (new cdhash) plus the inherited quarantine flag
     # trips Gatekeeper's tamper check ("Hermes is damaged and can't be opened").
-    # Strip quarantine + re-apply a clean deep ad-hoc signature (no
-    # hardened-runtime flag, which an ad-hoc build can't satisfy). Skipped when a
-    # real signing identity is configured so a signed build isn't clobbered.
+    # Strip quarantine + re-apply a clean ad-hoc signature (no hardened-runtime
+    # flag, which an ad-hoc build can't satisfy). Keep the desktop entitlements
+    # on the main bundle and Electron helper apps; without them macOS TCC can
+    # keep prompting for microphone / screen audio while the GUI never receives
+    # usable access. Skipped when a real signing identity is configured so a
+    # signed build isn't clobbered.
     if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${APPLE_SIGNING_IDENTITY:-}" ] && command -v codesign >/dev/null 2>&1; then
         xattr -cr "$app" 2>/dev/null || true
-        codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        local main_entitlements="$desktop_dir/electron/entitlements.mac.plist"
+        local helper_entitlements="$desktop_dir/electron/entitlements.mac.inherit.plist"
+        if [ -f "$main_entitlements" ] && [ -f "$helper_entitlements" ]; then
+            while IFS= read -r -d '' helper_app; do
+                codesign --force --sign - --entitlements "$helper_entitlements" "$helper_app" >/dev/null 2>&1 || true
+            done < <(find "$app/Contents/Frameworks" -maxdepth 1 -name 'Hermes Helper*.app' -type d -print0 2>/dev/null)
+            codesign --force --sign - --entitlements "$main_entitlements" "$app" >/dev/null 2>&1 || true
+        else
+            codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        fi
     fi
 
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import os
+import plistlib
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +14,10 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli import main as cli_main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
 def _ns(**kw):
@@ -1015,6 +1022,257 @@ def test_stop_desktop_build_lock_no_release_dir(tmp_path, monkeypatch):
     with patch("psutil.process_iter") as it:
         assert cli_main._stop_desktop_processes_locking_build(desktop_dir) == []
     it.assert_not_called()
+
+
+def test_desktop_macos_relaunchable_fixup_preserves_packaged_entitlements(
+    tmp_path, monkeypatch
+):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    exe = _make_packaged_executable(root, monkeypatch)
+    app = exe.parents[2]
+    helper_app = app / "Contents" / "Frameworks" / "Hermes Helper.app"
+    helper_app.mkdir(parents=True)
+
+    main_entitlements = desktop_dir / "electron" / "entitlements.mac.plist"
+    helper_entitlements = desktop_dir / "electron" / "entitlements.mac.inherit.plist"
+    main_entitlements.parent.mkdir()
+    main_entitlements.write_text("main", encoding="utf-8")
+    helper_entitlements.write_text("inherit", encoding="utf-8")
+
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/codesign"), \
+         patch("hermes_cli.main.subprocess.run") as mock_run:
+        cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    codesign_commands = [
+        call.args[0] for call in mock_run.call_args_list
+        if call.args[0][0] == "/usr/bin/codesign"
+    ]
+    assert codesign_commands == [
+        [
+            "/usr/bin/codesign", "--force", "--sign", "-", "--entitlements",
+            str(helper_entitlements), str(helper_app),
+        ],
+        [
+            "/usr/bin/codesign", "--force", "--sign", "-", "--entitlements",
+            str(main_entitlements), str(app),
+        ],
+    ]
+
+
+def test_desktop_macos_relaunchable_fixup_deep_signs_without_entitlement_plists(
+    tmp_path, monkeypatch
+):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    exe = _make_packaged_executable(root, monkeypatch)
+    app = exe.parents[2]
+
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/codesign"), \
+         patch("hermes_cli.main.subprocess.run") as mock_run:
+        cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    codesign_commands = [
+        call.args[0] for call in mock_run.call_args_list
+        if call.args[0][0] == "/usr/bin/codesign"
+    ]
+    assert codesign_commands == [
+        [
+            "/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app),
+        ],
+    ]
+
+
+def _make_codesignable_test_app(
+    app: Path, executable_name: str, bundle_identifier: str
+) -> Path:
+    executable = app / "Contents" / "MacOS" / executable_name
+    executable.parent.mkdir(parents=True)
+    shutil.copyfile("/usr/bin/true", executable)
+    executable.chmod(0o755)
+    info = {
+        "CFBundleExecutable": executable_name,
+        "CFBundleIdentifier": bundle_identifier,
+        "CFBundleName": executable_name,
+        "CFBundlePackageType": "APPL",
+        "CFBundleVersion": "1",
+    }
+    with (app / "Contents" / "Info.plist").open("wb") as handle:
+        plistlib.dump(info, handle)
+    return executable
+
+
+def _write_test_entitlements(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as handle:
+        plistlib.dump({"com.apple.security.device.audio-input": True}, handle)
+
+
+def _display_codesign_entitlements(app: Path) -> dict:
+    result = subprocess.run(
+        [
+            "/usr/bin/codesign",
+            "--display",
+            "--entitlements",
+            "-",
+            "--xml",
+            str(app),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return plistlib.loads(result.stdout) if result.stdout else {}
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS codesign")
+def test_desktop_macos_relaunchable_fixup_embeds_entitlements_in_real_bundles(
+    tmp_path, monkeypatch
+):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+    executable = _make_codesignable_test_app(
+        app, "Hermes", "ai.hermes.desktop.codesign-test"
+    )
+    helper_app = app / "Contents" / "Frameworks" / "Hermes Helper.app"
+    _make_codesignable_test_app(
+        helper_app, "Hermes Helper", "ai.hermes.desktop.codesign-test.helper"
+    )
+    main_entitlements = desktop_dir / "electron" / "entitlements.mac.plist"
+    helper_entitlements = desktop_dir / "electron" / "entitlements.mac.inherit.plist"
+    _write_test_entitlements(main_entitlements)
+    _write_test_entitlements(helper_entitlements)
+
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main, "_desktop_packaged_executable", lambda _desktop_dir: executable
+    )
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+
+    cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    expected = {"com.apple.security.device.audio-input": True}
+    assert _display_codesign_entitlements(app) == expected
+    assert _display_codesign_entitlements(helper_app) == expected
+    subprocess.run(
+        ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS codesign")
+def test_desktop_macos_relaunchable_fixup_missing_plists_uses_valid_deep_fallback(
+    tmp_path, monkeypatch
+):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+    executable = _make_codesignable_test_app(
+        app, "Hermes", "ai.hermes.desktop.codesign-fallback-test"
+    )
+    helper_app = app / "Contents" / "Frameworks" / "Hermes Helper.app"
+    _make_codesignable_test_app(
+        helper_app,
+        "Hermes Helper",
+        "ai.hermes.desktop.codesign-fallback-test.helper",
+    )
+
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main, "_desktop_packaged_executable", lambda _desktop_dir: executable
+    )
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+
+    cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    assert _display_codesign_entitlements(app) == {}
+    assert _display_codesign_entitlements(helper_app) == {}
+    subprocess.run(
+        ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _run_installer_macos_resign(app: Path, desktop_dir: Path) -> None:
+    environment = os.environ.copy()
+    environment.pop("CSC_LINK", None)
+    environment.pop("APPLE_SIGNING_IDENTITY", None)
+    subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1" --manifest >/dev/null\n'
+            '_desktop_macos_adhoc_resign "$2" "$3"',
+            "hermes-installer-codesign-test",
+            str(INSTALL_SH),
+            str(app),
+            str(desktop_dir),
+        ],
+        check=True,
+        capture_output=True,
+        env=environment,
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS codesign")
+def test_installer_macos_resign_embeds_entitlements_in_real_bundles(tmp_path):
+    desktop_dir = tmp_path / "apps" / "desktop"
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+    _make_codesignable_test_app(
+        app, "Hermes", "ai.hermes.installer.codesign-test"
+    )
+    helper_app = app / "Contents" / "Frameworks" / "Hermes Helper.app"
+    _make_codesignable_test_app(
+        helper_app, "Hermes Helper", "ai.hermes.installer.codesign-test.helper"
+    )
+    _write_test_entitlements(desktop_dir / "electron" / "entitlements.mac.plist")
+    _write_test_entitlements(
+        desktop_dir / "electron" / "entitlements.mac.inherit.plist"
+    )
+
+    _run_installer_macos_resign(app, desktop_dir)
+
+    expected = {"com.apple.security.device.audio-input": True}
+    assert _display_codesign_entitlements(app) == expected
+    assert _display_codesign_entitlements(helper_app) == expected
+    subprocess.run(
+        ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS codesign")
+def test_installer_macos_resign_missing_plists_uses_valid_deep_fallback(tmp_path):
+    desktop_dir = tmp_path / "apps" / "desktop"
+    app = desktop_dir / "release" / "mac-arm64" / "Hermes.app"
+    _make_codesignable_test_app(
+        app, "Hermes", "ai.hermes.installer.codesign-fallback-test"
+    )
+    helper_app = app / "Contents" / "Frameworks" / "Hermes Helper.app"
+    _make_codesignable_test_app(
+        helper_app,
+        "Hermes Helper",
+        "ai.hermes.installer.codesign-fallback-test.helper",
+    )
+
+    _run_installer_macos_resign(app, desktop_dir)
+
+    assert _display_codesign_entitlements(app) == {}
+    assert _display_codesign_entitlements(helper_app) == {}
+    subprocess.run(
+        ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
+        check=True,
+        capture_output=True,
+    )
 
 
 def test_force_adhoc_signing_disables_discovery_on_local_packaged_rebuild(monkeypatch):

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1052,12 +1052,12 @@ def test_desktop_macos_relaunchable_fixup_preserves_packaged_entitlements(
     ]
     assert codesign_commands == [
         [
-            "/usr/bin/codesign", "--force", "--sign", "-", "--entitlements",
-            str(helper_entitlements), str(helper_app),
+            "/usr/bin/codesign", "--force", "--options", "runtime", "--sign", "-",
+            "--entitlements", str(helper_entitlements), str(helper_app),
         ],
         [
-            "/usr/bin/codesign", "--force", "--sign", "-", "--entitlements",
-            str(main_entitlements), str(app),
+            "/usr/bin/codesign", "--force", "--options", "runtime", "--sign", "-",
+            "--entitlements", str(main_entitlements), str(app),
         ],
     ]
 
@@ -1082,7 +1082,8 @@ def test_desktop_macos_relaunchable_fixup_deep_signs_without_entitlement_plists(
     ]
     assert codesign_commands == [
         [
-            "/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app),
+            "/usr/bin/codesign", "--force", "--deep", "--options", "runtime",
+            "--sign", "-", str(app),
         ],
     ]
 
@@ -1122,10 +1123,27 @@ def _display_codesign_entitlements(app: Path) -> dict:
             "--xml",
             str(app),
         ],
-        check=True,
+        check=False,
         capture_output=True,
     )
-    return plistlib.loads(result.stdout) if result.stdout else {}
+    if result.returncode != 0 or not result.stdout:
+        return {}
+    return plistlib.loads(result.stdout)
+
+
+def _display_codesign_flags(app: Path) -> str:
+    result = subprocess.run(
+        ["/usr/bin/codesign", "--display", "--verbose=2", str(app)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    # codesign prints details on stderr
+    text = (result.stderr or "") + (result.stdout or "")
+    for line in text.splitlines():
+        if line.strip().startswith("flags="):
+            return line.strip()
+    return text
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS codesign")
@@ -1159,6 +1177,8 @@ def test_desktop_macos_relaunchable_fixup_embeds_entitlements_in_real_bundles(
     expected = {"com.apple.security.device.audio-input": True}
     assert _display_codesign_entitlements(app) == expected
     assert _display_codesign_entitlements(helper_app) == expected
+    assert "runtime" in _display_codesign_flags(app)
+    assert "runtime" in _display_codesign_flags(helper_app)
     subprocess.run(
         ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
         check=True,
@@ -1194,6 +1214,7 @@ def test_desktop_macos_relaunchable_fixup_missing_plists_uses_valid_deep_fallbac
 
     assert _display_codesign_entitlements(app) == {}
     assert _display_codesign_entitlements(helper_app) == {}
+    assert "runtime" in _display_codesign_flags(app)
     subprocess.run(
         ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
         check=True,
@@ -1243,6 +1264,8 @@ def test_installer_macos_resign_embeds_entitlements_in_real_bundles(tmp_path):
     expected = {"com.apple.security.device.audio-input": True}
     assert _display_codesign_entitlements(app) == expected
     assert _display_codesign_entitlements(helper_app) == expected
+    assert "runtime" in _display_codesign_flags(app)
+    assert "runtime" in _display_codesign_flags(helper_app)
     subprocess.run(
         ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
         check=True,
@@ -1268,6 +1291,7 @@ def test_installer_macos_resign_missing_plists_uses_valid_deep_fallback(tmp_path
 
     assert _display_codesign_entitlements(app) == {}
     assert _display_codesign_entitlements(helper_app) == {}
+    assert "runtime" in _display_codesign_flags(app)
     subprocess.run(
         ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)],
         check=True,


### PR DESCRIPTION
## Summary
- preserve Electron entitlements when macOS ad-hoc re-signs the desktop app from either the installer or the packaged `hermes desktop --build-only` path
- apply inherited entitlements to Helper apps and desktop entitlements to the main bundle
- retain the previous deep-sign fallback when entitlement plists are unavailable
- add real macOS `codesign` behavior coverage for both re-sign paths

## Why
A plain deep ad-hoc signature discards the entitlements produced by electron-builder, which can cause repeated microphone and screen-capture permission prompts. The same signing mechanism existed in both `scripts/install.sh` and `hermes_cli.main._desktop_macos_relaunchable_fixup`, so both paths must follow the same policy.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py -q --tb=short` — 67 passed
- `scripts/run_tests.sh tests/test_install_sh*.py -q --tb=short` — 33 passed
- `bash -n scripts/install.sh` — passed

The macOS behavior tests sign synthetic Mach-O app/Helper bundles, inspect embedded entitlements with `codesign --display --entitlements - --xml`, and verify the missing-plist fallback with `codesign --verify --deep --strict`.

Forward-port of the focused installer fix originally prepared in commit 0d1048350d, extended to cover the sibling packaged-build path identified during review.
