### PR TITLE
feat(discord): require exact bot ID allowlist

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -21,6 +21,7 @@ import os
 from typing import Optional
 
 from gateway.config import Platform
+from gateway.platforms.helpers import parse_numeric_id_allowlist
 from gateway.session import SessionSource
 from gateway.whatsapp_identity import (
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
@@ -357,6 +358,15 @@ class GatewayAuthorizationMixin:
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
             if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+                # Discord requires an exact bot user-ID match in addition to the
+                # broad mode. This gate deliberately runs before the human
+                # allowlist: putting a bot ID in DISCORD_ALLOWED_USERS must not
+                # bypass the bot-specific allowlist.
+                if source.platform == Platform.DISCORD:
+                    raw_allowed_bot_ids = os.getenv("DISCORD_ALLOWED_BOT_IDS", "").strip()
+                    allowed_bot_ids = parse_numeric_id_allowlist(raw_allowed_bot_ids)
+                    if not user_id or str(user_id) not in allowed_bot_ids:
+                        return False
                 return True
 
         if not user_id:

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 from utils import atomic_json_write
 
@@ -19,6 +19,20 @@ if TYPE_CHECKING:
     from gateway.platforms.base import MessageEvent
 
 logger = logging.getLogger(__name__)
+
+
+def parse_numeric_id_allowlist(value: Any) -> set[str]:
+    """Parse comma-separated or iterable ASCII numeric IDs, dropping malformed values."""
+    if isinstance(value, (list, tuple, set, frozenset)):
+        values = value
+    else:
+        values = str(value or "").split(",")
+    parsed: set[str] = set()
+    for raw_value in values:
+        candidate = str(raw_value).strip()
+        if candidate and candidate.isascii() and candidate.isdigit():
+            parsed.add(candidate)
+    return parsed
 
 
 # ─── Message Deduplication ────────────────────────────────────────────────────

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -302,7 +302,9 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
         channel/scope ids where ``require_mention`` is waived — same scope
         vocabulary the connector's δ scope grants + ε floor use).
       - ``allowOtherBots``     ← ``{PLATFORM}_ALLOW_BOTS`` in {"mentions","all"}
-        (whether bot-authored messages are admitted; default off).
+        for platforms whose full bot policy fits this broad flag. Discord is
+        always projected as ``False`` because its exact-ID allowlist and
+        mentions/all distinction cannot be represented by the relay contract.
 
     Read from the relay platform's config block (the platform the connector
     fronts, e.g. ``discord:``), falling back to the bridged top-level keys, then
@@ -346,16 +348,20 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
     except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
         pass
 
-    # allow_other_bots ← {PLATFORM}_ALLOW_BOTS in {"mentions","all"} (same gate as
-    # the gateway's own authz_mixin DISCORD_ALLOW_BOTS bypass).
+    # Discord bot relay is deliberately fail-closed. The connector's generic
+    # policy can carry only a broad boolean, not DISCORD_ALLOWED_BOT_IDS or the
+    # mentions/all distinction. Direct Discord intake still supports exact bot
+    # IDs; relayed Discord bot input remains off until the wire contract can
+    # preserve both controls end to end.
     allow_bots_env = os.environ.get(f"{platform.upper()}_ALLOW_BOTS", "").lower().strip()
-    allow_other_bots = allow_bots_env in {"mentions", "all"}
+    allow_other_bots = platform != "discord" and allow_bots_env in {"mentions", "all"}
 
     require_address = bool(require_mention) if require_mention is not None else False
 
