### PR TITLE
fix(reasoning): use profile reasoning shape on iteration-limit summary

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1757,8 +1757,39 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             agent._resolve_lmstudio_summary_reasoning_effort()
             if _is_lmstudio_summary else None
         )
+        try:
+            from providers import get_provider_profile
+            _summary_profile = get_provider_profile(agent.provider)
+        except Exception:
+            _summary_profile = None
+        _profile_top_level: dict = {}
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
-            if agent.reasoning_config is not None:
+            if _summary_profile is not None:
+                # Delegate the reasoning wire shape to the provider profile —
+                # the same hook the main loop uses via
+                # ChatCompletionsTransport._build_kwargs_from_profile().
+                # Hand-building extra_body.reasoning here bypassed profile
+                # quirks: on OpenRouter, reasoning-mandatory Anthropic models
+                # (Claude 4.6+/fable) 400 on ANY reasoning field during
+                # tool-continuation turns, so the profile omits it and routes
+                # effort onto top-level `verbosity` instead (#42991).
+                from agent.transports.chat_completions import _reasoning_config_for_model
+                try:
+                    _profile_reasoning_body, _profile_top_level = (
+                        _summary_profile.build_api_kwargs_extras(
+                            reasoning_config=_reasoning_config_for_model(
+                                agent.model, agent.reasoning_config
+                            ),
+                            supports_reasoning=True,
+                            model=agent.model,
+                            base_url=agent.base_url,
+                            session_id=getattr(agent, "session_id", None),
+                        )
+                    )
+                    summary_extra_body.update(_profile_reasoning_body)
+                except Exception:
+                    pass  # best-effort: omit reasoning rather than fail the summary
+            elif agent.reasoning_config is not None:
                 summary_extra_body["reasoning"] = agent.reasoning_config
             else:
                 summary_extra_body["reasoning"] = {
@@ -1787,17 +1818,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_kwargs.update(agent._max_tokens_param(agent.max_tokens))
             if _lm_reasoning_effort is not None:
                 summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
+            if _profile_top_level:
+                summary_kwargs.update(_profile_top_level)
 
             # Merge the profile's canonical body even when routing is unset:
             # profiles may always emit required metadata such as Portal tags.
             provider_preferences = _provider_preferences_for_agent(agent)
             profile_extra_body = {}
             try:
-                from providers import get_provider_profile
-
-                provider_profile = get_provider_profile(agent.provider)
-                if provider_profile is not None:
-                    profile_extra_body = provider_profile.build_extra_body(
+                if _summary_profile is not None:
+                    profile_extra_body = _summary_profile.build_extra_body(
                         session_id=getattr(agent, "session_id", None),
                         provider_preferences=provider_preferences or None,
                         model=agent.model,
@@ -1889,6 +1919,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     summary_kwargs.update(agent._max_tokens_param(agent.max_tokens))
                 if _lm_reasoning_effort is not None:
                     summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
+                if _profile_top_level:
+                    summary_kwargs.update(_profile_top_level)
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3678,6 +3678,46 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_omits_reasoning_for_anthropic_mandatory_openrouter_model(self, agent):
+        """Regression: the summary call must go through the OpenRouter
+        profile's build_api_kwargs_extras(). Reasoning-mandatory Anthropic
+        models (Claude 4.6+/fable) 400 on any extra_body.reasoning during
+        tool-continuation turns (#42991); the profile omits it and routes
+        the effort onto top-level `verbosity` instead."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "openrouter"
+        agent.model = "anthropic/claude-fable-5"
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "reasoning" not in kwargs.get("extra_body", {})
+        assert kwargs.get("verbosity") == "high"
+
+    def test_summary_keeps_reasoning_for_reasoning_optional_openrouter_model(self, agent):
+        """Anthropic models that still accept a disable-thinking form keep the
+        extra_body.reasoning passthrough — the mandatory-model omission must
+        not overreach onto the legacy allowlist."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "openrouter"
+        agent.model = "anthropic/claude-sonnet-4.5"
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
+        assert "verbosity" not in kwargs
+
     def test_summary_request_removes_orphan_tool_result(self, agent):
         """Regression: max-iterations summary request must NOT contain
         orphan tool results (tool_call_id with no matching assistant tool_call)."""


### PR DESCRIPTION
## Symptom

When a session on `anthropic/claude-fable-5` (or any reasoning-mandatory Anthropic model, Claude 4.6+) via OpenRouter hits the iteration limit, the grace-summary request fails with the HTTP 400 that #42991 already fixed on the main loop: OpenRouter emits Anthropic `thinking: {type: "disabled"}` on tool-continuation turns whenever a `reasoning` field is present, and these models reject any disable form.

## Root cause

`handle_max_iterations()` in `agent/chat_completion_helpers.py` hand-builds `summary_extra_body["reasoning"]` gated only by `AIAgent._supports_reasoning_extra_body()` — which returns True for `anthropic/`-prefixed models on OpenRouter. It then calls only `provider_profile.build_extra_body()` before invoking `client.chat.completions.create()` directly, never `build_api_kwargs_extras()` — the hook where the OpenRouter profile's `_anthropic_reasoning_is_mandatory` branch omits `reasoning` and routes the effort onto top-level `verbosity` (#42991, #43432). The summary path therefore bypasses the fix the main loop gets from `ChatCompletionsTransport._build_kwargs_from_profile()`.

## Fix

Resolve the provider profile once in `handle_max_iterations()` and, when one exists, delegate the reasoning wire shape to `profile.build_api_kwargs_extras()` — merging its extra_body into the summary body and applying its top-level kwargs (`verbosity`, the Grok `x-grok-conv-id` cache header) to both the initial and retry summary calls. The reasoning config is passed through `_reasoning_config_for_model()` first, matching the transport. The hand-built `reasoning` dict remains only as the no-profile fallback, and the duplicate `get_provider_profile()` lookup further down the path is collapsed into the single early resolution.

Side effects, all in the direction of main-loop parity: Nous summary calls now get the profile's omit-when-disabled behavior, and `custom`-provider summary calls get top-level `reasoning_effort` instead of an `extra_body.reasoning` the endpoint never sees on the main loop.

## Tests

Two regression tests in `tests/run_agent/test_run_agent.py::TestHandleMaxIterations`:

- `test_summary_omits_reasoning_for_anthropic_mandatory_openrouter_model` — `anthropic/claude-fable-5`, effort `high`: asserts no `reasoning` key in `extra_body` and `verbosity == "high"` (proves the profile hook ran, not just that reasoning was dropped).
- `test_summary_keeps_reasoning_for_reasoning_optional_openrouter_model` — `anthropic/claude-sonnet-4.5` (legacy allowlist): asserts the `reasoning` passthrough is untouched and no `verbosity` is set, so the omission doesn't overreach.

`scripts/run_tests.sh tests/run_agent/test_run_agent.py` — 418 passed, 0 failed. `scripts/run_tests.sh tests/providers tests/agent/transports tests/agent/test_chat_completion_helpers_provider_sort.py` — 484 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)