### PR TITLE
fix(projects): prevent database init races

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -28,6 +28,7 @@ import os
 import re
 import secrets
 import sqlite3
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -149,7 +150,19 @@ def _normalize_path(path: str) -> str:
 # Connection management
 # ---------------------------------------------------------------------------
 
-_INITIALIZED_PATHS: set[str] = set()
+_INITIALIZED_PATHS: dict[str, tuple[int, int]] = {}
+_INIT_LOCK = threading.RLock()
+
+
+def _file_identity(path: Path) -> Optional[tuple[int, int]]:
+    """Return a stable identity for a database file, if the filesystem has one."""
+    try:
+        stat_result = path.stat()
+    except OSError:
+        return None
+    if not stat_result.st_ino:
+        return None
+    return int(stat_result.st_dev), int(stat_result.st_ino)
 
 
 def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
@@ -157,26 +170,32 @@ def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
 
     WAL with DELETE fallback for network filesystems (shared helper from
     ``hermes_state``). Schema init is idempotent (``CREATE TABLE IF NOT
-    EXISTS`` + additive migrations) and cached per-path per-process.
+    EXISTS`` + additive migrations) and cached per file identity per-process.
     """
     path = db_path if db_path is not None else projects_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     resolved = str(path.resolve())
-    conn = sqlite3.connect(str(path))
-    try:
-        conn.row_factory = sqlite3.Row
-        from hermes_state import apply_wal_with_fallback
+    with _INIT_LOCK:
+        conn = sqlite3.connect(str(path))
+        try:
+            conn.row_factory = sqlite3.Row
+            from hermes_state import apply_wal_with_fallback
 
-        apply_wal_with_fallback(conn, db_label="projects.db")
-        conn.execute("PRAGMA foreign_keys=ON")
-        if resolved not in _INITIALIZED_PATHS:
-            conn.executescript(SCHEMA_SQL)
-            _migrate_add_optional_columns(conn)
-            _INITIALIZED_PATHS.add(resolved)
-    except Exception:
-        conn.close()
-        raise
-    return conn
+            apply_wal_with_fallback(conn, db_label="projects.db")
+            conn.execute("PRAGMA foreign_keys=ON")
+            identity = _file_identity(path)
+            if identity is None or _INITIALIZED_PATHS.get(resolved) != identity:
+                conn.executescript(SCHEMA_SQL)
+                _migrate_add_optional_columns(conn)
+                identity = _file_identity(path)
+                if identity is None:
+                    _INITIALIZED_PATHS.pop(resolved, None)
+                else:
+                    _INITIALIZED_PATHS[resolved] = identity
+        except Exception:
+            conn.close()
+            raise
+        return conn
 
 
 @contextlib.contextmanager

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import sqlite3
+import threading
 
 import pytest
 
@@ -172,3 +174,63 @@ def test_db_path_under_hermes_home():
     # Resolves under HERMES_HOME (set by the autouse isolation fixture).
     assert pdb.projects_db_path().name == "projects.db"
     assert os.path.basename(str(pdb.projects_db_path().parent))  # non-empty parent
+
+
+def test_concurrent_first_connect_does_not_race_wal_initialization(tmp_path):
+    """Fresh stores must initialize cleanly even when desktop workers open them together."""
+    db_path = tmp_path / "projects.db"
+    barrier = threading.Barrier(12)
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            barrier.wait(timeout=5)
+            with pdb.connect_closing(db_path) as db:
+                db.execute("SELECT 1 FROM projects").fetchone()
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+
+
+def test_connect_reinitializes_replaced_database(tmp_path):
+    """Replacing projects.db in-process must not leave its schema cache stale."""
+    db_path = tmp_path / "projects.db"
+    with pdb.connect_closing(db_path):
+        pass
+
+    replacement = tmp_path / "legacy-projects.db"
+    legacy = sqlite3.connect(str(replacement))
+    try:
+        legacy.execute(
+            "CREATE TABLE projects ("
+            "id TEXT PRIMARY KEY, slug TEXT NOT NULL UNIQUE, name TEXT NOT NULL, "
+            "description TEXT, created_at INTEGER NOT NULL, "
+            "archived INTEGER NOT NULL DEFAULT 0)"
+        )
+        legacy.commit()
+    finally:
+        legacy.close()
+    os.replace(replacement, db_path)
+
+    with pdb.connect_closing(db_path) as db:
+        project_id = pdb.create_project(
+            db,
+            name="Recovered",
+            icon="folder",
+            color="#2f855a",
+            board_slug="work",
+            primary_path="/tmp/recovered",
+        )
+        project = pdb.get_project(db, project_id)
+
+    assert project is not None
+    assert project.icon == "folder"
+    assert project.board_slug == "work"


### PR DESCRIPTION
## Summary

- Serialize first opens of projects.db so concurrent desktop workers cannot race WAL setup.
- Re-run idempotent schema setup when projects.db is atomically replaced, so restored legacy snapshots receive current columns.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_projects_db.py -k 'concurrent_first_connect or reinitializes_replaced' -q`
- `uv run ruff check hermes_cli/projects_db.py tests/hermes_cli/test_projects_db.py`
- `.venv/Scripts/python.exe -m py_compile hermes_cli/projects_db.py tests/hermes_cli/test_projects_db.py`

## Scope

Does not change active SQLite-handle behavior or add a cross-process lock.
