### PR TITLE
feat(telegram): add reasoning and fast pickers

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2646,7 +2646,8 @@ class GatewaySlashCommandsMixin:
             /reasoning show|on               Show model reasoning in responses
             /reasoning hide|off              Hide model reasoning from responses
         """
-        from gateway.run import _hermes_home, _platform_config_key
+        from gateway.run import _hermes_home, _load_gateway_config, _platform_config_key
+        from gateway.display_config import resolve_display_setting
         import yaml
 
         raw_args = event.get_command_args().strip()
@@ -2657,7 +2658,19 @@ class GatewaySlashCommandsMixin:
         # reads — same fix as /model (#30479).
         _reasoning_source = await asyncio.to_thread(self._normalize_source_for_session_key, event.source)
         session_key = self._session_key_for_source(_reasoning_source)
-        self._show_reasoning = self._load_show_reasoning()
+        platform_key = _platform_config_key(_reasoning_source.platform)
+        try:
+            display_config = _load_gateway_config()
+        except Exception:
+            display_config = {}
+        self._show_reasoning = bool(
+            resolve_display_setting(
+                display_config,
+                platform_key,
+                "show_reasoning",
+                False,
+            )
+        )
         self._reasoning_config = self._resolve_session_reasoning_config(
             source=event.source,
             session_key=session_key,
@@ -2688,10 +2701,13 @@ class GatewaySlashCommandsMixin:
             rc = self._reasoning_config
             if rc is None:
                 level = t("gateway.reasoning.level_default")
+                picker_effort = "default"
             elif rc.get("enabled") is False:
                 level = t("gateway.reasoning.level_disabled")
+                picker_effort = "none"
             else:
                 level = rc.get("effort", "medium")
+                picker_effort = str(level)
             display_state = (
                 t("gateway.reasoning.display_on")
                 if self._show_reasoning
@@ -2703,6 +2719,55 @@ class GatewaySlashCommandsMixin:
                 if has_session_override
                 else t("gateway.reasoning.scope_global")
             )
+
+            adapter = self.adapters.get(_reasoning_source.platform)
+            send_picker = getattr(adapter, "send_reasoning_picker", None)
+            if _reasoning_source.chat_type == "dm" and callable(send_picker):
+                async def _on_reasoning_selected(_chat_id: str, selection: str) -> str:
+                    selected = str(selection or "").strip().lower()
+                    if selected in {"show", "on"}:
+                        self._show_reasoning = True
+                        _save_config_key(f"display.platforms.{platform_key}.show_reasoning", True)
+                        return t("gateway.reasoning.display_set_on", platform=platform_key)
+
+                    if selected in {"hide", "off"}:
+                        self._show_reasoning = False
+                        _save_config_key(f"display.platforms.{platform_key}.show_reasoning", False)
+                        return t("gateway.reasoning.display_set_off", platform=platform_key)
+
+                    if selected == "reset":
+                        self._set_session_reasoning_override(session_key, None)
+                        self._reasoning_config = self._load_reasoning_config()
+                        self._evict_cached_agent(session_key)
+                        return t("gateway.reasoning.reset_done")
+
+                    if selected == "none":
+                        parsed = {"enabled": False}
+                    elif selected in {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}:
+                        parsed = {"enabled": True, "effort": selected}
+                    else:
+                        return t("gateway.reasoning.unknown_arg", arg=selected)
+
+                    self._reasoning_config = parsed
+                    self._set_session_reasoning_override(session_key, parsed)
+                    self._evict_cached_agent(session_key)
+                    return t("gateway.reasoning.set_session", effort=selected)
+
+                metadata = self._thread_metadata_for_source(
+                    _reasoning_source,
+                    self._reply_anchor_for_event(event),
+                )
+                result = await send_picker(
+                    chat_id=_reasoning_source.chat_id,
+                    current_effort=picker_effort,
+                    display_enabled=bool(self._show_reasoning),
+                    session_key=session_key,
+                    on_reasoning_selected=_on_reasoning_selected,
+                    metadata=metadata,
+                )
+                if result.success:
+                    return None
+
             return t(
                 "gateway.reasoning.status",
                 level=level,
@@ -2711,7 +2776,6 @@ class GatewaySlashCommandsMixin:
             )
 
         # Display toggle (per-platform)
-        platform_key = _platform_config_key(event.source.platform)
         if args in {"show", "on"}:
             self._show_reasoning = True
             _save_config_key(f"display.platforms.{platform_key}.show_reasoning", True)
@@ -2893,6 +2957,48 @@ class GatewaySlashCommandsMixin:
             except Exception as e:
                 logger.error("Failed to save config key %s: %s", key_path, e)
                 return False
+
+        if not args:
+            adapter = self.adapters.get(event.source.platform)
+            send_picker = getattr(adapter, "send_fast_picker", None)
+            if event.source.chat_type == "dm" and callable(send_picker):
+                source = await asyncio.to_thread(
+                    self._normalize_source_for_session_key,
+                    event.source,
+                )
+                session_key = self._session_key_for_source(source)
+                current_mode = "fast" if self._service_tier == "priority" else "normal"
+
+                async def _on_fast_selected(_chat_id: str, selection: str) -> str:
+                    selected = str(selection or "").strip().lower()
+                    if selected in {"fast", "on"}:
+                        self._service_tier = "priority"
+                        saved_value = "fast"
+                        label = t("gateway.fast.label_fast")
+                    elif selected in {"normal", "off"}:
+                        self._service_tier = None
+                        saved_value = "normal"
+                        label = t("gateway.fast.label_normal")
+                    else:
+                        return t("gateway.fast.unknown_arg", arg=selected)
+
+                    if _save_config_key("agent.service_tier", saved_value):
+                        return t("gateway.fast.saved", label=label)
+                    return t("gateway.fast.session_only", label=label)
+
+                metadata = self._thread_metadata_for_source(
+                    source,
+                    self._reply_anchor_for_event(event),
+                )
+                result = await send_picker(
+                    chat_id=source.chat_id,
+                    current_mode=current_mode,
+                    session_key=session_key,
+                    on_fast_selected=_on_fast_selected,
+                    metadata=metadata,
+                )
+                if result.success:
+                    return None
 
         if not args or args == "status":
             status = t("gateway.fast.status_fast") if self._service_tier == "priority" else t("gateway.fast.status_normal")

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -16,6 +16,7 @@ import os
 import html as _html
 import re
 import threading
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -450,6 +451,8 @@ class TelegramAdapter(BasePlatformAdapter):
     _SPLIT_THRESHOLD = 4000
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
+    _SETTINGS_PICKER_TTL_SECONDS = 10 * 60
+    _SETTINGS_PICKER_MAX_ENTRIES = 128
 
     # Telegram's edit_message applies MarkdownV2 formatting only on the
     # finalize=True path.  Without this flag, stream_consumer._send_or_edit
@@ -643,6 +646,11 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
+        # Interactive /reasoning and /fast picker state per message. A chat can
+        # have multiple DM topics, so chat_id alone would let one topic's picker
+        # overwrite another's state.
+        self._reasoning_picker_state: Dict[tuple[str, int], dict] = {}
+        self._fast_picker_state: Dict[tuple[str, int], dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -4773,6 +4781,174 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    def _prune_settings_picker_state(
+        self,
+        state: Dict[tuple[str, int], dict],
+        *,
+        session_key: str,
+    ) -> None:
+        """Expire abandoned pickers and keep one active picker per session."""
+        now = time.monotonic()
+        stale_keys = [
+            key
+            for key, item in state.items()
+            if item.get("session_key") == session_key
+            or now - float(item.get("created_at", 0.0)) >= self._SETTINGS_PICKER_TTL_SECONDS
+        ]
+        for key in stale_keys:
+            state.pop(key, None)
+
+        overflow = len(state) - self._SETTINGS_PICKER_MAX_ENTRIES + 1
+        if overflow > 0:
+            oldest = sorted(
+                state,
+                key=lambda key: float(state[key].get("created_at", 0.0)),
+            )[:overflow]
+            for key in oldest:
+                state.pop(key, None)
+
+    async def send_reasoning_picker(
+        self,
+        chat_id: str,
+        current_effort: str,
+        display_enabled: bool,
+        session_key: str,
+        on_reasoning_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an inline-keyboard picker for /reasoning settings."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            effort = str(current_effort or "default")
+            display = "shown" if display_enabled else "hidden"
+            text = self.format_message(
+                (
+                    "🧠 *Reasoning Settings*\n\n"
+                    f"Current effort: `{effort}`\n"
+                    f"Reasoning display: `{display}`\n\n"
+                    "Effort buttons update this chat session; display buttons update Telegram. "
+                    "Use `/reasoning <level> --global` to persist effort globally."
+                )
+            )
+            keyboard = InlineKeyboardMarkup([
+                [
+                    InlineKeyboardButton("None", callback_data="rp:none"),
+                    InlineKeyboardButton("Minimal", callback_data="rp:minimal"),
+                    InlineKeyboardButton("Low", callback_data="rp:low"),
+                ],
+                [
+                    InlineKeyboardButton("Medium", callback_data="rp:medium"),
+                    InlineKeyboardButton("High", callback_data="rp:high"),
+                    InlineKeyboardButton("XHigh", callback_data="rp:xhigh"),
+                ],
+                [
+                    InlineKeyboardButton("Max", callback_data="rp:max"),
+                    InlineKeyboardButton("Ultra", callback_data="rp:ultra"),
+                ],
+                [
+                    InlineKeyboardButton("Show reasoning", callback_data="rp:show"),
+                    InlineKeyboardButton("Hide reasoning", callback_data="rp:hide"),
+                ],
+                [
+                    InlineKeyboardButton("Reset session", callback_data="rp:reset"),
+                    InlineKeyboardButton("✗ Cancel", callback_data="rp:cancel"),
+                ],
+            ])
+            thread_id = metadata.get("thread_id") if metadata else None
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                ),
+                **self._link_preview_kwargs(),
+            )
+            self._prune_settings_picker_state(
+                self._reasoning_picker_state,
+                session_key=session_key,
+            )
+            self._reasoning_picker_state[(str(chat_id), int(msg.message_id))] = {
+                "msg_id": msg.message_id,
+                "session_key": session_key,
+                "on_reasoning_selected": on_reasoning_selected,
+                "created_at": time.monotonic(),
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_reasoning_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_fast_picker(
+        self,
+        chat_id: str,
+        current_mode: str,
+        session_key: str,
+        on_fast_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an inline-keyboard picker for /fast mode."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            mode = str(current_mode or "normal")
+            text = self.format_message(
+                (
+                    "⚡ *Fast Mode*\n\n"
+                    f"Current mode: `{mode}`\n\n"
+                    "Fast uses OpenAI Priority Processing / Anthropic Fast Mode "
+                    "when the current model supports it. This setting applies gateway-wide."
+                )
+            )
+            keyboard = InlineKeyboardMarkup([
+                [
+                    InlineKeyboardButton("Normal", callback_data="fp:normal"),
+                    InlineKeyboardButton("Fast", callback_data="fp:fast"),
+                ],
+                [InlineKeyboardButton("✗ Cancel", callback_data="fp:cancel")],
+            ])
+            thread_id = metadata.get("thread_id") if metadata else None
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                ),
+                **self._link_preview_kwargs(),
+            )
+            self._prune_settings_picker_state(
+                self._fast_picker_state,
+                session_key=session_key,
+            )
+            self._fast_picker_state[(str(chat_id), int(msg.message_id))] = {
+                "msg_id": msg.message_id,
+                "session_key": session_key,
+                "on_fast_selected": on_fast_selected,
+                "created_at": time.monotonic(),
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_fast_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -5295,6 +5471,112 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    async def _handle_reasoning_picker_callback(
+        self, query, data: str, chat_id: str
+    ) -> None:
+        """Handle /reasoning picker callbacks (rp:<selection>)."""
+        message_id = getattr(getattr(query, "message", None), "message_id", None)
+        if message_id is None:
+            await query.answer(text="Picker expired — use /reasoning again.")
+            return
+        state_key = (chat_id, int(message_id))
+        state = self._reasoning_picker_state.pop(state_key, None)
+        if not state:
+            await query.answer(text="Picker expired — use /reasoning again.")
+            return
+
+        selection = data.split(":", 1)[1] if ":" in data else ""
+        if selection == "cancel":
+            await query.edit_message_text(
+                text="Reasoning selection cancelled.",
+                reply_markup=None,
+            )
+            await query.answer()
+            return
+
+        callback = state.get("on_reasoning_selected")
+        if not callback:
+            await query.answer(text="Picker expired.")
+            return
+
+        try:
+            result_text = await callback(chat_id, selection)
+            failed = False
+        except Exception as exc:
+            logger.error("Reasoning picker update failed: %s", exc)
+            result_text = "Failed to update reasoning settings. Please try again."
+            failed = True
+
+        try:
+            await query.edit_message_text(
+                text=self.format_message(str(result_text)),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=None,
+            )
+        except Exception:
+            try:
+                await query.edit_message_text(
+                    text=str(result_text),
+                    parse_mode=None,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+        await query.answer(text="Update failed." if failed else "Reasoning updated!")
+
+    async def _handle_fast_picker_callback(
+        self, query, data: str, chat_id: str
+    ) -> None:
+        """Handle /fast picker callbacks (fp:<normal|fast>)."""
+        message_id = getattr(getattr(query, "message", None), "message_id", None)
+        if message_id is None:
+            await query.answer(text="Picker expired — use /fast again.")
+            return
+        state_key = (chat_id, int(message_id))
+        state = self._fast_picker_state.pop(state_key, None)
+        if not state:
+            await query.answer(text="Picker expired — use /fast again.")
+            return
+
+        selection = data.split(":", 1)[1] if ":" in data else ""
+        if selection == "cancel":
+            await query.edit_message_text(
+                text="Fast mode selection cancelled.",
+                reply_markup=None,
+            )
+            await query.answer()
+            return
+
+        callback = state.get("on_fast_selected")
+        if not callback:
+            await query.answer(text="Picker expired.")
+            return
+
+        try:
+            result_text = await callback(chat_id, selection)
+            failed = False
+        except Exception as exc:
+            logger.error("Fast picker update failed: %s", exc)
+            result_text = "Failed to update fast mode. Please try again."
+            failed = True
+
+        try:
+            await query.edit_message_text(
+                text=self.format_message(str(result_text)),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=None,
+            )
+        except Exception:
+            try:
+                await query.edit_message_text(
+                    text=str(result_text),
+                    parse_mode=None,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+        await query.answer(text="Update failed." if failed else "Fast mode updated!")
+
     async def _notify_clarify_expired(self, query, user_display: str) -> None:
         """Tell the user a clarify tap arrived too late to be delivered.
 
