### PR TITLE
fix(gateway): let internal events bypass Telegram topic lobby

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10304,7 +10304,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
-        if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
+        if not is_internal and await asyncio.to_thread(
+            self._is_telegram_topic_root_lobby, source
+        ):
             # Debounce the lobby reminder so a user who forgets about
             # topic mode and fires ten prompts doesn't get ten copies.
             if self._should_send_telegram_lobby_reminder(source):

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -184,6 +184,34 @@ async def test_root_telegram_dm_prompt_is_system_lobby_when_topic_mode_enabled(m
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("thread_id", [None, "1"])
+async def test_internal_root_telegram_dm_event_bypasses_topic_lobby(
+    monkeypatch, thread_id
+):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner._handle_message_with_agent = AsyncMock(return_value="agent response")
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    event = MessageEvent(
+        text="[SYSTEM: kanban task completed]",
+        source=_make_source(thread_id=thread_id),
+        message_id="wake-1",
+        internal=True,
+    )
+    result = await runner._handle_message(event)
+
+    assert result == "agent response"
+    assert runner._handle_message_with_agent.await_count == 1
+    assert runner._handle_message_with_agent.await_args.args[0] is event
+
+
+@pytest.mark.asyncio
 async def test_root_telegram_dm_new_shows_create_topic_instruction(monkeypatch):
     import gateway.run as gateway_run
 


### PR DESCRIPTION
## Summary
- apply the Telegram DM topic root-lobby gate only to user-originated events
- keep the existing root/General lobby reminder behavior for external messages
- cover internal kanban-style wakes with both an omitted `thread_id` and Telegram General topic ID `1`

## Current-main proof
On `f6d1fd511ca8173f634fd42a582e43c3d6181762`, an `internal=True` root-DM event returned the lobby reminder and `_handle_message_with_agent` was never called (`agent_calls=0`). After this change, both root forms reach the agent dispatch path while the existing external-message lobby regression remains green.

## Sibling-path audit
`_is_telegram_topic_root_lobby` has one other dispatch use: the explicit `/new` command path. That path remains unchanged because it owns user-facing command semantics rather than the general internal-event gate. Kanban notifier, internal authorization, busy-session, async session-store, and adjacent topic-session tests are included in the validation below.

## Validation
- `uv run --extra dev pytest -q tests/gateway/test_telegram_topic_mode.py -k 'root_telegram_dm_prompt_is_system_lobby or internal_root_telegram_dm_event_bypasses_topic_lobby or general_topic_is_treated_as_root_lobby'` (4 passed)
- `uv run --extra dev pytest -q tests/gateway/test_telegram_topic_mode.py tests/gateway/test_internal_event_bypass_pairing.py tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_async_session_store.py` (63 passed)
- `uv run --extra dev pytest -q tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py tests/gateway/test_kanban_watchers_mixin.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_dm_topics.py` (64 passed)
- `uv run --extra dev ruff check gateway/run.py tests/gateway/test_telegram_topic_mode.py`
- `git diff --check`
- publish gate and gitleaks passed

Closes #63911
