### PR TITLE
fix(kanban): redact worker logs at write time

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8063,30 +8063,36 @@ def _default_spawn(
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
-    # Use 'a' so a re-run on unblock appends rather than overwrites.
-    log_f = open(log_path, "ab")
+    if cmd and _looks_like_path(cmd[0]) and not os.path.exists(cmd[0]):
+        raise RuntimeError(
+            "`hermes` executable not found on PATH. "
+            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+        )
+
+    wrapped_cmd = [
+        sys.executable,
+        "-m",
+        "hermes_cli.kanban_worker_log",
+        str(log_path),
+        "--",
+        *cmd,
+    ]
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
+            wrapped_cmd,
             cwd=workspace if os.path.isdir(workspace) else None,
             stdin=subprocess.DEVNULL,
-            stdout=log_f,
+            stdout=subprocess.DEVNULL,
             stderr=subprocess.STDOUT,
             env=env,
             start_new_session=True,
             creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )
     except FileNotFoundError:
-        log_f.close()
         raise RuntimeError(
             "`hermes` executable not found on PATH. "
             "Install Hermes Agent or activate its venv before running the kanban dispatcher."
         )
-    # NOTE: we intentionally do NOT close log_f here — we want Popen's
-    # child process to keep writing after this function returns.  The
-    # handle is kept alive by the child's inheritance.  The parent's
-    # reference goes out of scope and is GC'd, but the OS-level FD stays
-    # open in the child until the child exits.
     return proc.pid
 
 

--- a/hermes_cli/kanban_worker_log.py
+++ b/hermes_cli/kanban_worker_log.py
@@ -1,0 +1,132 @@
+"""Redacting stdout wrapper for kanban worker subprocesses."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import re
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+
+_PRIVATE_KEY_BEGIN_RE = re.compile(r"-----BEGIN[A-Z ]*PRIVATE KEY-----")
+_PRIVATE_KEY_END_RE = re.compile(r"-----END[A-Z ]*PRIVATE KEY-----")
+
+
+def open_worker_log_file(log_path: Path):
+    """Open a worker log for append with owner-only permissions."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.chmod(log_path, 0o600)
+    except OSError:
+        pass
+    return os.fdopen(fd, "ab", buffering=0)
+
+
+def copy_redacted_worker_log_stream(src, dst) -> None:
+    """Copy worker stdout to *dst*, redacting secret-shaped output per line."""
+    from agent.redact import redact_terminal_output
+
+    sample_key = "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----"
+    redact_private_blocks = redact_terminal_output(sample_key) != sample_key
+    inside_private_key = False
+
+    while True:
+        raw = src.readline()
+        if not raw:
+            break
+        text = raw.decode("utf-8", errors="replace")
+        if redact_private_blocks:
+            if inside_private_key:
+                if _PRIVATE_KEY_END_RE.search(text):
+                    dst.write(b"[REDACTED PRIVATE KEY]\n")
+                    inside_private_key = False
+                continue
+            if (
+                _PRIVATE_KEY_BEGIN_RE.search(text)
+                and not _PRIVATE_KEY_END_RE.search(text)
+            ):
+                inside_private_key = True
+                continue
+        redacted = redact_terminal_output(text)
+        dst.write(redacted.encode("utf-8", errors="replace"))
+
+    if inside_private_key:
+        dst.write(b"[REDACTED PRIVATE KEY]\n")
+
+
+def _install_signal_forwarders(proc: subprocess.Popen) -> dict[int, object]:
+    previous: dict[int, object] = {}
+
+    def _forward(signum, _frame) -> None:
+        if proc.poll() is None:
+            with contextlib.suppress(Exception):
+                proc.send_signal(signum)
+
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        previous[signum] = signal.getsignal(signum)
+        signal.signal(signum, _forward)
+    return previous
+
+
+def _restore_signal_handlers(previous: dict[int, object]) -> None:
+    for signum, handler in previous.items():
+        with contextlib.suppress(Exception):
+            signal.signal(signum, handler)
+
+
+def run_worker_with_redacted_log(log_path: Path, command: list[str]) -> int:
+    """Run *command*, copying its combined stdout/stderr into a redacted log."""
+    try:
+        with open_worker_log_file(log_path) as log_f:
+            try:
+                proc = subprocess.Popen(  # noqa: S603 -- caller supplies argv
+                    command,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
+            except FileNotFoundError as exc:
+                log_f.write(f"Worker launch failed: {exc}\n".encode("utf-8"))
+                return 127
+
+            previous_handlers = _install_signal_forwarders(proc)
+            try:
+                if proc.stdout is not None:
+                    copy_redacted_worker_log_stream(proc.stdout, log_f)
+                return int(proc.wait())
+            finally:
+                _restore_signal_handlers(previous_handlers)
+                if proc.poll() is None:
+                    with contextlib.suppress(Exception):
+                        proc.terminate()
+                if proc.stdout is not None:
+                    with contextlib.suppress(Exception):
+                        proc.stdout.close()
+    except Exception as exc:
+        with contextlib.suppress(Exception):
+            sys.stderr.write(f"kanban worker log wrapper failed: {exc}\n")
+        return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_path")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        sys.stderr.write("kanban worker log wrapper: missing command\n")
+        return 2
+    return run_worker_with_redacted_log(Path(args.log_path), command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -11,9 +11,12 @@ parity across every registered verb.
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
+import stat
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -22,6 +25,7 @@ from types import SimpleNamespace
 import pytest
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_worker_log
 from hermes_cli.kanban import run_slash
 
 
@@ -715,6 +719,55 @@ def test_worker_log_rotation_config_defaults_and_overrides():
         "worker_log_rotate_bytes": 10,
         "worker_log_backup_count": 4,
     }) == (10, 4)
