### PR TITLE
fix(tests): stop log queue listener to prevent FATAL on 3.11 shutdown

### DIFF
--- a/tests/cli/test_surrogate_sanitization.py
+++ b/tests/cli/test_surrogate_sanitization.py
@@ -16,6 +16,24 @@ from run_agent import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stop_log_queue_listener():
+    """Stop the async logging QueueListener after each test.
+
+    AIAgent.__init__ → setup_logging() starts a QueueListener daemon
+    thread (_monitor). On Python 3.11 the daemon can still be mid-loop
+    when the interpreter begins shutdown, and accessing partially-torn-down
+    logging objects produces "FATAL: exception not rethread" at process
+    exit — a non-zero exit code in CI even though every test passed.
+    """
+    yield
+    try:
+        from hermes_logging import _reset_queued_handlers
+        _reset_queued_handlers()
+    except Exception:
+        pass
+
+
 class TestSanitizeSurrogates:
     """Test the _sanitize_surrogates() helper."""
 


### PR DESCRIPTION
## What does this PR do?

`tests/cli/test_surrogate_sanitization.py` fails in CI on Python 3.11 with `FATAL: exception not rethrown` at process exit, even though all 28 tests pass. The non-zero exit code causes the CI job to fail.

The `TestRunConversationSurrogateSanitization` test creates a full `AIAgent`, which calls `setup_logging()` → starts a `QueueListener` daemon thread (`_monitor`). On Python 3.11 the daemon can still be mid-loop when the interpreter begins shutdown, and accessing partially-torn-down logging objects produces the `FATAL` message.

**Fix:** Add an autouse fixture that calls `hermes_logging._reset_queued_handlers()` after each test to stop the listener and join its worker thread cleanly before interpreter shutdown.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/cli/test_surrogate_sanitization.py`: Add autouse `_stop_log_queue_listener` fixture that tears down the async logging `QueueListener` after each test

## How to Test

1. `scripts/run_tests.sh tests/cli/test_surrogate_sanitization.py -q`
2. All 28 tests pass, exit code 0 (no `FATAL: exception not rethrown`)

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh tests/cli/test_surrogate_sanitization.py -q` and all tests pass
