### PR TITLE
fix(gateway): query owning systemd manager for drain timing

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -342,12 +342,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    user_manager = False
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
                 # systemd cgroup line ends with the unit name
                 if ".service" in line:
+                    # User units live below user.slice/user@<uid>.service and
+                    # must be queried through the per-user manager.  System
+                    # units live below system.slice.  Do not probe both:
+                    # ``systemctl --user show missing.service`` exits 0 and
+                    # reports the manager's default TimeoutStopUSec, which can
+                    # produce a false mismatch for a real system unit.
+                    user_manager = "/user.slice/" in line
                     parts = line.strip().split("/")
                     for p in reversed(parts):
                         if p.endswith(".service"):
@@ -360,33 +368,38 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Query only the manager that owns the cgroup and require a loaded unit.
+    # systemctl's successful response for an unknown unit includes manager
+    # defaults, so return None unless LoadState confirms this exact unit.
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
-        try:
-            result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
-                capture_output=True, text=True, timeout=2.0,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-            continue
-        if result.returncode != 0:
-            continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
-        for line in result.stdout.splitlines():
-            if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                # Try numeric microseconds first
-                if value.isdigit():
-                    timeout_us = int(value)
-                else:
-                    timeout_us = _parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
-        if timeout_us is not None:
-            break
+    flag = ["--user"] if user_manager else []
+    try:
+        result = subprocess.run(
+            [
+                "systemctl", *flag, "show", unit_name,
+                "--property=LoadState", "--property=TimeoutStopUSec",
+            ],
+            capture_output=True, text=True, timeout=2.0,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    properties = {}
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            properties[key] = value.strip()
+    if properties.get("LoadState") != "loaded":
+        return None
+
+    # Value is typically "1min 30s" or a numeric count of microseconds.
+    value = properties.get("TimeoutStopUSec", "")
+    if value.isdigit():
+        timeout_us = int(value)
+    else:
+        timeout_us = _parse_systemd_duration_to_us(value)
 
     if timeout_us is None:
         return None

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -248,3 +248,64 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    @staticmethod
+    def _mock_cgroup_and_systemctl(monkeypatch, cgroup, stdout):
+        import builtins
+        import io
+
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/cgroup":
+                return io.StringIO(cgroup)
+            return real_open(path, *args, **kwargs)
+
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            return sf.subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        return calls
+
+    def test_system_unit_queries_only_system_manager(self, monkeypatch):
+        calls = self._mock_cgroup_and_systemctl(
+            monkeypatch,
+            "0::/system.slice/hermes-gateway.service\n",
+            "LoadState=loaded\nTimeoutStopUSec=3min 30s\n",
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["mismatch"] is False
+        assert calls == [[
+            "systemctl", "show", "hermes-gateway.service",
+            "--property=LoadState", "--property=TimeoutStopUSec",
+        ]]
+
+    def test_user_unit_queries_only_user_manager(self, monkeypatch):
+        calls = self._mock_cgroup_and_systemctl(
+            monkeypatch,
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service\n",
+            "LoadState=loaded\nTimeoutStopUSec=3min 30s\n",
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["mismatch"] is False
+        assert calls[0][1] == "--user"
+
+    def test_unknown_unit_manager_defaults_are_ignored(self, monkeypatch):
+        self._mock_cgroup_and_systemctl(
+            monkeypatch,
+            "0::/system.slice/hermes-gateway.service\n",
+            "LoadState=not-found\nTimeoutStopUSec=1min 30s\n",
+        )
+
+        assert sf.check_systemd_timing_alignment(180.0) is None


### PR DESCRIPTION
## Summary
- infer the owning systemd manager from the gateway cgroup
- query only that manager and require `LoadState=loaded`
- ignore manager defaults returned for nonexistent units

## Why
`systemctl --user show missing.service` exits successfully and reports the user manager default `TimeoutStopUSec`. A gateway running as a system unit was therefore warned that its stop timeout was 90 seconds even though its loaded system unit correctly used 210 seconds.

## Test plan
- `PYTHONPATH=. python -m pytest tests/gateway/test_shutdown_forensics.py -q` (33 passed)
- regression coverage for system units, user units, and `LoadState=not-found`