### PR TITLE
fix(deepinfra): restore provider-prefix aliases for model parsing

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -47,7 +47,7 @@ def _resolve_requests_verify() -> bool | str:
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
-    "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
+    "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek", "deepinfra",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",
     "xiaomi",
@@ -58,7 +58,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
-    "github-models", "kimi", "moonshot", "kimi-cn", "moonshot-cn", "claude", "deep-seek",
+    "github-models", "kimi", "moonshot", "kimi-cn", "moonshot-cn", "claude", "deep-seek", "deep-infra",
     "ollama",
     "stepfun", "opencode", "zen", "go", "kilo", "dashscope", "aliyun", "qwen",
     "mimo", "xiaomi-mimo",


### PR DESCRIPTION
## Summary

Follow-up to #63969 (merged). The salvage removed `deepinfra` and `deep-infra` from the static `_PROVIDER_PREFIXES` frozenset in `agent/model_metadata.py` believing they were redundant with `ProviderProfile.aliases`. They are not — this set is static and does not auto-extend from profiles. Without these entries, `deepinfra:vendor/model` prefix stripping is broken.

## Test

Verified `_strip_provider_prefix("deepinfra:vendor/model") == "vendor/model"` and `_strip_provider_prefix("deep-infra:vendor/model") == "vendor/model"` with 304 tests passing including `tests/agent/test_model_metadata.py`.

Found by hermes-agent-dev Codex review of #63969.