### PR TITLE
feat(skills): add apple-shortcuts bundled skill

### DIFF
--- a/skills/apple/apple-shortcuts/SKILL.md
+++ b/skills/apple/apple-shortcuts/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: apple-shortcuts
+description: "Run and automate macOS Shortcuts via the shortcuts CLI."
+version: 1.0.0
+author: Nick Coleman, Hermes Agent
+license: MIT
+platforms: [macos]
+metadata:
+  hermes:
+    tags: [Shortcuts, automation, macOS, Apple, HomeKit, Focus]
+prerequisites:
+  commands: [shortcuts]
+---
+
+# Apple Shortcuts Skill
+
+Run the user's macOS Shortcuts from the `terminal` tool via the first-party `shortcuts` CLI, and use Shortcuts personal automations to trigger Hermes on real-world events. This skill does not create or edit shortcuts — the user builds those in Shortcuts.app; it runs them.
+
+## When to Use
+
+- User asks to run a shortcut by name, or to do something one of their shortcuts already does
+- Controlling apps that expose Shortcuts actions (HomeKit scenes, Focus modes, Music, third-party apps)
+- A macOS capability has no CLI or dedicated skill — a user-built Shortcut is often the cleanest bridge
+- NOT for Reminders, Notes, or iMessage (dedicated `apple-*` skills exist), and NOT for agent-side scheduling (use the cronjob tool)
+
+## Prerequisites
+
+- macOS 12+ (the `shortcuts` binary ships with the OS — nothing to install)
+- Shortcuts that control other apps trigger a one-time Automation permission prompt on first run; the user must click Allow on the Mac
+- Shortcuts sync from iPhone/iPad via iCloud, so phone-built shortcuts are runnable here
+
+## How to Run
+
+```bash
+shortcuts list                          # all shortcut names, one per line
+shortcuts list --folders                # folder organization
+shortcuts run "Shortcut Name"           # run by exact name (quote it)
+```
+
+## Quick Reference
+
+```bash
+# Pass input from a file, capture output to a file
+shortcuts run "Resize Image" --input-path photo.jpg --output-path resized.jpg
+
+# Pipe text in via stdin, read result on stdout
+echo "hello" | shortcuts run "Uppercase Text" | cat
+
+# View a shortcut in Shortcuts.app (for the user, not headless)
+shortcuts view "Shortcut Name"
+```
+
+Names are matched exactly, including spaces and emoji — always quote. Use `shortcuts list` first rather than guessing a name.
+
+## Procedure
+
+1. Discover: `shortcuts list` and pick the exact name.
+2. Check interactivity: prefer shortcuts that take defined input and produce output. If a shortcut shows alerts, menus, or "Ask Each Time" fields, it will block or fail when run headless — ask the user to make an agent-friendly variant that reads input and returns text.
+3. Run with `--input-path`/stdin and capture stdout or `--output-path`.
+4. Verify the result (see Verification) — do not assume success from a silent exit.
+
+### Hermes as an automation target
+
+Shortcuts **personal automations** (Focus change, arriving at a location, time of day, charger connected, NFC tag) can trigger Hermes with zero new code: add a "Send Message" action to the automation that messages the line the user's Hermes gateway listens on (iMessage or Telegram). Example: an automation on "Work Focus turned on" sends "I just started work focus — silence non-urgent alerts and give me today's agenda" to the Hermes number. The gateway treats it as a normal inbound message and the agent reacts. Set the automation to "Run Immediately" so it fires without confirmation.
+
+### Bridging missing capabilities
+
+When an Apple app has no CLI (one-off Calendar writes, grabbing a recent photo), prefer asking the user to build a small Shortcut exposing that action, then run it here — more reliable than UI scripting.
+
+## Pitfalls
+
+- Interactive shortcuts hang the `terminal` call — there is no headless flag; recognize blocking runs and stop them rather than waiting
+- Exit codes are unreliable for failures *inside* a shortcut; prefer shortcuts that emit checkable output text
+- First run against a new app blocks on the Automation permission dialog — tell the user to expect it
+- `shortcuts run` gives no progress output; long-running shortcuts look identical to hung ones — know the expected duration before running
+
+## Verification
+
+- After a run, check the expected side effect (output file exists, `--output-path` file is non-empty, stdout matches) instead of trusting exit code 0
+- `shortcuts list | grep -c .` confirms the CLI and iCloud sync are working at all

