### PR TITLE
fix(acp): honor approvals.timeout config in ACP edit approval prompt (#63302)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1422,10 +1422,17 @@ class HermesACPAgent(acp.Agent):
             try:
                 from acp_adapter.edit_approval import make_acp_edit_approval_requester
 
+                from hermes_cli.config import load_config
+                _acp_cfg = load_config()
+                _edit_timeout = float(
+                    _acp_cfg.get("approvals", {}).get("timeout", 60)
+                )
+
                 edit_approval_requester = make_acp_edit_approval_requester(
                     conn.request_permission,
                     loop,
                     session_id,
+                    timeout=_edit_timeout,
                     auto_approve_getter=lambda: self._edit_approval_policy_for_state(state),
                 )
             except Exception:


### PR DESCRIPTION
Fixes #63302

The ACP edit approval prompt hardcodes a 60-second timeout instead of reading the `approvals.timeout` config key, which is already documented as the approval timeout and respected by the dangerous-command approval path.

**Change:** Read `approvals.timeout` from the config and pass it as the `timeout` parameter to `make_acp_edit_approval_requester`. Falls back to 60 if the key is unset, preserving existing behavior by default.