### PR TITLE
fix(lsp): repair native Windows npm launchers

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -56,7 +56,11 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import quote, unquote
 
-from hermes_cli._subprocess_compat import windows_batch_command, windows_hide_flags
+from hermes_cli._subprocess_compat import (
+    kill_process_tree,
+    windows_batch_proxy_command,
+    windows_hide_flags,
+)
 
 from agent.lsp.protocol import (
     ERROR_CONTENT_MODIFIED,
@@ -296,15 +300,9 @@ class LSPClient:
             raise
 
     @staticmethod
-    def _win_shell_command(cmd: List[str], env: Dict[str, str]) -> str:
-        """Build a safely quoted command for a Windows batch launcher.
-
-        ``cmd.exe`` treats characters such as ``&`` as operators even when
-        Python passes arguments as a list. Put each argument in the child
-        environment and expand it inside quotes so valid Windows paths and
-        arguments containing shell metacharacters retain their identity.
-        """
-        return windows_batch_command(cmd, env, prefix="HERMES_LSP_COMMAND")
+    def _win_batch_proxy_command(cmd: List[str]) -> List[str]:
+        """Build native argv for the explicit, AutoRun-disabled batch relay."""
+        return windows_batch_proxy_command(cmd)
 
     async def _spawn(self) -> None:
         env = dict(os.environ)
@@ -340,9 +338,9 @@ class LSPClient:
                 "creationflags": creationflags,
             }
             if use_windows_shell:
