### PR TITLE
fix(matrix): make generated voice replies compatible with Element iOS

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13142,20 +13142,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Generate TTS audio and send as a voice message before the text reply."""
         import uuid as _uuid
         audio_path = None
+        generated_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import (
+                _convert_to_opus,
+                _strip_markdown_for_tts,
+                _strip_reasoning_for_tts,
+                text_to_speech_tool,
+            )
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            tts_text = _strip_markdown_for_tts(
+                _strip_reasoning_for_tts(text[:4000])
+            )
             if not tts_text:
                 return
 
-            # Telegram's adapter only sends native voice bubbles for OGG/Opus.
-            # Other platforms keep the existing MP3 default.
-            audio_ext = "ogg" if event.source.platform == Platform.TELEGRAM else "mp3"
+            # Matrix and Telegram native voice renderers require Ogg/Opus.
+            # Generate to MP3 for provider compatibility, then transcode below.
+            needs_opus_voice = event.source.platform in {
+                Platform.MATRIX,
+                Platform.TELEGRAM,
+            }
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.{audio_ext}",
+                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 
@@ -13170,9 +13181,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Use the actual file path from result (may differ after opus conversion)
             actual_path = result.get("file_path", audio_path)
+            generated_path = actual_path
             if not result.get("success") or not os.path.isfile(actual_path):
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
                 return
+
+            if needs_opus_voice and not str(actual_path).lower().endswith(".ogg"):
+                opus_path = await asyncio.to_thread(_convert_to_opus, actual_path)
+                if opus_path and os.path.isfile(opus_path):
+                    actual_path = opus_path
+                else:
+                    logger.warning(
+                        "Auto voice reply could not convert %s to Ogg/Opus for %s; sending original audio",
+                        actual_path,
+                        event.source.platform.value,
+                    )
 
             adapter = self._adapter_for_source(event.source)
 
@@ -13208,7 +13231,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:
-            for p in {audio_path, actual_path} - {None}:
+            for p in {audio_path, generated_path, actual_path} - {None}:
                 try:
                     os.unlink(p)
                 except OSError:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -51,11 +51,16 @@ Environment variables:
 from __future__ import annotations
 
 import asyncio
+import array
 import inspect
 import logging
 import mimetypes
 import os
 import re
+import shutil
+import subprocess
+import sys
+import tempfile
 import time
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from dataclasses import dataclass, field
@@ -133,6 +138,96 @@ from gateway.platforms.base import (
 from gateway.platforms.helpers import ThreadParticipationTracker
 
 logger = logging.getLogger(__name__)
+
+
+def _probe_audio_duration_ms(data: bytes, content_type: str) -> Optional[int]:
+    """Return audio duration in milliseconds for Matrix voice metadata."""
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+
+    suffix = ".ogg" if content_type == "audio/ogg" else ".audio"
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp:
+            temp.write(data)
+            temp_path = temp.name
+        result = subprocess.run(
+            [
+                ffprobe,
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                temp_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        duration = float(result.stdout.strip())
+        if duration <= 0:
+            return None
+        return max(1, round(duration * 1000))
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+    finally:
+        if temp_path:
+            try:
+                Path(temp_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _matrix_voice_metadata_for_file(path: Path) -> Dict[str, Any]:
+    """Return best-effort duration and waveform metadata for voice events."""
+    metadata: Dict[str, Any] = {}
+    duration = _probe_audio_duration_ms(path.read_bytes(), "audio/ogg")
+    if duration is not None:
+        metadata["duration"] = duration
+
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return metadata
+    try:
+        result = subprocess.run(
+            [ffmpeg, "-v", "error", "-i", str(path), "-ac", "1", "-ar", "8000", "-f", "s16le", "-"],
+            capture_output=True,
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout:
+            return metadata
+        samples = array.array("h")
+        samples.frombytes(result.stdout)
+        if sys.byteorder != "little":
+            samples.byteswap()
+        if samples:
+            bins = 100
+            count = len(samples)
+            metadata["waveform"] = [
+                min(
+                    1024,
+                    int(
+                        max(
+                            abs(value)
+                            for value in samples[
+                                idx * count // bins : max(idx + 1, (idx + 1) * count // bins)
+                            ]
+                        )
+                        / 32767
+                        * 1024
+                    ),
+                )
+                for idx in range(bins)
+            ]
+    except (OSError, ValueError, subprocess.SubprocessError):
+        logger.debug("Matrix: failed to build voice waveform for %s", path, exc_info=True)
+    return metadata
+
 
 _MATRIX_BANG_COMMAND_RE = re.compile(
     r"^!([A-Za-z][A-Za-z0-9_-]*)(?=$|\s)(.*)$",
@@ -1969,16 +2064,51 @@ class MatrixAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Upload an audio file as a voice message (MSC3245 native voice)."""
-        return await self._send_local_file(
-            chat_id,
-            audio_path,
-            "m.audio",
-            caption,
-            reply_to,
-            metadata=metadata,
-            is_voice=True,
-        )
+        """Upload audio as a Matrix native voice message when possible.
+
+        Matrix clients expect MSC3245 voice messages to contain Opus audio
+        in an OGG container. TTS providers commonly return MP3 or WAV, so
+        convert those files at the adapter boundary instead of relying on
+        the upstream caller to know which platform is delivering the audio.
+        """
+        source = Path(audio_path).expanduser()
+        converted_path: Optional[str] = None
+        upload_path = str(source)
+        is_voice = source.suffix.lower() == ".ogg"
+        try:
+            if not is_voice:
+                try:
+                    from tools.tts_tool import _convert_to_opus
+                    converted_path = await asyncio.to_thread(
+                        _convert_to_opus, str(source)
+                    )
+                except Exception as exc:
+                    logger.warning("Matrix: voice conversion failed: %s", exc)
+
+                if converted_path:
+                    upload_path = converted_path
+                    is_voice = True
+                else:
+                    logger.warning(
+                        "Matrix: sending %s as regular audio; OGG/Opus conversion unavailable",
+                        source.name,
+                    )
+
+            return await self._send_local_file(
+                chat_id,
+                upload_path,
+                "m.audio",
+                caption,
+                reply_to,
+                metadata=metadata,
+                is_voice=is_voice,
+            )
+        finally:
+            if converted_path and converted_path != str(source):
+                try:
+                    Path(converted_path).unlink(missing_ok=True)
+                except OSError:
+                    logger.debug("Matrix: failed to remove temporary voice file %s", converted_path)
 
     async def send_video(
         self,
@@ -2148,6 +2278,7 @@ class MatrixAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         is_voice: bool = False,
+        voice_metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
         if len(data) > self._max_media_bytes:
@@ -2186,13 +2317,23 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
         # Build media message content.
+        audio_duration_ms = None
+        if is_voice:
+            audio_duration_ms = await asyncio.to_thread(
+                _probe_audio_duration_ms, data, content_type
+            )
+            if voice_metadata:
+                audio_duration_ms = voice_metadata.get("duration") or audio_duration_ms
+        media_info: Dict[str, Any] = {
+            "mimetype": content_type,
+            "size": len(data),
+        }
+        if audio_duration_ms is not None:
+            media_info["duration"] = audio_duration_ms
         msg_content: Dict[str, Any] = {
             "msgtype": msgtype,
             "body": caption or filename,
-            "info": {
-                "mimetype": content_type,
-                "size": len(data),
-            },
+            "info": media_info,
         }
         if encrypted_file is not None:
             file_payload = encrypted_file.serialize()
@@ -2204,6 +2345,14 @@ class MatrixAdapter(BasePlatformAdapter):
         # Add MSC3245 voice flag for native voice messages.
         if is_voice:
             msg_content["org.matrix.msc3245.voice"] = {}
+            waveform = (voice_metadata or {}).get("waveform")
+            if audio_duration_ms is not None or waveform is not None:
+                audio_metadata: Dict[str, Any] = {}
+                if audio_duration_ms is not None:
+                    audio_metadata["duration"] = audio_duration_ms
+                if waveform is not None:
+                    audio_metadata["waveform"] = waveform
+                msg_content["org.matrix.msc1767.audio"] = audio_metadata
 
         self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
 
@@ -2251,10 +2400,23 @@ class MatrixAdapter(BasePlatformAdapter):
 
         fname = file_name or p.name
         ct = mimetypes.guess_type(fname)[0] or "application/octet-stream"
+        if is_voice and p.suffix.lower() == ".ogg":
+            # Match Element iOS' own native voice-message sender.
+            ct = "audio/ogg"
         data = p.read_bytes()
+        voice_metadata = _matrix_voice_metadata_for_file(p) if is_voice else None
 
         return await self._upload_and_send(
-            room_id, data, fname, ct, msgtype, caption, reply_to, metadata, is_voice
+            room_id,
+            data,
+            fname,
+            ct,
+            msgtype,
+            caption,
+            reply_to,
+            metadata,
+            is_voice,
+            voice_metadata,
         )
 
     # ------------------------------------------------------------------

--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -323,17 +323,26 @@ class TestMatrixSendVoiceMSC3245:
 
             self.adapter._client.send_message_event = mock_send_message_event
 
-            await self.adapter.send_voice(
-                chat_id="!room:example.org",
-                audio_path=temp_path,
-                caption="Test voice",
-            )
+            with patch(
+                "plugins.platforms.matrix.adapter._matrix_voice_metadata_for_file",
+                return_value={"duration": 1234, "waveform": [0, 512, 1024]},
+            ):
+                await self.adapter.send_voice(
+                    chat_id="!room:example.org",
+                    audio_path=temp_path,
+                    caption="Test voice",
+                )
 
             assert sent_content is not None, "No message was sent"
             assert "org.matrix.msc3245.voice" in sent_content, \
                 f"MSC3245 voice field missing from content: {sent_content.keys()}"
             assert sent_content["msgtype"] == "m.audio"
             assert sent_content["info"]["mimetype"] == "audio/ogg"
+            assert sent_content["info"]["duration"] == 1234
+            assert sent_content["org.matrix.msc1767.audio"] == {
+                "duration": 1234,
+                "waveform": [0, 512, 1024],
+            }
             assert self.upload_call is not None, "Expected upload_media() to be called"
             assert isinstance(self.upload_call["data"], bytes)
             assert self.upload_call["mime_type"] == "audio/ogg"

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -433,7 +433,7 @@ class TestSendVoiceReply:
             await runner._send_voice_reply(event, "Hello world")
 
         mock_adapter.send_voice.assert_called_once()
-        assert mock_tts.call_args.kwargs["output_path"].endswith(".ogg")
+        assert mock_tts.call_args.kwargs["output_path"].endswith(".mp3")
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
 
@@ -458,6 +458,56 @@ class TestSendVoiceReply:
 
         mock_adapter.send_voice.assert_called_once()
         assert mock_tts.call_args.kwargs["output_path"].endswith(".mp3")
+
+    @pytest.mark.asyncio
+    async def test_matrix_auto_voice_reply_converts_to_ogg(self, runner):
+        from gateway.config import Platform
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        event = _make_event()
+        event.source.platform = Platform.MATRIX
+        runner.adapters[event.source.platform] = mock_adapter
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.mp3"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result) as mock_tts, \
+             patch("tools.tts_tool._convert_to_opus", return_value="/tmp/test.ogg") as mock_convert, \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(event, "Hello world")
+
+        mock_tts.assert_called_once()
+        assert mock_tts.call_args.kwargs["output_path"].endswith(".mp3")
+        mock_convert.assert_called_once_with("/tmp/test.mp3")
+        mock_adapter.send_voice.assert_called_once()
+        assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == "/tmp/test.ogg"
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_does_not_synthesize_display_reasoning(self, runner):
+        from gateway.config import Platform
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        event = _make_event()
+        event.source.platform = Platform.MATRIX
+        runner.adapters[event.source.platform] = mock_adapter
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+        response = (
+            "💭 **Reasoning:**\n```\nI should inspect the event first.\n```\n\n"
+            "The voice message is ready."
+        )
+
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result) as mock_tts, \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(event, response)
+
+        assert mock_tts.call_args.kwargs["text"] == "The voice message is ready."
 
     @pytest.mark.asyncio
     async def test_auto_voice_reply_uses_thread_metadata_helper(self, runner):