-    # Nothing non-default to declare ⇒ let the connector keep its quiet default
-    # (matches absence-of-row semantics on the connector side).
-    if not require_address and not free_response and not allow_other_bots:
+    # Non-Discord platforms can omit an all-default row. Discord must actively
+    # send allowOtherBots=false so an older permissive connector policy cannot
+    # survive an upgrade as stale state.
+    if platform != "discord" and not require_address and not free_response and not allow_other_bots:
         return None
 
     return {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2429,6 +2429,8 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
+        "allow_bots": "none",          # none | mentions | all for bot-authored messages
+        "allowed_bot_ids": [],         # Required exact bot user-ID allowlist when allow_bots is enabled
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -106,7 +106,12 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 
-from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
+from gateway.platforms.helpers import (
+    MessageDeduplicator,
+    ThreadParticipationTracker,
+    convert_table_to_bullets,
+    parse_numeric_id_allowlist,
+)
 from utils import atomic_json_write, env_float, env_int
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -1128,19 +1133,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 _role_authorized = False
                 if getattr(message.author, "bot", False):
-                    allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-                    if allow_bots == "none":
+                    if not adapter_self._discord_bot_message_is_allowed(message):
                         return
-                    elif allow_bots == "mentions":
-                        if not self._self_is_explicitly_mentioned(message):
-                            return
-                    if (
-                        self._discord_bots_require_inline_mention()
-                        and not self._self_is_raw_mentioned(message)
-                    ):
-                        return
-                    # "all" falls through; bot is permitted — skip the
-                    # human-user allowlist below (bots aren't in it).
+                    # Permitted bots skip the human-user allowlist below (bots
+                    # are intentionally scoped by the bot policy instead).
                 else:
                     # Non-bot: enforce the configured user/role allowlists.
                     # Pass guild + is_dm so role checks are scoped to the
@@ -4900,6 +4896,41 @@ class DiscordAdapter(BasePlatformAdapter):
             "on",
         }
 
