### PR TITLE
fix(mcp): resolve completed future in poll loop to stop TimeoutError spin (#63892)

### DIFF
--- a/tests/tools/test_mcp_loop_completed_future_timeout.py
+++ b/tests/tools/test_mcp_loop_completed_future_timeout.py
@@ -1,0 +1,58 @@
+"""Regression: a completed future whose stored exception is a real
+TimeoutError must surface once, promptly — not spin.
+
+On Py>=3.8 concurrent.futures.TimeoutError IS builtin TimeoutError, so
+_run_on_mcp_loop's poll ``except concurrent.futures.TimeoutError`` also
+catches a DONE future whose coroutine raised a real TimeoutError (e.g. an
+inner asyncio.wait_for hitting mcp_servers.<srv>.timeout). Before the fix,
+re-resolving the done future re-raised the same exception every poll with no
+sleep — a tight spin appending frames to __traceback__ unboundedly, growing
+RSS until the gateway OOM'd. The loop now resolves a done future once.
+"""
+import concurrent.futures
+import time
+
+import pytest
+
+
+@pytest.fixture
+def mcp_loop():
+    import tools.mcp_tool as mcp_tool
+
+    mcp_tool._ensure_mcp_loop()
+    yield mcp_tool
+    mcp_tool._stop_mcp_loop()
+
+
+def test_inner_timeout_surfaces_once_without_spinning(mcp_loop):
+    import asyncio
+
+    async def inner():
+        # Completes (does not stay pending) with a real TimeoutError well
+        # before the outer _run_on_mcp_loop deadline below.
+        return await asyncio.wait_for(asyncio.sleep(60), timeout=0.2)
+
+    start = time.monotonic()
+    with pytest.raises((concurrent.futures.TimeoutError, TimeoutError)) as exc:
+        # Generous outer timeout: a fixed loop returns the inner TimeoutError
+        # in ~0.2s; the buggy spin would instead burn until this 10s deadline
+        # and raise the "MCP call timed out after ..." wrapper message.
+        mcp_loop._run_on_mcp_loop(inner, timeout=10)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5, f"poll spun instead of resolving promptly ({elapsed:.1f}s)"
+    assert "MCP call timed out after" not in str(exc.value)
+
+
+def test_success_race_after_poll_timeout_returns_value(mcp_loop):
+    """A future that completes successfully between a poll's timeout raise and
+    the done() check must return its value — not a re-raised poll timeout."""
+    import asyncio
+
+    async def slow_ok():
+        await asyncio.sleep(0.25)
+        return "ok"
+
+    # wait_timeout starts at 0.1s, so the first few polls time out while the
+    # coroutine is still sleeping; the loop must eventually return the value.
+    assert mcp_loop._run_on_mcp_loop(slow_ok, timeout=10) == "ok"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3676,6 +3676,16 @@ def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
         try:
             return future.result(timeout=wait_timeout)
         except concurrent.futures.TimeoutError:
+            # On Py>=3.8 concurrent.futures.TimeoutError IS builtin TimeoutError,
+            # so this also catches a COMPLETED future whose stored exception is a
+            # real TimeoutError (e.g. an inner asyncio.wait_for hitting the
+            # configured mcp_servers.<srv>.timeout). Re-resolving a done future
+            # returns instantly and re-raises the same exception object, tightly
+            # spinning and growing its __traceback__ unboundedly (gateway OOM).
+            # Resolve once when done: value on a poll/success race, real
+            # exception otherwise — capping the traceback at constant depth.
+            if future.done():
+                return future.result()
             continue
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a P0 gateway OOM in the MCP tool poll loop.

`_run_on_mcp_loop()` in `tools/mcp_tool.py` polls a `concurrent.futures.Future`
and treats `concurrent.futures.TimeoutError` as *"poll expired, keep waiting"*:

```python
try:
    return future.result(timeout=wait_timeout)
except concurrent.futures.TimeoutError:
    continue
```

On Python >= 3.8, `concurrent.futures.TimeoutError` **is** the builtin
`TimeoutError` (same class). So the `except` also catches the case where the
future has **already COMPLETED and its coroutine's stored exception is a real
`TimeoutError`** — e.g. an inner `asyncio.wait_for(...)` around an MCP
`call_tool` hitting the configured `mcp_servers.<srv>.timeout`.

When that happens the loop degenerates: `future.result()` returns instantly
(the future is done), re-raises the *same* exception object, the `except`
swallows it, `continue` — a tight spin with no sleep. Each re-raise appends
frames to that one exception object's `__traceback__`, a live-object leak that
grows RSS at ~108 MB/s and OOM-kills the gateway ~33s after the tool timeout
fires. The tool-error handler is never reached, so logs stay silent.

The fix resolves a **done** future once inside the handler: a poll/success race
returns the value, a real stored exception is raised exactly once — capping the
traceback at constant depth and surfacing a single clean `TimeoutError` to the
tool-error path. `if future.done(): raise` alone would be wrong (it would
re-raise the *poll* timeout when the future completed successfully between the
poll raise and the check); `return future.result()` handles both cases.

## Related Issue

Fixes #63892

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` — in `_run_on_mcp_loop()`'s poll loop, on
  `concurrent.futures.TimeoutError` check `future.done()` and, if so, return
  `future.result()` (resolve once) instead of unconditionally `continue`.
- `tests/tools/test_mcp_loop_completed_future_timeout.py` — regression tests:
  a completed future carrying a real `TimeoutError` surfaces once and promptly
  (no spin); a future that completes successfully mid-poll returns its value.

## How to Test

```
scripts/run_tests.sh tests/tools/test_mcp_loop_completed_future_timeout.py tests/tools/test_mcp_tool.py
```

Result: PASS. Confirmed the regression test **fails without the fix** — the
poll spins ~15s and raises the `MCP call timed out after ...` wrapper instead
of the inner `TimeoutError` — and **passes with it** (returns in ~0.2s).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests and they pass (`scripts/run_tests.sh tests/tools/test_mcp_loop_completed_future_timeout.py tests/tools/test_mcp_tool.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Credits

Diagnosis, standalone repro, measured impact figures, and the two-line fix
approach are from the issue reporter in #63892 — this PR implements their
suggested guard and adds regression coverage.
