### PR TITLE
fix(desktop): ensure node-pty spawn-helper is executable

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -115,6 +116,7 @@ export function stageNodePty({ platform = process.platform, arch = process.arch 
       }
       if (entry.name === 'spawn-helper') {
         cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
+        chmodSync(join(destPrebuild, entry.name), 0o775)
       }
     }
   } else {


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
chmods node-pty's `spawn-helper` binary to be executable


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
resolves issue https://x.com/dineshgadge/status/2076024678452539691
https://github.com/microsoft/node-pty/pull/866

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- adds a chmod call to `stage-native-deps.mjs`
