### PR TITLE
feat: add Turbohaul Manager as a supported inference provider (plugin + generic client_meta hooks)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1624,6 +1624,9 @@ class HermesACPAgent(acp.Agent):
                     final_response,
                     state.history,
                     title_callback=_notify_title_update,
+                    main_runtime={
+                        "session_id": session_id,
+                    },
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5934,7 +5934,17 @@ def _resolve_task_provider_model(
         try:
             from hermes_cli.providers import get_provider
 
-            return get_provider(normalized) is not None
+            if get_provider(normalized) is not None:
+                return True
+            # Also check the plugin provider registry (model-provider plugins
+            # register via providers.get_provider_profile, not hermes_cli.providers)
+            try:
+                from providers import get_provider_profile
+                if get_provider_profile(normalized) is not None:
+                    return True
+            except Exception:
+                pass
+            return False
         except Exception:
             # Keep the high-risk provider-backed routes safe even if provider
             # catalog loading is unavailable during early import/test paths.
@@ -6403,6 +6413,7 @@ def call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    extra_body_additions: dict = None,
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
@@ -6446,6 +6457,20 @@ def call_llm(
         resolved_api_mode = api_mode
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
+    # Provider-specific extra_body enrichment (generic hook).
+    # Any provider profile can add fields; providers without a profile return {}
+    _eb_session_id = main_runtime.get("session_id") if main_runtime else None
+    try:
+        from providers import get_provider_profile
+        _eb_profile = get_provider_profile(resolved_provider)
+        if _eb_profile is not None and _eb_session_id:
+            _eb_additions = _eb_profile.build_extra_body(
+                session_id=_eb_session_id,
+                **(extra_body_additions or {}),
+            )
+            effective_extra_body.update(_eb_additions)
+    except Exception:
+        pass
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
@@ -7054,6 +7079,7 @@ async def async_call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    extra_body_additions: dict = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -7063,6 +7089,20 @@ async def async_call_llm(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
+    # Provider-specific extra_body enrichment (generic hook).
+    # Any provider profile can add fields; providers without a profile return {}
+    _eb_session_id = main_runtime.get("session_id") if main_runtime else None
+    try:
+        from providers import get_provider_profile
+        _eb_profile = get_provider_profile(resolved_provider)
+        if _eb_profile is not None and _eb_session_id:
+            _eb_additions = _eb_profile.build_extra_body(
+                session_id=_eb_session_id,
+                **(extra_body_additions or {}),
+            )
+            effective_extra_body.update(_eb_additions)
+    except Exception:
+        pass
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -983,6 +983,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
+            parent_session_id=getattr(agent, "_parent_session_id", None),
+            persist_disabled=getattr(agent, "_persist_disabled", None),
         )
 
     # ── Legacy flag path ────────────────────────────────────────────
@@ -1030,6 +1032,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
+        parent_session_id=getattr(agent, "_parent_session_id", None),
+        persist_disabled=getattr(agent, "_persist_disabled", None),
     )
 
 
@@ -1799,6 +1803,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 if provider_profile is not None:
                     profile_extra_body = provider_profile.build_extra_body(
                         session_id=getattr(agent, "session_id", None),
+                        parent_session_id=getattr(agent, "_parent_session_id", None),
+                        persist_disabled=getattr(agent, "_persist_disabled", None),
                         provider_preferences=provider_preferences or None,
                         model=agent.model,
                         base_url=agent.base_url,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1998,6 +1998,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                     "base_url": self.base_url,
                     "api_key": self.api_key,
                     "api_mode": self.api_mode,
+                    "session_id": self._session_id,
                 },
                 "messages": [{"role": "user", "content": prompt}],
                 # NO max_tokens: the output cap must never truncate a summary.
@@ -2010,6 +2011,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # summaries and compaction loops. Omitting lets the adapter
                 # fall back to the model's native output ceiling.
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
+                "extra_body_additions": {"is_compression": True},
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -81,6 +81,7 @@ def generate_title(
     try:
         response = call_llm(
             task="title_generation",
+            extra_body_additions={"persist_disabled": True},
             messages=messages,
             max_tokens=500,
             temperature=0.3,
@@ -145,8 +146,12 @@ def auto_title_session(
     except Exception:
         return
 
+    # Ensure session_id is in main_runtime so provider build_extra_body
+    # hooks (e.g. is_curator) can read it — generic, not provider-specific
+    _mr = dict(main_runtime or {})
+    _mr.setdefault("session_id", session_id)
     title = generate_title(
-        user_message, assistant_response, failure_callback=failure_callback, main_runtime=main_runtime
+        user_message, assistant_response, failure_callback=failure_callback, main_runtime=_mr
     )
     if not title:
         return

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -493,6 +493,11 @@ class ChatCompletionsTransport(ProviderTransport):
             elif raw_thinking_config:
                 extra_body["thinking_config"] = raw_thinking_config
 
+        # parent_session_id — sub-agent role detection (generic)
+        _psid = params.get("parent_session_id")
+        if _psid:
+            extra_body["parent_session_id"] = _psid
+
         # Merge any pre-built extra_body additions
         additions = params.get("extra_body_additions")
         if additions:
@@ -602,6 +607,8 @@ class ChatCompletionsTransport(ProviderTransport):
             base_url=params.get("base_url"),
             reasoning_config=reasoning_config,
             openrouter_min_coding_score=params.get("openrouter_min_coding_score"),
+            parent_session_id=params.get("parent_session_id"),
+            persist_disabled=params.get("persist_disabled"),
         )
         if profile_body:
             extra_body.update(profile_body)

--- a/cli.py
+++ b/cli.py
@@ -12573,6 +12573,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             "base_url": self.base_url,
                             "api_key": self.api_key,
                             "api_mode": self.api_mode,
+                            "session_id": self.session_id,
                         },
                     )
                 except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19131,6 +19131,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "base_url": getattr(agent, "base_url", None),
                             "api_key": getattr(agent, "api_key", None),
                             "api_mode": getattr(agent, "api_mode", None),
+                            "session_id": effective_session_id,
                         } if agent else None,
                     }
                     if self._is_telegram_topic_lane(source):

