### PR TITLE
fix(mcp): dedupe equivalent structured content

### DIFF
--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -18,6 +18,15 @@ class _FakeContentBlock:
         self.type = block_type
 
 
+class _FakeImageContentBlock:
+    """Minimal image block with MCP ImageContent-like attributes."""
+
+    def __init__(self):
+        self.type = "image"
+        self.data = "not-base64"
+        self.mimeType = "image/png"
+
+
 class _FakeCallToolResult:
     """Minimal CallToolResult stand-in.
 
@@ -62,6 +71,17 @@ def _patch_mcp_server():
         yield fake_session
 
 
+def _call_tool_result(session, content, structured):
+    session.call_tool = AsyncMock(
+        return_value=_FakeCallToolResult(
+            content=content,
+            structuredContent=structured,
+        )
+    )
+    handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+    return json.loads(handler({}))
+
+
 class TestStructuredContentPreservation:
     """Ensure structuredContent from CallToolResult is forwarded."""
 
@@ -95,6 +115,39 @@ class TestStructuredContentPreservation:
         assert data["result"] == "OK"
         assert data["structuredContent"] == payload
 
+    def test_fastmcp_semantic_duplicate_omits_structured_content(self, _patch_mcp_server):
+        """FastMCP dict tools mirror structuredContent as one JSON TextContent."""
+        payload = {"value": "secret-123", "revealed": True, "items": [1, 2]}
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock(json.dumps(payload))],
+            payload,
+        )
+        assert data == {"result": json.dumps(payload)}
+
+    def test_duplicate_with_different_whitespace_and_key_formatting(self, _patch_mcp_server):
+        """Semantic equality, not byte equality, controls the narrow dedupe."""
+        payload = {"b": [2, 3], "a": {"nested": True}}
+        text = json.dumps({"a": {"nested": True}, "b": [2, 3]}, indent=2)
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock(text)],
+            payload,
+        )
+        assert data == {"result": text}
+
+    def test_supplementary_human_file_text_remains_combined(self, _patch_mcp_server):
+        """File/body text plus metadata is not a duplicate FastMCP payload."""
+        file_text = "import os\nprint('hello')\n"
+        metadata = {"fileName": "main.py", "filePath": "/tmp/main.py", "fileType": "python"}
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock(file_text)],
+            metadata,
+        )
+        assert data["result"] == file_text
+        assert data["structuredContent"] == metadata
+
     def test_both_content_and_structured_desktop_commander(self, _patch_mcp_server):
         """Real-world case: Desktop Commander returns file text in content,
         metadata in structuredContent.  Agent must see file contents."""
@@ -112,6 +165,48 @@ class TestStructuredContentPreservation:
         data = json.loads(raw)
         assert data["result"] == file_text
         assert data["structuredContent"] == metadata
+
+    def test_multiple_text_blocks_remain_combined(self, _patch_mcp_server):
+        """Multiple text blocks may carry extra context; do not dedupe."""
+        payload = {"value": 1}
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock(json.dumps(payload)), _FakeContentBlock("human note")],
+            payload,
+        )
+        assert data["result"] == f"{json.dumps(payload)}\nhuman note"
+        assert data["structuredContent"] == payload
+
+    def test_image_or_media_content_remains_combined(self, _patch_mcp_server):
+        """Image/MEDIA content must keep structured metadata attached."""
+        payload = {"value": 1}
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock(json.dumps(payload)), _FakeImageContentBlock()],
+            payload,
+        )
+        assert data["result"] == json.dumps(payload)
+        assert data["structuredContent"] == payload
+
+    def test_media_text_content_remains_combined(self, _patch_mcp_server):
+        """Already-materialized MEDIA tags are not treated as duplicate JSON text."""
+        payload = {"image": "metadata"}
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock("MEDIA:/tmp/render.png")],
+            payload,
+        )
+        assert data["result"] == "MEDIA:/tmp/render.png"
+        assert data["structuredContent"] == payload
+
+    def test_json_string_semantics_are_deduped(self, _patch_mcp_server):
+        """JSON-native scalar semantics still dedupe when values are equal."""
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock('"2026-07-13T12:34:56+00:00"')],
+            "2026-07-13T12:34:56+00:00",
+        )
+        assert data == {"result": '"2026-07-13T12:34:56+00:00"'}
 
     def test_structured_content_none_falls_back_to_text(self, _patch_mcp_server):
         """When structuredContent is explicitly None, fall back to text."""

--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -136,6 +136,33 @@ class TestStructuredContentPreservation:
         )
         assert data == {"result": text}
 
+    def test_top_level_boolean_number_mismatch_preserves_structured_content(
+        self, _patch_mcp_server
+    ):
+        """JSON booleans are not equivalent to numbers for dedupe."""
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock("true")],
+            1,
+        )
+        assert data["result"] == "true"
+        assert data["structuredContent"] == 1
+
+    def test_nested_boolean_number_mismatch_preserves_structured_content(
+        self, _patch_mcp_server
+    ):
+        """Nested JSON booleans are not equivalent to numbers for dedupe."""
+        text_payload = {"items": [{"enabled": False}]}
+        structured_payload = {"items": [{"enabled": 0}]}
+        text = json.dumps(text_payload)
+        data = _call_tool_result(
+            _patch_mcp_server,
+            [_FakeContentBlock(text)],
+            structured_payload,
+        )
+        assert data["result"] == text
+        assert data["structuredContent"] == structured_payload
+
     def test_supplementary_human_file_text_remains_combined(self, _patch_mcp_server):
         """File/body text plus metadata is not a duplicate FastMCP payload."""
         file_text = "import os\nprint('hello')\n"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -703,7 +703,31 @@ def _mcp_structured_content_duplicates_text(
         parsed = json.loads(text)
     except (TypeError, json.JSONDecodeError):
         return False
-    return parsed == structured
+    return _json_values_equivalent(parsed, structured)
+
+
+def _json_values_equivalent(left: Any, right: Any) -> bool:
+    """Return True only when two JSON-native values match type-sensitively."""
+    if type(left) is not type(right):
+        return False
+
+    if isinstance(left, dict):
+        if left.keys() != right.keys():
+            return False
+        return all(_json_values_equivalent(left[key], right[key]) for key in left)
+
+    if isinstance(left, list):
+        if len(left) != len(right):
+            return False
+        return all(
+            _json_values_equivalent(left_item, right_item)
+            for left_item, right_item in zip(left, right)
+        )
+
+    if left is None or isinstance(left, (bool, int, float, str)):
+        return left == right
+
+    return False
 
 
 def _cache_mcp_image_block(block) -> str:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -670,6 +670,42 @@ def _mcp_image_extension_for_mime_type(mime_type: str) -> str:
     return mimetypes.guess_extension(normalized) or ".png"
 
 
+def _mcp_block_is_image(block) -> bool:
+    """Return True when *block* looks like an MCP ImageContent block."""
+    data = getattr(block, "data", None)
+    mime_type = getattr(block, "mimeType", None)
+    normalized_mime = str(mime_type or "").split(";", 1)[0].strip().lower()
+    return data is not None and normalized_mime.startswith("image/")
+
+
+def _mcp_structured_content_duplicates_text(
+    content_blocks: List[Any],
+    structured: Any,
+) -> bool:
+    """Return True for FastMCP's one-block JSON text mirror of structuredContent.
+
+    Conservative by design: only dedupe one textual JSON content block, with no
+    image/MEDIA content, when json.loads(text) is semantically equal to the SDK's
+    structuredContent value. Other combinations may carry supplementary
+    human-readable content and must stay combined.
+    """
+    if len(content_blocks) != 1:
+        return False
+
+    block = content_blocks[0]
+    if _mcp_block_is_image(block):
+        return False
+    text = getattr(block, "text", None)
+    if not isinstance(text, str) or "MEDIA:" in text:
+        return False
+
+    try:
+        parsed = json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        return False
+    return parsed == structured
+
+
 def _cache_mcp_image_block(block) -> str:
     """Cache an MCP ``ImageContent`` block to the shared image cache and
     return a ``MEDIA:<path>`` tag that Hermes gateways know how to render.
