### PR TITLE
fix(tests): avoid oversubscribing runner workers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1283,16 +1283,18 @@ def profile_env(tmp_path, monkeypatch):
 
 ### Python
 **ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
-hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
-on a 16+ core developer machine with API keys set diverges from CI in ways
-that have caused multiple "works locally, fails in CI" incidents (and the reverse).
+hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8)
+and runs every test file in a fresh subprocess. Its automatic pool uses one worker
+per reported CPU; `-j` or `HERMES_TEST_WORKERS` overrides that count. Direct `pytest`
+on a developer machine with API keys set diverges from CI in ways that have caused
+multiple "works locally, fails in CI" incidents (and the reverse).
 
 ```bash
 scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
 scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+scripts/run_tests.sh -j 16                           # override automatic parallelism
 ```
 
 **Flake policy:** the runner auto-retries a failing test FILE once in a fresh
@@ -1305,8 +1307,9 @@ negative-timing races).
 
 #### Subprocess-per-test-file isolation
 
-Every test file runs in a freshly-spawned Python subprocess via `run_tests_parallel.py`. This means module-level dicts/sets and
-ContextVars from one test file cannot leak into the next.
+Every test file runs in a freshly-spawned Python subprocess via
+`run_tests_parallel.py`. This means module-level dicts/sets and ContextVars from
+one test file cannot leak into the next.
 
 #### Why the wrapper
 

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -645,6 +645,15 @@ def _slice_files(
     return target
 
 
+def _default_worker_count() -> int:
+    """Use one test subprocess per reported CPU unless explicitly overridden."""
+    configured = os.environ.get("HERMES_TEST_WORKERS")
+    if configured:
+        return int(configured)
+
+    return os.cpu_count() or 4
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -654,8 +663,8 @@ def main() -> int:
         "-j",
         "--jobs",
         type=int,
-        default=int(os.environ.get("HERMES_TEST_WORKERS") or (os.cpu_count() or 4) * 2),
-        help="Parallel worker count (default: $HERMES_TEST_WORKERS or cpu_count*2)",
+        default=_default_worker_count(),
+        help="Parallel worker count (default: $HERMES_TEST_WORKERS or cpu_count)",
     )
     parser.add_argument(
         "--paths",

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import pytest
 
+from scripts import run_tests_parallel
+
 
 # Both tests share the same handoff file: the leaker writes here, the
 # verifier reads here. We park it in $TMPDIR with a unique-per-run name
@@ -185,6 +187,30 @@ def test_grandchild_leak_is_killed_by_runner(tmp_path: Path) -> None:
             f"diag={diag!r} test_pid={test_pid} test_pgid={test_pgid}; "
             f"runner output:\n{proc.stdout}"
         )
+
+
+# ── Automatic worker count ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(("cpu_count", "expected"), [(32, 32), (None, 4)])
+def test_default_worker_count_matches_cpu_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    cpu_count: int | None,
+    expected: int,
+) -> None:
+    """The automatic pool must not oversubscribe the reported CPU capacity."""
+    monkeypatch.delenv("HERMES_TEST_WORKERS", raising=False)
+    monkeypatch.setattr(run_tests_parallel.os, "cpu_count", lambda: cpu_count)
+
+    assert run_tests_parallel._default_worker_count() == expected
+
+
+def test_default_worker_count_honors_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit worker count still wins over automatic CPU sizing."""
+    monkeypatch.setenv("HERMES_TEST_WORKERS", "7")
+    monkeypatch.setattr(run_tests_parallel.os, "cpu_count", lambda: 32)
+
+    assert run_tests_parallel._default_worker_count() == 7
 
 
 # ── Bare pytest-flag passthrough ─────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Stops the per-file test runner from launching twice as many pytest subprocesses as the machine reports CPUs.

`run_tests_parallel.py` documented an `os.cpu_count()` default, while the parser used `cpu_count * 2`. On a 32-thread host that created 64 simultaneous Python processes and caused false 5- and 10-second deadline failures in process/interrupt tests that passed directly and at lower worker counts.

The automatic default is now one subprocess per reported CPU. Explicit `-j` and `HERMES_TEST_WORKERS` overrides are unchanged. This corrects runner policy instead of weakening valid timing assertions.

## Related Issue

Follow-up to the per-file runner introduced in #29016. No open duplicate issue or PR was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/run_tests_parallel.py`
  - Use `HERMES_TEST_WORKERS` when set; otherwise default to `os.cpu_count()` with the existing fallback of 4.
  - Update `--jobs` help text to match the actual policy.
- `tests/test_run_tests_parallel.py`
  - Prove 32 reported CPUs produce 32 workers, not 64.
  - Cover the no-CPU fallback and explicit environment override.
- `AGENTS.md`
  - Document the actual per-file subprocess runner and `-j` / `HERMES_TEST_WORKERS` overrides.

## How to Test

1. Run `scripts/run_tests.sh tests/test_run_tests_parallel.py -q`.
2. On a 32-thread host, run the per-file runner without an override and confirm it reports `running with -j 32`.
3. Use `-j` and `HERMES_TEST_WORKERS` separately and confirm each explicit override wins.

Final focused verification after rebasing onto current `main`:

```text
10 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused runner regression on the final rebased head: 10 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora Linux x86_64, 32 reported CPU threads

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — runner help/docstring and `AGENTS.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — `AGENTS.md` updated
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — existing cross-platform `os.cpu_count()` and environment handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
/tmp/hermes-pr-venv/bin/python -m pytest tests/test_run_tests_parallel.py -q
10 passed in 2.03s
```
