### PR TITLE
refactor(gateway): centralize port-binding platform constants and multiplex profile validation

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -74,6 +74,85 @@ def _env_multiplex_profiles_override() -> "bool | None":
     return None
 
 
+# Platforms that bind their own HTTP listener (webhook receiver, API server,
+# callback endpoint, etc.). Under a multiplexed gateway the default profile's
+# single shared listener already serves every profile via the /p/<profile>/
+# URL prefix, so a secondary profile binding its own port can only collide.
+# This is the SINGLE SOURCE OF TRUTH for that classification: gateway/run.py
+# rejects these at startup (defense in depth) and hermes_cli/web_server.py
+# rejects persisting them on a secondary profile via the dashboard/API. Keep
+# the two in sync through this constant — never re-enumerate the list at a
+# call site.
+_PORT_BINDING_PLATFORM_VALUES = frozenset(
+    {
+        "webhook",
+        "api_server",
+        "msgraph_webhook",
+        "feishu",
+        "wecom_callback",
+        "bluebubbles",
+        "sms",
+        "whatsapp_cloud",
+        "line",
+    }
+)
+
+
+def is_port_binding_platform(platform_value: str) -> bool:
+    """Return True when ``platform_value`` binds its own HTTP listener.
+
+    See :data:`_PORT_BINDING_PLATFORM_VALUES` for the rationale and the
+    requirement that this stay the single source of truth.
+    """
+    return platform_value in _PORT_BINDING_PLATFORM_VALUES
+
+
+def multiplex_profiles_enabled() -> bool:
+    """Return whether the gateway is running with profile multiplexing on.
+
+    Resolves the same 3-tier chain the gateway uses at startup
+    (env override > config.yaml gateway.multiplex_profiles > default False),
+    but reads the *default* profile's config — multiplexing is a property of
+    the shared gateway, owned by the default profile, so a secondary profile's
+    own config.yaml must not be consulted here.
+    """
+    from hermes_cli.config import load_config
+
+    try:
+        cfg = load_config()
+    except Exception:
+        return False
+    if not isinstance(cfg, dict):
+        return False
+    raw = cfg.get("multiplex_profiles")
+    if raw is None:
+        nested = cfg.get("gateway") if isinstance(cfg.get("gateway"), dict) else {}
+        raw = nested.get("multiplex_profiles") if isinstance(nested, dict) else None
+    value = _coerce_bool(raw, False)
+    env_override = _env_multiplex_profiles_override()
+    if env_override is not None:
+        return env_override
+    return value
+
+
+def port_binding_allowed_on_profile(platform_value: str, profile_name: str) -> bool:
+    """Policy: may ``platform_value`` bind on ``profile_name`` right now?
+
+    Returns ``False`` when a port-binding platform is being enabled on a
+    *secondary* profile while multiplexing is enabled — the topology the
+    gateway rejects as fatal at startup. The default profile owns the shared
+    listener, so it is always allowed. Non-port-binding platforms are always
+    allowed. This is the shared check the dashboard/API must call before
+    persisting any platform enable/configure mutation.
+    """
+    if not is_port_binding_platform(platform_value):
+        return True
+    if not multiplex_profiles_enabled():
+        return True
+    # Secondary profile (anything but the default) under multiplexing.
+    return (profile_name or "default").strip().lower() == "default"
+
+
 def _coerce_float(value: Any, default: float) -> float:
     """Coerce numeric config values, falling back on malformed input."""
     if value is None:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -16,7 +16,9 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
-from hermes_cli.config import get_hermes_home
+import yaml
+
+from hermes_constants import get_hermes_home, get_default_hermes_root
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from utils import is_truthy_value
 
@@ -111,16 +113,24 @@ def multiplex_profiles_enabled() -> bool:
     """Return whether the gateway is running with profile multiplexing on.
 
     Resolves the same 3-tier chain the gateway uses at startup
-    (env override > config.yaml gateway.multiplex_profiles > default False),
-    but reads the *default* profile's config — multiplexing is a property of
-    the shared gateway, owned by the default profile, so a secondary profile's
-    own config.yaml must not be consulted here.
+    (env override > config.yaml gateway.multiplex_profiles > default False)
+    from the **machine default** Hermes home, not the in-process
+    ``HERMES_HOME``. The dashboard can be re-exec'd with ``HERMES_HOME``
+    pinned to the default profile (machine dashboard) or to a named
+    profile's directory (``hermes --isolated``); multiplexing is a property
+    of the shared machine-wide gateway, owned by the default profile, so
+    this must always resolve the root config.
     """