--- a/tests/plugins/test_matrix_voice_delivery.py
+++ b/tests/plugins/test_matrix_voice_delivery.py
@@ -1,0 +1,75 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+from plugins.platforms.matrix.adapter import MatrixAdapter
+
+
+class _FakeMatrixClient:
+    crypto = None
+
+    async def upload_media(self, data, *, mime_type, filename, size):
+        self.upload = (data, mime_type, filename, size)
+        return "mxc://example.org/audio"
+
+    async def send_message_event(self, room_id, event_type, content):
+        self.event = content
+        return "$event"
+
+
+def test_matrix_voice_event_includes_duration_metadata(monkeypatch):
+    client = _FakeMatrixClient()
+    adapter = object.__new__(MatrixAdapter)
+    adapter._client = client
+    adapter._encryption = False
+    adapter._max_media_bytes = 1024 * 1024
+    adapter._apply_relation_metadata = lambda *args, **kwargs: None
+    monkeypatch.setattr(
+        "plugins.platforms.matrix.adapter._probe_audio_duration_ms",
+        lambda data, content_type: 3210,
+    )
+
+    result = asyncio.run(
+        adapter._upload_and_send(
+            "!room:example.org",
+            b"ogg",
+            "reply.ogg",
+            "audio/ogg",
+            "m.audio",
+            is_voice=True,
+        )
+    )
+
+    assert result.success is True
+    assert client.upload[1] == "audio/ogg"
+    assert client.event["info"]["mimetype"] == "audio/ogg"
+    assert client.event["info"]["duration"] == 3210
+    assert client.event["org.matrix.msc1767.audio"]["duration"] == 3210
+    assert client.event["org.matrix.msc3245.voice"] == {}
+
+
+
+def test_matrix_send_voice_converts_non_ogg_audio(tmp_path, monkeypatch):
+    source = tmp_path / "reply.mp3"
+    converted = tmp_path / "reply.ogg"
+    source.write_bytes(b"mp3")
+    converted.write_bytes(b"ogg")
+
+    convert = Mock(return_value=str(converted))
+    monkeypatch.setattr("tools.tts_tool._convert_to_opus", convert)
+
+    adapter = object.__new__(MatrixAdapter)
+    adapter._send_local_file = AsyncMock(return_value="sent")
+
+    result = asyncio.run(adapter.send_voice("!room:example.org", str(source)))
+
+    assert result == "sent"
+    convert.assert_called_once_with(str(source))
+    adapter._send_local_file.assert_awaited_once_with(
+        "!room:example.org",
+        str(converted),
+        "m.audio",
+        None,
+        None,
+        metadata=None,
+        is_voice=True,
+    )

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -68,3 +68,33 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_matrix_converts_local_tts_to_opus_voice(tmp_path, monkeypatch):
+    out = tmp_path / "speech.wav"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"ogg")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    def fake_generate(_text: str, path: str, _config: dict) -> str:
+        Path(path).write_bytes(b"wav")
+        return path
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "matrix")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "kittentts"})
+    monkeypatch.setattr(tts_tool, "_import_kittentts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_kittentts", fake_generate)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
+    convert.assert_called_once_with(str(out))

