### PR TITLE
fix(web): make default foreground color visible (0% -> 100% opacity)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -51,9 +51,9 @@
   /* LENS_0 — from design-language/src/ui/components/overlays/index.tsx.
      These are the defaults for the `default` (Hermes Teal) dashboard theme;
      ThemeProvider rewrites them as inline styles when a user switches themes. */
-  --foreground: color-mix(in srgb, #ffffff 0%, transparent);
+  --foreground: color-mix(in srgb, #ffffff 100%, transparent);
   --foreground-base: #ffffff;
-  --foreground-alpha: 0;
+  --foreground-alpha: 1;
   --midground: color-mix(in srgb, #ffe6cb 100%, transparent);
   --midground-base: #ffe6cb;
   --midground-alpha: 1;


### PR DESCRIPTION
## Description

The CSS `:root` default for `--foreground` was set to `0%` white (`color-mix(in srgb, #ffffff 0%, transparent)`), making it fully transparent. The ThemeProvider normally overrides this on mount, but on long sessions with heavy re-renders the default (transparent) could temporarily apply, causing invisible text blocks in the chat area.

### Root Cause

Line 54 in `web/src/index.css`:
```css
--foreground: color-mix(in srgb, #ffffff 0%, transparent);  /* 0% white = fully transparent! */
```

The `0%` in the color-mix function means 0% of the first color (`#ffffff`) and 100% of the second (`transparent`), resulting in full transparency.

### Fix

Changed to `100%` so the default foreground is fully opaque white:
```css
--foreground: color-mix(in srgb, #ffffff 100%, transparent);  /* 100% white = fully opaque */
```

Also updated `--foreground-alpha` from `0` to `1` for consistency.

Fixes #63384