### PR TITLE
fix(feishu): preserve profile scope for SDK-thread callbacks

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1441,6 +1441,11 @@ class FeishuAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.FEISHU)
 
+        # SDK callbacks arrive on Feishu-owned threads, which do not inherit
+        # the profile ContextVars active while this adapter was constructed.
+        # Retain the owning home so callback work can restore both home and
+        # credential scope before it touches config, rules, or agent runtime.
+        self._profile_home = Path(get_hermes_home())
         self._settings = self._load_settings(config.extra or {})
         self._apply_settings(self._settings)
         self._client: Optional[Any] = None
@@ -2678,14 +2683,47 @@ class FeishuAdapter(BasePlatformAdapter):
         return loop is not None and not bool(getattr(loop, "is_closed", lambda: False)())
 
     def _submit_on_loop(self, loop: Any, coro: Any) -> bool:
-        """Schedule background work on the adapter loop with shared failure logging."""
+        """Schedule SDK callback work under this adapter's profile context."""
+        import contextvars
+
         from agent.async_utils import safe_schedule_threadsafe
-        future = safe_schedule_threadsafe(
-            coro, loop,
-            logger=logger,
-            log_message="[Feishu] Failed to schedule background callback work",
-            log_level=logging.WARNING,
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            reset_secret_scope,
+            set_secret_scope,
         )
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_home = Path(
+            getattr(self, "_profile_home", None) or get_hermes_home()
+        )
+
+        def _schedule_in_profile_context():
+            home_token = set_hermes_home_override(profile_home)
+            secret_token = set_secret_scope(
+                build_profile_secret_scope(profile_home)
+            )
+            try:
+                return safe_schedule_threadsafe(
+                    coro,
+                    loop,
+                    logger=logger,
+                    log_message=(
+                        "[Feishu] Failed to schedule background callback work"
+                    ),
+                    log_level=logging.WARNING,
+                )
+            finally:
+                reset_secret_scope(secret_token)
+                reset_hermes_home_override(home_token)
+
+        # asyncio.run_coroutine_threadsafe captures the caller's Context for
+        # the task it installs on ``loop``. Use a fresh copy so resetting the
+        # SDK thread after submission cannot mutate the task's profile scope.
+        future = contextvars.copy_context().run(_schedule_in_profile_context)
         if future is None:
             return False
         future.add_done_callback(self._log_background_failure)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1502,6 +1502,11 @@ class FeishuAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.FEISHU)
 
+        # SDK callbacks arrive on Feishu-owned threads, which do not inherit
+        # the profile ContextVars active while this adapter was constructed.
+        # Retain the owning home so callback work can restore both home and
+        # credential scope before it touches config, rules, or agent runtime.
+        self._profile_home = Path(get_hermes_home())
         self._settings = self._load_settings(config.extra or {})
         self._apply_settings(self._settings)
         self._client: Optional[Any] = None
@@ -2755,14 +2760,47 @@ class FeishuAdapter(BasePlatformAdapter):
         return loop is not None and not bool(getattr(loop, "is_closed", lambda: False)())
 
     def _submit_on_loop(self, loop: Any, coro: Any) -> bool:
-        """Schedule background work on the adapter loop with shared failure logging."""
+        """Schedule SDK callback work under this adapter's profile context."""
+        import contextvars
+
         from agent.async_utils import safe_schedule_threadsafe
-        future = safe_schedule_threadsafe(
-            coro, loop,
-            logger=logger,
-            log_message="[Feishu] Failed to schedule background callback work",
-            log_level=logging.WARNING,
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            reset_secret_scope,
+            set_secret_scope,
         )
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_home = Path(
+            getattr(self, "_profile_home", None) or get_hermes_home()
+        )
+
+        def _schedule_in_profile_context():
+            home_token = set_hermes_home_override(profile_home)
+            secret_token = set_secret_scope(
+                build_profile_secret_scope(profile_home)
+            )
+            try:
+                return safe_schedule_threadsafe(
+                    coro,
+                    loop,
+                    logger=logger,
+                    log_message=(
+                        "[Feishu] Failed to schedule background callback work"
+                    ),
+                    log_level=logging.WARNING,
+                )
+            finally:
+                reset_secret_scope(secret_token)
+                reset_hermes_home_override(home_token)
+
+        # asyncio.run_coroutine_threadsafe captures the caller's Context for
+        # the task it installs on ``loop``. Use a fresh copy so resetting the
+        # SDK thread after submission cannot mutate the task's profile scope.
+        future = contextvars.copy_context().run(_schedule_in_profile_context)
         if future is None:
             return False
         future.add_done_callback(self._log_background_failure)

