### PR TITLE
fix(desktop): clear project scope on profile switch

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -409,15 +409,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // A profile switch/create drops to a fresh new-session draft so the
   // previously open session doesn't bleed across contexts. Skip initial value.
   const freshSessionRequest = useStore($freshSessionRequest)
-  const lastFreshRef = useRef(freshSessionRequest)
+  const lastFreshTokenRef = useRef(freshSessionRequest?.token ?? 0)
 
   useEffect(() => {
-    if (freshSessionRequest === lastFreshRef.current) {
+    if (!freshSessionRequest || freshSessionRequest.token === lastFreshTokenRef.current) {
       return
     }
 
-    lastFreshRef.current = freshSessionRequest
-    startFreshSessionDraft()
+    lastFreshTokenRef.current = freshSessionRequest.token
+    const { workspaceTarget } = freshSessionRequest
+
+    startFreshSessionDraft(workspaceTarget === undefined ? undefined : { workspaceTarget })
   }, [freshSessionRequest, startFreshSessionDraft])
 
   // Swapping the live gateway to another profile must re-pull that profile's

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -19,9 +19,19 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ queryClient: { invalidateQueries: vi.fn() } }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, $profiles, ensureGatewayProfile, prewarmProfileBackend, refreshProfiles } =
-  await import('./profile')
+const {
+  $activeGatewayProfile,
+  $freshSessionRequest,
+  $profiles,
+  $showAllProfiles,
+  ensureGatewayProfile,
+  newSessionInProfile,
+  prewarmProfileBackend,
+  refreshProfiles,
+  selectProfile
+} = await import('./profile')
 
+const { $projectScope, ALL_PROJECTS } = await import('./project-scope')
 const { $connection } = await import('./session')
 const { queryClient } = await import('@/lib/query-client')
 const { getProfiles } = await import('@/hermes')
