### PR TITLE
fix(profiles): resolve symlinked profiles dir in active-profile detection

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -370,7 +370,13 @@ def _resolve_active_profile_name() -> str:
         root_real = _hermes_root_path().resolve()
     except (OSError, RuntimeError):
         return "default"
-    profiles_dir = root_real / "profiles"
+    # Resolve the profiles dir too: when <root>/profiles is a symlink,
+    # home_real (fully resolved) would never be relative_to() the
+    # unresolved symlink path, misreporting a named profile as "default".
+    try:
+        profiles_dir = (root_real / "profiles").resolve()
+    except (OSError, RuntimeError):
+        profiles_dir = root_real / "profiles"
     try:
         rel = home_real.relative_to(profiles_dir)
         parts = rel.parts
@@ -407,12 +413,19 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
     target_profile: Optional[str] = None
     area: Optional[str] = None
 
+    parts: Optional[tuple] = None
     try:
-        rel = target.relative_to(root_real)
+        parts = target.relative_to(root_real).parts
     except ValueError:
-        return None
+        # <root>/profiles may be a symlink (e.g. ~/.hermes/profiles ->
+        # /repo/.hermes/profiles). target is fully resolved, so match it
+        # against the RESOLVED profiles dir and rebuild canonical parts.
+        try:
+            profiles_real = (root_real / "profiles").resolve()
+            parts = ("profiles",) + target.relative_to(profiles_real).parts
+        except (ValueError, OSError, RuntimeError):
+            return None
 
-    parts = rel.parts
     if not parts:
         return None
 

--- a/tests/tools/test_cross_profile_guard.py
+++ b/tests/tools/test_cross_profile_guard.py
@@ -256,3 +256,66 @@ class TestSystemPromptActiveProfile:
         # Both branches present (default and named profile).
         assert "Active Hermes profile: default" in src
         assert "Active Hermes profile: {active_profile}" in src
+
+
+# ---------------------------------------------------------------------------
+# Symlinked profiles dir (2026-07-13 incident: ~/.hermes/profiles ->
+# /repo/.hermes/profiles made a claudio-lab session identify as "default")
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkedProfilesDir:
+    @pytest.fixture
+    def symlinked_hermes(self, tmp_path, monkeypatch):
+        """Root whose profiles/ is a symlink to an external directory."""
+        root = tmp_path / "dot-hermes"
+        root.mkdir()
+        real_profiles = tmp_path / "repo" / "profiles"
+        lab_home = real_profiles / "claudio-lab"
+        (lab_home / "skills").mkdir(parents=True)
+        (real_profiles / "other" / "skills").mkdir(parents=True)
+        (root / "profiles").symlink_to(real_profiles)
+
+        # HERMES_HOME via the symlinked path, as `hermes -p <name>` sets it.
+        sym_home = root / "profiles" / "claudio-lab"
+        monkeypatch.setenv("HERMES_HOME", str(sym_home))
+
+        import hermes_constants
+        monkeypatch.setattr(
+            hermes_constants, "get_default_hermes_root", lambda: root
+        )
+        import agent.file_safety as fs
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: sym_home)
+        monkeypatch.setattr(fs, "_hermes_root_path", lambda: root)
+        return {"root": root, "lab_home": lab_home, "sym_home": sym_home}
+
+    def test_active_profile_resolves_through_symlink(self, symlinked_hermes):
+        from agent.file_safety import _resolve_active_profile_name
+
+        assert _resolve_active_profile_name() == "claudio-lab"
+
+    def test_own_profile_write_not_flagged(self, symlinked_hermes):
+        from agent.file_safety import classify_cross_profile_target
+
+        target = symlinked_hermes["sym_home"] / "skills" / "x" / "SKILL.md"
+        assert classify_cross_profile_target(str(target)) is None
+
+    def test_other_profile_write_flagged_through_symlink(self, symlinked_hermes):
+        from agent.file_safety import classify_cross_profile_target
+
+        target = (
+            symlinked_hermes["root"] / "profiles" / "other" / "skills" / "y.md"
+        )
+        info = classify_cross_profile_target(str(target))
+        assert info is not None
+        assert info["active_profile"] == "claudio-lab"
+        assert info["target_profile"] == "other"
+        assert info["area"] == "skills"
+
+    def test_default_area_write_flagged(self, symlinked_hermes):
+        from agent.file_safety import classify_cross_profile_target
+
+        target = symlinked_hermes["root"] / "skills" / "z" / "SKILL.md"
+        info = classify_cross_profile_target(str(target))
+        assert info is not None
+        assert info["target_profile"] == "default"

--- a/tests/tools/test_cross_profile_guard.py
+++ b/tests/tools/test_cross_profile_guard.py
@@ -13,6 +13,7 @@ This file tests that the tool surfaces:
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -264,6 +265,10 @@ class TestSystemPromptActiveProfile:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Symlinks require elevated privileges on Windows",
+)
 class TestSymlinkedProfilesDir:
     @pytest.fixture
     def symlinked_hermes(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

When `<hermes-root>/profiles` is a **symlink** (e.g. `~/.hermes/profiles -> /srv/repo/.hermes/profiles`, a common layout when profile state is kept in a versioned/ops directory), `agent/file_safety.py::_resolve_active_profile_name()` misidentifies a named-profile session as `default`:

- `HERMES_HOME` (set by `hermes -p <name>`) is fully `.resolve()`d → the symlink **target** path
- the profiles dir it's compared against (`root_real / "profiles"`) is **not** resolved → the symlink path
- `relative_to()` raises → fallback to `"default"`

## Impact

1. **System prompt lies about the profile** — the agent under `hermes -p claudio-lab` is told `Active Hermes profile: default`, so it treats the default profile's `~/.hermes/skills|plugins|cron|memories` as its own.
2. **Cross-profile write guard is weakened** — `classify_cross_profile_target()` uses the same resolution, so writes to the *default* profile's scoped areas go unflagged (they look in-profile), and writes to the session's *own* profile can be spuriously flagged.

Reproduced on Linux with:
```
ln -s /srv/repo/.hermes/profiles ~/.hermes/profiles
HERMES_HOME=~/.hermes/profiles/mylab python -c \ 'from agent.file_safety import _resolve_active_profile_name; print(_resolve_active_profile_name())'
# prints: default   (expected: mylab)
```

## Fix

- `_resolve_active_profile_name`: resolve `<root>/profiles` before the `relative_to()` comparison (same failure-safe fallback semantics as before).
- `classify_cross_profile_target`: when the resolved target doesn't sit under the unresolved root, retry against the **resolved** profiles dir and rebuild canonical `("profiles", <name>, <area>, ...)` parts, so guard classification works through the symlink in both directions.

## Tests

New `TestSymlinkedProfilesDir` class in `tests/tools/test_cross_profile_guard.py` modeling the symlinked layout: active-profile resolution, own-profile write not flagged, other-profile write flagged, default-area write flagged.

```
pytest tests/tools/test_cross_profile_guard.py tests/agent/test_file_safety.py
38 passed
```

Related: #20920 tracks other `HERMES_HOME` handling issues in `file_safety.py`; this one is specifically symlink resolution asymmetry and is independent of that change.