### PR TITLE
fix(windows): honor HERMES_HOME in first-launch PATH prefill

### DIFF
--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -212,33 +212,50 @@ def _augment_path_with_known_tools() -> None:
     and when the directories don't exist.  The User PATH broadcast still
     happens in the background for future shells; this just smooths over
     the first-launch gap.
+
+    The Hermes-owned tool dirs are resolved through ``get_hermes_home()`` —
+    the single source of truth ``scripts/install.ps1`` already mirrors
+    (``$HermesHome = $env:HERMES_HOME or %LOCALAPPDATA%\\hermes``) — so a
+    custom ``HERMES_HOME`` install (multi-profile / non-C-drive / redirected
+    AppData) is honored instead of being silently ignored.  WinGet drops its
+    shims under ``%LOCALAPPDATA%\\Microsoft\\WinGet\\Links`` regardless of
+    ``HERMES_HOME``, so that entry stays rooted at ``LOCALAPPDATA``.
     """
     if not is_windows():
         return
 
+    # Resolve Hermes-owned tool dirs via the single source of truth so a
+    # custom HERMES_HOME is honored — install.ps1 roots PortableGit/venv at
+    # $HermesHome = HERMES_HOME or %LOCALAPPDATA%\hermes, and this prefill
+    # must mirror that, not a hardcoded %LOCALAPPDATA%\hermes.  Local import:
+    # stdio.py is imported early in startup, so import hermes_constants lazily
+    # to avoid any circular-import risk.
+    from hermes_constants import get_hermes_home
 
+    hermes_home = str(get_hermes_home())
     local_appdata = os.environ.get("LOCALAPPDATA", "")
-    if not local_appdata:
-        return
 
     # Known tool dirs installed by scripts/install.ps1.  Kept in sync with
     # the PATH entries that installer adds to User scope — the two lists
     # should match so this prefill fully mirrors what a fresh shell would
     # see on next launch.
     candidate_dirs = [
-        os.path.join(local_appdata, "hermes", "git", "cmd"),
-        os.path.join(local_appdata, "hermes", "git", "bin"),
-        os.path.join(local_appdata, "hermes", "git", "usr", "bin"),
+        os.path.join(hermes_home, "git", "cmd"),
+        os.path.join(hermes_home, "git", "bin"),
+        os.path.join(hermes_home, "git", "usr", "bin"),
         # Hermes venv Scripts directory — host of the hermes.exe shim itself,
         # also where any pip-installed console scripts land.  Usually already
         # on PATH when the user invokes hermes, but harmless to include.
-        os.path.join(local_appdata, "hermes", "hermes-agent", "venv", "Scripts"),
-        # WinGet packages directory — where ``winget install`` drops CLI
-        # shims by default (ripgrep lands here as rg.exe).  Covers the case
-        # of a system-Git install + ripgrep-via-winget that isn't yet on
-        # the spawning shell's PATH.
-        os.path.join(local_appdata, "Microsoft", "WinGet", "Links"),
+        os.path.join(hermes_home, "hermes-agent", "venv", "Scripts"),
     ]
+    # WinGet packages directory — where ``winget install`` drops CLI shims by
+    # default (ripgrep lands here as rg.exe).  This is NOT under HERMES_HOME,
+    # so keep it rooted at LOCALAPPDATA.  Covers the case of a system-Git
+    # install + ripgrep-via-winget that isn't yet on the spawning shell's PATH.
+    if local_appdata:
+        candidate_dirs.append(
+            os.path.join(local_appdata, "Microsoft", "WinGet", "Links")
+        )
 
     existing = os.environ.get("PATH", "")
     existing_lower = {p.lower() for p in existing.split(os.pathsep) if p}

--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -265,4 +265,10 @@ def _augment_path_with_known_tools() -> None:
             prepend.append(d)
 
     if prepend:
-        os.environ["PATH"] = os.pathsep.join([*prepend, existing])
+        # Drop an empty ``existing`` before joining: ``os.pathsep.join([dir,
+        # ""])`` would leave a trailing separator, i.e. an empty PATH element,
+        # which resolves to the current working directory on Windows — an
+        # unintended and unsafe lookup location.  This branch is reachable when
+        # LOCALAPPDATA is unset (custom HERMES_HOME), where PATH can legitimately
+        # be empty.
+        os.environ["PATH"] = os.pathsep.join(p for p in [*prepend, existing] if p)

--- a/tests/hermes_cli/test_stdio_path_augment.py
+++ b/tests/hermes_cli/test_stdio_path_augment.py
@@ -42,8 +42,37 @@ def test_augment_path_honors_custom_hermes_home(monkeypatch, tmp_path):
 
     entries = os.environ["PATH"].split(os.pathsep)
     assert str(git_cmd) in entries
-    # baseline must be preserved (prepend, not replace).
+    # baseline must be preserved (prepend, not replace)...
     assert str(baseline) in entries
+    # ...and the Hermes tool dir must be PREPENDED — appear before the prior
+    # PATH — so Hermes-managed tools win name collisions with the ambient PATH.
+    assert entries.index(str(git_cmd)) < entries.index(str(baseline))
+
+
+def test_augment_path_empty_existing_has_no_trailing_separator(monkeypatch, tmp_path):
+    """An empty existing PATH must not produce an empty PATH element.
+
+    ``os.pathsep.join([dir, ""])`` would leave a trailing separator; on Windows
+    an empty PATH element resolves to the current working directory, which is
+    unintended and unsafe.  This is reachable when LOCALAPPDATA is unset (custom
+    HERMES_HOME), where PATH can legitimately be empty.  Fails before the fix
+    (join leaves ``"...git\\cmd;"``); passes after (empty segments filtered).
+    """
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+
+    hermes_home = tmp_path / "custom_home"
+    git_cmd = hermes_home / "git" / "cmd"
+    git_cmd.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setenv("PATH", "")
+
+    stdio._augment_path_with_known_tools()
+
+    entries = os.environ["PATH"].split(os.pathsep)
+    assert "" not in entries, "empty PATH element (trailing separator) must not be emitted"
+    assert str(git_cmd) in entries
 
 
 def test_augment_path_default_profile_uses_localappdata(monkeypatch, tmp_path):
@@ -71,3 +100,6 @@ def test_augment_path_default_profile_uses_localappdata(monkeypatch, tmp_path):
 
     entries = os.environ["PATH"].split(os.pathsep)
     assert str(git_cmd) in entries
+    # The prior PATH must be preserved and the tool dir prepended before it.
+    assert str(baseline) in entries
+    assert entries.index(str(git_cmd)) < entries.index(str(baseline))

--- a/tests/hermes_cli/test_stdio_path_augment.py
+++ b/tests/hermes_cli/test_stdio_path_augment.py
@@ -1,0 +1,73 @@
+"""Regression tests for ``_augment_path_with_known_tools`` HERMES_HOME support.
+
+The first-launch Windows PATH prefill in ``hermes_cli.stdio`` must resolve its
+Hermes-owned tool directories through ``get_hermes_home()`` — the single source
+of truth ``scripts/install.ps1`` mirrors — so a custom ``HERMES_HOME`` install
+(multi-profile / non-C-drive / redirected AppData) is honored rather than
+silently ignored.  These tests run headless on any platform (Windows detection
+and, where needed, the platform default are monkeypatched).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import hermes_cli.stdio as stdio
+
+
+def test_augment_path_honors_custom_hermes_home(monkeypatch, tmp_path):
+    """A custom HERMES_HOME's git\\cmd dir is prepended to PATH.
+
+    Fails before the fix (prefill hardcodes %LOCALAPPDATA%\\hermes, which does
+    not contain the tool dir); passes after (dirs resolve via get_hermes_home).
+    """
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+
+    hermes_home = tmp_path / "custom_home"
+    git_cmd = hermes_home / "git" / "cmd"
+    git_cmd.mkdir(parents=True)
+
+    # LOCALAPPDATA points at a DIFFERENT dir with no hermes/git/cmd under it,
+    # so the only way git_cmd gets onto PATH is via HERMES_HOME resolution.
+    appdata = tmp_path / "appdata"
+    appdata.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("LOCALAPPDATA", str(appdata))
+    baseline = tmp_path / "baseline"
+    monkeypatch.setenv("PATH", str(baseline))
+
+    stdio._augment_path_with_known_tools()
+
+    entries = os.environ["PATH"].split(os.pathsep)
+    assert str(git_cmd) in entries
+    # baseline must be preserved (prepend, not replace).
+    assert str(baseline) in entries
+
+
+def test_augment_path_default_profile_uses_localappdata(monkeypatch, tmp_path):
+    """Default profile (HERMES_HOME unset) still prepends %LOCALAPPDATA%\\hermes.
+
+    Guards the superset property: when HERMES_HOME is unset the resolved dirs
+    must be byte-identical to the old %LOCALAPPDATA%\\hermes behavior.
+    """
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    # Force the win32 platform default so get_hermes_home() falls back to
+    # %LOCALAPPDATA%\hermes exactly as it does on a real default-profile
+    # Windows install.
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    appdata = tmp_path / "appdata"
+    git_cmd = appdata / "hermes" / "git" / "cmd"
+    git_cmd.mkdir(parents=True)
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(appdata))
+    baseline = tmp_path / "baseline"
+    monkeypatch.setenv("PATH", str(baseline))
+
+    stdio._augment_path_with_known_tools()
+
+    entries = os.environ["PATH"].split(os.pathsep)
+    assert str(git_cmd) in entries


