### PR TITLE
fix(delegate): surface child's resolved toolsets in async completion block (#63887)

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1430,3 +1430,35 @@ def test_async_batch_block_surfaces_resolved_child_toolsets():
     # resolved toolset list, exposing the mismatch to the parent.
     toolset_line = text.split("Toolsets available:")[1].split("\n")[0]
     assert "file" not in toolset_line
+
+
+@pytest.mark.parametrize("status", ["interrupted", "timeout", "error"])
+def test_async_batch_block_surfaces_toolsets_on_synthetic_results(status):
+    """The resolved-toolsets diagnostic must survive the synthetic result entries
+    too (interrupted / timed-out / errored children), not just successful ones —
+    those are exactly the runs where a capability mismatch is most worth seeing.
+    Regression for the per-subagent guarantee gap noted on #63887: fabricated
+    entries used to omit ``toolsets`` so the formatter dropped the line for them.
+    """
+    from tools.process_registry import format_process_notification
+
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-xyz",
+        "is_batch": True,
+        "goals": ["Patch the config file and verify the change"],
+        "results": [
+            {
+                "task_index": 0,
+                "status": status,
+                "summary": None,
+                "error": "child did not finish",
+                "toolsets": ["todo", "web"],
+            },
+        ],
+        "role": "leaf",
+        "model": "deepseek-v4-flash",
+    }
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "Toolsets available: todo, web" in text

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1369,3 +1369,64 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+    def test_reader_still_streams_full_output_to_eof(self, registry):
+        """No-orphan case: the reader must still capture ALL output through
+        true EOF (the early-exit path must not race away buffered tail)."""
+        script = (
+            "for i in 1 2 3 4 5; do echo line-$i; done; "
+            "sleep 0.3; echo tail-after-sleep"
+        )
+        proc = subprocess.Popen(
+            ["sh", "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            preexec_fn=os.setsid,
+        )
+        s = _make_session(sid="proc_orphan_fulldrain")
+        s.process = proc
+        s.pid = proc.pid
+        registry._running[s.id] = s
+
+        registry._reader_loop(s)
+
+        assert s.exited is True
+        assert s.exit_code == 0
+        for i in range(1, 6):
+            assert f"line-{i}" in s.output_buffer
+        assert "tail-after-sleep" in s.output_buffer
+
+
+def test_async_batch_block_surfaces_resolved_child_toolsets():
+    """A batch completion block must render each subagent's RESOLVED toolsets so
+    the parent can catch a goal/capability mismatch — e.g. a "write a file" goal
+    dispatched to a child that never held the file toolset, which a budget-tier
+    child may report as completed with a fabricated verification (issue #63887).
+    """
+    from tools.process_registry import format_process_notification
+
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-abc",
+        "is_batch": True,
+        "goals": ["Write a bridge request file to ~/.hermes/bridge/requests/x.md"],
+        "results": [
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Created the bridge request file and confirmed via cat.",
+                "toolsets": ["todo"],
+            },
+        ],
+        "role": "leaf",
+        "model": "deepseek-v4-flash",
+    }
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "Toolsets available: todo" in text
+    # The impossible capability (file) must be visibly absent from the child's
+    # resolved toolset list, exposing the mismatch to the parent.
+    toolset_line = text.split("Toolsets available:")[1].split("\n")[0]
+    assert "file" not in toolset_line

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2815,3 +2815,62 @@ def test_model_not_found_notice_absent_when_fallback_chain_configured(monkeypatc
     text = _format_async(evt)
     assert text.count("SUBAGENT MODEL REJECTED") == 1
     assert "No fallback chain is configured" not in text
+
+
+def test_async_batch_block_surfaces_resolved_child_toolsets():
+    """A batch completion block must render each subagent's RESOLVED toolsets so
+    the parent can catch a goal/capability mismatch — e.g. a "write a file" goal
+    dispatched to a child that never held the file toolset, which a budget-tier
+    child may report as completed with a fabricated verification (issue #63887).
+    """
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-abc",
+        "is_batch": True,
+        "goals": ["Write a bridge request file to ~/.hermes/bridge/requests/x.md"],
+        "results": [
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Created the bridge request file and confirmed via cat.",
+                "toolsets": ["todo"],
+            },
+        ],
+        "role": "leaf",
+        "model": "deepseek-v4-flash",
+    }
+    text = _format_async(evt)
+    assert "Toolsets available: todo" in text
+    # The impossible capability (file) must be visibly absent from the child's
+    # resolved toolset list, exposing the mismatch to the parent.
+    toolset_line = text.split("Toolsets available:")[1].split("\n")[0]
+    assert "file" not in toolset_line
+
+
+@pytest.mark.parametrize("status", ["interrupted", "timeout", "error"])
+def test_async_batch_block_surfaces_toolsets_on_synthetic_results(status):
+    """The resolved-toolsets diagnostic must survive the synthetic result entries
+    too (interrupted / timed-out / errored children), not just successful ones —
+    those are exactly the runs where a capability mismatch is most worth seeing.
+    Regression for the per-subagent guarantee gap noted on #63887: fabricated
+    entries used to omit ``toolsets`` so the formatter dropped the line for them.
+    """
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-xyz",
+        "is_batch": True,
+        "goals": ["Patch the config file and verify the change"],
+        "results": [
+            {
+                "task_index": 0,
+                "status": status,
+                "summary": None,
+                "error": "child did not finish",
+                "toolsets": ["todo", "web"],
+            },
+        ],
+        "role": "leaf",
+        "model": "deepseek-v4-flash",
+    }
+    text = _format_async(evt)
+    assert "Toolsets available: todo, web" in text

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2300,6 +2300,10 @@ def _run_single_child(
                     else "after_llm_calls" if is_timeout
                     else None
                 ),
