### PR TITLE
feat(sessions): add safe stale-session cleanup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -62,6 +62,7 @@ except ModuleNotFoundError:
     pass
 
 import os
+import sqlite3
 import sys
 
 
@@ -13726,13 +13727,46 @@ def main():
         "--yes", "-y", action="store_true", help="Skip confirmation"
     )
 
+    sessions_finalize_stale = sessions_subparsers.add_parser(
+        "finalize-stale",
+        help="Finalize a bounded batch of idle open sessions (DB only)",
+    )
+    sessions_finalize_stale.add_argument(
+        "--idle-for",
+        required=True,
+        metavar="AGE",
+        help="Only finalize sessions idle longer than AGE (e.g. 7d, 12h)",
+    )
+    sessions_finalize_stale.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum sessions to finalize (default 100; hard cap 1000)",
+    )
+    sessions_finalize_stale.add_argument(
+        "--reason",
+        default="stale_open_cleanup",
+        help="End reason to record (default: stale_open_cleanup)",
+    )
+    sessions_finalize_stale.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Observe candidates without changing the database",
+    )
+    sessions_finalize_stale.add_argument(
+        "--yes", "-y", action="store_true", help="Apply without prompting"
+    )
+    sessions_finalize_stale.add_argument(
+        "--json", action="store_true", help="Emit one structured JSON receipt"
+    )
+
     sessions_prune = sessions_subparsers.add_parser(
         "prune",
         help="Delete old sessions (filterable by time window, source, title, ...)",
     )
     _add_session_filter_args(
         sessions_prune,
-        "Delete sessions older than AGE — days if bare number, or a duration "
+        "Delete ended sessions whose started_at is older than AGE — days if bare number, or a duration "
         "like '5h'/'2d'/'1w', or an ISO timestamp (bare prune with no filters "
         "defaults to 90 days; any filter matches all ages)",
     )
@@ -13740,6 +13774,15 @@ def main():
         "--include-archived",
         action="store_true",
         help="Also delete archived sessions (excluded by default)",
