### PR TITLE
fix(gateway): report runtime source version in /health, not stale dist-info metadata

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -76,23 +76,25 @@ logger = logging.getLogger(__name__)
 
 
 def _hermes_version() -> str:
-    """Return the hermes-agent version string, or "dev" if it can't be resolved.
+    """Return the canonical Hermes Agent version string.
 
-    Tries the installed package metadata first (authoritative for a pip/uv
-    install), then the in-tree ``hermes_cli.__version__`` (covers editable /
-    source checkouts where metadata may be stale or absent). Never raises —
-    a version probe must not be able to break the health endpoint.
+    ``hermes_cli.__version__`` is the runtime source of truth used by the CLI,
+    dashboard, portal tags, and release script. Prefer it over installed
+    distribution metadata because editable/source checkouts can retain stale
+    ``hermes_agent-*.dist-info`` after a source update until the environment is
+    reinstalled. Never raises — a version probe must not be able to break the
+    health endpoint.
     """
-    try:
-        from importlib.metadata import version
-
-        return version("hermes-agent")
-    except Exception:
-        pass
     try:
         from hermes_cli import __version__
 
         return __version__
+    except Exception:
+        pass
+    try:
+        from importlib.metadata import version
+
+        return version("hermes-agent")
     except Exception:
         return "dev"
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,7 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _IdempotencyCache,
     _derive_chat_session_id,
+    _hermes_version,
     _redact_api_error_text,
     check_api_server_requirements,
     cors_middleware,
@@ -723,6 +724,29 @@ class TestHealthEndpoint:
             assert "version" in data
             assert isinstance(data["version"], str)
             assert data["version"] != ""
+
+    def test_health_version_prefers_runtime_source_over_stale_metadata(self):
+        """Editable installs can leave importlib.metadata at an older release.
+
+        The health endpoint must report the running Hermes source version, not
+        stale ``hermes_agent-*.dist-info`` metadata from before a source update.
+        """
+        from hermes_cli import __version__
+
+        with patch("importlib.metadata.version", return_value="0.18.0"):
+            assert _hermes_version() == __version__
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint_prefers_runtime_version_over_stale_metadata(self, adapter):
+        from hermes_cli import __version__
+
+        app = _create_app(adapter)
+        with patch("importlib.metadata.version", return_value="0.18.0"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/health")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["version"] == __version__
 
     @pytest.mark.asyncio
     async def test_v1_health_alias_returns_ok(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Fixes `/health` (and `/health/detailed`) reporting a **stale version** on editable/source installs.

`_hermes_version()` currently prefers `importlib.metadata.version("hermes-agent")` and only falls back to `hermes_cli.__version__` when metadata lookup **raises**. But stale metadata doesn't raise — on editable/source checkouts (including the standard git-based install that `hermes-setup` performs), `hermes_agent-*.dist-info` can survive a source update unchanged, so the fallback never fires and the health endpoints keep reporting the previous release while the CLI, dashboard, and release tags all report the new one.

Observed live: CLI, dashboard, and `pyproject.toml` all at `0.18.2` while `/health` returned `0.18.0` from a stale `hermes_agent-0.18.0.dist-info` left behind by a source update.

The fix flips the preference: use `hermes_cli.__version__` (the runtime source of truth shared by the CLI and dashboard) first, and fall back to distribution metadata only when the source import fails. The never-raise contract of the version probe is unchanged. Since `gateway.platforms.api_server` ships in the same package as `hermes_cli`, the source import succeeding is the overwhelmingly common path; the metadata fallback remains for exotic packaging situations.

This closes a gap in the version reporting introduced by #40620 (which added the `version` field to `/health`).

## Related Issue

No tracking issue — small bug fix; behavior introduced in #40620.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — `_hermes_version()`: prefer `hermes_cli.__version__`, fall back to `importlib.metadata`; docstring updated to document why.
- `tests/gateway/test_api_server.py` — two behavioral tests:
  - `test_health_version_prefers_runtime_source_over_stale_metadata` — patches `importlib.metadata.version` to return a stale `0.18.0` and asserts `_hermes_version()` returns the runtime source version.
  - `test_health_endpoint_prefers_runtime_version_over_stale_metadata` — same assertion end-to-end through `GET /health`.

## How to Test

1. On a git/source checkout, simulate a stale dist-info (or just patch it): `python -c "from unittest.mock import patch; from gateway.platforms.api_server import _hermes_version; import hermes_cli; \
   print(_hermes_version() == hermes_cli.__version__ or 'FAIL')"` — before this fix, with stale metadata present, `/health` reports the dist-info version instead.
2. `pytest tests/gateway/test_api_server.py -q` — includes the two new regression tests.
3. Real-world repro: perform a source update on a git install without reinstalling the package, then `curl 127.0.0.1:<port>/health` — version now matches `hermes --version`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#40620 added the field; #31125 targets `/api/gateway/status`, a different surface)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite (`scripts/run_tests.sh`, 1987 files / ~38k tests). Result: 46 failures, all **pre-existing at upstream `main` (55624e10b)** and unrelated to this change — I re-ran the 19 affected files at the base commit and on this branch with identical invocation: the failure sets are byte-identical (46 = 46), and this branch adds 2 passing tests (1601 → 1603 passed on that subset). The pre-existing failures are platform/environment-dependent on macOS (WSL/systemd/pty/etc.).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon, Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring of `_hermes_version` explains the preference order) — README/`docs/` N/A
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered: pure-Python import-order change, no platform-specific behavior
- [x] Tool descriptions/schemas — N/A (no tool behavior changed)

## Screenshots / Logs

Live mismatch that motivated the fix (git install, post source-update, pre-reinstall):

```
$ hermes --version
Hermes Agent v0.18.2 (…)
$ curl -fsS http://127.0.0.1:8642/health
{"status": "ok", "platform": "hermes-agent", "version": "0.18.0"}
```

After the fix, `/health` reports `0.18.2`, matching the CLI and dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