--- a/tests/tools/test_tts_reasoning.py
+++ b/tests/tools/test_tts_reasoning.py
@@ -1,0 +1,15 @@
+from tools.tts_tool import _strip_reasoning_for_tts
+
+
+def test_strip_reasoning_code_block_from_voice_text():
+    text = "💭 **Reasoning:**\n```\nI should inspect the event first.\n```\n\nThe voice message is ready."
+    assert _strip_reasoning_for_tts(text) == "The voice message is ready."
+
+
+def test_strip_reasoning_blockquote_from_voice_text():
+    text = "> 💭 **Reasoning:**\n> I should inspect the event first.\n\nThe voice message is ready."
+    assert _strip_reasoning_for_tts(text) == "The voice message is ready."
+
+
+def test_leave_normal_text_unchanged():
+    assert _strip_reasoning_for_tts("The voice message is ready.") == "The voice message is ready."

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -889,7 +889,7 @@ def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -
 
 
 # ===========================================================================
-# ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
+# ffmpeg Opus conversion (local/cloud audio -> OGG Opus for voice bubbles)
 # ===========================================================================
 def _has_ffmpeg() -> bool:
     """Check if ffmpeg is available on the system."""
@@ -913,7 +913,8 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     try:
         result = subprocess.run(
             ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
-             "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
+             "-ac", "1", "-ar", "48000", "-b:a", "64k",
+             "-application", "audio", "-f", "ogg", ogg_path, "-y"],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
             creationflags=windows_hide_flags(),