### PR DESCRIPTION
## What does this PR do?

The first-launch Windows PATH prefill — `_augment_path_with_known_tools()` in `hermes_cli/stdio.py` — hardcodes `%LOCALAPPDATA%\hermes\...` for the Hermes-managed tool directories. But `scripts/install.ps1` roots those tools at `$HermesHome = $env:HERMES_HOME or %LOCALAPPDATA%\hermes` (install.ps1:26-27). So on a **custom `HERMES_HOME` install** (multi-profile, non-C-drive, or redirected AppData) the installer drops PortableGit/venv under `$HERMES_HOME\...`, while this prefill still looks under `%LOCALAPPDATA%\hermes\...`. Every `os.path.isdir()` check fails and the prefill silently no-ops — defeating the function on exactly the installs it exists to help: `rg`/`npm`/`git` report "command not found" on first launch until the shell is restarted.

This resolves the three Hermes-owned tool dirs through `get_hermes_home()` — the single source of truth `install.ps1` already mirrors. WinGet drops its shims under `%LOCALAPPDATA%\Microsoft\WinGet\Links` regardless of `HERMES_HOME`, so that entry stays rooted at `LOCALAPPDATA`.

Mirrors `install.ps1` precedence: `$HermesHome = $env:HERMES_HOME` when set, else `%LOCALAPPDATA%\hermes` — the same precedence `get_hermes_home()` implements.

