### PR TITLE
fix(memory): scope Mem0 Qdrant storage to the active profile

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -114,16 +114,27 @@ hermes memory setup mem0 --mode oss \
 hermes memory setup mem0 --mode oss --oss-llm-key sk-...
 ```
 
-Or edit `$HERMES_HOME/mem0.json` directly:
+Or edit `$HERMES_HOME/mem0.json` directly. For local Qdrant,
+`hermes memory setup` resolves the default to the active profile's
+`$HERMES_HOME/mem0_qdrant` directory and stores the resolved absolute path:
+
 ```json
 {
   "mode": "oss",
   "oss": {
     "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
     "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small"}},
-    "vector_store": {"provider": "qdrant", "config": {"path": "~/.hermes/mem0_qdrant"}}
+    "vector_store": {"provider": "qdrant", "config": {"path": "/absolute/path/to/active-hermes-home/mem0_qdrant"}}
   }
 }
+```
+
+To deliberately keep using the legacy shared store from a named profile,
+set it as an explicit override:
+
+```bash
+hermes memory setup mem0 --mode oss --oss-llm-key sk-... \
+  --oss-vector-path ~/.hermes/mem0_qdrant
 ```
 
 ### OSS to Platform
@@ -159,8 +170,9 @@ Circuit breaker tripped after 5 consecutive failures. Resets after 2 minutes.
 ### OSS: Qdrant connection refused
 
 ```bash
-# If using local Qdrant, check the storage path is writable:
-ls -la ~/.hermes/mem0_qdrant
+# If using local Qdrant, check the active profile's storage path is writable.
+# HERMES_HOME defaults to ~/.hermes for the default profile.
+ls -la "${HERMES_HOME:-$HOME/.hermes}/mem0_qdrant"
 
 # If using Qdrant server, check it's reachable:
 curl http://localhost:6333/healthz