--- a/skills/apple/apple-shortcuts/SKILL.md
+++ b/skills/apple/apple-shortcuts/SKILL.md
@@ -33,7 +33,7 @@ Run the user's macOS Shortcuts from the `terminal` tool via the first-party `sho
 
 ```bash
 shortcuts list                          # all shortcut names, one per line
-shortcuts list --folders                # folder organization
+shortcuts list --folders                # folder names only
 shortcuts run "Shortcut Name"           # run by exact name (quote it)
 ```
 
@@ -61,7 +61,7 @@ Names are matched exactly, including spaces and emoji — always quote. Use `sho
 
 ### Hermes as an automation target
 
-Shortcuts **personal automations** (Focus change, arriving at a location, time of day, charger connected, NFC tag) can trigger Hermes with zero new code: add a "Send Message" action to the automation that messages the line the user's Hermes gateway listens on (iMessage or Telegram). Example: an automation on "Work Focus turned on" sends "I just started work focus — silence non-urgent alerts and give me today's agenda" to the Hermes number. The gateway treats it as a normal inbound message and the agent reacts. Set the automation to "Run Immediately" so it fires without confirmation.
+Shortcuts **personal automations** (Focus change, arriving at a location, time of day, charger connected, NFC tag — built in the Shortcuts app on the user's iPhone/iPad; macOS has no personal-automations surface) can trigger Hermes with zero new code: add a "Send Message" action to the automation that messages the line the user's Hermes gateway listens on (iMessage or Telegram). Example: an automation on "Work Focus turned on" sends "I just started work focus — silence non-urgent alerts and give me today's agenda" to the Hermes number. The gateway treats it as a normal inbound message and the agent reacts. Set the automation to "Run Immediately" so it fires without confirmation.
 
 ### Bridging missing capabilities
 

--- a/tests/skills/test_apple_shortcuts_skill.py
+++ b/tests/skills/test_apple_shortcuts_skill.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2] / "skills" / "apple" / "apple-shortcuts" / "SKILL.md"
+)
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+
+def _frontmatter() -> str:
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    match = re.match(r"\A---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match is not None, "SKILL.md missing YAML frontmatter"
+    return match.group(1)
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL_PATH.is_file()
+
+
+def test_description_is_hardline_compliant() -> None:
+    match = re.search(r'^description: "?(.*?)"?$', _frontmatter(), re.MULTILINE)
+    assert match is not None, "missing description"
+    description = match.group(1)
+    assert len(description) <= 60
+    assert description.endswith(".")
+
+
+def test_platform_gated_to_macos_only() -> None:
+    match = re.search(r"^platforms: \[(.*?)\]$", _frontmatter(), re.MULTILINE)
+    assert match is not None, "missing platforms gating"
+    assert [p.strip() for p in match.group(1).split(",")] == ["macos"]
+
+
+def test_platform_gate_matches_darwin_not_linux(monkeypatch) -> None:
+    import agent.skill_utils as skill_utils
+
+    monkeypatch.setattr(skill_utils.sys, "platform", "darwin")
+    assert skill_utils.skill_matches_platform_list(["macos"])
+    monkeypatch.setattr(skill_utils.sys, "platform", "linux")
+    assert not skill_utils.skill_matches_platform_list(["macos"])
+
+
+def test_prerequisites_declare_shortcuts_command() -> None:
+    assert re.search(r"^\s+commands: \[shortcuts\]$", _frontmatter(), re.MULTILINE)
+
+
+def test_body_sections_present_in_canonical_order() -> None:
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    positions = [text.find(section) for section in REQUIRED_SECTIONS]
+    assert -1 not in positions, (
+        f"missing sections: {[s for s, p in zip(REQUIRED_SECTIONS, positions) if p == -1]}"
+    )
+    assert positions == sorted(positions), "sections out of canonical order"

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -18,6 +18,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 |-------|-------------|------|
 | [`apple-notes`](/docs/user-guide/skills/bundled/apple/apple-apple-notes) | Manage Apple Notes via memo CLI: create, search, edit. | `apple/apple-notes` |
 | [`apple-reminders`](/docs/user-guide/skills/bundled/apple/apple-apple-reminders) | Apple Reminders via remindctl: add, list, complete. | `apple/apple-reminders` |
+| [`apple-shortcuts`](/docs/user-guide/skills/bundled/apple/apple-apple-shortcuts) | Run and automate macOS Shortcuts via the shortcuts CLI. | `apple/apple-shortcuts` |
 | [`findmy`](/docs/user-guide/skills/bundled/apple/apple-findmy) | Track Apple devices/AirTags via FindMy.app on macOS. | `apple/findmy` |
 | [`imessage`](/docs/user-guide/skills/bundled/apple/apple-imessage) | Send and receive iMessages/SMS via the imsg CLI on macOS. | `apple/imessage` |
 | [`macos-computer-use`](/docs/user-guide/skills/bundled/apple/apple-macos-computer-use) | Drive the macOS desktop in the background — screenshots, mouse, keyboard, scroll, drag — without stealing the user's cursor, keyboard focus, or Space. Works with any tool-capable model. Load this skill whenever the `computer_use` tool is... | `apple/macos-computer-use` |

--- a/website/docs/user-guide/skills/bundled/apple/apple-apple-shortcuts.md
+++ b/website/docs/user-guide/skills/bundled/apple/apple-apple-shortcuts.md
@@ -1,0 +1,96 @@
+---
+title: "Apple Shortcuts — Run and automate macOS Shortcuts via the shortcuts CLI"
+sidebar_label: "Apple Shortcuts"
+description: "Run and automate macOS Shortcuts via the shortcuts CLI"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Apple Shortcuts
+
+Run and automate macOS Shortcuts via the shortcuts CLI.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/apple/apple-shortcuts` |
+| Version | `1.0.0` |
+| Author | Nick Coleman, Hermes Agent |
+| License | MIT |
+| Platforms | macos |
+| Tags | `Shortcuts`, `automation`, `macOS`, `Apple`, `HomeKit`, `Focus` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Apple Shortcuts Skill
+
+Run the user's macOS Shortcuts from the `terminal` tool via the first-party `shortcuts` CLI, and use Shortcuts personal automations to trigger Hermes on real-world events. This skill does not create or edit shortcuts — the user builds those in Shortcuts.app; it runs them.
+
+## When to Use
+
+- User asks to run a shortcut by name, or to do something one of their shortcuts already does
+- Controlling apps that expose Shortcuts actions (HomeKit scenes, Focus modes, Music, third-party apps)
+- A macOS capability has no CLI or dedicated skill — a user-built Shortcut is often the cleanest bridge
+- NOT for Reminders, Notes, or iMessage (dedicated `apple-*` skills exist), and NOT for agent-side scheduling (use the cronjob tool)
+
+## Prerequisites
+
+- macOS 12+ (the `shortcuts` binary ships with the OS — nothing to install)
+- Shortcuts that control other apps trigger a one-time Automation permission prompt on first run; the user must click Allow on the Mac
+- Shortcuts sync from iPhone/iPad via iCloud, so phone-built shortcuts are runnable here
+
+## How to Run
+
+```bash
+shortcuts list                          # all shortcut names, one per line
+shortcuts list --folders                # folder organization
+shortcuts run "Shortcut Name"           # run by exact name (quote it)
+```
+
+## Quick Reference
+
+```bash
+# Pass input from a file, capture output to a file
+shortcuts run "Resize Image" --input-path photo.jpg --output-path resized.jpg
+
+# Pipe text in via stdin, read result on stdout
+echo "hello" | shortcuts run "Uppercase Text" | cat
+
+# View a shortcut in Shortcuts.app (for the user, not headless)
+shortcuts view "Shortcut Name"
+```
+
+Names are matched exactly, including spaces and emoji — always quote. Use `shortcuts list` first rather than guessing a name.
+
+## Procedure
+
+1. Discover: `shortcuts list` and pick the exact name.
+2. Check interactivity: prefer shortcuts that take defined input and produce output. If a shortcut shows alerts, menus, or "Ask Each Time" fields, it will block or fail when run headless — ask the user to make an agent-friendly variant that reads input and returns text.
+3. Run with `--input-path`/stdin and capture stdout or `--output-path`.
+4. Verify the result (see Verification) — do not assume success from a silent exit.
+
+### Hermes as an automation target
+
+Shortcuts **personal automations** (Focus change, arriving at a location, time of day, charger connected, NFC tag) can trigger Hermes with zero new code: add a "Send Message" action to the automation that messages the line the user's Hermes gateway listens on (iMessage or Telegram). Example: an automation on "Work Focus turned on" sends "I just started work focus — silence non-urgent alerts and give me today's agenda" to the Hermes number. The gateway treats it as a normal inbound message and the agent reacts. Set the automation to "Run Immediately" so it fires without confirmation.
+
+### Bridging missing capabilities
+
+When an Apple app has no CLI (one-off Calendar writes, grabbing a recent photo), prefer asking the user to build a small Shortcut exposing that action, then run it here — more reliable than UI scripting.
+
+## Pitfalls
+
+- Interactive shortcuts hang the `terminal` call — there is no headless flag; recognize blocking runs and stop them rather than waiting
+- Exit codes are unreliable for failures *inside* a shortcut; prefer shortcuts that emit checkable output text
+- First run against a new app blocks on the Automation permission dialog — tell the user to expect it
+- `shortcuts run` gives no progress output; long-running shortcuts look identical to hung ones — know the expected duration before running
+
+## Verification
+
+- After a run, check the expected side effect (output file exists, `--output-path` file is non-empty, stdout matches) instead of trusting exit code 0
+- `shortcuts list | grep -c .` confirms the CLI and iCloud sync are working at all

