### PR TITLE
fix(discord): support role mentions and creator-owned threads

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2429,6 +2429,7 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
+        "thread_owner_routing": False,    # If True, only threads this bot created get mention-free follow-ups
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4854,18 +4854,67 @@ class DiscordAdapter(BasePlatformAdapter):
         content = getattr(message, "content", "") or ""
         return {match.group(1) for match in re.finditer(r"<@!?(\d+)>", content)}
 
+    def _raw_mentioned_role_ids(self, message: Any) -> set:
+        """Extract Discord role-mention IDs directly from raw message content.
+
+        Covers the raw ``<@&ROLE_ID>`` form so explicit role pings still count
+        even when Discord fails to hydrate ``message.role_mentions``.
+        """
+        content = getattr(message, "content", "") or ""
+        return {match.group(1) for match in re.finditer(r"<@&(\d+)>", content)}
+
+    def _self_role_ids(self, message: Any) -> set[str]:
+        """Return Discord role IDs that belong to this bot in the message's guild."""
+        if not self._client or not self._client.user:
+            return set()
+
+        guild = getattr(message, "guild", None) or getattr(getattr(message, "channel", None), "guild", None)
+        if guild is None:
+            return set()
+
+        member = None
+        get_member = getattr(guild, "get_member", None)
+        if callable(get_member):
+            try:
+                member = get_member(self._client.user.id)
+            except Exception:
+                member = None
+
+        if member is None:
+            member = getattr(guild, "me", None)
+
+        role_ids: set[str] = set()
+        for role in (getattr(member, "roles", None) or []):
+            role_id = getattr(role, "id", None)
+            if role_id is not None:
+                role_ids.add(str(role_id))
+        return role_ids
+
     def _self_is_explicitly_mentioned(self, message: Any) -> bool:
         """Return True when this bot is explicitly @mentioned in the message.
 
         Treats the bot as mentioned if it is either present in the resolved
-        ``message.mentions`` list OR referenced by its raw ``<@ID>`` / ``<@!ID>``
-        form in the message content.
+        ``message.mentions`` list, referenced by its raw ``<@ID>`` / ``<@!ID>``
+        form in the message content, or pinged via one of the bot's own roles
+        (resolved or raw ``<@&ROLE_ID>`` form).
         """
         if not self._client or not self._client.user:
             return False
         if self._client.user in getattr(message, "mentions", []):
             return True
-        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+        if str(self._client.user.id) in self._raw_mentioned_user_ids(message):
+            return True
+
+        self_role_ids = self._self_role_ids(message)
+        if not self_role_ids:
+            return False
+
+        resolved_role_ids = {
+            str(getattr(role, "id"))
+            for role in (getattr(message, "role_mentions", None) or [])
+            if getattr(role, "id", None) is not None
+        }
+        return bool(self_role_ids & (resolved_role_ids | self._raw_mentioned_role_ids(message)))
 
     def _self_is_raw_mentioned(self, message: Any) -> bool:
         """Return True only when this bot has an inline mention token.
@@ -4877,7 +4926,10 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         if not self._client or not self._client.user:
             return False
-        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+        if str(self._client.user.id) in self._raw_mentioned_user_ids(message):
+            return True
+        self_role_ids = self._self_role_ids(message)
+        return bool(self_role_ids and (self_role_ids & self._raw_mentioned_role_ids(message)))
 
     def _discord_bots_require_inline_mention(self) -> bool:
         """Whether another bot must type an inline @mention to trigger us.
@@ -6172,6 +6224,7 @@ class DiscordAdapter(BasePlatformAdapter):
         raw_content = message.content.strip()
         normalized_content = raw_content
         mention_prefix = False
+        in_bot_thread = False
 
         snapshot_attachments = []
         if hasattr(message, "message_snapshots") and message.message_snapshots:
@@ -6188,6 +6241,8 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._client.user:
                 normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
                 normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+            for role_id in self._self_role_ids(message):
