### PR TITLE
fix(qqbot): support dm chat_type in send/upload/keyboard paths

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,7 +1100,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:
@@ -2375,7 +2375,7 @@ class QQAdapter(BasePlatformAdapter):
         """Upload media and return file_info."""
         path = (
             f"/v2/users/{target_id}/files"
-            if target_type == "c2c"
+            if target_type in {"c2c", "dm"}
             else f"/v2/groups/{target_id}/files"
         )
 
@@ -2480,7 +2480,7 @@ class QQAdapter(BasePlatformAdapter):
 
         for attempt in range(3):
             try:
-                if chat_type == "c2c":
+                if chat_type in {"c2c", "dm"}:
                     return await self._send_c2c_text(chat_id, content, reply_to)
                 elif chat_type == "group":
                     return await self._send_group_text(chat_id, content, reply_to)
@@ -2607,7 +2607,7 @@ class QQAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         truncated = formatted[: self.MAX_MESSAGE_LENGTH]
         try:
-            if chat_type == "c2c":
+            if chat_type in {"c2c", "dm"}:
                 return await self._send_c2c_text(
                     chat_id, truncated, reply_to, keyboard=keyboard,
                 )
@@ -2937,7 +2937,7 @@ class QQAdapter(BasePlatformAdapter):
                 "POST",
                 (
                     f"/v2/users/{chat_id}/messages"
-                    if chat_type == "c2c"
+                    if chat_type in {"c2c", "dm"}
                     else f"/v2/groups/{chat_id}/messages"
                 ),
                 body,

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -316,7 +316,7 @@ class ChunkedUploader:
         file_size: int,
         hashes: Dict[str, str],
     ) -> _PrepareResult:
-        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        base = "/v2/users" if chat_type in {"c2c", "dm"} else "/v2/groups"
         path = f"{base}/{target_id}/upload_prepare"
         body = {
             "file_type": file_type,
@@ -451,7 +451,7 @@ class ChunkedUploader:
         retry_timeout: float,
     ) -> None:
         """Call ``upload_part_finish``, retrying on biz_code 40093001."""
-        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        base = "/v2/users" if chat_type in {"c2c", "dm"} else "/v2/groups"
         path = f"{base}/{target_id}/upload_part_finish"
         body = {
             "upload_id": upload_id,
@@ -502,7 +502,7 @@ class ChunkedUploader:
         This reuses the ``/files`` endpoint (same as the simple URL-based upload)
         but signals the chunked-completion path by sending only ``upload_id``.
         """
-        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        base = "/v2/users" if chat_type in {"c2c", "dm"} else "/v2/groups"
         path = f"{base}/{target_id}/files"
         body = {"upload_id": upload_id}
 

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -376,7 +376,7 @@ class ApprovalSender:
         )
 
         try:
-            if chat_type == "c2c":
+            if chat_type in {"c2c", "dm"}:
                 await self._post_c2c(chat_id, text, msg_id, keyboard)
             elif chat_type == "group":
                 await self._post_group(chat_id, text, msg_id, keyboard)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1660,6 +1660,33 @@ class TestDefaultInteractionDispatch:
 
 
     @pytest.mark.asyncio
+    async def test_approval_click_dm_session_authorizes_operator(self):
+        """DM session (chat_type='dm') should authorize the matching operator."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-dm",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-dm:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-dm", "once", False)]
+
+    @pytest.mark.asyncio
     async def test_approval_click_rejects_unauthorized_operator(self):
         adapter = self._make_adapter()
         resolve_calls = []


### PR DESCRIPTION
## What

Upstream established DM message intake with `chat_type='dm'`, but the send, upload, and keyboard callback paths only matched `c2c`. This caused DM replies to silently fail with 'Unknown chat type'.

## Fix

Changed 9 locations across 3 files to accept both `c2c` and `dm`:

- `gateway/platforms/qqbot/adapter.py`: send text, send media, send keyboard, reply dispatch, operator check
- `gateway/platforms/qqbot/chunked_upload.py`: upload_prepare, upload_part_finish, upload_commit
- `gateway/platforms/qqbot/keyboards.py`: approval button callback

## Related issues

Closes / relates to #35760, #32528, #34432, #40655 (approval button / c2c-dm mismatch)

## Notes

This is the same change as #39133 for the authorization check, but extended to all outbound paths that still only checked `c2c`.