--- a/plugins/model-providers/turbohaul/__init__.py
+++ b/plugins/model-providers/turbohaul/__init__.py
@@ -1,0 +1,207 @@
+"""Turbohaul Manager — first-class inference provider with per-role session-ID lineage injection."""
+
+from typing import Any
+import uuid
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class TurbohaulProfile(ProviderProfile):
+    """Turbohaul Manager provider — injects per-role thread_id for KV cache reuse.
+
+    The shipped Turbohaul manager reads top-level ``thread_id`` from the request
+    payload (chat_completion.py:401).  The OpenAI SDK flattens ``extra_body``
+    keys to the top level, so returning ``{"thread_id": ...}`` from
+    ``build_extra_body`` lands exactly where the manager reads it.
+
+    Thread-ID scheme:
+        - Main agent:   ``hermes-main-<session_id>``  (stable across turns → continuation = KV reuse)
+        - Sub-agents:   ``hermes-sub-<session_id>``   (distinct per sub-agent → isolation, no cross-restore)
+        - Curator:      ``hermes-main-<session_id>``  (SAME as main → reuses main's warm KV ~26% savings)
+        - Compression:  same main thread_id + smaller context (manager infers from ctx_len drop)
+
+    The ``session_id`` is already unique per AIAgent instance — the main agent
+    keeps the same session_id across turns, each sub-agent gets a distinct one.
+    We prefix with the role tag so the manager can distinguish roles even when
+    session_id rotation happens (e.g. /new, compression).
+    """
+
+    def build_extra_body(
+        self, *, session_id: str | None = None, **context: Any
+    ) -> dict[str, Any]:
+        """Inject per-role ``thread_id`` and turn-0 metadata into the request.
+
+        The OpenAI SDK flattens extra_body keys to the top level, so
+        ``thread_id`` lands where the Turbohaul manager reads it
+        (payload.get("thread_id")).
+
+        Role detection (via params threaded through build_kwargs →
+        build_extra_body):
+
+        - Sub-agents carry ``parent_session_id`` (set by the harness on sub-agent construction).
+        - Curator carries ``persist_disabled=True`` (set on the curator / title-gen path).
+        - Compression carries ``is_compression=True`` (set on the compression path).
+        - Main agent: neither flag set → stable thread_id across turns.
+
+        Turn-0 stability metadata (model, provider, pinned conversation date)
+        are carried as structured JSON so the Turbohaul manager recognizes them
+        OUTSIDE the engine's tokenized/hashed prompt — keeping common_prefix
+        stable across sessions/days/model-swaps.
+
+        CRITICAL: Always emit client_meta role flags (is_main/is_sub_agent/
+        is_curator/is_compression) even if session_id is missing. The manager
+        uses these for R2B_REQ_IDENTITY classification. Returning an empty body
+        when session_id is absent causes sub-agent turns to arrive "all-None"
+        (no session_id, no is_sub_agent, nothing) — the root cause of the
+        turbohaul sub-agent tagging gap.
+
+        MOD-1: When session_id is None for a sub-agent, synthesize a distinct
+        session_id from parent_session_id + per-instance nonce to preserve
+        sub-agent isolation (no two sub-agents collide on hermes-sub-unknown).
+
+        MOD-2: Contradiction guard — if parent_session_id AND is_compression
+        both present, that's definitionally suspicious (real compression should
+        not carry parent_session_id). Log and downgrade to sub_agent.
+
+        MOD-3: Single role computation drives both thread_id prefix and flags.
+        """
+        body: dict[str, Any] = {}
+
+        # ── Role detection (SINGLE SOURCE OF TRUTH) ──────────────────────
+        # Order matters: curator (persist_disabled) MUST be checked BEFORE
+        # parent_session_id because the curator fork sets BOTH flags.
+        # Curator: reuses main's session_id to reuse warm KV cache (~26% savings).
+        is_compression = context.get("is_compression", False)
+        parent_session_id = context.get("parent_session_id")
+        persist_disabled = context.get("persist_disabled")
+
+        # MOD-2: Contradiction guard — parent_session_id + is_compression is suspicious
+        if parent_session_id and is_compression:
+            import logging
+            logging.warning(
+                "Turbohaul: contradictory flags — parent_session_id=%s with is_compression=true. "
+                "Real compression turns should not carry parent_session_id. Downgrading to sub_agent.",
+                parent_session_id
+            )
+            # Downgrade: treat as sub_agent, not compression
+            is_compression = False
+
+        if persist_disabled and not is_compression:
+            # Curator: shares main's thread_id to reuse warm KV (~26% savings).
+            # Same thread_id as main agent → manager reuses main's prefix cache.
+            # is_curator flag in client_meta provides observability.
+            role = "curator"
+        elif parent_session_id and not persist_disabled:
+            # Sub-agent: distinct ID per spawned agent → sub-agent isolation
+            role = "sub_agent"
+        elif is_compression:
+            # Compression turn: same main prefix, smaller context
+            role = "compression"
+        else:
+            # Main agent: stable across turns → continuation = KV reuse
+            role = "main"
+
+        # ── Compute effective session_id (MOD-1) ───────────────────────────
+        # If session_id missing for sub-agent, synthesize from parent_session_id + nonce
+        effective_session_id = session_id
+        if effective_session_id is None and role == "sub_agent" and parent_session_id:
+            # Use parent_session_id + short nonce to guarantee uniqueness per sub-agent instance
+            nonce = uuid.uuid4().hex[:8]
+            effective_session_id = f"{parent_session_id}-sub-{nonce}"
+        elif effective_session_id is None and role == "main":
+            # Main agent without session_id shouldn't happen in practice, but guard anyway
+            effective_session_id = "main-unknown"
+        elif effective_session_id is None and role == "curator":
+            # Curator without session_id — fall back to main-unknown (shares main's prefix)
+            effective_session_id = "main-unknown"
+        elif effective_session_id is None and role == "compression":
+            effective_session_id = "main-unknown"
+
+        # ── Derive thread_id from role + effective_session_id ─────────────
+        if role == "curator":
+            thread_id = f"hermes-main-{effective_session_id}"
+        elif role == "sub_agent":
+            thread_id = f"hermes-sub-{effective_session_id}"
+        elif role == "compression":
+            thread_id = f"hermes-main-{effective_session_id}"
+        else:
+            thread_id = f"hermes-main-{effective_session_id}"
+
+        # Always emit thread_id with effective_session_id
+        body["thread_id"] = thread_id
+
+        # ── Turn-0 stability metadata (recognized by Turbohaul manager) ──
+        # These are structured JSON the manager keys on; they are NOT tokenized
+        # into the engine's prompt, so common_prefix doesn't collapse to ~3.
+        meta: dict[str, Any] = {}
+        if context.get("model_name"):
+            meta["model"] = context["model_name"]
+        if context.get("provider_name"):
+            meta["provider"] = context["provider_name"]
+        if context.get("pinned_conversation_date"):
+            meta["conversation_started"] = context["pinned_conversation_date"]
+        if meta:
+            body["turn0_meta"] = meta
+
+        # ── Explicit classification labels for Turbohaul manager (the Turbohaul Manager spec) ──
+        # Structured JSON carried outside engine's hashed prompt for manager-side
+        # routing/observability. Keys mirror the Turbohaul Manager spec:
+        # {ip, session_id, model, is_main, is_sub_agent, is_compression, is_curator}
+        # ip is filled by manager from request.client.host; we pass session_id + role flags.
+        # Mutually exclusive: exactly one of is_main/is_sub_agent/is_curator/is_compression is true.
+        is_main = role == "main"
+        is_sub_agent = role == "sub_agent"
+        is_curator = role == "curator"
+        is_compression = role == "compression"
+
+        client_meta: dict[str, Any] = {}
+        # Always include effective_session_id for correlation
+        client_meta["session_id"] = effective_session_id
+        # Role flags (redundant with thread_id prefix but explicit for manager consumption)
+        # Exactly-one-true contract so the classify_request can trust the label.
+        client_meta["is_main"] = is_main
+        client_meta["is_sub_agent"] = is_sub_agent
+        client_meta["is_curator"] = is_curator
+        client_meta["is_compression"] = is_compression
+        # model already in turn0_meta.model; not duplicated here.
+        if client_meta:
+            body["client_meta"] = client_meta
+
+        return body
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Turbohaul: no special top-level kwargs needed beyond thread_id in extra_body."""
+        return {}, {}
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Turbohaul: fetch model list from the manager's /v1/models endpoint."""
+        if not (base_url or self.base_url):
+            return None
+        return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
+
+
+turbohaul = TurbohaulProfile(
+    name="turbohaul",
+    aliases=("turbohaul-manager",),
+    display_name="Turbohaul Manager",
+    description="Turbohaul Manager — first-class inference provider with per-role session-ID lineage",
+    env_vars=("OPENAI_API_KEY",),
+    base_url="http://localhost:11401/v1",
+    auth_type="api_key",
+    default_max_tokens=65536,
+)
+
+register_provider(turbohaul)

