### PR TITLE
fix(patch): make a half-formed replace call recoverable instead of a dead end

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -102,7 +102,14 @@ def _proposal_for_patch_replace(arguments: dict[str, Any]) -> EditProposal:
     old_string = arguments.get("old_string")
     new_string = arguments.get("new_string")
     if old_string is None or new_string is None:
-        raise ValueError("old_string and new_string required")
+        # This runs BEFORE patch_tool, so a bare "required" here would dead-end
+        # the model with the same message patch_tool was fixed to stop emitting —
+        # and the caller wraps it as "Edit approval denied", which misattributes
+        # a malformed call to the user refusing it. Reuse the tool's guidance so
+        # both layers say the same thing. Imported lazily: this module is kept
+        # isolated from the tool registry (see module docstring).
+        from tools.file_tools import REPLACE_MODE_ARGS_HELP
+        raise ValueError(REPLACE_MODE_ARGS_HELP)
 
     old_text = _read_text_if_exists(path)
     if old_text is None:
@@ -243,6 +250,13 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
 
     try:
         proposal = build_edit_proposal(tool_name, arguments)
+    except ValueError as exc:
+        # A malformed tool call, not a refusal. Framing it as "Edit approval
+        # denied" tells the model the user rejected the edit, so it retries the
+        # same broken call or gives up instead of fixing its arguments. Surface
+        # the argument guidance on its own.
+        logger.warning("Malformed %s call reached ACP edit approval: %s", tool_name, exc)
+        return json.dumps({"error": str(exc), "success": False}, ensure_ascii=False)
     except Exception as exc:
         logger.warning("Could not build ACP edit approval proposal for %s: %s", tool_name, exc)
         return json.dumps({"error": f"Edit approval denied: could not prepare diff ({exc})"}, ensure_ascii=False)

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -267,3 +267,70 @@ def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_
         "session",
         str(tmp_path),
     )
+
+
+def test_patch_replace_missing_args_carries_tool_guidance():
+    """The ACP proposal builder runs before patch_tool and must not dead-end.
+
+    It previously raised a bare "old_string and new_string required". The caller
+    wraps a build failure as "Edit approval denied: could not prepare diff (...)",
+    so a malformed call was reported to the model as if the user had refused it,
+    with no route back. It now raises the same guidance patch_tool returns.
+    """
+    import pytest
+
+    from acp_adapter.edit_approval import _proposal_for_patch_replace
+    from tools.file_tools import REPLACE_MODE_ARGS_HELP
+
+    with pytest.raises(ValueError) as excinfo:
+        _proposal_for_patch_replace({"path": "f.py", "new_string": "x"})
+
+    message = str(excinfo.value)
+    assert message == REPLACE_MODE_ARGS_HELP, "must stay in sync with the tool's error"
+    assert "mode='patch'" in message
+    assert "not rewrite" in message.lower()
+
+
+def test_malformed_patch_call_is_not_reported_as_a_denial():
+    """A malformed call must not be framed as the user refusing the edit.
+
+    build_edit_proposal raises before patch_tool runs. That ValueError used to be
+    wrapped as "Edit approval denied: could not prepare diff (...)", telling the
+    model its edit was rejected when in fact its arguments were wrong — so it
+    retries the same broken call or gives up rather than fixing them.
+    """
+    from acp_adapter.edit_approval import (
+        maybe_require_edit_approval,
+        set_edit_approval_requester,
+    )
+
+    set_edit_approval_requester(lambda proposal: True)
+    raw = maybe_require_edit_approval(
+        "patch", {"mode": "replace", "path": "f.py", "new_string": "x"}
+    )
+
+    result = json.loads(raw)
+    assert not result["error"].startswith("Edit approval denied"), (
+        "a malformed call must not be attributed to the user"
+    )
+    assert result["success"] is False
+    assert "mode='patch'" in result["error"], "must still carry the recovery guidance"
+
+
+def test_genuine_denial_still_reads_as_a_denial(tmp_path):
+    """The narrowed ValueError branch must not swallow real refusals."""
+    from acp_adapter.edit_approval import (
+        maybe_require_edit_approval,
+        set_edit_approval_requester,
+    )
+
+    target = tmp_path / "f.py"
+    target.write_text("x = 1\n")
+
+    set_edit_approval_requester(lambda proposal: False)
+    raw = maybe_require_edit_approval(
+        "patch",
+        {"mode": "replace", "path": str(target), "old_string": "x = 1", "new_string": "x = 2"},
+    )
+
+    assert "Edit approval denied" in json.loads(raw)["error"]

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -236,6 +236,133 @@ class TestPatchHandler:
         assert "Unknown mode" in result["error"]
 
     @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_missing_strings_offers_patch_mode(self, mock_get):
