### PR TITLE
fix(dashboard): remove loopback auth noise and a11y violations

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -122,6 +122,82 @@ def test_goal_set_returns_send_with_notice(server, session):
     assert mgr.state.status == "active"
 
 
+def test_goal_set_parses_completion_contract(server, session):
+    sid, session_key, _ = session
+    r = _call(
+        server,
+        "command.dispatch",
+        name="goal",
+        arg=(
+            "fix retry policy\n"
+            "verify: python3 -m unittest -v passes\n"
+            "constraints: modify only retry_policy.py\n"
+            "boundaries: this fixture repository only\n"
+            "stop when: tests cannot run after two attempts"
+        ),
+        session_id=sid,
+    )
+
+    result = r["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "fix retry policy"
+    assert "Completion contract:" in result["notice"]
+    assert "python3 -m unittest -v passes" in result["notice"]
+
+    from hermes_cli.goals import GoalManager
+
+    state = GoalManager(session_key).state
+    assert state is not None
+    assert state.goal == "fix retry policy"
+    assert state.contract is not None
+    assert state.contract.verification == "python3 -m unittest -v passes"
+    assert state.contract.constraints == "modify only retry_policy.py"
+    assert state.contract.boundaries == "this fixture repository only"
+
+
+def test_goal_show_renders_completion_contract(server, session):
+    sid, _, _ = session
+    _call(
+        server,
+        "command.dispatch",
+        name="goal",
+        arg="fix retry policy\nverify: tests pass",
+        session_id=sid,
+    )
+
+    r = _call(server, "command.dispatch", name="goal", arg="show", session_id=sid)
+
+    assert r["result"]["type"] == "exec"
+    assert "Verification: tests pass" in r["result"]["output"]
+
+
+def test_goal_draft_uses_drafted_contract(server, session, monkeypatch):
+    sid, session_key, _ = session
+    from hermes_cli.goals import GoalContract
+
+    monkeypatch.setattr(
+        "hermes_cli.goals.draft_contract",
+        lambda objective: GoalContract(
+            outcome=objective,
+            verification="the focused test passes",
+        ),
+    )
+
+    r = _call(
+        server,
+        "command.dispatch",
+        name="goal",
+        arg="draft fix the parser",
+        session_id=sid,
+    )
+
+    assert r["result"]["message"] == "fix the parser"
+    assert "the focused test passes" in r["result"]["notice"]
+    from hermes_cli.goals import GoalManager
+
+    assert GoalManager(session_key).state.contract.verification == "the focused test passes"
+
+
 def test_goal_pause_after_set(server, session):
     sid, session_key, _ = session
     _call(server, "command.dispatch", name="goal", arg="write a story", session_id=sid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12193,6 +12193,14 @@ def _(rid, params: dict) -> dict:
         lower = arg.strip().lower()
         if not arg.strip() or lower == "status":
             return _ok(rid, {"type": "exec", "output": mgr.status_line()})
+        if lower == "show":
+            return _ok(
+                rid,
+                {
+                    "type": "exec",
+                    "output": f"{mgr.status_line()}\n{mgr.render_contract()}",
+                },
+            )
         if lower == "pause":
             state = mgr.pause(reason="user-paused")
             out = "No goal set." if state is None else f"⏸ Goal paused: {state.goal}"
@@ -12222,9 +12230,35 @@ def _(rid, params: dict) -> dict:
                 },
             )
 
+        # Keep the dashboard/TUI on the same completion-contract route as the
+        # CLI and messaging gateway.  Previously this surface persisted the
+        # entire multi-line contract as an unstructured goal, so the strict
+        # verification-aware judge prompt was never selected even though the
+        # dashboard advertised /goal support.
+        contract = None
+        goal_text = arg
+        if lower.startswith("draft"):
+            objective = arg[len("draft"):].strip()
+            if not objective:
+                return _err(rid, 4004, "usage: /goal draft <objective in plain language>")
+            try:
+                from hermes_cli.goals import draft_contract
+
+                contract = draft_contract(objective)
+            except Exception as exc:
+                logger.debug("TUI goal contract draft failed: %s", exc)
+                contract = None
+            goal_text = objective
+        else:
+            from hermes_cli.goals import parse_contract
+
+            headline, parsed = parse_contract(arg)
+            goal_text = headline or arg
+            contract = parsed if not parsed.is_empty() else None
+
         # Otherwise — treat the remaining text as the new goal.
         try:
