### PR TITLE
fix(security): enforce critical command guard across approval modes

### DIFF
--- a/tests/tools/test_command_risk_guard.py
+++ b/tests/tools/test_command_risk_guard.py
@@ -1,0 +1,158 @@
+"""Focused tests for Hermes-native critical shell-command risk classification."""
+
+import json
+import shlex
+from unittest.mock import MagicMock
+
+import pytest
+
+import tools.approval as approval
+import tools.terminal_tool as terminal_tool
+
+
+@pytest.mark.parametrize(
+    "command,category",
+    [
+        ('command rm -rf "/"', "critical_filesystem_destruction"),
+        ("/bin/rm -rf /", "critical_filesystem_destruction"),
+        ("env MODE=safe command rm -rf /", "critical_filesystem_destruction"),
+        ("command reboot", "critical_host_disruption"),
+        ("/sbin/reboot", "critical_host_disruption"),
+        ("bash -O extglob -c 'reboot'", "critical_host_disruption"),
+        ("bash -o errexit -c 'reboot'", "critical_host_disruption"),
+        ("bash -c 'echo safe; reboot'", "critical_host_disruption"),
+        ('bash -c \'sh -c "echo safe; reboot"\'', "critical_host_disruption"),
+        ("bash -lc 'rm -rf /'", "critical_filesystem_destruction"),
+        ('sh -c "systemctl reboot"', "critical_host_disruption"),
+        ("/usr/bin/env X=1 /sbin/reboot", "critical_host_disruption"),
+        ("bash --rcfile /tmp/x -c 'reboot'", "critical_host_disruption"),
+        ("command -p reboot", "critical_host_disruption"),
+        ("command -- /sbin/reboot", "critical_host_disruption"),
+        ("/usr/bin/env -i /bin/bash -c reboot", "critical_host_disruption"),
+        ("nohup -- /sbin/reboot", "critical_host_disruption"),
+    ],
+)
+def test_classifies_critical_intent_through_basic_shell_indirection(command, category):
+    classification = approval.classify_command_risk(command)
+
+    assert classification is not None
+    assert classification["level"] == "critical"
+    assert classification["category"] == category
+    assert classification["reason"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "command rm -rf /tmp/hermes-cache",
+        "bash -lc 'printf \"%s\\n\" \"rm -rf /\"'",
+        "bash -c 'echo \"safe; reboot\"'",
+        "echo mkfs.ext4",
+        "echo 'mkfs.ext4 /dev/sda'",
+        "printf '%s' 'dd if=/dev/zero of=/dev/sda'",
+        "echo 'kill -1'",
+        "printf '%s\\n' 'kill -9 -1'",
+        "echo '> /dev/sda'",
+        'bash -c "echo \\"safe; reboot\\""',
+        "bash -c 'sh -c \"echo \\\"safe; reboot\\\"\"'",
+        "bash -c 'sh -c \"printf \\\"%s\\\" \\\"dd if=/dev/zero of=/dev/sda\\\"\"'",
+        "echo command reboot",
+        "systemctl status reboot.target",
+    ],
+)
+def test_benign_near_neighbors_are_not_classified_as_critical(command):
+    assert approval.classify_command_risk(command) is None
+
+
+@pytest.mark.parametrize(
+    "command,category,reason",
+    [
+        (
+            "bash -lc 'rm -rf /'",
+            "critical_filesystem_destruction",
+            "recursive delete of root filesystem",
+        ),
+        (
+            "bash -O extglob -c 'reboot'",
+            "critical_host_disruption",
+            "system shutdown/reboot",
+        ),
+        (
+            "bash -o errexit -c 'reboot'",
+            "critical_host_disruption",
+            "system shutdown/reboot",
+        ),
+    ],
+)
+def test_combined_guard_blocks_critical_category_even_when_approvals_are_off(
+    monkeypatch, command, category, reason
+):
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "off")
+
+    result = approval.check_all_command_guards(command, "local")
+
+    assert result["approved"] is False
+    assert result["hardline"] is True
+    assert result["risk_category"] == category
+    assert reason in result["message"]
+
+
+def _nested_shell_command(depth):
+    payload = "command reboot"
+    for _ in range(depth):
+        payload = f"bash -c {shlex.quote(payload)}"
+    return payload
+
+
+@pytest.mark.parametrize("depth", [4, 6, 8])
+def test_classifies_critical_intent_at_arbitrary_literal_shell_depth(depth):
+    command = _nested_shell_command(depth)
+
+    risk = approval.classify_command_risk(command)
+
+    assert risk is not None
+    assert risk["category"] == "critical_host_disruption"
+    assert approval.check_all_command_guards(command, "local")["approved"] is False
+
+
+@pytest.mark.parametrize("option_count", [7, 16, 64])
+def test_shell_payload_scan_has_no_fixed_option_count_cap(option_count):
+    command = "bash " + " ".join(["-e"] * option_count) + " -c reboot"
+
+    risk = approval.classify_command_risk(command)
+
+    assert risk is not None
+    assert risk["category"] == "critical_host_disruption"
+    assert approval.check_all_command_guards(command, "local")["approved"] is False
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_terminal_result_preserves_critical_category_reason_without_execution(
+    monkeypatch, tmp_path, force
+):
+    config = {
+        "env_type": "local",
+        "timeout": 30,
+        "cwd": str(tmp_path),
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+    fake_env = MagicMock()
+    fake_env.execute.return_value = {"output": "SHOULD NOT RUN", "returncode": 0}
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setitem(terminal_tool._active_environments, "default", fake_env)
+    monkeypatch.setitem(terminal_tool._last_activity, "default", 0.0)
+
+    result = json.loads(
+        terminal_tool.terminal_tool(command="command reboot", force=force)
+    )
+
+    assert result["status"] == "blocked"
+    assert result["risk_category"] == "critical_host_disruption"
+    assert "system shutdown/reboot" in result["error"]
+    fake_env.execute.assert_not_called()

--- a/tests/tools/test_command_risk_guard.py
+++ b/tests/tools/test_command_risk_guard.py
@@ -126,6 +126,40 @@ def test_shell_payload_scan_has_no_fixed_option_count_cap(option_count):
     assert approval.check_all_command_guards(command, "local")["approved"] is False
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "docker run --rm --privileged alpine sh -c reboot",
+        "docker run --rm --privileged=true alpine sh -c reboot",
+        "docker run --rm -v /:/host alpine sh -c 'rm -rf /host'",
+        "docker run --rm --volume=/:/host alpine sh -c 'rm -rf /host'",
+        "docker run --rm --mount type=bind,src=/,dst=/host alpine sh -c reboot",
+        "podman run --rm --privileged alpine sh -c reboot",
+    ],
+)
+def test_host_connected_container_payload_is_guarded(command):
+    risk = approval.classify_command_risk(command)
+
+    assert risk is not None
+    assert risk["category"] in {
+        "critical_filesystem_destruction",
+        "critical_host_disruption",
+    }
+    assert approval.check_all_command_guards(command, "local")["approved"] is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "docker run --rm alpine sh -c reboot",
+        "podman run --rm alpine sh -c 'rm -rf /'",
+    ],
+)
+def test_isolated_container_payload_keeps_container_boundary(command):
+    assert approval.classify_command_risk(command) is None
+    assert approval.check_critical_command_guard(command) is None
+
+
 @pytest.mark.parametrize("force", [False, True])
 def test_terminal_result_preserves_critical_category_reason_without_execution(
     monkeypatch, tmp_path, force

--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -158,6 +158,7 @@ def _install_fake_tools_package():
     sys.modules["tools.approval"] = types.SimpleNamespace(
         detect_dangerous_command=lambda *args, **kwargs: None,
         check_dangerous_command=lambda *args, **kwargs: {"approved": True},
+        check_critical_command_guard=lambda *args, **kwargs: None,
         check_all_command_guards=lambda *args, **kwargs: {"approved": True},
         load_permanent_allowlist=lambda *args, **kwargs: [],
         DANGEROUS_PATTERNS=[],

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1584,6 +1584,106 @@ def _iter_critical_command_variants(
             )
 
 
+_CONTAINER_RUNNERS = {"docker", "podman", "nerdctl"}
+_CONTAINER_OPTIONS_WITH_VALUE = {
+    "--add-host", "--annotation", "--attach", "--cap-add", "--cap-drop",
+    "--cgroup-parent", "--cidfile", "--device", "--dns", "--dns-option",
+    "--dns-search", "--entrypoint", "--env", "--env-file", "--expose",
+    "--gpus", "--group-add", "--hostname", "--ipc", "--label",
+    "--label-file", "--log-driver", "--log-opt", "--memory", "--mount",
+    "--name", "--network", "--network-alias", "--pid", "--platform",
+    "--publish", "--pull", "--restart", "--runtime", "--security-opt",
+    "--shm-size", "--stop-signal", "--stop-timeout", "--sysctl", "--tmpfs",
+    "--ulimit", "--user", "--userns", "--uts", "--volume",
+    "--volumes-from", "--workdir", "-a", "-c", "-e", "-h", "-l", "-m",
+    "-p", "-u", "-v", "-w",
+}
+
+
+def _container_root_bind_target(spec: str, *, mount_style: bool) -> str | None:
+    """Return the container target when *spec* bind-mounts host root."""
+    if mount_style:
+        fields = {}
+        for item in spec.split(","):
+            key, separator, value = item.partition("=")
+            if separator:
+                fields[key.strip().lower()] = value.strip()
+        mount_type = fields.get("type", "bind").lower()
+        source = fields.get("src") or fields.get("source")
+        target = fields.get("dst") or fields.get("destination") or fields.get("target")
+        if mount_type == "bind" and source == "/" and target:
+            return target.rstrip("/") or "/"
+        return None
+
+    parts = spec.split(":")
+    if len(parts) >= 2 and parts[0] == "/" and parts[1]:
+        return parts[1].rstrip("/") or "/"
+    return None
+
+
+def _iter_host_connected_container_payloads(command: str):
+    """Yield host-impacting payloads while preserving isolated containers."""
+    seen: set[str] = set()
+    for command_variant in _command_detection_variants(command):
+        try:
+            words = shlex.split(command_variant, posix=True)
+        except ValueError:
+            continue
+        if not words or os.path.basename(words[0]).lower() not in _CONTAINER_RUNNERS:
+            continue
+
+        try:
+            run_index = next(
+                index for index, word in enumerate(words[1:], start=1) if word == "run"
+            )
+        except StopIteration:
+            continue
+
+        privileged = False
+        root_bind_targets: list[str] = []
+        position = run_index + 1
+        image_index: int | None = None
+        while position < len(words):
+            word = words[position]
+            if word == "--":
+                image_index = position + 1 if position + 1 < len(words) else None
+                break
+            if not word.startswith("-") or word == "-":
+                image_index = position
+                break
+
+            option, separator, inline_value = word.partition("=")
+            if option == "--privileged":
+                privileged = not separator or inline_value.lower() not in {"0", "false", "no"}
+            if option in {"-v", "--volume", "--mount"}:
+                if separator:
+                    option_value = inline_value
+                elif position + 1 < len(words):
+                    position += 1
+                    option_value = words[position]
+                else:
+                    option_value = ""
+                target = _container_root_bind_target(
+                    option_value, mount_style=option == "--mount"
+                )
+                if target:
+                    root_bind_targets.append(target)
+            elif option in _CONTAINER_OPTIONS_WITH_VALUE and not separator:
+                position += 1
+            position += 1
+
+        if image_index is None or image_index >= len(words) or image_index + 1 >= len(words):
+            continue
+        payload = shlex.join(words[image_index + 1 :])
+        candidates = [payload] if privileged else []
+        for target in root_bind_targets:
+            candidates.append(payload if target == "/" else payload.replace(target, "/"))
+        for candidate in candidates:
+            if candidate not in seen:
+                seen.add(candidate)
+                yield candidate
+
+
 def classify_command_risk(command: str) -> dict | None:
     """Classify unrecoverable shell intent using stable Hermes categories.
 
@@ -1592,7 +1692,11 @@ def classify_command_risk(command: str) -> dict | None:
     normalization plus literal wrapper handling. Ordinary dangerous commands
     continue through the normal approval flow.
     """
-    for command_variant in _iter_critical_command_variants(command):
+    for command_variant in (
+        variant
+        for candidate_command in [command, *_iter_host_connected_container_payloads(command)]
+        for variant in _iter_critical_command_variants(candidate_command)
+    ):
         normalized = command_variant.lower()
         for pattern_re, reason in HARDLINE_PATTERNS_COMPILED:
             if not pattern_re.search(normalized):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -432,14 +432,14 @@ HARDLINE_PATTERNS = [
     (_RM_FLAG_PREFIX + _hardline_rm_path(_HARDLINE_SYSTEM_DIRS), "recursive delete of system directory"),
     (_RM_FLAG_PREFIX + _hardline_rm_path(r'(?:~|\$\{?HOME\}?)(?:/?|/\*)?'), "recursive delete of home directory"),
     # Filesystem format
-    (r'\bmkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
+    (_CMDPOS + r'mkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
     # Raw block device overwrites (dd + redirection)
-    (r'\bdd\b[^\n]*\bof=/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "dd to raw block device"),
-    (r'>\s*/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b', "redirect to raw block device"),
+    (_CMDPOS + r'dd\b[^\n]*\bof=/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "dd to raw block device"),
+    (r">\s*/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b(?=(?:[^'\"]|'[^']*'|\"[^\"]*\")*$)", "redirect to raw block device"),
     # Fork bomb (classic shell form)
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Kill every process on the system
-    (r'\bkill\s+(-[^\s]+\s+)*-1\b', "kill all processes"),
+    (_CMDPOS + r'kill\s+(-[^\s]+\s+)*-1\b', "kill all processes"),
     # System shutdown / reboot — anchor to command position (start of line,
     # after a command separator, or after sudo/env wrappers) so we don't
     # false-positive on "echo reboot" or "grep 'shutdown' logs".
@@ -461,6 +461,23 @@ HARDLINE_PATTERNS_COMPILED = [
     (re.compile(pattern, _RE_FLAGS), description)
     for pattern, description in HARDLINE_PATTERNS
 ]
+
+_CRITICAL_FILESYSTEM_REASONS = {
+    "recursive delete of root filesystem",
+    "recursive delete of system directory",
+    "recursive delete of home directory",
+    "format filesystem (mkfs)",
+    "dd to raw block device",
+    "redirect to raw block device",
+}
+_CRITICAL_HOST_REASONS = {
+    "fork bomb",
+    "kill all processes",
+    "system shutdown/reboot",
+    "init 0/6 (shutdown/reboot)",
+    "systemctl poweroff/reboot",
+    "telinit 0/6 (shutdown/reboot)",
+}
 
 
 # =========================================================================
@@ -503,12 +520,10 @@ def detect_hardline_command(command: str) -> tuple:
     Returns:
         (is_hardline, description) or (False, None)
     """
-    for command_variant in _command_detection_variants(command):
-        normalized = command_variant.lower()
-        for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
-            if pattern_re.search(normalized):
-                return (True, description)
-    return (False, None)
+    classification = classify_command_risk(command)
+    if classification is None:
+        return (False, None)
+    return (True, classification["reason"])
 
 
 def _match_user_deny_rule(command: str) -> str | None:
@@ -558,11 +573,13 @@ def _user_deny_block_result(pattern: str) -> dict:
     }
 
 
-def _hardline_block_result(description: str) -> dict:
+def _hardline_block_result(description: str, category: str) -> dict:
     """Build the standard block result for a hardline match."""
     return {
         "approved": False,
         "hardline": True,
+        "risk_category": category,
+        "description": description,
         "message": (
             f"BLOCKED (hardline): {description}. "
             "This command is on the unconditional blocklist and cannot "
@@ -1361,24 +1378,37 @@ def _iter_shell_command_word_spans(command: str):
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
         prefix_words = 0
-        skip_wrapper_options = False
         skip_next_wrapper_arg = False
+        wrapper: str | None = None
         while prefix_words < 12:
             word_start, word_end, word = _read_shell_word(command, pos)
             if word_start == word_end:
                 break
             deobfuscated = _deobfuscate_shell_word_for_detection(word)
             lower_word = deobfuscated.lower()
+            command_name = lower_word.rsplit("/", 1)[-1]
             if skip_next_wrapper_arg:
                 skip_next_wrapper_arg = False
                 pos = word_end
                 prefix_words += 1
                 continue
-            if skip_wrapper_options and lower_word.startswith("-"):
+            if wrapper and lower_word == "--":
+                pos = word_end
+                prefix_words += 1
+                continue
+            if wrapper and lower_word.startswith("-"):
                 option_name = lower_word.split("=", 1)[0]
+                options_with_arg = {
+                    "sudo": _SUDO_OPTIONS_WITH_ARG,
+                    "env": {"-C", "--chdir", "-S", "--split-string", "-u", "--unset"},
+                    "exec": {"-a"},
+                }.get(wrapper, set())
+                if wrapper == "command" and lower_word not in {"-p"}:
+                    break
+                if wrapper == "nohup":
+                    break
                 skip_next_wrapper_arg = (
-                    "=" not in lower_word
-                    and option_name in _SUDO_OPTIONS_WITH_ARG
+                    "=" not in lower_word and option_name in options_with_arg
                 )
                 pos = word_end
                 prefix_words += 1
@@ -1387,12 +1417,11 @@ def _iter_shell_command_word_spans(command: str):
             yield (word_start, word_end, word)
             prefix_words += 1
 
-            if lower_word in _COMMAND_WRAPPER_WORDS:
-                skip_wrapper_options = lower_word in {"sudo", "env"}
+            if command_name in _COMMAND_WRAPPER_WORDS:
+                wrapper = command_name
                 pos = word_end
                 continue
             if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
-                skip_wrapper_options = False
                 pos = word_end
                 continue
             break
@@ -1429,6 +1458,172 @@ def _command_detection_variants(command: str):
             continue
         seen.add(variant)
         yield variant
+
+
+_SHELL_COMMAND_NAMES = {"bash", "dash", "ksh", "sh", "zsh"}
+
+
+def _mask_quoted_shell_separators(script: str) -> str:
+    """Hide control separators that are literal data inside shell quotes."""
+    chars = list(script)
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(chars):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote is None:
+            if char in {"'", '"'}:
+                quote = char
+            continue
+        if char == quote:
+            quote = None
+        elif char in {";", "|", "&", "\n", "\r"}:
+            chars[index] = " "
+    return "".join(chars)
+
+
+def _unwrap_literal_shell_payload(word: str) -> str | None:
+    """Decode exactly one shell-word layer, preserving nested script quotes."""
+    try:
+        values = shlex.split(word, posix=True)
+    except ValueError:
+        return None
+    return values[0] if len(values) == 1 else None
+
+
+def _iter_literal_shell_payloads(command: str):
+    """Yield literal scripts passed to a shell's ``-c``-style option.
+
+    This deliberately handles only command words and literal shell arguments
+    already understood by Hermes' non-executing tokenizer. Dynamic expansion
+    is left to the existing approval scanners rather than guessed here.
+    """
+    for _word_start, word_end, word in _iter_shell_command_word_spans(command):
+        executable = _deobfuscate_shell_word_for_detection(word)
+        if executable.rsplit("/", 1)[-1].lower() not in _SHELL_COMMAND_NAMES:
+            continue
+
+        pos = word_end
+        expects_payload = False
+        option_takes_argument = False
+        while pos < len(command):
+            arg_start, arg_end, arg = _read_shell_word(command, pos)
+            if arg_start == arg_end:
+                break
+            literal = _deobfuscate_shell_word_for_detection(arg)
+            if expects_payload:
+                payload = _unwrap_literal_shell_payload(arg)
+                if payload:
+                    yield payload
+                break
+            if option_takes_argument:
+                option_takes_argument = False
+            elif literal in {"-o", "-O", "--rcfile", "--init-file"}:
+                option_takes_argument = True
+            elif literal.startswith("-") and not literal.startswith("--") and "c" in literal[1:]:
+                expects_payload = True
+            elif not literal.startswith("-"):
+                break
+            pos = arg_end
+
+
+def _iter_critical_command_variants(
+    command: str, *, _seen_sources: set[str] | None = None
+):
+    """Yield normalized critical-intent candidates without executing a shell."""
+    if _seen_sources is None:
+        _seen_sources = set()
+    literal_source = command.strip()
+    if not literal_source or literal_source in _seen_sources:
+        return
+    _seen_sources.add(literal_source)
+    seen: set[str] = set()
+    # escapes; otherwise `bash -c "echo \\"safe; reboot\\""` is flattened into
+    # syntax that looks like a second executable command.
+    literal_source = command.strip()
+    source = _normalize_command_for_detection(
+        _mask_quoted_shell_separators(literal_source)
+    ).strip()
+    normalized = source
+    for variant in (normalized,):
+        if variant not in seen:
+            seen.add(variant)
+            yield variant
+
+        # Hermes' tokenizer already identifies executable words after basic
+        # wrappers such as sudo/env/command. Normalize explicit executable paths
+        # (for example /bin/rm or ./reboot), then mark wrapped command words as
+        # command starts so command-position-aware hardline rules see them.
+        for word_start, word_end, word in _iter_shell_command_word_spans(variant):
+            command_word = _deobfuscate_shell_word_for_detection(word)
+            command_word = command_word.rsplit("/", 1)[-1] if "/" in command_word else command_word
+            effective = variant[:word_start] + command_word + variant[word_end:]
+            if effective not in seen:
+                seen.add(effective)
+                yield effective
+            if word_start <= 0:
+                continue
+            unwrapped = effective[:word_start] + "\n" + effective[word_start:]
+            if unwrapped not in seen:
+                seen.add(unwrapped)
+                yield unwrapped
+
+        # A literal script passed to `sh -c` / `bash -lc` is itself a command
+        # line. Re-run the same narrow classifier over it, with a small depth
+        # bound for nested wrappers.
+        for payload in _iter_literal_shell_payloads(literal_source):
+            payload = payload.strip()
+            if len(payload) >= len(literal_source):
+                continue
+            yield from _iter_critical_command_variants(
+                payload, _seen_sources=_seen_sources
+            )
+
+
+def classify_command_risk(command: str) -> dict | None:
+    """Classify unrecoverable shell intent using stable Hermes categories.
+
+    The classifier is intentionally small: it labels only the existing
+    unconditional hardline floor, while applying Hermes' existing shell
+    normalization plus literal wrapper handling. Ordinary dangerous commands
+    continue through the normal approval flow.
+    """
+    for command_variant in _iter_critical_command_variants(command):
+        normalized = command_variant.lower()
+        for pattern_re, reason in HARDLINE_PATTERNS_COMPILED:
+            if not pattern_re.search(normalized):
+                continue
+            if reason in _CRITICAL_FILESYSTEM_REASONS:
+                category = "critical_filesystem_destruction"
+            elif reason in _CRITICAL_HOST_REASONS:
+                category = "critical_host_disruption"
+            else:
+                category = "critical_destructive_operation"
+            return {
+                "level": "critical",
+                "category": category,
+                "reason": reason,
+            }
+    return None
+
+
+def check_critical_command_guard(command: str) -> dict | None:
+    """Return the unconditional critical-command block result, if any.
+
+    This narrow entry point is safe to call from execution paths that bypass
+    ordinary approval prompts after explicit user confirmation. Critical
+    destructive intent remains non-bypassable there.
+    """
+    critical_risk = classify_command_risk(command)
+    if critical_risk is None:
+        return None
+    description = critical_risk["reason"]
+    logger.warning("Hardline block: %s (command: %s)", description, command[:200])
+    return _hardline_block_result(description, critical_risk["category"])
 
 
 def _is_verification_artifact_cleanup(command: str) -> bool:
@@ -2355,10 +2550,9 @@ def check_dangerous_command(command: str, env_type: str,
     # unconditionally, BEFORE the yolo bypass.  Opting into yolo is
     # trusting the agent with your files and services, not trusting it
     # to wipe the disk or power the box off.
-    is_hardline, hardline_desc = detect_hardline_command(command)
-    if is_hardline:
-        logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
-        return _hardline_block_result(hardline_desc)
+    critical_block = check_critical_command_guard(command)
+    if critical_block is not None:
+        return critical_block
 
     # User-defined deny rules (approvals.deny in config.yaml): like the
     # hardline floor, these fire BEFORE the yolo bypass — a deny rule is the
@@ -2655,10 +2849,9 @@ def check_all_command_guards(command: str, env_type: str,
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
     # kill -1). Applies BEFORE yolo / mode=off / cron approve-mode so
     # no session-level setting can bypass it.
-    is_hardline, hardline_desc = detect_hardline_command(command)
-    if is_hardline:
-        logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
-        return _hardline_block_result(hardline_desc)
+    critical_block = check_critical_command_guard(command)
+    if critical_block is not None:
+        return critical_block
 
     # == Sudo stdin guard ==
     # Like the hardline floor above, this is unconditional: there is never a

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -253,6 +253,7 @@ def _reset_cached_sudo_passwords() -> None:
 
 # Dangerous command detection + approval now consolidated in tools/approval.py
 from tools.approval import (
+    check_critical_command_guard as _check_critical_guard_impl,
     check_all_command_guards as _check_all_guards_impl,
 )
 
@@ -2270,18 +2271,29 @@ def terminal_tool(
                     "status": "error",
                 }, ensure_ascii=False)
 
-        # Pre-exec security checks (tirith + dangerous command detection)
-        # Skip check if force=True (user has confirmed they want to run it)
+        # Pre-exec security checks (tirith + dangerous command detection).
+        # Explicit confirmation may bypass ordinary approval prompts, but the
+        # catastrophic hardline floor remains unconditional.
         approval_note = None
         # True when the user explicitly approved this run (or pre-confirmed via
         # force).  Drives the clean-interrupt-slate clear before env.execute so
         # an approved command can't be SIGINT-killed by a bit that landed during
         # the approval-wait (see clear_current_thread_interrupt).
+        # Force only bypasses ordinary approval prompts. If a critical command
+        # reaches this path, route it back through the consolidated guard so it
+        # returns the standard non-bypassable block result.
+        has_host_access = _docker_has_host_access(config)
+        if (
+            force
+            and (env_type != "docker" or has_host_access)
+            and _check_critical_guard_impl(command) is not None
+        ):
+            force = False
         _approved_run = bool(force)
         if not force:
             approval = _check_all_guards(
                 command, env_type,
-                has_host_access=_docker_has_host_access(config),
+                has_host_access=has_host_access,
             )
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
@@ -2308,7 +2320,8 @@ def terminal_tool(
                     "output": "",
                     "exit_code": -1,
                     "error": approval.get("message", fallback_msg),
-                    "status": "blocked"
+                    "status": "blocked",
+                    "risk_category": approval.get("risk_category"),
                 }, ensure_ascii=False)
             # Track whether approval was explicitly granted by the user
             if approval.get("user_approved"):


### PR DESCRIPTION
## Summary

- add a deterministic critical-command classifier to Hermes' existing approval/hardline path
- block critical destructive local or host-access commands even when approvals are disabled, in YOLO/cron modes, or terminal `force=True` is used
- preserve the isolated-container boundary while treating explicitly privileged containers and host-root bind mounts as host-connected
- return a stable `risk_category` in blocked terminal results
- add regression coverage for shell wrappers/options, quoted-text false positives, path-qualified executables, deep option sequences, container runtimes, and approval bypass modes

## Security properties

- no new hook, plugin, runtime dependency, configuration key, or network behavior
- classification occurs before terminal execution
- isolated Docker/Podman payloads remain outside the host guard
- `--privileged=false`, non-root mounts, and quoted/echoed command text remain allowed
- privileged Docker/Podman/Nerdctl payloads and destructive operations targeting a host-root bind mount are guarded

## Verification

```text
593 passed in 20.90s
15 passed in 1.43s
11 additional adversarial container cases passed
py_compile: PASS
git diff --check: PASS
```

The focused suites cover `test_command_risk_guard.py`, hardline blocklist, approval and deny rules, cron approval mode, and managed Browserbase/Modal fixture compatibility.