+                normalized_content = normalized_content.replace(f"<@&{role_id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
@@ -6580,14 +6635,21 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not media_urls
                 and not pending_text_injection
             ):
-                logger.info(
-                    "[%s] Ignoring mention-only message from %s in %s",
-                    self.name,
-                    getattr(message.author, "display_name", getattr(message.author, "name", "unknown")),
-                    getattr(message.channel, "id", "unknown"),
-                )
-                return
-            event_text = "(The user sent a message with no text content)"
+                # In another bot's thread, an explicit bare mention is an
+                # intentional "join this thread" signal. Preserve that by
+                # surfacing a small placeholder text turn instead of dropping it.
+                if is_thread and not in_bot_thread:
+                    event_text = "(The user explicitly mentioned you to join this thread)"
+                else:
+                    logger.info(
+                        "[%s] Ignoring mention-only message from %s in %s",
+                        self.name,
+                        getattr(message.author, "display_name", getattr(message.author, "name", "unknown")),
+                        getattr(message.channel, "id", "unknown"),
+                    )
+                    return
+            if not event_text or not event_text.strip():
+                event_text = "(The user sent a message with no text content)"
 
         _chan = message.channel
         _parent_id = str(getattr(_chan, "parent_id", "") or "")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -850,9 +850,13 @@ class DiscordAdapter(BasePlatformAdapter):
         self._ambient_pcm_cache: Optional[bytes] = None  # decoded ambient bed
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
         # Track threads where the bot has participated so follow-up messages
-        # in those threads don't require @mention.  Persisted to disk so the
+        # in those threads don't require @mention. Persisted to disk so the
         # set survives gateway restarts.
         self._threads = ThreadParticipationTracker("discord")
+        # Track threads this bot CREATED. In creator-owns-thread mode, only
+        # these threads get ambient follow-ups; merely replying once in another
+        # bot's thread is not enough to claim it.
+        self._owned_threads = ThreadParticipationTracker("discord_owned")
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
@@ -4686,6 +4690,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Track thread participation so follow-ups don't require @mention
         if thread_id:
             self._threads.mark(thread_id)
+            self._owned_threads.mark(thread_id)
 
         # If a message was provided, kick off a new Hermes session in the thread
         starter = (message or "").strip()
@@ -4962,6 +4967,21 @@ class DiscordAdapter(BasePlatformAdapter):
                 return configured.lower() not in {"false", "0", "no", "off"}
             return bool(configured)
         return os.getenv("DISCORD_THREAD_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
+
+    def _discord_thread_owner_routing(self) -> bool:
+        """Return whether only bot-created threads get ambient follow-ups.
+
+        When enabled, a Discord bot only treats a thread as mention-free if it
+        CREATED that thread itself. Merely having replied once in a thread does
+        not grant ownership, which prevents two Hermes profiles from both
+        latching onto the same thread forever after a single explicit mention.
+        """
+        configured = self.config.extra.get("thread_owner_routing")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            return bool(configured)
+        return os.getenv("DISCORD_THREAD_OWNER_ROUTING", "false").lower() in {"true", "1", "yes", "on"}
 
     def _discord_history_backfill(self) -> bool:
         """Return whether history backfill is enabled for shared sessions."""
@@ -6204,14 +6224,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 or is_voice_linked_channel
             )
 
-            # Skip the mention check if the message is in a thread where
-            # the bot has previously participated (auto-created or replied in)
-            # — UNLESS thread_require_mention is enabled, in which case threads
-            # are gated the same as channels.  Useful when multiple bots share
-            # a thread.
+            # Skip the mention check if the message is in a thread the bot may
+            # ambiently own. Default behavior keys off prior participation;
+            # creator-owns-thread mode narrows that to threads this bot
+            # created itself. UNLESS thread_require_mention is enabled, in
+            # which case threads are gated the same as channels.
+            ambient_thread_ids = self._owned_threads if self._discord_thread_owner_routing() else self._threads
             in_bot_thread = (
                 is_thread
-                and thread_id in self._threads
+                and bool(thread_id)
+                and thread_id in ambient_thread_ids
                 and not self._discord_thread_require_mention()
             )
 