@@ -5334,6 +5616,19 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Reasoning/Fast settings picker callbacks ---
+        if data.startswith("rp:"):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_reasoning_picker_callback(query, data, chat_id)
+            return
+
+        if data.startswith("fp:"):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_fast_picker_callback(query, data, chat_id)
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):

--- a/tests/gateway/test_telegram_reasoning_fast_picker.py
+++ b/tests/gateway/test_telegram_reasoning_fast_picker.py
@@ -1,0 +1,327 @@
+"""Tests for Telegram inline-keyboard /reasoning and /fast pickers."""
+
+import sys
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+import gateway.run as gateway_run
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+class _RecordingButton:
+    def __init__(self, text, callback_data=None, **_kwargs):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class _RecordingMarkup:
+    def __init__(self, rows):
+        self.inline_keyboard = rows
+
+
+def _callback_data(markup):
+    return [button.callback_data for row in markup.inline_keyboard for button in row]
+
+
+def test_send_reasoning_picker_renders_effort_buttons(monkeypatch):
+    import plugins.platforms.telegram.adapter as tg
+
+    monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=101))
+    callback = AsyncMock()
+
+    result = asyncio.run(adapter.send_reasoning_picker(
+        chat_id="12345",
+        current_effort="medium",
+        display_enabled=False,
+        session_key="sk1",
+        on_reasoning_selected=callback,
+    ))
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.call_args[1]
+    assert "Reasoning" in kwargs["text"]
+    data = _callback_data(kwargs["reply_markup"])
+    assert "rp:none" in data
+    assert "rp:medium" in data
+    assert "rp:high" in data
+    assert "rp:xhigh" in data
+    assert "rp:max" in data
+    assert "rp:ultra" in data
+    assert "rp:show" in data
+    assert "rp:reset" in data
+    assert adapter._reasoning_picker_state[("12345", 101)]["session_key"] == "sk1"
+
+
+def test_reasoning_picker_state_does_not_collide_within_chat(monkeypatch):
+    import plugins.platforms.telegram.adapter as tg
+
+    monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(side_effect=[
+        SimpleNamespace(message_id=101),
+        SimpleNamespace(message_id=102),
+    ])
+
+    for session_key in ("topic-a", "topic-b"):
+        asyncio.run(adapter.send_reasoning_picker(
+            chat_id="12345",
+            current_effort="medium",
+            display_enabled=False,
+            session_key=session_key,
+            on_reasoning_selected=AsyncMock(),
+        ))
+
+    assert adapter._reasoning_picker_state[("12345", 101)]["session_key"] == "topic-a"
+    assert adapter._reasoning_picker_state[("12345", 102)]["session_key"] == "topic-b"
+
+
+def test_reasoning_picker_prunes_expired_and_superseded_state(monkeypatch):
+    import plugins.platforms.telegram.adapter as tg
+
+    adapter = _make_adapter()
+    adapter._reasoning_picker_state = {
+        ("12345", 100): {"session_key": "same-session", "created_at": 995.0},
+        ("12345", 101): {"session_key": "expired-session", "created_at": 0.0},
+        ("12345", 102): {"session_key": "active-session", "created_at": 999.0},
+    }
+    monkeypatch.setattr(tg.time, "monotonic", lambda: 1000.0)
+
+    adapter._prune_settings_picker_state(
+        adapter._reasoning_picker_state,
+        session_key="same-session",
+    )
+
+    assert set(adapter._reasoning_picker_state) == {("12345", 102)}
+
+
+def test_reasoning_picker_callback_invokes_selection_and_clears_state():
+    adapter = _make_adapter()
+    callback = AsyncMock(return_value="Reasoning effort set to high.")
+    adapter._reasoning_picker_state[("12345", 101)] = {
+        "session_key": "sk1",
+        "on_reasoning_selected": callback,
+    }
+
+    query = AsyncMock()
+    query.data = "rp:high"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_id = 101
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    asyncio.run(adapter._handle_reasoning_picker_callback(query, "rp:high", "12345"))
+
+    callback.assert_awaited_once_with("12345", "high")
+    query.edit_message_text.assert_awaited()
+    assert "Reasoning effort set to high" in query.edit_message_text.call_args[1]["text"]
+    assert ("12345", 101) not in adapter._reasoning_picker_state
+
+
+def test_reasoning_picker_callback_is_single_use():
+    adapter = _make_adapter()
+    callback = AsyncMock(return_value="Reasoning effort set to high.")
+    adapter._reasoning_picker_state[("12345", 101)] = {
+        "session_key": "sk1",
+        "on_reasoning_selected": callback,
+    }
+
+    query = AsyncMock()
+    query.message = MagicMock(chat_id=12345, message_id=101)
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    asyncio.run(adapter._handle_reasoning_picker_callback(query, "rp:high", "12345"))
+    asyncio.run(adapter._handle_reasoning_picker_callback(query, "rp:low", "12345"))
+
+    callback.assert_awaited_once_with("12345", "high")
+    assert "Picker expired" in query.answer.await_args_list[-1].kwargs["text"]
+
+
+def test_send_fast_picker_renders_mode_buttons(monkeypatch):
+    import plugins.platforms.telegram.adapter as tg
+
+    monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=102))
+    callback = AsyncMock()
+
+    result = asyncio.run(adapter.send_fast_picker(
+        chat_id="12345",
+        current_mode="normal",
+        session_key="sk1",
+        on_fast_selected=callback,
+    ))
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.call_args[1]
+    assert "Fast Mode" in kwargs["text"]
+    data = _callback_data(kwargs["reply_markup"])
+    assert "fp:normal" in data
+    assert "fp:fast" in data
+    assert "fp:cancel" in data
+    assert adapter._fast_picker_state[("12345", 102)]["session_key"] == "sk1"
+
+
+def test_fast_picker_callback_invokes_selection_and_clears_state():
+    adapter = _make_adapter()
+    callback = AsyncMock(return_value="Fast mode set to FAST.")
+    adapter._fast_picker_state[("12345", 102)] = {
+        "session_key": "sk1",
+        "on_fast_selected": callback,
+    }
+
+    query = AsyncMock()
+    query.data = "fp:fast"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_id = 102
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    asyncio.run(adapter._handle_fast_picker_callback(query, "fp:fast", "12345"))
+
+    callback.assert_awaited_once_with("12345", "fast")
+    query.edit_message_text.assert_awaited()
+    assert "Fast mode set to FAST" in query.edit_message_text.call_args[1]["text"]
+    assert ("12345", 102) not in adapter._fast_picker_state
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_reasoning_overrides = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._reasoning_config = {"enabled": True, "effort": "medium"}
+    runner._service_tier = None
+    runner._show_reasoning = False
+    runner._session_db = None
+    runner.config = SimpleNamespace(group_sessions_per_user=True, thread_sessions_per_user=False)
+    runner.session_store = None
+    return runner
+
+
+def test_reasoning_command_without_args_sends_telegram_picker(monkeypatch, tmp_path):
+    runner = _make_runner()
+    adapter = SimpleNamespace(send_reasoning_picker=AsyncMock(return_value=SimpleNamespace(success=True)))
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "show_reasoning": False,
+                "platforms": {"telegram": {"show_reasoning": True}},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_reasoning_config",
+        lambda source=None, session_key=None: {"enabled": True, "effort": "medium"},
+    )
+
+    response = asyncio.run(runner._handle_reasoning_command(_make_event("/reasoning")))
+
+    assert response is None
+    adapter.send_reasoning_picker.assert_awaited_once()
+    kwargs = adapter.send_reasoning_picker.call_args.kwargs
+    assert kwargs["chat_id"] == "12345"
+    assert kwargs["current_effort"] == "medium"
+    assert kwargs["display_enabled"] is True
+
+    callback = kwargs["on_reasoning_selected"]
+    for effort in ("max", "ultra"):
+        result = asyncio.run(callback("12345", effort))
+        assert effort in result
+        assert runner._reasoning_config == {"enabled": True, "effort": effort}
+
+
+def test_fast_command_without_args_sends_telegram_picker(monkeypatch, tmp_path):
+    runner = _make_runner()
+    adapter = SimpleNamespace(send_fast_picker=AsyncMock(return_value=SimpleNamespace(success=True)))
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(runner, "_load_service_tier", lambda: "priority")
+    to_thread_calls = []
+
+    async def _record_to_thread(func, *args):
+        to_thread_calls.append(func)
+        return func(*args)
+
+    monkeypatch.setattr(asyncio, "to_thread", _record_to_thread)
+
+    response = asyncio.run(runner._handle_fast_command(_make_event("/fast")))
+
+    assert response is None
+    adapter.send_fast_picker.assert_awaited_once()
+    kwargs = adapter.send_fast_picker.call_args.kwargs
+    assert kwargs["chat_id"] == "12345"
+    assert kwargs["current_mode"] == "fast"
+    assert runner._normalize_source_for_session_key in to_thread_calls

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1126,6 +1126,13 @@ The current model and provider are displayed at the top. All navigation happens 
 If you know the exact model name, type `/model <name>` directly to skip the picker. You can also type `/model <name> --global` to persist the change across sessions.
 :::
 
