### PR TITLE
fix(tests): unbreak E2E approval + surrogate sanitization tests on main

### DIFF
--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -421,6 +421,18 @@ class TestBlockingApprovalE2E:
         os.environ.pop("HERMES_GATEWAY_SESSION", None)
         os.environ.pop("HERMES_EXEC_ASK", None)
         os.environ.pop("HERMES_SESSION_KEY", None)
+        # Force manual approval mode — these tests exercise the blocking
+        # gateway flow, not smart approval. The default became "smart"
+        # (#62661), which routes through _smart_approve() first and
+        # delays the notify callback past the test's wait window.
+        self._approval_mode_patch = patch(
+            "tools.approval._get_approval_config",
+            return_value={"mode": "manual"},
+        )
+        self._approval_mode_patch.start()
+
+    def teardown_method(self):
+        self._approval_mode_patch.stop()
 
     def test_blocking_approval_approve_once(self):
         """check_all_command_guards blocks until resolve_gateway_approval is called."""


### PR DESCRIPTION
## What does this PR do?

Fixes two failing test files on `main`:

### 1. `tests/gateway/test_approve_deny_commands.py` — smart approval default change

Commit `62a76bd3d` (`feat: make smart approvals the default`, #62661) changed `approvals.mode` from `"manual"` to `"smart"`. The `TestBlockingApprovalE2E` tests did not patch the approval mode, so `check_all_command_guards` routed through `_smart_approve()` first → `call_llm()` → tried all auxiliary providers → all failed (no API keys in test env) → returned `"escalate"` → fell through to the gateway blocking path. The LLM failure cascade took longer than the test's 2.5s wait window (50 × 0.05s), so the notify callback had not fired yet when `assert len(notified) == 1` ran.

**Fix:** Patch `_get_approval_config` to return `{"mode": "manual"}` in `setup_method`/`teardown_method`, matching the pattern already used by `test_blocking_approval_uses_canonical_timeout` in the same class.

### 2. `tests/cli/test_surrogate_sanitization.py` — `FATAL: exception not rethread` on Python 3.11

The `TestRunConversationSurrogateSanitization` test creates a full `AIAgent`, which starts a `QueueListener` daemon thread (`_monitor`) via `setup_logging()`. On Python 3.11 the daemon can still be mid-loop when the interpreter begins shutdown, and accessing partially-torn-down logging objects produces `FATAL: exception not rethread` at process exit — a non-zero exit code in CI even though every test passed (28/28).

**Fix:** Add an autouse fixture that calls `_reset_queued_handlers()` after each test to stop the listener and join its worker thread cleanly before interpreter shutdown.

## Related Issue

Follow-up to #62661

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/gateway/test_approve_deny_commands.py`: Force `{"mode": "manual"}` in `TestBlockingApprovalE2E.setup_method`/`teardown_method`
- `tests/cli/test_surrogate_sanitization.py`: Add autouse `_stop_log_queue_listener` fixture

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_approve_deny_commands.py tests/cli/test_surrogate_sanitization.py -q`
2. All 57 tests pass (29 + 28), exit code 0

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh` on both files and all tests pass
