### PR TITLE
fix(cli): shut down oneshot memory providers

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -390,40 +390,60 @@ def _run_agent(
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
 
-    agent = AIAgent(
-        api_key=runtime.get("api_key"),
-        base_url=runtime.get("base_url"),
-        provider=runtime.get("provider"),
-        api_mode=runtime.get("api_mode"),
-        model=effective_model,
-        enabled_toolsets=toolsets_list,
-        quiet_mode=True,
-        platform="cli",
-        session_db=session_db,
-        credential_pool=runtime.get("credential_pool"),
-        fallback_model=_fb or None,
-        # Interactive callbacks are intentionally NOT wired beyond this
-        # one.  In oneshot mode there's no user sitting at a terminal:
-        #   - clarify  → returns a synthetic "pick a default" instruction
-        #                so the agent continues instead of stalling on
-        #                the tool's built-in "not available" error
-        #   - sudo password prompt → terminal_tool gates on
-        #                HERMES_INTERACTIVE which we never set
-        #   - shell-hook approval → auto-approved via HERMES_ACCEPT_HOOKS=1
-        #                (set above); also falls back to deny on non-tty
-        #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
-        #   - skill secret capture → returns gracefully when no callback set
-        clarify_callback=_oneshot_clarify_callback,
-    )
+    agent = None
+    try:
+        agent = AIAgent(
+            api_key=runtime.get("api_key"),
+            base_url=runtime.get("base_url"),
+            provider=runtime.get("provider"),
+            api_mode=runtime.get("api_mode"),
+            model=effective_model,
+            enabled_toolsets=toolsets_list,
+            quiet_mode=True,
+            platform="cli",
+            session_db=session_db,
+            credential_pool=runtime.get("credential_pool"),
+            fallback_model=_fb or None,
+            # Interactive callbacks are intentionally NOT wired beyond this
+            # one.  In oneshot mode there's no user sitting at a terminal:
+            #   - clarify  → returns a synthetic "pick a default" instruction
+            #                so the agent continues instead of stalling on
+            #                the tool's built-in "not available" error
+            #   - sudo password prompt → terminal_tool gates on
+            #                HERMES_INTERACTIVE which we never set
+            #   - shell-hook approval → auto-approved via HERMES_ACCEPT_HOOKS=1
+            #                (set above); also falls back to deny on non-tty
+            #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
+            #   - skill secret capture → returns gracefully when no callback set
+            clarify_callback=_oneshot_clarify_callback,
+        )
 
-    # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
-    # display callbacks that would bypass our stdout capture.
-    agent.suppress_status_output = True
-    agent.stream_delta_callback = None
-    agent.tool_gen_callback = None
+        # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
+        # display callbacks that would bypass our stdout capture.
+        agent.suppress_status_output = True
+        agent.stream_delta_callback = None
+        agent.tool_gen_callback = None
 
-    result = agent.run_conversation(prompt)
-    return (result.get("final_response") or "", result)
+        result = agent.run_conversation(prompt)
+        return (result.get("final_response") or "", result)
+    finally:
+        # Oneshot bypasses cli.py, including its atexit cleanup.  Mirror the
+        # supported AIAgent lifecycle explicitly so memory-provider workers do
+        # not survive into interpreter finalization after the response prints.
+        if agent is not None and hasattr(agent, "shutdown_memory_provider"):
+            try:
+                session_messages = getattr(agent, "_session_messages", None)
+                agent.shutdown_memory_provider(
+                    session_messages if isinstance(session_messages, list) else []
+                )
+            except Exception as exc:
+                logging.debug("Oneshot memory-provider shutdown failed: %s", exc)
+        close_session_db = getattr(session_db, "close", None)
+        if callable(close_session_db):
+            try:
+                close_session_db()
+            except Exception as exc:
+                logging.debug("Oneshot session database close failed: %s", exc)
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -819,11 +819,16 @@ def test_oneshot_distinguishes_disabled_mcp_from_unknown(monkeypatch, capsys):
 
 
 def test_oneshot_wires_session_db_for_recall(monkeypatch):
-    """hermes -z bypasses HermesCLI, but recall still needs SessionDB."""
+    """hermes -z owns both SessionDB and the agent lifecycle it bypasses."""
     from hermes_cli.oneshot import _run_agent
 
     captured = {}
-    sentinel_db = object()
+
+    class SentinelDB:
+        def close(self):
+            captured["session_db_closed"] = True
+
+    sentinel_db = SentinelDB()
 
     class FakeAgent:
         def __init__(self, **kwargs):
@@ -831,10 +836,14 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
             self.suppress_status_output = False
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
+            self._session_messages = [{"role": "user", "content": "recall this"}]
 
         def run_conversation(self, prompt, **_kwargs):
             captured["prompt"] = prompt
             return {"final_response": "ok", "failed": False, "partial": False}
+
+        def shutdown_memory_provider(self, messages):
+            captured["memory_shutdown_messages"] = messages
 
     class FakeSessionDB:
         def __new__(cls):
@@ -884,6 +893,10 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"
+    assert captured["memory_shutdown_messages"] == [
+        {"role": "user", "content": "recall this"}
+    ]
+    assert captured["session_db_closed"] is True
 
 
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):


### PR DESCRIPTION
## Summary
- mirror the interactive CLI memory-provider lifecycle in `hermes -z`
- close the oneshot-owned SessionDB after agent shutdown
- extend the existing oneshot integration test to assert both resources close

## Reproduction
With Honcho active, a successful `hermes -z` tool call printed its final response and then exited 134 with SIGABRT. A native backtrace showed Python finalizing while a daemon Honcho HTTP worker was blocked in socket receive. `hermes_cli/oneshot.py` bypasses `cli.py` and returned without calling `AIAgent.shutdown_memory_provider()`.

After this patch, real Honcho write and read oneshots both returned the expected marker, empty stderr, and exit 0.

## Test
`scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py`

Result: 48 passed.