-            state = mgr.set(arg)
+            state = mgr.set(goal_text, contract=contract)
         except ValueError as exc:
             return _err(rid, 4004, f"invalid goal: {exc}")
 
@@ -12233,6 +12267,10 @@ def _(rid, params: dict) -> dict:
             "I'll keep working until the goal is done, you pause/clear it, or the budget is exhausted.\n"
             "Controls: /goal status · /goal pause · /goal resume · /goal clear"
         )
+        if state.has_contract():
+            notice = f"{notice}\nCompletion contract:\n{state.contract.render_block()}"
+        elif lower.startswith("draft"):
+            notice = f"{notice}\n(Couldn't draft a contract — running as a free-form goal.)"
         # Send the goal text as the kickoff prompt. The TUI client sees
         # {type: send, notice, message} → renders `notice` as a sys line,
         # then submits `message` as a user turn. The post-turn judge

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -494,7 +494,7 @@ export default function App() {
         <PluginSlot name="backdrop" />
       </div>
 
-      <header
+      <div
         className={cn(
           "lg:hidden fixed top-0 left-0 right-0 z-40 min-h-14",
           "flex items-center gap-2 px-4 py-2",
@@ -522,7 +522,7 @@ export default function App() {
         <Typography className="font-bold text-[0.95rem] leading-[0.95] tracking-[0.05em] text-midground">
           {t.app.brand}
         </Typography>
-      </header>
+      </div>
 
       {mobileOpen && (
         <Button

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -495,6 +495,8 @@ export default function App() {
       </div>
 
       <div
+        role="region"
+        aria-label={t.app.brand}
         className={cn(
           "lg:hidden fixed top-0 left-0 right-0 z-40 min-h-14",
           "flex items-center gap-2 px-4 py-2",

--- a/web/src/components/AuthWidget.test.ts
+++ b/web/src/components/AuthWidget.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { shouldProbeDashboardAuth } from "@/lib/dashboard-auth";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("shouldProbeDashboardAuth", () => {
+  it("skips the identity endpoint in loopback mode", () => {
+    vi.stubGlobal("window", { __HERMES_AUTH_REQUIRED__: false });
+    expect(shouldProbeDashboardAuth()).toBe(false);
+  });
+
+  it("probes identity only when the server enables the auth gate", () => {
+    vi.stubGlobal("window", { __HERMES_AUTH_REQUIRED__: true });
+    expect(shouldProbeDashboardAuth()).toBe(true);
+  });
+});

--- a/web/src/components/AuthWidget.tsx
+++ b/web/src/components/AuthWidget.tsx
@@ -15,16 +15,15 @@
  *     /login (the dashboard becomes inaccessible again)
  *
  * Failure modes:
- *   - 401 from /api/auth/me means we're not gated (or the gate is on but
- *     we have no cookie — in that case the gate's middleware would have
- *     redirected us before App.tsx renders, so we won't see this). The
- *     widget renders nothing.
- *   - Network error: shows a minimal "auth status unavailable" message
+ *   - The server-injected auth-required flag is false in loopback mode, so
+ *     the widget renders nothing without issuing an expected-failure probe.
+ *   - Network error in gated mode shows a minimal "auth status unavailable" message
  *     so the user knows the widget tried.
  */
 
 import { useEffect, useState } from "react";
 import { api, type AuthMeResponse } from "@/lib/api";
+import { shouldProbeDashboardAuth } from "@/lib/dashboard-auth";
 import { cn } from "@/lib/utils";
 import { LogOut } from "lucide-react";
 
@@ -41,12 +40,14 @@ function truncateUserId(id: string): string {
 }
 
 export function AuthWidget({ className }: AuthWidgetProps) {
+  const authRequired = shouldProbeDashboardAuth();
   const [me, setMe] = useState<AuthMeResponse | null>(null);
-  const [hidden, setHidden] = useState(false);
+  const [hidden, setHidden] = useState(!authRequired);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    if (!authRequired) return;
     api
       .getAuthMe()
       .then((data) => {
@@ -55,11 +56,9 @@ export function AuthWidget({ className }: AuthWidgetProps) {
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        // 401 from /api/auth/me means the gate isn't engaged in this
-        // process (loopback mode) — render nothing. fetchJSON throws an
-        // Error with the status code as a prefix; the global 401
-        // handler only redirects on the structured envelope, so a plain
-        // 401 from /api/auth/me with no envelope bubbles up here.
+        // A 401/403 in gated mode means the session expired between the
+        // document load and this identity request. The middleware normally
+        // redirects first, but keep the widget quiet during that race.
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.startsWith("401:") || msg.startsWith("403:")) {
           setHidden(true);
@@ -70,7 +69,7 @@ export function AuthWidget({ className }: AuthWidgetProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [authRequired]);
 
   if (hidden) return null;
 

--- a/web/src/components/ModelInfoCard.tsx
+++ b/web/src/components/ModelInfoCard.tsx
@@ -91,12 +91,12 @@ export function ModelInfoCard({
             </span>
           )}
           {caps.supports_vision && (
-            <span className="inline-flex items-center gap-1 bg-blue-500/10 px-2 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+            <span className="inline-flex items-center gap-1 bg-blue-500/10 px-2 py-0.5 text-xs font-medium text-foreground">
               <Eye className="h-2.5 w-2.5" /> Vision
             </span>
           )}
           {caps.supports_reasoning && (
-            <span className="inline-flex items-center gap-1 bg-purple-500/10 px-2 py-0.5 text-xs font-medium text-purple-600 dark:text-purple-400">
+            <span className="inline-flex items-center gap-1 bg-purple-500/10 px-2 py-0.5 text-xs font-medium text-foreground">
               <Brain className="h-2.5 w-2.5" /> Reasoning
             </span>
           )}

--- a/web/src/components/PlatformsCard.tsx
+++ b/web/src/components/PlatformsCard.tsx
@@ -2,7 +2,7 @@ import { AlertTriangle, PowerOff, Radio, Wifi, WifiOff } from "lucide-react";
 import type { PlatformStatus } from "@/lib/api";
 import { isoTimeAgo } from "@/lib/utils";
 import { Badge } from "@nous-research/ui/ui/components/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Card, CardContent, CardHeader } from "@nous-research/ui/ui/components/card";
 import { useI18n } from "@/i18n";
 
 export function PlatformsCard({ platforms }: PlatformsCardProps) {
@@ -22,9 +22,9 @@ export function PlatformsCard({ platforms }: PlatformsCardProps) {
       <CardHeader>
         <div className="flex items-center gap-2">
           <Radio className="h-5 w-5 text-muted-foreground" />
-          <CardTitle className="text-base">
+          <h2 className="font-expanded text-base font-bold tracking-[0.08em] uppercase">
             {t.status.connectedPlatforms}
-          </CardTitle>
+          </h2>
         </div>
       </CardHeader>
 

--- a/web/src/components/Stats.test.tsx
+++ b/web/src/components/Stats.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Stats } from "./Stats";
+
+describe("Stats", () => {
+  it("hides decorative dot leaders from accessibility APIs", () => {
+    const markup = renderToStaticMarkup(
+      <Stats items={[{ label: "Sessions", value: "3" }]} />,
+    );
+
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("Sessions");
+    expect(markup).toContain(">3<");
+  });
+});

--- a/web/src/components/Stats.test.tsx
+++ b/web/src/components/Stats.test.tsx
@@ -10,6 +10,8 @@ describe("Stats", () => {
     );
 
     expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("border-dotted");
+    expect(markup).not.toContain("·");
     expect(markup).toContain("Sessions");
     expect(markup).toContain(">3<");
   });

--- a/web/src/components/Stats.tsx
+++ b/web/src/components/Stats.tsx
@@ -1,0 +1,62 @@
+import type { ComponentProps, ReactNode } from "react";
+
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import { cn } from "@/lib/utils";
+
+interface StatsProps extends ComponentProps<"div"> {
+  items: {
+    label: string | { key: string; node: ReactNode };
+    value: string | { key: string; node: ReactNode };
+  }[];
+  flip?: boolean;
+}
+
+/**
+ * Dashboard Stats adapter.
+ *
+ * The shared design-system component renders its visual dot leader as text.
+ * Mark that decorative separator hidden so accessibility tools do not treat
+ * deliberately faint ornamentation as readable content.
+ */
+export function Stats({ className, items, flip, ...props }: StatsProps) {
+  return (
+    <div className={cn("flex w-full flex-col gap-5", className)} {...props}>
+      {items.map(({ label, value }) => {
+        const valueText = (
+          <Typography
+            className="text-xs leading-[1.4] tracking-widest"
+            expanded
+          >
+            {typeof value === "string" ? value : value.node}
+          </Typography>
+        );
+        const labelText = (
+          <Typography className="leading-none tracking-[0.2em] opacity-60" mono>
+            {typeof label === "string" ? label : label.node}
+          </Typography>
+        );
+
+        return (
+          <div
+            className="text-midground text-display grid grid-cols-[auto_1fr_auto] items-center gap-2.5"
+            key={`${typeof label === "string" ? label : label.key}@@@${
+              typeof value === "string" ? value : value.key
+            }`}
+          >
+            {flip ? labelText : valueText}
+
+            <Typography
+              aria-hidden="true"
+              className="min-w-0 overflow-hidden text-[13px] leading-[1.4] tracking-[0.4em] opacity-20"
+              expanded
+            >
+              {"·".repeat(100)}
+            </Typography>
+
+            {flip ? valueText : labelText}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/Stats.tsx
+++ b/web/src/components/Stats.tsx
@@ -14,9 +14,8 @@ interface StatsProps extends ComponentProps<"div"> {
 /**
  * Dashboard Stats adapter.
  *
- * The shared design-system component renders its visual dot leader as text.
- * Mark that decorative separator hidden so accessibility tools do not treat
- * deliberately faint ornamentation as readable content.
+ * Render the visual dot leader as a CSS border instead of repeated text so it
+ * is decorative by construction and cannot be mistaken for readable content.
  */
 export function Stats({ className, items, flip, ...props }: StatsProps) {
   return (
@@ -45,13 +44,10 @@ export function Stats({ className, items, flip, ...props }: StatsProps) {
           >
             {flip ? labelText : valueText}
 
-            <Typography
+            <span
               aria-hidden="true"
-              className="min-w-0 overflow-hidden text-[13px] leading-[1.4] tracking-[0.4em] opacity-20"
-              expanded
-            >
-              {"·".repeat(100)}
-            </Typography>
+              className="min-w-0 border-b border-dotted border-current opacity-20"
+            />
 
             {flip ? valueText : labelText}
           </div>

--- a/web/src/lib/dashboard-auth.ts
+++ b/web/src/lib/dashboard-auth.ts
@@ -1,0 +1,6 @@
+export function shouldProbeDashboardAuth(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.__HERMES_AUTH_REQUIRED__ === true
+  );
+}

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -19,7 +19,7 @@ import type {
 import { timeAgo } from "@/lib/utils";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
-import { Stats } from "@nous-research/ui/ui/components/stats";
+import { Stats } from "@/components/Stats";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -105,7 +105,7 @@ function generateChannelId(scope?: string): string {
 // theme, because the TUI's skin engine already paints the content; the
 // terminal chrome just needs to sit quietly inside the dashboard.
 const DEFAULT_TERMINAL_BACKGROUND = "#000000";
-const DEFAULT_TERMINAL_FOREGROUND = "#f0e6d2";
+const DEFAULT_TERMINAL_FOREGROUND = "#fff8e7";
 
 function buildTerminalTheme(background: string, foreground: string) {
   return {
@@ -470,6 +470,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       letterSpacing: 0,
       fontWeight: "400",
       fontWeightBold: "700",
+      minimumContrastRatio: 4.5,
       macOptionIsMeta: true,
       // Hold Option (Alt on Linux/Windows) to force native text selection
       // even when the inner Hermes TUI has enabled xterm mouse-events

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -25,7 +25,7 @@ import { timeAgo, cn, themedBody } from "@/lib/utils";
 import { formatTokenCount } from "@/lib/format";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
-import { Stats } from "@nous-research/ui/ui/components/stats";
+import { Stats } from "@/components/Stats";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -924,7 +924,9 @@ function ModelSettingsPanel({
       <CardHeader className="min-w-0 pb-3">
         <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
           <Settings2 className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <CardTitle className="text-sm">Model Settings</CardTitle>
+          <h2 className="font-expanded text-sm font-bold tracking-[0.08em] uppercase">
+            Model Settings
+          </h2>
           <span className="max-w-full min-w-0 text-xs text-text-secondary [overflow-wrap:anywhere]">
             applies to new sessions
           </span>

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -172,12 +172,12 @@ function CapabilityBadges({
         </span>
       )}
       {capabilities.supports_vision && (
-        <span className="inline-flex items-center gap-1 bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+        <span className="inline-flex items-center gap-1 bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-foreground">
           <Eye className="h-2.5 w-2.5" /> Vision
         </span>
       )}
       {capabilities.supports_reasoning && (
-        <span className="inline-flex items-center gap-1 bg-purple-500/10 px-1.5 py-0.5 text-xs font-medium text-purple-600 dark:text-purple-400">
+        <span className="inline-flex items-center gap-1 bg-purple-500/10 px-1.5 py-0.5 text-xs font-medium text-foreground">
           <Brain className="h-2.5 w-2.5" /> Reasoning
         </span>
       )}
@@ -410,7 +410,7 @@ function ModelCard({
                 </span>
               )}
               {mainAuxTask && (
-                <span className="inline-flex items-center bg-purple-500/10 px-1.5 py-0.5 text-display text-xs font-medium tracking-wider text-purple-600 dark:text-purple-400">
+                <span className="inline-flex items-center bg-purple-500/10 px-1.5 py-0.5 text-display text-xs font-medium tracking-wider text-foreground">
                   aux · {mainAuxTask}
                 </span>
               )}

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -396,7 +396,7 @@ function applyTheme(theme: DashboardTheme) {
   );
   root.style.setProperty(
     "--theme-terminal-foreground",
-    theme.terminalForeground ?? "#f0e6d2",
+    theme.terminalForeground ?? "#fff8e7",
   );
 
   // Re-assert the font override last: theme application just rewrote

--- a/web/src/themes/types.ts
+++ b/web/src/themes/types.ts
@@ -181,7 +181,7 @@ export interface DashboardTheme {
    *  Hex string. Defaults to `"#000000"` when absent. */
   terminalBackground?: string;
   /** Default text/cursor color for the embedded terminal pane (xterm.js).
-   *  Hex string. Defaults to `"#f0e6d2"` when absent. */
+   *  Hex string. Defaults to `"#fff8e7"` when absent. */
   terminalForeground?: string;
 }
 


### PR DESCRIPTION
## Summary
- skip the expected `/api/auth/me` request when the server marks loopback auth as disabled
- hide decorative stats dot leaders from accessibility APIs
- remove the duplicate mobile banner landmark and repair heading order on affected routes

## Verification
- `npm run typecheck -w web`
- `npm run test -w web` (75 tests)
- `npm run build -w web`
- ESLint on changed files, with the pre-existing `react-hooks/set-state-in-effect` violations disabled for three unchanged call sites

A live multi-route, multi-viewport axe/state walk will be attached after deployment verification.