### PR TITLE
fix(gateway): surface flagged agent failures in streaming /v1/responses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3052,17 +3052,29 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
-                # If the agent produced a final_response but no text
-                # deltas were streamed (e.g. some providers only emit
-                # the full response at the end), emit a single fallback
-                # delta so Responses clients still receive a live text part.
+                # Surface flagged agent failures (failed=True, or
+                # completed=False with an error) as response.failed even when
+                # partial text was already streamed. Previously
+                # `result.get("error") and not final_response_text` could
+                # never fire for retry-exhausted failures (final_response
+                # carries the error text, so final_response_text was always
+                # truthy), masking mid-stream stalls as response.completed
+                # with zero usage. Mirrors the /v1/chat/completions handling.
+                _r_failed = bool(result.get("failed")) if isinstance(result, dict) else False
+                _r_completed = bool(result.get("completed", True)) if isinstance(result, dict) else True
+                _r_err = result.get("error") if isinstance(result, dict) else None
                 agent_final = result.get("final_response", "") if isinstance(result, dict) else ""
-                if agent_final and not final_text_parts:
-                    await _emit_text_delta(agent_final)
-                if agent_final and not final_response_text:
-                    final_response_text = agent_final
-                if isinstance(result, dict) and result.get("error") and not final_response_text:
-                    agent_error = _redact_api_error_text(result["error"])
+                if _r_failed or (not _r_completed and _r_err):
+                    agent_error = _redact_api_error_text(_r_err or agent_final or "agent run failed")
+                else:
+                    # If the agent produced a final_response but no text
+                    # deltas were streamed (e.g. some providers only emit
+                    # the full response at the end), emit a single fallback
+                    # delta so Responses clients still receive a live text part.
+                    if agent_final and not final_text_parts:
+                        await _emit_text_delta(agent_final)
+                    if agent_final and not final_response_text:
+                        final_response_text = agent_final
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = _redact_api_error_text(e)


### PR DESCRIPTION
## Problem

When a streaming `/v1/responses` run ends with a flagged failure (`result.failed=True`, or `completed=False` with an error — e.g. provider retries exhausted after a mid-stream stall), the handler only sets `agent_error` when `final_response_text` is empty:

```python
if isinstance(result, dict) and result.get("error") and not final_response_text:
    agent_error = _redact_api_error_text(result["error"])
```

For retry-exhausted failures `final_response` carries the error text, so `final_response_text` is always truthy and this path can never fire. Clients receive `response.completed` with zero usage instead of `response.failed` — mid-stream stalls are silently masked as successful completions.

The non-streaming `/v1/chat/completions` paths already check the flags (`is_failed = bool(result.get("failed"))`); the streaming Responses handler is the one spot that doesn't.

## Change

Check `failed` / `completed` + `error` before falling back to the final-response-as-text path, mirroring the chat/completions handling. On flagged failure, emit `response.failed` with the redacted error instead of masking it.

## Validation

Battle-tested as a local hotfix on our gateway deployment since 2026-07-06 — it was found in production when a wedged upstream (codex degradation window) produced repeated stalls that the platform recorded as successful zero-usage completions, wedging its turn pipeline. With the fix, those runs surface as `response.failed` and the platform's retry/fallback ladder engages correctly.

Related: `opencode-port/responses-failed-error-detail` adds error-code detail to already-failed responses; this PR fixes failures never being flagged at all — independent scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyKb8BdHrf6YtiWwj31Zr2
