### PR TITLE
feat(telegram): add configurable compact topic titles

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -958,6 +958,10 @@ platform_toolsets:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames
+#       dm_topic_titles:
+#         style: readable             # readable (default) | compact
+#         compact_max_words: 2        # Compact titles keep 1..6 Unicode words
+#         # generic_titles: ["New Topic"]  # Optional localized/custom placeholders; falls back to the first user message
 #       command_menu:
 #         # Telegram allows up to 100 BotCommands; Hermes defaults to 60 so
 #         # all built-in commands plus common skill commands stay visible

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -15,6 +15,11 @@ from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
 from utils import atomic_json_write
+from gateway.telegram_topic_titles import (
+    TelegramTopicTitleOptions,
+    resolve_telegram_topic_title_contexts,
+    telegram_topic_title_options,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +138,62 @@ def _warn_slack_directory(team_id: str, detail: str) -> None:
             team_id,
             detail,
         )
+
+
+def _configured_telegram_topic_title_options() -> TelegramTopicTitleOptions:
+    """Load Telegram topic-title policy without exposing config to callers."""
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        telegram = config.platforms.get(Platform.TELEGRAM)
+        return telegram_topic_title_options(getattr(telegram, "extra", None) or {})
+    except Exception:
+        return TelegramTopicTitleOptions()
+
+
+def _merge_telegram_topic_title_context(
+    entries: List[Dict[str, Any]],
+    contexts: List[Dict[str, Any]],
+    *,
+    options: TelegramTopicTitleOptions,
+) -> None:
+    """Apply bound session titles and stable aliases to Telegram topic entries."""
+    by_id = {str(entry.get("id") or ""): entry for entry in entries}
+    base_names: Dict[str, str] = {}
+    for entry in entries:
+        entry_id = str(entry.get("id") or "")
+        chat_id = entry_id.split(":", 1)[0]
+        name = str(entry.get("name") or "")
+        base_name = name.split(" / ", 1)[0].strip() or chat_id
+        if chat_id:
+            base_names.setdefault(chat_id, base_name)
+
+    resolved_titles = resolve_telegram_topic_title_contexts(
+        contexts,
+        options=options,
+    )
+    for context, resolved in zip(contexts, resolved_titles):
+        chat_id = str(context.get("chat_id") or "")
+        thread_id = str(context.get("thread_id") or "")
+        if not chat_id or not thread_id:
+            continue
+
+        entry_id = f"{chat_id}:{thread_id}"
+        base_name = base_names.get(chat_id, chat_id)
+        entry = by_id.get(entry_id)
+        if entry is None:
+            new_entry: Dict[str, Any] = {
+                "id": entry_id,
+                "type": "dm",
+                "thread_id": thread_id,
+            }
+            entries.append(new_entry)
+            by_id[entry_id] = new_entry
+            entry = new_entry
+        entry["name"] = f"{base_name} / {resolved}"
+        entry["topic_label"] = resolved
+        entry["aliases"] = [resolved, f"topic {thread_id}"]
 
 
 # ---------------------------------------------------------------------------
@@ -368,24 +429,47 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
     return channels
 
 
-def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
+def _build_from_sessions(platform_name: str) -> List[Dict[str, Any]]:
     """Pull known channels/contacts from gateway session origin data.
 
     state.db is the primary source (#9006): gateway session rows persist
     origin_json.  Falls back to sessions.json for pre-migration databases.
     """
     entries = _build_from_sessions_db(platform_name)
-    if entries:
-        return entries
-    return _build_from_sessions_json(platform_name)
+    if not entries:
+        entries = _build_from_sessions_json(platform_name)
+
+    if platform_name == "telegram":
+        options = _configured_telegram_topic_title_options()
+        if options.style != "compact":
+            return entries
+        try:
+            from hermes_state import SessionDB
+
+            db = SessionDB(db_path=get_hermes_home() / "state.db")
+            try:
+                contexts = db.list_telegram_topic_title_context()
+            finally:
+                db.close()
+            _merge_telegram_topic_title_context(
+                entries,
+                contexts,
+                options=options,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Channel directory: Telegram topic-title enrichment failed: %s",
+                exc,
+            )
+    return entries
 
 
 def _build_from_sessions_db(platform_name: str) -> List[Dict[str, str]]:
     """Pull channels/contacts from state.db gateway session rows."""
-    entries: List[Dict[str, str]] = []
+    entries: List[Dict[str, Any]] = []
     try:
         from hermes_state import SessionDB
-        db = SessionDB()
+        db = SessionDB(db_path=get_hermes_home() / "state.db")
         try:
             lister = getattr(db, "list_gateway_sessions", None)
             if not callable(lister):
@@ -520,12 +604,29 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
 
     query = _normalize_channel_query(name)
 
-    # 1. Exact name match, including the display labels shown by send_message(action="list")
+    # 1. Exact primary-name match, including display labels shown by
+    # send_message(action="list"). Preserve the established first-match
+    # behavior for primary names.
     for ch in channels:
-        if _normalize_channel_query(ch["name"]) == query:
+        if _normalize_channel_query(str(ch.get("name", ""))) == query:
             return ch["id"]
         if _normalize_channel_query(_channel_target_name(platform_name, ch)) == query:
             return ch["id"]
+
+    # Aliases are generated independently per chat, so the same compact title
+    # can legitimately occur in more than one DM. Never choose one arbitrarily.
+    alias_matches = [
+        ch
+        for ch in channels
+        if any(
+            _normalize_channel_query(str(alias)) == query
+            for alias in (ch.get("aliases") or [])
+        )
+    ]
+    if len(alias_matches) == 1:
+        return alias_matches[0]["id"]
+    if len(alias_matches) > 1:
+        return None
 
     # 2. Guild-qualified match for Discord ("GuildName/channel")
     if "/" in query:
@@ -535,8 +636,15 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
             if guild == guild_part and _normalize_channel_query(ch["name"]) == ch_part:
                 return ch["id"]
 
-    # 3. Partial prefix match (only if unambiguous)
-    matches = [ch for ch in channels if _normalize_channel_query(ch["name"]).startswith(query)]
+    # 3. Partial prefix match across names and aliases (only if unambiguous)
+    matches = []
+    for ch in channels:
+        candidates = [ch.get("name", ""), *(ch.get("aliases") or [])]
+        if any(
+            _normalize_channel_query(str(candidate)).startswith(query)
+            for candidate in candidates
+        ):
+            matches.append(ch)
     if len(matches) == 1:
         return matches[0]["id"]
 

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -18,6 +18,7 @@ from utils import atomic_json_write
 from gateway.telegram_topic_titles import (
     TelegramTopicTitleOptions,
     resolve_telegram_topic_title_contexts,
+    telegram_operator_topic_ids,
     telegram_topic_title_options,
 )
 
@@ -140,16 +141,19 @@ def _warn_slack_directory(team_id: str, detail: str) -> None:
         )
 
 
-def _configured_telegram_topic_title_options() -> TelegramTopicTitleOptions:
-    """Load Telegram topic-title policy without exposing config to callers."""
+def _configured_telegram_topic_title_settings() -> tuple[
+    TelegramTopicTitleOptions, frozenset[tuple[str, str]]
+]:
+    """Load topic-title policy and operator-declared Telegram topic ids."""
     try:
         from gateway.config import Platform, load_gateway_config
 
         config = load_gateway_config()
         telegram = config.platforms.get(Platform.TELEGRAM)
