### PR TITLE
fix(security): redact secrets in session_search output

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -20,6 +20,7 @@ from tools.session_search_tool import (
     _is_compression_ended,
     _resolve_to_parent,
     _session_link,
+    _shape_message,
     session_search,
 )
 
@@ -823,3 +824,214 @@ class TestLegacyContinuationPlusDelegation:
 
         # Delegation child must NOT appear
         assert "s_delegate" not in sids
+
+
+# =========================================================================
+# Output redaction (#54027)
+# =========================================================================
+
+# Fake credentials shaped to match agent.redact prefix patterns. Never real.
+_FAKE_OPENAI_KEY = "sk-hermesFAKEtestkey1234567890abcdefghij"
+_FAKE_GITHUB_PAT = "ghp_FAKEtestpat567890abcdefghijklmnopqrs"
+
+
+def _seed_secret_session(db):
+    """One session whose stored content embeds credential-shaped tokens.
+
+    The key sits inside the first 60 chars of the first user message so it
+    also flows through the browse shape's preview column.
+    """
+    now = int(time.time())
+    db.create_session("s_secrets", source="cli")
+    db._conn.execute("UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                     (now - 5000, "Deploy Key Rotation", "s_secrets"))
+    db.append_message("s_secrets", role="user",
+                      content=f"Use key {_FAKE_OPENAI_KEY} for the wombat deploy")
+    db.append_message("s_secrets", role="assistant",
+                      content=f"Deployed with token {_FAKE_GITHUB_PAT}; wombat rollout done.")
+    db._conn.commit()
+
+
+class TestOutputRedaction:
+    """Stored session text is redacted on its way back into model context.
+
+    Transcripts are written before any output-time redaction ran on them
+    (and DBs older than the redactor entirely so), so recall is the one
+    boundary every stored secret must pass to leak. Same policy as
+    read_file / search_files: redact_sensitive_text(..., file_read=True),
+    which emits non-reusable sentinels («redacted:sk-…») instead of
+    head/tail-preserving masks (issue #35519).
+    """
+
+    def test_discover_window_content_redacted(self, db):
+        _seed_secret_session(db)
+        raw = session_search(query="wombat", db=db)
+        assert _FAKE_OPENAI_KEY not in raw
+        assert _FAKE_GITHUB_PAT not in raw
+        result = json.loads(raw)
+        assert result["count"] >= 1
+        contents = [m.get("content") or ""
+                    for hit in result["results"] for m in hit["messages"]]
+        assert any("«redacted:sk-…»" in c for c in contents)
+
+    def test_discover_snippet_redacted(self, db):
+        _seed_secret_session(db)
+        result = json.loads(session_search(query="wombat", db=db))
+        assert result["count"] >= 1
+        for hit in result["results"]:
+            assert _FAKE_OPENAI_KEY not in hit["snippet"]
+            assert _FAKE_GITHUB_PAT not in hit["snippet"]
+
+    def test_read_shape_redacted(self, db):
+        _seed_secret_session(db)
+        raw = session_search(session_id="s_secrets", db=db)
+        assert _FAKE_OPENAI_KEY not in raw
+        assert _FAKE_GITHUB_PAT not in raw
+        contents = [m.get("content") or "" for m in json.loads(raw)["messages"]]
+        assert any("«redacted:sk-…»" in c for c in contents)
+        assert any("«redacted:ghp_…»" in c for c in contents)
+
+    def test_scroll_shape_redacted(self, db):
+        _seed_secret_session(db)
+        anchor = json.loads(session_search(session_id="s_secrets", db=db))["messages"][0]["id"]
+        raw = session_search(session_id="s_secrets", around_message_id=anchor, db=db)
+        assert json.loads(raw)["mode"] == "scroll"
+        assert _FAKE_OPENAI_KEY not in raw
+        assert _FAKE_GITHUB_PAT not in raw
+
+    def test_browse_preview_redacted(self, db):
+        _seed_secret_session(db)
+        raw = session_search(db=db)
+        assert _FAKE_OPENAI_KEY not in raw
+        previews = [r.get("preview") or "" for r in json.loads(raw)["results"]]
+        assert any("«redacted:sk-…»" in p for p in previews)
+
+    def test_multimodal_content_parts_redacted(self, db):
+        # content round-trips _decode_content and comes back as a LIST of
+        # parts for multimodal messages — string-only redaction would skip it.
+        db.create_session("s_multi", source="cli")
+        db.append_message("s_multi", role="user", content=[
+            {"type": "text", "text": f"key is {_FAKE_OPENAI_KEY} ok"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+        ])
+        raw = session_search(session_id="s_multi", db=db)
+        assert _FAKE_OPENAI_KEY not in raw
+        parts = json.loads(raw)["messages"][0]["content"]
+        assert isinstance(parts, list)
+        assert "«redacted:sk-…»" in parts[0]["text"]
+        assert parts[1]["image_url"]["url"] == "https://example.com/x.png"
+
+    def test_tool_calls_arguments_redacted(self, db):
+        # tool_calls are FTS-indexed (discover can anchor on them) and
+        # deserialize to structured dicts — their string leaves must redact.
+        db.create_session("s_calls", source="cli")
+        db.append_message("s_calls", role="assistant", content="", tool_calls=[{
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "terminal",
+                         "arguments": f'{{"cmd": "export OPENAI_API_KEY={_FAKE_OPENAI_KEY}"}}'},
+        }])
+        raw = session_search(session_id="s_calls", db=db)
+        assert _FAKE_OPENAI_KEY not in raw
+        call = json.loads(raw)["messages"][0]["tool_calls"][0]
+        assert call["function"]["name"] == "terminal"
+        assert "«redacted:sk-…»" in call["function"]["arguments"]
+
+    def test_session_title_redacted_everywhere(self, db):
+        # Titles are stored text too (generated or user-set) and flow through
+        # browse, read/scroll session_meta, and discover result rows.
+        now = int(time.time())
+        db.create_session("s_titled", source="cli")
+        db._conn.execute("UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                         (now - 100, f"Rotating {_FAKE_GITHUB_PAT} today", "s_titled"))
+        db.append_message("s_titled", role="user", content="rotate the aardvark token")
+        db._conn.commit()
+
+        for raw in (
+            session_search(db=db),                                   # browse
+            session_search(session_id="s_titled", db=db),            # read
+            session_search(query="aardvark", db=db),                 # discover
+        ):
+            assert _FAKE_GITHUB_PAT not in raw
+            assert "«redacted:ghp_…»" in raw
+
+    def test_benign_content_passes_unchanged(self, db):
+        # Redaction must not mangle ordinary session text (#57735-class risk).
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(session_id="s_oldest", db=db))
+        contents = [m.get("content") for m in result["messages"]]
+        assert "Let's build a Minecraft modpack" in contents
+        assert "Done. Modpack repo created with NeoForge 1.21.1." in contents
+
+    # Longest raw fragment that survives truncate-then-redact, per pattern.
+    # Cutting mid-credential leaves a prefix the redactor no longer matches,
+    # so these are the byte counts that would ship if the order were flipped.
+    @pytest.mark.parametrize("fake_key,evade_len", [
+        ("sk-hermesFAKEtestkey1234567890abcdefghij", 12),
+        ("AIzaFAKEtestkey1234567890abcdefghijklmno", 33),
+        ("xai-FAKEtestkey1234567890abcdefghijklmnop", 33),
+        ("github_pat_FAKEtestpat1234567890abcdefghij", 20),
+        ("AKIAFAKETESTKEY12345", 19),
+    ])
+    def test_redaction_precedes_content_truncation(self, fake_key, evade_len):
+        # Discover bounds bookends/windows via max_content_len; redaction must
+        # run BEFORE that slice. Each cut lands at the longest fragment that
+        # still evades its pattern, so this asserts the ORDERING — flip it and
+        # these raw bytes reach output.
+        lead = "wombat " * 10
+        shaped = _shape_message(
+            {
+                "id": 1,
+                "role": "user",
+                "content": f"{lead}{fake_key} trailing",
+                "timestamp": "2026-07-13T00:00:00",
+            },
+            max_content_len=len(lead) + evade_len,
+        )
+        assert fake_key not in shaped["content"]
+        assert fake_key[:evade_len] not in shaped["content"]
+
+    def test_redaction_precedes_truncation_for_delimiter_bounded_secrets(self):
+        # The severe case: a PEM's `-----END …-----` footer is what makes the
+        # block match. Truncate first and the footer is gone, so nothing
+        # matches and the whole key body ships up to the cap — unbounded, not
+        # a short prefix. This is why no slice-first scheme is safe: the
+        # terminator can sit beyond any margin you pick.
+        body = "MIIEowIBAAKCAQEAxFAKEtestkeymaterial"
+        pem = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            + f"{body}0123456789\n" * 8
+            + "-----END RSA PRIVATE KEY-----"
+        )
+        lead = "wombat " * 10
+        full = f"{lead}{pem}"
+        shaped = _shape_message(
+            {"id": 1, "role": "user", "content": full, "timestamp": "t"},
+            max_content_len=len(full) - 40,   # cuts the END footer
+        )
+        assert body not in shaped["content"]
+
+    def test_known_gap_opaque_assignments_are_not_covered(self):
+        # SCOPE PIN, not an aspiration. `file_read=True` forces `code_file`
+        # (agent/redact.py:678), which skips the ENV/JSON/YAML assignment
+        # redactors (:687) to avoid source-code false positives. So opaque
+        # unprefixed values still pass — recall inherits exactly read_file's
+        # coverage, no more. This narrows the leak; it does not close it.
+        # If a future change extends coverage here, update this test rather
+        # than assuming it was always covered.
+        opaque = "MY_SERVICE_TOKEN=opaqueopaqueopaqueopaque"
+        shaped = _shape_message(
+            {"id": 1, "role": "user", "content": opaque, "timestamp": "t"},
+        )
+        assert shaped["content"] == opaque
+
+    def test_truncation_metadata_reports_stored_length_not_redacted(self):
+        # Sentinels change length; original_content_chars describes the stored
+        # message, not our transform (upstream's contract, preserved).
+        lead = "wombat " * 10
+        content = f"{lead}{_FAKE_OPENAI_KEY} trailing"
+        shaped = _shape_message(
+            {"id": 1, "role": "user", "content": content, "timestamp": "t"},
+            max_content_len=len(lead),
+        )
+        assert shaped["original_content_chars"] == len(content)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -247,6 +247,42 @@ def _order_for_recall(raw_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]
     )
 
 
