### PR TITLE
fix(clarify): propagate tool call identity to gateway requests

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2315,6 +2315,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
                     callback=agent.clarify_callback,
+                    tool_call_id=tool_call_id,
                 ),
                 next_args,
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1325,6 +1325,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
                     callback=agent.clarify_callback,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
                 )
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,

--- a/tests/agent/test_clarify_occurrence.py
+++ b/tests/agent/test_clarify_occurrence.py
@@ -1,0 +1,37 @@
+import json
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import invoke_tool
+
+
+def test_invoke_tool_propagates_clarify_tool_call_id_to_callback():
+    received = {}
+
+    def clarify_callback(question, choices, *, tool_call_id=None):
+        received.update(question=question, choices=choices, tool_call_id=tool_call_id)
+        return "B"
+
+    agent = SimpleNamespace(
+        clarify_callback=clarify_callback,
+        session_id="session-1",
+        _current_turn_id="turn-1",
+        _current_api_request_id="request-1",
+        _memory_manager=None,
+    )
+
+    result = json.loads(invoke_tool(
+        agent,
+        "clarify",
+        {"question": "Choose", "choices": ["A", "B"]},
+        effective_task_id="task-1",
+        tool_call_id="call-concurrent-b",
+        pre_tool_block_checked=True,
+        skip_tool_request_middleware=True,
+    ))
+
+    assert result["user_response"] == "B"
+    assert received == {
+        "question": "Choose",
+        "choices": ["A", "B"],
+        "tool_call_id": "call-concurrent-b",
+    }

--- a/tests/agent/test_clarify_occurrence.py
+++ b/tests/agent/test_clarify_occurrence.py
@@ -1,7 +1,11 @@
 import json
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from agent.agent_runtime_helpers import invoke_tool
+from run_agent import AIAgent
 
 
 def test_invoke_tool_propagates_clarify_tool_call_id_to_callback():
@@ -34,4 +38,62 @@ def test_invoke_tool_propagates_clarify_tool_call_id_to_callback():
         "question": "Choose",
         "choices": ["A", "B"],
         "tool_call_id": "call-concurrent-b",
+    }
+
+
+def test_sequential_tool_path_propagates_clarify_tool_call_id_to_callback():
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-clarify-test-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    tool_defs = [{
+        "type": "function",
+        "function": {
+            "name": "clarify",
+            "description": "ask",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }]
+    received = {}
+
+    def clarify_callback(question, choices, *, tool_call_id=None):
+        received.update(question=question, choices=choices, tool_call_id=tool_call_id)
+        return "A"
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=tool_defs),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            clarify_callback=clarify_callback,
+        )
+    agent.client = MagicMock()
+    setattr(agent, "tool_delay", 0)
+    agent._flush_messages_to_session_db = MagicMock()
+    tool_call = SimpleNamespace(
+        id="call-sequential",
+        type="function",
+        function=SimpleNamespace(
+            name="clarify",
+            arguments=json.dumps({"question": "Choose", "choices": ["A", "B"]}),
+        ),
+    )
+
+    messages = []
+    agent._execute_tool_calls_sequential(
+        SimpleNamespace(content="", tool_calls=[tool_call]),
+        messages,
+        "task-1",
+    )
+
+    assert received == {
+        "question": "Choose",
+        "choices": ["A", "B"],
+        "tool_call_id": "call-sequential",
     }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,25 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+def test_clarify_request_carries_tool_call_id_without_tool_progress_side_channel(monkeypatch):
+    calls = []
+
+    def fake_block(event_type, sid, payload, **kwargs):
+        calls.append((event_type, sid, payload, kwargs))
+        return "A"
+
+    monkeypatch.setattr(server, "_block", fake_block)
+
+    callback = server._agent_cbs("sid-direct-clarify")["clarify_callback"]
+    assert callback("Choose", ["A", "B"], tool_call_id="call-direct-2") == "A"
+    assert calls == [(
+        "clarify.request",
+        "sid-direct-clarify",
+        {"question": "Choose", "choices": ["A", "B"], "tool_call_id": "call-direct-2"},
+        {},
+    )]
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -1,6 +1,8 @@
 """Tests for tools/clarify_tool.py - Interactive clarifying questions."""
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional
 
 
@@ -155,6 +157,60 @@ class TestClarifyToolCallbackHandling:
 
         result = json.loads(clarify_tool("Q?", callback=mock_callback))
         assert result["user_response"] == "response with spaces"
