### PR TITLE
fix(serve): bridge terminal.backend config to TERMINAL_ENV in start_server (#63141)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17008,6 +17008,14 @@ def start_server(
     except Exception as exc:
         _log.debug("Nous auth keepalive did not start: %s", exc)
 
+
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+
+        apply_terminal_config_to_env()
+    except Exception:
+        _log.debug("Failed to apply terminal config to env", exc_info=True)
+
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token
     # injection / WS-auth paths can branch on it consistently.  Phase 3.5
     # uses this to decide whether to refuse the bind, log the gate-on


### PR DESCRIPTION
## Description

The headless serve backend (used by Desktop) never called apply_terminal_config_to_env() for its own process environment. This meant terminal.backend: docker in config.yaml was ignored - the terminal tool always ran in local mode, bypassing the Docker sandbox entirely.

## Fix

Added apply_terminal_config_to_env() call in start_server() before the uvicorn server starts, matching the pattern already used for dashboard PTY child processes.

Fixes #63141