-        return telegram_topic_title_options(getattr(telegram, "extra", None) or {})
+        extra = getattr(telegram, "extra", None) or {}
+        return telegram_topic_title_options(extra), telegram_operator_topic_ids(extra)
     except Exception:
-        return TelegramTopicTitleOptions()
+        return TelegramTopicTitleOptions(), frozenset()
 
 
 def _merge_telegram_topic_title_context(
@@ -157,8 +161,9 @@ def _merge_telegram_topic_title_context(
     contexts: List[Dict[str, Any]],
     *,
     options: TelegramTopicTitleOptions,
+    operator_topic_ids: frozenset[tuple[str, str]] = frozenset(),
 ) -> None:
-    """Apply bound session titles and stable aliases to Telegram topic entries."""
+    """Apply auto-title labels without rewriting operator-declared topics."""
     by_id = {str(entry.get("id") or ""): entry for entry in entries}
     base_names: Dict[str, str] = {}
     for entry in entries:
@@ -169,11 +174,20 @@ def _merge_telegram_topic_title_context(
         if chat_id:
             base_names.setdefault(chat_id, base_name)
 
+    auto_contexts = [
+        context
+        for context in contexts
+        if (
+            str(context.get("chat_id") or ""),
+            str(context.get("thread_id") or ""),
+        )
+        not in operator_topic_ids
+    ]
     resolved_titles = resolve_telegram_topic_title_contexts(
-        contexts,
+        auto_contexts,
         options=options,
     )
-    for context, resolved in zip(contexts, resolved_titles):
+    for context, resolved in zip(auto_contexts, resolved_titles):
         chat_id = str(context.get("chat_id") or "")
         thread_id = str(context.get("thread_id") or "")
         if not chat_id or not thread_id:
@@ -440,7 +454,7 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, Any]]:
         entries = _build_from_sessions_json(platform_name)
 
     if platform_name == "telegram":
-        options = _configured_telegram_topic_title_options()
+        options, operator_topic_ids = _configured_telegram_topic_title_settings()
         if options.style != "compact":
             return entries
         try:
@@ -455,6 +469,7 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, Any]]:
                 entries,
                 contexts,
                 options=options,
+                operator_topic_ids=operator_topic_ids,
             )
         except Exception as exc:
             logger.debug(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,6 +69,12 @@ from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.telegram_topic_titles import (
+    TelegramTopicTitleOptions,
+    resolve_telegram_topic_title_contexts,
+    sanitize_telegram_topic_title as _sanitize_telegram_topic_title_policy,
+    telegram_topic_title_options,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -15989,16 +15995,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("Failed to send Telegram topic setup image", exc_info=True)
 
+    def _telegram_topic_title_options(self, source: SessionSource) -> TelegramTopicTitleOptions:
+        """Resolve topic-title presentation settings for this Telegram lane."""
+        platform_cfg = (
+            self.config.platforms.get(source.platform)
+            if getattr(self, "config", None) and getattr(self.config, "platforms", None)
+            else None
+        )
+        extra = getattr(platform_cfg, "extra", None) or {} if platform_cfg is not None else {}
+        return telegram_topic_title_options(extra)
+
     def _sanitize_telegram_topic_title(self, title: str) -> str:
-        """Return a Bot API-safe forum topic name from a generated session title."""
-        cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
-        if not cleaned:
-            return "Hermes Chat"
-        # Telegram forum topic names are short (currently 1-128 chars). Keep
-        # extra room for multi-byte titles and avoid trailing ellipsis churn.
-        if len(cleaned) > 120:
-            cleaned = cleaned[:117].rstrip() + "..."
-        return cleaned
+        """Preserve the existing readable Bot API-safe title contract."""
+        return _sanitize_telegram_topic_title_policy(
+            title,
+            options=TelegramTopicTitleOptions(),
+        )
+
+    async def _resolved_telegram_topic_title(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+    ) -> str:
+        """Resolve a configured title with stable per-chat compact deduplication."""
+        options = self._telegram_topic_title_options(source)
+        if options.style != "compact":
+            return _sanitize_telegram_topic_title_policy(title, options=options)
+
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None or not source.chat_id:
+            return _sanitize_telegram_topic_title_policy(title, options=options)
+
+        try:
+            contexts = await session_db.list_telegram_topic_title_context(
+                chat_id=str(source.chat_id)
+            )
+        except Exception:
+            logger.debug("Failed to load Telegram topic titles before rename", exc_info=True)
+            contexts = []
+
+        resolved_titles = resolve_telegram_topic_title_contexts(
+            contexts,
+            options=options,
+            title_overrides={str(session_id): title},
+        )
+        for context, resolved in zip(contexts, resolved_titles):
+            if str(context.get("session_id") or "") == str(session_id):
+                return resolved
+
+        return _sanitize_telegram_topic_title_policy(title, options=options)
 
     def _is_discord_auto_thread_lane(self, source: SessionSource) -> bool:
         """Return True only for Discord threads Hermes just auto-created."""
@@ -16138,7 +16184,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if adapter is None:
             return
-        topic_name = self._sanitize_telegram_topic_title(title)
+        topic_name = await self._resolved_telegram_topic_title(
+            source,
+            session_id,
+            title,
+        )
         try:
             rename_topic = getattr(adapter, "rename_dm_topic", None)
             if rename_topic is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -73,6 +73,7 @@ from gateway.telegram_topic_titles import (
     TelegramTopicTitleOptions,
     resolve_telegram_topic_title_contexts,
     sanitize_telegram_topic_title as _sanitize_telegram_topic_title_policy,
+    telegram_operator_topic_ids,
     telegram_topic_title_options,
 )
 
@@ -15995,15 +15996,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("Failed to send Telegram topic setup image", exc_info=True)
 
-    def _telegram_topic_title_options(self, source: SessionSource) -> TelegramTopicTitleOptions:
-        """Resolve topic-title presentation settings for this Telegram lane."""
+    def _telegram_topic_title_extra(self, source: SessionSource) -> Dict[str, Any]:
+        """Return Telegram platform extras for shared title policy decisions."""
         platform_cfg = (
             self.config.platforms.get(source.platform)
             if getattr(self, "config", None) and getattr(self.config, "platforms", None)
             else None
         )
-        extra = getattr(platform_cfg, "extra", None) or {} if platform_cfg is not None else {}
-        return telegram_topic_title_options(extra)
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg is not None else None
+        return extra if isinstance(extra, dict) else {}
+
+    def _telegram_topic_title_options(self, source: SessionSource) -> TelegramTopicTitleOptions:
+        """Resolve topic-title presentation settings for this Telegram lane."""
+        return telegram_topic_title_options(self._telegram_topic_title_extra(source))
 
     def _sanitize_telegram_topic_title(self, title: str) -> str:
         """Preserve the existing readable Bot API-safe title contract."""
@@ -16035,12 +16040,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to load Telegram topic titles before rename", exc_info=True)
             contexts = []
 
+        operator_topic_ids = telegram_operator_topic_ids(
+            self._telegram_topic_title_extra(source)
+        )
+        auto_contexts = [
+            context
+            for context in contexts
+            if (
+                str(context.get("chat_id") or ""),
+                str(context.get("thread_id") or ""),
+            )
+            not in operator_topic_ids
+        ]
         resolved_titles = resolve_telegram_topic_title_contexts(
-            contexts,
+            auto_contexts,
             options=options,
             title_overrides={str(session_id): title},
         )
-        for context, resolved in zip(contexts, resolved_titles):
+        for context, resolved in zip(auto_contexts, resolved_titles):
             if str(context.get("session_id") or "") == str(session_id):
                 return resolved
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16022,9 +16022,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         session_id: str,
         title: str,
-    ) -> str:
-        """Resolve a configured title with stable per-chat compact deduplication."""
+    ) -> Optional[str]:
+        """Resolve an auto-topic title, or ``None`` for operator-declared topics."""
         options = self._telegram_topic_title_options(source)
