### PR TITLE
chore(whatsapp-bridge): wire npm test to node --test

### DIFF
--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",


### PR DESCRIPTION
## Summary
- add the missing `npm test` script to the WhatsApp bridge package
- run the existing Node test suites through the standard package command

## Test plan
- `npm ci` — 0 vulnerabilities
- `npm test` — 21 passed, 0 failed

This intentionally changes only the package script; current dependency pins remain untouched.