+    def _discord_allow_bots_mode(self) -> str:
+        """Return the validated bot-input mode with env taking precedence."""
+        configured = os.getenv("DISCORD_ALLOW_BOTS")
+        if configured is None:
+            configured = self.config.extra.get("allow_bots", "none")
+        mode = str(configured or "none").lower().strip()
+        return mode if mode in {"mentions", "all"} else "none"
+
+    def _discord_allowed_bot_ids(self) -> set[str]:
+        """Return the exact bot-ID allowlist with env taking precedence."""
+        configured = os.getenv("DISCORD_ALLOWED_BOT_IDS")
+        if configured is None:
+            configured = self.config.extra.get("allowed_bot_ids", ())
+        return parse_numeric_id_allowlist(configured)
+
+    def _discord_bot_message_is_allowed(self, message: Any) -> bool:
+        """Require both an enabled bot mode and an exact Discord bot-ID match."""
+        allow_bots = self._discord_allow_bots_mode()
+        if allow_bots == "none":
+            return False
+
+        allowed_bot_ids = self._discord_allowed_bot_ids()
+        author_id = str(getattr(message.author, "id", ""))
+        if not author_id or author_id not in allowed_bot_ids:
+            return False
+
+        if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
+            return False
+        if (
+            self._discord_bots_require_inline_mention()
+            and not self._self_is_raw_mentioned(message)
+        ):
+            return False
+        return True
+
     def _discord_channel_keys(self, message: Any, parent_channel_id: Optional[str] = None) -> set[str]:
         """Return channel identifiers accepted by Discord channel config gates.
 
@@ -5024,8 +5055,8 @@ class DiscordAdapter(BasePlatformAdapter):
             return ""
 
         # Determine which bot messages to include in context
-        allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-        include_other_bots = allow_bots_raw != "none"
+        include_other_bots = self._discord_allow_bots_mode() != "none"
+        allowed_bot_ids = self._discord_allowed_bot_ids()
 
         # Use the in-memory cache to narrow the fetch window on hot paths.
         # If we know our last message ID in this channel, pass it as `after`
@@ -5071,7 +5102,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 if (
                     is_bot_author
                     and msg.author != self._client.user
-                    and not include_other_bots
+                    and (
+                        not include_other_bots
+                        or str(getattr(msg.author, "id", "")) not in allowed_bot_ids
+                    )
                 ):
                     return None
                 if not content and msg.attachments:
@@ -8254,6 +8288,7 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
     ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
     ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``,
+    ``DISCORD_ALLOW_BOTS``, ``DISCORD_ALLOWED_BOT_IDS``,
     ``DISCORD_BOTS_REQUIRE_INLINE_MENTION``).
     Rather than rewrite ~50 call sites inside the adapter to read from
     ``PlatformConfig.extra`` instead, this hook keeps the existing
@@ -8269,6 +8304,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
     if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
         os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
+    if "allow_bots" in discord_cfg and "DISCORD_ALLOW_BOTS" not in os.environ:
+        os.environ["DISCORD_ALLOW_BOTS"] = str(discord_cfg["allow_bots"]).lower()
+    allowed_bot_ids = discord_cfg.get("allowed_bot_ids")
+    if allowed_bot_ids is not None and "DISCORD_ALLOWED_BOT_IDS" not in os.environ:
+        if isinstance(allowed_bot_ids, list):
+            allowed_bot_ids = ",".join(str(value) for value in allowed_bot_ids)
+        os.environ["DISCORD_ALLOWED_BOT_IDS"] = str(allowed_bot_ids)
     if "bots_require_inline_mention" in discord_cfg and not os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION"):
         os.environ["DISCORD_BOTS_REQUIRE_INLINE_MENTION"] = str(discord_cfg["bots_require_inline_mention"]).lower()
     platforms_cfg = yaml_cfg.get("platforms")

--- a/tests/gateway/relay/test_relay_policy_send.py
+++ b/tests/gateway/relay/test_relay_policy_send.py
@@ -26,6 +26,8 @@ def _clean_env(monkeypatch):
         "GATEWAY_RELAY_PLATFORMS",
         "GATEWAY_RELAY_BOT_IDS",
         "DISCORD_ALLOW_BOTS",
+        "DISCORD_ALLOWED_BOT_IDS",
+        "SLACK_ALLOW_BOTS",
     ):
         monkeypatch.delenv(k, raising=False)
     monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {}, raising=False)
@@ -51,15 +53,27 @@ def test_projection_maps_require_mention_and_free_response(monkeypatch):
     }
 
 
-def test_projection_allow_other_bots_from_env(monkeypatch):
+def test_projection_discord_refuses_other_bots_even_when_enabled_locally(monkeypatch):
     monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "123456789012345678")
     monkeypatch.setattr(
         "gateway.run._load_gateway_config",
         lambda: {"discord": {"require_mention": True}},
         raising=False,
     )
     pol = relay.relay_relevance_policy()
+    assert pol is not None and pol["allowOtherBots"] is False
+
+
+def test_projection_non_discord_platform_preserves_allow_other_bots(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"slack": {"require_mention": True}},
+        raising=False,
+    )
+    pol = relay.relay_relevance_policy("slack")
     assert pol is not None and pol["allowOtherBots"] is True
 
 
@@ -85,12 +99,22 @@ def test_projection_falls_back_to_top_level_require_mention(monkeypatch):
     assert pol is not None and pol["requireAddress"] is True
 
 
-def test_projection_none_when_all_default(monkeypatch):
-    # No require_mention, no free-response, no allow-bots ⇒ nothing to declare
-    # (the connector's quiet default already matches).
+def test_projection_discord_declares_fail_closed_default(monkeypatch):
+    # Discord must actively overwrite a stale connector policy that once
+    # allowed bots, even when every local relevance knob is now at default.
     monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
     monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {"discord": {}}, raising=False)
-    assert relay.relay_relevance_policy() is None
+    assert relay.relay_relevance_policy() == {
+        "platform": "discord",
+        "requireAddress": False,
+        "freeResponseScopes": [],
+        "allowOtherBots": False,
+    }
+
+
+def test_projection_none_when_non_discord_all_default(monkeypatch):
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {"slack": {}}, raising=False)
+    assert relay.relay_relevance_policy("slack") is None
 
 
 def test_projection_none_when_platform_unresolved(monkeypatch):
@@ -152,13 +176,18 @@ def test_send_skips_when_no_secret(monkeypatch):
     assert called["n"] == 0  # never attempted without a secret to auth with
 
 
-def test_send_skips_when_nothing_to_declare(monkeypatch):
+def test_send_posts_discord_fail_closed_default(monkeypatch):
     _arm(monkeypatch)
     monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {"discord": {}}, raising=False)
-    called = {"n": 0}
-    monkeypatch.setattr(relay, "_post_policy", lambda **k: called.__setitem__("n", called["n"] + 1) or 200)
-    assert relay.send_relay_policy() is False
-    assert called["n"] == 0  # no redundant write of the default
+    captured = {}
+
+    def _fake_post(**kwargs):
+        captured.update(kwargs)
+        return 200
+
+    monkeypatch.setattr(relay, "_post_policy", _fake_post)
+    assert relay.send_relay_policy() is True
+    assert captured["policy"]["allowOtherBots"] is False
 
 
 def test_send_fail_soft_on_transport_error(monkeypatch):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -675,6 +675,76 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("DISCORD_BOTS_REQUIRE_INLINE_MENTION") == "true"
 
+    def test_bridges_discord_bot_id_allowlist_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  allow_bots: mentions\n"
+            "  allowed_bot_ids:\n"
+            "    - \"111222333\"\n"
+            "    - \"999888777\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_ALLOW_BOTS", raising=False)
+        monkeypatch.delenv("DISCORD_ALLOWED_BOT_IDS", raising=False)
+
+        try:
+            load_gateway_config()
+
+            assert os.environ.get("DISCORD_ALLOW_BOTS") == "mentions"
+            assert os.environ.get("DISCORD_ALLOWED_BOT_IDS") == "111222333,999888777"
+        finally:
+            # The plugin config bridge writes directly to os.environ, so remove
+            # its values before pytest moves on to tests that assert defaults.
+            os.environ.pop("DISCORD_ALLOW_BOTS", None)
+            os.environ.pop("DISCORD_ALLOWED_BOT_IDS", None)
+
+    def test_discord_bot_policy_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  allow_bots: all\n"
+            "  allowed_bot_ids:\n"
+            "    - \"111222333\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+        monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "999888777")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_ALLOW_BOTS") == "mentions"
+        assert os.environ.get("DISCORD_ALLOWED_BOT_IDS") == "999888777"
+
+    def test_discord_bot_policy_yaml_does_not_overwrite_explicit_empty_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  allow_bots: all\n"
+            "  allowed_bot_ids:\n"
+            "    - \"111222333\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_ALLOW_BOTS", "")
+        monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_ALLOW_BOTS") == ""
+        assert os.environ.get("DISCORD_ALLOWED_BOT_IDS") == ""
+
     def test_bots_require_inline_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
         """Explicit env var should win over config.yaml for inline bot mention gating."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_bot_auth_bypass.py
