### PR TITLE
fix(tools): escalate repeated malformed patch calls instead of looping (#63880)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -168,6 +168,51 @@ class TestPatchHandler:
         assert "Unknown mode" in result["error"]
 
     @patch("tools.file_tools._get_file_ops")
+    def test_repeated_missing_path_escalates_hint(self, mock_get):
+        """Identical malformed patch calls must escalate a break-the-loop hint
+        instead of returning the same bare error forever (issue #63880)."""
+        import tools.file_tools as ft
+        from tools.file_tools import patch_tool
+        ft._patch_failure_tracker.pop("loop-task", None)
+        results = [
+            json.loads(patch_tool(mode="replace", path=None, old_string="a",
+                                  new_string="b", task_id="loop-task"))
+            for _ in range(4)
+        ]
+        # Every call still reports the error with actionable context.
+        assert all("path required" in r["error"] for r in results)
+        # First two rejects: no hint yet; from the third the loop-breaker fires.
+        assert "_hint" not in results[0]
+        assert "_hint" not in results[1]
+        assert "_hint" in results[2]
+        assert "#3" in results[2]["_hint"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_valid_patch_resets_arg_failure_escalation(self, mock_get):
+        """A call that passes arg validation clears the malformed-call counter
+        so escalation only ever counts *consecutive* bad calls."""
+        import tools.file_tools as ft
+        from tools.file_tools import patch_tool
+        ft._patch_failure_tracker.pop("reset-task", None)
+
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "operations": 1}
+        mock_get.return_value.patch_replace.return_value = result_obj
+
+        # Two bad calls, then a good one, then a bad one again.
+        for _ in range(2):
+            patch_tool(mode="replace", path=None, old_string="a",
+                       new_string="b", task_id="reset-task")
+        patch_tool(mode="replace", path="/tmp/f.py", old_string="a",
+                   new_string="b", task_id="reset-task")
+        after_reset = json.loads(patch_tool(
+            mode="replace", path=None, old_string="a", new_string="b",
+            task_id="reset-task"))
+        # Counter was reset by the valid call, so this lone bad call is #1
+        # again — no premature escalation.
+        assert "_hint" not in after_reset
+
+    @patch("tools.file_tools._get_file_ops")
     def test_patch_v4a_rejects_traversal_in_update_header(self, mock_get):
         """V4A '*** Update File:' headers come from patch content, which can
         carry prompt-injection-controlled paths (skill content, web extract).

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -52,7 +53,12 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        # The tool resolves symlinks (e.g. macOS /tmp -> /private/tmp), so
+        # compare the realpath rather than the literal string.
+        mock_ops.write_file.assert_called_once()
+        called_path, called_content = mock_ops.write_file.call_args[0]
+        assert os.path.realpath(called_path) == os.path.realpath("/tmp/out.txt")
+        assert called_content == "hello world!\n"
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -143,8 +149,39 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        # Path is resolved (symlink-canonicalized) before dispatch.
+        mock_ops.patch_replace.assert_called_once()
+        args = mock_ops.patch_replace.call_args[0]
+        assert os.path.realpath(args[0]) == os.path.realpath("/tmp/f.py")
+        assert args[1:] == ("foo", "bar", False)
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_replace_all_flag(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "replacements": 5}
+        mock_ops.patch_replace.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+        patch_tool(mode="replace", path="/tmp/f.py",
+                   old_string="x", new_string="y", replace_all=True)
+        mock_ops.patch_replace.assert_called_once()
+        args = mock_ops.patch_replace.call_args[0]
+        assert os.path.realpath(args[0]) == os.path.realpath("/tmp/f.py")
+        assert args[1:] == ("x", "y", True)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_missing_path_errors(self, mock_get):
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(mode="replace", path=None, old_string="a", new_string="b"))
+        assert "error" in result
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_missing_strings_errors(self, mock_get):
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(mode="replace", path="/tmp/f.py", old_string=None, new_string="b"))
+        assert "error" in result
 
     @patch("tools.file_tools._get_file_ops")
     def test_patch_mode_calls_patch_v4a(self, mock_get):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,7 +71,12 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        # The tool resolves symlinks (e.g. macOS /tmp -> /private/tmp), so
+        # compare the realpath rather than the literal string.
+        mock_ops.write_file.assert_called_once()
+        called_path, called_content = mock_ops.write_file.call_args[0]
+        assert os.path.realpath(called_path) == os.path.realpath("/tmp/out.txt")
+        assert called_content == "hello world!\n"
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -161,7 +167,12 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        # Path is resolved (symlink-canonicalized) before dispatch, so compare
+        # realpaths (macOS /tmp -> /private/tmp) rather than the literal string.
+        mock_ops.patch_replace.assert_called_once()
+        args = mock_ops.patch_replace.call_args[0]
+        assert os.path.realpath(args[0]) == os.path.realpath("/tmp/f.py")
+        assert args[1:] == ("foo", "bar", False)
 
 
     @patch("tools.file_tools._get_file_ops")
@@ -184,6 +195,51 @@ class TestPatchHandler:
         result = json.loads(patch_tool(mode="invalid_mode"))
         assert "error" in result
         assert "Unknown mode" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_repeated_missing_path_escalates_hint(self, mock_get):
+        """Identical malformed patch calls must escalate a break-the-loop hint
+        instead of returning the same bare error forever (issue #63880)."""
+        import tools.file_tools as ft
+        from tools.file_tools import patch_tool
+        ft._patch_failure_tracker.pop("loop-task", None)
+        results = [
+            json.loads(patch_tool(mode="replace", path=None, old_string="a",
+                                  new_string="b", task_id="loop-task"))
+            for _ in range(4)
+        ]
+        # Every call still reports the error with actionable context.
+        assert all("path required" in r["error"] for r in results)
+        # First two rejects: no hint yet; from the third the loop-breaker fires.
+        assert "_hint" not in results[0]
+        assert "_hint" not in results[1]
+        assert "_hint" in results[2]
+        assert "#3" in results[2]["_hint"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_valid_patch_resets_arg_failure_escalation(self, mock_get):
+        """A call that passes arg validation clears the malformed-call counter
+        so escalation only ever counts *consecutive* bad calls."""
+        import tools.file_tools as ft
+        from tools.file_tools import patch_tool
+        ft._patch_failure_tracker.pop("reset-task", None)
+
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "operations": 1}
+        mock_get.return_value.patch_replace.return_value = result_obj
+
+        # Two bad calls, then a good one, then a bad one again.
+        for _ in range(2):
+            patch_tool(mode="replace", path=None, old_string="a",
+                       new_string="b", task_id="reset-task")
+        patch_tool(mode="replace", path="/tmp/f.py", old_string="a",
+                   new_string="b", task_id="reset-task")
+        after_reset = json.loads(patch_tool(
+            mode="replace", path=None, old_string="a", new_string="b",
+            task_id="reset-task"))
+        # Counter was reset by the valid call, so this lone bad call is #1
+        # again — no premature escalation.
+        assert "_hint" not in after_reset
 
     @patch("tools.file_tools._get_file_ops")
     def test_patch_v4a_rejects_traversal_in_update_header(self, mock_get):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -788,7 +788,7 @@ class TestDedupInvalidationTaskResolution:
 
         task_id = "acp-dedup"
         monkeypatch.setattr(tt, "_task_env_overrides", {task_id: {"cwd": str(workspace)}})
-        (workspace / "data.txt").write_text("v1\n")
+        (workspace / "data.txt").write_text("v1\n", encoding="utf-8")
 
         # The task resolves the relative path into the workspace; the default
         # task (the old buggy resolution) would resolve into proc.
@@ -1032,7 +1032,7 @@ class TestNotFoundCache:
         assert _check_not_found_cache("read", str(target), tid) is not None
 
         # Out-of-band creation: plain filesystem write, no tool hook fires.
-        target.write_text("real content\n")
+        target.write_text("real content\n", encoding="utf-8")
 
         # The cached miss must NOT be served once the path exists…
         assert _check_not_found_cache("read", str(target), tid) is None, (
@@ -1056,7 +1056,7 @@ class TestNotFoundCache:
         assert _check_not_found_cache("search", str(missing_dir), tid) is not None
 
         missing_dir.mkdir()
-        (missing_dir / "x.txt").write_text("hi\n")
+        (missing_dir / "x.txt").write_text("hi\n", encoding="utf-8")
 
         assert _check_not_found_cache("search", str(missing_dir), tid) is None, (
             "stale 'Path not found' served after the directory was created"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -863,6 +863,48 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
         for rp in resolved_paths:
             task_failures.pop(rp, None)
 
+
+# Synthetic tracker-key prefix for argument-validation failures (missing
+# path / old_string / patch content, or an unknown mode).  Namespaced with a
+# NUL byte so it can never collide with a real resolved file-system path.
+_ARG_FAILURE_PREFIX = "\x00arg:"
+
+
+def _patch_arg_error(task_id: str, key: str, message: str) -> str:
+    """Return an actionable arg-validation error, escalating on repeats.
+
+    A malformed patch call (no ``path``, missing ``old_string``/``new_string``,
+    empty ``patch`` body, or an unknown ``mode``) is a distinct loop failure
+    mode from a stale ``old_string``: the bare error ("path required") gives
+    the model nothing to change, so it re-sends the identical call — the
+    12-in-a-row ``{"error": "path required"}`` bursts seen in blocker reports.
+    Track these like content failures so a run of identical rejects escalates
+    into a break-the-loop hint instead of burning the turn.
+    """
+    count = _record_patch_failure(task_id, _ARG_FAILURE_PREFIX + key)
+    if count >= 3:
+        return tool_error(
+            message,
+            _hint=(
+                f"This is reject #{count} of the same malformed patch call. "
+                "Stop resending identical arguments — supply the missing or "
+                "corrected fields (or switch to write_file) before calling "
+                "patch again."
+            ),
+        )
+    return tool_error(message)
+
+
+def _reset_patch_arg_failures(task_id: str) -> None:
+    """Clear arg-validation failure counters once a call passes validation."""
+    with _patch_failure_lock:
+        task_failures = _patch_failure_tracker.get(task_id)
+        if not task_failures:
+            return
+        for key in [k for k in task_failures if k.startswith(_ARG_FAILURE_PREFIX)]:
+            task_failures.pop(key, None)
+
+
 # Per-task bounds for the containers inside each _read_tracker[task_id].
 # A CLI session uses one stable task_id for its lifetime; without these
 # caps, a 10k-read session would accumulate ~1.5MB of dict/set state that
@@ -1947,9 +1989,19 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 
             if mode == "replace":
                 if not path:
-                    return tool_error("path required")
+                    return _patch_arg_error(
+                        task_id, "replace:path",
+                        "path required: replace mode needs `path`, "
+                        "`old_string`, and `new_string`. Provide the file "
+                        "path to edit.",
+                    )
                 if old_string is None or new_string is None:
-                    return tool_error("old_string and new_string required")
+                    return _patch_arg_error(
+                        task_id, f"replace:old_new:{path}",
+                        "old_string and new_string required: replace mode "
+                        "needs both — the exact text to find and its "
+                        "replacement.",
+                    )
                 # Pass the resolved ABSOLUTE path to the shell layer so it
                 # operates on the exact file the tool layer resolved — the
                 # shell's own cwd may differ (worktree-cwd bug), and a relative
@@ -1959,7 +2011,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
-                    return tool_error("patch content required")
+                    return _patch_arg_error(
+                        task_id, "patch:content",
+                        "patch content required: patch mode needs the V4A "
+                        "`patch` text, or use replace mode with path/"
+                        "old_string/new_string.",
+                    )
                 # Rewrite V4A headers to the resolved absolute paths so the
                 # shell layer patches the exact files the tool layer resolved
                 # (locked/reported). Without this a relative header re-resolves
@@ -1970,8 +2027,16 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 )
                 result = file_ops.patch_v4a(patch_for_ops)
             else:
-                return tool_error(f"Unknown mode: {mode}")
+                return _patch_arg_error(
+                    task_id, f"mode:{mode}",
+                    f"Unknown mode: {mode}. Use `replace` (path/old_string/"
+                    "new_string) or `patch` (V4A patch text).",
+                )
 
+            # A call that reached here passed arg validation — clear any
+            # accumulated malformed-call counters so the escalation window
+            # only ever counts *consecutive* bad calls.
+            _reset_patch_arg_failures(task_id)
             result_dict = result.to_dict()
             if stale_warnings:
                 result_dict["_warning"] = stale_warnings[0] if len(stale_warnings) == 1 else " | ".join(stale_warnings)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -841,6 +841,47 @@ def _collect_v4a_header_paths(patch: str) -> tuple[list[str], list[str]] | str:
     return paths, content_paths
 
 
+# Synthetic tracker-key prefix for argument-validation failures (missing
+# path / old_string / patch content, or an unknown mode).  Namespaced with a
+# NUL byte so it can never collide with a real resolved file-system path.
+_ARG_FAILURE_PREFIX = "\x00arg:"
+
+
+def _patch_arg_error(task_id: str, key: str, message: str) -> str:
+    """Return an actionable arg-validation error, escalating on repeats.
+
+    A malformed patch call (no ``path``, missing ``old_string``/``new_string``,
+    empty ``patch`` body, or an unknown ``mode``) is a distinct loop failure
+    mode from a stale ``old_string``: the bare error ("path required") gives
+    the model nothing to change, so it re-sends the identical call — the
+    12-in-a-row ``{"error": "path required"}`` bursts seen in blocker reports.
+    Track these like content failures so a run of identical rejects escalates
+    into a break-the-loop hint instead of burning the turn.
+    """
+    count = _record_patch_failure(task_id, _ARG_FAILURE_PREFIX + key)
+    if count >= 3:
+        return tool_error(
+            message,
+            _hint=(
+                f"This is reject #{count} of the same malformed patch call. "
+                "Stop resending identical arguments — supply the missing or "
+                "corrected fields (or switch to write_file) before calling "
+                "patch again."
+            ),
+        )
+    return tool_error(message)
+
+
+def _reset_patch_arg_failures(task_id: str) -> None:
+    """Clear arg-validation failure counters once a call passes validation."""
+    with _patch_failure_lock:
+        task_failures = _patch_failure_tracker.get(task_id)
+        if not task_failures:
+            return
+        for key in [k for k in task_failures if k.startswith(_ARG_FAILURE_PREFIX)]:
+            task_failures.pop(key, None)
+
+
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False,
@@ -876,18 +917,41 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # which file is edited even when the shell's cwd differs.
             if mode == "replace":
                 if not path:
-                    return tool_error("path required")
+                    return _patch_arg_error(
+                        task_id, "replace:path",
+                        "path required: replace mode needs `path`, "
+                        "`old_string`, and `new_string`. Provide the file "
+                        "path to edit.",
+                    )
                 if old_string is None or new_string is None:
-                    return tool_error("old_string and new_string required")
+                    return _patch_arg_error(
+                        task_id, f"replace:old_new:{path}",
+                        "old_string and new_string required: replace mode "
+                        "needs both — the exact text to find and its "
+                        "replacement.",
+                    )
                 _replace_target = _path_to_resolved.get(path) or path
                 result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
-                    return tool_error("patch content required")
+                    return _patch_arg_error(
+                        task_id, "patch:content",
+                        "patch content required: patch mode needs the V4A "
+                        "`patch` text, or use replace mode with path/"
+                        "old_string/new_string.",
+                    )
                 result = file_ops.patch_v4a(_rewrite_v4a_patch_paths_for_host(patch, _path_to_resolved, file_ops))
             else:
-                return tool_error(f"Unknown mode: {mode}")
+                return _patch_arg_error(
+                    task_id, f"mode:{mode}",
+                    f"Unknown mode: {mode}. Use `replace` (path/old_string/"
+                    "new_string) or `patch` (V4A patch text).",
+                )
 
+            # A call that reached here passed arg validation — clear any
+            # accumulated malformed-call counters so the escalation window
+            # only ever counts *consecutive* bad calls.
+            _reset_patch_arg_failures(task_id)
             result_dict = result.to_dict()
             if stale_warnings:
                 result_dict["_warning"] = " | ".join(stale_warnings)


### PR DESCRIPTION
## What does this PR do?

Stops the patch tool from stalling a turn when the model repeatedly sends a
**malformed** patch call.

Argument-validation errors in `patch_tool` — missing `path`, missing
`old_string`/`new_string`, an empty V4A `patch` body, or an unknown `mode` —
returned a bare terse message (`{"error": "path required"}`) and, unlike an
`old_string`-not-found failure, were **not** run through the existing
consecutive-failure tracker. The model gets nothing actionable to change, so it
re-sends the identical malformed call and burns the turn. Blocker report #63880
captured this as `Tool patch returned error: {"error": "path required"}`
repeated 12 times in one turn, followed by `same_tool_failure_warning`.

The fix routes every arg-validation reject through a new `_patch_arg_error`
helper that:

1. Returns an **actionable** error naming exactly which args the chosen mode
   needs (and pointing at `write_file` as a fallback).
2. Records identical rejects in the **existing** per-task failure tracker
   (`_patch_failure_tracker`) under a NUL-namespaced synthetic key, and
   escalates a break-the-loop `_hint` after 3 consecutive rejects — the same
   escalation pattern already used for `old_string`-not-found loops.

A call that passes validation clears the counters, so the escalation window
only ever counts *consecutive* bad calls.

Scope note: the blocker report also lists a verifier-tempfile collision/cleanup
symptom and a `$HERMES_KANBAN_TASK` expansion symptom. Those are separate
agent-behavior issues on different code paths; this PR is deliberately focused
on the patch-tool loop (the `tool/file` + `comp/agent` portion) and does not
touch them.

## Related Issue

Fixes #63880

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py`
  - New `_patch_arg_error(task_id, key, message)` — actionable arg-validation
    error that records the reject in `_patch_failure_tracker` and attaches an
    escalating `_hint` after 3 consecutive identical rejects.
  - New `_reset_patch_arg_failures(task_id)` — clears arg-failure counters once
    a call passes validation (keeps the window to *consecutive* bad calls).
  - `_ARG_FAILURE_PREFIX` — NUL-byte-namespaced key prefix so synthetic
    arg-failure keys can't collide with a real resolved file path.
  - `patch_tool` replace/patch/unknown-mode validation now returns via
    `_patch_arg_error` and clears arg counters after validation passes.
- `tests/tools/test_file_tools.py`
  - `test_repeated_missing_path_escalates_hint` — 4 identical bad calls; hint
    fires from the 3rd.
  - `test_valid_patch_resets_arg_failure_escalation` — a valid call in between
    resets the counter so a later lone bad call doesn't prematurely escalate.
  - Made 3 sibling path assertions symlink-robust (`os.path.realpath`) so the
    file's suite passes on macOS as well as Linux CI.

## How to Test

```
scripts/run_tests.sh tests/tools/test_file_tools.py
```

Result: `54 tests passed, 0 failed`. Includes the two new escalation tests.

This PR also makes three sibling assertions in the same file
(`test_writes_content`, `test_replace_mode_calls_patch_replace`,
`test_replace_mode_replace_all_flag`) symlink-robust: they asserted literal
`/tmp` paths but the file tools resolve symlinks before dispatch, so they
failed on macOS (`/tmp`→`/private/tmp`) while passing on Linux CI. They now
compare `os.path.realpath` of the dispatched path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected tests and they pass (see note on pre-existing macOS-only failures above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — the synthetic key uses a NUL prefix and pure-Python dict ops, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (error-message wording only; tool contract unchanged)
