### PR TITLE
fix(ci): exclude skipped jobs from timing deltas + show per-job wait times

### DIFF
--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -198,6 +198,38 @@ def _normalize_job(raw: dict) -> dict:
     }
 
 
+def _annotate_wait_times(jobs: list[dict]) -> None:
+    """Annotate each job with ``wait_s`` — how long it sat idle before starting.
+
+    Wait time = ``started_at - max(completed_at of all jobs that finished
+    before this job started)``. Jobs with no predecessor (e.g. ``detect``)
+    get ``wait_s = 0``. Skipped jobs get ``wait_s = None``.
+
+    This is a timestamp heuristic, not a workflow-YAML dependency parse: it
+    infers dependencies from temporal ordering rather than ``needs:``
+    declarations. It's accurate for pipeline-shaped CI where the critical
+    path is linear at each stage (detect → parallel lanes → gate → report).
+    """
+    for j in jobs:
+        if is_skipped(j):
+            j["wait_s"] = None
+            continue
+        started = parse_ts(j.get("started_at"))
+        if started is None:
+            j["wait_s"] = None
+            continue
+        latest_dep_end: datetime | None = None
+        for other in jobs:
+            if other is j or is_skipped(other):
+                continue
+            other_end = parse_ts(other.get("completed_at"))
+            if other_end is None or other_end > started:
+                continue
+            if latest_dep_end is None or other_end > latest_dep_end:
+                latest_dep_end = other_end
+        j["wait_s"] = (started - latest_dep_end).total_seconds() if latest_dep_end else 0.0
+
+
 def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
     """Collect job/step timings from the GitHub API.
 
@@ -248,6 +280,7 @@ def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
     all_jobs = [_normalize_job(j) for j in direct + sub_jobs_raw]
     all_jobs = [j for j in all_jobs if j["status"] not in ("in_progress", "queued")]
     all_jobs.sort(key=lambda j: j.get("started_at") or "")
+    _annotate_wait_times(all_jobs)
 
     return {
         "run_id": run_id,
@@ -363,6 +396,8 @@ def compute_stats(timings: dict, baseline: dict | None = None) -> dict:
 
     skipped = sum(1 for j in jobs_all if is_skipped(j))
     bl_skipped = sum(1 for j in bl_jobs_all if is_skipped(j))
+    total_wait = sum(j.get("wait_s") or 0 for j in jobs)
+    bl_total_wait = sum(j.get("wait_s") or 0 for j in bl_jobs)
 
     return {
         "wall": wall,
@@ -375,6 +410,8 @@ def compute_stats(timings: dict, baseline: dict | None = None) -> dict:
         "no_baseline": no_baseline,
         "skipped": skipped,
         "bl_skipped": bl_skipped,
+        "total_wait": total_wait,
+        "bl_total_wait": bl_total_wait,
         "total_jobs": len(jobs_all),
     }
 
@@ -423,6 +460,12 @@ h2 { font-size: 18px; margin: 32px 0 12px; }
 }
 .gantt-bar:hover { color: #fff; z-index: 10; }
 .gantt-bar.current { background: #1f6feb; top: 5px; z-index: 2; }
+.gantt-bar.wait {
+  background: repeating-linear-gradient(
+    45deg, #30363d, #30363d 3px, transparent 3px, transparent 6px
+  );
+  top: 5px; z-index: 1; opacity: 0.6;
+}
 .gantt-bar.baseline {
   background: transparent; border: 1px dashed #8b949e; top: 2px; height: 24px; z-index: 1;
 }
@@ -533,11 +576,25 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
             d_text, d_cls = fmt_delta(dur, bl.get("duration_s"))
             delta_info = f' — {d_text}'
 
+        # Wait bar: shows idle time before the job started running
+        wait_bar = ""
+        wait_s = j.get("wait_s")
+        if wait_s and wait_s >= 1.0:
+            wait_left = (s - cur_t0).total_seconds() - wait_s
+            wait_left_pct = max(wait_left / total_s * 100, 0)
+            wait_width_pct = max(wait_s / total_s * 100, 0.3)
+            wait_bar = (
+                f'<div class="gantt-bar wait" '
+                f'style="left:{wait_left_pct:.2f}%;width:{wait_width_pct:.2f}%" '
+                f'title="{escape(j["name"])} — waited: {fmt_dur(wait_s)}"></div>'
+            )
+
         rows.append(
             f'<div class="gantt-row">'
             f'<div class="gantt-label" title="{escape(j["name"])}">{name_display}</div>'
             f'<div class="gantt-track">'
             f'{bl_bar}'
+            f'{wait_bar}'
             f'<div class="gantt-bar current" '
             f'style="left:{left:.2f}%;width:{width:.2f}%" '
             f'title="{escape(j["name"])}: {fmt_dur(dur)}{delta_info}"></div>'
@@ -555,6 +612,7 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
     legend = (
         '<div class="legend">'
         '<span><span class="legend-swatch" style="background:#1f6feb"></span>Current</span>'
+        '<span><span class="legend-swatch" style="background:repeating-linear-gradient(45deg,#30363d,#30363d 3px,transparent 3px,transparent 6px);opacity:0.6"></span>Wait</span>'
     )
     if baseline:
         legend += '<span><span class="legend-swatch" style="border:1px dashed #8b949e"></span>Baseline (main)</span>'
@@ -587,6 +645,8 @@ def _stats_cards(stats: dict) -> str:
         f'<div class="stat-value slower">{stats["slower"]}</div></div>',
         f'<div class="stat-card"><span class="stat-label">Unchanged</span>'
         f'<div class="stat-value neutral">{stats["unchanged"]}</div></div>',
+        f'<div class="stat-card"><span class="stat-label">Skipped</span>'
+        f'<div class="stat-value neutral">{stats["skipped"]}</div></div>',
         f'<div class="stat-card"><span class="stat-label">No Baseline</span>'
         f'<div class="stat-value neutral">{stats["no_baseline"]}</div></div>',
     ]
@@ -612,30 +672,37 @@ def _job_table(timings: dict, baseline: dict | None) -> str:
                 f'<td class="num neutral">skipped</td>'
                 f'<td class="num neutral">—</td>'
                 f'<td class="num neutral">—</td>'
+                f'<td class="num neutral">—</td>'
                 f'<td class="{concl_cls}" style="text-align:center">{concl_icon}</td>'
                 f'</tr>'
             )
             continue
 
         dur = j.get("duration_s")
+        wait = j.get("wait_s")
         bl = bl_map.get(j["name"])
         bl_dur = bl.get("duration_s") if bl and not is_skipped(bl) else None
+        bl_wait = bl.get("wait_s") if bl and not is_skipped(bl) else None
         delta_text, delta_cls = fmt_delta(dur, bl_dur)
+        wait_delta_text, wait_delta_cls = fmt_delta(wait, bl_wait)
 
         rows.append(
             f'<tr>'
             f'<td class="job-name">{name}</td>'
             f'<td class="num">{fmt_dur(dur)}</td>'
+            f'<td class="num">{fmt_dur(wait)}</td>'
             f'<td class="num">{fmt_dur(bl_dur)}</td>'
             f'<td class="num {delta_cls}">{delta_text}</td>'
+            f'<td class="num {wait_delta_cls}">{wait_delta_text}</td>'
             f'<td class="{concl_cls}" style="text-align:center">{concl_icon}</td>'
             f'</tr>'
         )
 
     return (
         '<table><thead><tr>'
-        '<th>Job</th><th class="num">Current</th><th class="num">Baseline</th>'
-        '<th class="num">Delta</th><th>Status</th>'
+        '<th>Job</th><th class="num">Run</th><th class="num">Wait</th>'
+        '<th class="num">Baseline</th><th class="num">Δ Run</th>'
+        '<th class="num">Δ Wait</th><th>Status</th>'
         '</tr></thead><tbody>' + "".join(rows) + '</tbody></table>'
     )
 
@@ -652,10 +719,13 @@ def _step_details(timings: dict, baseline: dict | None) -> str:
         bl_steps = {s["name"]: s for s in bl.get("steps", [])}
 
         dur = j.get("duration_s") or 0
-        bl_dur = bl.get("duration_s") if bl else None
+        wait = j.get("wait_s")
+        bl_dur = bl.get("duration_s") if bl and not is_skipped(bl) else None
         delta_text, delta_cls = fmt_delta(dur, bl_dur)
 
         summary_text = f'{escape(j["name"])} — {fmt_dur(dur)}'
+        if wait is not None and wait >= 1.0:
+            summary_text += f' <span class="neutral">(wait {fmt_dur(wait)})</span>'
         if bl_dur is not None:
             summary_text += f' <span class="{delta_cls}">({delta_text})</span>'
 
@@ -811,9 +881,16 @@ def generate_summary(timings: dict, baseline: dict | None = None) -> str:
         compute_d = d
     lines.append(f"| Total compute | {fmt_dur(stats['compute'])} | {fmt_dur(stats['bl_compute'])} | {compute_d} |")
 
+    wait_d = ""
+    if stats["bl_total_wait"] is not None:
+        d, _ = fmt_delta(stats["total_wait"], stats["bl_total_wait"])
+        wait_d = d
+    lines.append(f"| Total wait | {fmt_dur(stats['total_wait'])} | {fmt_dur(stats['bl_total_wait'])} | {wait_d} |")
+
     lines.append(f"| Jobs faster | {stats['faster']} | — | — |")
     lines.append(f"| Jobs slower | {stats['slower']} | — | — |")
     lines.append(f"| Jobs unchanged | {stats['unchanged']} | — | — |")
+    lines.append(f"| Jobs skipped | {stats['skipped']} | {stats['bl_skipped']} | — |")
     lines.append(f"| Jobs without baseline | {stats['no_baseline']} | — | — |")
     lines.append("")
 

--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -157,6 +157,17 @@ def dur_s(started: str | None, completed: str | None) -> float | None:
     return (e - s).total_seconds()
 
 
+def is_skipped(job: dict) -> bool:
+    """A job is 'skipped' when GitHub didn't actually run it.
+
+    Skipped jobs have conclusion == 'skipped' and typically have null or
+    equal started_at/completed_at timestamps, yielding duration_s of None
+    or 0. They should be excluded from delta comparisons, gantt bars,
+    regression tables, and aggregate stats (wall/compute).
+    """
+    return job.get("conclusion") == "skipped"
+
+
 # ---------------------------------------------------------------------------
 # Timings collection
 # ---------------------------------------------------------------------------
@@ -309,10 +320,13 @@ def fmt_tick(seconds: int) -> str:
 # ---------------------------------------------------------------------------
 
 def compute_stats(timings: dict, baseline: dict | None = None) -> dict:
-    jobs = timings.get("jobs", [])
-    bl_jobs = {j["name"]: j for j in (baseline or {}).get("jobs", [])}
+    jobs_all = timings.get("jobs", [])
+    jobs = [j for j in jobs_all if not is_skipped(j)]
+    bl_jobs_all = (baseline or {}).get("jobs", [])
+    bl_jobs = [j for j in bl_jobs_all if not is_skipped(j)]
+    bl_map = {j["name"]: j for j in bl_jobs}
 
-    # Wall time
+    # Wall time (skipped jobs have no real timestamps)
     starts = [s for s in (parse_ts(j.get("started_at")) for j in jobs) if s is not None]
     ends = [e for e in (parse_ts(j.get("completed_at")) for j in jobs) if e is not None]
     wall = (max(ends) - min(starts)).total_seconds() if starts and ends else 0
@@ -322,19 +336,19 @@ def compute_stats(timings: dict, baseline: dict | None = None) -> dict:
     bl_wall = None
     bl_compute = None
     if baseline:
-        bl_starts = [s for s in (parse_ts(j.get("started_at")) for j in baseline.get("jobs", [])) if s is not None]
-        bl_ends = [e for e in (parse_ts(j.get("completed_at")) for j in baseline.get("jobs", [])) if e is not None]
+        bl_starts = [s for s in (parse_ts(j.get("started_at")) for j in bl_jobs) if s is not None]
+        bl_ends = [e for e in (parse_ts(j.get("completed_at")) for j in bl_jobs) if e is not None]
         if bl_starts and bl_ends:
             bl_wall = (max(bl_ends) - min(bl_starts)).total_seconds()
-        bl_compute = sum(j.get("duration_s") or 0 for j in baseline.get("jobs", []))
+        bl_compute = sum(j.get("duration_s") or 0 for j in bl_jobs)
 
-    # Per-job deltas
+    # Per-job deltas (skipped excluded)
     faster = 0
     slower = 0
     unchanged = 0
     no_baseline = 0
     for j in jobs:
-        bl = bl_jobs.get(j["name"])
+        bl = bl_map.get(j["name"])
         if not bl:
             no_baseline += 1
             continue
@@ -347,6 +361,9 @@ def compute_stats(timings: dict, baseline: dict | None = None) -> dict:
         else:
             faster += 1
 
+    skipped = sum(1 for j in jobs_all if is_skipped(j))
+    bl_skipped = sum(1 for j in bl_jobs_all if is_skipped(j))
+
     return {
         "wall": wall,
         "compute": compute,
@@ -356,7 +373,9 @@ def compute_stats(timings: dict, baseline: dict | None = None) -> dict:
         "slower": slower,
         "unchanged": unchanged,
         "no_baseline": no_baseline,
-        "total_jobs": len(jobs),
+        "skipped": skipped,
+        "bl_skipped": bl_skipped,
+        "total_jobs": len(jobs_all),
     }
 
 
@@ -447,7 +466,8 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
     (relative to each run's earliest job start). The axis scale spans
     0..max_end across both runs so bars are directly comparable.
     """