--- a/website/docs/user-guide/skills/bundled/apple/apple-apple-shortcuts.md
+++ b/website/docs/user-guide/skills/bundled/apple/apple-apple-shortcuts.md
@@ -49,7 +49,7 @@ Run the user's macOS Shortcuts from the `terminal` tool via the first-party `sho
 
 ```bash
 shortcuts list                          # all shortcut names, one per line
-shortcuts list --folders                # folder organization
+shortcuts list --folders                # folder names only
 shortcuts run "Shortcut Name"           # run by exact name (quote it)
 ```
 
@@ -77,7 +77,7 @@ Names are matched exactly, including spaces and emoji — always quote. Use `sho
 
 ### Hermes as an automation target
 
-Shortcuts **personal automations** (Focus change, arriving at a location, time of day, charger connected, NFC tag) can trigger Hermes with zero new code: add a "Send Message" action to the automation that messages the line the user's Hermes gateway listens on (iMessage or Telegram). Example: an automation on "Work Focus turned on" sends "I just started work focus — silence non-urgent alerts and give me today's agenda" to the Hermes number. The gateway treats it as a normal inbound message and the agent reacts. Set the automation to "Run Immediately" so it fires without confirmation.
+Shortcuts **personal automations** (Focus change, arriving at a location, time of day, charger connected, NFC tag — built in the Shortcuts app on the user's iPhone/iPad; macOS has no personal-automations surface) can trigger Hermes with zero new code: add a "Send Message" action to the automation that messages the line the user's Hermes gateway listens on (iMessage or Telegram). Example: an automation on "Work Focus turned on" sends "I just started work focus — silence non-urgent alerts and give me today's agenda" to the Hermes number. The gateway treats it as a normal inbound message and the agent reacts. Set the automation to "Run Immediately" so it fires without confirmation.
 
 ### Bridging missing capabilities
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -142,6 +142,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/bundled/apple/apple-apple-notes',
                     'user-guide/skills/bundled/apple/apple-apple-reminders',
+                    'user-guide/skills/bundled/apple/apple-apple-shortcuts',
                     'user-guide/skills/bundled/apple/apple-findmy',
                     'user-guide/skills/bundled/apple/apple-imessage',
                     'user-guide/skills/bundled/apple/apple-macos-computer-use',


### PR DESCRIPTION
## Summary
- New bundled skill `skills/apple/apple-shortcuts` — run macOS Shortcuts via the first-party `shortcuts` CLI (Footprint Ladder rung 2: CLI + skill; no core tools or toolset changes)
- Documents using Shortcuts personal automations as event triggers for a running Hermes gateway (Focus/arrival/time → message to the gateway's line)
- Structure tests at `tests/skills/test_apple_shortcuts_skill.py`; doc page generated via `website/scripts/generate-skill-docs.py`

## Manual verification (macOS 15)
- [x] `shortcuts list` returns shortcut names
- [ ] `shortcuts run` with stdin input produces expected stdout (pending — needs a user-chosen side-effect-free shortcut)
- [x] `scripts/run_tests.sh tests/skills/ -q` green (300 tests passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAtW1iwDZEGJ4VNjEGKDRV