### PR TITLE
fix(tests): pin tui_gateway config home in goal-command tests (order-dependent config leak)

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -34,7 +34,7 @@ def hermes_home(tmp_path, monkeypatch):
 
 
 @pytest.fixture()
-def server(hermes_home):
+def server(hermes_home, monkeypatch):
     with patch.dict(
         "sys.modules",
         {
@@ -43,6 +43,21 @@ def server(hermes_home):
         },
     ):
         mod = importlib.import_module("tui_gateway.server")
+        # Pin config resolution to the isolated HERMES_HOME. Sibling test
+        # files (test_billing_rpc, test_delegation_session_lifecycle,
+        # test_gateway_owned_session_reap, ...) import tui_gateway.server at
+        # collection time — BEFORE the conftest env isolation runs — so the
+        # module-level ``_hermes_home = get_hermes_home()`` snapshot freezes
+        # the developer's real home. When any of them precede this file in
+        # the same process, ``importlib.import_module`` returns that cached
+        # module and ``_load_cfg()`` would read the REAL config.yaml (e.g. a
+        # local MoA preset) instead of the one ``_write_moa_config`` writes.
+        # Also reset the mtime-keyed config cache; monkeypatch restores the
+        # originals on teardown so nothing leaks to later tests either.
+        monkeypatch.setattr(mod, "_hermes_home", hermes_home)
+        monkeypatch.setattr(mod, "_cfg_cache", None)
+        monkeypatch.setattr(mod, "_cfg_mtime", None)
+        monkeypatch.setattr(mod, "_cfg_path", None)
         yield mod
         # Reset module-level session state without re-importing. importlib.reload
         # would re-register the module's atexit hooks (ThreadPoolExecutor


### PR DESCRIPTION
## What does this PR do?

Fixes a test-hermeticity leak: `tests/tui_gateway/test_goal_command.py::test_moa_arg_is_always_one_shot` passes when the file runs alone but fails when certain sibling files precede it in the same pytest process — and *what* it fails with depends on the developer's real `~/.hermes/config.yaml`.

**Leak mechanism.** `test_billing_rpc.py`, `test_delegation_session_lifecycle.py`, and `test_gateway_owned_session_reap.py` all import `tui_gateway.server` at module scope, i.e. at collection time — before the `_hermetic_environment` autouse fixture in `tests/conftest.py` has redirected `HERMES_HOME` to a per-test tempdir. The server module snapshots its config home once at import:

```python
_hermes_home = get_hermes_home()   # tui_gateway/server.py, module level
```

so that snapshot freezes the developer's REAL Hermes home. When `test_goal_command.py` later runs in the same process, its `server` fixture's `importlib.import_module("tui_gateway.server")` returns the already-cached module, and `_load_cfg()` (which resolves `Path(_hermes_home) / "config.yaml"`, with an mtime-keyed cache in `_cfg_cache`/`_cfg_mtime`/`_cfg_path`) reads the developer's real config instead of the file the test's `_write_moa_config` helper wrote into the isolated home. If the real config sets a `moa.default_preset`, the `/moa` one-shot pins that preset and the assertion `s["model_override"]["model"] == "default"` fails, e.g.:

```
AssertionError: assert 'moa-audex' == 'default'
```

Run alone, the file passes because the import happens inside the fixture, after the isolated `HERMES_HOME` is in place — a classic import-order heisenbug.

**Why the fix is test-side.** The production behavior (resolve the home once at startup, cache the parsed config by path+mtime) is intentional and correct for a long-lived gateway process; the bug is only that this test file assumed a fresh import. The `server` fixture already follows a reset-not-reload approach for module state (`_sessions`/`_pending`/`_answers` are cleared instead of `importlib.reload`, to avoid duplicate atexit hooks). This change extends the same approach to config resolution: `monkeypatch.setattr` pins the already-imported module's `_hermes_home` to the test's isolated home and clears the `_cfg_cache`/`_cfg_mtime`/`_cfg_path` trio. `monkeypatch` restores the originals on teardown, so the fixture cannot leak state into tests that run after it, in either direction.

## Related Issue

No open issue; test-only hermeticity fix, reproduction included below.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tui_gateway/test_goal_command.py`: the `server` fixture now takes `monkeypatch` and, after importing `tui_gateway.server`, pins `_hermes_home` to the isolated `hermes_home` and resets `_cfg_cache`, `_cfg_mtime`, `_cfg_path` to `None`. Comment documents the collection-time-import leak for the next reader. No production code touched.

## How to Test

1. On `main`, put a `moa:` section with a non-`default` `default_preset` in your real `$HERMES_HOME/config.yaml` (any name, e.g. `myset`), then run each trigger ordering in one process:
   `pytest tests/tui_gateway/test_billing_rpc.py tests/tui_gateway/test_goal_command.py -q`
   `pytest tests/tui_gateway/test_delegation_session_lifecycle.py tests/tui_gateway/test_goal_command.py -q`
   `pytest tests/tui_gateway/test_gateway_owned_session_reap.py tests/tui_gateway/test_goal_command.py -q`
   → `test_moa_arg_is_always_one_shot` fails with `assert '<your preset>' == 'default'`, while `pytest tests/tui_gateway/test_goal_command.py -q` alone passes.
2. With this PR, all three orderings pass (31/27/23 passed respectively), the file alone still passes (15 passed), and the reversed orderings (`test_goal_command.py` first) also pass — the fixture restores the module globals on teardown.
3. `pytest tests/tui_gateway/ -q` produces the same results as `main` apart from the fixed test.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tui_gateway/ -q` — identical results to `main` except the fixed test (3 unrelated tests fail on my machine on `main` and on this branch alike; they pass in isolation and are untouched here)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (fixture comment documents the leak)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-pytest change, path handling via `Path`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (main, `test_billing_rpc.py` then `test_goal_command.py`, one process):

```
>       assert s["model_override"]["model"] == "default"
E       AssertionError: assert 'moa-audex' == 'default'
FAILED tests/tui_gateway/test_goal_command.py::test_moa_arg_is_always_one_shot
1 failed, 30 passed
```

After (this PR, same command): `31 passed`.