+    )
+    sessions_prune.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum sessions to prune (default 100; hard cap 1000)",
+    )
+    sessions_prune.add_argument(
+        "--json", action="store_true", help="Emit one structured JSON receipt"
     )
 
     sessions_archive = sessions_subparsers.add_parser(
@@ -13808,6 +13851,21 @@ def main():
         import json as _json
 
         action = args.sessions_action
+        cleanup_action = action in {"finalize-stale", "prune"}
+
+        def _cleanup_error(error: str) -> int:
+            """Emit a machine-readable cleanup error when requested."""
+            if getattr(args, "json", False):
+                print(_json.dumps({
+                    "operation": action,
+                    "mode": "dry-run" if getattr(args, "dry_run", False) else "apply",
+                    "status": "error",
+                    "error": error,
+                    "transaction_committed": False,
+                }, sort_keys=True))
+            else:
+                print(f"Error: {error}")
+            return 1
 
         # 'repair' must run BEFORE opening SessionDB(): a malformed schema is
         # exactly the case where SessionDB() can't open, so it operates on the
@@ -13859,7 +13917,10 @@ def main():
 
             db = SessionDB()
         except Exception as e:
-            print(f"Error: Could not open session database: {e}")
+            error = f"Could not open session database: {e}"
+            if cleanup_action:
+                return _cleanup_error(error)
+            print(f"Error: {error}")
             return
 
         # Hide third-party tool sessions by default, but honour explicit --source
@@ -14364,6 +14425,69 @@ def main():
             else:
                 print(f"Session '{args.session_id}' not found.")
 
+        elif action == "finalize-stale":
+            from hermes_cli.session_filters import parse_duration_seconds
+
+            idle_for_seconds = parse_duration_seconds(args.idle_for)
+            if idle_for_seconds is None or idle_for_seconds <= 0:
+                payload = {
+                    "operation": "finalize-stale",
+                    "mode": "dry-run" if args.dry_run else "apply",
+                    "status": "error",
+                    "error": "--idle-for must be a positive duration such as 7d or 12h",
+                    "transaction_committed": False,
+                }
+            elif not args.dry_run and not args.yes:
+                payload = {
+                    "operation": "finalize-stale",
+                    "mode": "apply",
+                    "status": "error",
+                    "error": "apply requires --yes (or use --dry-run)",
+                    "transaction_committed": False,
+                }
+            else:
+                try:
+                    payload = (
+                        db.list_stale_open_candidates(
+                            idle_for_seconds=idle_for_seconds, limit=args.limit
+                        )
+                        if args.dry_run
+                        else db.finalize_stale_sessions(
+                            idle_for_seconds=idle_for_seconds,
+                            limit=args.limit,
+                            reason=args.reason,
+                        )
+                    )
+                    payload.update(
+                        operation="finalize-stale",
+                        mode="dry-run" if args.dry_run else "apply",
+                        status="ok",
+                        error=None,
+                    )
+                except (ValueError, sqlite3.Error) as exc:
+                    payload = {
+                        "operation": "finalize-stale",
+                        "mode": "dry-run" if args.dry_run else "apply",
+                        "status": "error",
+                        "error": str(exc),
+                        "transaction_committed": False,
+                        "mutated_ids": [],
+                    }
+            if args.json:
+                print(_json.dumps(payload, sort_keys=True))
+            elif payload["status"] == "ok":
+                if args.dry_run:
+                    print(
+                        f"Would finalize {payload['observed_candidates']} stale open session(s); "
+                        "nothing changed."
+                    )
+                else:
+                    print(f"Finalized {len(payload['mutated_ids'])} stale open session(s).")
+            else:
+                print(f"Error: {payload['error']}")
+            db.close()
+            return 0 if payload["status"] == "ok" else 1
+
         elif action in ("prune", "archive"):
             from hermes_cli.session_filters import (
                 build_prune_filters,
@@ -14399,8 +14523,11 @@ def main():
 
             try:
                 filters = build_prune_filters(args)
-            except ValueError as e:
-                print(f"Error: {e}")
+            except ValueError as exc:
+                if action == "prune":
+                    db.close()
+                    return _cleanup_error(str(exc))
+                print(f"Error: {exc}")
                 return
 
             if action == "archive" and not any(
@@ -14421,10 +14548,33 @@ def main():
             else:
                 filters["archived"] = False
 
-            candidates = db.list_prune_candidates(**filters)
+            if action == "prune" and args.json and not args.dry_run and not args.yes:
+                db.close()
+                return _cleanup_error("apply requires --yes (or use --dry-run)")
+            try:
+                candidates = db.list_prune_candidates(
+                    **filters,
+                    limit=args.limit if action == "prune" else None,
+                )
+            except (ValueError, sqlite3.Error) as exc:
+                if action == "prune":
+                    db.close()
+                    return _cleanup_error(str(exc))
+                print(f"Error: {exc}")
+                return
             verb = "Delete" if action == "prune" else "Archive"
             if not candidates:
-                print(f"No sessions match ({describe_filters(filters)}).")
+                if action == "prune" and args.json:
+                    print(_json.dumps({
+                        "operation": "prune", "mode": "dry-run" if args.dry_run else "apply",
+                        "status": "ok", "error": None, "limit": args.limit,
+                        "observed_candidates": 0, "observed_ids": [],
+                        "db_pruned_count": 0, "db_pruned_ids": [],
+                        "filesystem_cleanup_status": "best_effort_unverified",
+                        "transaction_committed": False,
+                    }, sort_keys=True))
+                else:
+                    print(f"No sessions match ({describe_filters(filters)}).")
                 return
 
             # Candidates are ordered oldest-first — surface the age span so
@@ -14436,6 +14586,17 @@ def main():
             )
 
             if args.dry_run or not args.yes:
+                if action == "prune" and args.json and args.dry_run:
+                    print(_json.dumps({
+                        "operation": "prune", "mode": "dry-run", "status": "ok",
+                        "error": None, "limit": args.limit,
+                        "observed_candidates": len(candidates),
+                        "observed_ids": [row["id"] for row in candidates],
+                        "db_pruned_count": 0, "db_pruned_ids": [],
+                        "filesystem_cleanup_status": "best_effort_unverified",
+                        "transaction_committed": False,
+                    }, sort_keys=True))
+                    return
                 shown = candidates if args.dry_run else candidates[:15]
                 print(
                     f"{len(candidates)} session(s) match "
@@ -14464,8 +14625,27 @@ def main():
 
             if action == "prune":
                 sessions_dir = get_hermes_home() / "sessions"
-                count = db.prune_sessions(sessions_dir=sessions_dir, **filters)
-                print(f"Pruned {count} session(s).")
+                try:
+                    receipt = db.prune_sessions_with_receipt(
+                        sessions_dir=sessions_dir, limit=args.limit, **filters
+                    )
+                except (ValueError, sqlite3.Error) as exc:
+                    db.close()
+                    return _cleanup_error(str(exc))
+                if args.json:
+                    receipt.update(
+                        operation="prune",
+                        mode="apply",
+                        status="ok",
+                        error=None,
+                        limit=args.limit,
+                        observed_candidates=len(candidates),
+                        observed_ids=[row["id"] for row in candidates],
+                        transaction_committed=True,
+                    )
+                    print(_json.dumps(receipt, sort_keys=True))
+                else:
+                    print(f"Pruned {receipt['db_pruned_count']} session(s).")
             else:
                 count = db.archive_sessions(**filters)
                 print(
@@ -14778,10 +14958,10 @@ def main():
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
-    else:
-        parser.print_help()
+        return args.func(args)
+    parser.print_help()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6082,6 +6082,156 @@ class SessionDB:
             self._remove_session_files(sessions_dir, sid)
         return count
 
+    # The CLI exposes the same bounds for stale finalization and bulk prune.
+    # Keep the cap in this storage layer too: callers outside argparse must not
+    # turn a bounded maintenance operation into an unbounded one.
+    _DEFAULT_MAINTENANCE_LIMIT = 100
+    _MAX_MAINTENANCE_LIMIT = 1000
+
+    @classmethod
+    def _bounded_maintenance_limit(
+        cls, limit: Optional[int], *, default: int = _DEFAULT_MAINTENANCE_LIMIT
+    ) -> int:
+        """Validate a bounded maintenance batch size for use inside SQLite."""
+        value = default if limit is None else limit
+        if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= cls._MAX_MAINTENANCE_LIMIT:
+            raise ValueError(
+                f"limit must be an integer between 1 and {cls._MAX_MAINTENANCE_LIMIT}"
+            )
+        return value
+
+    @staticmethod
+    def _stale_open_activity_sql() -> str:
+        """Return the authoritative last-activity expression for stale opens."""
+        return (
+            "COALESCE((SELECT MAX(m.timestamp) FROM messages m "
+            "WHERE m.session_id = s.id), s.started_at)"
+        )
+
+    def list_stale_open_candidates(
+        self,
+        *,
+        idle_for_seconds: float,
+        limit: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Observe bounded, still-open sessions idle before a cutoff.
+
+        This is deliberately a read-only preview.  Callers must not reuse its
+        IDs for mutation; :meth:`finalize_stale_sessions` reselects under its
+        own ``BEGIN IMMEDIATE`` transaction.
+        """
+        if idle_for_seconds <= 0:
+            raise ValueError("idle_for_seconds must be greater than zero")
+        batch_limit = self._bounded_maintenance_limit(limit)
+        cutoff = (time.time() if now is None else now) - idle_for_seconds
+        activity = self._stale_open_activity_sql()
+        with self._lock:
+            rows = self._conn.execute(
+                f"""SELECT s.id, {activity} AS last_activity
+                    FROM sessions s
+                    WHERE s.ended_at IS NULL
+                      AND s.end_reason IS NULL
+                      AND {activity} < ?
+                    ORDER BY last_activity ASC, s.id ASC
+                    LIMIT ?""",
+                (cutoff, batch_limit),
+            ).fetchall()
+        observed_ids = [row["id"] for row in rows]
+        return {
+            "cutoff": cutoff,
+            "limit": batch_limit,
+            "observed_candidates": len(observed_ids),
+            "observed_ids": observed_ids,
+            "mutated_ids": [],
+            "skipped_after_revalidation": [],
+            "transaction_committed": False,
+        }
+
+    def _finalize_stale_session(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        session_id: str,
+        cutoff: float,
+        ended_at: float,
+        reason: str,
+    ) -> bool:
+        """Finalize one still-stale row, preserving concurrent finalization."""
+        activity = self._stale_open_activity_sql()
+        cursor = conn.execute(
+            f"""UPDATE sessions AS s
+                SET ended_at = ?, end_reason = ?
+                WHERE id = ?
+                  AND ended_at IS NULL
+                  AND end_reason IS NULL
+                  AND {activity} < ?""",
+            (ended_at, reason, session_id, cutoff),
+        )
+        return cursor.rowcount == 1
+
+    def finalize_stale_sessions(
+        self,
+        *,
+        idle_for_seconds: float,
+        reason: str = "stale_open_cleanup",
+        limit: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Monotonically finalize one bounded batch of stale open sessions.
+
+        The candidate query and guarded per-row update run under one
+        :meth:`_execute_write` transaction, which starts with ``BEGIN
+        IMMEDIATE``.  Existing end metadata is never overwritten; an exception
+        rolls back the entire local SQLite transaction before propagating.
+        """
+        if idle_for_seconds <= 0:
+            raise ValueError("idle_for_seconds must be greater than zero")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("reason must be a non-empty string")
+        batch_limit = self._bounded_maintenance_limit(limit)
+        cutoff = (time.time() if now is None else now) - idle_for_seconds
+        activity = self._stale_open_activity_sql()
+
+        def _do(conn):
+            rows = conn.execute(
+                f"""SELECT s.id, {activity} AS last_activity
+                    FROM sessions s
+                    WHERE s.ended_at IS NULL
+                      AND s.end_reason IS NULL
+                      AND {activity} < ?
+                    ORDER BY last_activity ASC, s.id ASC
+                    LIMIT ?""",
+                (cutoff, batch_limit),
+            ).fetchall()
+            observed_ids = [row["id"] for row in rows]
+            mutated_ids: list[str] = []
+            skipped_ids: list[str] = []
+            for row in rows:
+                if self._finalize_stale_session(
+                    conn,
+                    session_id=row["id"],
+                    cutoff=cutoff,
+                    ended_at=row["last_activity"],
+                    reason=reason,
+                ):
+                    mutated_ids.append(row["id"])
+                else:
+                    skipped_ids.append(row["id"])
+            return observed_ids, mutated_ids, skipped_ids
+
+        observed_ids, mutated_ids, skipped_ids = self._execute_write(_do)
+        return {
+            "cutoff": cutoff,
+            "limit": batch_limit,
+            "reason": reason,
+            "observed_candidates": len(observed_ids),
+            "observed_ids": observed_ids,
+            "mutated_ids": mutated_ids,
+            "skipped_after_revalidation": skipped_ids,
+            "transaction_committed": True,
+        }
+
     @staticmethod
     def _prune_filter_where(
         *,
@@ -6206,6 +6356,7 @@ class SessionDB:
         self,
         older_than_days: Optional[float] = None,
         source: str = None,
+        limit: Optional[int] = None,
         **filters,
     ) -> List[Dict[str, Any]]:
         """Return the sessions a matching :meth:`prune_sessions` /
@@ -6219,13 +6370,17 @@ class SessionDB:
         """
         if filters.get("started_before") is None and older_than_days is not None:
             filters["started_before"] = time.time() - (older_than_days * 86400)
+        batch_limit = self._bounded_maintenance_limit(limit) if limit is not None else None
         where, params = self._prune_filter_where(source=source, **filters)
+        limit_sql = " LIMIT ?" if batch_limit is not None else ""
+        if batch_limit is not None:
+            params.append(batch_limit)
         with self._lock:
             cursor = self._conn.execute(
                 f"""SELECT s.id, s.source, s.title, s.model, s.started_at,
                            s.ended_at, s.message_count, s.archived
                     FROM sessions s WHERE {where}
-                    ORDER BY s.started_at ASC""",
+                    ORDER BY s.started_at ASC, s.id ASC{limit_sql}""",
                 params,
             )
             return [dict(row) for row in cursor.fetchall()]
@@ -6259,10 +6414,61 @@ class SessionDB:
     def prune_sessions(
         self,
         older_than_days: Optional[float] = 90,
-        source: str = None,
+        source: Optional[str] = None,
         sessions_dir: Optional[Path] = None,
+        limit: Optional[int] = None,
         **filters,
     ) -> int:
+        """Delete ended sessions matching filters and return the DB row count.
+
+        Temporal filters are always evaluated against ``started_at``.  An
+        optional limit is applied by the transactional candidate query, not by
+        the CLI display layer.
+        """
+        count, _ = self._prune_sessions_impl(
+            older_than_days=older_than_days,
+            source=source,
+            sessions_dir=sessions_dir,
+            limit=limit,
+            **filters,
+        )
+        return count
+
+    def prune_sessions_with_receipt(
+        self,
+        older_than_days: Optional[float] = 90,
+        source: Optional[str] = None,
+        sessions_dir: Optional[Path] = None,
+        limit: Optional[int] = None,
+        **filters,
+    ) -> Dict[str, Any]:
+        """Prune with an auditable DB receipt for non-interactive callers.
+
+        The filesystem pass runs after commit and deliberately remains marked
+        unverified: ``_remove_session_files`` is best effort and does not prove
+        every unlink to this caller.
+        """
+        count, removed_ids = self._prune_sessions_impl(
+            older_than_days=older_than_days,
+            source=source,
+            sessions_dir=sessions_dir,
+            limit=limit,
+            **filters,
+        )
+        return {
+            "db_pruned_count": count,
+            "db_pruned_ids": removed_ids,
+            "filesystem_cleanup_status": "best_effort_unverified",
+        }
+
+    def _prune_sessions_impl(
+        self,
+        older_than_days: Optional[float] = 90,
+        source: Optional[str] = None,
+        sessions_dir: Optional[Path] = None,
+        limit: Optional[int] = None,
+        **filters,
+    ) -> Tuple[int, List[str]]:
         """Delete sessions matching the filters. Returns count deleted.
 
         Default behavior (no keyword filters) is unchanged: delete ended
@@ -6297,14 +6503,20 @@ class SessionDB:
         """
         if filters.get("started_before") is None and older_than_days is not None:
             filters["started_before"] = time.time() - (older_than_days * 86400)
+        batch_limit = self._bounded_maintenance_limit(limit) if limit is not None else None
         where, where_params = self._prune_filter_where(source=source, **filters)
+        limit_sql = " LIMIT ?" if batch_limit is not None else ""
+        if batch_limit is not None:
+            where_params.append(batch_limit)
         removed_ids: list[str] = []
 
         def _do(conn):
             cursor = conn.execute(
-                f"SELECT s.id FROM sessions s WHERE {where}", where_params
+                f"""SELECT s.id FROM sessions s WHERE {where}
+                    ORDER BY s.started_at ASC, s.id ASC{limit_sql}""",
+                where_params,
             )
-            session_ids = {row["id"] for row in cursor.fetchall()}
+            session_ids = [row["id"] for row in cursor.fetchall()]
 
             if not session_ids:
                 return 0
@@ -6314,7 +6526,7 @@ class SessionDB:
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "
                 f"WHERE parent_session_id IN ({placeholders})",
-                list(session_ids),
+                session_ids,
             )
 
             for sid in session_ids:
@@ -6324,10 +6536,11 @@ class SessionDB:
             return len(session_ids)
 
         count = self._execute_write(_do)
-        # Clean up on-disk files outside the DB transaction
+        # Files are removed after the committed DB transaction. Their outcome
+        # remains best-effort because the historical helper swallows OSErrors.
         for sid in removed_ids:
             self._remove_session_files(sessions_dir, sid)
-        return count
+        return count, removed_ids
 
     # ── Meta key/value (for scheduler bookkeeping) ──
 

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -1,4 +1,9 @@
+import json
+import os
+import sqlite3
+import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -165,8 +170,13 @@ def _run_prune(monkeypatch, capsys, argv_tail, candidates=None):
             seen.update(kwargs)
             return rows
 
-        def prune_sessions(self, **kwargs):
-            return len(rows)
+        def prune_sessions_with_receipt(self, **kwargs):
+            seen["apply"] = kwargs
+            return {
+                "db_pruned_count": len(rows),
+                "db_pruned_ids": [row["id"] for row in rows],
+                "filesystem_cleanup_status": "best_effort_unverified",
+            }
 
         def close(self):
             pass
@@ -220,3 +230,175 @@ def test_sessions_prune_preview_shows_oldest_newest(monkeypatch, capsys):
     assert "2 session(s) match" in out
     assert f"oldest {format_epoch(1_600_000_000.0)}" in out
     assert f"newest {format_epoch(1_700_000_000.0)}" in out
+
+
+def test_sessions_finalize_stale_json_dry_run_is_observation_only(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def list_stale_open_candidates(self, **kwargs):
+            assert kwargs == {"idle_for_seconds": 7 * 86400, "limit": 100}
+            return {
+                "cutoff": 1.0,
+                "limit": 100,
+                "observed_candidates": 1,
+                "observed_ids": ["old"],
+                "mutated_ids": [],
+                "skipped_after_revalidation": [],
+                "transaction_committed": False,
+            }
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "finalize-stale", "--idle-for", "7d", "--dry-run", "--json"],
+    )
+
+    main_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["operation"] == "finalize-stale"
+    assert payload["mode"] == "dry-run"
+    assert payload["status"] == "ok"
+    assert payload["mutated_ids"] == []
+    assert payload["transaction_committed"] is False
+
+
+def test_sessions_prune_json_passes_limit_and_reports_filesystem_uncertainty(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    row = {
+        "id": "old", "source": "cli", "title": "old", "model": None,
+        "started_at": 1.0, "ended_at": 2.0, "message_count": 1, "archived": 0,
+    }
+
+    class FakeDB:
+        def list_prune_candidates(self, **kwargs):
+            assert kwargs["limit"] == 1
+            assert kwargs["end_reason"] == "stale_open_cleanup"
+            return [row]
+
+        def prune_sessions_with_receipt(self, **kwargs):
+            assert kwargs["limit"] == 1
+            return {
+                "db_pruned_count": 1,
+                "db_pruned_ids": ["old"],
+                "filesystem_cleanup_status": "best_effort_unverified",
+            }
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes", "sessions", "prune", "--end-reason", "stale_open_cleanup",
+            "--limit", "1", "--yes", "--json",
+        ],
+    )
+
+    main_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["db_pruned_ids"] == ["old"]
+    assert payload["filesystem_cleanup_status"] == "best_effort_unverified"
+    assert payload["transaction_committed"] is True
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_sessions_entrypoint(tmp_path, *argv):
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "sessions", *argv],
+        cwd=_PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "operation"),
+    [
+        (
+            ("finalize-stale", "--idle-for", "nope", "--dry-run", "--json"),
+            "finalize-stale",
+        ),
+        (("finalize-stale", "--idle-for", "1d", "--json"), "finalize-stale"),
+        (
+            (
+                "finalize-stale",
+                "--idle-for",
+                "1d",
+                "--dry-run",
+                "--limit",
+                "1001",
+                "--json",
+            ),
+            "finalize-stale",
+        ),
+        (("prune", "--limit", "1001", "--dry-run", "--json"), "prune"),
+        (
+            ("prune", "--older-than", "nonsense", "--dry-run", "--json"),
+            "prune",
+        ),
+        (("prune", "--source", "cli", "--json"), "prune"),
+    ],
+)
+def test_sessions_cleanup_entrypoint_errors_are_json_and_nonzero(
+    tmp_path, argv, operation
+):
+    result = _run_sessions_entrypoint(tmp_path, *argv)
+
+    assert result.returncode != 0
+    payload = json.loads(result.stdout)
+    assert result.stdout == json.dumps(payload, sort_keys=True) + "\n"
+    assert payload["operation"] == operation
+    assert payload["status"] == "error"
+
+
+def test_sessions_cleanup_entrypoint_sqlite_contention_is_json_and_nonzero(tmp_path):
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    db.close()
+    setup = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        setup.execute("PRAGMA journal_mode=DELETE")
+    finally:
+        setup.close()
+    blocker = sqlite3.connect(db_path, isolation_level=None, timeout=0.01)
+    try:
+        blocker.execute("BEGIN EXCLUSIVE")
+        result = _run_sessions_entrypoint(
+            tmp_path,
+            "finalize-stale",
+            "--idle-for",
+            "1d",
+            "--dry-run",
+            "--json",
+        )
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    assert result.returncode != 0
+    payload = json.loads(result.stdout)
+    assert result.stdout == json.dumps(payload, sort_keys=True) + "\n"
+    assert payload["operation"] == "finalize-stale"
+    assert payload["status"] == "error"
+    assert payload["transaction_committed"] is False

--- a/tests/hermes_state/test_finalize_stale_sessions.py
+++ b/tests/hermes_state/test_finalize_stale_sessions.py
@@ -1,0 +1,174 @@
+"""Regression coverage for monotone stale-session finalization."""
+
+import sqlite3
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _make_stale(db: SessionDB, session_id: str, *, started_at: float) -> None:
+    db.create_session(session_id=session_id, source="cli")
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (started_at, session_id),
+        )
+    )
+
+
+@pytest.fixture()
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    yield database
+    database.close()
+
+
+def test_finalize_stale_dry_run_observes_without_mutating(db):
+    now = time.time()
+    _make_stale(db, "old", started_at=now - 10_000)
+
+    result = db.list_stale_open_candidates(idle_for_seconds=3600, now=now)
+
+    assert result["observed_ids"] == ["old"]
+    assert result["mutated_ids"] == []
+    assert result["transaction_committed"] is False
+    assert db.get_session("old")["ended_at"] is None
+
+
+def test_finalize_stale_uses_last_message_activity_and_is_idempotent(db):
+    now = time.time()
+    _make_stale(db, "active", started_at=now - 10_000)
+    db.append_message("active", role="user", content="still here", timestamp=now - 30)
+    _make_stale(db, "old", started_at=now - 10_000)
+
+    result = db.finalize_stale_sessions(
+        idle_for_seconds=3600,
+        reason="stale_open_cleanup",
+        now=now,
+    )
+
+    assert result["mutated_ids"] == ["old"]
+    assert result["skipped_after_revalidation"] == []
+    assert result["transaction_committed"] is True
+    assert db.get_session("active")["ended_at"] is None
+    assert db.get_session("old")["end_reason"] == "stale_open_cleanup"
+    assert db.finalize_stale_sessions(
+        idle_for_seconds=3600, reason="stale_open_cleanup", now=now
+    )["mutated_ids"] == []
+
+
+def test_finalize_stale_preserves_existing_finalization_and_orders_limited_batch(db):
+    now = time.time()
+    _make_stale(db, "third", started_at=now - 3_000)
+    _make_stale(db, "first", started_at=now - 5_000)
+    _make_stale(db, "second", started_at=now - 4_000)
+    db.end_session("second", end_reason="already_closed")
+
+    result = db.finalize_stale_sessions(
+        idle_for_seconds=3600, reason="stale_open_cleanup", limit=1, now=now
+    )
+
+    assert result["mutated_ids"] == ["first"]
+    assert db.get_session("second")["end_reason"] == "already_closed"
+    assert db.get_session("third")["ended_at"] is None
+
+
+@pytest.mark.parametrize("limit", [0, -1, 1001])
+def test_finalize_stale_rejects_out_of_bounds_limit(db, limit):
+    with pytest.raises(ValueError, match="limit"):
+        db.finalize_stale_sessions(
+            idle_for_seconds=3600, reason="stale_open_cleanup", limit=limit
+        )
+
+
+def test_recent_writer_commit_before_apply_is_preserved(tmp_path):
+    db_path = tmp_path / "state.db"
+    cleaner = SessionDB(db_path)
+    writer = SessionDB(db_path)
+    now = time.time()
+    _make_stale(cleaner, "raced", started_at=now - 10_000)
+
+    # A second real WAL connection commits activity after a dry-run preview but
+    # before the cleanup acquires its write transaction.
+    assert cleaner.list_stale_open_candidates(
+        idle_for_seconds=3600, now=now
+    )["observed_ids"] == ["raced"]
+    writer.append_message("raced", role="user", content="new", timestamp=now - 5)
+
+    result = cleaner.finalize_stale_sessions(
+        idle_for_seconds=3600, reason="stale_open_cleanup", now=now
+    )
+
+    assert result["mutated_ids"] == []
+    assert cleaner.get_session("raced")["ended_at"] is None
+    writer.close()
+    cleaner.close()
+
+
+def test_finalize_stale_rolls_back_entire_batch_on_update_failure(db, monkeypatch):
+    now = time.time()
+    _make_stale(db, "first", started_at=now - 5_000)
+    _make_stale(db, "second", started_at=now - 4_000)
+    original = db._finalize_stale_session
+    calls = 0
+
+    def fail_second(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected update failure")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(db, "_finalize_stale_session", fail_second)
+    with pytest.raises(RuntimeError, match="injected"):
+        db.finalize_stale_sessions(
+            idle_for_seconds=3600, reason="stale_open_cleanup", now=now
+        )
+
+    assert db.get_session("first")["ended_at"] is None
+    assert db.get_session("second")["ended_at"] is None
+
+
+def test_finalize_stale_lock_contention_leaves_rows_open(db, monkeypatch):
+    now = time.time()
+    _make_stale(db, "old", started_at=now - 10_000)
+    blocker = sqlite3.connect(str(db.db_path), isolation_level=None, timeout=0.01)
+    try:
+        blocker.execute("BEGIN IMMEDIATE")
+        monkeypatch.setattr(db, "_WRITE_MAX_RETRIES", 1)
+        with pytest.raises(sqlite3.OperationalError, match="locked|busy"):
+            db.finalize_stale_sessions(
+                idle_for_seconds=3600, reason="stale_open_cleanup", now=now
+            )
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    assert db.get_session("old")["ended_at"] is None
+
+
+def test_prune_limit_is_applied_inside_transaction_and_receipt_is_honest(db):
+    now = time.time()
+    for session_id, age in (("first", 5_000), ("second", 4_000)):
+        _make_stale(db, session_id, started_at=now - age)
+        db.end_session(session_id, end_reason="stale_open_cleanup")
+
+    preview = db.list_prune_candidates(
+        older_than_days=None, started_before=now, limit=1
+    )
+    receipt = db.prune_sessions_with_receipt(
+        older_than_days=None,
+        started_before=now,
+        limit=1,
+    )
+
+    assert [row["id"] for row in preview] == ["first"]
+    assert receipt == {
+        "db_pruned_count": 1,
+        "db_pruned_ids": ["first"],
+        "filesystem_cleanup_status": "best_effort_unverified",
+    }
+    assert db.get_session("first") is None
+    assert db.get_session("second") is not None


### PR DESCRIPTION
## Why

Open sessions left behind by interrupted or abandoned runs need a safe, auditable cleanup path. This adds bounded native maintenance commands without treating session-file deletion as a transactional guarantee.

## Architecture

- `hermes sessions finalize-stale` observes or finalizes a bounded batch of idle, still-open sessions.
- Finalization is DB-only and runs candidate selection plus guarded updates in one SQLite write transaction.
- `hermes sessions prune` now accepts a bounded `--limit` and emits an auditable JSON receipt when requested.
- Storage-layer limit validation prevents non-CLI callers from bypassing the maintenance cap.

## Safety invariants

- Finalization is monotone: existing end metadata is never overwritten.
- Candidate eligibility uses the latest message timestamp, falling back to `started_at`.
- The write path reselects and revalidates candidates under `BEGIN IMMEDIATE`; dry-run IDs are never reused for mutation.
- Batches default to 100 and are capped at 1000.
- Prune is separate from finalization.
- Filesystem cleanup remains explicitly best-effort and auditable; only the SQLite mutation has transactional truth.
- This PR provides no global backup or rollback mechanism.

## CLI contract

- `finalize-stale` requires `--idle-for`; mutation also requires `--yes`.
- `--dry-run --json` produces a single structured receipt without DB mutation.
- Cleanup validation, SQLite errors, and confirmation errors return non-zero and produce one structured JSON error receipt when `--json` is requested.

## Validation

- `scripts/run_tests.sh tests/hermes_state/test_finalize_stale_sessions.py tests/hermes_cli/test_sessions_delete.py -q` — 27 passed (executed after cherry-picking onto refreshed upstream `main`).
- `python -m py_compile hermes_cli/main.py hermes_state.py tests/hermes_cli/test_sessions_delete.py tests/hermes_state/test_finalize_stale_sessions.py` — passed.
- `git diff --check origin/main...HEAD` — passed; PR diff is limited to the four scoped files.
- Final Silas review: approved; 171 unique tests and 6/6 repros reported corrected, with no finding.

## Runtime note

The legacy cron is already paused, but this PR performs no cron cutover: it does not reactivate, disable, or otherwise alter any live cron/runtime/session/profile/gateway state.
