### PR TITLE
fix(gateway): interrupt api_server runs on shutdown timeout

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -997,6 +997,25 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return 0
 
+    def interrupt_active_runs(self, reason: str) -> int:
+        """Interrupt active API-run agents during gateway shutdown.
+
+        The gateway drain accounts for API-server work through
+        ``active_agent_work_count()``, but those agents are owned by this
+        adapter rather than ``GatewayRunner._running_agents``.  Expose the same
+        cooperative interrupt used by ``POST /v1/runs/{run_id}/stop`` so a
+        shutdown timeout can stop long-running API work before process teardown.
+        """
+        interrupted = 0
+        for run_id, agent in list(self._active_run_agents.items()):
+            try:
+                agent.interrupt(reason)
+                interrupted += 1
+                logger.debug("[api_server] interrupted active run %s during shutdown", run_id)
+            except Exception as exc:
+                logger.debug("[api_server] failed interrupting active run %s: %s", run_id, exc)
+        return interrupted
+
     @staticmethod
     def _gateway_is_draining() -> bool:
         """Whether the owning gateway currently refuses new agent turns."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4164,6 +4164,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return 0
 
+    def _interrupt_api_server_runs(self, reason: str) -> int:
+        """Interrupt API-server agents that are not in ``_running_agents``."""
+        try:
+            adapter = getattr(self, "adapters", {}).get(Platform.API_SERVER)
+            helper = getattr(adapter, "interrupt_active_runs", None)
+            return max(0, int(helper(reason))) if callable(helper) else 0
+        except Exception as exc:
+            logger.debug("Failed interrupting api_server runs during shutdown: %s", exc)
+            return 0
+
     # ── scale-to-zero idle detection / dormant-quiesce (Phase 0) ──────────────
     # The gateway-side BEHAVIOUR that consumes the relay scale-to-zero primitives
     # (gateway-gateway Phase 5). Pure logic lives in gateway/scale_to_zero.py; the
@@ -5786,6 +5796,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
+        interrupted_api = self._interrupt_api_server_runs(reason)
+        if interrupted_api:
+            logger.debug("Interrupted %d api_server run(s) during shutdown", interrupted_api)
 
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
@@ -8307,7 +8320,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
                 )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
-                while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
+                while (
+                    self._running_agents
+                    or self._active_api_run_count()
+                ) and asyncio.get_running_loop().time() < interrupt_deadline:
                     self._update_runtime_status("draining")
                     await asyncio.sleep(0.1)
 

--- a/tests/gateway/test_api_server_active_work_drain.py
+++ b/tests/gateway/test_api_server_active_work_drain.py
@@ -144,6 +144,15 @@ class TestAPIServerAdapterWorkCount:
 
         assert adapter.active_agent_work_count() == 1
 
+    def test_interrupt_active_runs_interrupts_adapter_owned_agents(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        adapter._active_run_agents = {"run-1": agent}
+
+        assert adapter.interrupt_active_runs("gateway shutdown") == 1
+
+        agent.interrupt.assert_called_once_with("gateway shutdown")
+
 
 class TestDrainWaitsForApiWork:
     @pytest.mark.asyncio
@@ -208,6 +217,17 @@ class TestDrainWaitsForApiWork:
         _snapshot, timed_out = await runner._drain_active_agents(0.1)
 
         assert timed_out is True
+
+    def test_shutdown_interrupt_reaches_api_server_runs(self):
+        runner, _adapter = make_restart_runner()
+        api = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        api._active_run_agents = {"run-1": agent}
+        runner.adapters = {Platform.API_SERVER: api}
+
+        runner._interrupt_running_agents("gateway shutdown")
+
+        agent.interrupt.assert_called_once_with("gateway shutdown")
 
     @pytest.mark.asyncio
     async def test_drain_still_waits_for_chat_cron_and_api_work(self):


### PR DESCRIPTION
## Summary

This closes the shutdown-timeout follow-up gap for API-server runs.

The gateway drain now counts adapter-owned API-server work via `active_agent_work_count()`, but when the drain times out it still only interrupts agents stored in `GatewayRunner._running_agents`. `/v1/runs` agents live inside `APIServerAdapter._active_run_agents`, so they can remain running after the gateway has decided shutdown/restart must interrupt remaining work.

## Why

`GatewayRunner._drain_active_agents()` can now time out because of active API-server work, and the timeout log explicitly reports `api_server run(s)`. However, the interrupt path did not reach those adapter-owned agents.

That means a long-running `/v1/runs` task can survive the shutdown interrupt phase until process teardown, instead of receiving the same cooperative interrupt used by `POST /v1/runs/{run_id}/stop`.

## Changes

- Add `APIServerAdapter.interrupt_active_runs(reason)` to interrupt active `/v1/runs` agents owned by the adapter.
- Have `GatewayRunner._interrupt_running_agents()` also interrupt active API-server runs.
- Keep the post-interrupt wait loop watching API-server work as well as `_running_agents`.
- Add regression coverage for both the adapter-owned interrupt hook and the gateway shutdown interrupt path.

## Tests

```text
$env:TMP='C:\tmp'; $env:TEMP='C:\tmp'; python -m pytest tests/gateway/test_api_server_active_work_drain.py -q --timeout-method=thread
18 passed in 3.17s

python -m ruff check --no-cache gateway/run.py gateway/platforms/api_server.py tests/gateway/test_api_server_active_work_drain.py