### PR TITLE
fix(file): distinguish safe-root write denials

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -26,7 +26,11 @@ from openai.types.chat.chat_completion_message_tool_call import (
     Function,
 )
 
-from agent.file_safety import get_read_block_error, is_write_denied
+from agent.file_safety import (
+    get_read_block_error,
+    get_write_denied_error,
+    is_write_denied,
+)
 from agent.redact import redact_sensitive_text
 from tools.environments.local import hermes_subprocess_env
 
@@ -727,10 +731,14 @@ class CopilotACPClient:
         elif method == "fs/write_text_file":
             try:
                 path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
-                if is_write_denied(str(path)):
-                    raise PermissionError(
-                        f"Write denied: '{path}' is a protected system/credential file."
+                denied = get_write_denied_error(str(path))
+                if denied is None and is_write_denied(str(path)):
+                    denied = (
+                        f"Write denied: '{path}' is a protected "
+                        "system/credential file."
                     )
+                if denied:
+                    raise PermissionError(denied)
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(str(params.get("content") or ""))
                 response = {

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -95,16 +95,16 @@ def get_safe_write_roots() -> set[str]:
     return roots
 
 
-def is_write_denied(path: str) -> bool:
-    """Return True if path is blocked by the write denylist or safe root."""
+def get_write_denied_reason(path: str) -> Optional[str]:
+    """Return the write-denial reason for *path*, or None when allowed."""
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
     if resolved in build_write_denied_paths(home):
-        return True
+        return "protected"
     for prefix in build_write_denied_prefixes(home):
         if resolved.startswith(prefix):
-            return True
+            return "protected"
 
     mcp_tokens_dir_name = "mcp-tokens"
 
@@ -121,13 +121,13 @@ def is_write_denied(path: str) -> bool:
         try:
             mcp_real = os.path.realpath(os.path.join(base_real, mcp_tokens_dir_name))
             if resolved == mcp_real or resolved.startswith(mcp_real + os.sep):
-                return True
+                return "protected"
         except Exception:
             pass
         try:
             pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
             if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
-                return True
+                return "protected"
         except Exception:
             pass
 
@@ -139,9 +139,29 @@ def is_write_denied(path: str) -> bool:
                 allowed = True
                 break
         if not allowed:
-            return True
+            return "outside_safe_root"
 
-    return False
+    return None
+
+
+def get_write_denied_error(path: str, action: str = "Write") -> Optional[str]:
+    """Return a user-facing write-denial error for *path*, if denied."""
+    reason = get_write_denied_reason(path)
+    if reason is None:
+        return None
+    if reason == "outside_safe_root":
+        raw_roots = os.getenv("HERMES_WRITE_SAFE_ROOT", "").strip()
+        root_detail = f" (HERMES_WRITE_SAFE_ROOT={raw_roots})" if raw_roots else ""
+        return (
+            f"{action} denied: '{path}' is outside the allowed write roots"
+            f"{root_detail}."
+        )
+    return f"{action} denied: '{path}' is a protected system/credential file."
+
+
+def is_write_denied(path: str) -> bool:
+    """Return True if path is blocked by the write denylist or safe root."""
+    return get_write_denied_reason(path) is not None
 
 
 # Common secret-bearing project-local environment file basenames.

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -762,11 +762,47 @@ class TestShellFileOpsWriteDenied:
         result = file_ops.write_file("~/.ssh/authorized_keys", "evil key")
         assert result.error is not None
         assert "denied" in result.error.lower()
+        assert "protected system/credential file" in result.error
 
     def test_patch_replace_denied_path(self, file_ops):
         result = file_ops.patch_replace("~/.ssh/authorized_keys", "old", "new")
         assert result.error is not None
         assert "denied" in result.error.lower()
+        assert "protected system/credential file" in result.error
+
+    def test_write_file_outside_safe_root_names_allowed_root(
+        self, file_ops, tmp_path, monkeypatch
+    ):
+        safe_root = tmp_path / "safe"
+        outside = tmp_path / "outside" / "note.txt"
+        safe_root.mkdir()
+        outside.parent.mkdir()
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        result = file_ops.write_file(str(outside), "content")
+
+        assert result.error is not None
+        assert "outside the allowed write roots" in result.error
+        assert f"HERMES_WRITE_SAFE_ROOT={safe_root}" in result.error
+        assert "protected system/credential file" not in result.error
+
+    def test_patch_replace_outside_safe_root_names_allowed_root(
+        self, file_ops, tmp_path, monkeypatch
+    ):
+        safe_root = tmp_path / "safe"
+        outside = tmp_path / "outside" / "note.txt"
+        safe_root.mkdir()
+        outside.parent.mkdir()
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        result = file_ops.patch_replace(str(outside), "old", "new")
+
+        assert result.error is not None
+        assert "outside the allowed write roots" in result.error
+        assert f"HERMES_WRITE_SAFE_ROOT={safe_root}" in result.error
+        assert "protected system/credential file" not in result.error
 
     def test_delete_file_denied_path(self, file_ops):
         result = file_ops.delete_file("~/.ssh/authorized_keys")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -37,6 +37,7 @@ from tools.binary_extensions import BINARY_EXTENSIONS
 from agent.file_safety import (
     build_write_denied_paths,
     build_write_denied_prefixes,
+    get_write_denied_error as _shared_write_denied_error,
     is_write_denied as _shared_is_write_denied,
 )
 
@@ -146,6 +147,11 @@ def _has_bom(text: Optional[str]) -> bool:
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
     return _shared_is_write_denied(path)
+
+
+def _write_denied_error(path: str, action: str = "Write") -> Optional[str]:
+    """Return the write-denial error for path, if any."""
+    return _shared_write_denied_error(path, action)
 
 
 # =============================================================================
@@ -1289,8 +1295,9 @@ class ShellFileOperations(FileOperations):
 
     def _python_delete(self, path: str, recursive: bool) -> WriteResult:
         path = self._expand_path(path)
-        if _is_write_denied(path):
-            return WriteResult(error=f"Delete denied: {path} is a protected path")
+        denied = _write_denied_error(path, "Delete")
+        if denied:
+            return WriteResult(error=denied)
 
         # We can't shell out to ``rm`` here — it doesn't exist on Windows
         # ``cmd.exe`` or PowerShell, so this code path is what's left when
@@ -1335,8 +1342,9 @@ class ShellFileOperations(FileOperations):
         src = self._expand_path(src)
         dst = self._expand_path(dst)
         for p in (src, dst):
-            if _is_write_denied(p):
-                return WriteResult(error=f"Move denied: {p} is a protected path")
+            denied = _write_denied_error(p, "Move")
+            if denied:
+                return WriteResult(error=denied)
         result = self._exec(
             f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
         )
@@ -1383,8 +1391,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
 
         # Block writes to sensitive paths
-        if _is_write_denied(path):
-            return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+        denied = _write_denied_error(path)
+        if denied:
+            return WriteResult(error=denied)
 
         # ── Fail-closed pre-write syntax gate ───────────────────────────
         # Validate the CANDIDATE content BEFORE any bytes touch disk —
@@ -1566,8 +1575,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
 
         # Block writes to sensitive paths
-        if _is_write_denied(path):
-            return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+        denied = _write_denied_error(path)
+        if denied:
+            return PatchResult(error=denied)
 
         # Read current content
         read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"


### PR DESCRIPTION
## Problem

Fixes #64003. `is_write_denied()` collapsed credential/system deny-list hits and `HERMES_WRITE_SAFE_ROOT` allowlist misses into the same boolean, so file tools reported an outside-root path as a protected credential file. That misled the agent and operator into treating an allowlist miss like a secret-path incident.

## Root cause

The shared file-safety helper returned only `True`/`False`, and both `write_file` and `patch_replace` emitted the protected-file diagnostic for every denial branch. ACP write handling had the same message shape.

## Fix

- Add a shared write-denial reason/error helper that distinguishes protected paths from safe-root misses.
- Surface `outside the allowed write roots (HERMES_WRITE_SAFE_ROOT=...)` for safe-root misses while preserving the protected credential/system message for real deny-list hits.
- Route write, patch, delete, move, and ACP text writes through the shared diagnostic helper.

## Tests

- `./scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_write_safety.py tests/agent/test_copilot_acp_client.py tests/run_agent/test_file_mutation_verifier.py`
- `git diff --check`