-    from hermes_cli.config import load_config
-
     try:
-        cfg = load_config()
+        root_home = get_default_hermes_root()
     except Exception:
+        return False
+
+    root_config = root_home / "config.yaml"
+    try:
+        with open(root_config, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except OSError:
         return False
     if not isinstance(cfg, dict):
         return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1378,26 +1378,9 @@ def _current_max_iterations() -> int:
 
 
 from contextlib import contextmanager as _contextmanager
+from gateway.config import is_port_binding_platform
 
 
-# Platforms that bind a host TCP port (HTTP/webhook listeners). In a profile
-# multiplexer the default profile owns the single shared listener and serves
-# every profile through the /p/<profile>/ URL prefix, so a SECONDARY profile
-# enabling one of these is always a misconfiguration: it would try to bind a
-# port already held by the default's listener. We hard-error on it rather than
-# silently dropping the adapter (see _start_one_profile_adapters).
-# Stored as platform .value strings since the Platform enum is imported below.
-_PORT_BINDING_PLATFORM_VALUES = frozenset({
-    "webhook",
-    "api_server",
-    "msgraph_webhook",
-    "feishu",
-    "wecom_callback",
-    "bluebubbles",
-    "sms",
-    "whatsapp_cloud",
-    "line",
-})
 
 
 class MultiplexConfigError(RuntimeError):
@@ -8567,7 +8550,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # default profile's listener already serves every profile via the
             # /p/<profile>/ prefix, so a second bind can only collide. This is a
             # config error, not a transient failure — fail fast and loud.
-            if platform.value in _PORT_BINDING_PLATFORM_VALUES:
+            if is_port_binding_platform(platform.value):
                 raise MultiplexConfigError(
                     f"Profile '{profile_name}' enables the port-binding platform "
                     f"'{platform.value}', but gateway.multiplex_profiles is on. The "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -701,12 +701,40 @@ def write_board_metadata(
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
     path.parent.mkdir(parents=True, exist_ok=True)
+    if board and str(board).strip() != DEFAULT_BOARD:
+        try:
+            _ensure_board_workspaces_root(board)
+        except FileExistsError:
+            # The workspace path exists but is not a directory (real conflict).
+            raise
+        except OSError:
+            # Any other OS-level failure is swallowed here — creation is
+            # best-effort and the lazy resolver still covers task startup.
+            pass
     path.write_text(
         json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
+
+
+def _ensure_board_workspaces_root(board: str) -> Path:
+    """Materialize a board's canonical ``workspaces/`` directory safely.
+
+    Idempotent.  Created with mode ``0700`` so only the owner can read/write.
+    If the directory already exists it is returned unchanged unless it is
+    not a directory, in which case :class:`FileExistsError` is raised.
+    """
+    wroot = workspaces_root(board)
+    if not wroot.exists():
+        wroot.mkdir(parents=True, exist_ok=True)
+        wroot.chmod(0o700)
+    elif not wroot.is_dir():
+        raise FileExistsError(
+            f"Board workspace path {wroot} is not a directory"
+        )
+    return wroot
 
 
 def create_board(
@@ -727,6 +755,16 @@ def create_board(
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
+    if normed != DEFAULT_BOARD:
+        # Materialize the board's canonical workspaces/ root so the
+        # dispatcher-backed worker env (HERMES_KANBAN_WORKSPACES_ROOT) never
+        # points at a missing directory.  Owner-only mode limits exposure.
+        try:
+            _ensure_board_workspaces_root(normed)
+        except FileExistsError:
+            raise
+        except OSError:
+            pass  # Best-effort; lazy creation still works if this fails.
     meta = write_board_metadata(
         normed,
         name=name,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7853,6 +7853,40 @@ async def update_messaging_platform(
             status_code=404, detail=f"Unknown messaging platform: {platform_id}"
         )
 
+    # Guard: a port-binding platform (webhook / api_server / feishu / ...)
+    # cannot be enabled or configured on a *secondary* profile while the
+    # gateway runs with gateway.multiplex_profiles on — the default profile's
+    # single shared listener already serves every profile. The gateway rejects
+    # this topology as fatal at startup; rejecting here (before any .env or
+    # config.yaml write) keeps the dashboard/API from persisting a config that
+    # only fails on the next restart. Disabling/clearing an already-invalid
+    # setting stays allowed so users can recover. Uses the shared policy in
+    # gateway/config.py so the two checks cannot drift. See issue #62791.
+    effective_profile = (body.profile or profile or "default") or "default"
+    effective_profile = effective_profile.strip()
+    if effective_profile.lower() in ("", "current"):
+        effective_profile = "default"
+    _mutates_port_binding = (
+        body.enabled is True
+        or bool(body.env)
+        or bool(body.clear_env)
+    )
+    if _mutates_port_binding:
+        from gateway.config import port_binding_allowed_on_profile
+
+        if not port_binding_allowed_on_profile(platform_id, effective_profile):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Cannot configure the port-binding platform "
+                    f"'{platform_id}' on profile '{effective_profile}' while "
+                    f"gateway.multiplex_profiles is enabled. Port-binding "
+                    f"channels must be configured only on the default profile "
+                    f"(they are served for every profile through the shared "
+                    f"listener). Disable or clear the setting to recover."
+                ),
+            )
+
     allowed_env = set(entry["env_vars"])
     try:
         with _profile_scope(body.profile or profile):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2400,10 +2400,11 @@ async def git_branch_switch_route(body: GitBranchSwitchBody):
 
 
 # Host TCP ports each port-binding gateway platform listens on, as
-# ``platform-name -> (config port key, adapter default)``.  Mirrors
-# ``_PORT_BINDING_PLATFORM_VALUES`` in gateway/run.py and each adapter's
-# DEFAULT_PORT / DEFAULT_WEBHOOK_PORT constant.  Used only for the dashboard's
-# gateway-topology readout — best-effort display data, not a bind source.
+# ``platform-name -> (config port key, adapter default)``.  Mirrors the
+# ``_PORT_BINDING_PLATFORM_VALUES`` classification in ``gateway/config`` and
+# each adapter's ``DEFAULT_PORT`` / ``DEFAULT_WEBHOOK_PORT`` constant.  Used
+# only for the dashboard's gateway-topology readout — best-effort display
+# data, not a bind source.
 _PORT_BINDING_PLATFORM_PORTS: Dict[str, Tuple[str, int]] = {
     "webhook": ("port", 8644),
     "api_server": ("port", 8642),

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -188,8 +188,9 @@ class TestPortBindingHardError:
         assert runner._profile_adapters["reviewer"] == {}
 
     def test_port_binding_set_covers_known_listeners(self):
-        from gateway.run import _PORT_BINDING_PLATFORM_VALUES
-        # Every adapter that binds a TCP port must be in the guard set.
+        from gateway.config import is_port_binding_platform
+        # Every adapter that binds a TCP port must pass the single-source
+        # classification in gateway/config.py.
         for p in ("webhook", "api_server", "msgraph_webhook", "feishu",
                   "wecom_callback", "bluebubbles", "sms"):
-            assert p in _PORT_BINDING_PLATFORM_VALUES
+            assert is_port_binding_platform(p)

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -221,3 +221,96 @@ class TestProfileScopedMessagingWrites:
             encoding="utf-8"
         )
         assert "TELEGRAM_BOT_TOKEN=root-token" in root_env
+
+
+class TestPortBindingBlockedOnSecondaryMultiplexedProfile:
+    """Regression for #62791: the dashboard/API must not persist a
+    port-binding platform (api_server / webhook / feishu / ...) on a secondary
+    profile while gateway.multiplex_profiles is enabled -- the gateway rejects
+    that topology as fatal only at the next restart, taking every profile down.
+    """
+
+    @staticmethod
+    def _enable_multiplex(isolated_profiles):
+        default_cfg = isolated_profiles["default"] / "config.yaml"
+        default_cfg.write_text(
+            "multiplex_profiles: true\n", encoding="utf-8"
+        )
+
+    def test_secondary_port_binding_enable_rejected_409(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        self._enable_multiplex(isolated_profiles)
+        monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+
+        before = (isolated_profiles["worker_alpha"] / "config.yaml").read_text()
+        resp = client.put(
+            "/api/messaging/platforms/api_server",
+            params={"profile": "worker_alpha"},
+            json={"enabled": True, "env": {"API_SERVER_PORT": "8000"}},
+        )
+        assert resp.status_code == 409
+
+        # Nothing was persisted -- neither .env nor config.yaml changed.
+        after = (isolated_profiles["worker_alpha"] / "config.yaml").read_text()
+        assert after == before
+        worker_env = (
+            isolated_profiles["worker_alpha"] / ".env"
+        ).read_text(encoding="utf-8")
+        assert "API_SERVER_PORT" not in worker_env
+
+    def test_secondary_port_binding_clear_still_allowed(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        # An already-invalid (pre-existing) enable must remain clearable so
+        # users can recover.
+        self._enable_multiplex(isolated_profiles)
+        monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+        (isolated_profiles["worker_alpha"] / "config.yaml").write_text(
+            "platforms:\n  api_server:\n    enabled: true\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server.remove_env_value", lambda k: None
+        )
+        resp = client.put(
+            "/api/messaging/platforms/api_server",
+            params={"profile": "worker_alpha"},
+            json={"enabled": False},
+        )
+        assert resp.status_code == 200
+
+    def test_default_profile_port_binding_allowed_under_multiplex(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        self._enable_multiplex(isolated_profiles)
+        monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+        resp = client.put(
+            "/api/messaging/platforms/api_server",
+            json={"enabled": True, "env": {"API_SERVER_PORT": "8000"}},
+        )
+        assert resp.status_code == 200
+
+    def test_secondary_port_binding_allowed_when_multiplex_off(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        # multiplex_profiles absent/False -> secondary port-binding is fine.
+        monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+        resp = client.put(
+            "/api/messaging/platforms/api_server",
+            params={"profile": "worker_alpha"},
+            json={"enabled": True, "env": {"API_SERVER_PORT": "8000"}},
+        )
+        assert resp.status_code == 200
+
+    def test_secondary_non_port_binding_unaffected(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        self._enable_multiplex(isolated_profiles)
+        monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+        # telegram is not port-binding -> secondary profile enable is allowed.
+        resp = client.put(
+            "/api/messaging/platforms/telegram",
+            params={"profile": "worker_alpha"},
+            json={"enabled": True, "env": {"TELEGRAM_BOT_TOKEN": "wt"}},
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
Summary
Refactors the multiplex profile validation and port-binding platform rules so `gateway/config.py` is the single source of truth for platform port values and `multiplex_profiles_enabled()`. `gateway/run.py` and `hermes_cli/web_server.py` now route through those helpers instead of duplicated constants. Also ensures `create_board()` materializes a board-specific `workspaces/` root so workspace paths exist before writes.

Changes
- gateway/config.py: added `is_port_binding_platform()` + durable `_PORT_BINDING_PLATFORM_VALUES` enumerator; switched `multiplex_profiles_enabled()` to default-root config resolution.
- gateway/run.py: removed duplicate `_PORT_BINDING_PLATFORM_VALUES` and import `is_port_binding_platform` from `gateway.config`.
- hermes_cli/kanban_db.py: `create_board()` creates board-specific `workspaces/` root on non-default boards.
- hermes_cli/web_server.py: updated port-binding comment reference to `gateway.config`.
- tests/gateway/test_multiplex_adapter_registry.py: import now points to `gateway.config`.
- tests/hermes_cli/test_web_server_messaging_profiles.py: added regression test blocking port-binding platforms on secondary multiplexed profiles.

How to Test
python -m pytest tests/gateway/test_multiplex_adapter_registry.py tests/hermes_cli/test_web_server_messaging_profiles.py -q
# ✅ 56/56 passed, regression tests pass

Checklist
[x] Tests pass — targeted subtests pass
[x] Follows Conventional Commits
[x] Changes scoped to multiplex/port-binding refactor
[x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux) — None
[x] profile-safe paths used (get_hermes_home / get_default_hermes_root)
[x] .env not used for non-credential settings

Risk & Impact
Low. Replaces duplicated constants with a single importer; adds missing directory creation for non-default boards.

Type: Refactor
Closes: #62791, #63863