+++ b/tests/gateway/test_discord_bot_auth_bypass.py
@@ -1,4 +1,4 @@
-"""Regression guard for #4466: DISCORD_ALLOW_BOTS works without DISCORD_ALLOWED_USERS.
+"""Regression guards for Discord bot authorisation.
 
 The bug had two sequential gates both rejecting bot messages:
 
@@ -9,8 +9,8 @@ The bug had two sequential gates both rejecting bot messages:
   Gate 2 — `_is_user_authorized` in gateway/run.py rejected bots at the
   gateway level even if they somehow reached that layer.
 
-These tests assert both gates now pass a bot message through when
-DISCORD_ALLOW_BOTS permits it AND no user allowlist entry exists.
+These tests assert both gates now require the bot policy and the exact
+Discord bot-ID allowlist while keeping the human allowlist separate.
 """
 
 from types import SimpleNamespace
@@ -28,6 +28,7 @@ def _isolate_discord_env(monkeypatch):
     """
     for var in (
         "DISCORD_ALLOW_BOTS",
+        "DISCORD_ALLOWED_BOT_IDS",
         "DISCORD_ALLOWED_USERS",
         "DISCORD_ALLOWED_ROLES",
         "DISCORD_ALLOW_ALL_USERS",
@@ -80,29 +81,45 @@ def _make_discord_human_source(user_id: str = "100200300"):
     )
 
 
-def test_discord_bot_authorized_when_allow_bots_mentions(monkeypatch):
-    """DISCORD_ALLOW_BOTS=mentions must authorize a bot sender even when
-    DISCORD_ALLOWED_USERS is set and the bot's ID is NOT in it.
-
-    This is the exact scenario from #4466 — a Cloudflare Worker webhook
-    posts Notion events to Discord, the Hermes bot gets @mentioned, and
-    the webhook's bot ID is not (and shouldn't be) on the human
-    allowlist.
-    """
+def test_discord_bot_rejected_without_exact_bot_allowlist(monkeypatch):
+    """The broad mode alone must not bypass the exact Discord bot-ID gate."""
     runner = _make_bare_runner()
 
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
     monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")  # human-only allowlist
 
     source = _make_discord_bot_source(bot_id="999888777")
+    assert runner._is_user_authorized(source) is False
+
+
+def test_discord_bot_authorized_when_exact_bot_id_is_listed(monkeypatch):
+    runner = _make_bare_runner()
+
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "111222333, 999888777")
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")
+
+    source = _make_discord_bot_source(bot_id="999888777")
     assert runner._is_user_authorized(source) is True
 
 