+
+
+def test_worker_log_file_created_owner_only(kanban_home):
+    log_path = kanban_home / "kanban" / "logs" / "t_secure.log"
+    log_path.parent.mkdir(parents=True)
+
+    with kanban_worker_log.open_worker_log_file(log_path) as handle:
+        handle.write(b"hello\n")
+
+    assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
+    assert log_path.read_text() == "hello\n"
+
+
+def test_worker_log_stream_redacts_tokens_and_private_key_blocks():
+    source = io.BytesIO(
+        b"token=ghp_abcdefghijklmnopqrst\n"
+        b"-----BEGIN PRIVATE KEY-----\n"
+        b"MIIfakepayload\n"
+        b"-----END PRIVATE KEY-----\n"
+        b"done\n"
+    )
+    target = io.BytesIO()
+
+    kanban_worker_log.copy_redacted_worker_log_stream(source, target)
+
+    text = target.getvalue().decode("utf-8")
+    assert "ghp_abcdefghijklmnopqrst" not in text
+    assert "MIIfakepayload" not in text
+    assert "[REDACTED PRIVATE KEY]" in text
+    assert "done" in text
+
+
+def test_worker_log_wrapper_runs_child_with_redacted_log(tmp_path):
+    log_path = tmp_path / "logs" / "t_wrapper.log"
+
+    rc = kanban_worker_log.run_worker_with_redacted_log(
+        log_path,
+        [
+            sys.executable,
+            "-c",
+            "print('token=ghp_abcdefghijklmnopqrst')",
+        ],
+    )
+
+    assert rc == 0
+    text = log_path.read_text()
+    assert "ghp_abcdefghijklmnopqrst" not in text
+    assert "token=" in text
+    assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
 
 
 def test_read_worker_log_tail(kanban_home):


### PR DESCRIPTION
## Problem

Fixes #63594. Kanban worker stdout/stderr was redirected directly into `<kanban-root>/kanban/logs/<task>.log`, bypassing the `security.redact_secrets` terminal-output redactor. The direct file open also used the process umask, so logs could be created group/world-readable.

## Root cause

`_default_spawn()` handed the task log file descriptor directly to `subprocess.Popen(stdout=..., stderr=STDOUT)`. Because the child wrote bytes to disk itself, the existing redaction layer never had a chance to scrub token-shaped output or PEM/private-key blocks.

## Fix

- Launch workers through a small Python log wrapper that runs the real worker command, reads combined stdout/stderr, redacts terminal output, and writes the task log with `0o600` permissions.
- Preserve fire-and-forget dispatch semantics by making the wrapper the tracked process; it stays alive for the worker lifetime and forwards SIGTERM/SIGINT to the child.
- Keep immediate spawn-failure behavior for a missing explicit Hermes executable before wrapping.

## Tests

- `./scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_redaction.py`
- `python3 -m compileall -q hermes_cli/kanban_worker_log.py hermes_cli/kanban_db.py`
- `git diff --check`