### PR TITLE
mcp_oauth: configurable redirect_host for WAF-safe OAuth redirect URIs

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -846,7 +846,13 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
         )
     client_name = cfg.get("client_name", "Hermes Agent")
     scope = cfg.get("scope")
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    # Some providers' WAFs (e.g. Reclaim.ai's AWS API Gateway) reject any
+    # authorize request whose query string contains a literal ``127.0.0.1``,
+    # returning ``{"message":"Forbidden"}``. ``redirect_host: localhost`` in
+    # the server's oauth config works around that; the callback listener
+    # still binds 127.0.0.1 either way.
+    redirect_host = cfg.get("redirect_host", "127.0.0.1")
+    redirect_uri = f"http://{redirect_host}:{port}/callback"
 
     metadata_kwargs: dict[str, Any] = {
         "client_name": client_name,


### PR DESCRIPTION
## Problem

Some MCP providers sit behind WAFs that reject any `/authorize` request whose query string contains a literal `127.0.0.1`. Reclaim.ai's MCP (`https://mcp.reclaim.ai`, AWS API Gateway) is a live example: every authorize attempt returns `{"message":"Forbidden"}` before reaching the OAuth application, because `_build_client_metadata` hardcodes

```python
redirect_uri = f"http://127.0.0.1:{port}/callback"
```

Clients that use `localhost` in the redirect URI (e.g. Claude Code) pass the same WAF fine, so the failure looks provider-side and is painful to diagnose — the browser shows Forbidden even for a logged-in user, for every client_id (valid, freshly-registered, or bogus).

## Fix

Add an optional `redirect_host` key to a server's `oauth` config block, defaulting to `127.0.0.1` (behavior unchanged for existing configs):

```yaml
mcp_servers:
  reclaim:
    url: https://mcp.reclaim.ai
    auth: oauth
    oauth:
      redirect_port: 8877
      redirect_host: localhost   # WAF-safe
```

The callback listener still binds `127.0.0.1` either way (`localhost` resolves there), so only the registered/requested redirect URI string changes.

## Verified

Live against Reclaim.ai's MCP: with `redirect_host: localhost`, DCR + authorize + token exchange + `tools/list` complete end-to-end (28 tools). With the default `127.0.0.1`, the same flow is 403-blocked at the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)