+def test_discord_bot_rejected_when_exact_bot_id_is_not_listed(monkeypatch):
+    runner = _make_bare_runner()
+
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "111222333")
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "999888777")
+
+    source = _make_discord_bot_source(bot_id="999888777")
+    assert runner._is_user_authorized(source) is False
+
+
 def test_discord_bot_authorized_when_allow_bots_all(monkeypatch):
-    """DISCORD_ALLOW_BOTS=all is a superset of =mentions — should also bypass."""
+    """The exact ID gate also applies when the broad mode is ``all``."""
     runner = _make_bare_runner()
 
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "999888777")
     monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")
 
     source = _make_discord_bot_source()

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -71,6 +71,7 @@ class TestDiscordBotFilter(unittest.TestCase):
         allow_bots="none",
         client_user=None,
         bots_require_inline_mention=False,
+        allowed_bot_ids=(),
     ):
         """Simulate the on_message filter logic and return whether message was accepted."""
         # Replicate the exact filter logic from discord.py on_message
@@ -79,9 +80,11 @@ class TestDiscordBotFilter(unittest.TestCase):
 
         if getattr(message.author, "bot", False):
             allow = allow_bots.lower().strip()
-            if allow == "none":
+            if allow not in {"mentions", "all"}:
                 return False
-            elif allow == "mentions":
+            if str(message.author.id) not in {str(bot_id) for bot_id in allowed_bot_ids}:
+                return False
+            if allow == "mentions":
                 if not self._self_is_explicitly_mentioned(message, client_user):
                     return False
             if (
@@ -113,32 +116,43 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot)
         self.assertFalse(self._run_filter(msg, "none"))
 
-    def test_allow_bots_all_accepts_bots(self):
-        """With allow_bots=all, all bot messages are accepted."""
+    def test_allow_bots_all_accepts_exactly_listed_bot(self):
+        """With allow_bots=all, an exactly listed bot is accepted."""
         bot = _make_author(bot=True)
         msg = _make_message(author=bot)
