### PR TITLE
feat(mcp): add TypeWhisper catalog entry

### DIFF
--- a/optional-mcps/typewhisper/manifest.yaml
+++ b/optional-mcps/typewhisper/manifest.yaml
@@ -1,0 +1,52 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: typewhisper
+description: Transcribe files and manage local speech-to-text workflows with TypeWhisper.
+source: https://github.com/TypeWhisper/typewhisper-mcp
+
+# The TypeWhisper MCP server is published on npm and communicates with the
+# TypeWhisper desktop app over its authenticated local HTTP API. Pinning the
+# package keeps catalog installs reproducible; update this version deliberately
+# when a newer server release has been reviewed.
+transport:
+  type: stdio
+  command: npx
+  args:
+    - "-y"
+    - "@typewhisper/mcp@0.1.2"
+
+# Local installations discover the API port and bearer token from TypeWhisper's
+# app-data directory on macOS or Windows. Remote installations can pass
+# TYPEWHISPER_API_BASE_URL and TYPEWHISPER_API_TOKEN through the server's `env`
+# block in ~/.hermes/config.yaml.
+auth:
+  type: none
+
+# Keep the default surface useful and non-destructive. The install-time tool
+# checklist still lets users opt into dictionary writes and deletes.
+tools:
+  default_enabled:
+    - typewhisper_status
+    - typewhisper_list_models
+    - typewhisper_transcribe_file
+    - typewhisper_search_history
+    - typewhisper_list_dictionary_terms
+    - typewhisper_list_dictionary_corrections
+
+post_install: |
+  TypeWhisper must be running with its local API enabled under
+  Settings > Advanced. Start a new Hermes session after enabling the API.
+
+  Local macOS and Windows installations discover the API connection and bearer
+  token automatically. For a remote TypeWhisper host, forward its loopback API
+  through a private tunnel and add TYPEWHISPER_API_BASE_URL plus
+  TYPEWHISPER_API_TOKEN to mcp_servers.typewhisper.env in your Hermes config.
+
+  File paths passed to typewhisper_transcribe_file must exist on the machine
+  running TypeWhisper. Shared or synchronized directories work for remote use.
+
+  Dictionary write and delete tools are disabled by default. Re-run the tool
+  checklist to enable them when needed:
+    hermes mcp configure typewhisper


### PR DESCRIPTION
## What does this PR do?

Adds TypeWhisper to the Nous-approved MCP catalog so users can install its local speech-to-text tools with:

```bash
hermes mcp install typewhisper
```

The catalog entry launches the published `@typewhisper/mcp@0.1.2` stdio server. TypeWhisper discovers its authenticated local API automatically on macOS and Windows; remote hosts can be configured through the MCP server's `env` block.

The default tool selection enables status, model listing, file transcription, history search, and read-only dictionary access. Dictionary writes and deletes remain available in the install checklist but are disabled by default.

## Type of Change

- [x] New feature

## Changes Made

- Add `optional-mcps/typewhisper/manifest.yaml`.
- Pin the reviewed npm server version for reproducible installs.
- Document local discovery, remote token configuration, host-side file paths, and tool reconfiguration.

The branch is rebased onto current `main`, including #68217. Hermes no longer supports pip/PyPI wheel or sdist distribution; catalog data now comes directly from the checkout for source/Docker installs and from the bundled `optional-mcps` store path for Nix installs.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_dashboard_admin_endpoints.py
```

The targeted suite passes all 129 tests on the current PR head.

The real install path was also exercised against a running TypeWhisper instance with an isolated `HERMES_HOME`:

```bash
HERMES_HOME="$(mktemp -d)" .venv/bin/hermes mcp install typewhisper
```

Hermes discovered all 10 tools and persisted the six manifest defaults.

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit used
- [x] Searched existing issues and PRs for TypeWhisper
- [x] Focused change with no unrelated refactors
- [x] Current catalog and dashboard contract tests cover the new manifest
- [x] Tested on macOS 27.0
- [x] Cross-platform behavior considered: the MCP package supports macOS and Windows discovery, plus explicit remote URL/token configuration
- [x] Documentation/config examples updated in the manifest; no core config keys or architecture changed
