### PR TITLE
fix(hindsight): preserve embedded config and shared HF compatibility

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -539,6 +539,16 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
+    configured_env = config.get("embedded_api_env") or config.get("hindsight_api_env") or {}
+    if isinstance(configured_env, dict):
+        for key, value in configured_env.items():
+            key = str(key)
+            if not (key.startswith("HINDSIGHT_API_") or key.startswith("HINDSIGHT_EMBED_")):
+                continue
+            if value is None or value == "":
+                continue
+            env_values[key] = str(value)
     return env_values
 
 
@@ -552,7 +562,15 @@ def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: st
     """Write the profile-scoped env file that standalone hindsight-embed uses."""
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
-    env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
+    existing = {
+        key: value
+        for key, value in _load_simple_env(profile_env).items()
+        if key.startswith("HINDSIGHT_API_") or key.startswith("HINDSIGHT_EMBED_")
+    }
+    env_values = {
+        **existing,
+        **_build_embedded_profile_env(config, llm_api_key=llm_api_key),
+    }
     profile_env.write_text(
         "".join(f"{key}={value}\n" for key, value in env_values.items()),
         encoding="utf-8",
@@ -1421,7 +1439,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     profile_env = _embedded_profile_env_path(self._config)
                     expected_env = _build_embedded_profile_env(self._config)
                     saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    config_changed = any(saved.get(key) != value for key, value in expected_env.items())
 
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -676,6 +676,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._client = None
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
+        self._prefetch_join_timeout = 3.0
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
@@ -1023,6 +1024,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
+            {"key": "prefetch_join_timeout", "description": "Maximum seconds to wait for auto-recall prefetch", "default": 3.0},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
             {"key": "port_health_grace_timeout", "description": "Seconds to wait for a slow daemon /health before treating it as stale (raise on busy/low-resource hosts; blank uses the 30s default)", "default": "", "when": {"mode": "local_embedded"}},
         ]
@@ -1281,6 +1283,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._config.get("idle_timeout") if self._config.get("idle_timeout") is not None else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
             _DEFAULT_IDLE_TIMEOUT,
         )
+        self._prefetch_join_timeout = float(self._config.get("prefetch_join_timeout", 3.0))
         # "local" is a legacy alias for "local_embedded"
         if self._mode == "local":
             self._mode = "local_embedded"
@@ -1484,7 +1487,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
-            self._prefetch_thread.join(timeout=3.0)
+            self._prefetch_thread.join(timeout=max(0.0, self._prefetch_join_timeout))
         with self._prefetch_lock:
             result = self._prefetch_result
             self._prefetch_result = ""

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _materialize_embedded_profile_env,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -416,6 +417,121 @@ class TestConfig:
         })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