+## Interactive Reasoning and Fast Pickers
+
+In Telegram DMs, sending `/reasoning` or `/fast` with no arguments opens an
+inline keyboard. Reasoning effort is session-scoped unless `--global` is used;
+fast mode applies gateway-wide. Typed forms such as `/reasoning high --global`
+and `/fast normal` remain available when you want to set a value directly.
+
 ## DNS-over-HTTPS Fallback IPs
 
 In some restricted networks, `api.telegram.org` may resolve to an IP that is unreachable. The Telegram adapter includes a **fallback IP** mechanism that transparently retries connections against alternative IPs while preserving the correct TLS hostname and SNI.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
@@ -1046,6 +1046,13 @@ gateway:
 如果你知道确切的模型名称，直接输入 `/model <name>` 跳过选择器。你也可以输入 `/model <name> --global` 跨会话持久化更改。
 :::
 
+## 交互式推理与快速模式选择器
+
+在 Telegram 私聊中，不带参数发送 `/reasoning` 或 `/fast` 会打开内联键盘。
+推理强度默认为当前会话生效（除非使用 `--global`），快速模式则作用于整个
+gateway。若要直接设置，也可以继续使用 `/reasoning high --global`、
+`/fast normal` 等带参数命令。
+
 ## DNS-over-HTTPS 备用 IP
 
 在某些受限网络中，`api.telegram.org` 可能解析到无法访问的 IP。Telegram 适配器包含一个**备用 IP** 机制，在保留正确 TLS 主机名和 SNI 的同时，透明地对备用 IP 重试连接。