@@ -2194,12 +2195,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram and Matrix voice messages require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed). Edge TTS always
+    # outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in {"telegram", "matrix"}
 
     # Determine output path
     if output_path:
@@ -2236,8 +2237,9 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
-        # Use .ogg for Telegram with providers that support native Opus output,
-        # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
+        # Use .ogg for Telegram or Matrix with providers that support native
+        # Opus output, otherwise fall back to .mp3 (other providers will be
+        # converted later when voice delivery requires it).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
@@ -2390,7 +2392,7 @@ def text_to_speech_tool(
                 "error": f"TTS generation produced no output (provider: {provider})"
             }, ensure_ascii=False)
 
-        # Try Opus conversion for Telegram compatibility.
+        # Try Opus conversion for Telegram and Matrix voice compatibility.
         # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV. Keep those native
         # formats for local/CLI playback and only convert when the current
         # platform actually needs Opus voice delivery.
@@ -2575,6 +2577,32 @@ _MD_HEADER = re.compile(r'^#+\s*', flags=re.MULTILINE)
 _MD_LIST_ITEM = re.compile(r'^\s*[-*]\s+', flags=re.MULTILINE)
 _MD_HR = re.compile(r'---+')
 _MD_EXCESS_NL = re.compile(r'\n{3,}')