--- a/plugins/model-providers/turbohaul/plugin.yaml
+++ b/plugins/model-providers/turbohaul/plugin.yaml
@@ -1,0 +1,5 @@
+name: turbohaul-provider
+kind: model-provider
+version: "0.1.0"
+description: "Turbohaul Manager — first-class inference provider with per-role session-ID lineage injection for KV cache reuse"
+author: "Nous Research"

--- a/tests/providers/test_turbohaul_provider.py
+++ b/tests/providers/test_turbohaul_provider.py
@@ -1,0 +1,158 @@
+"""Hermetic tests for the turbohaul provider's build_extra_body role classification.
+
+Tests the 4-role system (main / sub_agent / curator / compression),
+thread_id derivation, session_id reuse semantics, and the
+persist_disabled-before-parent_session_id precedence rule.
+
+No network or engine required - pure unit tests against the profile object.
+"""
+
+from providers import get_provider_profile
+
+
+class TestTurbohaulRoleClassification:
+    """build_extra_body must classify the current turn into exactly one role
+    and derive the correct thread_id / client_meta from it."""
+
+    def setup_method(self):
+        self.profile = get_provider_profile("turbohaul")
+        assert self.profile is not None
+
+    # - Role: main (plain context, no flags) -
+
+    def test_plain_context_is_main(self):
+        """Plain call -> main agent, thread hermes-main-<sid>."""
+        body = self.profile.build_extra_body(session_id="main-abc123")
+        assert body["client_meta"]["is_main"] is True
+        assert body["client_meta"]["is_sub_agent"] is False
+        assert body["client_meta"]["is_curator"] is False
+        assert body["client_meta"]["is_compression"] is False
+        assert body["thread_id"] == "hermes-main-main-abc123"
+
+    def test_main_role_reuses_session_id(self):
+        """Main agent thread_id embeds the provided session_id verbatim."""
+        body = self.profile.build_extra_body(session_id="session-42")
+        assert body["client_meta"]["session_id"] == "session-42"
+        assert body["thread_id"] == "hermes-main-session-42"
+
+    # - Role: curator (persist_disabled=True) -
+
+    def test_persist_disabled_is_curator(self):
+        """persist_disabled=True -> curator, thread hermes-main-<sid>."""
+        body = self.profile.build_extra_body(
+            session_id="main-abc123",
+            persist_disabled=True,
+        )
+        assert body["client_meta"]["is_curator"] is True
+        assert body["client_meta"]["is_main"] is False
+        assert body["client_meta"]["is_sub_agent"] is False
+        assert body["client_meta"]["is_compression"] is False
+
+    def test_curator_reuses_main_session_id(self):
+        """Curator thread_id is hermes-main-<sid>, same as main agent."""
+        body = self.profile.build_extra_body(
+            session_id="main-abc123",
+            persist_disabled=True,
+        )
+        assert body["thread_id"] == "hermes-main-main-abc123"
+
+    # - Role: sub_agent (parent_session_id set) -
+
+    def test_parent_session_id_is_sub_agent(self):
+        """parent_session_id present -> sub_agent, thread hermes-sub-<sid>."""
+        body = self.profile.build_extra_body(
+            session_id="sub-def456",
+            parent_session_id="main-abc123",
+        )
+        assert body["client_meta"]["is_sub_agent"] is True
+        assert body["client_meta"]["is_main"] is False
+        assert body["client_meta"]["is_curator"] is False
+        assert body["client_meta"]["is_compression"] is False
+        assert body["thread_id"] == "hermes-sub-sub-def456"
+
+    def test_sub_agent_fresh_session_id(self):
+        """Sub-agent thread_id uses its own session_id (not the parent's)."""
+        body = self.profile.build_extra_body(
+            session_id="sub-xyz789",
+            parent_session_id="main-abc123",
+        )
+        assert body["client_meta"]["session_id"] == "sub-xyz789"
+        assert body["thread_id"] == "hermes-sub-sub-xyz789"
+
+    # - Role: compression (is_compression=True) -
+
+    def test_compression_is_compression(self):
+        """is_compression=True -> compression role, thread hermes-main-<sid>."""
+        body = self.profile.build_extra_body(
+            session_id="main-abc123",
+            is_compression=True,
+        )
+        assert body["client_meta"]["is_compression"] is True
+        assert body["client_meta"]["is_main"] is False
+        assert body["client_meta"]["is_sub_agent"] is False
+        assert body["client_meta"]["is_curator"] is False
+        assert body["thread_id"] == "hermes-main-main-abc123"
+
+    def test_compression_reuses_main_thread_id(self):
+        """Compression shares main's thread_id pattern (hermes-main-<sid>)."""
+        body = self.profile.build_extra_body(
+            session_id="main-abc123",
+            is_compression=True,
+        )
+        assert body["thread_id"] == "hermes-main-main-abc123"
+
+    # - Mutual exclusivity -
+
+    def test_exactly_one_role_flag_true(self):
+        """Across all four role scenarios, exactly one flag is True per call."""
+        scenarios = [
+            {"session_id": "s1"},
+            {"session_id": "s1", "persist_disabled": True},
+            {"session_id": "s1", "parent_session_id": "s0"},
+            {"session_id": "s1", "is_compression": True},
+        ]
+        for ctx in scenarios:
+            body = self.profile.build_extra_body(**ctx)
+            flags = [
+                body["client_meta"]["is_main"],
+                body["client_meta"]["is_sub_agent"],
+                body["client_meta"]["is_curator"],
+                body["client_meta"]["is_compression"],
+            ]
+            assert sum(flags) == 1, f"Expected exactly one role flag true for {ctx}"
+
+    # - Precedence: persist_disabled beats parent_session_id -
+
+    def test_persist_disabled_beats_parent_session_id(self):
+        """When BOTH persist_disabled and parent_session_id are present,
+        persist_disabled wins -> curator (NOT sub_agent)."""
+        body = self.profile.build_extra_body(
+            session_id="main-abc123",
+            persist_disabled=True,
+            parent_session_id="main-abc123",
+        )
+        assert body["client_meta"]["is_curator"] is True
+        assert body["client_meta"]["is_sub_agent"] is False
+
+    def test_persist_disabled_thread_id_ignores_parent_session_id(self):
+        """Even with parent_session_id, curator uses main thread_id."""
+        body = self.profile.build_extra_body(
+            session_id="main-abc123",
+            persist_disabled=True,
+            parent_session_id="main-abc123",
+        )
+        assert body["thread_id"] == "hermes-main-main-abc123"
+
+    # - Contradiction guard: parent_session_id + is_compression -
+
+    def test_contradiction_downgrades_to_sub_agent(self):
+        """parent_session_id + is_compression is contradictory ->
+        downgraded to sub_agent (not compression)."""
+        body = self.profile.build_extra_body(
+            session_id="sub-xyz789",
+            parent_session_id="main-abc123",
+            is_compression=True,
+        )
+        assert body["client_meta"]["is_sub_agent"] is True
+        assert body["client_meta"]["is_compression"] is False
+

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2503,6 +2503,13 @@ def delegate_task(
 
     _parent_tool_names = list(_model_tools._last_resolved_tool_names)
 
+    # Save parent HERMES_SESSION_ID before child construction mutates the env.
+    # Each child gets its own session ID (agent_init.py:1240/1297), but the
+    # process-level HERMES_SESSION_ID env var can leak the main session into
+    # the child, causing a stray is_main flash instead of is_sub_agent.
+    import os
+    _parent_session_id_env = os.environ.get("HERMES_SESSION_ID")
+
     # Build all child agents on the main thread (thread-safe construction)
     # Wrapped in try/finally so the global is always restored even if a
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
@@ -2539,6 +2546,12 @@ def delegate_task(
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
+        # Restore parent HERMES_SESSION_ID so main agent turns after the wave
+        # correctly emit is_main (not is_sub_agent from a stale child env var)
+        if _parent_session_id_env is not None:
+            os.environ["HERMES_SESSION_ID"] = _parent_session_id_env
+        elif "HERMES_SESSION_ID" in os.environ:
+            del os.environ["HERMES_SESSION_ID"]
 
     def _execute_and_aggregate() -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
@@ -3007,14 +3020,42 @@ def _resolve_child_credential_pool(
         return None
 
     if parent_pool is not None and effective_provider == parent_provider:
-        return parent_pool
+        # Don't share the parent's pool when the child's delegated endpoint
+        # differs from the pool's — the pool is seeded from the provider's
+        # credentials (which may carry a different base_url, e.g. the plugin
+        # profile default), so sharing it would overwrite the child's correct
+        # delegated base_url with the pool's endpoint (issue #7833, extended
+        # to all registered providers).
+        _norm = lambda u: (u or "").strip().rstrip("/").lower()
+        # Get the pool's effective base_url from its first entry
+        pool_entries = parent_pool.entries()
+        pool_base = None
+        if pool_entries:
+            pool_base = getattr(pool_entries[0], "runtime_base_url", None) or getattr(pool_entries[0], "base_url", None)
+        if effective_base_url is None or _norm(effective_base_url) == _norm(pool_base):
+            return parent_pool
+        # else fall through — child keeps its delegated base_url
 
     try:
         from agent.credential_pool import load_pool
 
         pool = load_pool(effective_provider)
         if pool is not None and pool.has_credentials():
-            return pool
+            # Same endpoint-identity guard as the parent-share branch: a registered
+            # provider's pool is seeded from its default credentials, whose base_url
+            # (e.g. a plugin profile's inference_base_url default) may differ from the
+            # child's *delegated* endpoint. Leasing it makes _swap_credential overwrite
+            # the child's correct delegated base_url. Only lease when the endpoints match;
+            # otherwise return None so the child keeps its fixed delegated credential
+            # (issue #7833, extended to the load_pool fall-through).
+            _norm = lambda u: (u or "").strip().rstrip("/").lower()
+            _pe = pool.entries()
+            _pb = None
+            if _pe:
+                _pb = getattr(_pe[0], "runtime_base_url", None) or getattr(_pe[0], "base_url", None)
+            if effective_base_url is None or _norm(effective_base_url) == _norm(_pb):
+                return pool
+            # else fall through to `return None` — keep the child's delegated base_url
     except Exception as exc:
         logger.debug(
             "Could not load credential pool for child provider '%s': %s",
@@ -3093,6 +3134,30 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         elif "api.kimi.com/coding" in base_lower:
             provider = "custom"
             api_mode = "anthropic_messages"
+
+        # If the user configured an explicit provider (e.g. via delegation.provider)
+        # and that provider is registered (either in hermes_cli.providers or the
+        # plugin registry), honour it instead of demoting to "custom". This ensures
+        # plugin-registered providers (model-provider plugins) keep their identity
+        # on the delegation path so build_extra_body fires with the right profile.
+        if configured_provider:
+            _cfg_prov_lower = configured_provider.strip().lower()
+            _cfg_prov_known = False
+            try:
+                from hermes_cli.providers import get_provider as _get_core_provider
+                if _get_core_provider(_cfg_prov_lower) is not None:
+                    _cfg_prov_known = True
+            except Exception:
+                pass
+            if not _cfg_prov_known:
+                try:
+                    from providers import get_provider_profile as _get_plugin_profile
+                    if _get_plugin_profile(_cfg_prov_lower) is not None:
+                        _cfg_prov_known = True
+                except Exception:
+                    pass
+            if _cfg_prov_known:
+                provider = configured_provider
 
         # Explicit delegation.api_mode in config always wins. Lets users force
         # a transport for non-standard endpoints the URL heuristic can't detect.


### PR DESCRIPTION
## What does this PR do?

Adds Turbohaul Manager as a supported inference provider through a self-contained plugin at `plugins/model-providers/turbohaul/`, alongside the existing model-provider plugins (openrouter / anthropic / gmi).

Turbohaul is a KV-cache-aware locally hosted inference server. To route and stabilize its per-conversation cache it needs a little structured context on each request: a session id plus a role flag identifying the turn as the main agent, a sub-agent, a curator/title turn, or a compression turn. This PR lets the harness pass that context to any provider that wants it — implemented by widening the existing generic `ProviderProfile.build_extra_body(...)` surface, with all Turbohaul-specific logic living in the plugin. There is no provider-specific branching in core: `git grep -i turbohaul` across core (everything except the plugin dir and `tests/`) returns zero, and when the provider is unused the base `build_extra_body` returns `{}`, so behavior is unchanged.

## How the role tagging works

On every request the plugin adds a small `client_meta` object with a session id and exactly one role flag, derived from the generic request context the harness already tracks:

- `is_main` - a normal main-agent turn; carries the main session id, stable across the conversation (thread `hermes-main-<session_id>`).
- `is_curator` - an auxiliary "curator" turn such as title generation (detected via `persist_disabled`); reuses the main session id read-only, so the backend can read main's cache without overwriting it.
- `is_sub_agent` - a delegated sub-agent (detected via `parent_session_id`); gets its own fresh session id (thread `hermes-sub-<session_id>`), distinct per sub-agent and stable for that sub-agent's lifetime.
- `is_compression` - a context-compression turn (detected via the `is_compression` marker); reuses the main session id.

Exactly one flag is set per request (curator is checked before sub-agent), so a KV-caching backend can key and stabilize its cache per role.

Because the classification is driven by each request's role in the harness - not by which model serves it - it behaves the same whether a single model handles everything or dedicated auxiliary models are configured for curator / compression / sub-agent work. Both configurations were verified end-to-end.

## Related Issue

Related: #7833 — this PR extends the existing same-endpoint credential-pool identity resolution (currently custom-provider-only) to all registered providers, so a delegated sub-agent keeps its configured `base_url`. No dedicated issue for the provider addition itself; happy to open one if preferred.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/turbohaul/__init__.py` + `plugin.yaml` — self-contained provider profile + role-to-`client_meta` classification (+212).
- Generic core hooks (~+134) threading request context (`session_id`, `parent_session_id`, `persist_disabled`, `is_compression`) into `build_extra_body(...)` on the main, auxiliary (title/curator), and compression paths: `agent/auxiliary_client.py`, `agent/chat_completion_helpers.py`, `agent/context_compressor.py`, `agent/title_generator.py`, `agent/transports/chat_completions.py`, `acp_adapter/server.py`, `cli.py`, `gateway/run.py`.
- `tools/delegate_tool.py` — extend the same-endpoint credential-pool guard (#7833) to all registered providers.
- `tests/providers/test_turbohaul_provider.py` — 12 hermetic unit tests for the role classification.
- Total: 12 files, +504/-4.

## How to Test

1. `pytest tests/providers/test_turbohaul_provider.py -q` → 12 passed (hermetic; no network/engine).
2. Configure a `turbohaul` provider endpoint in `config.yaml` and run a session; the plugin emits `client_meta` with the correct role flag per turn (is_main / is_sub_agent / is_curator / is_compression) plus stable per-role session/thread ids. Verified live against a running Turbohaul server across both single-model and auxiliary-model topologies.
3. With no `turbohaul` provider configured, behavior is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `test(turbohaul):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux (Docker; container Debian 13 / Python 3.13, host Debian 12 / TrueNAS SCALE Version: 25.10.1 - Goldeye)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verified live: all four role tags (is_main / is_sub_agent / is_curator / is_compression) fire with the expected session/thread ids across single-model and auxiliary-model runs.
