### PR TITLE
[codex] fix kanban stale nonrunning task runs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5854,6 +5854,141 @@ def schedule_task(
         return True
 
 
+def _reconcile_nonrunning_active_runs(conn: sqlite3.Connection) -> list[str]:
+    """Close stale active-run pointers on tasks that are no longer running.
+
+    Normal lifecycle transitions close ``tasks.current_run_id`` in the same
+    transaction that moves a task off ``running``. This pass is a dispatcher
+    backstop for corrupted or direct-write states where ``tasks.status`` is
+    already non-running but the active ``task_runs`` row still looks live.
+    """
+    now = int(time.time())
+    repaired: list[str] = []
+    with write_txn(conn):
+        rows = conn.execute(
+            """
+            SELECT
+                t.id,
+                t.status AS task_status,
+                t.result,
+                t.completed_at,
+                t.last_failure_error,
+                t.current_run_id,
+                r.id AS run_id,
+                r.ended_at AS run_ended_at
+            FROM tasks t
+            LEFT JOIN task_runs r ON r.id = t.current_run_id
+            WHERE t.status != 'running'
+              AND t.current_run_id IS NOT NULL
+            """
+        ).fetchall()
+        for row in rows:
+            task_id = row["id"]
+            task_status = row["task_status"]
+            run_id = row["run_id"]
+
+            if task_status == "done":
+                run_status = "done"
+                outcome = "completed"
+                summary = (
+                    row["result"]
+                    or "invariant recovery: task already done"
+                )
+                try:
+                    ended_at = (
+                        int(row["completed_at"])
+                        if row["completed_at"] is not None
+                        else now
+                    )
+                except (TypeError, ValueError):
+                    ended_at = now
+            elif task_status in {"blocked", "triage"}:
+                run_status = "blocked"
+                outcome = "blocked"
+                summary = (
+                    row["last_failure_error"]
+                    or f"invariant recovery: task already {task_status}"
+                )
+                ended_at = now
+            elif task_status == "scheduled":
+                run_status = "scheduled"
+                outcome = "scheduled"
+                summary = "invariant recovery: task already scheduled"
+                ended_at = now
+            else:
+                run_status = "reclaimed"
+                outcome = "reclaimed"
+                summary = (
+                    "invariant recovery: task status "
+                    f"{task_status} with stale active run"
+                )
+                ended_at = now
+
+            if run_id is not None and row["run_ended_at"] is None:
+                conn.execute(
+                    """
+                    UPDATE task_runs
+                       SET status        = ?,
+                           outcome       = ?,
+                           summary       = COALESCE(summary, ?),
+                           error         = COALESCE(error, ?),
+                           ended_at      = ?,
+                           claim_lock    = NULL,
+                           claim_expires = NULL,
+                           worker_pid    = NULL
+                     WHERE id = ?
+                       AND ended_at IS NULL
+                    """,
+                    (
+                        run_status,
+                        outcome,
+                        summary,
+                        summary if outcome == "reclaimed" else None,
+                        ended_at,
+                        int(run_id),
+                    ),
+                )
+
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET current_run_id = NULL,
+                       claim_lock     = NULL,
+                       claim_expires  = NULL,
+                       worker_pid     = NULL,
+                       last_heartbeat_at = NULL,
+                       consecutive_failures = CASE
+                           WHEN status = 'done' THEN 0
+                           ELSE consecutive_failures
+                       END,
+                       last_failure_error = CASE
+                           WHEN status = 'done' THEN NULL
+                           ELSE last_failure_error
+                       END
+                 WHERE id = ?
+                   AND current_run_id IS ?
+                   AND status = ?
+                """,
+                (task_id, row["current_run_id"], task_status),
+            )
+            if cur.rowcount != 1:
+                continue
+            _append_event(
+                conn,
+                task_id,
+                "run_reconciled",
+                {
+                    "reason": "nonrunning_task_with_active_run",
+                    "status": task_status,
+                    "run_id": int(run_id) if run_id is not None else None,
+                    "outcome": outcome if run_id is not None else None,
+                },
+                run_id=(int(run_id) if run_id is not None else None),
+            )
+            repaired.append(task_id)
+    return repaired
+
+
 # Dispatcher (one-shot pass)
 # ---------------------------------------------------------------------------
 
@@ -7284,6 +7419,8 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    if not dry_run:
+        _reconcile_nonrunning_active_runs(conn)
     result.reclaimed = release_stale_claims(conn)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5878,6 +5878,7 @@ def _reconcile_nonrunning_active_runs(conn: sqlite3.Connection) -> list[str]:
                 r.ended_at AS run_ended_at
             FROM tasks t
             LEFT JOIN task_runs r ON r.id = t.current_run_id
+                                  AND r.task_id = t.id
             WHERE t.status != 'running'
               AND t.current_run_id IS NOT NULL
             """

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2389,6 +2389,129 @@ def test_unblock_normal_path_no_spurious_run(kanban_home):
         conn.close()
 
 
+def test_dispatch_reconciles_done_task_with_stale_running_run(kanban_home):
+    """A task already marked done must not keep an active run forever.
+
+    Regression for a live board state where direct/local completion wrote
+    ``tasks.status='done'`` and ``completed_at`` but left
+    ``tasks.current_run_id`` pointing at a ``task_runs`` row that still had
+    ``status='running'`` and ``ended_at IS NULL``.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="done with stale run", assignee="worker")
+        kb.claim_task(conn, tid)
+        run_id = kb.latest_run(conn, tid).id
+        completed_at = int(time.time()) - 7
+        route_meta = {"route_snapshot": {"model": "test-model"}}
+        with kb.write_txn(conn):
+            conn.execute(
+                """
+                UPDATE tasks
+                   SET status = 'done',
+                       result = ?,
+                       completed_at = ?,
+                       worker_pid = ?,
+                       claim_lock = 'test-host:stale',
+                       claim_expires = ?
+                 WHERE id = ?
+                """,
+                (
+                    "completed outside kernel",
+                    completed_at,
+                    999999,
+                    completed_at - 1,
+                    tid,
+                ),
+            )
+            conn.execute(
+                "UPDATE task_runs SET worker_pid = ?, metadata = ? WHERE id = ?",
+                (999999, json.dumps(route_meta), run_id),
+            )
+
+        kb.dispatch_once(conn, spawn_fn=lambda _task, _workspace: None)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "done"
+        assert task.current_run_id is None
+        assert task.worker_pid is None
+        assert task.claim_lock is None
+        run = kb.get_run(conn, run_id)
+        assert run.status == "done"
+        assert run.outcome == "completed"
+        assert run.ended_at == completed_at
+        assert run.summary == "completed outside kernel"
+        assert run.metadata == route_meta
+        assert not conn.execute(
+            "SELECT 1 FROM task_runs WHERE task_id = ? AND ended_at IS NULL",
+            (tid,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def test_dispatch_reconciles_blocked_task_with_stale_running_run(kanban_home):
+    """A blocked task cannot retain a dead active run skipped by crash scans."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="blocked with stale run", assignee="worker")
+        kb.claim_task(conn, tid)
+        run_id = kb.latest_run(conn, tid).id
+        assert kb.block_task(conn, tid, reason="needs human decision")
+        with kb.write_txn(conn):
+            conn.execute(
+                """
+                UPDATE tasks
+                   SET status = 'blocked',
+                       current_run_id = ?,
+                       last_failure_error = ?,
+                       worker_pid = ?,
+                       claim_lock = 'test-host:stale',
+                       claim_expires = ?
+                 WHERE id = ?
+                """,
+                (
+                    run_id,
+                    "needs human decision",
+                    999998,
+                    int(time.time()) - 1,
+                    tid,
+                ),
+            )
+            conn.execute(
+                """
+                UPDATE task_runs
+                   SET status = 'running',
+                       outcome = NULL,
+                       ended_at = NULL,
+                       worker_pid = ?,
+                       claim_lock = 'test-host:stale',
+                       claim_expires = ?
+                 WHERE id = ?
+                """,
+                (999998, int(time.time()) - 1, run_id),
+            )
+
+        kb.dispatch_once(conn, spawn_fn=lambda _task, _workspace: None)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.current_run_id is None
+        assert task.worker_pid is None
+        assert task.claim_lock is None
+        run = kb.get_run(conn, run_id)
+        assert run.status == "blocked"
+        assert run.outcome == "blocked"
+        assert run.summary == "needs human decision"
+        assert run.ended_at is not None
+        assert not conn.execute(
+            "SELECT 1 FROM task_runs WHERE task_id = ? AND ended_at IS NULL",
+            (tid,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
 def test_migration_backfill_idempotent_under_re_run(tmp_path, monkeypatch):
     """init_db must be safe to re-run repeatedly. Each call should leave
     at most one run row per in-flight task, even if called while a

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2512,6 +2512,58 @@ def test_dispatch_reconciles_blocked_task_with_stale_running_run(kanban_home):
         conn.close()
 
 
+def test_dispatch_reconcile_dangling_pointer_preserves_foreign_active_run(kanban_home):
+    """A non-running task cannot close another task's active run by pointer."""
+    conn = kb.connect()
+    try:
+        owner_id = kb.create_task(conn, title="foreign run owner", assignee="worker")
+        dangling_id = kb.create_task(conn, title="dangling foreign pointer", assignee="worker")
+        assert kb.claim_task(conn, owner_id)
+        foreign_run_id = kb.latest_run(conn, owner_id).id
+        completed_at = int(time.time()) - 11
+        with kb.write_txn(conn):
+            conn.execute(
+                """
+                UPDATE tasks
+                   SET status = 'done',
+                       result = ?,
+                       completed_at = ?,
+                       current_run_id = ?,
+                       worker_pid = ?,
+                       claim_lock = 'test-host:foreign',
+                       claim_expires = ?
+                 WHERE id = ?
+                """,
+                (
+                    "completed with bad pointer",
+                    completed_at,
+                    foreign_run_id,
+                    123456,
+                    completed_at - 1,
+                    dangling_id,
+                ),
+            )
+
+        kb.dispatch_once(conn, spawn_fn=lambda _task, _workspace: None)
+
+        dangling = kb.get_task(conn, dangling_id)
+        assert dangling.status == "done"
+        assert dangling.current_run_id is None
+        assert dangling.worker_pid is None
+        assert dangling.claim_lock is None
+
+        owner = kb.get_task(conn, owner_id)
+        assert owner.status == "running"
+        assert owner.current_run_id == foreign_run_id
+        foreign_run = kb.get_run(conn, foreign_run_id)
+        assert foreign_run.task_id == owner_id
+        assert foreign_run.status == "running"
+        assert foreign_run.outcome is None
+        assert foreign_run.ended_at is None
+    finally:
+        conn.close()
+
+
 def test_migration_backfill_idempotent_under_re_run(tmp_path, monkeypatch):
     """init_db must be safe to re-run repeatedly. Each call should leave
     at most one run row per in-flight task, even if called while a


### PR DESCRIPTION
## Summary

- Re-adopts reviewed local commit `7c9c9c3b9e83892d24450ee2c020f31ad6cbb6ad` onto current `upstream/main`.
- Adds a dispatcher backstop that reconciles tasks whose `status != 'running'` while `current_run_id` still points at an active run.
- Adds regression coverage for already-done and blocked tasks with stale running run rows.

## Scope and hashes

- Base: `f6d1fd511ca8173f634fd42a582e43c3d6181762`
- Head: `2e82312ec49edb905a9a0f89a2f79a24fca90782`
- Reviewed source commit: `7c9c9c3b9e83892d24450ee2c020f31ad6cbb6ad`
- Stable patch-id: `df0c4058f17303a466ab7ffe38795bdaad911f53`
- Diff SHA256: `f7163c077fd05cd6b0482364a61fbeaea1bfdcb19d59d8aa4e3c3bbe75811f68`
- Changed files only:
  - `hermes_cli/kanban_db.py`, SHA256 `69e164afe7f604dbcd17c35885b39a00794d4a2e5ae8a157b097aea1c61d7d3c`
  - `tests/hermes_cli/test_kanban_core_functionality.py`, SHA256 `34535feb48d68238e650e581b8ced408b71f0c9f8e841d9ae2630866c193b321`

## Validation

- `python -m pytest -q tests/hermes_cli/test_kanban_core_functionality.py::test_dispatch_reconciles_done_task_with_stale_running_run tests/hermes_cli/test_kanban_core_functionality.py::test_dispatch_reconciles_blocked_task_with_stale_running_run` -> `2 passed in 0.35s`
- `python -m pytest -q tests/hermes_cli/test_kanban_db.py` -> `230 passed in 9.77s`
- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py` -> passed
- `git diff --check upstream/main...HEAD -- hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py` -> passed
- `python -m pytest -q tests/hermes_cli/test_kanban_core_functionality.py` -> `169 passed, 1 skipped, 1 failed in 9.26s`

The red core-functionality test is inherited baseline red: `tests/hermes_cli/test_kanban_core_functionality.py::test_dispatch_once_integrates_stale_detection` also fails on clean `upstream/main` at `f6d1fd511ca8173f634fd42a582e43c3d6181762` with the same `tests/conftest.py live-system guard: blocked os.kill(99999, 15)` error.

## Live board inventory

Read-only query against `/Users/agent/.hermes/kanban.db`; no task bodies or comments were selected or printed.

```sql
SELECT t.id AS task_id,
       t.status AS task_status,
       t.current_run_id AS current_run_id,
       r.status AS run_status,
       r.outcome AS run_outcome,
       r.ended_at AS run_ended_at,
       t.worker_pid AS task_worker_pid,
       r.worker_pid AS run_worker_pid
FROM tasks t
LEFT JOIN task_runs r ON r.id = t.current_run_id
WHERE t.status != 'running'
  AND t.current_run_id IS NOT NULL
ORDER BY t.status, t.id;
```

Affected count: `1`

| task_id | task_status | current_run_id | run_status | run_outcome | run_ended_at | task_worker_pid | run_worker_pid |
| --- | --- | ---: | --- | --- | --- | ---: | ---: |
| `t_86ef5458` | `done` | `1647` | `running` | NULL | NULL | `74062` | `74062` |

## Live repair plan, not run

Do not run this until review-required approval is granted and live writers are quiesced.

Backup and pre-check:

```bash
ts=$(date -u +%Y%m%dT%H%M%SZ)
dir="$HOME/.hermes/kanban-artifacts/reconcile-$ts"
mkdir -p "$dir"
sqlite3 -readonly "$HOME/.hermes/kanban.db" "PRAGMA quick_check;" | tee "$dir/quick_check.before.txt"
sqlite3 -readonly -header -csv "$HOME/.hermes/kanban.db" "SELECT t.id AS task_id, t.status AS task_status, t.current_run_id AS current_run_id, r.status AS run_status, r.outcome AS run_outcome, r.ended_at AS run_ended_at, t.worker_pid AS task_worker_pid, r.worker_pid AS run_worker_pid FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id WHERE t.status != 'running' AND t.current_run_id IS NOT NULL ORDER BY t.status, t.id;" > "$dir/nonrunning-current-run.before.csv"
sqlite3 "$HOME/.hermes/kanban.db" ".backup '$dir/kanban.db.before-reconcile.sqlite'"
shasum -a 256 "$dir/kanban.db.before-reconcile.sqlite" "$HOME/.hermes/kanban.db" "$HOME/.hermes/kanban.db-wal" "$HOME/.hermes/kanban.db-shm" > "$dir/sha256.before.txt"
```

Scoped reconciliation command:

```bash
/Users/agent/.hermes/hermes-agent/venv/bin/python - <<'PY'
from hermes_cli import kanban_db as kb

conn = kb.connect()
try:
    repaired = kb._reconcile_nonrunning_active_runs(conn)
    print("\n".join(repaired))
finally:
    conn.close()
PY
```

Post-change invariant:

```bash
sqlite3 -readonly "$HOME/.hermes/kanban.db" "SELECT COUNT(*) FROM tasks WHERE status != 'running' AND current_run_id IS NOT NULL;"
sqlite3 -readonly -header -column "$HOME/.hermes/kanban.db" "SELECT t.id, t.status, t.current_run_id, r.status, r.outcome, r.ended_at FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id WHERE t.status != 'running' AND t.current_run_id IS NOT NULL ORDER BY t.status, t.id;"
```

Rollback, only after stopping gateway/dispatcher/live writers:

```bash
cp "$HOME/.hermes/kanban.db" "$dir/kanban.db.rollback-target.$(date -u +%Y%m%dT%H%M%SZ)"
cp "$dir/kanban.db.before-reconcile.sqlite" "$HOME/.hermes/kanban.db"
rm -f "$HOME/.hermes/kanban.db-wal" "$HOME/.hermes/kanban.db-shm"
sqlite3 -readonly "$HOME/.hermes/kanban.db" "PRAGMA integrity_check;"
sqlite3 -readonly "$HOME/.hermes/kanban.db" "SELECT COUNT(*) FROM tasks WHERE status != 'running' AND current_run_id IS NOT NULL;"
```