--- a/plugins/platforms/feishu/feishu_comment_rules.py
+++ b/plugins/platforms/feishu/feishu_comment_rules.py
@@ -24,13 +24,29 @@ logger = logging.getLogger(__name__)
 # Paths
 # ---------------------------------------------------------------------------
 #
-# Uses the canonical ``get_hermes_home()`` helper (HERMES_HOME-aware and
-# profile-safe). Resolved at import time; this module is lazy-imported by
-# the Feishu comment event handler, which runs long after profile overrides
-# have been applied, so freezing paths here is safe.
+# Keep the public constants for CLI callers and tests that patch them, but
+# resolve their default values at call time.  A multiplexed gateway can serve
+# multiple Feishu adapters from one process, so whichever profile imports this
+# module first must not pin every later comment event to that profile.
 
 RULES_FILE = get_hermes_home() / "feishu_comment_rules.json"
 PAIRING_FILE = get_hermes_home() / "feishu_comment_pairing.json"
+_RULES_FILE_AT_IMPORT = RULES_FILE
+_PAIRING_FILE_AT_IMPORT = PAIRING_FILE
+
+
+def _rules_file() -> Path:
+    configured = Path(RULES_FILE)
+    if configured != _RULES_FILE_AT_IMPORT:
+        return configured
+    return get_hermes_home() / "feishu_comment_rules.json"
+
+
+def _pairing_file() -> Path:
+    configured = Path(PAIRING_FILE)
+    if configured != _PAIRING_FILE_AT_IMPORT:
+        return configured
+    return get_hermes_home() / "feishu_comment_pairing.json"
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -105,6 +121,38 @@ class _MtimeCache:
 
 _rules_cache = _MtimeCache(RULES_FILE)
 _pairing_cache = _MtimeCache(PAIRING_FILE)