-    jobs = [j for j in timings.get("jobs", []) if j.get("started_at") and j.get("completed_at")]
+    jobs = [j for j in timings.get("jobs", [])
+            if j.get("started_at") and j.get("completed_at") and not is_skipped(j)]
     bl_map = {j["name"]: j for j in (baseline or {}).get("jobs", [])}
 
     # Current run: relative offsets from earliest start
@@ -463,6 +483,8 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
     bl_max = 0.0
     bl_jobs_timed = []
     for bl_j in bl_map.values():
+        if is_skipped(bl_j):
+            continue
         s = parse_ts(bl_j.get("started_at"))
         e = parse_ts(bl_j.get("completed_at"))
         if s is not None and e is not None:
@@ -489,7 +511,7 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
 
         bl = bl_map.get(j["name"])
         bl_bar = ""
-        if bl and bl_t0 is not None:
+        if bl and not is_skipped(bl) and bl_t0 is not None:
             bl_s = parse_ts(bl.get("started_at"))
             bl_e = parse_ts(bl.get("completed_at"))
             if bl_s is not None and bl_e is not None:
@@ -507,7 +529,7 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
             name_display = f'{escape(j["workflow_name"])} / {escape(j["name"])}'
 
         delta_info = ""
-        if bl and bl.get("duration_s") is not None:
+        if bl and not is_skipped(bl) and bl.get("duration_s") is not None:
             d_text, d_cls = fmt_delta(dur, bl.get("duration_s"))
             delta_info = f' — {d_text}'
 
