### PR TITLE
fix(compaction): cap post-tool compression attempts per turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4793,7 +4793,12 @@ def run_conversation(
                         messages, tools=agent.tools or None
                     )
 
-                if agent.compression_enabled and _compressor.should_compress(_real_tokens):
+                if (
+                    agent.compression_enabled
+                    and compression_attempts < 3
+                    and _compressor.should_compress(_real_tokens)
+                ):
+                    compression_attempts += 1
                     agent._safe_print("  ⟳ compacting context…")
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -1,0 +1,30 @@
+"""Regression guard for the post-tool automatic-compression attempt cap.
+
+The pre-API and overflow compression paths share ``compression_attempts`` as a
+three-pass per-turn backstop. The post-tool path must use the same counter;
+otherwise a long tool loop can compact after every tool response for the
+lifetime of the turn.
+"""
+from __future__ import annotations
+
+import inspect
+
+
+def _post_tool_compression_block() -> str:
+    from agent import conversation_loop
+
+    source = inspect.getsource(conversation_loop.run_conversation)
+    start = source.index("# Use real token counts from the API response")
+    end = source.index("# Save session log incrementally", start)
+    return source[start:end]
+
+
+def test_post_tool_compression_uses_shared_per_turn_attempt_cap():
+    block = _post_tool_compression_block()
+
+    assert "compression_attempts < 3" in block, (
+        "post-tool compression must stop after the shared three attempts per turn"
+    )
+    assert "compression_attempts += 1" in block, (
+        "post-tool compression must consume one shared per-turn attempt"
+    )


### PR DESCRIPTION
## Problem

The preflight and overflow compression paths share a `compression_attempts < 3` per-turn cap, but the post-tool compression path in `run_conversation` (agent/conversation_loop.py) neither checked nor incremented the counter. During a long tool turn that rapidly regenerates context (large tool responses / file reads adding 60-90K tokens between passes), post-tool compression can therefore re-fire indefinitely.

Observed in production (v0.18.2, gpt-5.6-sol via openai-codex, compression threshold at 50%): one session compacted 4 times in ~13 minutes. Each compaction genuinely reduced estimated message tokens 30-43%, but the same long tool turn regrew past threshold and re-triggered — with each compaction itself a full main-model summarization call (`auxiliary.compression.provider: main`), the session spent most of its wall clock compacting.

## Fix

Apply the same shared guard the other two paths use: gate post-tool compression on `compression_attempts < 3` and increment the shared counter before compacting.

## Tests

- New regression test `tests/test_post_tool_compression_attempt_cap.py` — failed before the change, passes after.
- Full related compression suite: 94/94 pass.

https://claude.ai/code/session_015StmTvr85VriETdW9Gy9D5