+_RULES_CACHE_AT_IMPORT = _rules_cache
+_PAIRING_CACHE_AT_IMPORT = _pairing_cache
+_rules_caches: Dict[Path, _MtimeCache] = {RULES_FILE: _rules_cache}
+_pairing_caches: Dict[Path, _MtimeCache] = {PAIRING_FILE: _pairing_cache}
+
+
+def _active_cache(
+    path: Path,
+    configured_cache: _MtimeCache,
+    import_cache: _MtimeCache,
+    caches: Dict[Path, _MtimeCache],
+) -> _MtimeCache:
+    """Return the cache for ``path``, preserving the existing patch seam."""
+    if configured_cache is not import_cache:
+        return configured_cache
+    cache = caches.get(path)
+    if cache is None:
+        cache = _MtimeCache(path)
+        caches[path] = cache
+    return cache
+
+
+def _active_rules_cache() -> _MtimeCache:
+    return _active_cache(
+        _rules_file(), _rules_cache, _RULES_CACHE_AT_IMPORT, _rules_caches
+    )
+
+
+def _active_pairing_cache() -> _MtimeCache:
+    return _active_cache(
+        _pairing_file(), _pairing_cache, _PAIRING_CACHE_AT_IMPORT, _pairing_caches
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +183,7 @@ def _parse_document_rule(raw: dict) -> CommentDocumentRule:
 
 def load_config() -> CommentsConfig:
     """Load comment rules from disk (mtime-cached)."""
-    raw = _rules_cache.load()
+    raw = _active_rules_cache().load()
     if not raw:
         return CommentsConfig()
 
@@ -223,7 +271,7 @@ def resolve_rule(
 
 def _load_pairing_approved() -> set:
     """Return set of approved user open_ids (mtime-cached)."""
-    data = _pairing_cache.load()
+    data = _active_pairing_cache().load()
     approved = data.get("approved", {})
     if isinstance(approved, dict):
         return set(approved.keys())
@@ -233,19 +281,21 @@ def _load_pairing_approved() -> set:
 
 
 def _save_pairing(data: dict) -> None:
-    PAIRING_FILE.parent.mkdir(parents=True, exist_ok=True)
-    tmp = PAIRING_FILE.with_suffix(".tmp")
+    pairing_file = _pairing_file()
+    pairing_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = pairing_file.with_suffix(".tmp")
     with open(tmp, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
-    tmp.replace(PAIRING_FILE)
+    tmp.replace(pairing_file)
     # Invalidate cache so next load picks up change
-    _pairing_cache._mtime = 0.0
-    _pairing_cache._data = None
+    cache = _active_pairing_cache()
+    cache._mtime = 0.0
+    cache._data = None
 
 
 def pairing_add(user_open_id: str) -> bool:
     """Add a user to the pairing-approved list. Returns True if newly added."""
-    data = _pairing_cache.load()
+    data = _active_pairing_cache().load()
     approved = data.get("approved", {})
     if not isinstance(approved, dict):
         approved = {}
@@ -259,7 +309,7 @@ def pairing_add(user_open_id: str) -> bool:
 
 def pairing_remove(user_open_id: str) -> bool:
     """Remove a user from the pairing-approved list. Returns True if removed."""
-    data = _pairing_cache.load()
+    data = _active_pairing_cache().load()
     approved = data.get("approved", {})
     if not isinstance(approved, dict):
         return False
@@ -273,7 +323,7 @@ def pairing_remove(user_open_id: str) -> bool:
 
 def pairing_list() -> Dict[str, Any]:
     """Return the approved dict  {user_open_id: {approved_at: ...}}."""
-    data = _pairing_cache.load()
+    data = _active_pairing_cache().load()
     approved = data.get("approved", {})
     return dict(approved) if isinstance(approved, dict) else {}
 
@@ -297,10 +347,12 @@ def is_user_allowed(rule: ResolvedCommentRule, user_open_id: str) -> bool:
 
 def _print_status() -> None:
     cfg = load_config()
-    print(f"Rules file: {RULES_FILE}")
-    print(f"  exists: {RULES_FILE.exists()}")
-    print(f"Pairing file: {PAIRING_FILE}")
-    print(f"  exists: {PAIRING_FILE.exists()}")
+    rules_file = _rules_file()
+    pairing_file = _pairing_file()
+    print(f"Rules file: {rules_file}")
+    print(f"  exists: {rules_file.exists()}")
+    print(f"Pairing file: {pairing_file}")
+    print(f"  exists: {pairing_file.exists()}")
     print()
     print("Top-level:")
     print(f"  enabled:    {cfg.enabled}")
@@ -366,7 +418,7 @@ def _main() -> int:
         "  pairing remove <user_open_id>        Remove user from pairing-approved list\n"
         "  pairing list                         List pairing-approved users\n"
         "\n"
-        f"Rules config file: {RULES_FILE}\n"
+        f"Rules config file: {_rules_file()}\n"
         "  Edit this JSON file directly to configure policies and document rules.\n"
         "  Changes take effect on the next comment event (no restart needed).\n"
     )

--- a/tests/gateway/test_feishu_comment_rules.py
+++ b/tests/gateway/test_feishu_comment_rules.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from plugins.platforms.feishu.feishu_comment_rules import (
     CommentsConfig,
     CommentDocumentRule,
@@ -232,7 +233,7 @@ class TestMtimeCache(unittest.TestCase):
             self.assertEqual(cache.load(), {"v": 1})
             # Modify file
             time.sleep(0.05)
-            with open(path, "w") as f2:
+            with open(path, "w", encoding="utf-8") as f2:
                 json.dump({"v": 2}, f2)
             # Force mtime change detection
             os.utime(path, (time.time() + 1, time.time() + 1))
@@ -276,12 +277,43 @@ class TestLoadConfig(unittest.TestCase):
         self.assertEqual(cfg.allow_from, frozenset())
         self.assertEqual(cfg.documents, {})
 
+    def test_load_config_tracks_active_profile_after_module_import(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            profile_a = root / "profile-a"
+            profile_b = root / "profile-b"
+            profile_a.mkdir()
+            profile_b.mkdir()
+            (profile_a / "feishu_comment_rules.json").write_text(
+                json.dumps({"policy": "allowlist", "allow_from": ["ou_a"]}),
+                encoding="utf-8",
+            )
+            (profile_b / "feishu_comment_rules.json").write_text(
+                json.dumps({"policy": "allowlist", "allow_from": ["ou_b"]}),
+                encoding="utf-8",
+            )
+
+            token = set_hermes_home_override(profile_a)
+            try:
+                cfg_a = load_config()
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(profile_b)
+            try:
+                cfg_b = load_config()
+            finally:
+                reset_hermes_home_override(token)
+
+        self.assertEqual(cfg_a.allow_from, frozenset(["ou_a"]))
+        self.assertEqual(cfg_b.allow_from, frozenset(["ou_b"]))
+
 
 class TestPairingStore(unittest.TestCase):
     def setUp(self):
         self._tmpdir = tempfile.mkdtemp()
         self._pairing_file = Path(self._tmpdir) / "pairing.json"
-        with open(self._pairing_file, "w") as f:
+        with open(self._pairing_file, "w", encoding="utf-8") as f:
             json.dump({"approved": {}}, f)
         self._patcher_file = patch("plugins.platforms.feishu.feishu_comment_rules.PAIRING_FILE", self._pairing_file)
         self._patcher_cache = patch(
@@ -314,6 +346,38 @@ class TestPairingStore(unittest.TestCase):
 
     def test_remove_nonexistent(self):
         self.assertFalse(pairing_remove("ou_nobody"))
+
+
+class TestProfileScopedPairingStore(unittest.TestCase):
+    def test_pairing_writes_stay_in_active_profile(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            profile_a = root / "profile-a"
+            profile_b = root / "profile-b"
+            profile_a.mkdir()
+            profile_b.mkdir()
+
+            token = set_hermes_home_override(profile_a)
+            try:
+                self.assertTrue(pairing_add("ou_a"))
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(profile_b)
+            try:
+                self.assertTrue(pairing_add("ou_b"))
+            finally:
+                reset_hermes_home_override(token)
+
+            pairing_a = json.loads(
+                (profile_a / "feishu_comment_pairing.json").read_text(encoding="utf-8")
+            )
+            pairing_b = json.loads(
+                (profile_b / "feishu_comment_pairing.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(set(pairing_a["approved"]), {"ou_a"})
+        self.assertEqual(set(pairing_b["approved"]), {"ou_b"})
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_feishu_comment_rules.py
+++ b/tests/gateway/test_feishu_comment_rules.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from plugins.platforms.feishu.feishu_comment_rules import (
     CommentsConfig,
     CommentDocumentRule,
@@ -126,12 +127,43 @@ class TestLoadConfig(unittest.TestCase):
         finally:
             path.unlink()
 
+    def test_load_config_tracks_active_profile_after_module_import(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            profile_a = root / "profile-a"
+            profile_b = root / "profile-b"
+            profile_a.mkdir()
+            profile_b.mkdir()
+            (profile_a / "feishu_comment_rules.json").write_text(
+                json.dumps({"policy": "allowlist", "allow_from": ["ou_a"]}),
+                encoding="utf-8",
+            )
+            (profile_b / "feishu_comment_rules.json").write_text(
+                json.dumps({"policy": "allowlist", "allow_from": ["ou_b"]}),
+                encoding="utf-8",
+            )
+
+            token = set_hermes_home_override(profile_a)
+            try:
+                cfg_a = load_config()
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(profile_b)
+            try:
+                cfg_b = load_config()
+            finally:
+                reset_hermes_home_override(token)
+
+        self.assertEqual(cfg_a.allow_from, frozenset(["ou_a"]))
+        self.assertEqual(cfg_b.allow_from, frozenset(["ou_b"]))
+
 
 class TestPairingStore(unittest.TestCase):
     def setUp(self):
         self._tmpdir = tempfile.mkdtemp()
         self._pairing_file = Path(self._tmpdir) / "pairing.json"
-        with open(self._pairing_file, "w") as f:
+        with open(self._pairing_file, "w", encoding="utf-8") as f:
             json.dump({"approved": {}}, f)
         self._patcher_file = patch("plugins.platforms.feishu.feishu_comment_rules.PAIRING_FILE", self._pairing_file)
         self._patcher_cache = patch(
@@ -152,6 +184,38 @@ class TestPairingStore(unittest.TestCase):
         self.assertTrue(pairing_add("ou_new"))
         approved = pairing_list()
         self.assertIn("ou_new", approved)
+
+
+class TestProfileScopedPairingStore(unittest.TestCase):
+    def test_pairing_writes_stay_in_active_profile(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            profile_a = root / "profile-a"
+            profile_b = root / "profile-b"
+            profile_a.mkdir()
+            profile_b.mkdir()
+
+            token = set_hermes_home_override(profile_a)
+            try:
+                self.assertTrue(pairing_add("ou_a"))
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(profile_b)
+            try:
+                self.assertTrue(pairing_add("ou_b"))
+            finally:
+                reset_hermes_home_override(token)
+
+            pairing_a = json.loads(
+                (profile_a / "feishu_comment_pairing.json").read_text(encoding="utf-8")
+            )
+            pairing_b = json.loads(
+                (profile_b / "feishu_comment_pairing.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(set(pairing_a["approved"]), {"ou_a"})
+        self.assertEqual(set(pairing_b["approved"]), {"ou_b"})
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_feishu_profile_scope.py
+++ b/tests/gateway/test_feishu_profile_scope.py
@@ -1,0 +1,86 @@
+"""Profile isolation for Feishu SDK-thread callbacks."""
+
+import asyncio
+import concurrent.futures
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+from agent.secret_scope import (
+    get_secret,
+    reset_secret_scope,
+    set_secret_scope,
+)
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+class TestFeishuCallbackProfileScope(unittest.TestCase):
+    def test_submit_restores_adapter_profile_home_and_secrets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            outer_home = root / "outer"
+            profile_home = root / "worker"
+            outer_home.mkdir()
+            profile_home.mkdir()
+            (profile_home / ".env").write_text(
+                "PROFILE_CALLBACK_SECRET=worker-secret\n",
+                encoding="utf-8",
+            )
+
+            adapter = FeishuAdapter.__new__(FeishuAdapter)
+            adapter._profile_home = profile_home
+            adapter._log_background_failure = Mock()
+            result_future = concurrent.futures.Future()
+            loop = asyncio.new_event_loop()
+            loop_ready = threading.Event()
+
+            def run_loop():
+                asyncio.set_event_loop(loop)
+                loop_ready.set()
+                loop.run_forever()
+
+            loop_thread = threading.Thread(target=run_loop, daemon=True)
+            loop_thread.start()
+            self.assertTrue(loop_ready.wait(timeout=5))
+
+            async def probe_context():
+                result_future.set_result(
+                    (
+                        get_hermes_home(),
+                        get_secret("PROFILE_CALLBACK_SECRET"),
+                    )
+                )
+
+            home_token = set_hermes_home_override(outer_home)
+            secret_token = set_secret_scope(
+                {"PROFILE_CALLBACK_SECRET": "outer-secret"}
+            )
+            try:
+                submitted = adapter._submit_on_loop(loop, probe_context())
+
+                self.assertTrue(submitted)
+                self.assertEqual(
+                    result_future.result(timeout=5),
+                    (profile_home, "worker-secret"),
+                )
+                self.assertEqual(get_hermes_home(), outer_home)
+                self.assertEqual(
+                    get_secret("PROFILE_CALLBACK_SECRET"), "outer-secret"
+                )
+            finally:
+                reset_secret_scope(secret_token)
+                reset_hermes_home_override(home_token)
+                loop.call_soon_threadsafe(loop.stop)
+                loop_thread.join(timeout=5)
+                loop.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Feishu's SDK invokes event callbacks on SDK-owned threads. Those threads do not inherit the profile `ContextVar` values that were active when a multiplexed adapter was constructed. Callback work scheduled through `_submit_on_loop()` could therefore run without the adapter's `HERMES_HOME` and secret scope.

This matters most for work that starts before or outside the normal message-turn wrapper, including drive-comment policy checks, pairing, reactions, meeting invitations, and card actions. In a multi-profile gateway, the first profile to import the comment-rules module could pin its rules and pairing paths for every later profile; unscoped credential reads could also fail closed.

This PR captures each adapter's owning profile home, schedules SDK callback work in a copied context containing that profile's home and secret mapping, and resets the submitting thread immediately afterward. It does not mutate `os.environ`. Comment-rule and pairing caches are also selected by the active profile path while retaining the existing public patch seams used by callers and tests.

## Related Issue

No dedicated issue. I searched the open PRs for Feishu callback, comment-rule, pairing, and multiplex profile-isolation fixes and found no matching change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Capture the adapter's profile home in `plugins/platforms/feishu/adapter.py` and restore both home and secret scope when SDK-thread callbacks are submitted.
- Resolve Feishu comment-rule and pairing files at call time, with independent mtime caches per profile.
- Add a real background-event-loop regression test proving that callback tasks see the adapter profile while the caller's outer context remains unchanged.
- Add same-process tests proving that rules and pairing writes stay in their active profiles.
- Specify UTF-8 for two existing text-file writes in the touched test file so the Windows compatibility check passes.

## How to Test

1. Run `python -m pytest -q tests/gateway/test_feishu_comment_rules.py tests/gateway/test_feishu_profile_scope.py`; 13 focused tests pass on current `main`.
2. Run `uvx ruff check` on the four changed Python files.
3. Run `git diff --check`.

A broader local Feishu run produced 138 passed and 18 skipped. One unrelated SSRF rebind test was intercepted by the machine's local HTTP proxy at `127.0.0.1:7890`; none of this PR's changed hunks are on that download path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A; behavior now follows the documented multiplex profile model
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

```text
Focused profile tests: 13 passed, 0 failed
Feishu-related surface: 138 passed, 18 skipped, 1 unrelated local-proxy failure
Ruff: All checks passed
Diff check: clean
```