@@ -575,11 +597,6 @@ def _job_table(timings: dict, baseline: dict | None) -> str:
     bl_map = {j["name"]: j for j in (baseline or {}).get("jobs", [])}
     rows = []
     for j in timings.get("jobs", []):
-        dur = j.get("duration_s")
-        bl = bl_map.get(j["name"])
-        bl_dur = bl.get("duration_s") if bl else None
-        delta_text, delta_cls = fmt_delta(dur, bl_dur)
-
         name = escape(j["name"])
         if j.get("workflow_name"):
             name = f'{escape(j["workflow_name"])} / {escape(j["name"])}'
@@ -587,6 +604,23 @@ def _job_table(timings: dict, baseline: dict | None) -> str:
         concl = j.get("conclusion", "")
         concl_icon = {"success": "✓", "failure": "✗", "skipped": "⊘"}.get(concl, "?")
         concl_cls = {"success": "faster", "failure": "slower", "skipped": "neutral"}.get(concl, "neutral")
+
+        if is_skipped(j):
+            rows.append(
+                f'<tr>'
+                f'<td class="job-name">{name}</td>'
+                f'<td class="num neutral">skipped</td>'
+                f'<td class="num neutral">—</td>'
+                f'<td class="num neutral">—</td>'
+                f'<td class="{concl_cls}" style="text-align:center">{concl_icon}</td>'
+                f'</tr>'
+            )
+            continue
+
+        dur = j.get("duration_s")
+        bl = bl_map.get(j["name"])
+        bl_dur = bl.get("duration_s") if bl and not is_skipped(bl) else None
+        delta_text, delta_cls = fmt_delta(dur, bl_dur)
 
         rows.append(
             f'<tr>'
@@ -611,6 +645,8 @@ def _step_details(timings: dict, baseline: dict | None) -> str:
     blocks = []
     for j in timings.get("jobs", []):
         if not j.get("steps"):
+            continue
+        if is_skipped(j):
             continue
         bl = bl_map.get(j["name"], {})
         bl_steps = {s["name"]: s for s in bl.get("steps", [])}
@@ -659,8 +695,10 @@ def _regressions(timings: dict, baseline: dict | None) -> str:
 
     deltas = []  # (abs_delta, job_name, step_name, current, baseline, is_slower)
     for j in timings.get("jobs", []):
+        if is_skipped(j):
+            continue
         bl = bl_map.get(j["name"])
-        if not bl:
+        if not bl or is_skipped(bl):
             continue
         bl_steps = {s["name"]: s for s in bl.get("steps", [])}
         for s in j.get("steps", []):

--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -670,6 +670,7 @@ def _job_table(timings: dict, baseline: dict | None) -> str:
                 f'<td class="num neutral">—</td>'
                 f'<td class="num neutral">—</td>'
                 f'<td class="num neutral">—</td>'
+                f'<td class="num neutral">—</td>'
                 f'<td class="{concl_cls}" style="text-align:center">{concl_icon}</td>'
                 f'</tr>'
             )

