### PR TITLE
fix(telegram): auto-title client-created DM topics

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3600,6 +3600,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
         return True
 
+    def _is_telegram_dm_topic_thread(self, source: SessionSource) -> bool:
+        """True for a concrete non-General topic in a Telegram private chat.
+
+        Unlike ``_is_telegram_topic_lane``, this does not require Hermes topic
+        mode. Telegram clients can create DM topics independently, and their
+        visible titles should still mirror the generated session title.
+        """
+        if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
+            return False
+        tid = str(source.thread_id or "")
+        return bool(tid and tid not in self._TELEGRAM_GENERAL_TOPIC_IDS)
+
     _TELEGRAM_LOBBY_REMINDER_COOLDOWN_S = 30.0
 
     def _should_send_telegram_lobby_reminder(self, source: SessionSource) -> bool:
@@ -13818,7 +13830,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         title: str,
     ) -> None:
         """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
-        if not await asyncio.to_thread(self._is_telegram_topic_lane, source) or not source.chat_id or not source.thread_id:
+        if not await asyncio.to_thread(self._is_telegram_dm_topic_thread, source) or not source.chat_id or not source.thread_id:
             return
 
         # Operator can fully disable per-topic auto-rename via
@@ -13926,7 +13938,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         title: str,
     ) -> None:
         """Schedule a topic rename from the auto-title background thread."""
-        if not title or not self._is_telegram_topic_lane(source):
+        if not title or not self._is_telegram_dm_topic_thread(source):
             return
         if self._telegram_topic_auto_rename_disabled(source):
             return
@@ -19316,7 +19328,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "api_mode": getattr(agent, "api_mode", None),
                         } if agent else None,
                     }
-                    if self._is_telegram_topic_lane(source):
+                    if self._is_telegram_dm_topic_thread(source):
                         maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
                             source,
                             effective_session_id,

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -914,6 +914,30 @@ async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_auto_generated_title_renames_dm_thread_without_topic_mode(tmp_path):
+    """Client-created DM topics should not depend on Hermes topic-mode state."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+    source = _make_source(thread_id="42")
+
+    assert runner._is_telegram_topic_lane(source) is False
+    assert runner._is_telegram_dm_topic_thread(source) is True
+
+    await runner._rename_telegram_topic_for_session_title(
+        source,
+        "sess-topic",
+        "Recovered Topic Title",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Recovered Topic Title",
+    )
+
+
+@pytest.mark.asyncio
 async def test_auto_generated_title_does_not_rename_topic_bound_to_other_session(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     db.apply_telegram_topic_migration()


### PR DESCRIPTION
## What does this PR do?

Telegram clients can create private-chat topics that have a concrete `thread_id` without Hermes `/topic` mode being enabled. Hermes still creates and titles the matching session, but the Telegram rename callback was gated by `_is_telegram_topic_lane()`, so the visible topic could remain `New Chat`.

This change adds a narrower predicate for title mirroring only. Topic routing and lobby behavior remain gated by Hermes topic mode.

Related to #16255. This complements #58430: that PR distinguishes configured topics from runtime-discovered cache entries, while this change covers client-created DM topics when Hermes topic-mode state is absent.

## Related Issue

No exact issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `_is_telegram_dm_topic_thread()` for concrete non-General Telegram DM topics.
- Use it only for auto-title callback wiring, scheduling, and rename eligibility.
- Preserve existing guards for General topics, operator-declared topics, disabled auto-rename, and conflicting session bindings.
- Add regression coverage for a client-created DM topic with no Hermes topic-mode state.

## How to Test

1. Run `pytest tests/gateway/test_telegram_topic_mode.py tests/gateway/test_title_command.py -q -o 'addopts='`.
2. Create a Telegram private-chat topic without enabling Hermes `/topic` mode.
3. Start a conversation and verify the generated session title is mirrored to the visible Telegram topic name.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the complete `pytest tests/ -q` suite.
- [x] I've added tests for my changes.
- [x] I've tested the focused gateway suites on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior is covered by docstrings and tests.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture workflow changed.
- [x] Cross-platform impact considered; the change is platform-scoped gateway logic.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Not included; the regression test covers the behavior without publishing user chat data.