+        """A half-formed replace call must be told what to do next.
+
+        The schema cannot express per-mode required params (anyOf/oneOf breaks
+        providers — see TestPatchSchemaShape), so the call lands here at runtime.
+        A bare "required" error is a dead end: the model retries blindly and
+        escapes by rewriting the whole file with write_file. The error must name
+        the working alternative and forbid the escape hatch.
+        """
+        from tools.file_tools import patch_tool
+
+        result = json.loads(patch_tool(mode="replace", path="f.py", old_string=None))
+        assert "error" in result
+        err = result["error"]
+        assert "mode='patch'" in err, "must point at the V4A alternative"
+        assert "*** Begin Patch" in err, "must show the format it is asking for"
+        assert "not rewrite" in err.lower(), "must forbid the whole-file escape hatch"
+        # The reason to reach for patch mode is anchoring, not exactness —
+        # replace mode is fuzzy too, so an "exactness" pitch would be false.
+        assert "fuzzy" in err.lower(), "must not imply replace mode needs exact text"
+
+    def test_repeated_failure_hint_prefers_patch_over_write_file(self, tmp_path):
+        """The escalating hint and the missing-args error must not conflict.
+
+        The hint keeps write_file as the last resort — #507 added it to break
+        an infinite retry loop, and a stuck agent is worse than a reformatted
+        file. But mode='patch' now comes first, because an anchored V4A hunk
+        solves the common case without discarding the rest of the file. The
+        error's prohibition is scoped to working around a malformed call, which
+        is a different situation from repeated genuine match failures.
+        """
+        from tools.file_tools import patch_tool
+
+        target = tmp_path / "sample.py"
+        target.write_text("def f():\n    return 1\n")
+        task = "hint-ordering"
+
+        hint = ""
+        for _ in range(4):
+            raw = patch_tool(mode="replace", path=str(target),
+                             old_string="nonexistent text", new_string="x",
+                             task_id=task)
+            hint = json.loads(raw).get("_hint", "") or hint
+
+        assert "failure #" in hint, f"escalating hint never fired: {hint!r}"
+        assert "mode='patch'" in hint, "hint should route to the anchored alternative"
+        assert "write_file" in hint, "#507's loop-breaker must survive"
+        assert hint.index("mode='patch'") < hint.index("write_file"), (
+            "patch mode must be offered before the whole-file rewrite"
+        )
+
+    def test_ambiguous_match_hint_offers_patch_mode(self, tmp_path):
+        """Ambiguity is where patch mode has a real structural advantage.
+
+        A short old_string that matches twice cannot be disambiguated by
+        re-reading the file, so the generic "verify current content" advice
+        does not apply. A V4A hunk's context lines can anchor it.
+        """
+        from tools.file_tools import patch_tool
+
+        target = tmp_path / "dup.py"
+        target.write_text("def f():\n    return 1\n\ndef g():\n    return 1\n")
+
+        result = json.loads(patch_tool(mode="replace", path=str(target),
+                                       old_string="    return 1",
+                                       new_string="    return 2",
+                                       task_id="ambig"))
+
+        assert result.get("error"), "duplicate match should not silently apply"
+        hint = result.get("_hint", "")
+        assert "mode='patch'" in hint, f"no patch-mode route offered: {hint!r}"
+        assert "replace_all" in hint, "replace_all is the other legitimate answer"
+        # The route must be described precisely enough to work. A hunk anchored
+        # only by the '@@ ... @@' header fails the SAME ambiguity check (the
+        # proximity fallback lives in the apply pass, which validation preempts),
+        # so pointing at patch mode without saying "context lines" would route the
+        # model into the dead end this tool exists to avoid.
+        assert "context" in hint.lower(), "must say what actually anchors the hunk"
+        assert "@@" in hint, "must warn that the header alone is not an anchor"
+
+    def test_v4a_context_lines_actually_resolve_ambiguity(self, tmp_path):
+        """The hint's advice must be true, not merely plausible.
+
+        Pins the behavioral difference the ambiguity hint depends on: a hunk
+        carrying a real context line succeeds on a region a short old_string
+        cannot disambiguate, while a hunk relying on the '@@ ... @@' header
+        alone fails.
+        """
+        from tools.file_tools import patch_tool
+
+        src = "def f():\n    return 1\n\ndef g():\n    return 1\n"
+
+        def fresh(name):
+            p = tmp_path / name
+            p.write_text(src)
+            return p
+
+        header_only = fresh("a.py")
+        result = json.loads(patch_tool(
+            mode="patch", task_id="v4a-hdr",
+            patch=("*** Begin Patch\n"
+                   f"*** Update File: {header_only}\n"
+                   "@@ def f(): @@\n"
+                   "-    return 1\n"
+                   "+    return 2\n"
+                   "*** End Patch\n"),
+        ))
+        assert result.get("error"), "header-only hunk should not be treated as anchored"
+        assert header_only.read_text() == src, "failed patch must not modify the file"
+
+        with_context = fresh("b.py")
+        result = json.loads(patch_tool(
+            mode="patch", task_id="v4a-ctx",
+            patch=("*** Begin Patch\n"
+                   f"*** Update File: {with_context}\n"
+                   "@@ context @@\n"
+                   " def f():\n"
+                   "-    return 1\n"
+                   "+    return 2\n"
+                   "*** End Patch\n"),
+        ))
+        assert not result.get("error"), f"context-anchored hunk should apply: {result}"
+        after = with_context.read_text()
+        assert "return 2" in after.split("def g")[0], "wrong region edited"
+        assert after.split("def g")[1].strip() == "():\n    return 1", "g() must be untouched"
+
+    @patch("tools.file_tools._get_file_ops")
     def test_patch_v4a_rejects_traversal_in_update_header(self, mock_get):
         """V4A '*** Update File:' headers come from patch content, which can
         carry prompt-injection-controlled paths (skill content, web extract).
@@ -666,6 +793,33 @@ class TestPatchSchemaShape:
         for name in ("path", "old_string", "new_string"):
             assert "REQUIRED when mode='replace'" in props[name]["description"]
         assert "REQUIRED when mode='patch'" in props["patch"]["description"]
+
+    def test_description_does_not_claim_v4a_needs_no_verbatim_text(self):
+        """patch_parser builds an update hunk's search pattern from its context
+        and removed lines, so a V4A hunk DOES need to reproduce them. The
+        description previously said the opposite, which sent a model that could
+        not anchor a region toward a whole-file rewrite instead.
+        """
+        desc = PATCH_SCHEMA["description"]
+        lowered = desc.lower()
+        assert "do not need to echo the old text" not in lowered
+        assert "reproduce the lines it removes" in lowered, (
+            "must state that an update hunk still needs its removed/context lines"
+        )
+
+    def test_description_pitches_patch_mode_on_anchoring_not_exactness(self):
+        """Both modes share one fuzzy matcher, so 'use patch mode when you cannot
+        reproduce the text exactly' is false. The real advantages are anchoring
+        and atomicity.
+        """
+        desc = PATCH_SCHEMA["description"]
+        lowered = desc.lower()
+        assert "anchor" in lowered, "must pitch patch mode on anchoring"
+        assert "atomic" in lowered, "must pitch patch mode on atomicity"
+        assert "fuzzy" in lowered, "must disclose that replace mode is fuzzy too"
+        assert "cannot construct old_string exactly" not in lowered
+        # The old_string property must not contradict the fuzzy claim above.
+        assert "Exact text to find" not in PATCH_SCHEMA["parameters"]["properties"]["old_string"]["description"]
 
     def test_no_anyof_required_stays_mode_only(self):
         # anyOf/oneOf at parameters level break Anthropic, Fireworks, and the

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1652,6 +1652,31 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         return tool_error(str(e))
 
 
+# Guidance for a half-formed replace call. Shared so every layer that can reject
+# one says the same thing — acp_adapter/edit_approval.py raises this too, since it
+# builds its diff preview before patch_tool ever runs and would otherwise dead-end
+# with its own bare "old_string and new_string required".
+REPLACE_MODE_ARGS_HELP = (
+    "replace mode requires BOTH old_string and new_string. "
+    "Read the file first and copy the target text into old_string — "
+    "matching is fuzzy, so minor whitespace and indentation differences "
+    "are tolerated. If the region is hard to pin down uniquely, re-issue "
+    "this call with mode='patch' and a V4A diff, whose context lines "
+    "anchor the change:\n"
+    "*** Begin Patch\n"
+    "*** Update File: <path>\n"
+    "@@ context hint @@\n"
+    " unchanged line\n"
+    "-removed line\n"
+    "+added line\n"
+    "*** End Patch\n"
+    "Do not rewrite the whole file with write_file to work around a malformed "
+    "call — that discards formatting and unrelated content. (After repeated "
+    "genuine match failures on the same file the tool will offer that as a "
+    "last resort; this is not that case.)"
+)
+
+
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False,
@@ -1764,7 +1789,15 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 if not path:
                     return tool_error("path required")
                 if old_string is None or new_string is None:
-                    return tool_error("old_string and new_string required")
+                    # The schema cannot enforce per-mode required params (schema_sanitizer
+                    # strips top-level anyOf/oneOf), so a model can reach here with a
+                    # half-formed replace call. A bare "required" error is a dead end: the
+                    # model retries, fails, and escapes by rewriting the whole file with
+                    # write_file — destroying indentation. Hand it the working alternative.
+                    return tool_error(REPLACE_MODE_ARGS_HELP)
+                # No old_string == new_string guard here: fuzzy_find_and_replace
+                # already rejects that (tools/fuzzy_match.py) and its result keeps
+                # the success=False envelope this layer's tool_error would drop.
                 # Pass the resolved ABSOLUTE path to the shell layer so it
                 # operates on the exact file the tool layer resolved — the
                 # shell's own cwd may differ (worktree-cwd bug), and a relative
@@ -1825,22 +1858,50 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # same path.  Most common cause is a stale view of the file —
                 # the model is retrying with the same old_string against
                 # content that has since changed.  Surface the failure count
-                # so the model recognises it's in a loop and breaks out by
-                # re-reading or falling back to write_file.
+                # so the model recognises it's in a loop and breaks out.
+                #
+                # write_file stays in this list as the last resort (#507: the
+                # point of the escalation is to break an infinite retry loop,
+                # and a stuck agent is worse than a reformatted file). But it
+                # is now ordered AFTER mode='patch', because an anchored V4A
+                # hunk solves the common case — a region that is hard to pin
+                # down uniquely — without discarding the rest of the file.
+                # The replace-mode error above forbids a whole-file rewrite as
+                # a *workaround for a malformed call*; this is the different,
+                # narrower case of genuine repeated failure, so the two are
+                # consistent rather than contradictory.
                 result_dict["_hint"] = (
                     f"This is failure #{failure_count} patching {path!r}. "
                     "Stop retrying with variations of the same old_string. "
                     "Either: (1) re-read the file fresh to verify current "
                     "content, (2) use a longer / more unique old_string with "
-                    "surrounding context lines, or (3) use write_file to "
-                    "replace the entire file if the targeted region is hard "
-                    "to anchor."
+                    "surrounding context lines, (3) switch to mode='patch' and "
+                    "let the V4A context lines anchor the change, or — only if "
+                    "the region genuinely cannot be anchored — (4) use "
+                    "write_file to replace the entire file, accepting that it "
+                    "discards the file's existing formatting."
                 )
             elif "Did you mean one of these sections?" not in str(result_dict["error"]):
                 result_dict["_hint"] = (
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."
                 )
+        elif (mode == "replace"
+              and result_dict.get("error")
+              and "matches for old_string" in str(result_dict["error"])):
+            # Ambiguity — not staleness — so the "re-read the file" advice above
+            # does not apply. This is the one failure where patch mode has a real
+            # structural advantage: a V4A hunk carries surrounding context lines,
+            # which disambiguate a region that a short old_string cannot.
+            result_dict["_hint"] = (
+                "old_string matched more than once. Either extend it with "
+                "surrounding lines until it is unique, set replace_all=true if "
+                "every occurrence should change, or switch to mode='patch' and "
+                "include the surrounding source lines in the hunk as context "
+                "(prefixed with a space) — those are what anchor the edit to one "
+                "region. The '@@ ... @@' header alone is NOT enough: it is only a "
+                "hint, and a hunk relying on it will fail the same ambiguity check."
+            )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -1979,13 +2040,33 @@ WRITE_FILE_SCHEMA = {
 PATCH_SCHEMA = {
     "name": "patch",
     "description": (
-        "Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. "
-        "Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. "
-        "Returns a unified diff. Auto-runs syntax checks after editing.\n\n"
-        "REPLACE MODE (mode='replace', default): find a unique string and replace it. "
-        "REQUIRED PARAMETERS: mode, path, old_string, new_string.\n"
-        "PATCH MODE (mode='patch'): apply V4A multi-file patches for bulk changes. "
-        "REQUIRED PARAMETERS: mode, patch."
+        "Edit files. Use this instead of sed/awk in terminal. Returns a unified diff. "
+        "Auto-runs syntax checks after editing. Both modes use the same fuzzy matcher "
+        "(9 strategies), so minor whitespace and indentation differences are tolerated "
+        "either way.\n\n"
+        "REPLACE MODE (mode='replace', default) — for a single substring that appears "
+        "exactly once. Read the file first and copy the target text into old_string. "
+        "REQUIRED PARAMETERS: mode, path, old_string, new_string.\n\n"
+        "PATCH MODE (mode='patch') — PREFER THIS when the edit spans multiple files or "
+        "several regions of one file (a V4A patch applies atomically, all hunks or none), "
+        "or when the target region is hard to pin down uniquely: a hunk's context lines "
+        "anchor the change where a short old_string would match in several places. "
+        "REQUIRED PARAMETERS: mode, patch.\n"
+        "  *** Begin Patch\n"
+        "  *** Update File: path/to/file\n"
+        "  @@ context hint @@\n"
+        "   unchanged context line (leading space)\n"
+        "  -removed line\n"
+        "  +added line\n"
+        "  *** End Patch\n\n"
+        "An update hunk still has to reproduce the lines it removes and the context "
+        "around them — patch mode buys anchoring and atomicity, not freedom from "
+        "knowing the file.\n"
+        "Do not reach for write_file to work around a failing edit: rewriting a whole "
+        "file discards its formatting and any content you did not intend to touch. "
+        "Re-read the file, or switch to mode='patch', first. (After several genuine "
+        "failures on the same file this tool will offer a whole-file rewrite as an "
+        "explicit last resort — take it only when offered.)"
     ),
     "parameters": {
         "type": "object",
@@ -2002,7 +2083,7 @@ PATCH_SCHEMA = {
             },
             "old_string": {
                 "type": "string",
-                "description": "REQUIRED when mode='replace'. Exact text to find and replace. Must be unique in the file unless replace_all=true. Include surrounding context lines to ensure uniqueness.",
+                "description": "REQUIRED when mode='replace'. Text to find and replace, copied from the file. Matching is fuzzy, so minor whitespace and indentation differences are tolerated, but it must be unique in the file unless replace_all=true. Include surrounding context lines to ensure uniqueness.",
             },
             "new_string": {
                 "type": "string",
@@ -2023,6 +2104,11 @@ PATCH_SCHEMA = {
                 "default": False,
             },
         },
+        # NOTE: no anyOf/oneOf here — see tests/tools/test_file_tools.py::
+        # TestPatchSchemaShape. Per-mode required sets break Anthropic, Fireworks and the
+        # Moonshot/Kimi sanitizer. Description-level guidance (above) plus an actionable
+        # runtime error (in patch_tool) are the provider-safe way to steer a model that
+        # arrives here with a half-formed replace call.
         "required": ["mode"],
     },
 }


### PR DESCRIPTION
## What does this PR do?

`PATCH_SCHEMA` cannot express per-mode required params: `anyOf`/`oneOf` at the parameters level breaks Anthropic, Fireworks and the Moonshot/Kimi sanitizer, so `required` is `["mode"]` and description-level guidance is the only provider-safe signal. `TestPatchSchemaShape` pins that invariant, and this PR keeps it.

The consequence is that a **half-formed `replace` call reaches `patch_tool` at runtime** with `old_string`/`new_string` missing. Today that returns:

```
old_string and new_string required
```

That is a dead end. The model cannot tell whether it omitted the argument or supplied it wrongly, so it retries blindly and eventually escapes the tool the only way it can: `write_file`, rewriting the entire file and discarding formatting and unrelated content.

This PR makes that error name the recovery route, via a shared `REPLACE_MODE_ARGS_HELP` so every layer that can reject such a call says the same thing.

## What patch mode is actually for

An earlier revision of this PR told the model to switch to `mode='patch'` when it *"cannot reproduce the original text exactly"*. **That rationale was false**, and it is worth recording so nobody reintroduces it.

Both modes route to the same fuzzy matcher — `tools/fuzzy_match.py`, 9 strategies including `line_trimmed` and `indentation_flexible`. Replace mode already tolerates whitespace and indentation drift. Verified end to end: a spaces-for-tabs `old_string` matches via `line_trimmed`, and the replacement comes back re-indented with the file's own tabs.

That also corrects the anecdote the earlier revision used as motivation. A model editing a tab-indented GDScript file did regenerate it from memory and turn every tab into a space — but not because replace mode could not match spaces against tabs. It can. The model abandoned replace mode for `write_file` because the error gave it nowhere else to go. The dead end was the cause; the exactness story was not.

What patch mode actually buys is **anchoring** and **atomicity**: a hunk's context lines pin an edit to one region where a short `old_string` matches several, and a multi-hunk patch applies all-or-nothing. The schema description, the runtime error, and the new ambiguity hint are written around that instead.

## Changes Made

**`tools/file_tools.py`**

- `PATCH_SCHEMA` description rewritten around anchoring and atomicity. Removes the claim that a V4A diff needs no verbatim old text — `patch_parser` builds an update hunk's search pattern from its context and removed lines, so it does need an anchor. The `old_string` property description no longer says *"Exact text"*, which contradicted the fuzzy-matching behaviour it sits next to.
- Missing-args error moved to `REPLACE_MODE_ARGS_HELP`. It discloses that matching is fuzzy and routes to patch mode for hard-to-anchor regions.
- **New hint on the ambiguous-match path**, which previously got no hint at all. It names context lines specifically: a hunk anchored only by its `@@ ... @@` header fails the *same* ambiguity check, because the proximity fallback for context hints lives in the apply pass that validation preempts. Pointing at patch mode without saying this would route the model into the dead end this PR exists to remove.
- The escalating 3-failure hint now offers `mode='patch'` before `write_file`. **`write_file` stays** — #507 added it deliberately as a loop-breaker, and a stuck agent is worse than a reformatted file. The prohibition elsewhere is scoped to working around a *malformed call*, and the schema now carries the matching last-resort carve-out, so the two no longer conflict. `tests/tools/test_patch_failure_tracking.py` passes unmodified.
- Comment at the `required` key recording *why* there is no `anyOf` (provider breakage), so the next person does not re-add it.
- **No `old_string == new_string` guard.** An earlier revision added one and claimed the case silently succeeded; that was wrong. `fuzzy_find_and_replace` already rejects it, and routing through `tool_error` would have *dropped* the `success=False` key the existing path returns.

**`acp_adapter/edit_approval.py`**

- Builds its diff preview *before* `patch_tool` runs, so it dead-ended with its own bare `"old_string and new_string required"`. It now raises the shared guidance.
- A malformed call is no longer wrapped as `"Edit approval denied: could not prepare diff (...)"`. Reporting a bad argument as a user refusal makes the model retry the same broken call or give up, rather than fix its arguments. Genuine refusals still read as denials.

## How to Test

```python
import json
from tools.file_tools import patch_tool

# before: {"error": "old_string and new_string required"}   <- dead end
# after:  names mode='patch', shows the V4A format, forbids the whole-file rewrite
json.loads(patch_tool(mode="replace", path="f.py", old_string=None))
```

The ambiguity route, which is the claim most worth checking — a duplicated region that replace mode cannot disambiguate:

```python
# f.py contains two identical "    return 1" lines
json.loads(patch_tool(mode="replace", path="f.py",
                      old_string="    return 1", new_string="    return 2"))
# -> error "Found 2 matches", plus a _hint naming context lines and replace_all

# a hunk with a real context line resolves it; a bare "@@ ... @@" header does not
```

Tests added:

`tests/tools/test_file_tools.py`
- `test_replace_mode_missing_strings_offers_patch_mode` — asserts the error names `mode='patch'`, shows `*** Begin Patch`, forbids the rewrite, and discloses fuzzy matching
- `test_repeated_failure_hint_prefers_patch_over_write_file` — pins the #507 reconciliation, including the ordering
- `test_ambiguous_match_hint_offers_patch_mode`
- `test_v4a_context_lines_actually_resolve_ambiguity` — pins the behavioural difference the hint depends on: a context-anchored hunk applies to the right region, a header-only hunk does not
- `test_description_does_not_claim_v4a_needs_no_verbatim_text`
- `test_description_pitches_patch_mode_on_anchoring_not_exactness`

`tests/acp/test_edit_approval.py`
- `test_patch_replace_missing_args_carries_tool_guidance` — asserts equality with `REPLACE_MODE_ARGS_HELP` so the two layers cannot drift
- `test_malformed_patch_call_is_not_reported_as_a_denial`
- `test_genuine_denial_still_reads_as_a_denial`

Seven of these fail against unmodified `main`; the other two are regression guards for pre-existing behaviour and pass either way, by design.

## Scope — what this does NOT cover

- **#54572 — inexact `old_string` matching the wrong region.** This PR now tells the model that matching is fuzzy, which is true and was already the behaviour, but it does not make mis-anchoring less likely. Worth tracking separately.
- **Repeated ambiguity does not escalate.** The new ambiguity branch does not record a consecutive failure, so a model looping on ambiguous matches never reaches #507's loop-breaker. Left alone deliberately — wiring it in changes escalation semantics beyond this fix — but it is the failure mode most likely to loop.
- #18426 (repeated patches duplicating content) and #59772 (inconsistent field names across `memory`, `patch` and `skill_manage`) are untouched.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issue

Related to #56253 — "Blind Parameter Trial Deadlocks". This is that failure mode in one tool: the model cannot introspect what it got wrong, so it guesses until it escapes.

Related to #53959 — `same_tool_failure_halt` should support fallback strategies instead of a hard stop. An error that names the working alternative is exactly that, at the tool layer.

Sibling: #63879 fixes the same dead-end → whole-file-rewrite pattern in `skill_manage`'s patch action.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux, Python 3.12
- [x] **Full suite:** `scripts/run_tests.sh` → **43,168 passed, 6 failed** (2,098 files). The 6 are unrelated and none touch `file_tools`, `fuzzy_match`, `patch_parser` or `edit_approval`:
  - `test_bedrock_integration`, `test_resolve_provider_openrouter_pool`, `test_tui_resume_flow`, `test_web_server` (×2) — fail identically on unmodified `main`
  - `test_startup_restart_race` — a known flaky race
- [x] **Targeted:** `scripts/run_tests.sh tests/tools/test_file_tools.py tests/tools/test_patch_failure_tracking.py tests/acp/test_edit_approval.py` → **75 passed, 0 failed**

### Documentation & Housekeeping

- [x] Tool description/schema updated — that is a substantial part of this change
- [x] No config keys added — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: no platform-specific code
