### PR TITLE
fix(providers): add api_key_header config option for custom auth header name

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -960,6 +960,22 @@ def init_agent(
                         client_kwargs["default_headers"] = dict(_ph.default_headers)
                 except Exception:
                     pass
+
+            # ── Custom API key header (e.g. Azure APIM expects "api-key" instead of
+            #    "Authorization: Bearer").  When the profile declares a non-default
+            #    api_key_header, inject it as a default_headers entry so the OpenAI
+            #    SDK sends both the conventional Authorization: Bearer (from its
+            #    own auth machinery) and the provider-specific header.  Azure APIM
+            #    and similar gateways pick up the header they recognise.
+            try:
+                from providers import get_provider_profile as _gpf
+                _ph = _gpf(agent.provider)
+                if _ph and _ph.api_key_header and api_key:
+                    _custom_headers = dict(client_kwargs.get("default_headers", {}))
+                    _custom_headers[_ph.api_key_header] = api_key
+                    client_kwargs["default_headers"] = _custom_headers
+            except Exception:
+                pass
         else:
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client

--- a/plugins/model-providers/azure-foundry/__init__.py
+++ b/plugins/model-providers/azure-foundry/__init__.py
@@ -16,6 +16,8 @@ azure_foundry = ProviderProfile(
     env_vars=("AZURE_FOUNDRY_API_KEY", "AZURE_FOUNDRY_BASE_URL"),
     base_url="",  # per-resource; user provides at setup
     auth_type="api_key",
+    api_key_header="api-key",
+    api_key_scheme="",  # plain key, no Bearer prefix
 )
 
 register_provider(azure_foundry)

--- a/providers/base.py
+++ b/providers/base.py
@@ -54,6 +54,8 @@ class ProviderProfile:
     base_url: str = ""
     models_url: str = ""  # explicit models endpoint; falls back to {base_url}/models
     auth_type: str = "api_key"   # api_key|oauth_device_code|oauth_external|copilot|aws_sdk
+    api_key_header: str = ""  # HTTP header name for the API key; empty = "Authorization" (Bearer scheme)
+    api_key_scheme: str = ""  # Auth scheme prefix; empty = "Bearer" (e.g. "" for api-key header, "Bearer" for Authorization)
     supports_health_check: bool = True  # False → doctor skips /models probe for this provider
 
     # ── Vision support ────────────────────────────────────────
@@ -200,7 +202,12 @@ class ProviderProfile:
 
         req = urllib.request.Request(url)
         if api_key:
-            req.add_header("Authorization", f"Bearer {api_key}")
+            _key_header = self.api_key_header or "Authorization"
+            _key_scheme = self.api_key_scheme or "Bearer"
+            if _key_header == "Authorization":
+                req.add_header(_key_header, f"{_key_scheme} {api_key}")
+            else:
+                req.add_header(_key_header, api_key)
         req.add_header("Accept", "application/json")
         # Some providers (e.g. OpenCode Zen) sit behind a WAF that blocks
         # the default ``Python-urllib/<ver>`` User-Agent.  Set a generic


### PR DESCRIPTION
## Description

Add `api_key_header` and `api_key_scheme` fields to `ProviderProfile` so providers that use a non-standard auth header can declare a custom header name. 

Azure APIM (API Management) instances expect the `api-key` header instead of `Authorization: Bearer` — this caused every request to fail with HTTP 401 when using `provider: azure-foundry` or `provider: custom` with an Azure APIM endpoint.

### Changes

1. **providers/base.py**: Add `api_key_header` and `api_key_scheme` fields to `ProviderProfile`
2. **plugins/model-providers/azure-foundry/__init__.py**: Set `api_key_header="api-key"` and `api_key_scheme=""` for Azure APIM compatibility
3. **agent/agent_init.py**: When building OpenAI client kwargs, inject the custom auth header into `default_headers` when the profile declares a non-default `api_key_header`

Fixes #63303