### PR TITLE
fix(cron): bound terminal cwd lock acquisition

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -400,6 +400,7 @@ def _consume_interrupted_flag(job_id: str) -> bool:
 # ticker thread.  A persistent single-thread executor preserves ordering across
 # ticks while keeping dispatch fire-and-forget, the same as the parallel pool.
 _sequential_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_TERMINAL_CWD_LOCK_TIMEOUT_SECONDS = 30.0
 
 
 class _ReadWriteLock:
@@ -425,11 +426,19 @@ class _ReadWriteLock:
         self._writer_active = False
         self._writers_waiting = 0
 
-    def acquire_read(self) -> None:
+    def acquire_read(self, timeout: Optional[float] = None) -> bool:
+        deadline = None if timeout is None else time.monotonic() + max(0.0, timeout)
         with self._cond:
             while self._writer_active or self._writers_waiting > 0:
-                self._cond.wait()
+                if deadline is None:
+                    self._cond.wait()
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._cond.wait(remaining)
             self._readers += 1
+            return True
 
     def release_read(self) -> None:
         with self._cond:
@@ -437,15 +446,23 @@ class _ReadWriteLock:
             if self._readers == 0:
                 self._cond.notify_all()
 
-    def acquire_write(self) -> None:
+    def acquire_write(self, timeout: Optional[float] = None) -> bool:
+        deadline = None if timeout is None else time.monotonic() + max(0.0, timeout)
         with self._cond:
             self._writers_waiting += 1
             try:
                 while self._writer_active or self._readers > 0:
-                    self._cond.wait()
+                    if deadline is None:
+                        self._cond.wait()
+                        continue
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return False
+                    self._cond.wait(remaining)
             finally:
                 self._writers_waiting -= 1
             self._writer_active = True
+            return True
 
     def release_write(self) -> None:
         with self._cond:
