### PR TITLE
fix(tui_gateway): reconcile config.set races with deferred agent build

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8693,6 +8693,265 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         server._sessions.clear()
 
 
+# ── Mid-build config.set reconciliation ────────────────────────────────────
+# _make_agent can block for seconds (MCP discovery, prompt/skill build). A
+# config.set landing in that window only updates the session dict — the agent
+# is still None, so the live-apply branch is skipped — and the build must not
+# install an agent constructed from the values snapshotted at build start.
+# These tests thread the real deferred build through an event-controlled
+# barrier and mutate the session mid-build.
+
+
+def _patch_deferred_build_collaborators(monkeypatch, emitted=None):
+    """Stub _start_agent_build's collaborators (worker/callbacks/pollers) so a
+    test can drive the real deferred-build thread against a fake _make_agent."""
+
+    class FakeWorker:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_SlashWorker", FakeWorker)
+    monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        (lambda ev, sid, payload: emitted.append((ev, sid, payload)))
+        if emitted is not None
+        else (lambda *a, **k: None),
+    )
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_probe_config_health", lambda *_a: None)
+
+
+def _deferred_build_session(**extra):
+    return {
+        "agent": None,
+        "agent_ready": threading.Event(),
+        "session_key": "reconcile-key",
+        "profile_home": None,
+        "model_override": None,
+        "create_reasoning_override": None,
+        "create_service_tier_override": None,
+        **extra,
+    }
+
+
+def test_deferred_build_adopts_reasoning_set_mid_build(monkeypatch):
+    """config.set reasoning racing the deferred build must not be lost: the
+    session dict is updated but the agent is still None (live-apply skipped),
+    and the build snapshotted the OLD value into its kwargs before blocking.
+    The installed agent and the session.info emitted at build completion must
+    reflect the newer value.
+    """
+    build_entered = threading.Event()
+    release_build = threading.Event()
+    emitted = []
+
+    def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
+        build_entered.set()
+        assert release_build.wait(timeout=10), "test never released the build"
+        return types.SimpleNamespace(
+            model="m1",
+            provider="p1",
+            reasoning_config=kwargs.get("reasoning_config_override"),
+            service_tier=kwargs.get("service_tier_override"),
+        )
+
+    _patch_deferred_build_collaborators(monkeypatch, emitted)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, session=None: {
+            "reasoning_effort": (getattr(agent, "reasoning_config", None) or {}).get(
+                "effort", ""
+            )
+        },
+    )
+
+    sid = "reconcile-reasoning-sid"
+    session = _deferred_build_session(
+        create_reasoning_override={"enabled": True, "effort": "low"}
+    )
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert build_entered.wait(timeout=10), "deferred build never started"
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"session_id": sid, "key": "reasoning", "value": "xhigh"},
+            }
+        )
+        assert resp["result"]["value"] == "xhigh"
+        # The change landed on the session dict only — the agent is mid-build.
+        assert session["agent"] is None
+        assert session["create_reasoning_override"] == {
+            "enabled": True,
+            "effort": "xhigh",
+        }
+        release_build.set()
+        assert session["agent_ready"].wait(timeout=10), "agent build did not finish"
+        assert session["agent"].reasoning_config == {"enabled": True, "effort": "xhigh"}
+        infos = [p for ev, esid, p in emitted if ev == "session.info" and esid == sid]
+        assert infos, "build completion never emitted session.info"
+        assert infos[-1]["reasoning_effort"] == "xhigh"
+    finally:
+        server._sessions.clear()
+
+
+class _SwitchRecordingAgent:
+    def __init__(self, model, provider, **attrs):
+        self.model = model
+        self.provider = provider
+        self.switch_calls = []
+        for name, value in attrs.items():
+            setattr(self, name, value)
+
+    def switch_model(self, new_model, new_provider, api_key="", base_url="", api_mode=""):
+        self.switch_calls.append((new_model, new_provider, base_url, api_mode))
+        self.model = new_model
+        self.provider = new_provider
+
+
+def test_deferred_build_adopts_model_pin_set_mid_build(monkeypatch):
+    """A model override pinned while the deferred build is in flight (the
+    agent-None paths of `/model X --provider Y` and `/moa` write
+    session["model_override"] directly) must be applied to the built agent via
+    the same in-place switch_model the live path uses. Otherwise the session
+    silently runs on the model snapshotted at build start and nothing ever
+    reconciles it — _sync_agent_model_with_config skips sessions that carry a
+    model_override.
+    """
+    build_entered = threading.Event()
+    release_build = threading.Event()
+
+    def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
+        build_entered.set()
+        assert release_build.wait(timeout=10), "test never released the build"
+        return _SwitchRecordingAgent("old/model", "old-provider")
+
+    _patch_deferred_build_collaborators(monkeypatch)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+
+    sid = "reconcile-model-sid"
+    session = _deferred_build_session()
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert build_entered.wait(timeout=10), "deferred build never started"
+        session["model_override"] = {
+            "model": "new/model",
+            "provider": "new-provider",
+            "base_url": "https://new.example/v1",
+            "api_key": "k",
+            "api_mode": "chat_completions",
+        }
+        release_build.set()
+        assert session["agent_ready"].wait(timeout=10), "agent build did not finish"
+        assert session["agent"].switch_calls == [
+            ("new/model", "new-provider", "https://new.example/v1", "chat_completions")
+        ]
+        assert session["agent"].model == "new/model"
+    finally:
+        server._sessions.clear()
+
+
+def test_deferred_build_does_not_reswitch_unchanged_model_override(monkeypatch):
+    """The install-time reconcile compares against the override the build was
+    handed: an override that did NOT change mid-build (every normal create and
+    deferred resume) must not trigger a redundant switch_model on install."""
+    override = {"model": "picked/model", "provider": "picked-provider"}
+
+    def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
+        return _SwitchRecordingAgent("picked/model", "picked-provider")
+
+    _patch_deferred_build_collaborators(monkeypatch)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+
+    sid = "no-reswitch-sid"
+    session = _deferred_build_session(model_override=override)
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert session["agent_ready"].wait(timeout=10), "agent build did not finish"
+        assert session["agent"].switch_calls == []
+    finally:
+        server._sessions.clear()
+
+
+def test_reset_session_agent_adopts_reasoning_set_mid_rebuild(monkeypatch):
+    """/new rebuilds the agent through the same seconds-long _make_agent. A
+    config.set reasoning landing mid-rebuild applies to the OLD (about to be
+    discarded) agent and the session dict; the freshly installed agent must
+    adopt it too instead of reverting to the snapshot taken at rebuild start.
+    """
+    build_entered = threading.Event()
+    release_build = threading.Event()
+
+    old_agent = types.SimpleNamespace(
+        model="m1",
+        provider="p1",
+        reasoning_config={"enabled": True, "effort": "low"},
+    )
+
+    def fake_make_agent(sid, key, session_id=None, **kwargs):
+        build_entered.set()
+        assert release_build.wait(timeout=10), "test never released the build"
+        return types.SimpleNamespace(
+            model="m1",
+            provider="p1",
+            reasoning_config=kwargs.get("reasoning_config_override"),
+        )
+
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: True)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_live_session_runtime", lambda *_a: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {})
+
+    sid = "reset-reconcile-sid"
+    session = _session(agent=old_agent)
+    session["create_reasoning_override"] = {"enabled": True, "effort": "low"}
+    server._sessions[sid] = session
+    try:
+        reset_thread = threading.Thread(
+            target=lambda: server._reset_session_agent(sid, session), daemon=True
+        )
+        reset_thread.start()
+        assert build_entered.wait(timeout=10), "reset rebuild never started"
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"session_id": sid, "key": "reasoning", "value": "xhigh"},
+            }
+        )
+        assert resp["result"]["value"] == "xhigh"
+        release_build.set()
+        reset_thread.join(timeout=10)
+        assert not reset_thread.is_alive(), "reset rebuild did not finish"
+        assert session["agent"] is not old_agent
+        assert session["agent"].reasoning_config == {"enabled": True, "effort": "xhigh"}
+    finally:
+        server._sessions.clear()
+
+
 # ── _get_usage active_subagents (TUI status-bar ⛓ indicator) ──────────────
 # Mirrors the classic CLI status bar: _get_usage embeds a live count of
 # background/async subagents from tools.async_delegation.active_count() so the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1304,6 +1304,62 @@ def _wait_agent(session: dict, rid: str, timeout: float = 30.0) -> dict | None:
     return _err(rid, 5032, err) if err else None
 
 
