### PR TITLE
fix(auth): add User-Agent header to PyJWKClient to avoid Cloudflare WAF blocks (#63273)

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -420,6 +420,7 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
                 self._jwks_url,
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={"User-Agent": "HermesAgent/1.0"},
             )
         return self._jwks_client
 

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -601,6 +601,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 disco["jwks_uri"],
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={"User-Agent": "HermesAgent/1.0"},
             )
         return self._jwks_client
 


### PR DESCRIPTION
Fixes #63273

The `SelfHostedOIDCProvider._get_jwks_client()` method creates `PyJWKClient` without any request headers, causing Cloudflare/WAF to block the JWKS fetch (urllib's default fingerprint is often rejected).

PyJWT 2.13+ supports a `headers` parameter on `PyJWKClient.__init__`. Pass `{"User-Agent": "HermesAgent/1.0"}` so the JWKS request uses a recognizable User-Agent string that passes common WAF policies.

Also applied the same fix to the nous dashboard auth provider for consistency.