**Root cause:** `install.ps1` roots tools at `$HermesHome = HERMES_HOME || %LOCALAPPDATA%\hermes`; the runtime prefill only ever checked `LOCALAPPDATA`, so a custom `HERMES_HOME` was silently ignored.

**Strict superset — no default-profile change:** with `HERMES_HOME` unset, `get_hermes_home()` returns `%LOCALAPPDATA%\hermes`, so the default profile's candidate dirs are byte-identical to before.

## Related Issue

No linked issue — code-originated correctness bug found by auditing `install.ps1` against the runtime prefill.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/stdio.py`: `_augment_path_with_known_tools()` now resolves `git\{cmd,bin,usr\bin}` and `hermes-agent\venv\Scripts` under `get_hermes_home()` instead of a hardcoded `%LOCALAPPDATA%\hermes`. WinGet `Links` stays on `LOCALAPPDATA` (guarded). The `hermes_constants` import is function-local to avoid any startup import cycle (`stdio.py` is imported early). Removed the `if not local_appdata: return` early-return since `hermes_home` is now the primary source; only the WinGet append is `LOCALAPPDATA`-guarded. Docstring updated to reference `HERMES_HOME`/`get_hermes_home()`.
- `tests/hermes_cli/test_stdio_path_augment.py` (new): regression coverage.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_stdio_path_augment.py -v` → 2 passed.
2. **Fail-before / pass-after:** with the production hunk reverted to `origin/main`, `test_augment_path_honors_custom_hermes_home` FAILS (the custom-`HERMES_HOME` `git\cmd` dir is not prepended); with the fix applied it PASSES. Verified both directions.
3. `test_augment_path_default_profile_uses_localappdata` guards the superset: with `HERMES_HOME` unset and the win32 default, `%LOCALAPPDATA%\hermes\git\cmd` is still prepended — no default-profile regression.
4. Tests are fully headless (`is_windows` / platform monkeypatched), so they run on Linux CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite (`tests/hermes_cli/ -k "stdio or path or windows"`) and my new tests pass; the one unrelated failure (`test_managed_uv`) is a pre-existing baseline reproducible on clean `origin/main` (local homebrew `uv` on PATH under single-process runs; CI isolates per file)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (headless; Windows-specific path logic exercised via monkeypatch)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the function docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — Windows-only code path; POSIX still early-returns via `is_windows()`; default Windows profile is byte-identical
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A