--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -521,24 +521,18 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
     cur_t0 = min(cur_starts)
     cur_max = (max(cur_ends) - cur_t0).total_seconds()
 
-    # Baseline run: relative offsets from its earliest start
-    bl_t0 = None
-    bl_max = 0.0
-    bl_jobs_timed = []
+    # Baseline run: max duration (for axis scale only — bars are aligned
+    # to the current job's start, not to the baseline timeline)
+    bl_max_dur = 0.0
     for bl_j in bl_map.values():
         if is_skipped(bl_j):
             continue
         s = parse_ts(bl_j.get("started_at"))
         e = parse_ts(bl_j.get("completed_at"))
         if s is not None and e is not None:
-            bl_jobs_timed.append((bl_j, s, e))
-            if bl_t0 is None or s < bl_t0:
-                bl_t0 = s
-            rel_end = (e - s).total_seconds() + (s - (bl_t0 or s)).total_seconds()
-    if bl_t0 is not None:
-        bl_max = max((e - bl_t0).total_seconds() for _, _, e in bl_jobs_timed) if bl_jobs_timed else 0
+            bl_max_dur = max(bl_max_dur, (e - s).total_seconds())
 
-    total_s = max(cur_max, bl_max)
+    total_s = max(cur_max, bl_max_dur)
     if total_s <= 0:
         total_s = 1
 
