### PR TITLE
fix(desktop): preserve backend pool ownership across child exits

### DIFF
--- a/apps/desktop/electron/backend-pool-lifecycle.test.ts
+++ b/apps/desktop/electron/backend-pool-lifecycle.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { test } from 'vitest'
+
+import { cleanupFailedPoolBackend, terminatePoolBackendEntry, watchPoolBackendChild } from './backend-pool-lifecycle'
+
+interface FakeEntry {
+  process: FakeChild | null
+}
+
+class FakeChild extends EventEmitter {
+  readonly name: string
+
+  constructor(name: string) {
+    super()
+    this.name = name
+  }
+}
+
+function watch(pool: Map<string, FakeEntry>, profile: string, entry: FakeEntry) {
+  const events: string[] = []
+
+  watchPoolBackendChild(pool, profile, entry, entry.process, {
+    onError: error => events.push(`error:${error.message}`),
+    onExit: (code, signal) => events.push(`exit:${signal || code}`)
+  })
+
+  return events
+}
+
+test('an old child exit preserves the replacement pool entry', () => {
+  const profile = 'work'
+  const oldEntry = { process: new FakeChild('old') }
+  const replacement = { process: new FakeChild('replacement') }
+  const pool = new Map([[profile, oldEntry]])
+  const events = watch(pool, profile, oldEntry)
+
+  pool.set(profile, replacement)
+  oldEntry.process.emit('exit', 0, null)
+
+  assert.equal(pool.get(profile), replacement)
+  assert.deepEqual(events, ['exit:0'])
+})
+
+test('an old child error preserves the replacement pool entry', () => {
+  const profile = 'work'
+  const oldEntry = { process: new FakeChild('old') }
+  const replacement = { process: new FakeChild('replacement') }
+  const pool = new Map([[profile, oldEntry]])
+  const events = watch(pool, profile, oldEntry)
+
+  pool.set(profile, replacement)
+  oldEntry.process.emit('error', new Error('late spawn error'))
+
+  assert.equal(pool.get(profile), replacement)
+  assert.deepEqual(events, ['error:late spawn error'])
+})
+
+test('spawn failure removes its owned entry and terminates the spawned child', async () => {
+  const profile = 'work'
+  const child = new FakeChild('spawned')
+  const entry = { process: child }
+  const pool = new Map([[profile, entry]])
+  const calls: string[] = []
+
+  await cleanupFailedPoolBackend(pool, profile, entry, {
+    stopBackendChild: process => calls.push(`term:${process?.name}`),
+    waitForBackendExit: async process => {
+      calls.push(`wait:${process?.name}`)
+    }
+  })
+
+  assert.equal(pool.has(profile), false)
+  assert.deepEqual(calls, ['term:spawned', 'wait:spawned'])
+})
+
+test('spawn failure terminates its child without removing a replacement entry', async () => {
+  const profile = 'work'
+  const child = new FakeChild('failed')
+  const failedEntry = { process: child }
+  const replacement = { process: new FakeChild('replacement') }
+  const pool = new Map([[profile, replacement]])
+  const terminated: FakeChild[] = []
+
+  await cleanupFailedPoolBackend(pool, profile, failedEntry, {
+    stopBackendChild: process => {
+      if (process) {
+        terminated.push(process)
+      }
+    },
+    waitForBackendExit: async () => {}
+  })
+
+  assert.equal(pool.get(profile), replacement)
+  assert.deepEqual(terminated, [child])
+})
+
+test('pool termination requests graceful stop before waiting for bounded escalation', async () => {
+  const child = new FakeChild('pooled')
+  const calls: string[] = []
+
+  await terminatePoolBackendEntry(
+    { process: child },
+    {
+      stopBackendChild: process => calls.push(`term:${process?.name}`),
+      waitForBackendExit: async process => {
+        calls.push(`wait:${process?.name}`)
+      }
+    }
+  )
+
+  assert.deepEqual(calls, ['term:pooled', 'wait:pooled'])
+})

