### PR TITLE
docs(cron): scope Provider recovery to the actual fallback trigger; state update durability

### DIFF
--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -526,12 +526,13 @@ Outputs are concatenated in the order listed.
 
 ## Provider recovery
 
-Cron jobs inherit your configured fallback providers and credential pool rotation. If the primary API key is rate-limited or the provider returns an error, the cron agent can:
+Cron jobs inherit your configured fallback providers and credential pool rotation. Recovery fires at two distinct points, and which one you are relying on matters when you are tuning an unattended fleet.
 
-- **Fall back to an alternate provider** if you have `fallback_providers` (or the legacy `fallback_model`) configured in `config.yaml`
-- **Rotate to the next credential** in your [credential pool](/user-guide/configuration#credential-pool-strategies) for the same provider
+**At agent construction (scheduler-time auth resolution).** If the primary provider fails authentication while the job's agent is being built, the scheduler walks `fallback_providers` (or the legacy `fallback_model`) from `config.yaml` and constructs the agent with the first provider/model pair that resolves. Provider and model move together, so a fallback entry never silently routes your primary model through a different provider.
 
-This means cron jobs that run at high frequency or during peak hours are more resilient — a single rate-limited key won't fail the entire run.
+**During the run (agent-level failover).** The constructed agent carries that same fallback chain plus your [credential pool](/user-guide/configuration#credential-pool-strategies). Rate limits, upstream-aggregator throttling, and billing or credit exhaustion first attempt credential-pool rotation on the same provider; when rotation cannot recover, the agent activates the next entry in the fallback chain and retries within the same turn. Authentication failures that survive a credential refresh escalate the same way.
+
+So a single rate-limited key will not fail the run, provided a rotation target or a fallback entry can actually take over. Two things follow for unattended jobs: a second key on the same capped plan is not a recovery path, because the cap applies to both, and once the chain is exhausted the run fails and is reported through the job's normal failure delivery. Pin `provider` / `model` per job, put at least one fallback entry on a different account or provider, and monitor the primary provider's quota directly rather than treating failover as a quota strategy.
 
 ## Schedule formats
 
@@ -745,6 +746,10 @@ The referenced jobs' most recent completed outputs are injected above the prompt
 ## Job storage
 
 Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{job_id}/{timestamp}.md`.
+
+The cron store is per profile. Each profile owns its own `jobs.json` under its own `HERMES_HOME`, so the paths above belong to the default profile, while a job authored in profile `coder` lives in `~/.hermes/profiles/coder/cron/jobs.json` and runs with that profile's `.env`, `config.yaml`, and skills. A job you cannot find is usually a job in another profile.
+
+Because the store sits under `HERMES_HOME` rather than inside the install, `hermes update` replaces the code without touching registered jobs, their schedules, or their pinned providers and models.
 
 :::tip
 Ask the agent to manage jobs through the `cronjob` tool, `hermes cron edit`, or `/cron` — not by patching `jobs.json` directly. Direct edits can fail silently when [file write safety](../security.md#file-write-safety) blocks the path (for example when `HERMES_WRITE_SAFE_ROOT` is set), and the [file-mutation verifier](../configuration.md#file-mutation-verifier) footer is the authoritative signal that nothing was saved.


### PR DESCRIPTION
## What does this PR do?

scopes the cron page's "Provider recovery" section to what the scheduler does at today's HEAD, and states update durability explicitly (asked in #37542, never answered by the docs).

the current section says a rate-limited or erroring provider "can fall back". in code, the scheduler walks the fallback chain only from the `except AuthError` branch at provider resolution in `cron/scheduler.py` (agent construction time). a quota cap or rate limit mid-run is not that, and does not fail over. I hit this live: a fleet on a capped plan stopped producing output with `fallback_providers` configured, and only a manual repoint restored it (details in my comment on #39056).

this complements #39189, which fixes the same conflict's other half on the fallback-providers page. together they close #39056.

durability: `~/.hermes/cron/jobs.json` sits outside the install, and a live `hermes update` (v0.17 tag to main, macOS, through a config migration) left all registered jobs and schedules untouched. the docs imply this but never say it; #37542 asked directly.

heads-up: #46535 and #47817 (both open) touch adjacent fallback behaviour; if they merge, the wording here may deserve a follow-up line about 429-during-token-refresh.

## Related Issue

Refs #39056 (cron.md half; #39189 covers fallback-providers.md), refs #37542.

## Type of Change

- [x] Documentation update