@@ -554,11 +548,14 @@ def _gantt_bars(timings: dict, baseline: dict | None) -> str:
 
         bl = bl_map.get(j["name"])
         bl_bar = ""
-        if bl and not is_skipped(bl) and bl_t0 is not None:
+        if bl and not is_skipped(bl):
             bl_s = parse_ts(bl.get("started_at"))
             bl_e = parse_ts(bl.get("completed_at"))
             if bl_s is not None and bl_e is not None:
-                bl_left = (bl_s - bl_t0).total_seconds() / total_s * 100
+                # Align baseline bar to the current job's start so the
+                # two durations are directly comparable — the baseline's
+                # own wait/position is irrelevant for a duration diff.
+                bl_left = left
                 bl_width = max((bl_e - bl_s).total_seconds() / total_s * 100, 0.5)
                 bl_dur = bl.get("duration_s") or 0
                 bl_bar = (


### PR DESCRIPTION
## What does this PR do?

The CI timing report (`scripts/ci/timings_report.py`) treated skipped jobs (conclusion `"skipped"`) as valid jobs with 0s duration. This polluted every downstream computation: skipped jobs counted as "unchanged" (0 vs 0) in faster/slower tallies, showed meaningless `0.0s (0%)` deltas in the job table, rendered phantom gantt bars, and inflated wall/compute totals.

Additionally, the report had no visibility into how long each job sat idle waiting for its dependencies to finish before it could start running — a significant chunk of CI wall time that was invisible.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**Commit 1 — `fix(ci): exclude skipped jobs from timing deltas and stats`**

- `scripts/ci/timings_report.py`: Added `is_skipped()` helper (`conclusion == "skipped"`)
- `compute_stats`: exclude skipped from wall/compute + faster/slower/unchanged; add `skipped` and `bl_skipped` counts
- `_gantt_bars`: filter skipped from current bars, baseline bars, and axis calc
- `_job_table`: show "skipped" label instead of durations/deltas
- `_step_details`: skip entirely (no meaningful step data)
- `_regressions`: exclude from both current and baseline sides
- `_stats_cards`: add Skipped card
- `generate_summary`: add skipped row in markdown summary table

**Commit 2 — `feat(ci): show per-job wait times in timing report`**

- `_annotate_wait_times()`: computes `wait_s` per job — `started_at - max(completed_at of all jobs that finished before this job started)`. Timestamp heuristic (no workflow YAML dependency parse needed), accurate for pipeline-shaped CI.
- Job table: new Wait + Δ Wait columns
- Gantt chart: hatched/striped bar segment before each run bar showing idle period
- Step details: `(wait Xs)` annotation in expandable summary
- Markdown summary: Total wait row with delta vs baseline
- `compute_stats`: `total_wait` / `bl_total_wait`

## How to Test

1. The `ci-timings` job runs automatically on every PR/push. Check the generated HTML report artifact.
2. Synthetic data tested locally with edge cases: all-skipped, single-job, empty timings, skipped-in-baseline, pipeline wait computation, full HTML+summary generation, CLI `--from-json` round-trip.
3. `ruff check scripts/ci/timings_report.py` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `ruff check` and all checks pass
- [x] I've tested on my platform: Ubuntu (NixOS)

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture changes, no tool behavior changes
