### PR TITLE
fix(update): detect profiled serve backends

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5845,6 +5845,53 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+def _is_hermes_dashboard_command(command: str) -> bool:
+    """Return whether *command* launches a Hermes dashboard/serve process.
+
+    Hermes' global ``--profile`` flag appears before the subcommand, so a
+    profiled backend looks like ``hermes --profile learning serve`` rather
+    than containing the old literal ``"hermes serve"`` pattern.  Parse the
+    argv shape instead of relying on adjacent words.  Stopping at the first
+    recognized top-level subcommand also avoids treating a chat prompt that
+    merely mentions ``hermes serve`` as a server process.
+    """
+    try:
+        tokens = shlex.split(command, posix=sys.platform != "win32")
+    except ValueError:
+        tokens = command.split()
+
+    entry_index = None
+    for index, raw_token in enumerate(tokens):
+        token = raw_token.strip("\"'").replace("\\", "/")
+        basename = token.rsplit("/", 1)[-1].lower()
+        if (
+            basename in {"hermes", "hermes.exe"}
+            or token.endswith("hermes_cli/main.py")
+            or token == "hermes_cli.main"
+        ):
+            entry_index = index
+            break
+    if entry_index is None:
+        return False
+
+    value_flags = set(_TOP_LEVEL_VALUE_FLAGS) | {"-p", "--profile"}
+    index = entry_index + 1
+    while index < len(tokens):
+        token = tokens[index].strip("\"'")
+        if token in _BUILTIN_SUBCOMMANDS:
+            return token in {"dashboard", "serve"}
+        if token.startswith("-"):
+            if "=" not in token and token in value_flags and index + 1 < len(tokens):
+                index += 2
+            else:
+                index += 1
+            continue
+        # An unknown positional before a recognized subcommand is a chat
+        # query/plugin command, not a dashboard invocation.
+        return False
+    return False
+
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -5874,17 +5921,6 @@ def _find_stale_dashboard_pids(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-        # The headless backend (`hermes serve`) is the same long-lived server
-        # under a different command name — the desktop app spawns it. Reap it
-        # on update for the same frontend/backend-mismatch reason.
-        "hermes serve",
-        "hermes_cli.main serve",
-        "hermes_cli/main.py serve",
-    ]
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5921,7 +5957,7 @@ def _find_stale_dashboard_pids(
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     if (
-                        any(p in current_cmd for p in patterns)
+                        _is_hermes_dashboard_command(current_cmd)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5929,8 +5965,8 @@ def _find_stale_dashboard_pids(
                         except ValueError:
                             pass
         else:
-            # Linux / macOS: scan the process table via ps and match against
-            # the same explicit patterns list used on Windows.  Using ps
+            # Linux / macOS: scan the process table via ps and classify each
+            # command with the same argv-aware helper used on Windows. Using ps
             # (rather than `pgrep -f "hermes.*dashboard"`) keeps us consistent
             # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
             # greedy regex matching unrelated cmdlines that merely contain
@@ -5954,7 +5990,7 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if _is_hermes_dashboard_command(command) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -22,6 +22,7 @@ import pytest
 
 from hermes_cli.main import (
     _find_stale_dashboard_pids,
+    _is_hermes_dashboard_command,
     _kill_stale_dashboard_processes,
     _warn_stale_dashboard_processes,  # back-compat alias
 )
@@ -46,6 +47,7 @@ def _refresh_bindings_against_live_module():
     the two pollutants above are load-bearing for their own tests.
     """
     global _find_stale_dashboard_pids
+    global _is_hermes_dashboard_command
     global _kill_stale_dashboard_processes
     global _warn_stale_dashboard_processes
 
@@ -54,6 +56,7 @@ def _refresh_bindings_against_live_module():
         live = importlib.import_module("hermes_cli.main")
 
     _find_stale_dashboard_pids = live._find_stale_dashboard_pids
+    _is_hermes_dashboard_command = live._is_hermes_dashboard_command
     _kill_stale_dashboard_processes = live._kill_stale_dashboard_processes
     _warn_stale_dashboard_processes = live._warn_stale_dashboard_processes
     yield
@@ -116,6 +119,28 @@ class TestFindStaleDashboardPids:
                 stderr="",
             )
             assert sorted(_find_stale_dashboard_pids()) == [12345, 12346, 12347]
+
+    def test_profiled_serve_and_dashboard_processes_match(self):
+        """Global profile flags sit between the entrypoint and subcommand."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(
+                        12345,
+                        "/venv/bin/python3 /venv/bin/hermes --profile learning "
+                        "serve --isolated --port 9124",
+                    ),
+                    _ps_line(12346, "python3 -m hermes_cli.main -p health serve"),
+                    _ps_line(12347, "hermes --profile=trading dashboard --no-open"),
+                ]) + "\n",
+                stderr="",
+            )
+            assert sorted(_find_stale_dashboard_pids()) == [12345, 12346, 12347]
+
+    def test_chat_prompt_mentioning_profiled_serve_is_not_matched(self):
+        command = "hermes chat -q restart hermes --profile learning serve"
+        assert _is_hermes_dashboard_command(command) is False
 
     def test_self_pid_excluded(self):
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## What does this PR do?

Detects profile-scoped `hermes serve` and `hermes dashboard` processes during `hermes update`, so stale Desktop/profile backends are stopped after files on disk change.

The previous scanner matched adjacent command substrings such as `hermes serve`. A profiled backend is launched as `hermes --profile learning serve`, so it was missed and could continue running old Python modules against newly updated files. A later lazy import could then fail with an old/new module API mismatch.

This replaces the substring list with a small argv-aware classifier. It recognizes the supported Hermes entrypoints, skips global option values including `-p` / `--profile`, and stops at the first top-level subcommand. That also avoids matching unrelated chat prompts that merely mention `hermes serve`.

## Related Issue

No exact existing issue found. This is the profile-scoped variant of the stale dashboard/backend mismatch already documented by `_find_stale_dashboard_pids`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` — classify dashboard/serve commands by argv shape on POSIX and Windows.
- `tests/hermes_cli/test_update_stale_dashboard.py` — cover `--profile`, `-p`, `--profile=...`, and prompt false positives.

## How to Test

1. Run `.venv/bin/python -m pytest -q tests/hermes_cli/test_update_stale_dashboard.py`.
2. Verify profiled `serve`/`dashboard` commands are returned while a chat prompt mentioning the same text is ignored.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused suite run instead)
- [x] I've added tests for my changes
- [x] I've tested on macOS 15.7.7

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered: the shared classifier is covered through both POSIX and WMIC scan paths
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

```text
24 passed in 0.91s
All checks passed! (ruff)
```