### PR DESCRIPTION
## What does this PR do?

Adds Telegram inline-keyboard pickers for bare `/reasoning` and `/fast` commands, matching the existing interactive `/model` experience. Reasoning effort remains session-scoped by default, while fast mode remains gateway-wide. Typed command arguments are unchanged and continue to provide the stable fallback path.

The pickers are limited to Telegram DMs. Picker state is keyed by `(chat_id, message_id)` so concurrent topics in the same private chat cannot overwrite each other.

## Related Issue

Fixes #61110

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add inline buttons for reasoning effort, reasoning display, session reset, and cancellation.
- Add inline buttons for normal/fast service tier selection and cancellation.
- Route `rp:` and `fp:` callback data before model-picker callbacks.
- Keep typed `/reasoning ...` and `/fast ...` behavior intact as fallbacks.
- Preserve Telegram topic/reply metadata when sending picker messages.
- Isolate callback state by message to support multiple DM topics safely.
- Expire abandoned picker state, cap retained entries, and claim callbacks before awaiting.
- Resolve the effective per-platform reasoning display setting and keep `/fast` source normalization off the event loop.
- Return generic user-facing errors while retaining detailed exceptions in logs.
- Document the Telegram DM picker behavior in English and Simplified Chinese.

## How to Test

1. Run `pytest tests/gateway/test_telegram_reasoning_fast_picker.py tests/gateway/test_fast_command.py tests/gateway/test_reasoning_command.py tests/gateway/test_telegram_model_picker.py -q -o 'addopts='`.
2. In a Telegram DM, run `/reasoning` and select an effort or display option.
3. Run `/fast` and select normal or fast mode.
4. Verify typed forms such as `/reasoning high` and `/fast normal` still work.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature.
- [ ] I've run the complete `pytest tests/ -q` suite.
- [x] I've added tests for my changes.
- [x] I've tested the focused gateway suites on macOS.

### Documentation & Housekeeping

- [x] Updated the Telegram messaging guide and Simplified Chinese translation.
- [x] `cli-config.yaml.example`: N/A; no config keys added.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture workflow changed.
- [x] Cross-platform impact considered; the feature is Telegram adapter behavior.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Not included; tests use synthetic IDs and no user chat data.
