### PR TITLE
fix(agent): evict old tool-result images on OpenAI-compatible path

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1866,6 +1866,12 @@ def init_agent(
     agent.compression_in_place = compression_in_place
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
 
+    # Maximum number of tool-result images to keep in the outgoing request.
+    # Older images are replaced with a text placeholder to prevent token
+    # bloat and local-model OOM from accumulating browser_vision screenshots.
+    # See agent/context_compressor.py:_evict_old_screenshots_openai
+    agent.max_tool_images = int(_agent_cfg.get("max_tool_images", 3))
+
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
     _ctx = getattr(agent.context_compressor, "context_length", 0)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1870,7 +1870,7 @@ def init_agent(
     # Older images are replaced with a text placeholder to prevent token
     # bloat and local-model OOM from accumulating browser_vision screenshots.
     # See agent/context_compressor.py:_evict_old_screenshots_openai
-    agent.max_tool_images = int(_agent_cfg.get("max_tool_images", 3))
+    agent.max_tool_images = int(_agent_section.get("max_tool_images", 3))
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -529,35 +529,86 @@ def _strip_images_from_content(content: Any) -> Any:
     return new_parts
 
 
+def _evict_old_screenshots_openai(
+    messages: List[Dict[str, Any]],
+    max_keep: int = 3,
+) -> None:
+    """Keep only the most recent ``max_keep`` tool-result images on the
+    OpenAI-compatible request path.
+
+    Base-64 images cost ~1,465 tokens each and accumulate across tool
+    calls.  Walk backward through ``messages``, keep the most recent N
+    tool-result images, and replace older ones with a short text
+    placeholder.
+
+    Port of ``_evict_old_screenshots`` (agent/anthropic_adapter.py) for
+    the chat_completions wire format where tool-role images are flat
+    ``image_url`` / ``input_image`` parts in the message ``content``
+    list — not nested inside Anthropic ``tool_result`` blocks.
+
+    Mutates ``messages`` in place.  Stored conversation history must
+    never be passed here; only the per-call ``api_messages`` copy.
+    """
+    if not max_keep or max_keep <= 0:
+        return
+    _Placeholder = {"type": "text", "text": "[screenshot removed to save context]"}
+    image_count = 0
+    for msg in reversed(messages):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "tool":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        # Check whether this tool message carries any image parts.
+        has_image = any(_is_image_part(p) for p in content)
+        if not has_image:
+            continue
+        image_count += 1
+        if image_count > max_keep:
+            msg["content"] = [
+                p if not _is_image_part(p) else _Placeholder
+                for p in content
+            ]
+
+
 def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Replace image parts in older messages with placeholder text.
 
-    The anchor is the *last* user message that has any image content. Every
-    message before that anchor gets its image parts replaced with a short
-    placeholder so the outgoing request stops re-shipping the same multi-MB
-    base-64 image blobs on every turn.
+    The anchor is the *last* message (user or tool role) that has any
+    image content.  Every message before that anchor gets its image parts
+    replaced with a short placeholder so the outgoing request stops
+    re-shipping the same multi-MB base-64 image blobs on every turn.
 
-    If no user message carries images, the list is returned unchanged.
-    If the only user message with images is the very first one (nothing
+    If no message carries images, the list is returned unchanged.
+    If the only image-bearing message is the very first one (nothing
     earlier to strip), the list is returned unchanged.
 
     Shallow copies of touched messages only; input is never mutated.
     Port of Kilo-Org/kilocode#9434 (adapted for the OpenAI-style message
     shape the hermes compressor emits).
+
+    .. note::
+
+       The anchor search now includes ``tool``-role messages so that
+       tool-result screenshots (e.g. from ``browser_vision``) are also
+       covered — previously only ``user``-role images anchored the strip,
+       leaving tool-role screenshots untouched in the typical
+       ``user → assistant(tool_calls) → tool(results)`` flow.
     """
     if not messages:
         return messages
 
-    # Find the newest user message that carries at least one image part.
-    # We anchor on image-bearing user messages (not all user messages) so
-    # a plain text follow-up after a big-image turn still strips the old
-    # image — matching the problem kilocode#9434 set out to solve.
+    # Find the newest message (user or tool) that carries at least one
+    # image part.  Including tool-role messages covers the typical
+    # browser_vision flow where no user message carries images.
     anchor = -1
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
         if not isinstance(msg, dict):
             continue
-        if msg.get("role") != "user":
+        if msg.get("role") not in ("user", "tool"):
             continue
         if _content_has_images(msg.get("content")):
             anchor = i

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -28,6 +28,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.context_compressor import _evict_old_screenshots_openai
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -955,6 +956,16 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Evict old tool-result images on the OpenAI-compatible path.
+        # Keeps the most recent N (default 3) screenshots and replaces
+        # older ones with a text placeholder.  Only touches the per-call
+        # api_messages copy — stored history is never mutated.
+        # Configurable via ``agent.max_tool_images`` (default 3).
+        # See: agent/context_compressor.py:_evict_old_screenshots_openai
+        _max_tool_imgs = getattr(agent, "max_tool_images", 3)
+        if _max_tool_imgs and _max_tool_imgs > 0:
+            _evict_old_screenshots_openai(api_messages, max_keep=_max_tool_imgs)
 
         # Calculate approximate request size for logging and pressure checks.
         # estimate_messages_tokens_rough(api_messages) includes the system

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1058,6 +1058,12 @@ DEFAULT_CONFIG = {
         # (docker/modal/ssh — they have their own probe).  Set False to
         # disable entirely.
         "environment_probe": True,
+        # Maximum number of tool-result images (browser_vision screenshots,
+        # vision_analyze outputs) to keep in the outgoing request on the
+        # OpenAI-compatible path. Older images are replaced with a
+        # "[screenshot removed to save context]" placeholder to prevent
+        # token bloat and local-model OOM. 0 disables eviction entirely.
+        "max_tool_images": 3,
         # Embedder-supplied environment description appended to the system
         # prompt's environment-hints block. Lets a host that wraps Hermes
         # (sandbox runner, managed platform) explain the runtime environment

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7649,3 +7649,75 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+
+class TestMaxToolImagesConfig:
+    """Config propagation for agent.max_tool_images (OpenAI-path screenshot eviction).
+
+    The agent section is read via ``_agent_section = _agent_cfg.get("agent", {})``
+    in agent/agent_init.py; the setting MUST live under ``agent:`` in config.yaml.
+    Regression test for #63933 review: an earlier draft read from top-level
+    ``_agent_cfg`` so ``agent.max_tool_images: 0`` was silently ignored.
+    """
+
+    def _make_agent(self, agent_section=None):
+        cfg = {"agent": agent_section} if agent_section is not None else {}
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value=cfg),
+        ):
+            a = AIAgent(
+                model="deepseek/deepseek-chat",
+                api_key="test-key-1234567890",
+                base_url="https://api.deepseek.com/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_default_is_3(self):
+        """No config → documented default of 3 retained images."""
+        agent = self._make_agent()
+        assert agent.max_tool_images == 3
+
+    def test_override_honored(self):
+        """agent.max_tool_images: 10 in config → attribute reflects the override."""
+        agent = self._make_agent(agent_section={"max_tool_images": 10})
+        assert agent.max_tool_images == 10
+
+    def test_zero_disables_eviction(self):
+        """agent.max_tool_images: 0 must be honored (disables eviction)."""
+        agent = self._make_agent(agent_section={"max_tool_images": 0})
+        assert agent.max_tool_images == 0
+
+    def test_top_level_key_ignored(self):
+        """A top-level ``max_tool_images`` (wrong path) must NOT leak through —
+        guards against the regression where init read from ``_agent_cfg`` directly."""
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            # top-level key set, agent section missing it → must stay default
+            patch("hermes_cli.config.load_config", return_value={"max_tool_images": 99}),
+        ):
+            a = AIAgent(
+                model="deepseek/deepseek-chat",
+                api_key="test-key-1234567890",
+                base_url="https://api.deepseek.com/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.max_tool_images == 3, (
+                "top-level max_tool_images must be ignored; only agent.max_tool_images counts"
+            )

--- a/tests/test_openai_image_eviction.py
+++ b/tests/test_openai_image_eviction.py
@@ -1,0 +1,260 @@
+"""Tests for tool-result image eviction on the OpenAI-compatible path.
+
+Background
+----------
+Tool-result images (browser_vision / vision_analyze screenshots)
+accumulate in conversation history on the chat_completions wire format
+and are re-sent every turn, causing token bloat and local-model OOM.
+
+_evict_old_screenshots_openai (agent/context_compressor.py) keeps the
+most recent N tool-result images and replaces older ones with a text
+placeholder.  It only touches the per-call api_messages copy — stored
+history is never mutated.
+
+See: GitHub issue #63849
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.context_compressor import (
+    _evict_old_screenshots_openai,
+    _is_image_part,
+    _strip_historical_media,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _img_part(url="data:image/png;base64,AAAA"):
+    """OpenAI chat.completions image_url part."""
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def _text_part(text="hello"):
+    return {"type": "text", "text": text}
+
+
+def _tool_msg(content, tool_call_id="call_1"):
+    """Tool-role message with multipart content."""
+    return {"role": "tool", "tool_call_id": tool_call_id, "content": content}
+
+
+def _user_msg(content):
+    return {"role": "user", "content": content}
+
+
+def _assistant_msg(content="ok"):
+    return {"role": "assistant", "content": content}
+
+
+# ---------------------------------------------------------------------------
+# _evict_old_screenshots_openai — unit tests
+# ---------------------------------------------------------------------------
+
+class TestEvictOldScreenshotsOpenAI:
+    """Pure-function tests; no I/O required."""
+
+    def test_keeps_most_recent_n_images(self):
+        """With default max_keep=3, only the last 3 images survive."""
+        msgs = [
+            _tool_msg([_img_part("img_1")], "c1"),
+            _tool_msg([_img_part("img_2")], "c2"),
+            _tool_msg([_img_part("img_3")], "c3"),
+            _tool_msg([_img_part("img_4")], "c4"),
+            _tool_msg([_img_part("img_5")], "c5"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=3)
+
+        # First two images evicted
+        assert msgs[0]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        assert msgs[1]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        # Last three kept
+        assert msgs[2]["content"][0]["type"] == "image_url"
+        assert msgs[3]["content"][0]["type"] == "image_url"
+        assert msgs[4]["content"][0]["type"] == "image_url"
+
+    def test_preserves_text_parts_in_tool_messages(self):
+        """Non-image parts in tool messages are never touched."""
+        msgs = [
+            _tool_msg([_img_part("img_1"), _text_part("result")], "c1"),
+            _tool_msg([_img_part("img_2"), _text_part("result")], "c2"),
+            _tool_msg([_img_part("img_3"), _text_part("result")], "c3"),
+            _tool_msg([_img_part("img_4"), _text_part("result")], "c4"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=2)
+
+        # First tool msg: image evicted, text preserved
+        assert msgs[0]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        assert msgs[0]["content"][1] == {"type": "text", "text": "result"}
+        # Second tool msg: image evicted, text preserved
+        assert msgs[1]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        assert msgs[1]["content"][1] == {"type": "text", "text": "result"}
+        # Last two: both kept
+        assert msgs[2]["content"][0]["type"] == "image_url"
+        assert msgs[3]["content"][0]["type"] == "image_url"
+
+    def test_ignores_non_tool_messages(self):
+        """Only tool-role messages are walked; user/assistant messages are skipped."""
+        msgs = [
+            _user_msg([_img_part("user_img")]),
+            _assistant_msg("saw screenshot"),
+            _tool_msg([_img_part("tool_img_1")], "c1"),
+            _tool_msg([_img_part("tool_img_2")], "c2"),
+            _tool_msg([_img_part("tool_img_3")], "c3"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=2)
+
+        # User message untouched
+        assert msgs[0]["content"][0]["type"] == "image_url"
+        # First tool evicted
+        assert msgs[2]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        # Last two tools kept
+        assert msgs[3]["content"][0]["type"] == "image_url"
+        assert msgs[4]["content"][0]["type"] == "image_url"
+
+    def test_no_images_noop(self):
+        """Messages with no images are returned unchanged."""
+        msgs = [
+            _user_msg("hello"),
+            _assistant_msg("hi"),
+            _tool_msg([_text_part("result")], "c1"),
+        ]
+        original = [m.copy() for m in msgs]
+        _evict_old_screenshots_openai(msgs, max_keep=3)
+        assert msgs == original
+
+    def test_empty_list_noop(self):
+        """Empty message list is returned unchanged."""
+        msgs = []
+        _evict_old_screenshots_openai(msgs, max_keep=3)
+        assert msgs == []
+
+    def test_string_content_skipped(self):
+        """Tool messages with string content (not list) are skipped."""
+        msgs = [
+            _tool_msg("plain text result", "c1"),
+            _tool_msg([_img_part("img_1")], "c2"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=1)
+        # String content untouched
+        assert msgs[0]["content"] == "plain text result"
+        # Only one image, within limit
+        assert msgs[1]["content"][0]["type"] == "image_url"
+
+    def test_max_keep_zero_disables_eviction(self):
+        """Setting max_keep=0 means nothing is evicted (all images kept)."""
+        msgs = [
+            _tool_msg([_img_part("img_1")], "c1"),
+            _tool_msg([_img_part("img_2")], "c2"),
+            _tool_msg([_img_part("img_3")], "c3"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=0)
+        # All images kept (0 means no limit applied — the > max_keep gate never fires)
+        assert msgs[0]["content"][0]["type"] == "image_url"
+        assert msgs[1]["content"][0]["type"] == "image_url"
+        assert msgs[2]["content"][0]["type"] == "image_url"
+
+    def test_input_image_type_recognized(self):
+        """input_image type (OpenAI Responses API) is recognized and evicted."""
+        msgs = [
+            _tool_msg([{"type": "input_image", "image_url": "img_1"}], "c1"),
+            _tool_msg([{"type": "input_image", "image_url": "img_2"}], "c2"),
+            _tool_msg([{"type": "input_image", "image_url": "img_3"}], "c3"),
+            _tool_msg([{"type": "input_image", "image_url": "img_4"}], "c4"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=2)
+        assert msgs[0]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        assert msgs[1]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        assert msgs[2]["content"][0]["type"] == "input_image"
+        assert msgs[3]["content"][0]["type"] == "input_image"
+
+    def test_mixed_image_types(self):
+        """Mix of image_url and input_image parts are all counted together."""
+        msgs = [
+            _tool_msg([_img_part("img_1")], "c1"),
+            _tool_msg([{"type": "input_image", "image_url": "img_2"}], "c2"),
+            _tool_msg([_img_part("img_3")], "c3"),
+            _tool_msg([{"type": "input_image", "image_url": "img_4"}], "c4"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=2)
+        assert msgs[0]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        assert msgs[1]["content"][0] == {"type": "text", "text": "[screenshot removed to save context]"}
+        assert msgs[2]["content"][0]["type"] == "image_url"
+        assert msgs[3]["content"][0]["type"] == "input_image"
+
+    def test_exact_max_keep_boundary(self):
+        """Exactly max_keep images means none are evicted."""
+        msgs = [
+            _tool_msg([_img_part("img_1")], "c1"),
+            _tool_msg([_img_part("img_2")], "c2"),
+            _tool_msg([_img_part("img_3")], "c3"),
+        ]
+        _evict_old_screenshots_openai(msgs, max_keep=3)
+        assert msgs[0]["content"][0]["type"] == "image_url"
+        assert msgs[1]["content"][0]["type"] == "image_url"
+        assert msgs[2]["content"][0]["type"] == "image_url"
+
+
+# ---------------------------------------------------------------------------
+# _strip_historical_media — anchor expansion tests
+# ---------------------------------------------------------------------------
+
+class TestStripHistoricalMediaAnchor:
+    """Verify that _strip_historical_media now anchors on tool-role images."""
+
+    def test_tool_role_image_used_as_anchor(self):
+        """A tool-role image anchors the strip — images before it are replaced."""
+        msgs = [
+            _user_msg([_img_part("old_user_img")]),
+            _assistant_msg("let me check"),
+            _tool_msg([_img_part("tool_screenshot")], "c1"),
+            _user_msg("what do you see?"),
+        ]
+        result = _strip_historical_media(msgs)
+
+        # The tool message at index 2 is the anchor.
+        # Messages before it with images get stripped.
+        # The user message at index 0 has an image before the anchor -> stripped.
+        assert result[0]["content"][0]["type"] == "text"
+        assert "stripped after compression" in result[0]["content"][0]["text"]
+        # Tool message image kept (it IS the anchor)
+        assert result[2]["content"][0]["type"] == "image_url"
+        # User message after anchor untouched
+        assert result[3]["content"] == "what do you see?"
+
+    def test_only_tool_images_no_user_images(self):
+        """Typical browser_vision flow: user text -> tool screenshots.
+        The last tool screenshot anchors; earlier ones are stripped."""
+        msgs = [
+            _user_msg("check this page"),
+            _assistant_msg("looking"),
+            _tool_msg([_img_part("screenshot_1")], "c1"),
+            _tool_msg([_img_part("screenshot_2")], "c2"),
+            _assistant_msg("I see..."),
+        ]
+        result = _strip_historical_media(msgs)
+
+        # Anchor is the last tool image (index 3).
+        # Index 2 is before anchor -> stripped.
+        assert "stripped" in result[2]["content"][0]["text"]
+        # Index 3 IS the anchor -> kept
+        assert result[3]["content"][0]["type"] == "image_url"
+
+    def test_user_image_before_tool_anchor(self):
+        """User image before tool anchor gets stripped."""
+        msgs = [
+            _user_msg([_img_part("user_img")]),
+            _assistant_msg("let me look"),
+            _tool_msg([_img_part("tool_screenshot")], "c1"),
+        ]
+        result = _strip_historical_media(msgs)
+
+        # Anchor is tool message at index 2.
+        # User image at index 0 is before anchor -> stripped.
+        assert result[0]["content"][0]["type"] == "text"
+        assert "stripped after compression" in result[0]["content"][0]["text"]


### PR DESCRIPTION
## Summary

Tool-result screenshots (browser_vision, vision_analyze) accumulate forever in conversation history on the chat_completions wire format and are re-sent every turn, causing token bloat and local-model OOM on OpenAI-compatible providers (LM Studio, Ollama, vLLM, OpenRouter).

## Fix

Port the Anthropic adapter's eviction strategy to the OpenAI-compatible path:

- **New function** `_evict_old_screenshots_openai()` in `context_compressor.py` — walks backward through tool-role messages, keeps the most recent N images (default 3), replaces older with `[screenshot removed to save context]` placeholder
- **Wired into** `conversation_loop.py` after `_sanitize_messages_surrogates` — only touches the per-call `api_messages` copy, stored history is never mutated
- **Fixed** `_strip_historical_media` anchor to also include tool-role messages — previously only user-role images anchored the strip, leaving tool screenshots untouched in the typical `user → assistant(tool_calls) → tool(results)` flow
- **Configurable** via `agent.max_tool_images` (default 3, set 0 to disable)

## Three gaps addressed (from issue #63849)

1. **Anthropic-only eviction** — `_evict_old_screenshots` only runs inside `convert_messages_to_anthropic()`, never for chat_completions
2. **Anchor excludes tool-role images** — `_strip_historical_media` only anchored on user-role messages
3. **4xx-only gate** — `_strip_images_from_messages` requires HTTP 4xx, local OOM crashes never trigger it (addressed by proactive eviction)

## Testing

13 unit tests in `tests/test_openai_image_eviction.py` covering:
- Eviction with various N values, boundary conditions
- Text part preservation in multipart tool messages
- Non-tool message immunity
- `input_image` and `image_url` type recognition
- Mixed image types
- `_strip_historical_media` anchor expansion for tool-role messages

## Config

Add to `config.yaml` under the agent section:

```yaml
agent:
  max_tool_images: 3  # default; set 0 to disable eviction
```

Fixes #63849