+def _redact_recalled_text(text: Any) -> Any:
+    """Redact secret shapes in stored session text before it re-enters context.
+
+    Session transcripts are written before any output-time redaction ran on
+    them (and older DBs predate the redactor entirely), so recall is the one
+    boundary every stored secret must pass to leak. ``file_read=True`` matches
+    the read_file / search_files policy: recalled content gets the
+    non-reusable sentinel treatment (issue #35519) and skips the source-code
+    ENV/JSON false-positive paths. Display boundary only — nothing here is
+    executed or written back to the store (#57735).
+    """
+    from agent.redact import redact_sensitive_text
+
+    if not isinstance(text, str) or not text:
+        return text
+    return redact_sensitive_text(text, file_read=True)
+
+
+def _redact_recalled_value(value: Any) -> Any:
+    """Recursively redact string leaves in stored structured values.
+
+    Message ``content`` round-trips through ``SessionDB._decode_content`` and
+    comes back as a list of parts for multimodal messages; ``tool_calls``
+    deserializes to a list of dicts (and is FTS-indexed, so discover can anchor
+    on it). Both must get the same treatment as plain string content. Dict keys
+    are structural, not stored prose — values only.
+    """
+    if isinstance(value, str):
+        return _redact_recalled_text(value)
+    if isinstance(value, list):
+        return [_redact_recalled_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _redact_recalled_value(v) for k, v in value.items()}
+    return value
+
+
 def _shape_message(
     m: Dict[str, Any],
     anchor_id: Optional[int] = None,
@@ -257,18 +293,34 @@ def _shape_message(
     When *max_content_len* is set, ``content`` is truncated to that many
     characters and ``content_truncated`` / ``original_content_chars`` metadata
     is added so callers know the payload was bounded.
+
+    Redaction runs *before* truncation, and the order is load-bearing. A cut
+    lands mid-credential and the surviving prefix no longer matches, so the raw
+    bytes ship: measured worst cases are 33 chars for ``AIza``/``xai-``, 20 for
+    ``github_pat_``, 19 for ``AKIA``. Delimiter-bounded secrets are worse — cut
+    the ``-----END …-----`` footer off a PEM block and the pattern cannot match
+    at all, so the whole key body leaks up to the cap. Redacting first means
+    the slice only ever cuts an already-substituted sentinel.
+
+    The cost is paying redaction on the full stored message rather than the
+    visible slice. That is deliberate: any slice-first scheme reopens the
+    delimiter case above, because the terminator can sit beyond any margin.
     """
-    raw_content = m.get("content")
-    if isinstance(raw_content, str) and "\x1b" in raw_content:
+    stored_content = m.get("content")
+    if isinstance(stored_content, str) and "\x1b" in stored_content:
         # Recalled messages can carry ANSI escape sequences (e.g. archived
-        # terminal output). Strip them before returning content to the model.
+        # terminal output). Strip them before redaction runs — an escape
+        # sequence interleaved mid-secret would split the pattern match.
         from tools.ansi_strip import strip_ansi
 
-        raw_content = strip_ansi(raw_content)
+        stored_content = strip_ansi(stored_content)
+    raw_content = _redact_recalled_value(stored_content)
     if max_content_len and raw_content and len(raw_content) > max_content_len:
         content = raw_content[:max_content_len] + "…"
         truncated = True
-        original_chars = len(raw_content)
+        # Report the STORED size, not the redacted one — sentinels change
+        # length and this metadata describes the message, not our transform.
+        original_chars = len(stored_content)
     else:
         content = raw_content
         truncated = False
@@ -282,7 +334,7 @@ def _shape_message(
     if m.get("tool_name"):
         entry["tool_name"] = m.get("tool_name")
     if m.get("tool_calls"):
-        entry["tool_calls"] = m.get("tool_calls")
+        entry["tool_calls"] = _redact_recalled_value(m.get("tool_calls"))
     if m.get("tool_call_id"):
         entry["tool_call_id"] = m.get("tool_call_id")
     if anchor_id is not None and m.get("id") == anchor_id:
@@ -406,10 +458,10 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
         logging.error("get_messages failed for %s: %s", session_id, e, exc_info=True)
         return tool_error(f"failed to load session: {e}", success=False)
 
-    shaped = [_shape_message(m) for m in rows]
-    total = len(shaped)
+    total = len(rows)
     truncated = total > head + tail
-    window = shaped[:head] + shaped[-tail:] if truncated else shaped
+    visible = rows[:head] + rows[-tail:] if truncated else rows
+    window = [_shape_message(m) for m in visible]
 
     response = {
         "success": True,
@@ -420,7 +472,7 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
             "when": _format_timestamp(meta.get("started_at")),
             "source": meta.get("source"),
             "model": meta.get("model"),
-            "title": meta.get("title"),
+            "title": _redact_recalled_text(meta.get("title")),
         },
         "message_count": total,
         "truncated": truncated,
@@ -456,12 +508,12 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
             results.append({
                 "session_id": sid,
                 "link": _session_link(sid, link_profile),
-                "title": s.get("title") or None,
+                "title": _redact_recalled_text(s.get("title")) or None,
                 "source": s.get("source", ""),
                 "started_at": s.get("started_at", ""),
                 "last_active": s.get("last_active", ""),
                 "message_count": s.get("message_count", 0),
-                "preview": s.get("preview", ""),
+                "preview": _redact_recalled_text(s.get("preview", "")),
             })
             if len(results) >= limit:
                 break
@@ -603,7 +655,7 @@ def _scroll(
             "when": _format_timestamp(session_meta.get("started_at")),
             "source": session_meta.get("source"),
             "model": session_meta.get("model"),
-            "title": session_meta.get("title"),
+            "title": _redact_recalled_text(session_meta.get("title")),
         },
         "window": window,
         "messages": [_shape_message(m, anchor_id=around_message_id) for m in messages],
@@ -666,15 +718,16 @@ def _title_match_result(
     else:
         view = {}
 
+    display_title = _redact_recalled_text(session_meta.get("title") or title_query)
     entry = {
         "session_id": session_id,
         "when": _format_timestamp(session_meta.get("started_at")),
         "source": session_meta.get("source", "unknown"),
         "model": session_meta.get("model") or "unknown",
-        "title": session_meta.get("title") or title_query,
+        "title": display_title,
         "matched_role": "session_title",
         "match_message_id": anchor_id,
-        "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
+        "snippet": f"Session title matched: {display_title}",
         "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or messages[:3])],
         "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
         "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or messages[-3:])],
@@ -808,10 +861,10 @@ def _discover(
             ),
             "source": session_meta.get("source") or match_info.get("source", "unknown"),
             "model": session_meta.get("model") or match_info.get("model") or "unknown",
-            "title": session_meta.get("title") or None,
+            "title": _redact_recalled_text(session_meta.get("title")) or None,
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
-            "snippet": match_info.get("snippet") or "",
+            "snippet": _redact_recalled_text(match_info.get("snippet") or ""),
             "bookend_start": [
                 _shape_message(m, max_content_len=1200)
                 for m in (view.get("bookend_start") or [])


### PR DESCRIPTION
## What does this PR do?

`session_search` returns stored session text **verbatim** on every output path — discover snippets and message windows, scroll, read, browse previews, and session titles. Session transcripts are written to the store before any output-time redaction runs on them (and databases older than the redactor entirely so), so any credential ever pasted or echoed into a session leaks back into fresh model context on recall.

This PR extends the protection `agent/redact.py` already gives file reads to session recall: session_search output now passes through `redact_sensitive_text(..., file_read=True)` at the display boundary — the exact policy `read_file` / `search_files` already use (non-reusable sentinels per #35519, source-code false-positive paths skipped). Coverage therefore matches the file-read path's: prefix- and structure-shaped credentials get sentinels, while opaque unprefixed values (`MY_TOKEN=<random>`) pass, exactly as they do on `read_file` — this narrows the leak, it does not eliminate it. Structured values are covered too: multimodal `content` comes back from `_decode_content` as a list of parts, and `tool_calls` deserialize to dicts (and are FTS-indexed, so discover can anchor a hit on them) — both get recursive string-leaf redaction, not just top-level strings.

Three deliberate placement choices:

- **Display boundary only.** session_search output is never executed and never written back to the store, so the corruption class from #57735 (redaction mangling executed text) cannot occur here.
- **The #43083 replay invariant is untouched.** That regression test protects `build_assistant_message` — the live session's own history, replayed verbatim to the model, where masking poisons subsequent tool calls. This PR redacts tool *results* — session_search output recalling stored history — which are never replayed as the assistant's own turns, whichever session they came from (scroll additionally rejects the active lineage outright; read mode can re-read any stored session by id, but still only ever as a tool result). And because `file_read=True` emits syntactically-invalid sentinels (`«redacted:sk-…»`) rather than plausible-looking truncations, a model that copies one out of recall output fails loudly instead of silently corrupting a stored credential — the same argument that motivated #35519 for `read_file`.
- **No index-time scrubbing.** Scrubbing at write time can't protect the years of text indexed before the guard existed; the output boundary is the one chokepoint every recall path passes through. (#54038 pursues the write-time side for `state.db` — complementary, not competing: even if it lands, only the output boundary covers already-written rows.)

The tool's "No LLM calls anywhere" promise is preserved — this is pure regex via the existing redactor, and the existing `HERMES_REDACT_SECRETS` / `security.redact_secrets` opt-out applies unchanged.

## Related Issue

Refs #54027, #39654, #23200

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/session_search_tool.py`
  - New `_redact_recalled_text()` (string) + `_redact_recalled_value()` (recursive over lists/dicts) helpers; deferred `agent.redact` import matching the codebase idiom.
  - `_shape_message`: redacts `content` (plain and multimodal part lists) and `tool_calls` — covers discover windows/bookends, scroll, read, and title-match results at one chokepoint.
  - Discover `snippet` (FTS5 excerpt), browse `preview`, and session `title` on every shape (browse rows, read/scroll `session_meta`, discover rows, and the title-match synthetic snippet).
  - `_read_session` now shapes only the visible head+tail window instead of shaping all rows and then truncating (avoids redacting messages that are never returned).
- `tests/tools/test_session_search.py` — new `TestOutputRedaction` class (9 tests): all four calling shapes assert credential-shaped tokens never reach output and non-reusable sentinels appear in their place; multimodal content parts, `tool_calls` arguments, and titles each covered; plus a benign-content pass-through test as a #57735-class regression guard.

## How to Test

1. `pytest tests/tools/test_session_search.py -q` — 62 pass (9 new). (Equivalently via `scripts/run_tests.sh`; direct pytest shown because the run was on Windows.)
2. Manually: paste a fake `sk-…` key into a session, start a new session, run `session_search(query=<term near the key>)` — the snippet and window show `«redacted:sk-…»` instead of the key; `session_search()` (browse) shows a redacted preview.
3. The existing global opt-out still works: `HERMES_REDACT_SECRETS=false` disables this pass too (the helper delegates to `redact_sensitive_text`, which honors the toggle).

Platform note: on my machine (Windows 11), `TestDiscoverySort::test_sort_*` is flaky under Python 3.12 **at the base commit as well** (5 failures in 8 runs with this PR's changes absent) — a pre-existing, unrelated flake; the full file is green on Python 3.14 here and the flake never touches the redaction tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (75 open PRs carry `redact` in the title as of 2026-07-13; none targets the session_search output boundary — #61001 is untrusted-content framing, and #54038 is write-time `state.db` scrubbing for the same #54027, complementary to this output-side guard)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the changed-area tests and they pass: `pytest tests/tools/test_session_search.py -q` (62 passed) and a broader `tests/tools/ + tests/agent/` sweep whose only failures in the changed file are the pre-existing Windows sort flake noted above (verified present at the base commit). I could not get the *full* suite green locally — it has Windows-local collection failures in adapters this PR doesn't touch — so I'm relying on CI for the authoritative cross-platform run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.14 and 3.12)

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (behavior documented in the helper docstrings; tool schema/description unchanged: output shape is identical, only secret bytes are replaced)
- [x] `cli-config.yaml.example` — N/A (no new config keys; reuses the existing `security.redact_secrets` toggle)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure string transformation, no I/O; tested on Windows, CI covers the rest
- [x] Tool descriptions/schemas — N/A (unchanged)

## Screenshots / Logs

```
$ pytest tests/tools/test_session_search.py -q
..............................................................           [100%]
62 passed
```

---

**AI-assisted disclosure:** Authored by David Kooi (@u00dxk2) with substantial AI assistance (Claude via Claude Code, with an adversarial review pass by Codex) — diff and tests AI-drafted, human-reviewed and human-submitted. The output-boundary chokepoint pattern comes from our own agent-ops toolkit, where we ship the same guard on our session-search: https://github.com/u00dxk2/agent-ops-patterns (`lib/snippet-redact.mjs`). This PR reuses **your** redactor (`agent/redact.py`) rather than importing foreign patterns — it's your env-scrubber's protection, extended to session-search output.