-        self.assertTrue(self._run_filter(msg, "all"))
+        self.assertTrue(self._run_filter(msg, "all", allowed_bot_ids={bot.id}))
+
+    def test_allow_bots_all_rejects_bot_without_exact_allowlist(self):
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot)
+        self.assertFalse(self._run_filter(msg, "all"))
 
     def test_allow_bots_mentions_rejects_without_mention(self):
         """With allow_bots=mentions, bot messages without @mention are rejected."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[])
-        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(
+            self._run_filter(msg, "mentions", our_user, allowed_bot_ids={bot.id})
+        )
 
     def test_allow_bots_mentions_accepts_with_mention(self):
-        """With allow_bots=mentions, bot messages with @mention are accepted."""
+        """With allow_bots=mentions, listed bot messages with @mention are accepted."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
-        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+        self.assertTrue(
+            self._run_filter(msg, "mentions", our_user, allowed_bot_ids={bot.id})
+        )
 
     def test_allow_bots_mentions_accepts_with_raw_content_mention(self):
         """Raw <@!ID> mention counts even when message.mentions is empty."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, content=f"<@!{our_user.id}> relay", mentions=[])
-        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+        self.assertTrue(
+            self._run_filter(msg, "mentions", our_user, allowed_bot_ids={bot.id})
+        )
 
     def test_inline_mention_requirement_off_preserves_reply_ping_behavior(self):
         """Default behavior: resolved reply-ping mentions still admit bot messages."""
@@ -152,6 +166,7 @@ class TestDiscordBotFilter(unittest.TestCase):
                 "all",
                 our_user,
                 bots_require_inline_mention=False,
+                allowed_bot_ids={bot.id},
             )
         )
 
@@ -167,6 +182,7 @@ class TestDiscordBotFilter(unittest.TestCase):
                 "all",
                 our_user,
                 bots_require_inline_mention=True,
+                allowed_bot_ids={bot.id},
             )
         )
 
@@ -186,6 +202,7 @@ class TestDiscordBotFilter(unittest.TestCase):
                 "all",
                 our_user,
                 bots_require_inline_mention=True,
+                allowed_bot_ids={bot.id},
             )
         )
 
@@ -213,8 +230,8 @@ class TestDiscordBotFilter(unittest.TestCase):
         """Allow_bots value should be case-insensitive."""
         bot = _make_author(bot=True)
         msg = _make_message(author=bot)
-        self.assertTrue(self._run_filter(msg, "ALL"))
-        self.assertTrue(self._run_filter(msg, "All"))
+        self.assertTrue(self._run_filter(msg, "ALL", allowed_bot_ids={bot.id}))
+        self.assertTrue(self._run_filter(msg, "All", allowed_bot_ids={bot.id}))
         self.assertFalse(self._run_filter(msg, "NONE"))
         self.assertFalse(self._run_filter(msg, "None"))
 

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -192,6 +192,84 @@ async def test_connect_only_requests_members_intent_when_needed(monkeypatch, all
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("allowed_bot_ids", "author_id", "should_handle"),
+    [
+        ("not-a-snowflake", "not-a-snowflake", False),
+        ("bad-id, 123456789", "123456789", True),
+    ],
+)
+async def test_production_on_message_enforces_exact_numeric_bot_id(
+    monkeypatch,
+    allowed_bot_ids,
+    author_id,
+    should_handle,
+):
+    """The registered intake handler must use the fail-closed exact-ID predicate."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", allowed_bot_ids)
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents, proxy=None, allowed_mentions=None, **_):
+        created["bot"] = FakeBot(intents=intents, allowed_mentions=allowed_mentions)
+        created["bot"].user.bot = True
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+    handle_message = AsyncMock()
+    monkeypatch.setattr(adapter, "_handle_message", handle_message)
+
+    assert await adapter.connect() is True
+    try:
+        bot = created["bot"]
+        channel = SimpleNamespace(
+            id=123,
+            name="wake-bridge",
+            guild=SimpleNamespace(id=456, name="Hermes Server"),
+            parent_id=None,
+        )
+        message = SimpleNamespace(
+            id=789,
+            type=getattr(discord_platform.discord, "MessageType").default,
+            author=SimpleNamespace(
+                id=author_id,
+                bot=True,
+                name="RelayBot",
+                display_name="RelayBot",
+            ),
+            channel=channel,
+            guild=channel.guild,
+            content=f"<@{bot.user.id}> wake",
+            mentions=[bot.user],
+        )
+
+        await bot._events["on_message"](message)
+
+        if should_handle:
+            handle_message.assert_awaited_once()
+        else:
+            handle_message.assert_not_awaited()
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "initial_allowed",
     [
         {"*"},

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -116,6 +116,7 @@ def adapter(monkeypatch):
         "DISCORD_HISTORY_BACKFILL",
         "DISCORD_HISTORY_BACKFILL_LIMIT",
         "DISCORD_ALLOW_BOTS",
+        "DISCORD_ALLOWED_BOT_IDS",
     ):
         monkeypatch.delenv(_var, raising=False)
 
@@ -140,6 +141,72 @@ def make_message(*, channel, content: str, mentions=None, msg_type=None):
         author=author,
         type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
     )