+
+    def test_callback_receives_stable_tool_call_id_when_supported(self):
+        received = {}
+
+        def callback(question, choices, *, tool_call_id=None):
+            received.update(question=question, choices=choices, tool_call_id=tool_call_id)
+            return "A"
+
+        result = json.loads(clarify_tool(
+            "Choose",
+            choices=["A", "B"],
+            callback=callback,
+            tool_call_id="call-clarify-2",
+        ))
+
+        assert result["user_response"] == "A"
+        assert received == {
+            "question": "Choose",
+            "choices": ["A", "B"],
+            "tool_call_id": "call-clarify-2",
+        }
+
+    def test_two_argument_callback_remains_backward_compatible_with_tool_call_id(self):
+        result = json.loads(clarify_tool(
+            "Choose",
+            callback=lambda question, choices: "legacy",
+            tool_call_id="call-clarify-legacy",
+        ))
+
+        assert result["user_response"] == "legacy"
+
+    def test_concurrent_clarifications_keep_ids_when_requests_arrive_reversed(self):
+        release_first = threading.Event()
+        requests = []
+
+        def callback(question, choices, *, tool_call_id=None):
+            if tool_call_id == "call-a":
+                release_first.wait(timeout=2)
+            else:
+                release_first.set()
+            requests.append((question, tool_call_id))
+            return question
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(
+                clarify_tool, "A", callback=callback, tool_call_id="call-a"
+            )
+            second = executor.submit(
+                clarify_tool, "B", callback=callback, tool_call_id="call-b"
+            )
+            first.result(timeout=3)
+            second.result(timeout=3)
+
+        assert requests == [("B", "call-b"), ("A", "call-a")]
 
 
 class TestCheckClarifyRequirements:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -12,6 +12,7 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
+import inspect
 from typing import List, Optional, Callable
 
 
@@ -57,6 +58,7 @@ def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
     callback: Optional[Callable] = None,
+    tool_call_id: Optional[str] = None,
 ) -> str:
     """
     Ask the user a question, optionally with multiple-choice options.
@@ -66,8 +68,10 @@ def clarify_tool(
         choices:  Up to 4 predefined answer choices. When omitted the
                   question is purely open-ended.
         callback: Platform-provided function that handles the actual UI
-                  interaction. Signature: callback(question, choices) -> str.
-                  Injected by the agent runner (cli.py / gateway).
+                  interaction. Existing two-argument callbacks remain supported;
+                  callbacks declaring ``tool_call_id`` receive the stable call ID.
+        tool_call_id: Stable identity of this tool occurrence, when invoked by
+                      the agent runtime.
 
     Returns:
         JSON string with the user's response.
@@ -99,7 +103,18 @@ def clarify_tool(
         )
 
     try:
-        user_response = callback(question, choices)
+        supports_tool_call_id = False
+        if tool_call_id:
+            try:
+                inspect.signature(callback).bind(question, choices, tool_call_id=tool_call_id)
+                supports_tool_call_id = True
+            except (TypeError, ValueError):
+                pass
+        user_response = (
+            callback(question, choices, tool_call_id=tool_call_id)
+            if supports_tool_call_id
+            else callback(question, choices)
+        )
     except Exception as exc:
         return json.dumps(
             {"error": f"Failed to get user input: {exc}"},

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3933,8 +3933,14 @@ def _agent_cbs(sid: str) -> dict:
         "notice_clear_callback": lambda key: _emit(
             "notification.clear", sid, {"key": key}
         ),
-        "clarify_callback": lambda q, c: _block(
-            "clarify.request", sid, {"question": q, "choices": c}
+        "clarify_callback": lambda q, c, tool_call_id=None: _block(
+            "clarify.request",
+            sid,
+            {
+                "question": q,
+                "choices": c,
+                **({"tool_call_id": tool_call_id} if tool_call_id else {}),
+            },
         ),
         # read_terminal tool (desktop GUI): same blocking bridge as clarify — the
         # renderer answers terminal.read.respond with the serialized buffer.


### PR DESCRIPTION
## Summary
- pass the stable `tool_call_id` into `clarify_tool` from the invoking runtime
- preserve compatibility with existing two-argument clarify callbacks
- include `tool_call_id` directly in the TUI gateway `clarify.request` payload
- avoid relying on `tool.start`, which can be disabled and is not causally safe for concurrent tool batches

## Why
Downstream viewers need to distinguish repeated `clarify` calls with identical question/choices. Correlating `tool.start` to `clarify.request` by session is unsafe because tool batches start concurrently and requests can arrive in a different order.

## Tests
- 355 tests passed across `test_clarify_tool.py`, `test_clarify_occurrence.py`, and `test_tui_gateway_server.py`
- concurrent clarifications preserve IDs when callbacks arrive in reverse order
- gateway payload carries identity without a tool-progress side channel
- legacy two-argument callbacks remain supported
- Ruff passed on all touched files