@@ -50,6 +60,8 @@ beforeEach(() => {
   openGatewayForProfile.mockClear()
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
+  $showAllProfiles.set(false)
+  $projectScope.set(ALL_PROJECTS)
   $connection.set(localConn())
   $profiles.set([])
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
@@ -150,6 +162,41 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
     openGatewayForProfile.mockRejectedValueOnce(new Error('spawn failed'))
 
     expect(() => prewarmProfileBackend('warm-failing')).not.toThrow()
+  })
+})
+
+describe('profile switch project isolation', () => {
+  it('clears the prior project scope and detaches the fresh draft before swapping gateways', () => {
+    $activeGatewayProfile.set('learning')
+    $projectScope.set('p_learning_ops')
+    const before = $freshSessionRequest.get()?.token ?? 0
+
+    selectProfile('default')
+
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+    expect($freshSessionRequest.get()).toEqual({ token: before + 1, workspaceTarget: null })
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('default')
+  })
+
+  it('keeps the current project when the active profile is reselected', () => {
+    $projectScope.set('p_default_ops')
+    const before = $freshSessionRequest.get()
+
+    selectProfile('default')
+
+    expect($projectScope.get()).toBe('p_default_ops')
+    expect($freshSessionRequest.get()).toBe(before)
+  })
+
+  it('detaches a per-profile new session from the previously entered project', () => {
+    $projectScope.set('p_learning_ops')
+    const before = $freshSessionRequest.get()?.token ?? 0
+
+    newSessionInProfile('health')
+
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+    expect($freshSessionRequest.get()).toEqual({ token: before + 1, workspaceTarget: null })
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('health')
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -12,7 +12,8 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { $gateway, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
-import { setConnection } from '@/store/session'
+import { resetProjectScope } from '@/store/project-scope'
+import { type NewChatWorkspaceTarget, setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -158,10 +159,18 @@ export const $newChatProfile = atom<string | null>(null)
 // draft: a profile switch/create (below), or deleting the project that owns the
 // currently-open session (store/projects). The chat controller subscribes and
 // resets to the intro draft, so we never strand the user in an orphaned view.
-export const $freshSessionRequest = atom(0)
+export interface FreshSessionRequest {
+  token: number
+  workspaceTarget?: NewChatWorkspaceTarget
+}
 
-export function requestFreshSession(): void {
-  $freshSessionRequest.set($freshSessionRequest.get() + 1)
+export const $freshSessionRequest = atom<FreshSessionRequest | null>(null)
+
+let freshSessionToken = 0
+
+export function requestFreshSession(workspaceTarget: NewChatWorkspaceTarget = undefined): void {
+  freshSessionToken += 1
+  $freshSessionRequest.set({ token: freshSessionToken, workspaceTarget })
 }
 
 // Route profile-scoped REST settings (config/env/skills/tools/model/…) to the
@@ -340,7 +349,12 @@ export function selectProfile(name: string): void {
   $newChatProfile.set(target)
 
   if (switching) {
-    requestFreshSession()
+    // Project ids and folders belong to one profile's projects.db. Clear the
+    // previous profile's scope before the fresh-draft observer runs, and make
+    // that draft explicitly detached so neither the old tree nor a remote
+    // profile's remembered cwd can leak into the target profile.
+    resetProjectScope()
+    requestFreshSession(null)
   }
 
   void ensureGatewayProfile(target)
@@ -355,7 +369,8 @@ export function selectProfile(name: string): void {
 export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
   $newChatProfile.set(target)
-  requestFreshSession()
+  resetProjectScope()
+  requestFreshSession(null)
   void ensureGatewayProfile(target)
 }
 

--- a/apps/desktop/src/store/project-scope.ts
+++ b/apps/desktop/src/store/project-scope.ts
@@ -1,0 +1,17 @@
+import { persistentAtom } from '@/lib/persisted'
+
+// Project ids are scoped by the active profile's projects.db. Keep the view
+// atom in a dependency-light module so profile switching can clear a project
+// id before the asynchronous gateway/catalog swap starts.
+export const ALL_PROJECTS = '__all_projects__'
+
+const PROJECT_SCOPE_KEY = 'hermes.desktop.projectScope'
+
+export const $projectScope = persistentAtom<string>(PROJECT_SCOPE_KEY, ALL_PROJECTS, {
+  decode: raw => raw || ALL_PROJECTS,
+  encode: value => value || ALL_PROJECTS
+})
+
+export function resetProjectScope(): void {
+  $projectScope.set(ALL_PROJECTS)
+}

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -6,11 +6,11 @@ import { translateNow } from '@/i18n'
 import { desktopDefaultCwd, selectDesktopPaths, writeDesktopFileText } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
-import { persistentAtom } from '@/lib/persisted'
 import { activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import { requestFreshSession } from '@/store/profile'
+import { $projectScope, ALL_PROJECTS, resetProjectScope } from '@/store/project-scope'
 import { $selectedStoredSessionId, $sessions, sessionMatchesStoredId, workspaceCwdForNewSession } from '@/store/session'
 import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
@@ -103,14 +103,7 @@ export const $reposScanning = atom(false)
 // pure view state (localStorage), distinct from the durable active-project
 // pointer in projects.db — though entering a project also makes it active so new
 // chats land there, exactly as selecting a profile does.
-export const ALL_PROJECTS = '__all_projects__'
-
-const PROJECT_SCOPE_KEY = 'hermes.desktop.projectScope'
-
-export const $projectScope = persistentAtom<string>(PROJECT_SCOPE_KEY, ALL_PROJECTS, {
-  decode: raw => raw || ALL_PROJECTS,
-  encode: value => value || ALL_PROJECTS
-})
+export { $projectScope, ALL_PROJECTS } from '@/store/project-scope'
 
 // Enter a project: scope the sidebar to it and make it the active project
 // (best-effort — the durable pointer is nice-to-have, the view scope is the
@@ -127,7 +120,7 @@ export function enterProject(id: string): void {
 }
 
 export function exitProjectScope(): void {
-  $projectScope.set(ALL_PROJECTS)
+  resetProjectScope()
 }
 
 // The cwd a NEW chat should start in. The "active project" is just an atom


### PR DESCRIPTION
## What does this PR do?

Prevents a fresh chat from inheriting the previous profile's entered project and working directory when switching Desktop profiles.

`$projectScope` is persisted globally while project IDs and trees belong to a profile-specific `projects.db`. `selectProfile()` requested a fresh draft synchronously, before the async gateway/catalog swap replaced the old project tree. `startFreshSessionDraft()` then resolved the new chat CWD from that stale project ID and tree. The session itself could be created in the correct target profile but still carry the previous profile's project path, making Profile A appear to remain inside Profile B (and grouping the session under the wrong project).

The fix clears the old project scope before requesting the draft and carries an explicit `null` workspace target atomically with that request. `null` uses the existing one-shot detached-workspace contract, so the old project tree and a remote connection's remembered CWD cannot leak across the switch.

## Related Issue

Fixes #54990

Related: #57911

This is intentionally narrower than the open alternatives:

- #39837 waits for the gateway swap but does not clear the persisted project ID or cached project tree.
- #56869 changes backend CWD precedence, which can override an explicit project/workspace choice.
- #57926 detaches bare remote new chats but does not clear a stale entered-project scope.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/project-scope.ts` — move the dependency-light persisted scope atom out of the project store so profile switching can reset it without a cycle.
- `apps/desktop/src/store/profile.ts` — clear project scope and request an explicitly detached draft on real profile switches and per-profile new-session actions.
- `apps/desktop/src/app/desktop-controller.tsx` — consume the workspace target carried by the fresh-session request.
- `apps/desktop/src/store/profile.test.ts` — cover cross-profile isolation, same-profile reselection, and the per-profile `+` action.

## How to Test

1. Enter a project in profile A.
2. Switch to profile B and start/send the fresh chat.
3. Confirm the project overview is shown and the new session does not contain profile A's CWD.
4. Re-select profile B while inside one of its projects and confirm the current project/session is preserved.

Automated checks:

```text
NODE_OPTIONS='--localstorage-file=/tmp/hermes-pr-vitest-localstorage' npm --workspace apps/desktop exec -- vitest run --environment jsdom src/store/profile.test.ts src/store/projects.test.ts src/app/session/hooks/use-session-actions.test.tsx
npm --workspace apps/desktop run typecheck
npm --workspace apps/desktop exec -- eslint src/store/profile.ts src/store/profile.test.ts src/store/projects.ts src/store/project-scope.ts src/app/desktop-controller.tsx
npm --workspace apps/desktop exec -- prettier --check src/store/profile.ts src/store/profile.test.ts src/store/projects.ts src/store/project-scope.ts src/app/desktop-controller.tsx
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and documented how this differs
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (Desktop-only change; focused Desktop checks run)
- [x] I've added tests for my changes
- [x] I've tested on macOS 15.7.7

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture contract changed
- [x] Cross-platform impact considered: renderer-only state logic, no platform-specific paths
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

```text
Test Files  3 passed (3)
Tests       41 passed (41)
TypeScript, ESLint, and Prettier checks passed
```