+def _install_agent_reconciled(session: dict, agent, built_kw: dict) -> None:
+    """Install a freshly built agent, adopting config.set values that raced the build.
+
+    ``_make_agent`` can block for seconds (MCP discovery, prompt/skill build).
+    A ``config.set`` reasoning/model change landing in that window only
+    updates the session dict — ``session["agent"]`` is still None (or the
+    about-to-be-discarded old agent on the /new path), so the live-apply
+    branch is skipped — and installing the built agent as-is would publish
+    the values snapshotted at build start, silently dropping the user's pick
+    for the life of the session. Compare the dict's current overrides against
+    what the build actually used (``built_kw``) and apply any drift to the
+    agent before publishing it, exactly as the live config.set path would
+    have. Both call sites emit ``session.info`` from the installed agent
+    right after, so the reconciled values reach the client.
+
+    Runs atomically with config.set's write-then-check under the session's
+    ``agent_config_lock``, so a concurrent mutation either observes the
+    installed agent (live-apply path) or is adopted here — never dropped.
+    """
+    lock = session.setdefault("agent_config_lock", threading.Lock())
+    with lock:
+        reasoning = session.get("create_reasoning_override")
+        if reasoning is not None and reasoning != built_kw.get(
+            "reasoning_config_override"
+        ):
+            agent.reasoning_config = reasoning
+        tier = session.get("create_service_tier_override")
+        if tier is not None and tier != built_kw.get("service_tier_override"):
+            agent.service_tier = tier
+        override = session.get("model_override")
+        if (
+            isinstance(override, dict)
+            and override.get("model")
+            and override != built_kw.get("model_override")
+        ):
+            # Same in-place swap the live /model path performs
+            # (_apply_model_switch). switch_model rolls back atomically on
+            # failure, so a failed reconcile keeps the built model — matching
+            # the live path's failed-switch-is-a-no-op contract.
+            try:
+                agent.switch_model(
+                    new_model=str(override.get("model") or ""),
+                    new_provider=override.get("provider") or "",
+                    api_key=override.get("api_key") or "",
+                    base_url=override.get("base_url") or "",
+                    api_mode=override.get("api_mode") or "",
+                )
+            except Exception:
+                logger.warning(
+                    "mid-build model switch reconcile failed; keeping %s",
+                    getattr(agent, "model", ""),
+                    exc_info=True,
+                )
+        session["agent"] = agent
+
+
 def _start_agent_build(sid: str, session: dict) -> None:
     """Start building the real AIAgent for a TUI session, once.
 
@@ -1392,7 +1448,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
 
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
-            current["agent"] = agent
+            _install_agent_reconciled(current, agent, kw)
             # Baseline for the per-turn config sync; the profile home
             # override is still active here.
             current["config_model_seen"] = _config_model_target()
@@ -4369,7 +4425,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         )
     finally:
         _clear_session_context(tokens)
-    session["agent"] = new_agent
+    _install_agent_reconciled(session, new_agent, reset_kw)
     session["config_model_seen"] = _config_model_target()
     session["attached_images"] = []
     session["edit_snapshots"] = {}
@@ -10626,14 +10682,23 @@ def _(rid, params: dict) -> dict:
                 # Model territory). Writing config.yaml here let every
                 # desktop model-menu selection rewrite the user's global
                 # agent.reasoning_effort to the preset default.
-                session["create_reasoning_override"] = parsed
-                if session.get("agent") is not None:
-                    session["agent"].reasoning_config = parsed
+                #
+                # Write-then-check must be atomic with the deferred build's
+                # reconcile-then-install (_install_agent_reconciled): without
+                # the lock, a value landing between the build's reconcile
+                # read and its agent install is silently lost — the built
+                # agent keeps the effort snapshotted at build start.
+                lock = session.setdefault("agent_config_lock", threading.Lock())
+                with lock:
+                    session["create_reasoning_override"] = parsed
+                    agent = session.get("agent")
+                if agent is not None:
+                    agent.reasoning_config = parsed
                     _persist_live_session_runtime(session)
                     _emit(
                         "session.info",
                         params.get("session_id", ""),
-                        _session_info(session["agent"], session),
+                        _session_info(agent, session),
                     )
             else:
                 _write_config_key("agent.reasoning_effort", arg)


### PR DESCRIPTION
## Summary

Fixes a race in the TUI gateway's deferred agent construction that silently loses a user's `config.set` pick for the life of the session.

**The race:**

1. `_start_agent_build` snapshots `session["create_reasoning_override"]` into the build kwargs, then calls `_make_agent`, which can block for seconds (MCP discovery, prompt/skill build).
2. If `config.set reasoning` arrives during that window, it updates `session["create_reasoning_override"]` — but because `session["agent"]` is still `None`, the live-apply branch is skipped: no agent is updated and no `session.info` is emitted.
3. The build then installs an agent constructed with the **old** reasoning value and emits `session.info` with the old effort. The session dict retains the new override, but nothing ever reconciles the built agent against it — the user's setting is silently lost until the session is rebuilt.

The same window affects two siblings:

- A model override pinned mid-build by the agent-`None` paths of `/model X --provider Y` and `/moa` (both write `session["model_override"]` directly). Nothing adopts it later — `_sync_agent_model_with_config` deliberately skips sessions carrying a `model_override` — so the turn silently runs on the model snapshotted at build start.
- The `/new` rebuild (`_reset_session_agent`) has the identical shape between snapshotting `reset_kw` and installing the new agent.

The eager build paths (eager resume, `session.branch`) are immune: they only register the session after the build completes, so no client can issue `config.set` against them mid-build.

## The fix

Freshly built agents are now installed through `_install_agent_reconciled()`, which compares the session dict's current overrides (reasoning / service tier / model) against what the build actually used and applies any drift to the agent before publishing it:

- reasoning / service tier as direct attribute sets — exactly what the live `config.set` path does;
- model via the same in-place `agent.switch_model()` the live `/model` path uses (it rolls back atomically on failure, so a failed reconcile keeps the built model — matching the live path's failed-switch-is-a-no-op contract).

The reconcile-and-install runs under a per-session `agent_config_lock`, and `config.set reasoning`'s write-then-check now holds the same lock. That makes the fix airtight rather than just narrowing the window: a concurrent mutation either observes the installed agent (live-apply path) or is adopted at install — there is no interleaving where it's dropped.

Comparing against the build-time snapshot rather than the agent's resolved attributes avoids redundant re-switches on deferred resumes, where the stored provider string (e.g. `custom:<name>`) can legitimately differ from the agent's resolved one.

## Tests

Four new tests in `tests/test_tui_gateway_server.py` thread the real deferred build through an event-controlled barrier (a fake `_make_agent` blocks on an `Event`) and mutate the session mid-build:

- `test_deferred_build_adopts_reasoning_set_mid_build` — issues a real `config.set reasoning` mid-build and asserts both the installed agent and the `session.info` emitted at build completion carry the newer value.
- `test_deferred_build_adopts_model_pin_set_mid_build` — pins `session["model_override"]` mid-build and asserts the built agent is switched in place to the pinned identity.
- `test_deferred_build_does_not_reswitch_unchanged_model_override` — regression guard: an override that did not change mid-build (every normal create / deferred resume) must not trigger a redundant `switch_model` on install.
- `test_reset_session_agent_adopts_reasoning_set_mid_rebuild` — the `/new` rebuild variant.

```
scripts/run_tests.sh tests/test_tui_gateway_server.py -q   # 326 passed
scripts/run_tests.sh tests/tui_gateway/ -q                 # 346 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
