### PR TITLE
fix(web): block unsafe final URLs from extract providers

### DIFF
--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -117,7 +117,7 @@ class TestEndToEnd:
              patch("tools.web_tools._get_extract_backend", return_value="fake"), \
              patch("tools.web_tools.async_is_safe_url", new=_AsyncTrue()), \
              patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):
-            result = json.loads(asyncio.new_event_loop().run_until_complete(
+            result = json.loads(asyncio.run(
                 wt.web_extract_tool(["https://example.com/big"], char_limit=5000)
             ))
 
@@ -128,6 +128,48 @@ class TestEndToEnd:
         # No LLM was involved: para 0 (head) and the last para (tail) are verbatim.
         assert "para 0 " in content
         assert "para 2999 " in content
+
+    def test_web_extract_blocks_provider_reported_private_final_url(self):
+        class FakeProvider:
+            name = "fake"
+            display_name = "Fake"
+
+            def supports_extract(self):
+                return True
+
+            async def extract(self, urls, **kwargs):
+                assert urls == ["https://example.com/redirect"]
+                return [
+                    {
+                        "url": "http://169.254.169.254/latest/meta-data/",
+                        "title": "metadata",
+                        "content": "SECRET_METADATA",
+                        "raw_content": "SECRET_METADATA",
+                        "metadata": {},
+                    }
+                ]
+
+        seen = []
+
+        async def fake_safe(url):
+            seen.append(url)
+            return url == "https://example.com/redirect"
+
+        with patch("tools.web_tools._ensure_web_plugins_loaded"), \
+             patch("tools.web_tools._get_extract_backend", return_value="fake"), \
+             patch("tools.web_tools.async_is_safe_url", new=fake_safe), \
+             patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):
+            result = json.loads(asyncio.run(
+                wt.web_extract_tool(["https://example.com/redirect"], char_limit=5000)
+            ))
+
+        assert seen == [
+            "https://example.com/redirect",
+            "http://169.254.169.254/latest/meta-data/",
+        ]
+        entry = result["results"][0]
+        assert entry["error"] == "Blocked: URL targets a private or internal network address"
+        assert "SECRET_METADATA" not in json.dumps(result)
 
 
 def _make_awaitable(value):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -963,6 +963,33 @@ async def web_extract_tool(
             by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
             results = [by_index[index] for index in range(len(urls))]
 
+        # Re-check provider-reported final URLs before any returned content is
+        # truncated, stored, or exposed to the model. The initial preflight only
+        # covers the caller-supplied URL; extract providers may follow
+        # redirects or canonicalize to a different final URL.
+        for result in results:
+            if result.get("error"):
+                continue
+            final_url = str(result.get("url") or "").strip()
+            if final_url and not await async_is_safe_url(final_url):
+                logger.info(
+                    "Blocked redirected web_extract result for unsafe final URL: %s",
+                    final_url,
+                )
+                result.clear()
+                result.update(
+                    {
+                        "url": final_url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": (
+                            "Blocked: URL targets a private or internal "
+                            "network address"
+                        ),
+                    }
+                )
+
         response = {"results": results}
         
         pages_extracted = len(response.get('results', []))


### PR DESCRIPTION
## Summary

This makes `web_extract_tool` re-check provider-reported final URLs before extracted content is truncated, stored, or returned to the model.

The tool already preflights caller-supplied URLs with `async_is_safe_url()`, and the Firecrawl provider has its own post-redirect re-check. Other extract providers can return a canonical/final URL after following redirects, but the central dispatcher accepted those results without re-validating the final URL.

## Why

The SSRF invariant for web extraction should be:

1. Check the caller-supplied URL before dispatching to a backend.
2. Check the backend-reported final URL before exposing any returned content.

Without step 2 in the shared dispatcher, non-Firecrawl extract providers could return content for a private/internal final URL after an initially safe public URL was accepted.

## Changes

- Re-check each successful extract result's `url` with `async_is_safe_url()` before truncation/storage/model exposure.
- Replace unsafe final-URL results with the same blocked error shape used by the initial preflight.
- Add regression coverage where the input URL is public-safe but the provider returns an AWS metadata final URL with sensitive content.
- Switch the existing truncate test from a manually-created event loop to `asyncio.run()` so the loop is closed cleanly.

## Validation

```text
python -m ruff check --no-cache tools/web_tools.py tests/tools/test_web_tools_truncate.py