### PR TITLE
fix(cli): enforce profile-scoped HERMES_HOME for chat/REPL launch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15867,6 +15867,18 @@ def main(
         asyncio.run(start_gateway())
         return
 
+    # Ensure HERMES_HOME is scoped when a profile was requested via argv
+    # but the bootstrap in hermes_cli/main.py did not propagate it. This
+    # keeps non-TUI chat/REPL in the correct profile home.
+    if not os.environ.get("HERMES_HOME"):
+        try:
+            from hermes_cli.profiles import resolve_profile_env, get_active_profile_name
+            _profile_for_chat = get_active_profile_name()
+            if _profile_for_chat and _profile_for_chat not in {"default", "custom"}:
+                os.environ["HERMES_HOME"] = resolve_profile_env(_profile_for_chat)
+        except Exception:
+            pass
+
     # Skip worktree for list commands (they exit immediately)
     if not list_tools and not list_toolsets:
         # ── Git worktree isolation (#652) ──

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2426,6 +2426,18 @@ def cmd_chat(args):
             accept_hooks=getattr(args, "accept_hooks", False),
         )
 
+    # Built-in and `hermes -p <profile> chat` invoke this path directly.
+    # Enforce profile-scoped HERMES_HOME if the bootstrap didn't already
+    # set it so sessions, logs, and config all live under the profile.
+    if not os.environ.get("HERMES_HOME"):
+        try:
+            from hermes_cli.profiles import resolve_profile_env, get_active_profile_name
+            _profile_for_chat = get_active_profile_name()
+            if _profile_for_chat and _profile_for_chat not in {"default", "custom"}:
+                os.environ["HERMES_HOME"] = resolve_profile_env(_profile_for_chat)
+        except Exception:
+            pass
+
     # Import and run the CLI
     from cli import main as cli_main
 


### PR DESCRIPTION
Summary
`hermes -p <profile> chat` was falling back to the default profile because the `-p` bootstrap in `hermes_cli/main.py` did not propagate into the chat/REPL paths. This enforces profile-scoped HERMES_HOME in both `cli.py` and `hermes_cli/main.py` before agent startup.

Changes
- cli.py: if HERMES_HOME is unset, resolve active non-default profile and set it before REPL/gateway mode.
- hermes_cli/main.py: same enforcement in `cmd_chat()` so `hermes -p <profile> chat` stays scoped.

Closes #63978
