### PR TITLE
fix: harden text tool calls and truncation retries

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2391,6 +2391,13 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if not tool_name:
         return None
 
+    # Some models emit the generic lowercase name ``shell`` for Hermes' native
+    # command runner.  Alias only that exact observed spelling, and only when
+    # the actual ``terminal`` tool is registered.  Do not map to a nonexistent
+    # ``bash`` tool or broaden this to casing/fuzzy variants.
+    if tool_name == "shell" and "terminal" in agent.valid_tool_names:
+        return "terminal"
+
     # VolcEngine api/plan workaround (issue #33007): the endpoint's
     # protocol-translation layer occasionally leaks raw XML attribute
     # fragments into tool_use.name, e.g.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -37,6 +37,7 @@ from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
+    promote_text_tool_call,
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
     _sanitize_messages_surrogates,
@@ -1641,6 +1642,12 @@ def run_conversation(
                     _finish_result = _cc_fr.normalize_response(response)
                     finish_reason = _finish_result.finish_reason
                     assistant_message = _finish_result
+                    if promote_text_tool_call(assistant_message):
+                        # A complete validated call is safe to execute even
+                        # when a provider reports ``length`` after emitting the
+                        # closing wrapper.  Incomplete JSON never promotes.
+                        if finish_reason == "length":
+                            finish_reason = "stop"
                     if agent._should_treat_stop_as_truncated(
                         finish_reason,
                         assistant_message,
@@ -1966,7 +1973,7 @@ def run_conversation(
                             _is_stub_stall = (
                                 getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                             )
-                            if truncated_tool_call_retries < 4:
+                            if truncated_tool_call_retries < 1:
                                 truncated_tool_call_retries += 1
                                 if _is_stub_stall:
                                     # The stream broke mid tool-call (network /
@@ -1974,26 +1981,25 @@ def run_conversation(
                                     # cap — say so instead of "max output tokens".
                                     agent._buffer_vprint(
                                         f"⚠️  Stream interrupted mid tool-call — "
-                                        f"retrying ({truncated_tool_call_retries}/4)..."
+                                        f"retrying ({truncated_tool_call_retries}/1)..."
                                     )
                                 else:
                                     agent._buffer_vprint(
                                         f"⚠️  Truncated tool call detected — "
                                         f"retrying API call "
-                                        f"({truncated_tool_call_retries}/4)..."
+                                        f"({truncated_tool_call_retries}/1)..."
                                     )
-                                # Boost max_tokens on each retry so the model has
-                                # more room to complete the tool-call JSON. A
-                                # network stall doesn't need a bigger budget, but
-                                # a genuine output-cap truncation does, and the
-                                # boost is harmless for the stall case.
-                                _tc_boost_base = agent.max_tokens if agent.max_tokens else 4096
-                                _tc_boost = _tc_boost_base * (2 ** truncated_tool_call_retries)
-                                _tc_requested_cap = agent._requested_output_cap_from_api_kwargs(api_kwargs)
-                                if _tc_requested_cap is not None:
-                                    _tc_boost = max(_tc_boost, _tc_requested_cap)
-                                _tc_boost_cap = max(32768, _tc_requested_cap or 0)
-                                agent._ephemeral_max_output_tokens = min(_tc_boost, _tc_boost_cap)
+                                # Escalate max_tokens exactly once for a real
+                                # output-cap truncation. A network stream stall
+                                # retries once at the existing token budget.
+                                if not _is_stub_stall:
+                                    _tc_boost_base = agent.max_tokens if agent.max_tokens else 4096
+                                    _tc_boost = _tc_boost_base * 2
+                                    _tc_requested_cap = agent._requested_output_cap_from_api_kwargs(api_kwargs)
+                                    if _tc_requested_cap is not None:
+                                        _tc_boost = max(_tc_boost, _tc_requested_cap)
+                                    _tc_boost_cap = max(32768, _tc_requested_cap or 0)
+                                    agent._ephemeral_max_output_tokens = min(_tc_boost, _tc_boost_cap)
                                 # Don't append the broken response to messages;
                                 # just re-run the same API call from the current
                                 # message state, giving the model another chance.
@@ -2001,7 +2007,7 @@ def run_conversation(
                             agent._flush_status_buffer()
                             if _is_stub_stall:
                                 agent._vprint(
-                                    f"{agent.log_prefix}⚠️  Stream kept dropping mid tool-call after 4 retries — the action was not executed.",
+                                    f"{agent.log_prefix}⚠️  Stream dropped mid tool-call again after one retry — the action was not executed.",
                                     force=True,
                                 )
                             else:
@@ -2024,6 +2030,7 @@ def run_conversation(
                                 "completed": False,
                                 "partial": True,
                                 "error": _final_response,
+                                "ungraded_error": True,
                             }
 
                     # If we have prior messages, roll back to last complete state
@@ -4286,6 +4293,8 @@ def run_conversation(
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
+            if promote_text_tool_call(assistant_message) and finish_reason == "length":
+                finish_reason = "stop"
             
             # Normalize content to string — some OpenAI-compatible servers
             # (llama-server, etc.) return content as a dict or list instead

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -14,9 +14,11 @@ re-exports from ``run_agent`` remain in place so existing imports
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
+from types import SimpleNamespace
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -26,6 +28,81 @@ logger = logging.getLogger(__name__)
 # below as well as by run_agent and the CLI for paste-from-clipboard
 # scrubbing.
 _SURROGATE_RE = re.compile(r'[\ud800-\udfff]')
+_TOOL_CALL_WRAPPER_RE = re.compile(
+    r"\A\s*<tool_call>(?P<payload>.*?)</tool_call>\s*\Z",
+    re.DOTALL,
+)
+
+
+def validate_tool_call_json(content: str) -> tuple[bool, dict[str, Any] | None, str | None]:
+    """Validate one model-emitted tool-call object, optionally XML-wrapped.
+
+    Some OpenAI-compatible models serialize a tool call into assistant text as
+    ``<tool_call>{...}</tool_call>``.  Only a single, complete outer wrapper
+    (or a bare JSON object) is accepted.  Prose, nested/multiple wrappers, and
+    non-object arguments fail closed rather than being repaired heuristically.
+    """
+    if not isinstance(content, str) or not content.strip():
+        return False, None, "tool call content must be a non-empty string"
+
+    stripped = content.strip()
+    wrapper_match = _TOOL_CALL_WRAPPER_RE.fullmatch(content)
+    if wrapper_match is not None:
+        payload = wrapper_match.group("payload").strip()
+        if "<tool_call>" in payload or "</tool_call>" in payload:
+            return False, None, "nested or multiple tool_call wrappers are not allowed"
+    elif "<tool_call>" in stripped or "</tool_call>" in stripped:
+        return False, None, "tool_call wrapper must contain the entire response"
+    else:
+        payload = stripped
+
+    try:
+        parsed = json.loads(payload)
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        return False, None, f"invalid tool call JSON: {exc}"
+
+    if not isinstance(parsed, dict):
+        return False, None, "tool call JSON must be an object"
+    name = parsed.get("name")
+    if not isinstance(name, str) or not name or name != name.strip():
+        return False, None, "tool call name must be a non-empty, unpadded string"
+    if not isinstance(parsed.get("arguments"), dict):
+        return False, None, "tool call arguments must be an object"
+    return True, parsed, None
+
+
+def is_tool_call_exemplar(content: str) -> bool:
+    """Return whether *content* is one complete validated tool-call object."""
+    valid, _, _ = validate_tool_call_json(content)
+    return valid
+
+
+def promote_text_tool_call(message: Any) -> bool:
+    """Promote one validated text exemplar to an OpenAI-style tool call.
+
+    Returns ``False`` without mutation when the message already contains tool
+    calls or its content is not one complete validated exemplar.
+    """
+    if getattr(message, "tool_calls", None):
+        return False
+    content = getattr(message, "content", None)
+    valid, parsed, _ = validate_tool_call_json(content)
+    if not valid or parsed is None:
+        return False
+
+    arguments = json.dumps(parsed["arguments"], separators=(",", ":"))
+    digest = hashlib.sha256(
+        f'{parsed["name"]}\0{arguments}'.encode("utf-8")
+    ).hexdigest()[:24]
+    message.tool_calls = [
+        SimpleNamespace(
+            id=f"call_text_{digest}",
+            type="function",
+            function=SimpleNamespace(name=parsed["name"], arguments=arguments),
+        )
+    ]
+    message.content = ""
+    return True
 
 
 def _sanitize_surrogates(text: str) -> str:
@@ -474,4 +551,7 @@ __all__ = [
     "_sanitize_tools_non_ascii",
     "_strip_images_from_messages",
     "_sanitize_structure_non_ascii",
+    "validate_tool_call_json",
+    "is_tool_call_exemplar",
+    "promote_text_tool_call",
 ]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5148,8 +5148,7 @@ class TestRunConversation:
 
     def test_truncated_tool_call_retries_once_before_refusing(self, agent):
         """When tool call args are truncated, the agent retries the API call
-        (up to 3 times). If a retry succeeds (valid JSON args), tool execution
-        proceeds."""
+        once. If that retry succeeds, tool execution proceeds."""
         self._setup_agent(agent)
         agent.valid_tool_names.add("write_file")
         bad_tc = _mock_tool_call(
@@ -5186,11 +5185,38 @@ class TestRunConversation:
         mock_hfc.assert_called_once()
         assert result["final_response"] == "Done!"
 
-    def test_stub_stall_mid_tool_call_recovers_within_3_retries(self, agent):
+    def test_truncated_tool_call_stops_ungraded_after_one_retry(self, agent):
+        self._setup_agent(agent)
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        truncated = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc],
+        )
+        agent.client.chat.completions.create.side_effect = [truncated, truncated]
+
+        with (
+            patch("run_agent.handle_function_call") as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("write the report")
+
+        assert agent.client.chat.completions.create.call_count == 2
+        first_kwargs, retry_kwargs = [
+            call.kwargs for call in agent.client.chat.completions.create.call_args_list
+        ]
+        assert first_kwargs.get("max_tokens") is None
+        assert retry_kwargs["max_tokens"] == 8192
+        assert result["ungraded_error"] is True
+        mock_hfc.assert_not_called()
+
+    def test_stub_stall_mid_tool_call_stops_after_one_retry(self, agent):
         """A network stream stall mid tool-call (PARTIAL_STREAM_STUB_ID) must
-        retry up to 3 times rather than hard-failing after one — and recover
-        if a retry produces a complete tool call. Regression for the false
-        'model hit max output tokens' on Opus when the stream simply dropped."""
+        retry once without burning four attempts."""
         from hermes_constants import PARTIAL_STREAM_STUB_ID
 
         self._setup_agent(agent)
@@ -5200,18 +5226,37 @@ class TestRunConversation:
             arguments='{"path":"report.md","content":"partial',
             call_id="c1",
         )
-        # Two consecutive stub-stall responses, then a clean tool call.
+        # Two consecutive stub-stall responses terminate without execution.
         stall1 = _mock_response(content="", finish_reason="length", tool_calls=[bad_tc])
         stall1.id = PARTIAL_STREAM_STUB_ID
         stall2 = _mock_response(content="", finish_reason="length", tool_calls=[bad_tc])
         stall2.id = PARTIAL_STREAM_STUB_ID
-        good_tc = _mock_tool_call(
-            name="write_file",
-            arguments='{"path":"report.md","content":"full content"}',
-            call_id="c2",
+        with (
+            patch("run_agent.handle_function_call") as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.client.chat.completions.create.side_effect = [stall1, stall2]
+            result = agent.run_conversation("write the report")
+
+        assert agent.client.chat.completions.create.call_count == 2
+        first_kwargs, retry_kwargs = [
+            call.kwargs for call in agent.client.chat.completions.create.call_args_list
+        ]
+        assert retry_kwargs.get("max_tokens") == first_kwargs.get("max_tokens")
+        assert result["ungraded_error"] is True
+        mock_hfc.assert_not_called()
+
+    def test_complete_wrapped_shell_call_executes_registered_terminal(self, agent):
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("terminal")
+        wrapped = _mock_response(
+            content='<tool_call>{"name":"shell","arguments":{"command":"pwd"}}</tool_call>',
+            finish_reason="length",
         )
-        good_resp = _mock_response(content="", finish_reason="stop", tool_calls=[good_tc])
         final_resp = _mock_response(content="Done!", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [wrapped, final_resp]
 
         with (
             patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
@@ -5219,14 +5264,11 @@ class TestRunConversation:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
-            agent.client.chat.completions.create.side_effect = [
-                stall1, stall2, good_resp, final_resp,
-            ]
-            result = agent.run_conversation("write the report")
+            result = agent.run_conversation("show the directory")
 
-        # Recovered on the 3rd attempt instead of refusing after the 1st.
-        mock_hfc.assert_called_once()
+        assert result["api_calls"] == 2
         assert result["final_response"] == "Done!"
+        assert mock_hfc.call_args.args[0] == "terminal"
 
     def test_truncated_tool_args_detected_when_finish_reason_not_length(self, agent):
         """When a router rewrites finish_reason from 'length' to 'tool_calls',

--- a/tests/run_agent/test_tool_call_boundary_hardening.py
+++ b/tests/run_agent/test_tool_call_boundary_hardening.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.message_sanitization import (
+    is_tool_call_exemplar,
+    promote_text_tool_call,
+    validate_tool_call_json,
+)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '<tool_call>{"name":"terminal","arguments":{"command":"pwd"}}</tool_call>',
+        '  <tool_call>\n{"name":"terminal","arguments":{"command":"pwd"}}\n</tool_call>  ',
+        '{"name":"terminal","arguments":{"command":"pwd"}}',
+    ],
+)
+def test_validate_tool_call_json_accepts_one_complete_object(payload: str) -> None:
+    valid, parsed, error = validate_tool_call_json(payload)
+
+    assert valid is True
+    assert parsed == {"name": "terminal", "arguments": {"command": "pwd"}}
+    assert error is None
+    assert is_tool_call_exemplar(payload) is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        'prefix <tool_call>{"name":"terminal","arguments":{}}</tool_call>',
+        '<tool_call>{"name":"terminal","arguments":{}}</tool_call> suffix',
+        '<tool_call>{"name":"terminal","arguments":{}}</tool_call>'
+        '<tool_call>{"name":"terminal","arguments":{}}</tool_call>',
+        '<tool_call><tool_call>{"name":"terminal","arguments":{}}</tool_call></tool_call>',
+        '<tool_call>{"name":"terminal","arguments":"{}"}</tool_call>',
+        '<tool_call>{"name":" terminal ","arguments":{}}</tool_call>',
+    ],
+)
+def test_validate_tool_call_json_rejects_ambiguous_or_unsafe_wrappers(
+    payload: str,
+) -> None:
+    valid, parsed, error = validate_tool_call_json(payload)
+
+    assert valid is False
+    assert parsed is None
+    assert error
+    assert is_tool_call_exemplar(payload) is False
+
+
+def _repair(tool_names: set[str], emitted_name: str) -> str | None:
+    from run_agent import AIAgent
+
+    stub = SimpleNamespace(valid_tool_names=tool_names)
+    repair = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+    return repair(emitted_name)
+
+
+def test_exact_shell_alias_resolves_to_registered_terminal() -> None:
+    assert _repair({"terminal", "read_file"}, "shell") == "terminal"
+
+
+def test_shell_alias_is_case_sensitive_and_fails_closed_without_terminal() -> None:
+    assert _repair({"terminal", "read_file"}, "Shell") is None
+    assert _repair({"bash", "read_file"}, "shell") is None
+
+
+def test_promote_text_tool_call_builds_structured_call() -> None:
+    message = SimpleNamespace(
+        content='<tool_call>{"name":"shell","arguments":{"command":"pwd"}}</tool_call>',
+        tool_calls=None,
+    )
+
+    assert promote_text_tool_call(message) is True
+    assert message.content == ""
+    assert len(message.tool_calls) == 1
+    assert message.tool_calls[0].type == "function"
+    assert message.tool_calls[0].function.name == "shell"
+    assert message.tool_calls[0].function.arguments == '{"command":"pwd"}'
+
+
+def test_promote_text_tool_call_does_not_override_or_parse_prose() -> None:
+    existing = [SimpleNamespace(id="existing")]
+    message = SimpleNamespace(
+        content='prefix <tool_call>{"name":"shell","arguments":{}}</tool_call>',
+        tool_calls=existing,
+    )
+
+    assert promote_text_tool_call(message) is False
+    assert message.tool_calls is existing


### PR DESCRIPTION
## Summary
- validate and promote exactly one complete bare or XML-wrapped tool-call object
- map exact lowercase `shell` to Hermes' registered `terminal` tool, failing closed when unavailable
- retry incomplete tool calls once, escalating max tokens only for a genuine output cap, then return an explicit ungraded error

## Safety
- rejects prose, nested/multiple wrappers, malformed JSON, padded names, and non-object arguments
- never executes incomplete tool arguments
- preserves existing structured tool-call validation and registered-tool checks

## Verification
- targeted regressions: 48 passed
- full run_agent suite: 464 passed, 2 environment failures reproduced unchanged on upstream main (optional `agent.copilot_acp_client` and `openai` modules absent)
- ruff check: passed
- git diff --check: passed

Hydra task-12231. Source-only PR: no install, deploy, or service restart performed. Live CHIMI currently runs /opt/hermes/venv Hermes 0.18.1 while coordinator IaC and pipx custody pins diverge; deployment requires a separate IaC reconciliation after merge/release.