+
+    @pytest.mark.parametrize("config_key", ["embedded_api_env", "hindsight_api_env"])
+    def test_embedded_profile_env_passes_through_only_safe_nonempty_overrides(
+        self, config_key
+    ):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            config_key: {
+                "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "local",
+                "HINDSIGHT_EMBED_VECTOR_SIZE": 1024,
+                "HINDSIGHT_API_EMPTY": "",
+                "HINDSIGHT_EMBED_NONE": None,
+                "UNRELATED_SETTING": "ignored",
+            },
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "local"
+        assert env["HINDSIGHT_EMBED_VECTOR_SIZE"] == "1024"
+        assert "HINDSIGHT_API_EMPTY" not in env
+        assert "HINDSIGHT_EMBED_NONE" not in env
+        assert "UNRELATED_SETTING" not in env
+
+    def test_materialize_embedded_profile_env_preserves_safe_keys_and_overrides_stale_values(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        profile_env.write_text(
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER=stale\n"
+            "HINDSIGHT_API_RERANKER_PROVIDER=local\n"
+            "HINDSIGHT_EMBED_CUSTOM_FLAG=kept\n"
+            "UNRELATED_SETTING=discarded\n",
+            encoding="utf-8",
+        )
+
+        _materialize_embedded_profile_env({
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embedded_api_env": {
+                "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "configured",
+            },
+        })
+
+        materialized = dict(
+            line.split("=", 1)
+            for line in profile_env.read_text(encoding="utf-8").splitlines()
+        )
+        assert materialized["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "configured"
+        assert materialized["HINDSIGHT_API_RERANKER_PROVIDER"] == "local"
+        assert materialized["HINDSIGHT_EMBED_CUSTOM_FLAG"] == "kept"
+        assert "UNRELATED_SETTING" not in materialized
+
+    def test_preserved_extra_profile_env_does_not_restart_embedded_daemon(
+        self, tmp_path, monkeypatch
+    ):
+        config = {
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("plugins.memory.hindsight._load_config", lambda: config)
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setattr("plugins.memory.hindsight.os.geteuid", lambda: 1000)
+        monkeypatch.setattr("importlib.metadata.version", lambda _name: "999.0")
+
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        expected = _build_embedded_profile_env(config)
+        profile_env.write_text(
+            "".join(f"{key}={value}\n" for key, value in expected.items())
+            + "HINDSIGHT_API_RERANKER_PROVIDER=local\n",
+            encoding="utf-8",
+        )
+
+        manager = SimpleNamespace(
+            is_running=MagicMock(return_value=True),
+            stop=MagicMock(),
+        )
+        client = SimpleNamespace(
+            _manager=manager,
+            _ensure_started=MagicMock(),
+        )
+        daemon_manager = SimpleNamespace(console=None)
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight_embed",
+            SimpleNamespace(daemon_embed_manager=daemon_manager),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight_embed.daemon_embed_manager",
+            daemon_manager,
+        )
+
+        class ImmediateThread:
+            def __init__(self, *, target, **_kwargs):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        monkeypatch.setattr("plugins.memory.hindsight.threading.Thread", ImmediateThread)
+
+        provider = HindsightMemoryProvider()
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        provider.initialize("session")
+
+        manager.stop.assert_not_called()
+        client._ensure_started.assert_called_once_with()
 
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -909,6 +909,16 @@ class TestPrefetch:
     def test_prefetch_returns_empty_when_no_result(self, provider):
         assert provider.prefetch("test") == ""
 
+    def test_prefetch_joins_live_thread_with_configured_timeout(self, provider_with_config):
+        provider = provider_with_config(prefetch_join_timeout=0.5)
+        live_thread = MagicMock()
+        live_thread.is_alive.return_value = True
+        provider._prefetch_thread = live_thread
+
+        provider.prefetch("test")
+
+        live_thread.join.assert_called_once_with(timeout=0.5)
+
     def test_prefetch_default_preamble(self, provider):
         provider._prefetch_result = "- some memory"
         result = provider.prefetch("test")

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -94,6 +94,26 @@ class TestAllowlist:
                 assert ld._spec_is_safe(spec), \
                     f"{feature}: spec {spec!r} fails safety check"
 
+    def test_trace_upload_hub_range_is_hindsight_compatible(self):
+        """Trace upload must not downgrade Hindsight's shared HF runtime."""
+        from packaging.requirements import Requirement
+        from packaging.version import Version
+
+        specs = ld.feature_specs("tool.trace_upload")
+        assert len(specs) == 1
+
+        spec = specs[0]
+        requirement = Requirement(spec)
+        assert requirement.name == "huggingface-hub"
+        assert ld._spec_is_safe(spec)
+
+        # transformers 5.12.0 requires huggingface-hub>=1.5.0,<2. Keep the
+        # whole compatible 1.x range available instead of forcing a downgrade.
+        assert Version("1.5.0") in requirement.specifier
+        assert Version("1.99.0") in requirement.specifier
+        assert Version("1.4.99") not in requirement.specifier
+        assert Version("2.0.0") not in requirement.specifier
+
     def test_feature_install_command_returns_pip_invocation(self):
         cmd = ld.feature_install_command("memory.honcho")
         assert cmd is not None

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -239,7 +239,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
-    "tool.trace_upload": ("huggingface-hub==1.2.3",),
+    # Keep compatible with Hindsight's transformers runtime when both share a venv.
+    "tool.trace_upload": ("huggingface-hub>=1.5.0,<2",),
 }
 
 


### PR DESCRIPTION
## Problem

RTrade's embedded Hindsight daemon became unusable after a Hermes update path activated trace upload:

1. `tool.trace_upload` pinned `huggingface-hub==1.2.3`, downgrading the shared venv below `transformers 5.12.0`'s required `>=1.5.0,<2` range. Local `sentence-transformers` imports then failed and every daemon start waited for the full startup timeout.
2. Embedded profile materialization rebuilt `.env` from only LLM/idle settings. It dropped configured local embeddings, reranker, port, and other safe Hindsight settings, creating config drift and restart churn.
3. `prefetch_join_timeout` was configured but the provider still used a hardcoded 3-second join.

## Fix

- Preserve configured `HINDSIGHT_API_*` / `HINDSIGHT_EMBED_*` values and existing safe profile values when materializing the embedded profile.
- Compare expected keys as a subset so unrelated preserved Hindsight settings do not force restarts.
- Honor and validate the configured `prefetch_join_timeout`.
- Change trace upload's shared Hugging Face dependency to `huggingface-hub>=1.5.0,<2` and add a compatibility regression test.

## Verification

- `uv run --extra dev pytest tests/plugins/memory/test_hindsight_provider.py tests/tools/test_lazy_deps.py -q` → 186 passed
- `uv run --extra dev ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py tools/lazy_deps.py tests/tools/test_lazy_deps.py` → passed
- `git diff --check origin/main...HEAD` → passed

No secrets or profile-specific values are included.