### PR TITLE
fix(i18n): align desktop zh/zh-hant allowSession wording with CLI

### DIFF
--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2170,7 +2170,7 @@ export const zhHant = defineLocale({
       run: '執行',
       command: '指令',
       moreOptions: '更多核准選項',
-      allowSession: '允許本工作階段',
+      allowSession: '本次工作階段內允許',
       alwaysAllowMenu: '一律允許…',
       jumpToApproval: '需要核准',
       reject: '拒絕',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2456,7 +2456,7 @@ export const zh: Translations = {
       run: '运行',
       command: '命令',
       moreOptions: '更多审批选项',
-      allowSession: '允许本会话',
+      allowSession: '本次会话内允许',
       alwaysAllowMenu: '始终允许…',
       jumpToApproval: '需要审批',
       reject: '拒绝',


### PR DESCRIPTION
## What does this PR do?

Improves the zh/zh-hant translation of the desktop "Allow this session" button to match the CLI's existing wording.

### English sources
```
# apps/desktop/src/i18n/en.ts:2300   (button label)
allowSession: 'Allow this session'

# locales/en.yaml:22                  (confirmation line)
allowed_session: "      ✓ Allowed for this session"
```

The intended reading of "Allow this session" is "allow (this command) **for** this session", not "allow the session itself". The session is the *scope* of the allow, not the object being allowed. The CLI's "Allowed **for** this session" makes the same scope reading explicit by keeping the preposition.

### Current Chinese (desktop) — mistranslates the scope as the object
- `zh.ts`:      `允许本会话`      (reads as "allow the session itself")
- `zh-hant.ts`: `允許本工作階段`  (same ambiguity)

### CLI already ships the correct scope-adverbial wording
Key `approval.allowed_session`:
- `zh.yaml`:      `本次会话内允许`
- `zh-hant.yaml`: `本次工作階段內允許`

This PR brings the desktop labels in line. Both surfaces (button vs. confirmation) describe the same scope; Chinese should express it uniformly. No behavior change.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `apps/desktop/src/i18n/zh.ts`: `allowSession` → `本次会话内允许`
- `apps/desktop/src/i18n/zh-hant.ts`: `allowSession` → `本次工作階段內允許`

## How to Test

Switch desktop to Simplified / Traditional Chinese, trigger an approval prompt, open the "▼" menu next to Run. The middle item now matches the CLI approval prompt.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(i18n): ...`)
- [x] Searched for duplicates — none
- [x] PR contains only related changes
- [ ] `pytest tests/ -q` — N/A (TypeScript catalog string)
- [ ] Added tests — N/A (compile-time typed catalog covers key parity)
- [ ] Tested on: N/A

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (UI copy)
- [x] Tool descriptions/schemas — N/A