--- a/plugins/memory/mem0/_oss_providers.py
+++ b/plugins/memory/mem0/_oss_providers.py
@@ -42,7 +42,7 @@ EMBEDDER_PROVIDERS: dict[str, dict[str, Any]] = {
 VECTOR_PROVIDERS: dict[str, dict[str, Any]] = {
     "qdrant": {
         "label": "Qdrant",
-        "default_config": {"path": os.path.expanduser("~/.hermes/mem0_qdrant")},
+        "default_config": {},
         "pip_dep": "qdrant-client",
     },
     "pgvector": {

--- a/plugins/memory/mem0/_oss_providers.py
+++ b/plugins/memory/mem0/_oss_providers.py
@@ -46,7 +46,7 @@ EMBEDDER_PROVIDERS: dict[str, dict[str, Any]] = {
 VECTOR_PROVIDERS: dict[str, dict[str, Any]] = {
     "qdrant": {
         "label": "Qdrant",
-        "default_config": {"path": os.path.expanduser("~/.hermes/mem0_qdrant")},
+        "default_config": {},
         "pip_dep": "qdrant-client",
     },
     "pgvector": {

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -152,8 +152,7 @@ def build_oss_config(flags: dict[str, str]) -> tuple[dict, dict[str, str]]:
     vector_def = VECTOR_PROVIDERS[vector_id]
     vector_config = dict(vector_def["default_config"])
     if vector_id == "qdrant":
-        if flags.get("oss_vector_path"):
-            vector_config["path"] = flags["oss_vector_path"]
+        vector_config["path"] = flags.get("oss_vector_path") or str(get_hermes_home() / "mem0_qdrant")
         if flags.get("oss_vector_url"):
             vector_config.pop("path", None)
             vector_config["url"] = flags["oss_vector_url"]

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -154,8 +154,7 @@ def build_oss_config(flags: dict[str, str]) -> tuple[dict, dict[str, str]]:
     vector_def = VECTOR_PROVIDERS[vector_id]
     vector_config = dict(vector_def["default_config"])
     if vector_id == "qdrant":
-        if flags.get("oss_vector_path"):
-            vector_config["path"] = flags["oss_vector_path"]
+        vector_config["path"] = flags.get("oss_vector_path") or str(get_hermes_home() / "mem0_qdrant")
         if flags.get("oss_vector_url"):
             vector_config.pop("path", None)
             vector_config["url"] = flags["oss_vector_url"]

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -146,6 +146,21 @@ class TestBuildOSSConfig:
         oss, _ = build_oss_config(flags)
         assert oss["vector_store"]["config"]["path"] == "/data/qdrant"
 
+    def test_default_qdrant_path_tracks_active_profile(self, tmp_path, monkeypatch):
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+        flags = parse_flags(["--mode", "oss", "--oss-llm-key", "sk-oai"])
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_a))
+        first, _ = build_oss_config(flags)
+        monkeypatch.setenv("HERMES_HOME", str(profile_b))
+        second, _ = build_oss_config(flags)
+
+        assert first["vector_store"]["config"]["path"] == str(profile_a / "mem0_qdrant")
+        assert second["vector_store"]["config"]["path"] == str(profile_b / "mem0_qdrant")
+
 
 class TestWriteEnv:
 

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -123,6 +123,21 @@ class TestBuildOSSConfig:
         oss, _ = build_oss_config(flags)
         assert oss["vector_store"]["config"]["path"] == "/data/qdrant"
 
+    def test_default_qdrant_path_tracks_active_profile(self, tmp_path, monkeypatch):
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+        flags = parse_flags(["--mode", "oss", "--oss-llm-key", "sk-oai"])
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_a))
+        first, _ = build_oss_config(flags)
+        monkeypatch.setenv("HERMES_HOME", str(profile_b))
+        second, _ = build_oss_config(flags)
+
+        assert first["vector_store"]["config"]["path"] == str(profile_a / "mem0_qdrant")
+        assert second["vector_store"]["config"]["path"] == str(profile_b / "mem0_qdrant")
+
 
 class TestWriteEnv:
 


### PR DESCRIPTION
## What does this PR do?

Named Hermes profiles use separate `HERMES_HOME` directories, but Mem0's OSS Qdrant default was materialized as the hard-coded `~/.hermes/mem0_qdrant`. A named profile that did not pass an explicit vector path therefore read and wrote the same local vector store as every other profile, defeating profile isolation and potentially surfacing memories from another profile.

This PR resolves the default Qdrant path from `get_hermes_home()` when OSS configuration is built. Explicit `--oss-vector-path` and `--oss-vector-url` values keep their existing precedence.

Migration note: this intentionally does not move data from the previously shared default store. Its ownership may already be ambiguous or mixed across profiles. Users who deliberately want the old location can keep it with an explicit vector path.

## Related Issue

No dedicated issue. I searched the open PRs for Mem0, Qdrant, and profile-isolation fixes and found no matching change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Remove the process-global Qdrant path from `plugins/memory/mem0/_oss_providers.py`.
- Derive the implicit local Qdrant path from the active profile in `plugins/memory/mem0/_setup.py`.
- Exercise the real `HERMES_HOME` resolver in a same-process profile-switch regression test while retaining coverage for explicit paths and remote URLs.
- Document the profile-scoped default path and show the old shared path only as an explicit compatibility override.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/memory/test_mem0_backend.py tests/plugins/memory/test_mem0_providers.py tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_v3.py --file-timeout 180`.
2. Confirm all 123 tests pass, including `test_default_qdrant_path_tracks_active_profile`.
3. Run Ruff on the three changed Python files and `python scripts/check-windows-footguns.py --diff origin/main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- updated the Mem0 README with profile-scoped and explicit legacy-path behavior
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

```text
Mem0 plugin surface: 123 tests passed, 0 failed
Ruff: All checks passed
Windows footgun check: No Windows footguns found
```