+        operator_topic_ids = telegram_operator_topic_ids(
+            self._telegram_topic_title_extra(source)
+        )
+        current_topic_id = (
+            str(source.chat_id or ""),
+            str(source.thread_id or ""),
+        )
+        if current_topic_id in operator_topic_ids:
+            return None
         if options.style != "compact":
             return _sanitize_telegram_topic_title_policy(title, options=options)
 
@@ -16040,9 +16049,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to load Telegram topic titles before rename", exc_info=True)
             contexts = []
 
-        operator_topic_ids = telegram_operator_topic_ids(
-            self._telegram_topic_title_extra(source)
-        )
         auto_contexts = [
             context
             for context in contexts
@@ -16206,6 +16212,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_id,
             title,
         )
+        if topic_name is None:
+            return
         try:
             rename_topic = getattr(adapter, "rename_dm_topic", None)
             if rename_topic is not None:

--- a/gateway/telegram_topic_titles.py
+++ b/gateway/telegram_topic_titles.py
@@ -1,0 +1,185 @@
+"""Policy helpers for Telegram DM topic title presentation.
+
+The default readable style preserves Hermes' existing auto-title behavior.
+Operators can opt into compact, Unicode-aware topic names through Telegram
+platform configuration without changing title generation for other surfaces.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+_READABLE_STYLE = "readable"
+_COMPACT_STYLE = "compact"
+_MIN_COMPACT_WORDS = 1
+_MAX_COMPACT_WORDS = 6
+_DEFAULT_COMPACT_WORDS = 2
+_MAX_TITLE_CHARS = 120
+_SAFE_FALLBACK_TITLE = "Hermes Chat"
+_GENERIC_GENERATED_TITLES = {
+    "hermes agent",
+    "hermes chat",
+    "new chat",
+    "new session",
+    "new topic",
+    "untitled",
+    "untitled session",
+}
+
+
+@dataclass(frozen=True)
+class TelegramTopicTitleOptions:
+    """Resolved user-facing options for Telegram DM topic titles."""
+
+    style: str = _READABLE_STYLE
+    compact_max_words: int = _DEFAULT_COMPACT_WORDS
+    generic_titles: tuple[str, ...] = ()
+
+
+def telegram_topic_title_options(extra: Optional[Mapping[str, Any]]) -> TelegramTopicTitleOptions:
+    """Resolve nested topic-title options from Telegram platform ``extra``.
+
+    Invalid values fail safe to the backward-compatible readable style. The
+    compact word count is clamped so configuration cannot create empty or
+    unreasonably long topic names.
+    """
+
+    raw = (extra or {}).get("dm_topic_titles")
+    config = raw if isinstance(raw, Mapping) else {}
+
+    style = str(config.get("style") or _READABLE_STYLE).strip().lower()
+    if style not in {_READABLE_STYLE, _COMPACT_STYLE}:
+        style = _READABLE_STYLE
+
+    raw_max_words = config.get("compact_max_words", _DEFAULT_COMPACT_WORDS)
+    try:
+        max_words = (
+            _DEFAULT_COMPACT_WORDS
+            if isinstance(raw_max_words, bool)
+            else int(raw_max_words)
+        )
+    except (TypeError, ValueError):
+        max_words = _DEFAULT_COMPACT_WORDS
+    max_words = max(_MIN_COMPACT_WORDS, min(_MAX_COMPACT_WORDS, max_words))
+
+    raw_generic_titles = config.get("generic_titles")
+    generic_titles = (
+        tuple(
+            title
+            for item in raw_generic_titles
+            if (title := re.sub(r"\s+", " ", str(item or "")).strip())
+        )
+        if isinstance(raw_generic_titles, (list, tuple))
+        else ()
+    )
+
+    return TelegramTopicTitleOptions(
+        style=style,
+        compact_max_words=max_words,
+        generic_titles=generic_titles,
+    )
+
+
+def _readable_title(title: str) -> str:
+    cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
+    if not cleaned:
+        return _SAFE_FALLBACK_TITLE
+    if len(cleaned) > _MAX_TITLE_CHARS:
+        return cleaned[: _MAX_TITLE_CHARS - 3].rstrip() + "..."
+    return cleaned
+
+
+def _unicode_words(text: str) -> list[str]:
+    """Return letters/digits in source order without language-specific rules."""
+
+    return re.findall(r"[^\W_]+", str(text or ""), flags=re.UNICODE)
+
+
+def _is_generic_generated_title(
+    title: str,
+    options: TelegramTopicTitleOptions,
+) -> bool:
+    normalized = re.sub(r"\s+", " ", str(title or "")).strip().casefold()
+    configured = {item.casefold() for item in options.generic_titles}
+    return not normalized or normalized in _GENERIC_GENERATED_TITLES or normalized in configured
+
+
+def sanitize_telegram_topic_title(
+    title: str,
+    *,
+    options: TelegramTopicTitleOptions,
+    fallback_text: Optional[str] = None,
+) -> str:
+    """Return a Bot API-safe title under the configured presentation policy."""
+
+    if options.style != _COMPACT_STYLE:
+        return _readable_title(title)
+
+    source = (
+        fallback_text
+        if _is_generic_generated_title(title, options) and fallback_text
+        else title
+    )
+    words = _unicode_words(source)
+    if not words and source != fallback_text and fallback_text:
+        words = _unicode_words(fallback_text)
+    if not words:
+        return _SAFE_FALLBACK_TITLE
+    compact = "-".join(word.lower() for word in words[: options.compact_max_words])
+    return compact[:_MAX_TITLE_CHARS].rstrip("-")
+
+
+def dedupe_telegram_topic_title(title: str, existing_titles: Iterable[str]) -> str:
+    """Append the first free integer suffix when a title already exists."""
+
+    existing = {str(item or "").strip().casefold() for item in existing_titles}
+    if title.casefold() not in existing:
+        return title
+
+    suffix = 2
+    while True:
+        suffix_text = str(suffix)
+        base = title[: _MAX_TITLE_CHARS - len(suffix_text)].rstrip("-")
+        candidate = f"{base}{suffix_text}"
+        if candidate.casefold() not in existing:
+            return candidate
+        suffix += 1
+
+
+def resolve_telegram_topic_title_contexts(
+    contexts: Sequence[Mapping[str, Any]],
+    *,
+    options: TelegramTopicTitleOptions,
+    title_overrides: Optional[Mapping[str, str]] = None,
+) -> list[str]:
+    """Resolve every ordered context through one shared dedupe state machine.
+
+    The returned list is aligned with ``contexts``. Runtime rename and channel
+    directory rebuild both use this function so they cannot disagree about
+    which stable thread receives a collision suffix.
+    """
+    overrides = title_overrides or {}
+    used_by_chat: dict[str, list[str]] = {}
+    resolved_titles: list[str] = []
+
+    for context in contexts:
+        chat_id = str(context.get("chat_id") or "")
+        session_id = str(context.get("session_id") or "")
+        title = overrides.get(session_id, str(context.get("title") or ""))
+        candidate = sanitize_telegram_topic_title(
+            title,
+            options=options,
+            fallback_text=context.get("first_user_message"),
+        )
+        used = used_by_chat.setdefault(chat_id, [])
+        resolved = (
+            dedupe_telegram_topic_title(candidate, used)
+            if options.style == _COMPACT_STYLE
+            else candidate
+        )
+        used.append(resolved)
+        resolved_titles.append(resolved)
+
+    return resolved_titles

--- a/gateway/telegram_topic_titles.py
+++ b/gateway/telegram_topic_titles.py
@@ -82,6 +82,32 @@ def telegram_topic_title_options(extra: Optional[Mapping[str, Any]]) -> Telegram
     )
 
 
+def telegram_operator_topic_ids(
+    extra: Optional[Mapping[str, Any]],
+) -> frozenset[tuple[str, str]]:
+    """Return normalized ids for topics explicitly declared by the operator."""
+    config = extra if isinstance(extra, Mapping) else {}
+    dm_topics = config.get("dm_topics", [])
+    if not isinstance(dm_topics, list):
+        return frozenset()
+
+    topic_ids: set[tuple[str, str]] = set()
+    for chat_entry in dm_topics:
+        if not isinstance(chat_entry, Mapping):
+            continue
+        chat_id = str(chat_entry.get("chat_id") or "")
+        topics = chat_entry.get("topics", [])
+        if not chat_id or not isinstance(topics, list):
+            continue
+        for topic in topics:
+            if not isinstance(topic, Mapping):
+                continue
+            thread_id = str(topic.get("thread_id") or "")
+            if thread_id:
+                topic_ids.add((chat_id, thread_id))
+    return frozenset(topic_ids)
+
+
 def _readable_title(title: str) -> str:
     cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
     if not cleaned:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10015,6 +10015,52 @@ class SessionDB:
                 return []
         return [dict(row) for row in rows]
 
+    def list_telegram_topic_title_context(
+        self,
+        *,
+        chat_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return bound topic rows with title and first-message context.
+
+        This read model keeps Telegram's runtime rename and channel-directory
+        labels on the same deterministic source of truth. Rows use stable
+        numeric thread order so compact-title suffixes survive resets/rebinding.
+        Missing topic-mode tables return an empty list without migrating.
+        """
+        with self._lock:
+            if self._conn is None:
+                return []
+            where_clause = "WHERE b.chat_id = ?" if chat_id is not None else ""
+            params = (str(chat_id),) if chat_id is not None else ()
+            try:
+                rows = self._conn.execute(
+                    f"""
+                    SELECT
+                        b.*,
+                        s.title,
+                        (
+                            SELECT m.content
+                            FROM messages m
+                            WHERE m.session_id = b.session_id
+                              AND m.role = 'user'
+                              AND TRIM(COALESCE(m.content, '')) != ''
+                            ORDER BY m.id ASC
+                            LIMIT 1
+                        ) AS first_user_message
+                    FROM telegram_dm_topic_bindings b
+                    LEFT JOIN sessions s ON s.id = b.session_id
+                    {where_clause}
+                    ORDER BY
+                        b.chat_id ASC,
+                        CAST(b.thread_id AS INTEGER) ASC,
+                        b.thread_id ASC
+                    """,
+                    params,
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return []
+        return [dict(row) for row in rows]
+
     def get_telegram_topic_binding_by_session(
         self,
         *,

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -530,6 +530,72 @@ gateway:
         assert by_id["208214988:42"]["name"] == "Ofir / daily-progress2"
         assert by_id["208214988:42"]["aliases"] == ["daily-progress2", "topic 42"]
 
+    def test_operator_declared_topic_is_preserved_and_does_not_consume_suffix(
+        self, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        (tmp_path / "config.yaml").write_text(
+            """
+gateway:
+  platforms:
+    telegram:
+      extra:
+        dm_topic_titles:
+          style: compact
+          compact_max_words: 2
+        dm_topics:
+          - chat_id: 208214988
+            topics:
+              - name: Operator General
+                thread_id: 41
+""".lstrip(),
+            encoding="utf-8",
+        )
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.apply_telegram_topic_migration()
+        for session_id, thread_id, chat_topic, title in [
+            ("sess-operator", "41", "Operator General", "Daily Progress Checkin"),
+            ("sess-auto", "42", "topic 42", "Daily Progress Update"),
+        ]:
+            db.create_session(session_id, source="telegram", user_id="208214988")
+            db.set_session_title(session_id, title)
+            origin = {
+                "platform": "telegram",
+                "chat_id": "208214988",
+                "chat_name": "Ofir",
+                "chat_topic": chat_topic,
+                "thread_id": thread_id,
+            }
+            db.record_gateway_session_peer(
+                session_id,
+                source="telegram",
+                user_id="208214988",
+                session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+                chat_id="208214988",
+                chat_type="dm",
+                thread_id=thread_id,
+                display_name="Ofir",
+                origin_json=json.dumps(origin),
+            )
+            db.bind_telegram_topic(
+                chat_id="208214988",
+                thread_id=thread_id,
+                user_id="208214988",
+                session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+                session_id=session_id,
+            )
+        db.close()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_from_sessions("telegram")
+
+        by_id = {entry["id"]: entry for entry in entries}
+        assert by_id["208214988:41"]["name"] == "Ofir / Operator General"
+        assert "aliases" not in by_id["208214988:41"]
+        assert by_id["208214988:42"]["name"] == "Ofir / daily-progress"
+        assert by_id["208214988:42"]["aliases"] == ["daily-progress", "topic 42"]
+
     def test_default_config_does_not_enrich_channel_directory(self, tmp_path):
         from hermes_state import SessionDB
 

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -16,8 +16,10 @@ from gateway.channel_directory import (
     _apply_channel_aliases,
     _build_from_sessions,
     _build_slack,
+    _merge_telegram_topic_title_context,
     _slack_directory_warning_last,
 )
+from gateway.telegram_topic_titles import TelegramTopicTitleOptions
 
 
 import pytest
@@ -239,6 +241,57 @@ class TestResolveChannelName:
         with self._setup(tmp_path, platforms):
             assert resolve_channel_name("telegram", "Coaching Chat / topic 17585") == "-1001:17585"
 
+    def test_compact_topic_alias_resolves_to_composite_id(self, tmp_path):
+        platforms = {
+            "telegram": [
+                {
+                    "id": "208214988:42",
+                    "name": "Ofir / daily-progress2",
+                    "type": "dm",
+                    "aliases": ["daily-progress2", "topic 42"],
+                }
+            ]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("telegram", "daily-progress2") == "208214988:42"
+            assert resolve_channel_name("telegram", "daily-prog") == "208214988:42"
+
+    def test_primary_name_takes_precedence_over_same_alias(self, tmp_path):
+        platforms = {
+            "telegram": [
+                {"id": "100", "name": "daily-progress", "type": "dm"},
+                {
+                    "id": "200:42",
+                    "name": "Bob / other-topic",
+                    "type": "dm",
+                    "aliases": ["daily-progress", "topic 42"],
+                },
+            ]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("telegram", "daily-progress") == "100"
+            assert resolve_channel_name("telegram", "daily-prog") is None
+
+    def test_duplicate_compact_topic_alias_is_ambiguous(self, tmp_path):
+        platforms = {
+            "telegram": [
+                {
+                    "id": "100:41",
+                    "name": "Alice / daily-progress",
+                    "type": "dm",
+                    "aliases": ["daily-progress", "topic 41"],
+                },
+                {
+                    "id": "200:42",
+                    "name": "Bob / daily-progress",
+                    "type": "dm",
+                    "aliases": ["daily-progress", "topic 42"],
+                },
+            ]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("telegram", "daily-progress") is None
+
     def test_id_match_takes_precedence_over_name(self, tmp_path):
         """A raw channel ID resolves to itself, even when a different
         channel happens to be named the same string. Case-sensitive: Slack
@@ -360,6 +413,167 @@ class TestBuildFromSessions:
         assert "Coaching Chat" in names
         assert "Coaching Chat / topic 17585" in names
         assert "Coaching Chat / topic 17587" in names
+
+
+class TestTelegramTopicTitleContext:
+    def test_compact_labels_and_aliases_match_runtime_deduplication(self):
+        entries = [
+            {"id": "208214988", "name": "Ofir", "type": "dm", "thread_id": None},
+            {"id": "208214988:41", "name": "Ofir / topic 41", "type": "dm", "thread_id": "41"},
+            {"id": "208214988:42", "name": "Ofir / topic 42", "type": "dm", "thread_id": "42"},
+        ]
+        contexts = [
+            {
+                "chat_id": "208214988",
+                "thread_id": "41",
+                "session_id": "sess-a",
+                "title": "Daily Progress Checkin",
+                "first_user_message": "first",
+            },
+            {
+                "chat_id": "208214988",
+                "thread_id": "42",
+                "session_id": "sess-b",
+                "title": "Daily Progress Update",
+                "first_user_message": "second",
+            },
+        ]
+
+        _merge_telegram_topic_title_context(
+            entries,
+            contexts,
+            options=TelegramTopicTitleOptions(style="compact", compact_max_words=2),
+        )
+
+        by_id = {entry["id"]: entry for entry in entries}
+        assert by_id["208214988:41"]["name"] == "Ofir / daily-progress"
+        assert by_id["208214988:42"]["name"] == "Ofir / daily-progress2"
+        assert by_id["208214988:42"]["aliases"] == ["daily-progress2", "topic 42"]
+
+    def test_readable_labels_remain_backward_compatible(self):
+        entries = [
+            {"id": "208214988:42", "name": "Ofir / topic 42", "type": "dm", "thread_id": "42"}
+        ]
+        contexts = [
+            {
+                "chat_id": "208214988",
+                "thread_id": "42",
+                "session_id": "sess-a",
+                "title": "Daily Progress Checkin",
+                "first_user_message": "first",
+            }
+        ]
+
+        _merge_telegram_topic_title_context(
+            entries,
+            contexts,
+            options=TelegramTopicTitleOptions(),
+        )
+
+        assert entries[0]["name"] == "Ofir / Daily Progress Checkin"
+        assert entries[0]["aliases"] == ["Daily Progress Checkin", "topic 42"]
+
+    def test_real_config_and_state_db_build_compact_directory_entries(self, tmp_path):
+        from hermes_state import SessionDB
+
+        (tmp_path / "config.yaml").write_text(
+            """
+gateway:
+  platforms:
+    telegram:
+      extra:
+        dm_topic_titles:
+          style: compact
+          compact_max_words: 2
+""".lstrip(),
+            encoding="utf-8",
+        )
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.apply_telegram_topic_migration()
+        for session_id, thread_id, title in [
+            ("sess-a", "41", "Daily Progress Checkin"),
+            ("sess-b", "42", "Daily Progress Update"),
+        ]:
+            db.create_session(session_id, source="telegram", user_id="208214988")
+            db.set_session_title(session_id, title)
+            origin = {
+                "platform": "telegram",
+                "chat_id": "208214988",
+                "chat_name": "Ofir",
+                "thread_id": thread_id,
+            }
+            db.record_gateway_session_peer(
+                session_id,
+                source="telegram",
+                user_id="208214988",
+                session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+                chat_id="208214988",
+                chat_type="dm",
+                thread_id=thread_id,
+                display_name="Ofir",
+                origin_json=json.dumps(origin),
+            )
+            db.bind_telegram_topic(
+                chat_id="208214988",
+                thread_id=thread_id,
+                user_id="208214988",
+                session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+                session_id=session_id,
+            )
+        db.close()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_from_sessions("telegram")
+
+        by_id = {entry["id"]: entry for entry in entries}
+        assert by_id["208214988:41"]["name"] == "Ofir / daily-progress"
+        assert by_id["208214988:42"]["name"] == "Ofir / daily-progress2"
+        assert by_id["208214988:42"]["aliases"] == ["daily-progress2", "topic 42"]
+
+    def test_default_config_does_not_enrich_channel_directory(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.apply_telegram_topic_migration()
+        db.create_session("sess-a", source="telegram", user_id="208214988")
+        db.set_session_title("sess-a", "Daily Progress Checkin")
+        origin = {
+            "platform": "telegram",
+            "chat_id": "208214988",
+            "chat_name": "Ofir",
+            "thread_id": "41",
+        }
+        db.record_gateway_session_peer(
+            "sess-a",
+            source="telegram",
+            user_id="208214988",
+            session_key="agent:main:telegram:dm:208214988:41",
+            chat_id="208214988",
+            chat_type="dm",
+            thread_id="41",
+            display_name="Ofir",
+            origin_json=json.dumps(origin),
+        )
+        db.bind_telegram_topic(
+            chat_id="208214988",
+            thread_id="41",
+            user_id="208214988",
+            session_key="agent:main:telegram:dm:208214988:41",
+            session_id="sess-a",
+        )
+        db.close()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_from_sessions("telegram")
+
+        assert entries == [
+            {
+                "id": "208214988:41",
+                "name": "Ofir / topic 41",
+                "type": "dm",
+                "thread_id": "41",
+            }
+        ]
 
 
 class TestFormatDirectoryForDisplay:

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -914,6 +914,108 @@ async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_compact_auto_title_rename_uses_configured_word_count_and_first_message(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.append_message("sess-topic", "user", "Compare keyboard switches for daily typing")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra["dm_topic_titles"] = {
+        "style": "compact",
+        "compact_max_words": 3,
+    }
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Hermes Agent",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="compare-keyboard-switches",
+    )
+
+
+@pytest.mark.asyncio
+async def test_compact_auto_title_rename_dedupes_titles_per_chat(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    for session_id, thread_id, title in [
+        ("sess-a", "41", "Daily Progress Checkin"),
+        ("sess-b", "42", "Daily Progress Update"),
+    ]:
+        db.create_session(session_id, source="telegram", user_id="208214988")
+        db.set_session_title(session_id, title)
+        db.bind_telegram_topic(
+            chat_id="208214988",
+            thread_id=thread_id,
+            user_id="208214988",
+            session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+            session_id=session_id,
+        )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra["dm_topic_titles"] = {
+        "style": "compact",
+        "compact_max_words": 2,
+    }
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-b",
+        "Daily Progress Update",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="daily-progress2",
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_compact_title_config_preserves_readable_auto_title(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra["dm_topic_titles"] = {
+        "style": "semantic",
+        "compact_max_words": 2,
+    }
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Keep This Readable",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Keep This Readable",
+    )
+
+
+@pytest.mark.asyncio
 async def test_auto_generated_title_does_not_rename_topic_bound_to_other_session(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     db.apply_telegram_topic_migration()
@@ -952,6 +1054,10 @@ async def test_operator_declared_topic_is_not_auto_renamed(tmp_path):
     )
     runner = _make_runner(session_db=db)
     runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra["dm_topic_titles"] = {
+        "style": "compact",
+        "compact_max_words": 2,
+    }
 
     # Give the adapter a concrete class with _get_dm_topic_info so the
     # class-based lookup in _rename_telegram_topic_for_session_title
@@ -1388,6 +1494,66 @@ def test_list_telegram_topic_bindings_for_chat_no_table(tmp_path):
         ).fetchall()
     }
     assert tables == set()
+
+
+def test_list_telegram_topic_title_context_includes_title_and_first_user_message(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    for session_id, thread_id, title, first_message in [
+        ("sess-b", "43", None, "בדיקת פריסת מקלדת"),
+        ("sess-a", "42", "Release Planning", "Plan the July release"),
+    ]:
+        db.create_session(session_id, source="telegram", user_id="208214988")
+        if title:
+            db.set_session_title(session_id, title)
+        db.append_message(session_id, "assistant", "")
+        db.append_message(session_id, "user", first_message)
+        db.append_message(session_id, "user", "later message")
+        db.bind_telegram_topic(
+            chat_id="208214988",
+            thread_id=thread_id,
+            user_id="208214988",
+            session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+            session_id=session_id,
+        )
+
+    rows = db.list_telegram_topic_title_context(chat_id="208214988")
+
+    assert [row["thread_id"] for row in rows] == ["42", "43"]
+    assert rows[0]["title"] == "Release Planning"
+    assert rows[0]["first_user_message"] == "Plan the July release"
+    assert rows[1]["title"] is None
+    assert rows[1]["first_user_message"] == "בדיקת פריסת מקלדת"
+
+
+def test_list_telegram_topic_title_context_without_migration_returns_empty(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    assert db.list_telegram_topic_title_context(chat_id="208214988") == []
+
+
+def test_list_telegram_topic_title_context_can_list_all_chats(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    for chat_id, session_id, thread_id in [
+        ("100", "sess-a", "41"),
+        ("200", "sess-b", "42"),
+    ]:
+        db.create_session(session_id, source="telegram", user_id=chat_id)
+        db.bind_telegram_topic(
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id=chat_id,
+            session_key=f"agent:main:telegram:dm:{chat_id}:{thread_id}",
+            session_id=session_id,
+        )
+
+    rows = db.list_telegram_topic_title_context()
+
+    assert [(row["chat_id"], row["thread_id"]) for row in rows] == [
+        ("100", "41"),
+        ("200", "42"),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -984,6 +984,48 @@ async def test_compact_auto_title_rename_dedupes_titles_per_chat(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_compact_runtime_dedupe_excludes_operator_declared_sibling(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    for session_id, thread_id, title in [
+        ("sess-operator", "41", "Daily Progress Checkin"),
+        ("sess-auto", "42", "Daily Progress Update"),
+    ]:
+        db.create_session(session_id, source="telegram", user_id="208214988")
+        db.set_session_title(session_id, title)
+        db.bind_telegram_topic(
+            chat_id="208214988",
+            thread_id=thread_id,
+            user_id="208214988",
+            session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+            session_id=session_id,
+        )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra.update({
+        "dm_topic_titles": {"style": "compact", "compact_max_words": 2},
+        "dm_topics": [
+            {
+                "chat_id": 208214988,
+                "topics": [{"name": "Operator General", "thread_id": 41}],
+            }
+        ],
+    })
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-auto",
+        "Daily Progress Update",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="daily-progress",
+    )
+
+
+@pytest.mark.asyncio
 async def test_invalid_compact_title_config_preserves_readable_auto_title(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     db.apply_telegram_topic_migration()

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1026,6 +1026,46 @@ async def test_compact_runtime_dedupe_excludes_operator_declared_sibling(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_compact_runtime_resolver_bypasses_current_operator_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-operator", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="41",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:41",
+        session_id="sess-operator",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra.update({
+        "dm_topic_titles": {"style": "compact", "compact_max_words": 2},
+        "dm_topics": [
+            {
+                "chat_id": 208214988,
+                "topics": [{"name": "Operator General", "thread_id": 41}],
+            }
+        ],
+    })
+    source = _make_source(thread_id="41")
+
+    assert await runner._resolved_telegram_topic_title(
+        source,
+        "sess-operator",
+        "Daily Progress Checkin",
+    ) is None
+
+    await runner._rename_telegram_topic_for_session_title(
+        source,
+        "sess-operator",
+        "Daily Progress Checkin",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_invalid_compact_title_config_preserves_readable_auto_title(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     db.apply_telegram_topic_migration()

--- a/tests/gateway/test_telegram_topic_titles.py
+++ b/tests/gateway/test_telegram_topic_titles.py
@@ -1,0 +1,146 @@
+"""Behavior contracts for configurable Telegram DM topic titles."""
+
+from gateway.telegram_topic_titles import (
+    TelegramTopicTitleOptions,
+    dedupe_telegram_topic_title,
+    resolve_telegram_topic_title_contexts,
+    sanitize_telegram_topic_title,
+    telegram_topic_title_options,
+)
+
+
+def test_default_options_preserve_readable_titles():
+    options = telegram_topic_title_options({})
+
+    assert options == TelegramTopicTitleOptions(style="readable", compact_max_words=2)
+    assert sanitize_telegram_topic_title(
+        "  Build   Telegram Topic UX  ", options=options
+    ) == "Build Telegram Topic UX"
+
+
+def test_nested_compact_options_are_parsed_and_word_count_is_clamped():
+    assert telegram_topic_title_options(
+        {"dm_topic_titles": {"style": "COMPACT", "compact_max_words": "3"}}
+    ) == TelegramTopicTitleOptions(style="compact", compact_max_words=3)
+    assert telegram_topic_title_options(
+        {"dm_topic_titles": {"style": "compact", "compact_max_words": 0}}
+    ).compact_max_words == 1
+    assert telegram_topic_title_options(
+        {"dm_topic_titles": {"style": "compact", "compact_max_words": 99}}
+    ).compact_max_words == 6
+    assert telegram_topic_title_options(
+        {"dm_topic_titles": {"style": "compact", "compact_max_words": True}}
+    ).compact_max_words == 2
+    assert telegram_topic_title_options(
+        {
+            "dm_topic_titles": {
+                "style": "compact",
+                "generic_titles": [" נושא   חדש ", ""],
+            }
+        }
+    ).generic_titles == ("נושא חדש",)
+
+
+def test_invalid_style_fails_safe_to_readable():
+    options = telegram_topic_title_options(
+        {"dm_topic_titles": {"style": "semantic", "compact_max_words": 2}}
+    )
+
+    assert options.style == "readable"
+    assert sanitize_telegram_topic_title("Keep This Readable", options=options) == "Keep This Readable"
+
+
+def test_compact_titles_keep_unicode_tokens_in_original_order():
+    options = TelegramTopicTitleOptions(style="compact", compact_max_words=2)
+
+    assert sanitize_telegram_topic_title("Telegram topic reliability", options=options) == "telegram-topic"
+    assert sanitize_telegram_topic_title("אבטחת Hermes Desktop מרחוק", options=options) == "אבטחת-hermes"
+    assert sanitize_telegram_topic_title("مراجعة أمان تيليجرام", options=options) == "مراجعة-أمان"
+    assert sanitize_telegram_topic_title("会話 タイトル 設定", options=options) == "会話-タイトル"
+
+
+def test_compact_word_count_is_configurable():
+    options = TelegramTopicTitleOptions(style="compact", compact_max_words=3)
+
+    assert sanitize_telegram_topic_title("Release planning dashboard polish", options=options) == "release-planning-dashboard"
+
+
+def test_compact_generic_or_empty_title_uses_first_message_fallback():
+    options = TelegramTopicTitleOptions(
+        style="compact",
+        compact_max_words=2,
+        generic_titles=("נושא חדש",),
+    )
+
+    assert sanitize_telegram_topic_title(
+        "Hermes Agent", options=options, fallback_text="Compare keyboard switches for typing"
+    ) == "compare-keyboard"
+    assert sanitize_telegram_topic_title(
+        "New Topic", options=options, fallback_text="Release planning dashboard"
+    ) == "release-planning"
+    assert sanitize_telegram_topic_title(
+        "נושא חדש", options=options, fallback_text="בדיקת פריסת מקלדת"
+    ) == "בדיקת-פריסת"
+    assert sanitize_telegram_topic_title(
+        "", options=options, fallback_text="مراجعة أمان تيليجرام"
+    ) == "مراجعة-أمان"
+
+
+def test_compact_without_any_tokens_uses_existing_safe_fallback():
+    options = TelegramTopicTitleOptions(style="compact", compact_max_words=2)
+
+    assert sanitize_telegram_topic_title("---", options=options, fallback_text="!!!") == "Hermes Chat"
+
+
+def test_readable_title_retains_existing_length_contract():
+    options = TelegramTopicTitleOptions(style="readable", compact_max_words=2)
+
+    result = sanitize_telegram_topic_title("x" * 200, options=options)
+
+    assert len(result) == 120
+    assert result.endswith("...")
+
+
+def test_compact_title_and_dedupe_suffix_stay_within_length_contract():
+    options = TelegramTopicTitleOptions(style="compact", compact_max_words=2)
+
+    compact = sanitize_telegram_topic_title("x" * 200, options=options)
+    duplicate = dedupe_telegram_topic_title(compact, [compact])
+
+    assert len(compact) == 120
+    assert len(duplicate) == 120
+    assert duplicate.endswith("2")
+
+
+def test_compact_title_retains_unicode_letters_and_digits_but_drops_punctuation():
+    options = TelegramTopicTitleOptions(style="compact", compact_max_words=4)
+
+    assert sanitize_telegram_topic_title(
+        "RAG / MCP: design_v2!!!", options=options
+    ) == "rag-mcp-design-v2"
+
+
+def test_dedupe_is_case_insensitive_and_appends_first_available_integer():
+    assert dedupe_telegram_topic_title("daily-progress", []) == "daily-progress"
+    assert dedupe_telegram_topic_title("Daily-Progress", ["daily-progress"]) == "Daily-Progress2"
+    assert dedupe_telegram_topic_title(
+        "daily-progress", ["daily-progress", "DAILY-PROGRESS2", "daily-progress4"]
+    ) == "daily-progress3"
+
+
+def test_context_resolver_processes_full_ordered_set_with_per_chat_dedupe():
+    contexts = [
+        {"chat_id": "100", "session_id": "a", "title": "Daily Progress Checkin"},
+        {"chat_id": "100", "session_id": "b", "title": "Daily Progress Update"},
+        {"chat_id": "200", "session_id": "c", "title": "Daily Progress Review"},
+    ]
+    options = TelegramTopicTitleOptions(style="compact", compact_max_words=2)
+
+    resolved = resolve_telegram_topic_title_contexts(
+        contexts,
+        options=options,
+        title_overrides={"a": "Daily Progress Retrospective"},
+    )
+
+    assert resolved == ["daily-progress", "daily-progress2", "daily-progress"]
+    assert len(resolved) == len(contexts)

--- a/tests/gateway/test_telegram_topic_titles.py
+++ b/tests/gateway/test_telegram_topic_titles.py
@@ -5,6 +5,7 @@ from gateway.telegram_topic_titles import (
     dedupe_telegram_topic_title,
     resolve_telegram_topic_title_contexts,
     sanitize_telegram_topic_title,
+    telegram_operator_topic_ids,
     telegram_topic_title_options,
 )
 
@@ -16,6 +17,25 @@ def test_default_options_preserve_readable_titles():
     assert sanitize_telegram_topic_title(
         "  Build   Telegram Topic UX  ", options=options
     ) == "Build Telegram Topic UX"
+
+
+def test_operator_topic_ids_are_normalized_and_malformed_values_are_ignored():
+    assert telegram_operator_topic_ids(
+        {
+            "dm_topics": [
+                {
+                    "chat_id": 208214988,
+                    "topics": [
+                        {"name": "Research", "thread_id": 41},
+                        None,
+                    ],
+                },
+                None,
+            ]
+        }
+    ) == frozenset({("208214988", "41")})
+    assert telegram_operator_topic_ids({"dm_topics": None}) == frozenset()
+    assert telegram_operator_topic_ids({"dm_topics": "invalid"}) == frozenset()
 
 
 def test_nested_compact_options_are_parsed_and_word_count_is_clamped():

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -787,7 +787,44 @@ Every topic gets its own conversation history, model state, tool execution, and 
 
 When Hermes generates a session title for a topic (via the auto-title pipeline, after the first exchange), the Telegram topic itself is renamed to match — e.g. "New Topic" becomes "Database migration plan". The rename is best-effort: failures are logged but don't break the session.
 
-To disable this and keep your manually-chosen topic names untouched, set:
+#### Optional compact topic titles
+
+By default, auto-renamed topics keep the full readable session title. You can opt
+into shorter, slug-style names without changing titles in the CLI, TUI, or other
+messaging platforms:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        dm_topic_titles:
+          style: compact       # readable (default) | compact
+          compact_max_words: 2 # 1..6; defaults to 2
+          # Optional localized/custom placeholders that should use first-message fallback:
+          generic_titles: ["נושא חדש"]
+```
+
+Compact mode keeps Unicode letters and digits in their original order, so it
+works consistently for English, Hebrew, Arabic, CJK, and mixed-language titles.
+For example, `Release planning dashboard` becomes `release-planning`. If the
+auto-title is empty or still a known placeholder (for example, `Hermes Agent`
+or `New Topic`), Hermes uses the first non-empty user message as the naming
+source. Add localized or deployment-specific placeholders through
+`generic_titles`; the title policy itself does not assume a particular language.
+
+Names are deduplicated per DM chat in stable Telegram thread order: repeated
+`daily-progress` topics become `daily-progress2`, `daily-progress3`, and so on.
+The same names are published as channel-directory aliases, so
+`send_message(target="telegram:daily-progress2", message="...")` resolves to
+the matching topic.
+Invalid settings fail safe to the backward-compatible `readable` style, and
+`compact_max_words` is clamped to `1..6`.
+
+This setting affects only user-created topics managed by `/topic`. Topics
+explicitly declared under `extra.dm_topics` keep their operator-chosen names.
+
+To disable auto-renaming entirely and keep your manually-chosen topic names untouched, set:
 
 ```yaml
 gateway:


### PR DESCRIPTION

<img width="503" height="548" alt="Screenshot 2026-07-16 at 14 44 03" src="https://github.com/user-attachments/assets/75434dbe-8408-47cb-9850-f0cda5bf385e" />

## What does this PR do?

Adds an opt-in, language-neutral `compact` presentation policy for auto-generated Telegram DM topic names while keeping the existing readable behavior as the default.

Today, an auto-generated session title is copied directly to the Telegram topic. Users who keep many DM topics open may prefer short, stable labels such as `daily-progress` or `release-planning-dashboard`. This PR adds that policy end-to-end — config parsing, runtime rename, stable per-chat deduplication, channel-directory aliases, tests, and docs — without changing title generation or any non-Telegram surface.

```yaml
gateway:
  platforms:
    telegram:
      extra:
        dm_topic_titles:
          style: compact
          compact_max_words: 2
          # Optional localized/custom placeholders:
          generic_titles: ["New Topic"]
```

### Behavior at a glance

| Case | Result |
|---|---|
| No config / `style: readable` | Existing readable title behavior is preserved |
| `style: compact`, 2 words | `Daily Progress Check-in` → `daily-progress` |
| Repeated compact name in one DM chat | `daily-progress`, `daily-progress2`, `daily-progress3` |
| Generic title plus first user message | `Hermes Agent` + `Compare keyboard switches…` → `compare-keyboard` |
| Hebrew / Arabic / CJK / mixed text | Unicode words are retained in source order |
| Invalid style | Fails safe to `readable` |
| Operator-declared `extra.dm_topics` topic | Keeps its configured name |

Compact names and suffixes are capped at 120 characters. Collision ordering uses stable Telegram thread order, so a reset/rebinding does not reshuffle aliases.

### Why this approach?

- **Opt-in and backward compatible:** the default path remains `readable`; channel-directory enrichment only runs in compact mode.
- **One policy implementation:** runtime rename and channel-directory discovery both use `gateway/telegram_topic_titles.py`, avoiding drift between the visible Telegram name and the `send_message` alias.
- **Language neutral:** tokenization uses Unicode letters/digits in source order. There are no English stopwords or ASCII-first heuristics.
- **Migration safe:** title context is read through `SessionDB`; installations without the topic-mode tables return an empty result rather than migrating during a read.
- **Narrow scope:** no Telegram adapter changes, dependencies, model-tool schema changes, or behavior changes outside Telegram DM topic mode.

## Related Issue

N/A — no dedicated issue. This is a scoped, opt-in UX feature on top of the existing Telegram DM topic-mode rename lifecycle.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/telegram_topic_titles.py` — shared config, Unicode compaction, generic-title fallback, 120-character bounds, and stable per-chat deduplication.
- `gateway/run.py` — applies the configured policy in the existing auto-title rename lifecycle while preserving disable/operator-declared/binding ownership guards.
- `hermes_state.py` — exposes ordered topic-title context through `SessionDB`, with chat-filtered and migration-safe paths.
- `gateway/channel_directory.py` — publishes compact names as ambiguity-safe aliases and uses the same resolver as runtime rename.
- `tests/gateway/test_telegram_topic_titles.py` — policy contracts for defaults, config validation, Unicode, fallback, length, and dedupe.
- `tests/gateway/test_telegram_topic_mode.py` — runtime rename, ownership, operator-declared exclusion, and state-query coverage.
- `tests/gateway/test_channel_directory.py` — real `config.yaml` + `state.db` integration under a temporary `HERMES_HOME`, plus alias ambiguity coverage.
- `website/docs/user-guide/messaging/telegram.md` and `cli-config.yaml.example` — user-facing configuration and behavior documentation.

### Review map

For a fast review, the core flow is:

1. `gateway/telegram_topic_titles.py` — policy and invariants.
2. `GatewayRunner._resolved_telegram_topic_title()` in `gateway/run.py` — runtime integration.
3. `SessionDB.list_telegram_topic_title_context()` in `hermes_state.py` — source-of-truth query and ordering.
4. `_merge_telegram_topic_title_context()` in `gateway/channel_directory.py` — directory/alias integration.
5. The three test files above — behavior and E2E proof.

### Explicitly out of scope

- Semantic/custom topic icons.
- Provisional rename before auto-title generation.
- Changes to Telegram topic creation or the Bot API adapter.
- Changes to session-title generation on other surfaces.

## How to Test

1. Run the focused feature and state suites:

   ```bash
   python -m pytest \
     tests/gateway/test_telegram_topic_titles.py \
     tests/gateway/test_telegram_topic_mode.py \
     tests/gateway/test_channel_directory.py \
     tests/test_hermes_state.py \
     tests/test_hermes_state_wal_fallback.py \
     tests/test_hermes_state_compression_locks.py \
     -q -n 0
   ```

   Result: **503 passed**.

2. Run static checks:

   ```bash
   ruff check gateway/telegram_topic_titles.py gateway/channel_directory.py gateway/run.py hermes_state.py \
     tests/gateway/test_telegram_topic_titles.py tests/gateway/test_telegram_topic_mode.py \
     tests/gateway/test_channel_directory.py
   python -m compileall -q gateway/telegram_topic_titles.py gateway/channel_directory.py gateway/run.py hermes_state.py
   git diff --check origin/main...HEAD
   ```

   Result: all passed.

3. Run the repository suite:

   ```bash
   scripts/run_tests.sh
   ```

   Result: the full isolated suite completed with **43 failures across 19 unrelated files**. None of the failures touch the files or code paths in this PR:

   - **40 failures reproduced** when the same failing-file set was run against a clean `origin/main` worktree.
   - The remaining three were timing flakes: `mem0_v3` and `delegate` passed on immediate rerun; `memory_monitor::test_periodic_timer_fires` failed intermittently on clean `origin/main` as well (2 of 3 baseline reruns).
   - The focused feature/state suites remain green: **503 passed**.

4. Optional manual verification: enable `style: compact` in `config.yaml`, allow one DM topic to auto-title, and confirm its visible name matches the compact alias shown by `send_message(action="list")`. Restore `readable` or remove the block to return to existing behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(telegram): ...`)
- [x] I searched for existing PRs; no open PR implements configurable language-neutral compact DM topic titles
- [x] My PR contains **only** changes related to this feature (one commit)
- [x] I've run the full isolated suite via `scripts/run_tests.sh`; 43 unrelated baseline/environment failures were verified as described in **How to Test**
- [x] I've added unit, runtime integration, and real temp-`HERMES_HOME` config/state tests
- [x] I've tested on my platform: macOS 26.5, Python 3.11

### Documentation & Housekeeping

- [x] Updated the Telegram user guide and relevant docstrings
- [x] Updated `cli-config.yaml.example` for the new config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or contributor-workflow change
- [x] Considered cross-platform impact: stdlib Unicode/SQLite/path handling only; no platform-specific process or filesystem behavior
- [x] Tool descriptions/schemas: N/A — no model-tool behavior or schema changes

## Screenshots / Logs

No screenshot is required for the default path because it is intentionally unchanged. The behavior table above shows the opt-in naming transformation; the tests verify the runtime Bot API call arguments and directory aliases without requiring a live bot token.