+
+
+def _strip_reasoning_for_tts(text: str) -> str:
+    """Remove gateway display-only reasoning prefixes before speech synthesis."""
+    text = re.sub(
+        r"^\s*💭\s*\*\*Reasoning:\*\*\s*\n```.*?```\s*",
+        "",
+        text,
+        count=1,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    text = re.sub(
+        r"^\s*>\s*💭\s*\*\*Reasoning:\*\*\s*\n(?:>.*(?:\n|$))*\s*",
+        "",
+        text,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r"^\s*-#\s*💭\s*Reasoning\s*\n(?:-#.*(?:\n|$))*\s*",
+        "",
+        text,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    return text.strip()
 
 
 def _strip_markdown_for_tts(text: str) -> str:


### PR DESCRIPTION
## Summary

Fix generated Matrix voice replies so they play correctly in Element iOS.

## What changed

- Convert automatic Matrix voice replies to standard mono OGG/Opus audio.
- Include MSC3245 voice-message metadata.
- Include MSC1767 duration and waveform metadata.
- Preserve the converted file through upload and cleanup.
- Prevent display-only reasoning text from being passed to TTS.
- Add regression tests for the gateway path, encoding, upload payload, event metadata, and TTS text selection.

## Why

The Matrix iOS SDK creates native voice messages as `m.audio` events with the MSC3245 voice flag and MSC1767 audio metadata:

https://github.com/matrix-org/matrix-ios-sdk/blob/097208ccc5bec72b37261d8ea0bc857c9ccd8361/MatrixSDK/Data/MXRoom.m#L1556-L1599

The SDK identifies voice messages using the `m.audio` type plus a recognised voice flag:

https://github.com/matrix-org/matrix-ios-sdk/blob/097208ccc5bec72b37261d8ea0bc857c9ccd8361/MatrixSDK/JSONModels/MXEvent.m#L546-L552

Element iOS converts OGG/Opus attachments to AAC/M4A for playback using its SwiftOGG integration:

https://github.com/element-hq/element-ios/blob/36a1788da26933557c468325da2851298ed0386b/Riot/Modules/Room/VoiceMessages/VoiceMessageAttachmentCacheManager.swift#L199-L247

This implementation follows that Matrix/Element event and playback path. It does not rely on undocumented `codecs=opus`, `application=voip`, or bitrate requirements.

## Testing

- `scripts/run_tests.sh` on all changed voice tests: 216 passed, 0 failed.
- Ruff, syntax checks, and diff checks pass.
- Tested on the Linux gateway with Element Desktop and Element iOS.
- Verified live Element iOS playback after gateway restart.

---

*Created by Theo — a Hermes Agent 🪽*
