### PR TITLE
perf(tools): text prefilter before AST parse in tool discovery

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -45,11 +45,20 @@ def _module_registers_tools(module_path: Path) -> bool:
 
     Only inspects module-body statements so that helper modules which happen
     to call ``registry.register()`` inside a function are not picked up.
+
+    A cheap text prefilter avoids the ``ast.parse`` cost for files that do not
+    mention both ``registry`` and ``register`` — a necessary condition for a
+    top-level ``registry.register()`` call to exist.
     """
     try:
         source = module_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if "registry" not in source or "register" not in source:
+        return False
+    try:
         tree = ast.parse(source, filename=str(module_path))
-    except (OSError, SyntaxError):
+    except SyntaxError:
         return False
 
     return any(_is_registry_register_call(stmt) for stmt in tree.body)


### PR DESCRIPTION
## What does this PR do?

`_module_registers_tools()` in `tools/registry.py` fully AST-parses every `tools/*.py` file (90 files) on every process start to find the ~32 that contain a top-level `registry.register()` call. The `ast.parse` call dominates — ~306ms of the ~340ms scan.

This PR adds a cheap text prefilter: after reading the file (which we need to do anyway), check that both `"registry"` and `"register"` appear in the source before calling `ast.parse`. Any file with a top-level `registry.register()` call must contain both strings, so this is a perfect superset — zero false negatives. 50 of 90 files skip the AST parse entirely.

The prefilter lives entirely inside `_module_registers_tools`; `discover_builtin_tools` and its public signature are unchanged.

## Related Issue

N/A — found while investigating slow `discover_builtin_tools` startup.

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `tools/registry.py`: `_module_registers_tools()` — read file first, text-check for `"registry"` and `"register"` before `ast.parse`, split OSError/SyntaxError handling

## How to Test

1. `pytest tests/tools/test_registry.py tests/test_toolsets.py -q` — 76 passed
2. Benchmark (median of 10 runs, 90 files):
   ```
   before (read + ast.parse all):  305.9ms
   after  (text prefilter + ast):   187.8ms
   speedup: 1.6x  (118ms saved)
   ```
3. Identical module set confirmed: 32 modules, same names, same order.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, no behavior change; existing tests cover
- [x] I've tested on my platform: NixOS (Linux 7.1.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, pure Python stdlib
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