+                # Same per-subagent toolsets guarantee as the success/exception
+                # entries above — a timed-out/errored child still surfaces which
+                # capabilities it held so the parent can catch a mismatch (#63887).
+                "toolsets": sorted(child_toolsets),
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
@@ -3061,6 +3065,12 @@ def delegate_task(
                                         "error": str(exc),
                                         "api_calls": 0,
                                         "duration_seconds": 0,
+                                        # Resolved toolsets guarantee also holds for
+                                        # fabricated entries: read them off the stashed
+                                        # child so the parent still sees them (#63887).
+                                        "toolsets": sorted(
+                                            getattr(_child_by_index.get(idx), "_delegate_child_toolsets", None) or []
+                                        ),
                                         "_child_role": getattr(
                                             _child_by_index.get(idx), "_delegate_role", None
                                         ),
@@ -3073,6 +3083,9 @@ def delegate_task(
                                     "error": "Parent agent interrupted — child did not finish in time",
                                     "api_calls": 0,
                                     "duration_seconds": 0,
+                                    "toolsets": sorted(
+                                        getattr(_child_by_index.get(idx), "_delegate_child_toolsets", None) or []
+                                    ),
                                     "_child_role": getattr(
                                         _child_by_index.get(idx), "_delegate_role", None
                                     ),
@@ -3098,6 +3111,9 @@ def delegate_task(
                                 "error": str(exc),
                                 "api_calls": 0,
                                 "duration_seconds": 0,
+                                "toolsets": sorted(
+                                    getattr(_child_by_index.get(idx), "_delegate_child_toolsets", None) or []
+                                ),
                                 "_child_role": getattr(
                                     _child_by_index.get(idx), "_delegate_role", None
                                 ),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1551,6 +1551,11 @@ def _build_child_agent(
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
+    # Stash the child's RESOLVED toolsets (post parent-intersection and
+    # blocked-tool stripping) so _run_single_child can surface them on the
+    # result entry — the entry is built in _run_single_child's scope, where
+    # child_toolsets is not visible (issue #63887).
+    child._delegate_child_toolsets = list(child_toolsets)
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
@@ -1983,6 +1988,11 @@ def _run_single_child(
     _saved_tool_names = getattr(
         child, "_delegate_saved_tool_names", list(model_tools._last_resolved_tool_names)
     )
+
+    # The child's RESOLVED toolsets (post parent-intersection and blocked-tool
+    # stripping), stashed by _build_child_agent. Surfaced on the result entry
+    # so the parent can catch a goal/capability mismatch (issue #63887).
+    child_toolsets = list(getattr(child, "_delegate_child_toolsets", []) or [])
 
     child_pool = getattr(child, "_credential_pool", None)
     leased_cred_id = None

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2386,6 +2386,13 @@ def _run_single_child(
             "summary": summary,
             "api_calls": api_calls,
             "duration_seconds": duration,
+            # The child's RESOLVED toolsets (post parent-intersection and
+            # blocked-tool stripping) — not what the caller requested. Surfaced
+            # in the completion block so the parent can catch a goal/capability
+            # mismatch (e.g. "write a file" dispatched to a child that never
+            # had the file toolset), which a budget-tier child may otherwise
+            # report as completed with a fabricated verification (issue #63887).
+            "toolsets": sorted(child_toolsets),
             "model": _model if isinstance(_model, str) else None,
             "exit_reason": exit_reason,
             "tokens": {
@@ -2535,6 +2542,7 @@ def _run_single_child(
             "error": str(exc),
             "api_calls": 0,
             "duration_seconds": duration,
+            "toolsets": sorted(child_toolsets),
             "_child_role": getattr(child, "_delegate_role", None),
         }
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -251,6 +251,11 @@ def _build_child_agent(
     child_session_ref["session_id"] = getattr(child, "session_id", "") or ""
     child._progress_identity_ref = child_session_ref
     child._delegate_depth, child._delegate_role = child_depth, effective_role  # post-degrade role
+    # Stash the child's RESOLVED toolsets (post parent-intersection and
+    # blocked-tool stripping) so the result-entry builders can surface them
+    # off the child — every entry path reads the child, so a single stash here
+    # covers success, failure, timeout and fabricated entries alike (#63887).
+    child._delegate_child_toolsets = list(child_toolsets)
     child._subagent_id, child._parent_subagent_id = subagent_id, parent_subagent_id
     _apply_child_compression_cap(child, delegation_cfg)
     # Ownership chain for action=list/steer/stop; weakref so a finished parent

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -35,6 +35,10 @@ def _fabricated_entry(idx: int, status: str, error: str, child: Any, duration: f
     return {
         "task_index": idx, "status": status, "summary": None, "error": error, "api_calls": 0,
         "duration_seconds": duration, "_child_role": getattr(child, "_delegate_role", None),
+        # Resolved toolsets survive the synthetic paths too (interrupt / timeout
+        # / raise) — those are exactly the runs where a capability mismatch is
+        # most worth seeing (#63887); empty when the child never got that far.
+        "toolsets": sorted(getattr(child, "_delegate_child_toolsets", None) or []),
     }
 
 def _append_missed_steer(entry: Dict[str, Any], late_steer: Optional[str]) -> None:
@@ -507,6 +511,13 @@ def _build_result_entry(
         # the parent's session cost by the aggregator).
         "_child_role": getattr(child, "_delegate_role", None),
         "_child_cost_usd": float(_cost or 0.0) if isinstance(_cost, (int, float)) else 0.0,
+        # The child's RESOLVED toolsets (post parent-intersection and
+        # blocked-tool stripping) — not what the caller requested. Surfaced so
+        # the parent can catch a goal/capability mismatch (e.g. "write a file"
+        # dispatched to a child that never held the file toolset), which a
+        # budget-tier child may otherwise report as completed with a fabricated
+        # verification narrative (#63887).
+        "toolsets": sorted(getattr(child, "_delegate_child_toolsets", None) or []),
     }
     # Model-visible per-delegation spend (unlike _child_cost_usd above).
     entry["cost_usd"] = round(entry["_child_cost_usd"], 6)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2175,6 +2175,14 @@ def _format_async_delegation(evt: dict) -> str:
                 header += f", {r['duration_seconds']}s"
             header += ") ---"
             lines.append(header)
+            # Resolved toolsets this subagent actually held (post parent
+            # intersection + blocked-tool stripping). Surfacing them lets the
+            # parent notice when a goal required a capability the child never
+            # had — a budget-tier child can otherwise report success with a
+            # fabricated verification narrative (issue #63887).
+            r_toolsets = r.get("toolsets")
+            if r_toolsets:
+                lines.append(f"Toolsets available: {', '.join(r_toolsets)}")
             if r_status in ("completed", "success") and r_summary:
                 lines.append(r_summary)
             elif r_summary:

--- a/tools/process_registry_notifications.py
+++ b/tools/process_registry_notifications.py
@@ -163,6 +163,14 @@ def _format_batch_delegation(evt: dict, deleg_id: str, completed_at: float) -> s
                   + (f", {r['duration_seconds']}s" if r.get("duration_seconds") is not None else "")
                   + (", TRUNCATED: hit max_iterations — work may be incomplete" if r_truncated else ""))
         lines += ["", header + ") ---"]
+        # Resolved toolsets this subagent actually held (post parent
+        # intersection + blocked-tool stripping). Surfacing them lets the parent
+        # notice when a goal required a capability the child never had — a
+        # budget-tier child can otherwise report success with a fabricated
+        # verification narrative (#63887).
+        r_toolsets = r.get("toolsets")
+        if r_toolsets:
+            lines.append(f"Toolsets available: {', '.join(r_toolsets)}")
         if r_status in _DONE and r_summary:
             if r_truncated:
                 lines.append(_TRUNCATED_SUMMARY_NOTE)
@@ -201,6 +209,12 @@ def _format_async_delegation(evt: dict) -> str:
         f"Status: {status}   API calls: {evt.get('api_calls', 0)}   Duration: {evt.get('duration_seconds', '?')}s"
         + (" [TRUNCATED: hit max_iterations — work may be incomplete]" if truncated else ""),
         "--- RESULT ---"]
+    # Same resolved-toolsets diagnostic as the batch block: the parent can catch
+    # a goal/capability mismatch the child may have masked with a fabricated
+    # verification narrative (#63887).
+    _toolsets = evt.get("toolsets")
+    if _toolsets:
+        lines.append(f"Toolsets available: {', '.join(_toolsets)}")
     if status in _DONE and summary:
         if truncated:
             lines.append(_TRUNCATED_SUMMARY_NOTE)


### PR DESCRIPTION
## What does this PR do?

Async delegation records each subagent's full task source (goal, context, role, model) in the completion block that re-enters the parent conversation — but **not the toolsets the child actually held** after parent-intersection and blocked-tool stripping.

Because of that, when a delegation goal structurally requires a toolset the child can never have (e.g. a Telegram parent whose `platform_toolsets` excludes `file`/`terminal` delegates *"Write a bridge request file to ~/.hermes/bridge/requests/<name>.md"*), dispatch proceeds silently. The child never has the tool to do the work, and a budget-tier child model then reports `completed` with a **fabricated verification narrative** ("Confirmed file contents match via `cat`") — nothing anywhere signals the capability mismatch.

This PR implements the issue's suggested minimum: it records each subagent's **resolved** toolset list on its result entry and renders it per-subagent in the batch completion block, so the parent (and human) can see the child never held the required capability and catch the mismatch.

The intersection rule itself is intentionally left unchanged — as the issue notes, "the child correctly cannot have file tools" is good design, not the bug.

## Related Issue

Fixes #63887

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`: add the resolved `child_toolsets` (post parent-intersection + blocked-tool stripping) to each per-task result `entry` — both the normal and the exception-path entry.
- `tools/process_registry.py`: in `_format_async_delegation`, render a `Toolsets available: …` line per subagent in the batch completion block.
- `tests/tools/test_delegate_completion_block.py`: new test asserting the resolved toolsets appear per-task and the impossible capability is visibly absent from the rendered block.

## How to Test

```
scripts/run_tests.sh tests/tools/test_delegate_completion_block.py tests/tools/test_process_registry.py
```

Result: all pass. The new test reproduces the issue scenario — a `completed` child whose resolved toolset is `["todo"]` — and asserts the block now surfaces `Toolsets available: todo` with `file` visibly absent, exposing the mismatch to the parent.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure string/dict rendering)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