--- a/apps/desktop/electron/backend-pool-lifecycle.ts
+++ b/apps/desktop/electron/backend-pool-lifecycle.ts
@@ -1,0 +1,69 @@
+/**
+ * Lifecycle coordination for lazily spawned profile backends.
+ *
+ * Kept separate from main.ts so the ownership races can be exercised with
+ * Vitest without booting Electron. The Map entry is the pool's ownership
+ * token: a child that exits late may only remove the exact entry it created.
+ */
+
+interface PoolChild {
+  once(event: 'error', listener: (error: Error) => void): unknown
+  once(event: 'exit', listener: (code: number | null, signal: string | null) => void): unknown
+}
+
+interface PoolEntry {
+  process: unknown | null
+}
+
+interface PoolChildCallbacks {
+  onError(error: Error): void
+  onExit(code: number | null, signal: string | null): void
+}
+
+interface PoolTermination<Entry extends PoolEntry> {
+  stopBackendChild(child: Entry['process']): void
+  waitForBackendExit(child: Entry['process']): Promise<void>
+}
+
+export function deletePoolEntryIfOwned<Entry>(pool: Map<string, Entry>, profile: string, entry: Entry) {
+  if (pool.get(profile) !== entry) {
+    return false
+  }
+
+  return pool.delete(profile)
+}
+
+export function watchPoolBackendChild<Entry>(
+  pool: Map<string, Entry>,
+  profile: string,
+  entry: Entry,
+  child: PoolChild,
+  callbacks: PoolChildCallbacks
+) {
+  child.once('error', error => {
+    deletePoolEntryIfOwned(pool, profile, entry)
+    callbacks.onError(error)
+  })
+  child.once('exit', (code, signal) => {
+    deletePoolEntryIfOwned(pool, profile, entry)
+    callbacks.onExit(code, signal)
+  })
+}
+
+export async function terminatePoolBackendEntry<Entry extends PoolEntry>(
+  entry: Entry,
+  { stopBackendChild, waitForBackendExit }: PoolTermination<Entry>
+) {
+  stopBackendChild(entry.process)
+  await waitForBackendExit(entry.process)
+}
+
+export async function cleanupFailedPoolBackend<Entry extends PoolEntry>(
+  pool: Map<string, Entry>,
+  profile: string,
+  entry: Entry,
+  termination: PoolTermination<Entry>
+) {
+  deletePoolEntryIfOwned(pool, profile, entry)
+  await terminatePoolBackendEntry(entry, termination)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,6 +35,11 @@ import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
 import { waitForHermesReady } from './backend-health'
+import {
+  cleanupFailedPoolBackend,
+  terminatePoolBackendEntry,
+  watchPoolBackendChild
+} from './backend-pool-lifecycle'
 import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure } from './backend-start-failure'
@@ -7643,7 +7648,10 @@ async function ensureBackend(profile) {
 
   const entry = { process: null, port: null, token: null, connectionPromise: null, lastActiveAt: Date.now() }
   entry.connectionPromise = spawnPoolBackend(key, entry).catch(error => {
-    backendPool.delete(key)
+    void cleanupFailedPoolBackend(backendPool, key, entry, {
+      stopBackendChild,
+      waitForBackendExit
+    }).catch(() => {})
     throw error
   })
   backendPool.set(key, entry)
@@ -7798,19 +7806,19 @@ async function spawnPoolBackend(profile, entry) {
     rejectStart = reject
   })
 
-  child.once('error', error => {
-    rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
-    backendPool.delete(profile)
-    rejectStart?.(error)
-  })
-  child.once('exit', (code, signal) => {
-    rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
-    backendPool.delete(profile)
+  watchPoolBackendChild(backendPool, profile, entry, child, {
+    onError: error => {
+      rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
+      rejectStart?.(error)
+    },
+    onExit: (code, signal) => {
+      rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
 
-    if (!ready) {
-      rejectStart?.(
-        new Error(`Hermes backend for profile "${profile}" exited before it became ready (${signal || code}).`)
-      )
+      if (!ready) {
+        rejectStart?.(
+          new Error(`Hermes backend for profile "${profile}" exited before it became ready (${signal || code}).`)
+        )
+      }
     }
   })
 
@@ -7856,7 +7864,7 @@ function stopPoolBackend(profile) {
   }
 
   backendPool.delete(profile)
-  stopBackendChild(entry.process)
+  void terminatePoolBackendEntry(entry, { stopBackendChild, waitForBackendExit }).catch(() => {})
 }
 
 async function teardownPoolBackendAndWait(profile) {
@@ -7867,10 +7875,7 @@ async function teardownPoolBackendAndWait(profile) {
   }
 
   backendPool.delete(profile)
-
-  stopBackendChild(entry.process)
-
-  await waitForBackendExit(entry.process)
+  await terminatePoolBackendEntry(entry, { stopBackendChild, waitForBackendExit })
 }
 
 function stopAllPoolBackends() {


### PR DESCRIPTION
## Summary
- prevent an older backend child from deleting a replacement entry for the same profile when it exits or errors late
- terminate a child whose spawn/start promise fails without deleting a newer replacement
- reuse the existing bounded SIGTERM-to-SIGKILL wait path for pool shutdown
- add behavior-based lifecycle tests collected by the current Electron Vitest project

## Scope
This is a current-TypeScript forward-port of the focused ownership fix from c851b7725b. It intentionally omits the old broad PPID-1 stray-process sweep because it could kill legitimately reparented processes.

## Test plan
- `npm run test:desktop:platforms --workspace apps/desktop -- electron/backend-pool-lifecycle.test.ts` — 5 passed
- `tsc -p apps/desktop/tsconfig.electron.json --noEmit` — passed
- scoped ESLint on `backend-pool-lifecycle.ts` and its test — passed

The full desktop typecheck was also attempted locally; its UI pass is currently blocked by unrelated installed `assistant-ui` / `react-streamdown` dependency-version errors on current `main`, while the changed Electron TypeScript project is clean.

## Reproduction
Child A begins shutting down; child B is inserted for the same profile before A emits `exit`. Previously A's handler deleted B from the pool, leaving B alive but untracked by reaping and shutdown.