@@ -2758,17 +2775,27 @@ def run_job(
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
 
     _holds_cwd_write = _job_workdir is not None
-    if _holds_cwd_write:
-        _terminal_cwd_lock.acquire_write()
-    else:
-        _terminal_cwd_lock.acquire_read()
+    _cwd_lock_acquired = False
 
-    # Everything after the acquire MUST live inside this try, so the finally
-    # below always releases the lock even if the env override or any later
-    # statement raises.  A leaked writer would deadlock the whole scheduler
-    # (every future job blocks on acquire_*); a leaked reader blocks all
-    # future writers.  Acquire itself can't leak (it either blocks or returns).
+    # Everything from acquire onward MUST live inside this try, so timeout or
+    # body failures return a normal cron failure and the finally below releases
+    # the lock only if it was actually acquired.
     try:
+        if _holds_cwd_write:
+            _cwd_lock_acquired = _terminal_cwd_lock.acquire_write(
+                timeout=_TERMINAL_CWD_LOCK_TIMEOUT_SECONDS
+            )
+        else:
+            _cwd_lock_acquired = _terminal_cwd_lock.acquire_read(
+                timeout=_TERMINAL_CWD_LOCK_TIMEOUT_SECONDS
+            )
+        if not _cwd_lock_acquired:
+            raise TimeoutError(
+                f"Cron job '{job_name}' timed out waiting for TERMINAL_CWD "
+                f"{'write' if _holds_cwd_write else 'read'} lock after "
+                f"{_TERMINAL_CWD_LOCK_TIMEOUT_SECONDS:g}s"
+            )
+
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
@@ -3325,10 +3352,11 @@ def run_job(
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
         # Release the cwd lock now that the env is restored, so a waiting
         # workdir job (or queued reader) can proceed without seeing the override.
-        if _holds_cwd_write:
-            _terminal_cwd_lock.release_write()
-        else:
-            _terminal_cwd_lock.release_read()
+        if _cwd_lock_acquired:
+            if _holds_cwd_write:
+                _terminal_cwd_lock.release_write()
+            else:
+                _terminal_cwd_lock.release_read()
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:

--- a/tests/cron/test_terminal_cwd_lock.py
+++ b/tests/cron/test_terminal_cwd_lock.py
@@ -11,6 +11,7 @@ These tests assert that contract.
 """
 
 import threading
+import time
 
 
 def _lock():
@@ -84,6 +85,30 @@ def test_writer_waits_for_active_reader():
     assert order == ["reader-release", "writer-acquire"]
 
 
+def test_writer_acquire_times_out_behind_active_reader():
+    """Bounded acquire prevents a stuck reader from blocking a writer forever."""
+    lock = _lock()
+    lock.acquire_read()
+    started = time.monotonic()
+    try:
+        assert lock.acquire_write(timeout=0.01) is False
+    finally:
+        lock.release_read()
+    assert time.monotonic() - started < 1.0
+
+
+def test_reader_acquire_times_out_behind_active_writer():
+    """Bounded acquire prevents a stuck writer from blocking readers forever."""
+    lock = _lock()
+    lock.acquire_write()
+    started = time.monotonic()
+    try:
+        assert lock.acquire_read(timeout=0.01) is False
+    finally:
+        lock.release_write()
+    assert time.monotonic() - started < 1.0
+
+
 def test_reader_never_observes_writer_override():
     """Regression: the cross-pool TERMINAL_CWD corruption.
 
@@ -132,6 +157,29 @@ def test_reader_never_observes_writer_override():
     assert not wt.is_alive() and not rt.is_alive()
     # The reader saw the restored value, never the writer's /project/A override.
     assert observations == ["<scheduler>"]
+
+
+def test_run_job_fails_fast_when_cwd_lock_is_stuck(tmp_path, monkeypatch):
+    """A leaked writer must not wedge a later cron job's worker forever."""
+    import cron.scheduler as sched
+
+    monkeypatch.setattr(sched, "_TERMINAL_CWD_LOCK_TIMEOUT_SECONDS", 0.01)
+    sched._terminal_cwd_lock.acquire_write()
+    try:
+        job = {
+            "id": "blocked-reader",
+            "name": "blocked-reader",
+            "prompt": "hi",
+        }
+
+        start = time.monotonic()
+        success, _out, _final, error = sched.run_job(job)
+    finally:
+        sched._terminal_cwd_lock.release_write()
+
+    assert success is False
+    assert "TERMINAL_CWD read lock" in (error or "")
+    assert time.monotonic() - start < 10.0
 
 
 def test_run_job_releases_cwd_lock_when_body_raises(tmp_path):


### PR DESCRIPTION
## Summary

Bound cron `TERMINAL_CWD` lock acquisition so a stale reader/writer cannot wedge scheduled jobs forever.

## Problem

Cron workdir isolation uses `_terminal_cwd_lock` to serialize the process-global `os.environ["TERMINAL_CWD"]` override:

- workdir jobs acquire the write lock
- workdir-less jobs acquire the read lock

The lock release path is protected once acquisition succeeds, but `acquire_read()` / `acquire_write()` themselves wait forever. If a prior job or thread gets stuck while holding the cwd lock, later cron workers block before their own job body can run. Those workers remain in the scheduler's in-flight guard and future ticks keep skipping the job as already running until the gateway is restarted.

This is the same scheduler-wedge class as #63935, but on the cwd isolation lock rather than `SessionDB()` initialization. #63935 explicitly calls this out as an unfixed sibling risk.

## Fix

- Add bounded wait support to `_ReadWriteLock.acquire_read()` and `acquire_write()`.
- Use an internal cron cwd-lock timeout when `run_job()` acquires the read/write lock.
- If the lock cannot be acquired in time, return a normal cron failure instead of hanging the worker forever.
- Track whether the lock was actually acquired so the `finally` path only releases held locks.

No user-facing config or env var is added.

## Tests

Added regressions in `tests/cron/test_terminal_cwd_lock.py`:

- writer acquisition times out behind a stuck reader
- reader acquisition times out behind a stuck writer
- `run_job()` fails fast when the cwd lock is stuck instead of blocking forever

Validation:

```text
ruff check --no-cache cron/scheduler.py tests/cron/test_terminal_cwd_lock.py