@@ -685,7 +721,7 @@ def _cache_mcp_image_block(block) -> str:
     data = getattr(block, "data", None)
     mime_type = getattr(block, "mimeType", None)
     normalized_mime = str(mime_type or "").split(";", 1)[0].strip().lower()
-    if data is None or not normalized_mime.startswith("image/"):
+    if not _mcp_block_is_image(block):
         return ""
 
     try:
@@ -3980,9 +4016,18 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # MCP spec: content is model-oriented (text), structuredContent
             # is machine-oriented (JSON metadata).  For an AI agent, content
             # is the primary payload; structuredContent supplements it.
+            #
+            # FastMCP dict-returning tools mirror structuredContent as a single
+            # JSON TextContent block. In only that semantically equivalent case,
+            # keep the existing text result and omit the duplicate structured
+            # payload to avoid doubling model context. Supplementary content
+            # (file body + metadata, images, multiple text blocks, non-JSON
+            # prose, unequal JSON) remains combined unchanged.
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
                 if text_result:
+                    if _mcp_structured_content_duplicates_text(result.content or [], structured):
+                        return json.dumps({"result": text_result}, ensure_ascii=False)
                     return json.dumps({
                         "result": text_result,
                         "structuredContent": structured,


### PR DESCRIPTION
## Summary
- dedupe FastMCP-style structuredContent only when one text content block parses as JSON equal to structuredContent
- keep supplementary text, multiple blocks, image/MEDIA content, non-JSON text, and unequal structured metadata combined
- add behavior tests for duplicate and non-duplicate structuredContent cases

## Tests
- uv run --extra dev ruff check tools/mcp_tool.py tests/tools/test_mcp_structured_content.py
- uv run --extra dev python -m pytest tests/tools/test_mcp_structured_content.py -q
- uv run --extra dev python -m pytest tests/tools/test_mcp*.py -q --disable-warnings

## Deployment impact
Valaskjalf: code-only MCP tool response formatting change. No config, migrations, adapters, live services, release, merge, or tags touched.