@@ -6237,6 +6259,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     thread_id = str(thread.id)
                     auto_threaded_channel = thread
                     self._threads.mark(thread_id)
+                    self._owned_threads.mark(thread_id)
                     # Pre-seed dedup: when _auto_create_thread creates a thread
                     # via message.create_thread(), Discord fires a second
                     # MESSAGE_CREATE event for the "thread starter message".
@@ -8269,6 +8292,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
     if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
         os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
+    if "thread_owner_routing" in discord_cfg and not os.getenv("DISCORD_THREAD_OWNER_ROUTING"):
+        os.environ["DISCORD_THREAD_OWNER_ROUTING"] = str(discord_cfg["thread_owner_routing"]).lower()
     if "bots_require_inline_mention" in discord_cfg and not os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION"):
         os.environ["DISCORD_BOTS_REQUIRE_INLINE_MENTION"] = str(discord_cfg["bots_require_inline_mention"]).lower()
     platforms_cfg = yaml_cfg.get("platforms")

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -638,6 +638,24 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
+    def test_bridges_discord_thread_owner_routing_from_config_yaml(self, tmp_path, monkeypatch):
+        """discord.thread_owner_routing in config.yaml should reach the runtime env var."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  thread_owner_routing: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_THREAD_OWNER_ROUTING", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_THREAD_OWNER_ROUTING") == "true"
+
     def test_thread_require_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
         """Explicit env var should win over config.yaml (env > yaml precedence)."""
         hermes_home = tmp_path / ".hermes"
@@ -656,6 +674,24 @@ class TestLoadGatewayConfig:
 
         # Env value preserved, not clobbered by yaml.
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
+
+    def test_thread_owner_routing_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
+        """Explicit env var should win over config.yaml for creator-owned thread routing."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  thread_owner_routing: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_THREAD_OWNER_ROUTING", "true")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_THREAD_OWNER_ROUTING") == "true"
 
     def test_bridges_discord_bots_require_inline_mention_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.bots_require_inline_mention should reach the runtime env var."""

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -128,12 +128,13 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None, msg_type=None):
+def make_message(*, channel, content: str, mentions=None, role_mentions=None, msg_type=None):
     author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
+        role_mentions=list(role_mentions or []),
         attachments=[],
         reference=None,
         created_at=datetime.now(timezone.utc),
@@ -808,6 +809,53 @@ async def test_discord_thread_owner_routing_keeps_bot_created_threads_open(adapt
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_bare_role_mention_joins_foreign_thread(adapter, monkeypatch):
+    """A bare role mention should wake the non-owner bot in another bot's thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["thread_owner_routing"] = True
+
+    role_id = 1522315013522718795
+    bot_member = SimpleNamespace(id=999, roles=[SimpleNamespace(id=role_id)])
+    guild = SimpleNamespace(
+        name="Hermes Server",
+        get_member=lambda user_id: bot_member if user_id == 999 else None,
+    )
+    thread = FakeThread(channel_id=456, name="hermes-owned thread", guild_name="Hermes Server")
+    thread.guild = guild
+    adapter._threads.mark("456")  # we replied here once, but did not create it
+
+    message = make_message(channel=thread, content=f"<@&{role_id}>")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "(The user explicitly mentioned you to join this thread)"
+
+
+@pytest.mark.asyncio
+async def test_discord_bare_role_mention_in_channel_still_ignored(adapter, monkeypatch):
+    """Bare mention-only pings stay ignored outside threads."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    role_id = 1522315013522718795
+    bot_member = SimpleNamespace(id=999, roles=[SimpleNamespace(id=role_id)])
+    guild = SimpleNamespace(
+        name="Hermes Server",
+        get_member=lambda user_id: bot_member if user_id == 999 else None,
+    )
+    channel = FakeTextChannel(channel_id=123)
+    channel.guild = guild
+
+    message = make_message(channel=channel, content=f"<@&{role_id}>")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
 
 
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -108,6 +108,7 @@ def adapter(monkeypatch):
     for _var in (
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_THREAD_REQUIRE_MENTION",
+        "DISCORD_THREAD_OWNER_ROUTING",
         "DISCORD_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
         "DISCORD_NO_THREAD_CHANNELS",
@@ -772,6 +773,41 @@ async def test_discord_thread_require_mention_via_config_extra(adapter, monkeypa
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_owner_routing_ignores_foreign_thread_followups(adapter, monkeypatch):
+    """Creator-owns-thread mode should not ambiently follow up in another bot's thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["thread_owner_routing"] = True
+
+    thread = FakeThread(channel_id=456, name="athena-owned thread")
+    adapter._threads.mark("456")  # we replied here once, but did not create it
+
+    message = make_message(channel=thread, content="ambient chatter — not ours")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_owner_routing_keeps_bot_created_threads_open(adapter, monkeypatch):
+    """Creator-owns-thread mode still allows ambient follow-ups in bot-created threads."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["thread_owner_routing"] = True
+
+    thread = FakeThread(channel_id=456, name="hermes-owned thread")
+    adapter._threads.mark("456")
+    adapter._owned_threads.mark("456")
+
+    message = make_message(channel=thread, content="follow-up without mention")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
 
 
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -280,6 +280,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_COMMAND_SYNC_POLICY` | No | `"safe"` | Controls native slash-command startup sync. `"safe"` diffs existing global commands and only updates what changed, recreating commands when Discord metadata changes cannot be applied via patch. `"bulk"` preserves the old `tree.sync()` behavior. `"off"` skips startup sync entirely. |
 | `DISCORD_REQUIRE_MENTION` | No | `true` | When `true`, the bot only responds in server channels when `@mentioned`. Set to `false` to respond to all messages in every channel. |
 | `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, the in-thread mention shortcut is disabled — threads are gated the same as channels, requiring `@mention` even after the bot has already participated. Use this when multiple bots share a thread and you want each to fire only on explicit `@mention`. |
+| `DISCORD_THREAD_OWNER_ROUTING` | No | `false` | When `true`, only threads this bot created itself stay mention-free. A single explicit reply inside another bot's thread does not claim ambient ownership. |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
@@ -316,6 +317,7 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
+  thread_owner_routing: false     # If true, only bot-created threads stay mention-free
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
@@ -352,6 +354,20 @@ In **multi-bot threads** where users address one bot per turn, this default beco
 discord:
   require_mention: true
   thread_require_mention: true    # multi-bot setup
+```
+
+#### `discord.thread_owner_routing`
+
+**Type:** boolean — **Default:** `false`
+
+A middle ground for multi-bot setups: when enabled, a bot only gets mention-free follow-ups inside threads that **it created itself**. If it merely replies once in another bot's thread, that does **not** make the thread ambiently routed to it.
+
+This is useful when you want "thread creator owns the thread" behavior instead of forcing an `@mention` on every turn. Explicit `@mentions` still work across bots.
+
+```yaml
+discord:
+  require_mention: true
+  thread_owner_routing: true      # creator owns thread
 ```
 
 #### `discord.free_response_channels`


### PR DESCRIPTION
## Summary
- allow a bot to treat its Discord role mentions as explicit mentions, including raw role tokens
- add optional creator-owned thread routing so a bot does not claim ambient follow-ups in another bot's thread
- preserve an explicit bare role ping as a request to join a foreign thread
- document and test the configuration

## Validation
- `uv run --with pytest --with pytest-asyncio python -m pytest -q tests/gateway/test_config.py tests/gateway/test_discord_free_response.py` (164 passed)

This addresses multi-bot Discord servers where each bot should only follow up ambiently in threads it created, while still responding to explicit role pings.