-                command_line = self._win_shell_command(cmd, env)
-                self._proc = await asyncio.create_subprocess_shell(
-                    command_line, **spawn_kwargs
+                proxy_command = self._win_batch_proxy_command(cmd)
+                self._proc = await asyncio.create_subprocess_exec(
+                    proxy_command[0], *proxy_command[1:], **spawn_kwargs
                 )
             else:
                 self._proc = await asyncio.create_subprocess_exec(
@@ -533,16 +531,27 @@ class LSPClient:
                 return
             if proc.returncode is None:
                 try:
-                    proc.terminate()
+                    # A server that received shutdown+exit gets one bounded
+                    # chance to leave cleanly before whole-tree termination.
+                    await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+                except asyncio.TimeoutError:
+                    # The shared compat helper delegates to agent.deadline's
+                    # portable tree-kill and retains its legacy fail-open
+                    # fallback for partial-install/teardown environments.
+                    await asyncio.to_thread(kill_process_tree, proc)
                     try:
                         await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                    except asyncio.TimeoutError:
-                        try:
-                            proc.kill()
-                            await proc.wait()
-                        except ProcessLookupError:
-                            pass
-                except ProcessLookupError:
+                    except (asyncio.TimeoutError, ProcessLookupError):
+                        pass
+            # asyncio's proactor subprocess transport keeps its pipe handles and
+            # a pending-connection callback alive even after the process exits.
+            # Close it while the loop is still running so GC never calls __del__
+            # against a closed loop and Windows releases the pipes promptly.
+            transport = getattr(proc, "_transport", None)
+            if transport is not None:
+                try:
+                    transport.close()
+                except Exception:  # noqa: BLE001
                     pass
 
     # ------------------------------------------------------------------

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -56,7 +56,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import quote, unquote
 
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import windows_batch_command, windows_hide_flags
 
 from agent.lsp.protocol import (
     ERROR_CONTENT_MODIFIED,
@@ -71,7 +71,6 @@ from agent.lsp.protocol import (
     make_response,
     read_message,
 )
-
 logger = logging.getLogger("agent.lsp.client")
 
 # Timeouts (seconds) — mirror OpenCode's constants, scaled to seconds.
@@ -281,12 +280,15 @@ class LSPClient:
             raise
 
     @staticmethod
-    def _win_wrap_cmd(cmd: List[str]) -> List[str]:
-        """On Windows, wrap .cmd/.bat shims so CreateProcess can run them."""
-        exe = cmd[0]
-        if exe.lower().endswith((".cmd", ".bat")):
-            return ["cmd.exe", "/c", *cmd]
-        return cmd
+    def _win_shell_command(cmd: List[str], env: Dict[str, str]) -> str:
+        """Build a safely quoted command for a Windows batch launcher.
+
+        ``cmd.exe`` treats characters such as ``&`` as operators even when
+        Python passes arguments as a list. Put each argument in the child
+        environment and expand it inside quotes so valid Windows paths and
+        arguments containing shell metacharacters retain their identity.
+        """
+        return windows_batch_command(cmd, env, prefix="HERMES_LSP_COMMAND")
 
     async def _spawn(self) -> None:
         env = dict(os.environ)
@@ -294,8 +296,9 @@ class LSPClient:
             env.update(self._env)
 
         cmd = self._command
-        if sys.platform == "win32":
-            cmd = self._win_wrap_cmd(cmd)
+        use_windows_shell = sys.platform == "win32" and cmd[0].lower().endswith(
+            (".cmd", ".bat")
+        )
         # Suppress the cmd.exe console window that would otherwise flash
         # every time we launch a ``.cmd``-wrapped language server
         # (e.g. pyright-langserver.CMD) from a console-less host such as
@@ -311,17 +314,24 @@ class LSPClient:
             # gateway's child set, it captures the LSP PID, records the
             # inherited pgid, and killpg() then kills the TUI parent itself.
             # See tui_gateway_crash.log "killpg → SIGTERM received" stacks.
-            self._proc = await asyncio.create_subprocess_exec(
-                cmd[0],
-                *cmd[1:],
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-                cwd=self._cwd,
-                start_new_session=True,
-                creationflags=creationflags,
-            )
+            spawn_kwargs = {
+                "stdin": asyncio.subprocess.PIPE,
+                "stdout": asyncio.subprocess.PIPE,
+                "stderr": asyncio.subprocess.PIPE,
+                "env": env,
+                "cwd": self._cwd,
+                "start_new_session": True,
+                "creationflags": creationflags,
+            }
+            if use_windows_shell:
+                command_line = self._win_shell_command(cmd, env)
+                self._proc = await asyncio.create_subprocess_shell(
+                    command_line, **spawn_kwargs
+                )
+            else:
+                self._proc = await asyncio.create_subprocess_exec(
+                    cmd[0], *cmd[1:], **spawn_kwargs
+                )
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -51,6 +51,7 @@ import asyncio
 import logging
 import os
 import sys
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
@@ -75,6 +76,7 @@ from agent.lsp.protocol import (
     make_response,
     read_message,
 )
+
 logger = logging.getLogger("agent.lsp.client")
 
 # Timeouts (seconds) — mirror OpenCode's constants, scaled to seconds.
@@ -83,7 +85,9 @@ DIAGNOSTICS_DOCUMENT_WAIT = 5.0
 DIAGNOSTICS_FULL_WAIT = 10.0
 DIAGNOSTICS_REQUEST_TIMEOUT = 3.0
 PUSH_DEBOUNCE = 0.15
-SHUTDOWN_GRACE = 1.0  # seconds between SIGTERM and SIGKILL
+# Maximum wait after the protocol-level ``shutdown`` + ``exit`` exchange,
+# POSIX ``terminate()``, and whole-tree termination before giving up on reaping.
+PROCESS_EXIT_GRACE_SECONDS = 1.0
 
 # Retry policy for transient ContentModified errors.
 MAX_CONTENT_MODIFIED_RETRIES = 3
@@ -328,24 +332,20 @@ class LSPClient:
             # gateway's child set, it captures the LSP PID, records the
             # inherited pgid, and killpg() then kills the TUI parent itself.
             # See tui_gateway_crash.log "killpg → SIGTERM received" stacks.
-            spawn_kwargs = {
-                "stdin": asyncio.subprocess.PIPE,
-                "stdout": asyncio.subprocess.PIPE,
-                "stderr": asyncio.subprocess.PIPE,
-                "env": env,
-                "cwd": self._cwd,
-                "start_new_session": True,
-                "creationflags": creationflags,
-            }
-            if use_windows_shell:
-                proxy_command = self._win_batch_proxy_command(cmd)
-                self._proc = await asyncio.create_subprocess_exec(
-                    proxy_command[0], *proxy_command[1:], **spawn_kwargs
-                )
-            else:
-                self._proc = await asyncio.create_subprocess_exec(
-                    cmd[0], *cmd[1:], **spawn_kwargs
-                )
+            spawn_command = (
+                self._win_batch_proxy_command(cmd) if use_windows_shell else cmd
+            )
+            self._proc = await asyncio.create_subprocess_exec(
+                spawn_command[0],
+                *spawn_command[1:],
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                cwd=self._cwd,
+                start_new_session=True,
+                creationflags=creationflags,
+            )
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"
@@ -482,8 +482,10 @@ class LSPClient:
     async def shutdown(self) -> None:
         """Best-effort graceful shutdown.
 
-        Sends ``shutdown`` + ``exit``, then SIGTERMs/SIGKILLs the
-        process if it doesn't exit cleanly.  Idempotent.
+        Sends ``shutdown`` + ``exit`` and gives the server one bounded chance
+        to exit cleanly. If it remains alive, shared process-tree cleanup snapshots
+        descendants before signaling the root on every platform. Every wait is
+        bounded. Idempotent.
         """
         if self._stopping:
             return
@@ -530,19 +532,66 @@ class LSPClient:
             if proc is None:
                 return
             if proc.returncode is None:
-                try:
-                    # A server that received shutdown+exit gets one bounded
-                    # chance to leave cleanly before whole-tree termination.
-                    await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                except asyncio.TimeoutError:
-                    # The shared compat helper delegates to agent.deadline's
-                    # portable tree-kill and retains its legacy fail-open
-                    # fallback for partial-install/teardown environments.
-                    await asyncio.to_thread(kill_process_tree, proc)
+                # Only shutdown() has sent the protocol shutdown+exit pair.
+                # Startup/transport failures must retire immediately rather
+                # than delaying the reader task behind a clean-exit grace wait.
+                needs_tree_kill = not self._stopping
+                if not needs_tree_kill:
                     try:
-                        await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                    except (asyncio.TimeoutError, ProcessLookupError):
-                        pass
+                        await asyncio.wait_for(
+                            proc.wait(), timeout=PROCESS_EXIT_GRACE_SECONDS
+                        )
+                    except asyncio.TimeoutError:
+                        # Do not terminate only the root on POSIX.  A server
+                        # may exit on SIGTERM while descendants keep running;
+                        # once reparented, a later parent walk cannot recover
+                        # ownership.  Enter the whole-tree helper first on
+                        # every platform so descendants are snapshotted before
+                        # any signal reaches the root.
+                        needs_tree_kill = True
+                if needs_tree_kill:
+                    # Use a dedicated daemon thread rather than the shared
+                    # asyncio executor.  Once ``start()`` returns this cleanup
+                    # cannot be cancelled out of an executor queue, and the
+                    # tree helper retains ownership of descendant discovery
+                    # even if reader retirement reaches its time budget.  In
+                    # particular, never kill only the proxy on timeout: doing
+                    # so can orphan cmd.exe and the language server before the
+                    # helper snapshots the tree.
+                    def _own_process_tree_cleanup() -> None:
+                        try:
+                            kill_process_tree(proc)
+                        except Exception:  # noqa: BLE001
+                            logger.debug(
+                                "[%s] process-tree cleanup failed",
+                                self.server_id,
+                                exc_info=True,
+                            )
+
+                    cleanup_thread = threading.Thread(
+                        target=_own_process_tree_cleanup,
+                        name=f"lsp-tree-kill-{getattr(proc, 'pid', 'unknown')}",
+                        daemon=True,
+                    )
+                    cleanup_thread.start()
+                    cleanup_deadline = (
+                        asyncio.get_running_loop().time()
+                        + PROCESS_EXIT_GRACE_SECONDS
+                    )
+                    while cleanup_thread.is_alive():
+                        remaining = (
+                            cleanup_deadline - asyncio.get_running_loop().time()
+                        )
+                        if remaining <= 0:
+                            break
+                        await asyncio.sleep(min(remaining, 0.01))
+                    if not cleanup_thread.is_alive():
+                        try:
+                            await asyncio.wait_for(
+                                proc.wait(), timeout=PROCESS_EXIT_GRACE_SECONDS
+                            )
+                        except (asyncio.TimeoutError, ProcessLookupError):
+                            pass
             # asyncio's proactor subprocess transport keeps its pipe handles and
             # a pending-connection callback alive even after the process exits.
             # Close it while the loop is still running so GC never calls __del__

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -56,7 +56,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import quote, unquote
 
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import windows_batch_command, windows_hide_flags
 
 from agent.lsp.protocol import (
     ERROR_CONTENT_MODIFIED,
@@ -71,7 +71,6 @@ from agent.lsp.protocol import (
     make_response,
     read_message,
 )
-
 logger = logging.getLogger("agent.lsp.client")
 
 # Timeouts (seconds) — mirror OpenCode's constants, scaled to seconds.
@@ -297,12 +296,15 @@ class LSPClient:
             raise
 
     @staticmethod
-    def _win_wrap_cmd(cmd: List[str]) -> List[str]:
-        """On Windows, wrap .cmd/.bat shims so CreateProcess can run them."""
-        exe = cmd[0]
-        if exe.lower().endswith((".cmd", ".bat")):
-            return ["cmd.exe", "/c", *cmd]
-        return cmd
+    def _win_shell_command(cmd: List[str], env: Dict[str, str]) -> str:
+        """Build a safely quoted command for a Windows batch launcher.
+
+        ``cmd.exe`` treats characters such as ``&`` as operators even when
+        Python passes arguments as a list. Put each argument in the child
+        environment and expand it inside quotes so valid Windows paths and
+        arguments containing shell metacharacters retain their identity.
+        """
+        return windows_batch_command(cmd, env, prefix="HERMES_LSP_COMMAND")
 
     async def _spawn(self) -> None:
         env = dict(os.environ)
@@ -310,8 +312,9 @@ class LSPClient:
             env.update(self._env)
 
         cmd = self._command
-        if sys.platform == "win32":
-            cmd = self._win_wrap_cmd(cmd)
+        use_windows_shell = sys.platform == "win32" and cmd[0].lower().endswith(
+            (".cmd", ".bat")
+        )
         # Suppress the cmd.exe console window that would otherwise flash
         # every time we launch a ``.cmd``-wrapped language server
         # (e.g. pyright-langserver.CMD) from a console-less host such as
@@ -327,17 +330,24 @@ class LSPClient:
             # gateway's child set, it captures the LSP PID, records the
             # inherited pgid, and killpg() then kills the TUI parent itself.
             # See tui_gateway_crash.log "killpg → SIGTERM received" stacks.
-            self._proc = await asyncio.create_subprocess_exec(
-                cmd[0],
-                *cmd[1:],
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-                cwd=self._cwd,
-                start_new_session=True,
-                creationflags=creationflags,
-            )
+            spawn_kwargs = {
+                "stdin": asyncio.subprocess.PIPE,
+                "stdout": asyncio.subprocess.PIPE,
+                "stderr": asyncio.subprocess.PIPE,
+                "env": env,
+                "cwd": self._cwd,
+                "start_new_session": True,
+                "creationflags": creationflags,
+            }
+            if use_windows_shell:
+                command_line = self._win_shell_command(cmd, env)
+                self._proc = await asyncio.create_subprocess_shell(
+                    command_line, **spawn_kwargs
+                )
+            else:
+                self._proc = await asyncio.create_subprocess_exec(
+                    cmd[0], *cmd[1:], **spawn_kwargs
+                )
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -122,6 +122,8 @@ _install_results: Dict[str, Optional[str]] = {}
 _install_lock_meta = threading.Lock()
 _WINDOWS_WRAPPER_SUFFIXES = (".exe", ".com", ".cmd", ".bat")
 _HERMES_NPM_WRAPPER_TAG = ".hermes"
+_DOS_HEADER_SIZE = 64
+_PE_HEADER_OFFSET_FIELD = 0x3C
 
 
 def _is_windows() -> bool:
@@ -143,14 +145,27 @@ def _is_windows_launchable(path: Path) -> bool:
     npm installs both an extensionless POSIX shell shim and a native
     ``.cmd`` wrapper. The shell shim is executable to MSYS, but native
     Windows Python cannot spawn it directly. Recognized Windows wrapper
-    suffixes are safe; an extensionless file is accepted only when it has
-    the ``MZ`` header used by native PE executables.
+    suffixes are safe; an extensionless file is accepted only when its DOS
+    ``MZ`` header points to a valid PE signature.
     """
     if path.suffix.lower() in _WINDOWS_WRAPPER_SUFFIXES:
         return True
     try:
         with path.open("rb") as handle:
-            return handle.read(2) == b"MZ"
+            dos_header = handle.read(_DOS_HEADER_SIZE)
+            if len(dos_header) < _DOS_HEADER_SIZE or dos_header[:2] != b"MZ":
+                return False
+            pe_offset = int.from_bytes(
+                dos_header[
+                    _PE_HEADER_OFFSET_FIELD : _PE_HEADER_OFFSET_FIELD + 4
+                ],
+                byteorder="little",
+            )
+            file_size = os.fstat(handle.fileno()).st_size
+            if pe_offset < _DOS_HEADER_SIZE or pe_offset + 4 > file_size:
+                return False
+            handle.seek(pe_offset)
+            return handle.read(4) == b"PE\0\0"
     except OSError:
         return False
 

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -1,9 +1,9 @@
 """Auto-installation of LSP server binaries.
 
 Tries to install missing servers using whatever package manager is
-appropriate.  All installs go to a Hermes-owned bin staging dir,
-``<HERMES_HOME>/lsp/bin/``, so we don't pollute the user's global
-toolchain.
+appropriate.  All installs go under ``<HERMES_HOME>/lsp/`` so we don't
+pollute the user's global toolchain.  Standalone binaries are staged in
+``bin/``; location-dependent npm wrappers stay in ``node_modules/.bin``.
 
 Strategies:
 
@@ -115,7 +115,7 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
 _install_locks: Dict[str, threading.Lock] = {}
 _install_results: Dict[str, Optional[str]] = {}
 _install_lock_meta = threading.Lock()
-_WINDOWS_WRAPPER_SUFFIXES = (".cmd", ".exe", ".bat")
+_WINDOWS_WRAPPER_SUFFIXES = (".exe", ".com", ".cmd", ".bat")
 
 
 def _is_windows() -> bool:
@@ -131,33 +131,71 @@ def hermes_lsp_bin_dir() -> Path:
     return p
 
 
+def _is_windows_launchable(path: Path) -> bool:
+    """Return whether ``path`` can be passed to Win32 ``CreateProcess``.
+
+    npm installs both an extensionless POSIX shell shim and a native
+    ``.cmd`` wrapper. The shell shim is executable to MSYS, but native
+    Windows Python cannot spawn it directly. Recognized Windows wrapper
+    suffixes are safe; an extensionless file is accepted only when it has
+    the ``MZ`` header used by native PE executables.
+    """
+    if path.suffix.lower() in _WINDOWS_WRAPPER_SUFFIXES:
+        return True
+    try:
+        with path.open("rb") as handle:
+            return handle.read(2) == b"MZ"
+    except OSError:
+        return False
+
+
 def _native_binary_candidates(base: Path) -> list[Path]:
-    """Return platform-native executable candidates for a staged binary."""
-    candidates = [base]
-    if _is_windows():
-        existing = {str(base).lower()}
-        for suffix in _WINDOWS_WRAPPER_SUFFIXES:
-            candidate = Path(str(base) + suffix)
-            key = str(candidate).lower()
-            if key not in existing:
-                candidates.append(candidate)
-                existing.add(key)
+    """Return executable candidates, preferring native Windows wrappers."""
+    if not _is_windows():
+        return [base]
+    candidates: list[Path] = []
+    existing: set[str] = set()
+    for suffix in _WINDOWS_WRAPPER_SUFFIXES:
+        candidate = Path(str(base) + suffix)
+        key = str(candidate).lower()
+        if key not in existing:
+            candidates.append(candidate)
+            existing.add(key)
+    base_key = str(base).lower()
+    if base_key not in existing:
+        candidates.append(base)
     return candidates
 
 
 def _existing_binary(name: str) -> Optional[str]:
-    """Probe the staging dir + PATH for a binary named ``name``."""
-    for staged in _native_binary_candidates(hermes_lsp_bin_dir() / name):
-        if staged.exists() and os.access(staged, os.X_OK):
-            return str(staged)
-    on_path = shutil.which(name)
-    if on_path:
-        return on_path
+    """Probe Hermes install locations + PATH for a binary named ``name``."""
+    bases = [hermes_lsp_bin_dir() / name]
+    if _is_windows():
+        # npm .cmd launchers use paths relative to node_modules/.bin. Moving
+        # or copying them into lsp/bin breaks those paths, so prefer the
+        # canonical npm location and execute the wrapper in place.
+        npm_bin = hermes_lsp_bin_dir().parent / "node_modules" / ".bin" / name
+        bases.insert(0, npm_bin)
+    for base in bases:
+        for staged in _native_binary_candidates(base):
+            if (
+                staged.exists()
+                and os.access(staged, os.X_OK)
+                and (not _is_windows() or _is_windows_launchable(staged))
+            ):
+                return str(staged)
     if _is_windows():
         for suffix in _WINDOWS_WRAPPER_SUFFIXES:
             on_path = shutil.which(f"{name}{suffix}")
             if on_path:
                 return on_path
+        on_path = shutil.which(name)
+        if on_path and _is_windows_launchable(Path(on_path)):
+            return on_path
+        return None
+    on_path = shutil.which(name)
+    if on_path:
+        return on_path
     return None
 
 
@@ -242,8 +280,9 @@ def _install_npm(
     """Install an npm package into our staging dir.
 
     Uses ``npm install --prefix`` so the binaries land in
-    ``<staging>/node_modules/.bin/<bin_name>`` and we symlink them up
-    one level for direct PATH-style access.
+    ``<staging>/node_modules/.bin/<bin_name>``.  POSIX launchers are
+    symlinked into our stable bin directory; Windows npm wrappers execute
+    in place because their package paths are relative to ``.bin``.
 
     ``extra_pkgs`` is a list of sibling packages to install in the
     same ``node_modules`` tree.  Used for LSP servers with runtime
@@ -286,14 +325,19 @@ def _install_npm(
     # Find the bin
     nm_bin = staging / "node_modules" / ".bin" / bin_name
     for c in _native_binary_candidates(nm_bin):
-        if c.exists():
+        if c.exists() and (not _is_windows() or _is_windows_launchable(c)):
+            if _is_windows():
+                # npm wrappers are location-dependent: their script path is
+                # relative to node_modules/.bin. Execute the native wrapper
+                # in place instead of copying a broken shim into lsp/bin.
+                return str(c)
             # Symlink into our `lsp/bin/` for stable PATH access.
             link = hermes_lsp_bin_dir() / c.name
             if not link.exists():
                 try:
                     link.symlink_to(c)
                 except (OSError, NotImplementedError):
-                    # Symlinks fail on some Windows setups — copy instead.
+                    # Some filesystems do not support symlinks; copy instead.
                     try:
                         shutil.copy2(c, link)
                     except OSError:
@@ -375,7 +419,9 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
         script_dirs.append(pip_target / "Scripts")
     for script_dir in script_dirs:
         for bin_path in _native_binary_candidates(script_dir / bin_name):
-            if bin_path.exists():
+            if bin_path.exists() and (
+                not _is_windows() or _is_windows_launchable(bin_path)
+            ):
                 link = hermes_lsp_bin_dir() / bin_path.name
                 if not link.exists():
                     try:

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -1,9 +1,10 @@
 """Auto-installation of LSP server binaries.
 
 Tries to install missing servers using whatever package manager is
-appropriate.  All installs go under ``<HERMES_HOME>/lsp/`` so we don't
-pollute the user's global toolchain.  Standalone binaries are staged in
-``bin/``; location-dependent npm wrappers stay in ``node_modules/.bin``.
+appropriate. All installs go under ``<HERMES_HOME>/lsp/`` so we don't
+pollute the user's global toolchain. Standalone binaries and Hermes-owned
+Windows npm launchers are staged in ``bin/``; package payloads and npm's
+canonical wrappers remain under ``node_modules/``.
 
 Strategies:
 
@@ -26,6 +27,7 @@ hadn't enabled LSP at all.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -61,7 +63,10 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
         # (tsserver) to be importable from the same node_modules tree;
         # otherwise initialize() fails with "Could not find a valid
         # TypeScript installation".  Install them together.
-        "extra_pkgs": ["typescript"],
+        # typescript-language-server 5.x loads lib/tsserver.js. TypeScript 7
+        # replaced that layout with the native compiler and no longer ships
+        # tsserver.js, so an unbounded ``typescript`` install cannot initialize.
+        "extra_pkgs": ["typescript@6"],
     },
     "@vue/language-server": {
         "strategy": "npm",
@@ -116,6 +121,7 @@ _install_locks: Dict[str, threading.Lock] = {}
 _install_results: Dict[str, Optional[str]] = {}
 _install_lock_meta = threading.Lock()
 _WINDOWS_WRAPPER_SUFFIXES = (".exe", ".com", ".cmd", ".bat")
+_HERMES_NPM_WRAPPER_TAG = ".hermes"
 
 
 def _is_windows() -> bool:
@@ -167,15 +173,26 @@ def _native_binary_candidates(base: Path) -> list[Path]:
     return candidates
 
 
-def _existing_binary(name: str) -> Optional[str]:
+def _existing_binary(
+    name: str,
+    *,
+    include_generated: bool = True,
+    include_staged: bool = True,
+) -> Optional[str]:
     """Probe Hermes install locations + PATH for a binary named ``name``."""
-    bases = [hermes_lsp_bin_dir() / name]
+    bases = [hermes_lsp_bin_dir() / name] if include_staged else []
     if _is_windows():
+        # Hermes-generated wrappers avoid npm's own unquoted ``SET dp0=%~dp0``
+        # prologue, which breaks when HERMES_HOME contains cmd metacharacters.
+        # Prefer them over both the canonical npm shim and stale pre-fix copies.
+        generated = hermes_lsp_bin_dir() / f"{name}{_HERMES_NPM_WRAPPER_TAG}"
         # npm .cmd launchers use paths relative to node_modules/.bin. Moving
         # or copying them into lsp/bin breaks those paths, so prefer the
-        # canonical npm location and execute the wrapper in place.
+        # canonical npm location only when no generated wrapper is available.
         npm_bin = hermes_lsp_bin_dir().parent / "node_modules" / ".bin" / name
         bases.insert(0, npm_bin)
+        if include_generated:
+            bases.insert(0, generated)
     for base in bases:
         for staged in _native_binary_candidates(base):
             if (
@@ -248,8 +265,27 @@ def _do_install(pkg: str) -> Optional[str]:
     strategy = recipe.get("strategy", "manual")
     bin_name = recipe.get("bin", pkg)
 
-    # Check if already present (shutil.which or staging dir)
-    existing = _existing_binary(bin_name)
+    # Upgrade existing npm installations in place. npm's own .cmd wrapper uses
+    # an unquoted ``SET dp0=%~dp0`` and fails when HERMES_HOME contains cmd
+    # metacharacters, so merely finding that canonical wrapper is not enough.
+    # Regenerate our relative launcher before accepting an existing npm bin.
+    if strategy == "npm" and _is_windows():
+        generated = _write_windows_node_wrapper(
+            hermes_lsp_bin_dir().parent,
+            recipe.get("pkg", pkg),
+            bin_name,
+        )
+        if generated is not None:
+            return str(generated)
+        # A tagged wrapper whose package/script disappeared is stale. Ignore it
+        # so auto-install can repair the package instead of returning a dead path.
+        existing = _existing_binary(
+            bin_name,
+            include_generated=False,
+            include_staged=False,
+        )
+    else:
+        existing = _existing_binary(bin_name)
     if existing:
         return existing
 
@@ -272,6 +308,105 @@ def _do_install(pkg: str) -> Optional[str]:
     return None
 
 
+def _npm_bin_script(staging: Path, pkg: str, bin_name: str) -> Optional[Path]:
+    """Resolve an installed npm package's executable JavaScript entry point."""
+    package_dir = staging / "node_modules" / Path(*pkg.split("/"))
+    package_json = package_dir / "package.json"
+    try:
+        metadata = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(metadata, dict):
+        return None
+
+    bin_spec = metadata.get("bin")
+    if isinstance(bin_spec, str):
+        entry = bin_spec
+    elif isinstance(bin_spec, dict):
+        entry = bin_spec.get(bin_name)
+    else:
+        return None
+    if not isinstance(entry, str) or not entry:
+        return None
+
+    try:
+        script = (package_dir / entry).resolve()
+        script.relative_to(package_dir.resolve())
+    except (OSError, ValueError):
+        return None
+    return script if script.is_file() else None
+
+
+def _batch_static_literal(value: str) -> Optional[str]:
+    """Escape static text embedded in an ASCII Windows batch launcher."""
+    if any(char in value for char in ('"', "\r", "\n", "\0")):
+        return None
+    # Percent signs in a batch file must be doubled. Delayed expansion is
+    # disabled by the generated launcher, so literal exclamation marks survive.
+    return value.replace("%", "%%")
+
+
+def _write_windows_node_wrapper(
+    staging: Path, pkg: str, bin_name: str
+) -> Optional[Path]:
+    """Create a location-independent wrapper for an installed npm binary.
+
+    npm's Windows shim computes its package root with the unquoted command
+    ``SET dp0=%~dp0``. If HERMES_HOME contains ``&`` (or another cmd
+    metacharacter), cmd.exe reparses the expanded path and the shim jumps into
+    the wrong command. The Hermes wrapper uses a quoted assignment, disables
+    delayed expansion, and launches the package's JS entry through node.
+
+    Paths under HERMES_HOME are expressed relative to ``%dp0%``. That keeps the
+    wrapper ASCII even when the user's home directory contains Unicode, while
+    quoted variable expansion preserves cmd metacharacters in the real path.
+    """
+    node = find_node_executable("node")
+    script = _npm_bin_script(staging, pkg, bin_name)
+    if not node or script is None:
+        return None
+
+    wrapper = hermes_lsp_bin_dir() / f"{bin_name}{_HERMES_NPM_WRAPPER_TAG}.cmd"
+    home = staging.parent
+    try:
+        node_path = Path(node).resolve()
+        node_path.relative_to(home.resolve())
+    except (OSError, ValueError):
+        node_ref = _batch_static_literal(str(node))
+    else:
+        node_rel = _batch_static_literal(os.path.relpath(node_path, wrapper.parent))
+        node_ref = f"%dp0%{node_rel}" if node_rel is not None else None
+
+    script_rel = _batch_static_literal(os.path.relpath(script, wrapper.parent))
+    if node_ref is None or script_rel is None:
+        return None
+    script_ref = f"%dp0%{script_rel}"
+    content = (
+        "@echo off\r\n"
+        "setlocal DisableDelayedExpansion\r\n"
+        'set "dp0=%~dp0"\r\n'
+        f'"{node_ref}" "{script_ref}" %*\r\n'
+    )
+    temp_wrapper = wrapper.with_name(
+        f".{wrapper.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
+    try:
+        # The dynamic home path lives in %dp0%; only package-relative paths and
+        # (for system Node) its resolved executable remain static. Refuse a
+        # non-ASCII static path rather than writing a code-page-fragile script.
+        content.encode("ascii")
+        temp_wrapper.write_text(content, encoding="ascii", newline="")
+        os.replace(temp_wrapper, wrapper)
+    except (OSError, UnicodeError):
+        try:
+            temp_wrapper.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+    return wrapper
+
+
 def _install_npm(
     pkg: str,
     bin_name: str,
@@ -280,9 +415,10 @@ def _install_npm(
     """Install an npm package into our staging dir.
 
     Uses ``npm install --prefix`` so the binaries land in
-    ``<staging>/node_modules/.bin/<bin_name>``.  POSIX launchers are
-    symlinked into our stable bin directory; Windows npm wrappers execute
-    in place because their package paths are relative to ``.bin``.
+    ``<staging>/node_modules/.bin/<bin_name>``. POSIX launchers are
+    symlinked into our stable bin directory. On Windows, Hermes writes a
+    location-independent wrapper that invokes the package's JavaScript entry
+    through node; npm's canonical wrapper remains untouched as a fallback.
 
     ``extra_pkgs`` is a list of sibling packages to install in the
     same ``node_modules`` tree.  Used for LSP servers with runtime
@@ -349,6 +485,10 @@ def _install_npm(
 
     # Find the bin
     nm_bin = staging / "node_modules" / ".bin" / bin_name
+    if _is_windows():
+        generated = _write_windows_node_wrapper(staging, pkg, bin_name)
+        if generated is not None:
+            return str(generated)
     for c in _native_binary_candidates(nm_bin):
         if c.exists() and (not _is_windows() or _is_windows_launchable(c)):
             if _is_windows():

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -34,7 +34,7 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import windows_batch_command, windows_hide_flags
 from hermes_constants import find_node_executable
 
 logger = logging.getLogger("agent.lsp.install")
@@ -304,14 +304,39 @@ def _install_npm(
             staging,
             " ".join(install_targets),
         )
+        command = [
+            npm,
+            "install",
+            "--prefix",
+            str(staging),
+            "--silent",
+            "--no-fund",
+            "--no-audit",
+            *install_targets,
+        ]
+        run_env = None
+        run_shell = False
+        run_command = command
+        if _is_windows() and npm.lower().endswith((".cmd", ".bat")):
+            # Batch launchers are reparsed by cmd.exe. Keep metacharacters in
+            # HERMES_HOME and package arguments inside quoted placeholders.
+            run_env = dict(os.environ)
+            run_command = windows_batch_command(
+                command,
+                run_env,
+                prefix="HERMES_LSP_INSTALL",
+            )
+            run_shell = True
         proc = subprocess.run(
-            [npm, "install", "--prefix", str(staging), "--silent", "--no-fund", "--no-audit", *install_targets],
+            run_command,
             check=False,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             timeout=300,
             stdin=subprocess.DEVNULL,
             creationflags=windows_hide_flags(),
+            env=run_env,
+            shell=run_shell,
         )
         if proc.returncode != 0:
             logger.warning(

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -36,7 +36,7 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_cli._subprocess_compat import windows_batch_command, windows_hide_flags
+from hermes_cli._subprocess_compat import run_windows_batch, windows_hide_flags
 from hermes_constants import find_node_executable
 
 logger = logging.getLogger("agent.lsp.install")
@@ -450,30 +450,31 @@ def _install_npm(
             "--no-audit",
             *install_targets,
         ]
-        run_env = None
-        run_shell = False
-        run_command = command
         if _is_windows() and npm.lower().endswith((".cmd", ".bat")):
             # Batch launchers are reparsed by cmd.exe. Keep metacharacters in
-            # HERMES_HOME and package arguments inside quoted placeholders.
-            run_env = dict(os.environ)
-            run_command = windows_batch_command(
+            # HERMES_HOME and package arguments inside quoted placeholders, and
+            # own the whole child tree if the bounded install times out.
+            proc = run_windows_batch(
                 command,
-                run_env,
+                env=os.environ,
                 prefix="HERMES_LSP_INSTALL",
+                timeout=300,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
-            run_shell = True
-        proc = subprocess.run(
-            run_command,
-            check=False,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-            timeout=300,
-            stdin=subprocess.DEVNULL,
-            creationflags=windows_hide_flags(),
-            env=run_env,
-            shell=run_shell,
-        )
+        else:
+            proc = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=300,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
         if proc.returncode != 0:
             logger.warning(
                 "[install] npm install failed for %s: %s", pkg, proc.stderr.strip()[:500]

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -153,6 +153,12 @@ def windows_batch_command(
     characters are rejected because ``cmd.exe`` cannot transport them without
     reparsing.
 
+    This function mutates the caller-provided environment mapping in place.
+    Callers must pass a disposable copy and then give that same mapping to
+    :class:`subprocess.Popen`. The generated placeholder variables are
+    intentionally inherited by the batch child (and its descendants): cmd.exe
+    expands them exactly once to transport argv without reparsing its values.
+
     Async callers should use :func:`windows_batch_proxy_command`: asyncio's
     exec API converts argv with native quoting rules that are not cmd.exe's
     rules, while the tiny native-Python proxy can pass this raw string directly
@@ -569,9 +575,9 @@ def kill_process_tree(proc: Any) -> None:
 def _legacy_kill_process_tree(proc: "subprocess.Popen") -> None:
     """Pre-#85125 local tree-kill — fallback when agent.deadline is unavailable.
 
-    Kept verbatim so ``kill_process_tree`` can honor its swallow-everything
-    contract even when the delegation path itself fails (partial install,
-    import cycle during teardown).
+    Retained so ``kill_process_tree`` can honor its swallow-everything contract
+    even when delegation fails (partial install or import cycle during teardown).
+    Windows terminates the tree before the root so descendants remain discoverable.
     """
     if IS_WINDOWS:
         # Ask Windows to terminate the tree while the root PID is still alive.

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -162,6 +162,16 @@ def windows_batch_command(
             placeholders.append('""')
             continue
         key = f"{prefix}_{index}"
+        # The placeholder is expanded inside a quoted command-line token. The
+        # native argv parser used by Node/Python treats a backslash immediately
+        # before that closing quote as an escape, so double only the trailing
+        # run for transport. Interior backslashes remain literal.
+        trailing_backslashes = len(value) - len(value.rstrip("\\"))
+        if trailing_backslashes:
+            value = (
+                value[:-trailing_backslashes]
+                + "\\" * (trailing_backslashes * 2)
+            )
         env[key] = value
         # The outer shell removes the carets without expanding the variable.
         # The inner /V:OFF shell then expands it while delayed expansion is off.

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -140,17 +140,32 @@ def windows_batch_command(
 ) -> str:
     """Return a safely quoted command line for a Windows batch launcher.
 
-    ``cmd.exe`` reparses shell metacharacters even when Python receives an
-    argument list. Store each argument in the child-only environment and
-    expand it inside quotes so valid paths and arguments containing ``&``,
-    ``%``, spaces, or parentheses retain their identity.
+    ``shell=True`` adds an outer ``cmd.exe``. Keep argument values out of that
+    shell entirely: it only removes the carets from ``^%NAME^%`` and starts a
+    second, explicit command processor. The inner shell disables AutoRun and
+    delayed expansion before expanding the child-only placeholders, preserving
+    valid values containing ``&``, ``%``, ``!``, ``^``, pipes, redirection
+    characters, spaces, or parentheses. Quotes and control characters are
+    rejected because ``cmd.exe`` cannot transport them without reparsing.
     """
     placeholders = []
     for index, arg in enumerate(command):
+        value = str(arg)
+        if any(char in value for char in ('"', "\r", "\n", "\0")):
+            raise ValueError(
+                "Windows batch arguments cannot contain quotes or control characters"
+            )
         key = f"{prefix}_{index}"
-        env[key] = str(arg)
-        placeholders.append(f'"%{key}%"')
-    return " ".join(placeholders)
+        env[key] = value
+        # The outer shell removes the carets without expanding the variable.
+        # The inner /V:OFF shell then expands it while delayed expansion is off.
+        placeholders.append(f'"^%{key}^%"')
+
+    comspec = os.environ.get("COMSPEC") or os.path.join(
+        os.environ.get("SystemRoot", r"C:\Windows"), "System32", "cmd.exe"
+    )
+    inner = " ".join(placeholders)
+    return f'"{comspec}" /e:on /v:off /d /s /c "{inner}"'
 
 
 # -----------------------------------------------------------------------------

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -31,14 +31,17 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import Mapping, MutableMapping, Sequence
+from typing import Any, Mapping, MutableMapping, Sequence
 
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
+    "run_windows_batch",
     "split_command_line",
     "suppress_platform_ver_console",
+    "kill_process_tree",
     "windows_batch_command",
+    "windows_batch_proxy_command",
     "windows_detach_flags",
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
@@ -103,8 +106,9 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
 
     ``shutil.which(name)`` *does* resolve ``.cmd`` via PATHEXT and returns
     the fully-qualified path. Callers that spawn a resolved batch shim must
-    still use :func:`windows_batch_command` with ``shell=True`` so ``cmd.exe``
-    cannot reinterpret metacharacters in valid paths and arguments.
+    still use :func:`windows_batch_command` with ``shell=False`` (or the async
+    :func:`windows_batch_proxy_command`) so ``cmd.exe`` cannot reinterpret
+    metacharacters in valid paths and arguments.
 
     On POSIX ``shutil.which`` also returns a fully-qualified path when
     found.  That's a small change from bare-name resolution (the OS does
@@ -112,8 +116,8 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     benefit of making the argv reproducible in logs.
 
     Behavior when the command is not on PATH:
-    - On Windows: return the bare name — caller can still try with
-      ``shell=True`` as a last resort, OR the subsequent Popen will
+    - On Windows: return the bare name — caller can still try with an explicit
+      command processor as a last resort, OR the subsequent Popen will
       raise FileNotFoundError with a readable error we want to surface.
     - On POSIX: same.  Bare ``npm`` on a Linux box without npm installed
       fails the same way it did before this function existed.
@@ -138,15 +142,21 @@ def windows_batch_command(
     *,
     prefix: str = "HERMES_BATCH_COMMAND",
 ) -> str:
-    """Return a safely quoted command line for a Windows batch launcher.
+    """Return a raw command line for an explicit Windows batch launcher.
 
-    ``shell=True`` adds an outer ``cmd.exe``. Keep argument values out of that
-    shell entirely: it only removes the carets from ``^%NAME^%`` and starts a
-    second, explicit command processor. The inner shell disables AutoRun and
-    delayed expansion before expanding the child-only placeholders, preserving
-    valid values containing ``&``, ``%``, ``!``, ``^``, pipes, redirection
-    characters, spaces, or parentheses. Quotes and control characters are
-    rejected because ``cmd.exe`` cannot transport them without reparsing.
+    Pass the returned *string* to :class:`subprocess.Popen` with
+    ``shell=False``. It starts exactly one explicit ``cmd.exe`` with ``/D``
+    (AutoRun disabled) and delayed expansion off. Argument values stay in the
+    child-only environment and expand inside quotes, preserving valid values
+    containing ``&``, ``%``, ``!``, ``^``, pipes, redirection characters,
+    spaces, parentheses, or trailing backslashes. Quotes and control
+    characters are rejected because ``cmd.exe`` cannot transport them without
+    reparsing.
+
+    Async callers should use :func:`windows_batch_proxy_command`: asyncio's
+    exec API converts argv with native quoting rules that are not cmd.exe's
+    rules, while the tiny native-Python proxy can pass this raw string directly
+    to ``CreateProcessW`` without introducing an implicit outer shell.
     """
     placeholders = []
     for index, arg in enumerate(command):
@@ -173,15 +183,82 @@ def windows_batch_command(
                 + "\\" * (trailing_backslashes * 2)
             )
         env[key] = value
-        # The outer shell removes the carets without expanding the variable.
-        # The inner /V:OFF shell then expands it while delayed expansion is off.
-        placeholders.append(f'"^%{key}^%"')
+        placeholders.append(f'"%{key}%"')
 
     comspec = os.environ.get("COMSPEC") or os.path.join(
         os.environ.get("SystemRoot", r"C:\Windows"), "System32", "cmd.exe"
     )
     inner = " ".join(placeholders)
     return f'"{comspec}" /e:on /v:off /d /s /c "{inner}"'
+
+
+def windows_batch_proxy_command(command: Sequence[str]) -> list[str]:
+    """Return native argv for the async batch relay used by LSP clients.
+
+    The proxy itself is a normal Python executable, so asyncio can launch it
+    with ``create_subprocess_exec`` and no implicit command processor. The
+    proxy then uses :func:`windows_batch_command` with ``shell=False`` while
+    inheriting the LSP pipes verbatim.
+    """
+    values = [str(arg) for arg in command]
+    for value in values:
+        if any(char in value for char in ('"', "\r", "\n", "\0")):
+            raise ValueError(
+                "Windows batch arguments cannot contain quotes or control characters"
+            )
+    return [
+        sys.executable,
+        os.path.abspath(__file__),
+        "--windows-batch-proxy",
+        *values,
+    ]
+
+
+def run_windows_batch(
+    command: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    prefix: str = "HERMES_BATCH_COMMAND",
+    timeout: float | None = None,
+    cwd: str | os.PathLike[str] | None = None,
+    text: bool = False,
+    encoding: str | None = None,
+    errors: str | None = None,
+    stdin=None,
+    creationflags: int = 0,
+) -> subprocess.CompletedProcess:
+    """Run a Windows batch launcher without an implicit shell.
+
+    Unlike ``subprocess.run(..., shell=True)``, this disables Command Processor
+    AutoRun and owns timeout cleanup for the complete ``cmd -> child`` tree.
+    Stdout and stderr are always captured, matching the two bounded batch call
+    sites that use this helper (npm installation and managed-Node probes).
+    """
+    run_env = dict(env if env is not None else os.environ)
+    command_line = windows_batch_command(command, run_env, prefix=prefix)
+    proc = subprocess.Popen(
+        command_line,
+        shell=False,
+        env=run_env,
+        cwd=cwd,
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=text,
+        encoding=encoding,
+        errors=errors,
+        creationflags=creationflags,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        kill_process_tree(proc)
+        try:
+            proc.communicate(timeout=2)
+        except Exception:
+            pass
+        raise
+    return subprocess.CompletedProcess(list(command), proc.returncode, stdout, stderr)
 
 
 # -----------------------------------------------------------------------------
@@ -440,7 +517,7 @@ def noninteractive_git_env(
 # -----------------------------------------------------------------------------
 
 
-def kill_process_tree(proc: "subprocess.Popen") -> None:
+def kill_process_tree(proc: Any) -> None:
     """Best-effort terminate *proc* and its descendants on both platforms.
 
     ``proc.kill()`` alone only terminates the direct child. On Windows a
@@ -496,22 +573,10 @@ def _legacy_kill_process_tree(proc: "subprocess.Popen") -> None:
     contract even when the delegation path itself fails (partial install,
     import cycle during teardown).
     """
-    if not IS_WINDOWS:
-        # Group-kill first: verify the child actually leads its own process
-        # group before signalling it, so we never blast a shared group.
-        try:
-            import signal as _signal
-
-            pgid = os.getpgid(proc.pid)
-            if pgid == proc.pid:
-                os.killpg(pgid, _signal.SIGKILL)  # windows-footgun: ok — inside `if not IS_WINDOWS` gate
-        except Exception:
-            pass
-    try:
-        proc.kill()
-    except OSError:
-        pass
     if IS_WINDOWS:
+        # Ask Windows to terminate the tree while the root PID is still alive.
+        # Killing the root first reparents its descendants and makes a later
+        # ``taskkill /T`` unable to discover them.
         try:
             subprocess.run(
                 ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
@@ -523,6 +588,31 @@ def _legacy_kill_process_tree(proc: "subprocess.Popen") -> None:
                 creationflags=windows_hide_flags(),
             )
         except Exception:
+            pass
+        try:
+            if proc.returncode is None:
+                proc.kill()
+        except OSError:
+            pass
+        return
+
+    if not IS_WINDOWS:
+        # Group-kill first: verify the child actually leads its own process
+        # group before signalling it, so we never blast a shared group.
+        try:
+            import signal as _signal
+
+            getpgid = getattr(os, "getpgid")
+            killpg = getattr(os, "killpg")
+            sigkill = getattr(_signal, "SIGKILL")
+            pgid = getpgid(proc.pid)
+            if pgid == proc.pid:
+                killpg(pgid, sigkill)
+        except Exception:
+            pass
+        try:
+            proc.kill()
+        except OSError:
             pass
 
 
@@ -627,3 +717,36 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
 
 # Backward-compat alias — existing call sites/tests import the historical name.
 _kill_git_process_tree = kill_process_tree
+
+
+def _windows_batch_proxy_main(command: Sequence[str]) -> int:
+    """Relay inherited stdio through one explicit, AutoRun-disabled cmd.exe."""
+    if not command:
+        return 2
+    env = dict(os.environ)
+    try:
+        command_line = windows_batch_command(
+            command,
+            env,
+            prefix=f"HERMES_BATCH_PROXY_{os.getpid()}",
+        )
+        # Deliberately NO creationflags: CREATE_NO_WINDOW without explicit
+        # STARTUPINFO handles makes cmd.exe drop inherited pipe output, which
+        # would silently break the LSP protocol. The proxy is already spawned
+        # with CREATE_NO_WINDOW by the client, so cmd.exe inherits that hidden
+        # console and no window appears (verified empirically on Windows 11).
+        proc = subprocess.Popen(command_line, shell=False, env=env)
+    except (OSError, ValueError) as exc:
+        print(f"Hermes batch proxy failed to start: {exc}", file=sys.stderr)
+        return 2
+    try:
+        return proc.wait()
+    except BaseException:
+        kill_process_tree(proc)
+        raise
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 3 and sys.argv[1] == "--windows-batch-proxy":
+        raise SystemExit(_windows_batch_proxy_main(sys.argv[2:]))
+    raise SystemExit(2)

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -21,9 +21,8 @@ Several common subprocess patterns break silently-or-loudly on Windows:
 This module centralizes the platform-branching logic so the rest of the
 codebase doesn't sprinkle ``if sys.platform == "win32":`` everywhere.
 
-**All helpers are no-ops on non-Windows** — calling them in Linux/macOS
-code paths is safe by design.  That's the "do no damage on POSIX"
-guarantee.
+Platform-flag helpers are no-ops on non-Windows. Windows command builders
+are only used after callers have identified a batch launcher.
 """
 
 from __future__ import annotations
@@ -32,13 +31,14 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import Mapping, Sequence
+from typing import Mapping, MutableMapping, Sequence
 
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
     "split_command_line",
     "suppress_platform_ver_console",
+    "windows_batch_command",
     "windows_detach_flags",
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
@@ -102,8 +102,9 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     because CreateProcessW doesn't execute batch files directly.
 
     ``shutil.which(name)`` *does* resolve ``.cmd`` via PATHEXT and returns
-    the fully-qualified path — which CreateProcessW accepts because the
-    extension tells Windows to route through ``cmd.exe /c``.
+    the fully-qualified path. Callers that spawn a resolved batch shim must
+    still use :func:`windows_batch_command` with ``shell=True`` so ``cmd.exe``
+    cannot reinterpret metacharacters in valid paths and arguments.
 
     On POSIX ``shutil.which`` also returns a fully-qualified path when
     found.  That's a small change from bare-name resolution (the OS does
@@ -129,6 +130,27 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     if resolved:
         return [resolved, *argv]
     return [name, *argv]
+
+
+def windows_batch_command(
+    command: Sequence[str],
+    env: MutableMapping[str, str],
+    *,
+    prefix: str = "HERMES_BATCH_COMMAND",
+) -> str:
+    """Return a safely quoted command line for a Windows batch launcher.
+
+    ``cmd.exe`` reparses shell metacharacters even when Python receives an
+    argument list. Store each argument in the child-only environment and
+    expand it inside quotes so valid paths and arguments containing ``&``,
+    ``%``, spaces, or parentheses retain their identity.
+    """
+    placeholders = []
+    for index, arg in enumerate(command):
+        key = f"{prefix}_{index}"
+        env[key] = str(arg)
+        placeholders.append(f'"%{key}%"')
+    return " ".join(placeholders)
 
 
 # -----------------------------------------------------------------------------

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -155,6 +155,12 @@ def windows_batch_command(
             raise ValueError(
                 "Windows batch arguments cannot contain quotes or control characters"
             )
+        if not value:
+            # ``cmd.exe`` leaves an undefined/empty ``%VAR%`` token literal in
+            # this parsing context. An explicit empty quoted token survives
+            # both shells and reaches the batch launcher as an empty argument.
+            placeholders.append('""')
+            continue
         key = f"{prefix}_{index}"
         env[key] = value
         # The outer shell removes the carets without expanding the variable.

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -102,17 +102,32 @@ def windows_batch_command(
 ) -> str:
     """Return a safely quoted command line for a Windows batch launcher.
 
-    ``cmd.exe`` reparses shell metacharacters even when Python receives an
-    argument list. Store each argument in the child-only environment and
-    expand it inside quotes so valid paths and arguments containing ``&``,
-    ``%``, spaces, or parentheses retain their identity.
+    ``shell=True`` adds an outer ``cmd.exe``. Keep argument values out of that
+    shell entirely: it only removes the carets from ``^%NAME^%`` and starts a
+    second, explicit command processor. The inner shell disables AutoRun and
+    delayed expansion before expanding the child-only placeholders, preserving
+    valid values containing ``&``, ``%``, ``!``, ``^``, pipes, redirection
+    characters, spaces, or parentheses. Quotes and control characters are
+    rejected because ``cmd.exe`` cannot transport them without reparsing.
     """
     placeholders = []
     for index, arg in enumerate(command):
+        value = str(arg)
+        if any(char in value for char in ('"', "\r", "\n", "\0")):
+            raise ValueError(
+                "Windows batch arguments cannot contain quotes or control characters"
+            )
         key = f"{prefix}_{index}"
-        env[key] = str(arg)
-        placeholders.append(f'"%{key}%"')
-    return " ".join(placeholders)
+        env[key] = value
+        # The outer shell removes the carets without expanding the variable.
+        # The inner /V:OFF shell then expands it while delayed expansion is off.
+        placeholders.append(f'"^%{key}^%"')
+
+    comspec = os.environ.get("COMSPEC") or os.path.join(
+        os.environ.get("SystemRoot", r"C:\Windows"), "System32", "cmd.exe"
+    )
+    inner = " ".join(placeholders)
+    return f'"{comspec}" /e:on /v:off /d /s /c "{inner}"'
 
 
 # -----------------------------------------------------------------------------

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -21,9 +21,8 @@ Several common subprocess patterns break silently-or-loudly on Windows:
 This module centralizes the platform-branching logic so the rest of the
 codebase doesn't sprinkle ``if sys.platform == "win32":`` everywhere.
 
-**All helpers are no-ops on non-Windows** — calling them in Linux/macOS
-code paths is safe by design.  That's the "do no damage on POSIX"
-guarantee.
+Platform-flag helpers are no-ops on non-Windows. Windows command builders
+are only used after callers have identified a batch launcher.
 """
 
 from __future__ import annotations
@@ -32,12 +31,13 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import Mapping, Sequence
+from typing import Mapping, MutableMapping, Sequence
 
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
     "suppress_platform_ver_console",
+    "windows_batch_command",
     "windows_detach_flags",
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
@@ -64,8 +64,9 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     because CreateProcessW doesn't execute batch files directly.
 
     ``shutil.which(name)`` *does* resolve ``.cmd`` via PATHEXT and returns
-    the fully-qualified path — which CreateProcessW accepts because the
-    extension tells Windows to route through ``cmd.exe /c``.
+    the fully-qualified path. Callers that spawn a resolved batch shim must
+    still use :func:`windows_batch_command` with ``shell=True`` so ``cmd.exe``
+    cannot reinterpret metacharacters in valid paths and arguments.
 
     On POSIX ``shutil.which`` also returns a fully-qualified path when
     found.  That's a small change from bare-name resolution (the OS does
@@ -91,6 +92,27 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     if resolved:
         return [resolved, *argv]
     return [name, *argv]
+
+
+def windows_batch_command(
+    command: Sequence[str],
+    env: MutableMapping[str, str],
+    *,
+    prefix: str = "HERMES_BATCH_COMMAND",
+) -> str:
+    """Return a safely quoted command line for a Windows batch launcher.
+
+    ``cmd.exe`` reparses shell metacharacters even when Python receives an
+    argument list. Store each argument in the child-only environment and
+    expand it inside quotes so valid paths and arguments containing ``&``,
+    ``%``, spaces, or parentheses retain their identity.
+    """
+    placeholders = []
+    for index, arg in enumerate(command):
+        key = f"{prefix}_{index}"
+        env[key] = str(arg)
+        placeholders.append(f'"%{key}%"')
+    return " ".join(placeholders)
 
 
 # -----------------------------------------------------------------------------

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -117,6 +117,12 @@ def windows_batch_command(
             raise ValueError(
                 "Windows batch arguments cannot contain quotes or control characters"
             )
+        if not value:
+            # ``cmd.exe`` leaves an undefined/empty ``%VAR%`` token literal in
+            # this parsing context. An explicit empty quoted token survives
+            # both shells and reaches the batch launcher as an empty argument.
+            placeholders.append('""')
+            continue
         key = f"{prefix}_{index}"
         env[key] = value
         # The outer shell removes the carets without expanding the variable.

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -490,7 +490,7 @@ def node_tool_runnable(path: str | None) -> bool:
 
     try:
         from hermes_cli._subprocess_compat import (
-            windows_batch_command,
+            run_windows_batch,
             windows_hide_flags,
         )
 
@@ -499,19 +499,22 @@ def node_tool_runnable(path: str | None) -> bool:
         use_windows_shell = sys.platform == "win32" and path.lower().endswith(
             (".cmd", ".bat")
         )
-        run_command = (
-            windows_batch_command(command, env, prefix="HERMES_NODE_PROBE")
-            if use_windows_shell
-            else command
-        )
-        result = subprocess.run(
-            run_command,
-            capture_output=True,
-            timeout=10,
-            env=env,
-            creationflags=windows_hide_flags(),
-            shell=use_windows_shell,
-        )
+        if use_windows_shell:
+            result = run_windows_batch(
+                command,
+                env=env,
+                prefix="HERMES_NODE_PROBE",
+                timeout=10,
+                creationflags=windows_hide_flags(),
+            )
+        else:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                timeout=10,
+                env=env,
+                creationflags=windows_hide_flags(),
+            )
     except (OSError, subprocess.TimeoutExpired, ValueError):
         return False
     return result.returncode == 0

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -489,14 +489,28 @@ def node_tool_runnable(path: str | None) -> bool:
     import subprocess
 
     try:
-        from hermes_cli._subprocess_compat import windows_hide_flags
+        from hermes_cli._subprocess_compat import (
+            windows_batch_command,
+            windows_hide_flags,
+        )
 
+        command = [path, "--version"]
+        env = with_hermes_node_path()
+        use_windows_shell = sys.platform == "win32" and path.lower().endswith(
+            (".cmd", ".bat")
+        )
+        run_command = (
+            windows_batch_command(command, env, prefix="HERMES_NODE_PROBE")
+            if use_windows_shell
+            else command
+        )
         result = subprocess.run(
-            [path, "--version"],
+            run_command,
             capture_output=True,
             timeout=10,
-            env=with_hermes_node_path(),
+            env=env,
             creationflags=windows_hide_flags(),
+            shell=use_windows_shell,
         )
     except (OSError, subprocess.TimeoutExpired, ValueError):
         return False

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -347,14 +347,28 @@ def node_tool_runnable(path: str | None) -> bool:
     import subprocess
 
     try:
-        from hermes_cli._subprocess_compat import windows_hide_flags
+        from hermes_cli._subprocess_compat import (
+            windows_batch_command,
+            windows_hide_flags,
+        )
 
+        command = [path, "--version"]
+        env = with_hermes_node_path()
+        use_windows_shell = sys.platform == "win32" and path.lower().endswith(
+            (".cmd", ".bat")
+        )
+        run_command = (
+            windows_batch_command(command, env, prefix="HERMES_NODE_PROBE")
+            if use_windows_shell
+            else command
+        )
         result = subprocess.run(
-            [path, "--version"],
+            run_command,
             capture_output=True,
             timeout=10,
-            env=with_hermes_node_path(),
+            env=env,
             creationflags=windows_hide_flags(),
+            shell=use_windows_shell,
         )
     except (OSError, subprocess.TimeoutExpired, ValueError):
         return False

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -20,6 +20,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 import time
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
@@ -54,7 +55,12 @@ def test_install_npm_passes_extras_to_npm_command(tmp_path, monkeypatch):
     monkeypatch.setattr(install_mod, "find_node_executable", lambda c: "/usr/bin/npm" if c == "npm" else None)
 
     extras = install_mod.INSTALL_RECIPES["typescript-language-server"]["extra_pkgs"]
-    assert extras == ["typescript@6"]
+    sdk_target = next(
+        target for target in extras if target.partition("@")[0] == "typescript"
+    )
+    # The server's current major still loads lib/tsserver.js, which TypeScript
+    # 7 removed. Keep the recipe compatible without freezing the whole list.
+    assert sdk_target.partition("@")[2].split(".", 1)[0] == "6"
     install_mod._install_npm(
         "typescript-language-server",
         "typescript-language-server",
@@ -63,11 +69,10 @@ def test_install_npm_passes_extras_to_npm_command(tmp_path, monkeypatch):
 
     cmd = captured["cmd"]
     assert "typescript-language-server" in cmd
-    assert "typescript@6" in cmd
     # Both must come AFTER the npm flags, in install-target position
     install_idx = cmd.index("install")
     assert cmd.index("typescript-language-server") > install_idx
-    assert cmd.index("typescript@6") > install_idx
+    assert cmd.index(sdk_target) > install_idx
 
 
 def test_install_npm_works_without_extras(tmp_path, monkeypatch):
@@ -329,20 +334,41 @@ def test_stale_posix_only_install_triggers_npm_repair(tmp_path, monkeypatch):
     assert repair_calls == [("pyright", "pyright-langserver", [])]
 
 
-def test_existing_binary_accepts_native_extensionless_pe_on_windows(tmp_path, monkeypatch):
+def test_existing_binary_accepts_native_extensionless_pe_on_windows(
+    tmp_path, monkeypatch
+):
     """A native PE executable remains valid even without a file suffix."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     from agent.lsp import install as install_mod
 
     binary = install_mod.hermes_lsp_bin_dir() / "custom-language-server"
-    binary.write_bytes(b"MZ\x90\x00native executable fixture")
+    dos_header = bytearray(64)
+    dos_header[:2] = b"MZ"
+    dos_header[0x3C:0x40] = (len(dos_header)).to_bytes(4, "little")
+    binary.write_bytes(bytes(dos_header) + b"PE\0\0")
     binary.chmod(0o755)
 
     monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
     monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
 
     assert install_mod._existing_binary("custom-language-server") == str(binary)
+
+
+def test_existing_binary_rejects_mz_prefixed_non_pe_on_windows(tmp_path, monkeypatch):
+    """A DOS marker alone must not make an arbitrary blob launchable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    binary = install_mod.hermes_lsp_bin_dir() / "custom-language-server"
+    binary.write_bytes(b"MZ\x90\x00not actually a PE executable")
+    binary.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("custom-language-server") is None
 
 
 def test_non_windows_candidates_preserve_extensionless_launcher(monkeypatch):
@@ -427,6 +453,132 @@ async def test_spawn_routes_windows_batch_launcher_through_native_proxy(
     assert not any(
         key.startswith("HERMES_LSP_COMMAND_")
         for key in captured["kwargs"]["env"]
+    )
+
+
+async def _exercise_bounded_lsp_cleanup(monkeypatch, expected_events):
+    """Drive cleanup with a process that exits only after forced cleanup."""
+    from agent.lsp import client as client_mod
+
+    events = []
+    finished = asyncio.Event()
+
+    class FakeProcess:
+        returncode = None
+        _transport = None
+
+        async def wait(self):
+            events.append("wait")
+            await finished.wait()
+            return 0
+
+        def terminate(self):
+            events.append("terminate")
+
+        def kill(self):
+            events.append("kill")
+            finished.set()
+
+    proc = FakeProcess()
+    client = client_mod.LSPClient(
+        server_id="cleanup-order-test",
+        workspace_root=".",
+        command=["server"],
+    )
+    setattr(client, "_proc", proc)
+    # Model shutdown(), the only path that sends protocol shutdown+exit and is
+    # therefore entitled to a clean-exit grace wait before forced cleanup.
+    setattr(client, "_stopping", True)
+    monkeypatch.setattr(client_mod, "PROCESS_EXIT_GRACE_SECONDS", 0.01)
+
+    def fake_kill_process_tree(actual_proc):
+        assert actual_proc is proc
+        events.append("tree-kill")
+        finished.set()
+
+    monkeypatch.setattr(client_mod, "kill_process_tree", fake_kill_process_tree)
+
+    await asyncio.wait_for(client._cleanup_process(), timeout=1.0)
+
+    assert events == expected_events
+
+
+@pytest.mark.windows_only
+@pytest.mark.asyncio
+async def test_lsp_cleanup_gives_clean_exit_one_bounded_chance_then_tree_kills(
+    monkeypatch,
+):
+    await _exercise_bounded_lsp_cleanup(
+        monkeypatch,
+        ["wait", "tree-kill", "wait"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_lsp_cleanup_never_kills_root_before_tree_worker_claims_cleanup(
+    monkeypatch,
+):
+    """A slow tree helper keeps ownership after bounded reader retirement."""
+    from agent.lsp import client as client_mod
+
+    release = threading.Event()
+    worker_started = threading.Event()
+    root_kills = []
+
+    class FakeProcess:
+        pid = 4242
+        returncode = None
+        _transport = None
+
+        async def wait(self):
+            await asyncio.Event().wait()
+
+        def kill(self):
+            root_kills.append("kill")
+
+    proc = FakeProcess()
+    client = client_mod.LSPClient(
+        server_id="owned-tree-cleanup-test",
+        workspace_root=".",
+        command=["server"],
+    )
+    setattr(client, "_proc", proc)
+    monkeypatch.setattr(client_mod, "PROCESS_EXIT_GRACE_SECONDS", 0.01)
+
+    def slow_tree_kill(actual_proc):
+        assert actual_proc is proc
+        worker_started.set()
+        release.wait(timeout=1.0)
+
+    monkeypatch.setattr(client_mod, "kill_process_tree", slow_tree_kill)
+
+    try:
+        await asyncio.wait_for(client._cleanup_process(), timeout=0.5)
+        assert worker_started.wait(timeout=0.5)
+        assert root_kills == []
+    finally:
+        release.set()
+
+
+@pytest.mark.linux_only
+@pytest.mark.asyncio
+async def test_lsp_cleanup_gives_clean_exit_one_bounded_chance_then_posix_escalates_linux(
+    monkeypatch,
+):
+    await _exercise_bounded_lsp_cleanup(
+        monkeypatch,
+        ["wait", "tree-kill", "wait"],
+    )
+
+
+@pytest.mark.macos_only
+@pytest.mark.asyncio
+async def test_lsp_cleanup_gives_clean_exit_one_bounded_chance_then_posix_escalates_macos(
+    monkeypatch,
+):
+    await _exercise_bounded_lsp_cleanup(
+        monkeypatch,
+        ["wait", "tree-kill", "wait"],
     )
 
 

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -20,6 +20,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
@@ -200,6 +201,64 @@ def test_auto_install_upgrades_preexisting_canonical_npm_wrapper(
     assert expected.exists()
 
 
+@pytest.mark.windows_only
+def test_preexisting_canonical_tree_repairs_and_spawns_in_hostile_home(
+    tmp_path, monkeypatch
+):
+    """The normal upgrade path repairs and runs a canonical-only install."""
+    from hermes_cli._subprocess_compat import windows_batch_proxy_command
+
+    home = tmp_path / "home&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("UNEXPANDED", "wrong")
+
+    from agent.lsp import install as install_mod
+
+    staging = install_mod.hermes_lsp_bin_dir().parent
+    npm_bin = staging / "node_modules" / ".bin"
+    npm_bin.mkdir(parents=True)
+    (npm_bin / "pyright-langserver.cmd").write_text("@echo off\n")
+    package_dir = staging / "node_modules" / "pyright"
+    package_dir.mkdir()
+    (package_dir / "package.json").write_text(
+        json.dumps({"bin": {"pyright-langserver": "capture.py"}}),
+        encoding="utf-8",
+    )
+    (package_dir / "capture.py").write_text(
+        "import json, sys\nprint(json.dumps(sys.argv[1:]))\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: sys.executable if name == "node" else None,
+    )
+    monkeypatch.setattr(
+        install_mod,
+        "_install_npm",
+        lambda *_args, **_kwargs: pytest.fail("existing package was reinstalled"),
+    )
+
+    resolved = install_mod._do_install("pyright")
+
+    expected = staging / "bin" / "pyright-langserver.hermes.cmd"
+    assert resolved == str(expected)
+    result = subprocess.run(
+        windows_batch_proxy_command([str(expected), "upgrade-ok"]),
+        shell=False,
+        env=dict(os.environ),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == ["upgrade-ok"]
+
+
 def test_auto_install_ignores_orphaned_generated_and_staged_npm_wrappers(
     tmp_path, monkeypatch
 ):
@@ -296,17 +355,21 @@ def test_non_windows_candidates_preserve_extensionless_launcher(monkeypatch):
     assert install_mod._native_binary_candidates(base) == [base]
 
 
-def test_windows_npm_wrapper_uses_quoted_shell_placeholders():
-    from agent.lsp.client import LSPClient
+def test_windows_batch_command_uses_explicit_autorun_disabled_shell():
+    from hermes_cli._subprocess_compat import windows_batch_command
 
     command = [r"C:\Hermes\lsp\node_modules\.bin\pyright-langserver.cmd", "--stdio"]
     env = {}
 
-    command_line = LSPClient._win_shell_command(command, env)
+    command_line = windows_batch_command(command, env, prefix="HERMES_LSP_COMMAND")
 
+    assert command_line.lower().startswith('"')
+    assert " /d " in command_line.lower()
     assert "/v:off" in command_line.lower()
-    assert '"^%HERMES_LSP_COMMAND_0^%"' in command_line
-    assert '"^%HERMES_LSP_COMMAND_1^%"' in command_line
+    assert '"%HERMES_LSP_COMMAND_0%"' in command_line
+    assert '"%HERMES_LSP_COMMAND_1%"' in command_line
+    assert "^%" not in command_line
+    assert command[0] not in command_line
     assert env["HERMES_LSP_COMMAND_0"] == command[0]
     assert env["HERMES_LSP_COMMAND_1"] == command[1]
 
@@ -315,14 +378,14 @@ def test_windows_npm_wrapper_uses_quoted_shell_placeholders():
     "argument", ['unsafe\"quote', "unsafe\rline", "unsafe\nline", "unsafe\0nul"]
 )
 def test_windows_npm_wrapper_rejects_untransportable_arguments(argument):
-    from agent.lsp.client import LSPClient
+    from hermes_cli._subprocess_compat import windows_batch_proxy_command
 
     with pytest.raises(ValueError, match="cannot contain quotes or control"):
-        LSPClient._win_shell_command([r"C:\Hermes\server.cmd", argument], {})
+        windows_batch_proxy_command([r"C:\Hermes\server.cmd", argument])
 
 
 @pytest.mark.asyncio
-async def test_spawn_routes_windows_batch_launcher_through_shell(
+async def test_spawn_routes_windows_batch_launcher_through_native_proxy(
     tmp_path, monkeypatch
 ):
     from agent.lsp import client as client_mod
@@ -333,17 +396,17 @@ async def test_spawn_routes_windows_batch_launcher_through_shell(
         stdout = None
         stderr = None
 
-    async def fake_shell(command_line, **kwargs):
-        captured["command_line"] = command_line
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
         captured["kwargs"] = kwargs
         return FakeProcess()
 
-    async def unexpected_exec(*_args, **_kwargs):
-        pytest.fail("Windows batch launcher bypassed create_subprocess_shell")
+    async def unexpected_shell(*_args, **_kwargs):
+        pytest.fail("Windows batch launcher used an implicit shell")
 
     monkeypatch.setattr(client_mod.sys, "platform", "win32")
-    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_shell", fake_shell)
-    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_exec", unexpected_exec)
+    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_shell", unexpected_shell)
+    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_exec", fake_exec)
     wrapper = tmp_path / "a&b" / "server.cmd"
     client = client_mod.LSPClient(
         server_id="test",
@@ -356,22 +419,25 @@ async def test_spawn_routes_windows_batch_launcher_through_shell(
     assert client._reader_task is not None
     await asyncio.gather(client._stderr_task, client._reader_task)
 
-    command_line = captured["command_line"]
-    assert "/v:off" in command_line.lower()
-    assert '"^%HERMES_LSP_COMMAND_0^%"' in command_line
-    assert '"^%HERMES_LSP_COMMAND_1^%"' in command_line
-    assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_0"] == str(wrapper)
-    assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_1"] == "--stdio"
+    args = captured["args"]
+    assert args[0] == sys.executable
+    assert args[1].endswith("_subprocess_compat.py")
+    assert args[2] == "--windows-batch-proxy"
+    assert list(args[-2:]) == [str(wrapper), "--stdio"]
+    assert not any(
+        key.startswith("HERMES_LSP_COMMAND_")
+        for key in captured["kwargs"]["env"]
+    )
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+@pytest.mark.windows_only
 @pytest.mark.parametrize(
     "argument",
     ["hello&%UNEXPANDED%!UNEXPANDED!()^caret|pipe<in>out", ""],
 )
 def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path, argument):
-    """Batch launchers preserve metacharacters through both cmd.exe layers."""
-    from agent.lsp.client import LSPClient
+    """The explicit /D shell preserves metacharacters without an outer shell."""
+    from hermes_cli._subprocess_compat import run_windows_batch
 
     wrapper = (
         tmp_path
@@ -384,24 +450,12 @@ def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path, argument):
     )
     env = dict(os.environ)
     env["UNEXPANDED"] = "wrong"
-    command_line = LSPClient._win_shell_command([str(wrapper), argument], env)
-    if argument:
-        assert argument not in command_line
-    else:
-        assert "HERMES_LSP_COMMAND_1" not in env
-
-    comspec = env.get("COMSPEC") or os.path.join(
-        env.get("SystemRoot", r"C:\Windows"), "System32", "cmd.exe"
-    )
-    outer_command = f'"{comspec}" /d /s /v:on /c "{command_line}"'
-    result = subprocess.run(
-        outer_command,
-        executable=comspec,
-        shell=False,
+    result = run_windows_batch(
+        [str(wrapper), argument],
         env=env,
-        check=False,
-        capture_output=True,
+        prefix="HERMES_LSP_COMMAND",
         text=True,
+        timeout=30,
     )
 
     assert result.returncode == 0, result.stderr
@@ -439,7 +493,7 @@ def test_install_npm_generates_location_independent_windows_wrapper(
             "node": "C:\\Program Files\\nodejs\\node.exe",
         }.get(name),
     )
-    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod, "run_windows_batch", fake_run)
 
     resolved = install_mod._install_npm("pyright", "pyright-langserver")
 
@@ -467,7 +521,7 @@ def test_npm_bin_script_rejects_non_object_package_metadata(tmp_path):
         is None
     )
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+@pytest.mark.windows_only
 def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch):
     """npm.cmd must receive the complete --prefix path through cmd.exe."""
     home = tmp_path / "home&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
@@ -513,7 +567,7 @@ def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch
     assert expected.exists()
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+@pytest.mark.windows_only
 def test_generated_npm_wrapper_keeps_managed_node_and_home_relative(
     tmp_path, monkeypatch
 ):
@@ -551,7 +605,7 @@ def test_generated_npm_wrapper_keeps_managed_node_and_home_relative(
     assert "capture.js" in content
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+@pytest.mark.windows_only
 @pytest.mark.parametrize(
     "argument",
     [
@@ -563,13 +617,16 @@ def test_generated_npm_wrapper_keeps_managed_node_and_home_relative(
 def test_generated_npm_wrapper_survives_real_metacharacter_home(
     tmp_path, monkeypatch, argument
 ):
-    """Exercise the generated wrapper through shell=True, exactly as LSP does."""
+    """Exercise the generated wrapper through the exact native LSP proxy."""
     home = tmp_path / "home&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("UNEXPANDED", "wrong")
 
     from agent.lsp import install as install_mod
-    from hermes_cli._subprocess_compat import windows_batch_command, windows_hide_flags
+    from hermes_cli._subprocess_compat import (
+        windows_batch_proxy_command,
+        windows_hide_flags,
+    )
 
     staging = install_mod.hermes_lsp_bin_dir().parent
     package_dir = staging / "node_modules" / "fixture-package"
@@ -594,12 +651,10 @@ def test_generated_npm_wrapper_survives_real_metacharacter_home(
     assert wrapper is not None
 
     env = dict(os.environ)
-    command_line = windows_batch_command(
-        [str(wrapper), argument, ""], env, prefix="HERMES_LSP_E2E"
-    )
+    proxy_command = windows_batch_proxy_command([str(wrapper), argument, ""])
     result = subprocess.run(
-        command_line,
-        shell=True,
+        proxy_command,
+        shell=False,
         env=env,
         check=False,
         capture_output=True,
@@ -612,6 +667,119 @@ def test_generated_npm_wrapper_survives_real_metacharacter_home(
 
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == [argument, ""]
+
+
+@pytest.mark.windows_only
+def test_run_windows_batch_timeout_kills_descendants(tmp_path):
+    """A timed-out batch operation must not leave its real child running."""
+    import psutil
+
+    from hermes_cli._subprocess_compat import run_windows_batch
+
+    root = tmp_path / "a&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
+    root.mkdir()
+    pid_file = root / "child.pid"
+    child = root / "child.py"
+    child.write_text(
+        "import os, pathlib, sys, time\n"
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()))\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    wrapper = root / "hang.cmd"
+    wrapper.write_text(
+        "@echo off\r\n"
+        "setlocal DisableDelayedExpansion\r\n"
+        'set "dp0=%~dp0"\r\n'
+        f'"{sys.executable}" "%dp0%child.py" "%dp0%child.pid"\r\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_windows_batch(
+            [str(wrapper)],
+            timeout=1.0,
+            stdin=subprocess.DEVNULL,
+        )
+
+    assert pid_file.exists()
+    child_pid = int(pid_file.read_text())
+    deadline = time.monotonic() + 3.0
+    while psutil.pid_exists(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert not psutil.pid_exists(child_pid)
+
+
+@pytest.mark.windows_only
+@pytest.mark.asyncio
+async def test_lsp_cleanup_kills_batch_proxy_descendants(tmp_path):
+    """Forced LSP cleanup owns Python proxy, cmd.exe, and server descendants."""
+    import psutil
+
+    from agent.lsp.client import LSPClient
+
+    root = tmp_path / "a&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
+    root.mkdir()
+    pid_file = root / "child.pid"
+    child = root / "child.py"
+    child.write_text(
+        "import os, pathlib, sys, time\n"
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()))\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    wrapper = root / "server.cmd"
+    wrapper.write_text(
+        "@echo off\r\n"
+        "setlocal DisableDelayedExpansion\r\n"
+        'set "dp0=%~dp0"\r\n'
+        f'"{sys.executable}" "%dp0%child.py" "%dp0%child.pid"\r\n',
+        encoding="utf-8",
+    )
+    client = LSPClient(
+        server_id="cleanup-test",
+        workspace_root=str(tmp_path),
+        command=[str(wrapper)],
+    )
+
+    await client._spawn()
+    assert client._proc is not None
+    proxy_pid = client._proc.pid
+    deadline = asyncio.get_running_loop().time() + 4.0
+    while not pid_file.exists() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.05)
+    assert pid_file.exists()
+    child_pid = int(pid_file.read_text())
+    assert psutil.pid_exists(proxy_pid)
+    assert psutil.pid_exists(child_pid)
+    descendants = psutil.Process(proxy_pid).children(recursive=True)
+    cmd_children = [
+        proc
+        for proc in descendants
+        if (proc.name() or "").lower() in {"cmd", "cmd.exe"}
+    ]
+    assert len(cmd_children) == 1
+    assert "/d" in [part.lower() for part in cmd_children[0].cmdline()]
+
+    await client._cleanup_process()
+
+    deadline = asyncio.get_running_loop().time() + 3.0
+    while (
+        (psutil.pid_exists(proxy_pid) or psutil.pid_exists(child_pid))
+        and asyncio.get_running_loop().time() < deadline
+    ):
+        await asyncio.sleep(0.05)
+    assert not psutil.pid_exists(proxy_pid)
+    assert not psutil.pid_exists(child_pid)
+    # asyncio's proactor subprocess transport keeps pipe handles open even
+    # after the process exits; close it explicitly so the loop teardown does
+    # not warn about an unclosed transport from the test's own child.
+    transport = getattr(client._proc, "_transport", None)
+    if transport is not None:
+        try:
+            transport.close()
+        except Exception:
+            pass
 
 
 def test_install_npm_uses_managed_resolver_off_windows(tmp_path, monkeypatch):

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -14,7 +14,10 @@ Covers:
 """
 from __future__ import annotations
 
+import asyncio
 import io
+import os
+import subprocess
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
@@ -146,6 +149,35 @@ def test_existing_binary_rejects_posix_only_shim_on_windows(tmp_path, monkeypatc
     assert install_mod.detect_status("pyright") == "missing"
 
 
+def test_stale_posix_only_install_triggers_npm_repair(tmp_path, monkeypatch):
+    """A broken pre-fix install must be rejected and repaired automatically."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    stale_shim = install_mod.hermes_lsp_bin_dir() / "pyright-langserver"
+    stale_shim.write_text("#!/bin/sh\nexit 0\n")
+    stale_shim.chmod(0o755)
+    repaired = (
+        install_mod.hermes_lsp_bin_dir().parent
+        / "node_modules"
+        / ".bin"
+        / "pyright-langserver.cmd"
+    )
+    repair_calls = []
+
+    def fake_install(pkg, bin_name, extra_pkgs=None):
+        repair_calls.append((pkg, bin_name, extra_pkgs))
+        return str(repaired)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(install_mod, "_install_npm", fake_install)
+
+    assert install_mod._do_install("pyright") == str(repaired)
+    assert repair_calls == [("pyright", "pyright-langserver", [])]
+
+
 def test_existing_binary_accepts_native_extensionless_pe_on_windows(tmp_path, monkeypatch):
     """A native PE executable remains valid even without a file suffix."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -172,11 +204,88 @@ def test_non_windows_candidates_preserve_extensionless_launcher(monkeypatch):
     assert install_mod._native_binary_candidates(base) == [base]
 
 
-def test_windows_npm_wrapper_runs_through_cmd_exe():
+def test_windows_npm_wrapper_uses_quoted_shell_placeholders():
     from agent.lsp.client import LSPClient
 
     command = [r"C:\Hermes\lsp\node_modules\.bin\pyright-langserver.cmd", "--stdio"]
-    assert LSPClient._win_wrap_cmd(command) == ["cmd.exe", "/c", *command]
+    env = {}
+
+    assert LSPClient._win_shell_command(command, env) == (
+        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
+    )
+    assert env["HERMES_LSP_COMMAND_0"] == command[0]
+    assert env["HERMES_LSP_COMMAND_1"] == command[1]
+
+
+@pytest.mark.asyncio
+async def test_spawn_routes_windows_batch_launcher_through_shell(
+    tmp_path, monkeypatch
+):
+    from agent.lsp import client as client_mod
+
+    captured = {}
+
+    class FakeProcess:
+        stdout = None
+        stderr = None
+
+    async def fake_shell(command_line, **kwargs):
+        captured["command_line"] = command_line
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    async def unexpected_exec(*_args, **_kwargs):
+        pytest.fail("Windows batch launcher bypassed create_subprocess_shell")
+
+    monkeypatch.setattr(client_mod.sys, "platform", "win32")
+    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_shell", fake_shell)
+    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_exec", unexpected_exec)
+    wrapper = tmp_path / "a&b" / "server.cmd"
+    client = client_mod.LSPClient(
+        server_id="test",
+        workspace_root=str(tmp_path),
+        command=[str(wrapper), "--stdio"],
+    )
+
+    await client._spawn()
+    assert client._stderr_task is not None
+    assert client._reader_task is not None
+    await asyncio.gather(client._stderr_task, client._reader_task)
+
+    assert captured["command_line"] == (
+        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
+    )
+    assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_0"] == str(wrapper)
+    assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_1"] == "--stdio"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
+    """A valid wrapper path containing ``&`` must not be split by cmd.exe."""
+    from agent.lsp.client import LSPClient
+
+    wrapper = tmp_path / "a&b%UNEXPANDED%" / "server.cmd"
+    wrapper.parent.mkdir()
+    wrapper.write_text(
+        "@echo off" + chr(13) + chr(10) + "echo READY [%1]" + chr(13) + chr(10)
+    )
+    env = dict(os.environ)
+    env["UNEXPANDED"] = "wrong"
+    command_line = LSPClient._win_shell_command(
+        [str(wrapper), "hello&%UNEXPANDED%"], env
+    )
+
+    result = subprocess.run(
+        command_line,
+        shell=True,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert 'READY ["hello&%UNEXPANDED%"]' in result.stdout
 
 
 def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):
@@ -205,6 +314,65 @@ def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch)
 
     assert resolved == str(npm_bin / "pyright-langserver.cmd")
     assert not (install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd").exists()
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch):
+    """npm.cmd must receive the complete --prefix path through cmd.exe."""
+    home = tmp_path / "home&b%UNEXPANDED%"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("UNEXPANDED", "wrong")
+
+    from agent.lsp import install as install_mod
+
+    fake_npm = home / "node" / "npm.cmd"
+    fake_npm.parent.mkdir(parents=True)
+    fake_npm.write_text(
+        os.linesep.join(
+            [
+                "@echo off",
+                'if "%~1"=="--version" (',
+                "    echo 1.0.0",
+                "    exit /b 0",
+                ")",
+                'set "prefix=%~3"',
+                r'if not exist "%prefix%\node_modules\.bin" mkdir "%prefix%\node_modules\.bin"',
+                r'> "%prefix%\node_modules\.bin\pyright-langserver.cmd" echo @echo off',
+                "exit /b 0",
+            ]
+        )
+        + os.linesep
+    )
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+
+    resolved = install_mod._install_npm("fake-package", "pyright-langserver")
+
+    expected = home / "lsp" / "node_modules" / ".bin" / "pyright-langserver.cmd"
+    assert resolved == str(expected)
+    assert expected.exists()
+
+
+def test_install_npm_uses_managed_resolver_off_windows(tmp_path, monkeypatch):
+    """Linux/macOS preserve current managed-Node npm resolution."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    captured = {}
+
+    def fake_run(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: "/managed/node/bin/npm" if name == "npm" else None,
+    )
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    assert install_mod._install_npm("pyright", "pyright-langserver") is None
+    assert captured["cmd"][0] == "/managed/node/bin/npm"
 
 @pytest.mark.windows_only
 def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -210,11 +210,21 @@ def test_windows_npm_wrapper_uses_quoted_shell_placeholders():
     command = [r"C:\Hermes\lsp\node_modules\.bin\pyright-langserver.cmd", "--stdio"]
     env = {}
 
-    assert LSPClient._win_shell_command(command, env) == (
-        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
-    )
+    command_line = LSPClient._win_shell_command(command, env)
+
+    assert "/v:off" in command_line.lower()
+    assert '"^%HERMES_LSP_COMMAND_0^%"' in command_line
+    assert '"^%HERMES_LSP_COMMAND_1^%"' in command_line
     assert env["HERMES_LSP_COMMAND_0"] == command[0]
     assert env["HERMES_LSP_COMMAND_1"] == command[1]
+
+
+@pytest.mark.parametrize("argument", ['unsafe\"quote', "unsafe\nline", "unsafe\0nul"])
+def test_windows_npm_wrapper_rejects_untransportable_arguments(argument):
+    from agent.lsp.client import LSPClient
+
+    with pytest.raises(ValueError, match="cannot contain quotes or control"):
+        LSPClient._win_shell_command([r"C:\Hermes\server.cmd", argument], {})
 
 
 @pytest.mark.asyncio
@@ -252,28 +262,33 @@ async def test_spawn_routes_windows_batch_launcher_through_shell(
     assert client._reader_task is not None
     await asyncio.gather(client._stderr_task, client._reader_task)
 
-    assert captured["command_line"] == (
-        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
-    )
+    command_line = captured["command_line"]
+    assert "/v:off" in command_line.lower()
+    assert '"^%HERMES_LSP_COMMAND_0^%"' in command_line
+    assert '"^%HERMES_LSP_COMMAND_1^%"' in command_line
     assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_0"] == str(wrapper)
     assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_1"] == "--stdio"
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
 def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
-    """A valid wrapper path containing ``&`` must not be split by cmd.exe."""
+    """Batch launchers preserve metacharacters through both cmd.exe layers."""
     from agent.lsp.client import LSPClient
 
-    wrapper = tmp_path / "a&b%UNEXPANDED%" / "server.cmd"
+    wrapper = (
+        tmp_path
+        / "a&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
+        / "server.cmd"
+    )
     wrapper.parent.mkdir()
     wrapper.write_text(
         "@echo off" + chr(13) + chr(10) + "echo READY [%1]" + chr(13) + chr(10)
     )
     env = dict(os.environ)
     env["UNEXPANDED"] = "wrong"
-    command_line = LSPClient._win_shell_command(
-        [str(wrapper), "hello&%UNEXPANDED%"], env
-    )
+    argument = "hello&%UNEXPANDED%!UNEXPANDED!()^caret|pipe<in>out"
+    command_line = LSPClient._win_shell_command([str(wrapper), argument], env)
+    assert argument not in command_line
 
     result = subprocess.run(
         command_line,
@@ -285,7 +300,7 @@ def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
-    assert 'READY ["hello&%UNEXPANDED%"]' in result.stdout
+    assert f'READY ["{argument}"]' in result.stdout
 
 
 def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):
@@ -318,7 +333,7 @@ def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch)
 @pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
 def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch):
     """npm.cmd must receive the complete --prefix path through cmd.exe."""
-    home = tmp_path / "home&b%UNEXPANDED%"
+    home = tmp_path / "home&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("UNEXPANDED", "wrong")
 

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -30,6 +30,33 @@ from agent.lsp.install import INSTALL_RECIPES
 
 
 
+def test_install_npm_passes_extras_to_npm_command(tmp_path, monkeypatch):
+    """Verify the npm subprocess is invoked with both pkg AND extras."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        # Pretend npm succeeded but binary doesn't exist — install code
+        # will return None, which is fine for this test.
+        return MagicMock(returncode=0, stderr="")
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda c: "/usr/bin/npm" if c == "npm" else None)
+
+    install_mod._install_npm("typescript-language-server", "typescript-language-server",
+                             extra_pkgs=["typescript"])
+
+    cmd = captured["cmd"]
+    assert "typescript-language-server" in cmd
+    assert "typescript" in cmd
+    # Both must come AFTER the npm flags, in install-target position
+    install_idx = cmd.index("install")
+    assert cmd.index("typescript-language-server") > install_idx
+    assert cmd.index("typescript") > install_idx
 
 
 def test_install_npm_works_without_extras(tmp_path, monkeypatch):
@@ -45,7 +72,7 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     from agent.lsp import install as install_mod
 
     monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
-    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/npm" if c == "npm" else None)
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda c: "/usr/bin/npm" if c == "npm" else None)
 
     install_mod._install_npm("pyright", "pyright-langserver")
 
@@ -60,6 +87,124 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
 
 
 
+
+def test_existing_binary_prefers_windows_wrapper_over_posix_shim(tmp_path, monkeypatch):
+    """A stale npm POSIX shim must not shadow its native Windows wrapper."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    staged = install_mod.hermes_lsp_bin_dir()
+    posix_shim = staged / "pyright-langserver"
+    posix_shim.write_text("#!/bin/sh\nexit 0\n")
+    posix_shim.chmod(0o755)
+    wrapper = staged / "pyright-langserver.cmd"
+    wrapper.write_text("@echo off\n")
+    wrapper.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") == str(wrapper)
+
+
+def test_existing_binary_prefers_canonical_npm_wrapper(tmp_path, monkeypatch):
+    """The npm .cmd must run in node_modules/.bin so its relative paths work."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    staged = install_mod.hermes_lsp_bin_dir()
+    (staged / "pyright-langserver").write_text("#!/bin/sh\nexit 0\n")
+    (staged / "pyright-langserver.cmd").write_text("@echo off\n")
+    npm_bin = staged.parent / "node_modules" / ".bin"
+    npm_bin.mkdir(parents=True)
+    canonical = npm_bin / "pyright-langserver.cmd"
+    canonical.write_text("@echo off\n")
+    canonical.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") == str(canonical)
+
+
+def test_existing_binary_rejects_posix_only_shim_on_windows(tmp_path, monkeypatch):
+    """An extensionless shebang script is not a Win32 executable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    shim = install_mod.hermes_lsp_bin_dir() / "pyright-langserver"
+    shim.write_text("#!/bin/sh\nexit 0\n")
+    shim.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") is None
+    assert install_mod.detect_status("pyright") == "missing"
+
+
+def test_existing_binary_accepts_native_extensionless_pe_on_windows(tmp_path, monkeypatch):
+    """A native PE executable remains valid even without a file suffix."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    binary = install_mod.hermes_lsp_bin_dir() / "custom-language-server"
+    binary.write_bytes(b"MZ\x90\x00native executable fixture")
+    binary.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("custom-language-server") == str(binary)
+
+
+def test_non_windows_candidates_preserve_extensionless_launcher(monkeypatch):
+    """Linux and macOS keep the existing extensionless candidate behavior."""
+    from agent.lsp import install as install_mod
+
+    base = install_mod.hermes_lsp_bin_dir() / "pyright-langserver"
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: False)
+
+    assert install_mod._native_binary_candidates(base) == [base]
+
+
+def test_windows_npm_wrapper_runs_through_cmd_exe():
+    from agent.lsp.client import LSPClient
+
+    command = [r"C:\Hermes\lsp\node_modules\.bin\pyright-langserver.cmd", "--stdio"]
+    assert LSPClient._win_wrap_cmd(command) == ["cmd.exe", "/c", *command]
+
+
+def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):
+    """npm repair should use .cmd where its relative package path stays valid."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    npm_bin = install_mod.hermes_lsp_bin_dir().parent / "node_modules" / ".bin"
+
+    def fake_run(cmd, **kwargs):
+        npm_bin.mkdir(parents=True, exist_ok=True)
+        (npm_bin / "pyright-langserver").write_text("#!/bin/sh\nexit 0\n")
+        (npm_bin / "pyright-langserver.cmd").write_text("@echo off\n")
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: "C:\\Program Files\\nodejs\\npm.cmd" if name == "npm" else None,
+    )
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    resolved = install_mod._install_npm("pyright", "pyright-langserver")
+
+    assert resolved == str(npm_bin / "pyright-langserver.cmd")
+    assert not (install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd").exists()
 
 @pytest.mark.windows_only
 def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):
@@ -106,8 +251,8 @@ def test_backend_warnings_fires_when_bash_installed_but_shellcheck_missing(tmp_p
     from agent.lsp import cli as lsp_cli
 
     def which(name):
-        if name == "bash-language-server":
-            return "/fake/bin/bash-language-server"
+        if name in {"bash-language-server", "bash-language-server.cmd"}:
+            return "C:\\fake\\bash-language-server.cmd"
         return None  # shellcheck missing
 
     with patch("shutil.which", side_effect=which):
@@ -123,8 +268,8 @@ def test_status_output_includes_backend_warnings_section(tmp_path, monkeypatch):
 
     # Pretend bash-language-server is installed but shellcheck is missing
     def which(name):
-        if name == "bash-language-server":
-            return "/fake/bin/bash-language-server"
+        if name in {"bash-language-server", "bash-language-server.cmd"}:
+            return "C:\\fake\\bash-language-server.cmd"
         return None
 
     from agent.lsp import cli as lsp_cli

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -219,7 +219,9 @@ def test_windows_npm_wrapper_uses_quoted_shell_placeholders():
     assert env["HERMES_LSP_COMMAND_1"] == command[1]
 
 
-@pytest.mark.parametrize("argument", ['unsafe\"quote', "unsafe\nline", "unsafe\0nul"])
+@pytest.mark.parametrize(
+    "argument", ['unsafe\"quote', "unsafe\rline", "unsafe\nline", "unsafe\0nul"]
+)
 def test_windows_npm_wrapper_rejects_untransportable_arguments(argument):
     from agent.lsp.client import LSPClient
 
@@ -271,7 +273,11 @@ async def test_spawn_routes_windows_batch_launcher_through_shell(
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
-def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
+@pytest.mark.parametrize(
+    "argument",
+    ["hello&%UNEXPANDED%!UNEXPANDED!()^caret|pipe<in>out", ""],
+)
+def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path, argument):
     """Batch launchers preserve metacharacters through both cmd.exe layers."""
     from agent.lsp.client import LSPClient
 
@@ -286,13 +292,20 @@ def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
     )
     env = dict(os.environ)
     env["UNEXPANDED"] = "wrong"
-    argument = "hello&%UNEXPANDED%!UNEXPANDED!()^caret|pipe<in>out"
     command_line = LSPClient._win_shell_command([str(wrapper), argument], env)
-    assert argument not in command_line
+    if argument:
+        assert argument not in command_line
+    else:
+        assert "HERMES_LSP_COMMAND_1" not in env
 
+    comspec = env.get("COMSPEC") or os.path.join(
+        env.get("SystemRoot", r"C:\Windows"), "System32", "cmd.exe"
+    )
+    outer_command = f'"{comspec}" /d /s /v:on /c "{command_line}"'
     result = subprocess.run(
-        command_line,
-        shell=True,
+        outer_command,
+        executable=comspec,
+        shell=False,
         env=env,
         check=False,
         capture_output=True,
@@ -300,7 +313,7 @@ def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
-    assert f'READY ["{argument}"]' in result.stdout
+    assert result.stdout.splitlines() == [f'READY ["{argument}"]']
 
 
 def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 import asyncio
 import io
+import json
 import os
 import subprocess
+import sys
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
@@ -50,16 +52,21 @@ def test_install_npm_passes_extras_to_npm_command(tmp_path, monkeypatch):
     monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
     monkeypatch.setattr(install_mod, "find_node_executable", lambda c: "/usr/bin/npm" if c == "npm" else None)
 
-    install_mod._install_npm("typescript-language-server", "typescript-language-server",
-                             extra_pkgs=["typescript"])
+    extras = install_mod.INSTALL_RECIPES["typescript-language-server"]["extra_pkgs"]
+    assert extras == ["typescript@6"]
+    install_mod._install_npm(
+        "typescript-language-server",
+        "typescript-language-server",
+        extra_pkgs=extras,
+    )
 
     cmd = captured["cmd"]
     assert "typescript-language-server" in cmd
-    assert "typescript" in cmd
+    assert "typescript@6" in cmd
     # Both must come AFTER the npm flags, in install-target position
     install_idx = cmd.index("install")
     assert cmd.index("typescript-language-server") > install_idx
-    assert cmd.index("typescript") > install_idx
+    assert cmd.index("typescript@6") > install_idx
 
 
 def test_install_npm_works_without_extras(tmp_path, monkeypatch):
@@ -130,6 +137,91 @@ def test_existing_binary_prefers_canonical_npm_wrapper(tmp_path, monkeypatch):
     monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
 
     assert install_mod._existing_binary("pyright-langserver") == str(canonical)
+
+
+def test_existing_binary_prefers_hermes_wrapper_over_canonical_npm(
+    tmp_path, monkeypatch
+):
+    """A generated wrapper must survive process restart and stay preferred."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    staged = install_mod.hermes_lsp_bin_dir()
+    generated = staged / "pyright-langserver.hermes.cmd"
+    generated.write_text("@echo off\n")
+    npm_bin = staged.parent / "node_modules" / ".bin"
+    npm_bin.mkdir(parents=True)
+    canonical = npm_bin / "pyright-langserver.cmd"
+    canonical.write_text("@echo off\n")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") == str(generated)
+
+
+def test_auto_install_upgrades_preexisting_canonical_npm_wrapper(
+    tmp_path, monkeypatch
+):
+    """Existing managed packages gain a safe wrapper without npm reinstall."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    staging = install_mod.hermes_lsp_bin_dir().parent
+    npm_bin = staging / "node_modules" / ".bin"
+    npm_bin.mkdir(parents=True)
+    (npm_bin / "pyright-langserver.cmd").write_text("@echo off\n")
+    package_dir = staging / "node_modules" / "pyright"
+    package_dir.mkdir()
+    (package_dir / "package.json").write_text(
+        json.dumps({"bin": {"pyright-langserver": "langserver.index.js"}}),
+        encoding="utf-8",
+    )
+    (package_dir / "langserver.index.js").write_text("// fixture\n")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: r"C:\Program Files\nodejs\node.exe" if name == "node" else None,
+    )
+    monkeypatch.setattr(
+        install_mod,
+        "_install_npm",
+        lambda *_args, **_kwargs: pytest.fail("existing package was reinstalled"),
+    )
+
+    resolved = install_mod._do_install("pyright")
+
+    expected = staging / "bin" / "pyright-langserver.hermes.cmd"
+    assert resolved == str(expected)
+    assert expected.exists()
+
+
+def test_auto_install_ignores_orphaned_generated_and_staged_npm_wrappers(
+    tmp_path, monkeypatch
+):
+    """Orphaned generated or copied wrappers must not suppress repair."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    orphan = install_mod.hermes_lsp_bin_dir() / "pyright-langserver.hermes.cmd"
+    orphan.write_text("@echo off\n")
+    stale_copy = install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd"
+    stale_copy.write_text("@echo off\n")
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda _name: None)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        install_mod,
+        "_install_npm",
+        lambda *_args, **_kwargs: "reinstalled-wrapper.cmd",
+    )
+
+    assert install_mod._do_install("pyright") == "reinstalled-wrapper.cmd"
 
 
 def test_existing_binary_rejects_posix_only_shim_on_windows(tmp_path, monkeypatch):
@@ -316,8 +408,10 @@ def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path, argument):
     assert result.stdout.splitlines() == [f'READY ["{argument}"]']
 
 
-def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):
-    """npm repair should use .cmd where its relative package path stays valid."""
+def test_install_npm_generates_location_independent_windows_wrapper(
+    tmp_path, monkeypatch
+):
+    """Managed npm bins use a Hermes wrapper instead of npm's fragile shim."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     from agent.lsp import install as install_mod
@@ -328,20 +422,50 @@ def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch)
         npm_bin.mkdir(parents=True, exist_ok=True)
         (npm_bin / "pyright-langserver").write_text("#!/bin/sh\nexit 0\n")
         (npm_bin / "pyright-langserver.cmd").write_text("@echo off\n")
+        package_dir = npm_bin.parent / "pyright"
+        package_dir.mkdir()
+        (package_dir / "package.json").write_text(
+            json.dumps({"bin": {"pyright-langserver": "langserver.index.js"}})
+        )
+        (package_dir / "langserver.index.js").write_text("// fixture\n")
         return MagicMock(returncode=0, stderr="")
 
     monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
     monkeypatch.setattr(
         install_mod,
         "find_node_executable",
-        lambda name: "C:\\Program Files\\nodejs\\npm.cmd" if name == "npm" else None,
+        lambda name: {
+            "npm": "C:\\Program Files\\nodejs\\npm.cmd",
+            "node": "C:\\Program Files\\nodejs\\node.exe",
+        }.get(name),
     )
     monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
 
     resolved = install_mod._install_npm("pyright", "pyright-langserver")
 
-    assert resolved == str(npm_bin / "pyright-langserver.cmd")
-    assert not (install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd").exists()
+    wrapper = install_mod.hermes_lsp_bin_dir() / "pyright-langserver.hermes.cmd"
+    assert resolved == str(wrapper)
+    content = wrapper.read_text(encoding="ascii")
+    assert "setlocal DisableDelayedExpansion" in content
+    assert 'set "dp0=%~dp0"' in content
+    assert "langserver.index.js" in content
+    assert (npm_bin / "pyright-langserver.cmd").exists()
+
+
+def test_npm_bin_script_rejects_non_object_package_metadata(tmp_path):
+    """Malformed-but-valid JSON metadata falls back instead of raising."""
+    from agent.lsp import install as install_mod
+
+    package_dir = tmp_path / "node_modules" / "fixture-package"
+    package_dir.mkdir(parents=True)
+    (package_dir / "package.json").write_text("[]", encoding="utf-8")
+
+    assert (
+        install_mod._npm_bin_script(
+            tmp_path, "fixture-package", "fixture-language-server"
+        )
+        is None
+    )
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
 def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch):
@@ -365,18 +489,129 @@ def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch
                 'set "prefix=%~3"',
                 r'if not exist "%prefix%\node_modules\.bin" mkdir "%prefix%\node_modules\.bin"',
                 r'> "%prefix%\node_modules\.bin\pyright-langserver.cmd" echo @echo off',
+                r'if not exist "%prefix%\node_modules\fake-package" mkdir "%prefix%\node_modules\fake-package"',
+                r'> "%prefix%\node_modules\fake-package\package.json" echo {"bin":{"pyright-langserver":"server.js"}}',
+                r'> "%prefix%\node_modules\fake-package\server.js" echo // fixture',
                 "exit /b 0",
             ]
         )
         + os.linesep
     )
     monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: str(fake_npm)
+        if name == "npm"
+        else r"C:\Program Files\nodejs\node.exe",
+    )
 
     resolved = install_mod._install_npm("fake-package", "pyright-langserver")
 
-    expected = home / "lsp" / "node_modules" / ".bin" / "pyright-langserver.cmd"
+    expected = home / "lsp" / "bin" / "pyright-langserver.hermes.cmd"
     assert resolved == str(expected)
     assert expected.exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+def test_generated_npm_wrapper_keeps_managed_node_and_home_relative(
+    tmp_path, monkeypatch
+):
+    """Managed Node and package paths must not bake HERMES_HOME into the shim."""
+    home = tmp_path / "home-ünicode&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent.lsp import install as install_mod
+
+    staging = install_mod.hermes_lsp_bin_dir().parent
+    package_dir = staging / "node_modules" / "fixture-package"
+    package_dir.mkdir(parents=True)
+    (package_dir / "package.json").write_text(
+        json.dumps({"bin": {"fixture-server": "capture.js"}}),
+        encoding="utf-8",
+    )
+    (package_dir / "capture.js").write_text("// fixture\n", encoding="utf-8")
+    managed_node = home / "node" / "node.exe"
+    managed_node.parent.mkdir(parents=True)
+    managed_node.write_bytes(b"MZ")
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: str(managed_node) if name == "node" else None,
+    )
+
+    wrapper = install_mod._write_windows_node_wrapper(
+        staging, "fixture-package", "fixture-server"
+    )
+    assert wrapper is not None
+    content = wrapper.read_text(encoding="ascii")
+    assert str(home) not in content
+    assert "%dp0%" in content
+    assert "node.exe" in content
+    assert "capture.js" in content
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+@pytest.mark.parametrize(
+    "argument",
+    [
+        "hello&%UNEXPANDED%!UNEXPANDED!()^caret|pipe<in>out",
+        "trailing\\",
+        "double-trailing\\\\",
+    ],
+)
+def test_generated_npm_wrapper_survives_real_metacharacter_home(
+    tmp_path, monkeypatch, argument
+):
+    """Exercise the generated wrapper through shell=True, exactly as LSP does."""
+    home = tmp_path / "home&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("UNEXPANDED", "wrong")
+
+    from agent.lsp import install as install_mod
+    from hermes_cli._subprocess_compat import windows_batch_command, windows_hide_flags
+
+    staging = install_mod.hermes_lsp_bin_dir().parent
+    package_dir = staging / "node_modules" / "fixture-package"
+    package_dir.mkdir(parents=True)
+    (package_dir / "package.json").write_text(
+        json.dumps({"bin": {"fixture-server": "capture.py"}}),
+        encoding="utf-8",
+    )
+    (package_dir / "capture.py").write_text(
+        "import json, sys\nprint(json.dumps(sys.argv[1:]))\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: sys.executable if name == "node" else None,
+    )
+
+    wrapper = install_mod._write_windows_node_wrapper(
+        staging, "fixture-package", "fixture-server"
+    )
+    assert wrapper is not None
+
+    env = dict(os.environ)
+    command_line = windows_batch_command(
+        [str(wrapper), argument, ""], env, prefix="HERMES_LSP_E2E"
+    )
+    result = subprocess.run(
+        command_line,
+        shell=True,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        creationflags=windows_hide_flags(),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [argument, ""]
 
 
 def test_install_npm_uses_managed_resolver_off_windows(tmp_path, monkeypatch):

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -14,7 +14,10 @@ Covers:
 """
 from __future__ import annotations
 
+import asyncio
 import io
+import os
+import subprocess
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
@@ -146,6 +149,35 @@ def test_existing_binary_rejects_posix_only_shim_on_windows(tmp_path, monkeypatc
     assert install_mod.detect_status("pyright") == "missing"
 
 
+def test_stale_posix_only_install_triggers_npm_repair(tmp_path, monkeypatch):
+    """A broken pre-fix install must be rejected and repaired automatically."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    stale_shim = install_mod.hermes_lsp_bin_dir() / "pyright-langserver"
+    stale_shim.write_text("#!/bin/sh\nexit 0\n")
+    stale_shim.chmod(0o755)
+    repaired = (
+        install_mod.hermes_lsp_bin_dir().parent
+        / "node_modules"
+        / ".bin"
+        / "pyright-langserver.cmd"
+    )
+    repair_calls = []
+
+    def fake_install(pkg, bin_name, extra_pkgs=None):
+        repair_calls.append((pkg, bin_name, extra_pkgs))
+        return str(repaired)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(install_mod, "_install_npm", fake_install)
+
+    assert install_mod._do_install("pyright") == str(repaired)
+    assert repair_calls == [("pyright", "pyright-langserver", [])]
+
+
 def test_existing_binary_accepts_native_extensionless_pe_on_windows(tmp_path, monkeypatch):
     """A native PE executable remains valid even without a file suffix."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -172,11 +204,88 @@ def test_non_windows_candidates_preserve_extensionless_launcher(monkeypatch):
     assert install_mod._native_binary_candidates(base) == [base]
 
 
-def test_windows_npm_wrapper_runs_through_cmd_exe():
+def test_windows_npm_wrapper_uses_quoted_shell_placeholders():
     from agent.lsp.client import LSPClient
 
     command = [r"C:\Hermes\lsp\node_modules\.bin\pyright-langserver.cmd", "--stdio"]
-    assert LSPClient._win_wrap_cmd(command) == ["cmd.exe", "/c", *command]
+    env = {}
+
+    assert LSPClient._win_shell_command(command, env) == (
+        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
+    )
+    assert env["HERMES_LSP_COMMAND_0"] == command[0]
+    assert env["HERMES_LSP_COMMAND_1"] == command[1]
+
+
+@pytest.mark.asyncio
+async def test_spawn_routes_windows_batch_launcher_through_shell(
+    tmp_path, monkeypatch
+):
+    from agent.lsp import client as client_mod
+
+    captured = {}
+
+    class FakeProcess:
+        stdout = None
+        stderr = None
+
+    async def fake_shell(command_line, **kwargs):
+        captured["command_line"] = command_line
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    async def unexpected_exec(*_args, **_kwargs):
+        pytest.fail("Windows batch launcher bypassed create_subprocess_shell")
+
+    monkeypatch.setattr(client_mod.sys, "platform", "win32")
+    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_shell", fake_shell)
+    monkeypatch.setattr(client_mod.asyncio, "create_subprocess_exec", unexpected_exec)
+    wrapper = tmp_path / "a&b" / "server.cmd"
+    client = client_mod.LSPClient(
+        server_id="test",
+        workspace_root=str(tmp_path),
+        command=[str(wrapper), "--stdio"],
+    )
+
+    await client._spawn()
+    assert client._stderr_task is not None
+    assert client._reader_task is not None
+    await asyncio.gather(client._stderr_task, client._reader_task)
+
+    assert captured["command_line"] == (
+        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
+    )
+    assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_0"] == str(wrapper)
+    assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_1"] == "--stdio"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
+    """A valid wrapper path containing ``&`` must not be split by cmd.exe."""
+    from agent.lsp.client import LSPClient
+
+    wrapper = tmp_path / "a&b%UNEXPANDED%" / "server.cmd"
+    wrapper.parent.mkdir()
+    wrapper.write_text(
+        "@echo off" + chr(13) + chr(10) + "echo READY [%1]" + chr(13) + chr(10)
+    )
+    env = dict(os.environ)
+    env["UNEXPANDED"] = "wrong"
+    command_line = LSPClient._win_shell_command(
+        [str(wrapper), "hello&%UNEXPANDED%"], env
+    )
+
+    result = subprocess.run(
+        command_line,
+        shell=True,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert 'READY ["hello&%UNEXPANDED%"]' in result.stdout
 
 
 def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):
@@ -205,6 +314,66 @@ def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch)
 
     assert resolved == str(npm_bin / "pyright-langserver.cmd")
     assert not (install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
+def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch):
+    """npm.cmd must receive the complete --prefix path through cmd.exe."""
+    home = tmp_path / "home&b%UNEXPANDED%"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("UNEXPANDED", "wrong")
+
+    from agent.lsp import install as install_mod
+
+    fake_npm = home / "node" / "npm.cmd"
+    fake_npm.parent.mkdir(parents=True)
+    fake_npm.write_text(
+        os.linesep.join(
+            [
+                "@echo off",
+                'if "%~1"=="--version" (',
+                "    echo 1.0.0",
+                "    exit /b 0",
+                ")",
+                'set "prefix=%~3"',
+                r'if not exist "%prefix%\node_modules\.bin" mkdir "%prefix%\node_modules\.bin"',
+                r'> "%prefix%\node_modules\.bin\pyright-langserver.cmd" echo @echo off',
+                "exit /b 0",
+            ]
+        )
+        + os.linesep
+    )
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+
+    resolved = install_mod._install_npm("fake-package", "pyright-langserver")
+
+    expected = home / "lsp" / "node_modules" / ".bin" / "pyright-langserver.cmd"
+    assert resolved == str(expected)
+    assert expected.exists()
+
+
+def test_install_npm_uses_managed_resolver_off_windows(tmp_path, monkeypatch):
+    """Linux/macOS preserve current managed-Node npm resolution."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    captured = {}
+
+    def fake_run(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: "/managed/node/bin/npm" if name == "npm" else None,
+    )
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    assert install_mod._install_npm("pyright", "pyright-langserver") is None
+    assert captured["cmd"][0] == "/managed/node/bin/npm"
 
 
 def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -30,6 +30,33 @@ from agent.lsp.install import INSTALL_RECIPES
 
 
 
+def test_install_npm_passes_extras_to_npm_command(tmp_path, monkeypatch):
+    """Verify the npm subprocess is invoked with both pkg AND extras."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        # Pretend npm succeeded but binary doesn't exist — install code
+        # will return None, which is fine for this test.
+        return MagicMock(returncode=0, stderr="")
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda c: "/usr/bin/npm" if c == "npm" else None)
+
+    install_mod._install_npm("typescript-language-server", "typescript-language-server",
+                             extra_pkgs=["typescript"])
+
+    cmd = captured["cmd"]
+    assert "typescript-language-server" in cmd
+    assert "typescript" in cmd
+    # Both must come AFTER the npm flags, in install-target position
+    install_idx = cmd.index("install")
+    assert cmd.index("typescript-language-server") > install_idx
+    assert cmd.index("typescript") > install_idx
 
 
 def test_install_npm_works_without_extras(tmp_path, monkeypatch):
@@ -45,7 +72,7 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     from agent.lsp import install as install_mod
 
     monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
-    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/npm" if c == "npm" else None)
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda c: "/usr/bin/npm" if c == "npm" else None)
 
     install_mod._install_npm("pyright", "pyright-langserver")
 
@@ -59,6 +86,125 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     assert install_targets == ["pyright"]
 
 
+
+
+def test_existing_binary_prefers_windows_wrapper_over_posix_shim(tmp_path, monkeypatch):
+    """A stale npm POSIX shim must not shadow its native Windows wrapper."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    staged = install_mod.hermes_lsp_bin_dir()
+    posix_shim = staged / "pyright-langserver"
+    posix_shim.write_text("#!/bin/sh\nexit 0\n")
+    posix_shim.chmod(0o755)
+    wrapper = staged / "pyright-langserver.cmd"
+    wrapper.write_text("@echo off\n")
+    wrapper.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") == str(wrapper)
+
+
+def test_existing_binary_prefers_canonical_npm_wrapper(tmp_path, monkeypatch):
+    """The npm .cmd must run in node_modules/.bin so its relative paths work."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    staged = install_mod.hermes_lsp_bin_dir()
+    (staged / "pyright-langserver").write_text("#!/bin/sh\nexit 0\n")
+    (staged / "pyright-langserver.cmd").write_text("@echo off\n")
+    npm_bin = staged.parent / "node_modules" / ".bin"
+    npm_bin.mkdir(parents=True)
+    canonical = npm_bin / "pyright-langserver.cmd"
+    canonical.write_text("@echo off\n")
+    canonical.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") == str(canonical)
+
+
+def test_existing_binary_rejects_posix_only_shim_on_windows(tmp_path, monkeypatch):
+    """An extensionless shebang script is not a Win32 executable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    shim = install_mod.hermes_lsp_bin_dir() / "pyright-langserver"
+    shim.write_text("#!/bin/sh\nexit 0\n")
+    shim.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") is None
+    assert install_mod.detect_status("pyright") == "missing"
+
+
+def test_existing_binary_accepts_native_extensionless_pe_on_windows(tmp_path, monkeypatch):
+    """A native PE executable remains valid even without a file suffix."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    binary = install_mod.hermes_lsp_bin_dir() / "custom-language-server"
+    binary.write_bytes(b"MZ\x90\x00native executable fixture")
+    binary.chmod(0o755)
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("custom-language-server") == str(binary)
+
+
+def test_non_windows_candidates_preserve_extensionless_launcher(monkeypatch):
+    """Linux and macOS keep the existing extensionless candidate behavior."""
+    from agent.lsp import install as install_mod
+
+    base = install_mod.hermes_lsp_bin_dir() / "pyright-langserver"
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: False)
+
+    assert install_mod._native_binary_candidates(base) == [base]
+
+
+def test_windows_npm_wrapper_runs_through_cmd_exe():
+    from agent.lsp.client import LSPClient
+
+    command = [r"C:\Hermes\lsp\node_modules\.bin\pyright-langserver.cmd", "--stdio"]
+    assert LSPClient._win_wrap_cmd(command) == ["cmd.exe", "/c", *command]
+
+
+def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):
+    """npm repair should use .cmd where its relative package path stays valid."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    npm_bin = install_mod.hermes_lsp_bin_dir().parent / "node_modules" / ".bin"
+
+    def fake_run(cmd, **kwargs):
+        npm_bin.mkdir(parents=True, exist_ok=True)
+        (npm_bin / "pyright-langserver").write_text("#!/bin/sh\nexit 0\n")
+        (npm_bin / "pyright-langserver.cmd").write_text("@echo off\n")
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        install_mod,
+        "find_node_executable",
+        lambda name: "C:\\Program Files\\nodejs\\npm.cmd" if name == "npm" else None,
+    )
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    resolved = install_mod._install_npm("pyright", "pyright-langserver")
+
+    assert resolved == str(npm_bin / "pyright-langserver.cmd")
+    assert not (install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd").exists()
 
 
 def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):
@@ -100,8 +246,8 @@ def test_backend_warnings_fires_when_bash_installed_but_shellcheck_missing(tmp_p
     from agent.lsp import cli as lsp_cli
 
     def which(name):
-        if name == "bash-language-server":
-            return "/fake/bin/bash-language-server"
+        if name in {"bash-language-server", "bash-language-server.cmd"}:
+            return "C:\\fake\\bash-language-server.cmd"
         return None  # shellcheck missing
 
     with patch("shutil.which", side_effect=which):
@@ -117,8 +263,8 @@ def test_status_output_includes_backend_warnings_section(tmp_path, monkeypatch):
 
     # Pretend bash-language-server is installed but shellcheck is missing
     def which(name):
-        if name == "bash-language-server":
-            return "/fake/bin/bash-language-server"
+        if name in {"bash-language-server", "bash-language-server.cmd"}:
+            return "C:\\fake\\bash-language-server.cmd"
         return None
 
     from agent.lsp import cli as lsp_cli

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -210,11 +210,21 @@ def test_windows_npm_wrapper_uses_quoted_shell_placeholders():
     command = [r"C:\Hermes\lsp\node_modules\.bin\pyright-langserver.cmd", "--stdio"]
     env = {}
 
-    assert LSPClient._win_shell_command(command, env) == (
-        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
-    )
+    command_line = LSPClient._win_shell_command(command, env)
+
+    assert "/v:off" in command_line.lower()
+    assert '"^%HERMES_LSP_COMMAND_0^%"' in command_line
+    assert '"^%HERMES_LSP_COMMAND_1^%"' in command_line
     assert env["HERMES_LSP_COMMAND_0"] == command[0]
     assert env["HERMES_LSP_COMMAND_1"] == command[1]
+
+
+@pytest.mark.parametrize("argument", ['unsafe\"quote', "unsafe\nline", "unsafe\0nul"])
+def test_windows_npm_wrapper_rejects_untransportable_arguments(argument):
+    from agent.lsp.client import LSPClient
+
+    with pytest.raises(ValueError, match="cannot contain quotes or control"):
+        LSPClient._win_shell_command([r"C:\Hermes\server.cmd", argument], {})
 
 
 @pytest.mark.asyncio
@@ -252,28 +262,33 @@ async def test_spawn_routes_windows_batch_launcher_through_shell(
     assert client._reader_task is not None
     await asyncio.gather(client._stderr_task, client._reader_task)
 
-    assert captured["command_line"] == (
-        '"%HERMES_LSP_COMMAND_0%" "%HERMES_LSP_COMMAND_1%"'
-    )
+    command_line = captured["command_line"]
+    assert "/v:off" in command_line.lower()
+    assert '"^%HERMES_LSP_COMMAND_0^%"' in command_line
+    assert '"^%HERMES_LSP_COMMAND_1^%"' in command_line
     assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_0"] == str(wrapper)
     assert captured["kwargs"]["env"]["HERMES_LSP_COMMAND_1"] == "--stdio"
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
 def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
-    """A valid wrapper path containing ``&`` must not be split by cmd.exe."""
+    """Batch launchers preserve metacharacters through both cmd.exe layers."""
     from agent.lsp.client import LSPClient
 
-    wrapper = tmp_path / "a&b%UNEXPANDED%" / "server.cmd"
+    wrapper = (
+        tmp_path
+        / "a&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
+        / "server.cmd"
+    )
     wrapper.parent.mkdir()
     wrapper.write_text(
         "@echo off" + chr(13) + chr(10) + "echo READY [%1]" + chr(13) + chr(10)
     )
     env = dict(os.environ)
     env["UNEXPANDED"] = "wrong"
-    command_line = LSPClient._win_shell_command(
-        [str(wrapper), "hello&%UNEXPANDED%"], env
-    )
+    argument = "hello&%UNEXPANDED%!UNEXPANDED!()^caret|pipe<in>out"
+    command_line = LSPClient._win_shell_command([str(wrapper), argument], env)
+    assert argument not in command_line
 
     result = subprocess.run(
         command_line,
@@ -285,7 +300,7 @@ def test_windows_npm_wrapper_handles_shell_metacharacters(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
-    assert 'READY ["hello&%UNEXPANDED%"]' in result.stdout
+    assert f'READY ["{argument}"]' in result.stdout
 
 
 def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch):
@@ -319,7 +334,7 @@ def test_install_npm_uses_native_windows_wrapper_in_place(tmp_path, monkeypatch)
 @pytest.mark.skipif(os.name != "nt", reason="Windows cmd.exe quoting")
 def test_install_npm_handles_metacharacters_in_hermes_home(tmp_path, monkeypatch):
     """npm.cmd must receive the complete --prefix path through cmd.exe."""
-    home = tmp_path / "home&b%UNEXPANDED%"
+    home = tmp_path / "home&b%UNEXPANDED%!UNEXPANDED!(x)^caret"
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("UNEXPANDED", "wrong")
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -207,6 +207,19 @@ class TestHermesManagedNode:
 
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows .cmd probe")
+def test_node_tool_runnable_handles_batch_path_metacharacters(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNEXPANDED", "wrong")
+    npm = tmp_path / "node&a%UNEXPANDED%" / "npm.cmd"
+    npm.parent.mkdir()
+    npm.write_text(
+        os.linesep.join(["@echo off", "echo 11.10.0", "exit /b 0"])
+        + os.linesep
+    )
+
+    assert node_tool_runnable(str(npm)) is True
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX shell stubs; Windows uses .cmd shims")
 class TestNodeToolRunnable:
     """node_tool_runnable() rejects broken Hermes-managed npm/node wrappers."""

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -207,7 +207,7 @@ class TestHermesManagedNode:
 
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows .cmd probe")
+@pytest.mark.windows_only
 def test_node_tool_runnable_handles_batch_path_metacharacters(tmp_path, monkeypatch):
     monkeypatch.setenv("UNEXPANDED", "wrong")
     npm = tmp_path / "node&a%UNEXPANDED%!UNEXPANDED!(x)^caret" / "npm.cmd"

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -210,7 +210,7 @@ class TestHermesManagedNode:
 @pytest.mark.skipif(os.name != "nt", reason="Windows .cmd probe")
 def test_node_tool_runnable_handles_batch_path_metacharacters(tmp_path, monkeypatch):
     monkeypatch.setenv("UNEXPANDED", "wrong")
-    npm = tmp_path / "node&a%UNEXPANDED%" / "npm.cmd"
+    npm = tmp_path / "node&a%UNEXPANDED%!UNEXPANDED!(x)^caret" / "npm.cmd"
     npm.parent.mkdir()
     npm.write_text(
         os.linesep.join(["@echo off", "echo 11.10.0", "exit /b 0"])

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -152,7 +152,7 @@ class TestHermesManagedNode:
 @pytest.mark.skipif(os.name != "nt", reason="Windows .cmd probe")
 def test_node_tool_runnable_handles_batch_path_metacharacters(tmp_path, monkeypatch):
     monkeypatch.setenv("UNEXPANDED", "wrong")
-    npm = tmp_path / "node&a%UNEXPANDED%" / "npm.cmd"
+    npm = tmp_path / "node&a%UNEXPANDED%!UNEXPANDED!(x)^caret" / "npm.cmd"
     npm.parent.mkdir()
     npm.write_text(
         os.linesep.join(["@echo off", "echo 11.10.0", "exit /b 0"])

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -149,6 +149,19 @@ class TestHermesManagedNode:
 
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows .cmd probe")
+def test_node_tool_runnable_handles_batch_path_metacharacters(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNEXPANDED", "wrong")
+    npm = tmp_path / "node&a%UNEXPANDED%" / "npm.cmd"
+    npm.parent.mkdir()
+    npm.write_text(
+        os.linesep.join(["@echo off", "echo 11.10.0", "exit /b 0"])
+        + os.linesep
+    )
+
+    assert node_tool_runnable(str(npm)) is True
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX shell stubs; Windows uses .cmd shims")
 class TestNodeToolRunnable:
     """node_tool_runnable() rejects broken Hermes-managed npm/node wrappers."""


### PR DESCRIPTION
## What does this PR do?

Repairs Hermes LSP installation and process handling on native Windows without changing non-Windows launcher selection.

Windows npm installs expose an extensionless POSIX shim beside native wrappers. MSYS can report the shim as executable, but Win32 `CreateProcess` rejects it with `WinError 193`. npm wrappers are also location-dependent and can break after copying, while ordinary `cmd.exe /c` interpolation corrupts valid paths and arguments containing shell metacharacters.

This PR fixes the full launcher boundary:

- prefer `.exe`, `.com`, `.cmd`, and `.bat` launchers on Windows;
- reject extensionless shell shims and accept extensionless candidates only after bounded DOS/PE signature screening;
- repair stale staged installs and generate Hermes-owned relative `.hermes.cmd` wrappers while preserving npm's canonical files;
- invoke batch launchers through one explicit AutoRun-disabled `cmd.exe`, without `shell=True` or command interpolation;
- preserve spaces, empty arguments, `%`, `!`, `&`, `^`, pipes, parentheses, and trailing backslashes while rejecting values `cmd.exe` cannot transport safely;
- terminate the complete proxy, command processor, and language-server tree during forced cleanup and bounded npm/Node probe timeouts;
- keep `typescript-language-server` on a compatible TypeScript 6 SDK line;
- preserve current non-Windows behavior.

The diagnostic transport and URI-identity work remains independently reviewable in #81915.

## Related Issue

Addresses #49470. Related alternatives #68494 and #77896 cover complementary or narrower launcher policies.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/lsp/install.py`: native launcher precedence, stale-install repair, package-entry validation, safe generated wrappers, and positive PE screening.
- `agent/lsp/client.py`: native batch relay selection and bounded process-tree cleanup.
- `hermes_cli/_subprocess_compat.py`: shared raw batch transport, descendant-tree termination, and explicit environment-mutation contract.
- `hermes_constants.py`: Windows-safe managed Node/npm health probes.
- Launcher, subprocess, constants, hostile-path, timeout, and real-process regression coverage.

The latest review pass also:

- replaced a literal TypeScript dependency snapshot with a compatibility invariant;
- documented and tested graceful shutdown before forced escalation;
- documented intentional child-environment placeholders;
- tightened extensionless screening from a bare `MZ` prefix to a bounded DOS header plus `PE\0\0` signature.

## How to Test

Verified on native Windows 11, Python 3.11.15, at head `4d91989a2f6aaa0d96fc1df59a4c331663cc63b8`, rebased onto current `main`:

1. Canonical full LSP directory:

   ```text
   92 passed, 2 skipped, 1 failed
   ```

   The single failure is the unchanged Windows `HOME`/`Path.expanduser()` expectation in `test_workspace.py::test_normalize_path_expands_tilde`, reproduced on exact `main` and outside this diff.

2. Focused launcher file:

   ```text
   36 passed, 2 skipped
   ```

3. Bounded-probe, Windows subprocess flags, and changed constants checks:

   ```text
   18 passed, 1 skipped
   ```

4. Fresh real npm installation inside a hostile metacharacter path:

   ```text
   Pyright 1.1.413: initialized, broken source diagnosed, corrected source clean
   TypeScript LS 6.0.0 + TypeScript 6.0.3: initialized, broken source diagnosed, corrected source clean
   POSIX npm shims present and rejected
   Canonical npm wrappers preserved
   Hermes .hermes.cmd wrappers selected
   ```

5. Pre-seeded upgrade path using the real canonical npm tree:

   ```text
   npm reinstall attempted: false
   Pyright: initialized, broken source diagnosed, corrected source clean
   TypeScript: initialized, broken source diagnosed, corrected source clean
   ```

6. Ruff check, changed production-file `ty`, compileall, `git diff --check`, range-diff after rebase, and independent specification/code-quality reviews all passed.

Fresh GitHub workflows were dispatched from the new head and currently require maintainer approval to start; no remote CI result is being claimed yet.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs and compared the overlapping implementations
- [x] My PR contains only launcher/install/process changes and their tests
- [ ] I've run `pytest tests/ -q` and all tests pass (the broader native-Windows baseline failures are documented above)
- [x] I've added regression and real-process tests
- [x] I've tested on native Windows 11

### Documentation & Housekeeping

- [x] Relevant docstrings and behavioral contracts are updated
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact was considered and non-Windows selection remains unchanged
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

Machine-readable runtime evidence was captured for the exact pushed head, including package versions, selected wrappers, initialization capabilities, broken-to-clean diagnostics, and the no-reinstall upgrade path.