+
+
+def test_bot_message_allowed_when_author_id_is_listed(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "55, 77")
+    message = make_message(
+        channel=FakeTextChannel(),
+        content="<@999> wake up",
+        mentions=[adapter._client.user],
+    )
+    message.author = SimpleNamespace(id=55, bot=True)
+
+    assert adapter._discord_bot_message_is_allowed(message) is True
+
+
+def test_bot_message_rejected_when_author_id_is_not_listed(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "77")
+    message = make_message(
+        channel=FakeTextChannel(),
+        content="<@999> wake up",
+        mentions=[adapter._client.user],
+    )
+    message.author = SimpleNamespace(id=55, bot=True)
+
+    assert adapter._discord_bot_message_is_allowed(message) is False
+
+
+def test_bot_message_rejected_when_exact_allowlist_is_empty(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    message = make_message(
+        channel=FakeTextChannel(),
+        content="<@999> wake up",
+        mentions=[adapter._client.user],
+    )
+    message.author = SimpleNamespace(id=55, bot=True)
+
+    assert adapter._discord_bot_message_is_allowed(message) is False
+
+
+def test_bot_message_rejected_for_unknown_allow_bots_mode(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "unexpected")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "55")
+    message = make_message(
+        channel=FakeTextChannel(),
+        content="<@999> wake up",
+        mentions=[adapter._client.user],
+    )
+    message.author = SimpleNamespace(id=55, bot=True)
+
+    assert adapter._discord_bot_message_is_allowed(message) is False
+
+
+def test_bot_id_env_override_takes_precedence_over_adapter_config(adapter, monkeypatch):
+    adapter.config.extra["allow_bots"] = "all"
+    adapter.config.extra["allowed_bot_ids"] = ["77"]
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "55")
+    message = make_message(
+        channel=FakeTextChannel(),
+        content="<@999> wake up",
+        mentions=[adapter._client.user],
+    )
+    message.author = SimpleNamespace(id=55, bot=True)
+
+    assert adapter._discord_bot_message_is_allowed(message) is True
 
 
 def make_history_message(
@@ -778,7 +845,7 @@ async def test_discord_thread_require_mention_via_config_extra(adapter, monkeypa
 @pytest.mark.asyncio
 async def test_fetch_channel_context_stops_at_self_message_and_reverses_to_chronological_order(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
-    adapter.config.extra["history_backfill_limit"] = 10
+    adapter.config.extra.update(history_backfill_limit=10, allowed_bot_ids=["55"])
 
     other_bot = SimpleNamespace(id=55, display_name="Gemini", name="Gemini", bot=True)
     human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
@@ -807,7 +874,7 @@ async def test_fetch_channel_context_stops_at_self_message_and_reverses_to_chron
 async def test_fetch_channel_context_skips_self_improvement_boundary_message(adapter, monkeypatch):
     """Delayed harness status bumps must not hide messages after the real reply."""
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
-    adapter.config.extra["history_backfill_limit"] = 10
+    adapter.config.extra.update(history_backfill_limit=10, allowed_bot_ids=["55"])
 
     codex = SimpleNamespace(id=55, display_name="Codex", name="Codex", bot=True)
     human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
@@ -966,6 +1033,31 @@ async def test_fetch_channel_context_skips_other_bots_when_allow_bots_none(adapt
     assert result == "[Recent channel messages]\n[Alice] human note"
 
 
+@pytest.mark.asyncio
+async def test_fetch_channel_context_skips_bot_outside_exact_allowlist(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOT_IDS", "77")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    unlisted_bot = SimpleNamespace(id=55, display_name="Gemini", name="Gemini", bot=True)
+    listed_bot = SimpleNamespace(id=77, display_name="Relay", name="Relay", bot=True)
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=listed_bot, content="trusted bot note", msg_id=3),
+            make_history_message(author=unlisted_bot, content="untrusted bot note", msg_id=2),
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=make_message(channel=channel, content="trigger"),
+    )
+
+    assert "trusted bot note" in result
+    assert "untrusted bot note" not in result
+
+
 # ---------------------------------------------------------------------------
 # TestChannelContextUnverifiedTagging
 # ---------------------------------------------------------------------------
@@ -1074,9 +1166,9 @@ class TestChannelContextUnverifiedTagging:
     async def test_bot_senders_bypass_auth_check(self, adapter, monkeypatch):
         """Bot messages are never tagged — the auth check is for human
         senders relative to the user allowlist, and bots are already gated
-        by DISCORD_ALLOW_BOTS."""
+        by DISCORD_ALLOW_BOTS and DISCORD_ALLOWED_BOT_IDS."""
         monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
-        adapter.config.extra["history_backfill_limit"] = 10
+        adapter.config.extra.update(history_backfill_limit=10, allowed_bot_ids=["58"])
         other_bot = SimpleNamespace(id=58, display_name="Gemini", name="Gemini", bot=True)
         channel = FakeHistoryChannel(
             [make_history_message(author=other_bot, content="bot note", msg_id=1)],
@@ -1211,7 +1303,7 @@ async def test_fetch_channel_context_cache_uses_latest_window_when_after_set(ada
     response, otherwise tool traces can crowd out the final answer.
     """
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
-    adapter.config.extra["history_backfill_limit"] = 3
+    adapter.config.extra.update(history_backfill_limit=3, allowed_bot_ids=["56"])
 
     codex = SimpleNamespace(id=56, display_name="Codex", name="Codex", bot=True)
     human = SimpleNamespace(id=57, display_name="Alice", name="Alice", bot=False)

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -264,7 +264,38 @@ You can run `hermes gateway` in the background or as a systemd service for persi
 
 ## Configuration Reference
 
-Discord behavior is controlled through two files: **`~/.hermes/.env`** for credentials and env-level toggles, and **`~/.hermes/config.yaml`** for structured settings. Environment variables always take precedence over config.yaml values when both are set.
+Put Discord behaviour in **`~/.hermes/config.yaml`**. Use
+**`~/.hermes/.env`** for the bot token and legacy environment overrides only.
+An explicit environment override takes precedence over the equivalent YAML key.
+
+### Bot input policy (`config.yaml`)
+
+`discord.allow_bots` controls whether Hermes accepts bot-authored messages:
+`"none"` (default), `"mentions"`, or `"all"`. Both enabled modes also require
+the author's exact ASCII numeric Discord user ID in `discord.allowed_bot_ids`.
+Malformed, empty, or missing IDs are ignored, and an empty resulting list rejects
+every bot. Human authorisation and `discord.require_mention` behaviour are
+unchanged.
+
+```yaml
+discord:
+  allow_bots: "mentions"
+  allowed_bot_ids:
+    - "123456789012345678"  # trusted wake bot user ID
+```
+
+:::caution Breaking upgrade requirement
+Existing installations using `discord.allow_bots: "mentions"` or `"all"` must
+now also configure `discord.allowed_bot_ids`. Without an exact numeric ID list,
+all bot-authored Discord messages are intentionally rejected.
+:::
+
+:::warning Bot-to-bot conversation is not supported
+This setting is for narrowly accepting input from a trusted wake or webhook bot,
+not for connecting auto-replying Hermes profiles. Discord bot-authored events
+delivered through the generic upstream relay remain disabled because the relay
+contract cannot express the exact-ID and per-message mention policy.
+:::
 
 ### Environment Variables (`.env`)
 
@@ -283,7 +314,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
-| `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
+| `DISCORD_ALLOW_BOTS` | No | `"none"` | Legacy environment override for `discord.allow_bots`. Configure bot-input mode and exact IDs under `discord:` in `config.yaml`; see below. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
@@ -301,15 +332,10 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Delay between split chunks when a single message exceeds Discord's length limit. |
 
-:::warning Bot-to-bot conversation is not supported
-`DISCORD_ALLOW_BOTS` exists to accept input from a specific trusted bot (e.g. a relay or webhook bot), not to let two Hermes profiles talk to each other. The default, `"none"`, ignores all other bots and is the safe setting.
-
-Wiring multiple Hermes profiles to reply to one another in a shared channel — by setting `"mentions"` or `"all"` across several profiles — is an unsupported topology. Discord auto-`@mentions` the replied-to author on every reply, so under `"mentions"` two bots will satisfy each other's mention gate indefinitely and ack-loop. There is no circuit breaker for this because the supported configuration is simply to leave `DISCORD_ALLOW_BOTS` at `"none"`. If you must accept a particular bot, scope the acceptance narrowly and never to another auto-replying agent.
-:::
-
 ### Config File (`config.yaml`)
 
-The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Config.yaml settings are applied as defaults — if the equivalent env var is already set, the env var wins.
+The `discord` section in `~/.hermes/config.yaml` contains structured behaviour
+settings. If a legacy equivalent environment override is already set, it wins.
 
 ```yaml
 # Discord-specific settings
@@ -318,6 +344,9 @@ discord:
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
+  allow_bots: "none"              # "none", "mentions", or "all"
+  allowed_bot_ids: []             # Required exact IDs when allow_bots is enabled
+  bots_require_inline_mention: false # Require a literal inline @mention from bots
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading


### PR DESCRIPTION
## Summary
- require `discord.allowed_bot_ids` exact numeric IDs whenever Discord bot input is enabled
- enforce the policy at direct adapter intake, gateway authorisation, and history backfill
- keep relayed Discord bot input fail-closed by actively projecting `allowOtherBots=false`, including default config
- document the config.yaml-first upgrade path and preserve human allowlists / mention behaviour

## Verification
- `pytest tests/gateway/relay/test_relay_policy_send.py tests/gateway/test_relay_upstream_authz.py tests/gateway/test_config.py tests/gateway/test_discord*.py -q -o addopts=` -- 673 passed
- production intake parameter test -- 2 passed (malformed rejection + listed numeric admission)
- `ruff check` on all changed Python files -- passed
- `git diff --check` -- passed
- independent read-only Codex review -- passed with no security or logic findings

## Notes
- no live profile configuration changed
- no gateway restarted
- the monolithic full-suite run was attempted but hit the repository test harness open-file/logging cascade and timed out at 600s; the complete touched surface above is green