### PR TITLE
fix(gemini): decouple reasoning effort from thought-summary visibility

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1997,7 +1997,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         )
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
             if agent.reasoning_config is not None:
-                summary_extra_body["reasoning"] = agent.reasoning_config
+                # Drop the Hermes-internal include_thoughts visibility key —
+                # it belongs to Gemini/Vertex thinking_config, not the
+                # OpenRouter-style reasoning object this endpoint receives.
+                summary_extra_body["reasoning"] = {
+                    k: v
+                    for k, v in agent.reasoning_config.items()
+                    if k != "include_thoughts"
+                }
             else:
                 summary_extra_body["reasoning"] = {
                     "enabled": True,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -58,7 +58,17 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if effort == "none":
         return {"includeThoughts": False}
 
-    thinking_config: Dict[str, Any] = {"includeThoughts": True}
+    # Visibility is independent of effort: ``include_thoughts`` only controls
+    # whether Gemini RETURNS thought summaries, never whether it thinks.
+    # The gateway/CLI resolve display.show_reasoning (incl. per-platform
+    # overrides and /reasoning show|hide) into this key before the request is
+    # built. Absent key = legacy behavior (summaries requested) so callers
+    # that don't resolve visibility keep working unchanged.
+    include_thoughts = reasoning_config.get("include_thoughts")
+    if not isinstance(include_thoughts, bool):
+        include_thoughts = True
+
+    thinking_config: Dict[str, Any] = {"includeThoughts": include_thoughts}
 
     # Gemini 2.5 accepts thinkingBudget; don't guess a budget from Hermes'
     # coarse effort levels. ``includeThoughts`` alone is enough to surface
@@ -86,6 +96,34 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
             )
 
     return thinking_config
+
+
+def _gemini_thought_tag_marker(raw_thinking_config: dict | None) -> str | None:
+    """Return the ``extra_body.google.thought_tag_marker`` value for a request.
+
+    Google's OpenAI-compat surface (Vertex and generativelanguage /openai)
+    returns thought summaries as PLAIN TEXT inside ``message.content`` when
+    ``include_thoughts`` is on — with no delimiter at all unless
+    ``thought_tag_marker`` is set ("If not specified, no tags will be
+    returned around the model's thoughts", Vertex OpenAI-compat docs).
+    Untagged summaries are indistinguishable from the final answer, so they
+    leaked to users verbatim (#gemini-reasoning-leak).
+
+    Emitting the marker makes the compat layer wrap summaries in
+    ``<think>…</think>`` — the exact tag every downstream stage already
+    understands: ``extract_reasoning`` captures it into ``msg["reasoning"]``,
+    ``strip_think_blocks`` removes it at the storage boundary, and the
+    stream consumer suppresses it live. The endpoint also strips the tags
+    from replayed context itself, so history stays clean.
+
+    Only meaningful when thoughts are requested; the native REST path marks
+    thought parts structurally (``part.thought``) and needs no marker.
+    """
+    if not isinstance(raw_thinking_config, dict):
+        return None
+    if raw_thinking_config.get("includeThoughts") is not True:
+        return None
+    return "think"
 
 
 def _snake_case_gemini_thinking_config(config: dict | None) -> dict | None:
@@ -491,6 +529,9 @@ class ChatCompletionsTransport(ProviderTransport):
                     openai_compat_extra = extra_body.get("extra_body", {})
                     google_extra = openai_compat_extra.get("google", {})
                     google_extra["thinking_config"] = thinking_config
+                    _tag_marker = _gemini_thought_tag_marker(raw_thinking_config)
+                    if _tag_marker:
+                        google_extra["thought_tag_marker"] = _tag_marker
                     openai_compat_extra["google"] = google_extra
                     extra_body["extra_body"] = openai_compat_extra
             elif raw_thinking_config:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1238,6 +1238,13 @@ display:
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.
+  #
+  # VISIBILITY ONLY — independent of agent.reasoning_effort. Hiding reasoning
+  # never disables the model's internal thinking; you can run high effort and
+  # still receive only the final answer. On Gemini/Vertex this maps directly
+  # onto thinking_config: reasoning_effort -> thinking_level (or budget) and
+  # show_reasoning -> include_thoughts, so hidden thought summaries are never
+  # returned by the API at all (not just filtered client-side).
   #   true:  Show the reasoning box
   #   false: Hide reasoning (default)
   show_reasoning: false

--- a/cli.py
+++ b/cli.py
@@ -3994,6 +3994,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # shared chokepoint in hermes_constants (Closes #21256).
         from hermes_constants import resolve_reasoning_config
         self.reasoning_config = resolve_reasoning_config(CLI_CONFIG, self.model)
+        # Reasoning visibility rides alongside effort: Gemini/Vertex map
+        # include_thoughts onto thinking_config so hidden reasoning is never
+        # returned in content. Effort itself is untouched — /reasoning hide
+        # does NOT disable model thinking.
+        if self.reasoning_config is not None:
+            self.reasoning_config = {
+                **self.reasoning_config,
+                "include_thoughts": bool(self.show_reasoning),
+            }
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
         )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1788,6 +1788,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
+        if reasoning_config is not None:
+            # Reasoning visibility (display.show_reasoning) is independent of
+            # effort — Gemini/Vertex map include_thoughts onto thinking_config
+            # so hidden thought summaries are never returned in content.
+            reasoning_config = {
+                **reasoning_config,
+                "include_thoughts": GatewayRunner._load_show_reasoning(),
+            }
         model = _resolve_gateway_model()
 
         # When the primary provider's auth fails (expired token / 429 quota

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5229,6 +5229,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 value_tokens.append(token)
         return " ".join(value_tokens).strip().lower(), persist_global
 
+    def _resolve_reasoning_visibility(self, source: Optional[SessionSource] = None) -> bool:
+        """Effective show_reasoning for *source*'s platform, resolved per turn.
+
+        Mirrors the response-side display gate (per-platform
+        display.platforms.<plat>.show_reasoning override, Mattermost
+        platform-only opt-in, global display.show_reasoning fallback) so the
+        REQUEST already encodes visibility: Gemini/Vertex map it onto
+        ``thinking_config.include_thoughts`` and never return thought
+        summaries the display layer would have to hide. Reads config.yaml
+        each call so ``/reasoning show|hide`` (which persists the platform
+        override without evicting cached agents) takes effect on the very
+        next turn.
+        """
+        default = bool(getattr(self, "_show_reasoning", False))
+        if source is None:
+            return default
+        try:
+            return _resolve_gateway_display_bool(
+                _load_gateway_config(),
+                _platform_config_key(source.platform),
+                "show_reasoning",
+                default=default,
+                platform=source.platform,
+                require_platform_override_for={Platform.MATTERMOST},
+            )
+        except Exception:
+            return False if source.platform == Platform.MATTERMOST else default
+
     def _resolve_session_reasoning_config(
         self,
         *,
@@ -5244,6 +5272,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *effective* model (session ``/model`` override included) so
         per-model overrides track what the session actually runs — when
         empty, the config's ``model.default`` is used.
+
+        The returned config also carries ``include_thoughts`` — the resolved
+        reasoning VISIBILITY for this platform. Effort (how hard the model
+        thinks) and visibility (whether thought summaries are returned/shown)
+        are independent controls; see _resolve_reasoning_visibility.
         """
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
@@ -5254,8 +5287,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         overrides = getattr(self, "_session_reasoning_overrides", {}) or {}
         if resolved_session_key and resolved_session_key in overrides:
-            return overrides[resolved_session_key]
-        return self._load_reasoning_config(model)
+            config = overrides[resolved_session_key]
+        else:
+            config = self._load_reasoning_config(model)
+        if config is None:
+            return None
+        # Copy before annotating — the session-override dict must not
+        # accumulate turn-scoped visibility state.
+        return {**config, "include_thoughts": self._resolve_reasoning_visibility(source)}
 
     def _set_session_reasoning_override(
         self,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2510,6 +2510,24 @@ class CLICommandsMixin:
         else:
             _cprint("  Failed to save timestamps setting to config.yaml")
 
+    def _sync_reasoning_visibility(self):
+        """Propagate show_reasoning into reasoning_config.include_thoughts.
+
+        Effort and visibility are independent: include_thoughts only tells
+        Gemini/Vertex whether to RETURN thought summaries (thinking_config),
+        never how hard to think. Updating the live agent too means
+        /reasoning show|hide takes effect on the very next request without
+        re-initializing the agent.
+        """
+        if self.reasoning_config is None:
+            return
+        self.reasoning_config = {
+            **self.reasoning_config,
+            "include_thoughts": bool(self.show_reasoning),
+        }
+        if self.agent:
+            self.agent.reasoning_config = self.reasoning_config
+
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.
 
@@ -2556,6 +2574,7 @@ class CLICommandsMixin:
         # Display toggle
         if arg in {"show", "on"}:
             self.show_reasoning = True
+            self._sync_reasoning_visibility()
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
             save_config_value("display.show_reasoning", True)
@@ -2564,10 +2583,12 @@ class CLICommandsMixin:
             return
         if arg in {"hide", "off"}:
             self.show_reasoning = False
+            self._sync_reasoning_visibility()
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
             save_config_value("display.show_reasoning", False)
             _cprint(f"  {_ACCENT}✓ Reasoning display: OFF (saved){_RST}")
+            _cprint(f"  {_DIM}  Model reasoning stays ON at the current effort — only the display is hidden.{_RST}")
             return
 
         # Full / clamped recap toggle
@@ -2595,6 +2616,7 @@ class CLICommandsMixin:
             return
 
         self.reasoning_config = parsed
+        self._sync_reasoning_visibility()
         self.agent = None  # Force agent re-init with new reasoning config
 
         if explicit_global and save_config_value("agent.reasoning_effort", arg):

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -26,6 +26,7 @@ class GeminiProfile(ProviderProfile):
         """
         from agent.transports.chat_completions import (
             _build_gemini_thinking_config,
+            _gemini_thought_tag_marker,
             _is_gemini_openai_compat_base_url,
             _snake_case_gemini_thinking_config,
         )
@@ -42,7 +43,15 @@ class GeminiProfile(ProviderProfile):
         if self.name == "gemini" and _is_gemini_openai_compat_base_url(base_url):
             thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
             if thinking_config:
-                body["extra_body"] = {"google": {"thinking_config": thinking_config}}
+                google: dict[str, Any] = {"thinking_config": thinking_config}
+                # Compat surface returns thought summaries as untagged
+                # message.content text unless the marker is set — see
+                # _gemini_thought_tag_marker. Native path (else branch)
+                # marks thought parts structurally and needs no marker.
+                tag_marker = _gemini_thought_tag_marker(raw_thinking_config)
+                if tag_marker:
+                    google["thought_tag_marker"] = tag_marker
+                body["extra_body"] = {"google": google}
         else:
             body["thinking_config"] = raw_thinking_config
         return body

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -31,6 +31,10 @@ class NousProfile(ProviderProfile):
         if supports_reasoning:
             if reasoning_config is not None:
                 rc = dict(reasoning_config)
+                # include_thoughts is Hermes-internal reasoning VISIBILITY
+                # (consumed by Gemini/Vertex thinking_config); it is not part
+                # of the OpenRouter-style reasoning schema this endpoint takes.
+                rc.pop("include_thoughts", None)
                 if rc.get("enabled") is False:
                     pass  # Nous omits reasoning when disabled
                 else:

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -155,7 +155,12 @@ class OpenRouterProfile(ProviderProfile):
                 if cfg.get("enabled", True) is not False and effort and effort != "none":
                     top_level["verbosity"] = effort
             elif reasoning_config is not None:
-                extra_body["reasoning"] = dict(reasoning_config)
+                rc = dict(reasoning_config)
+                # include_thoughts is Hermes-internal reasoning VISIBILITY
+                # (consumed by Gemini/Vertex thinking_config); OpenRouter's
+                # reasoning schema doesn't know it — don't send it.
+                rc.pop("include_thoughts", None)
+                extra_body["reasoning"] = rc
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 

--- a/plugins/model-providers/vertex/__init__.py
+++ b/plugins/model-providers/vertex/__init__.py
@@ -34,6 +34,7 @@ class VertexProfile(ProviderProfile):
         """
         from agent.transports.chat_completions import (
             _build_gemini_thinking_config,
+            _gemini_thought_tag_marker,
             _snake_case_gemini_thinking_config,
         )
 
@@ -47,7 +48,15 @@ class VertexProfile(ProviderProfile):
         thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
         if not thinking_config:
             return {}
-        return {"extra_body": {"google": {"thinking_config": thinking_config}}}
+        google: dict[str, Any] = {"thinking_config": thinking_config}
+        # When thought summaries ARE requested (display on), have Vertex wrap
+        # them in <think> tags — without the marker the compat layer splices
+        # them into message.content as plain text indistinguishable from the
+        # answer, which is how reasoning leaked to users with display off.
+        tag_marker = _gemini_thought_tag_marker(raw_thinking_config)
+        if tag_marker:
+            google["thought_tag_marker"] = tag_marker
+        return {"extra_body": {"google": google}}
 
     def fetch_models(
         self,

--- a/tests/agent/transports/test_gemini_reasoning_visibility.py
+++ b/tests/agent/transports/test_gemini_reasoning_visibility.py
@@ -1,0 +1,336 @@
+"""Reasoning effort vs. reasoning VISIBILITY separation for Gemini/Vertex.
+
+Regression tests for the Gemini thought-summary leak: with
+``display.show_reasoning: false`` (and every platform override off), Hermes
+still asked Vertex for thought summaries (``include_thoughts: true`` was
+hardcoded whenever thinking was enabled) and Vertex's OpenAI-compat surface
+returned them as UNTAGGED plain text inside ``message.content`` — so users
+saw blocks like::
+
+    **Recalling User Details**
+    I'm recalling...
+
+before (or instead of) the actual answer, and no display gate could catch
+them.
+
+The fix has two halves:
+
+* Request: ``reasoning_config["include_thoughts"]`` (resolved from
+  display.show_reasoning / per-platform overrides / ``/reasoning show|hide``)
+  maps onto ``thinking_config.include_thoughts`` — independent of
+  ``thinking_level``, which still comes from ``agent.reasoning_effort``.
+* Response (display ON only): ``extra_body.google.thought_tag_marker`` makes
+  the compat layer wrap summaries in ``<think>`` tags so the existing
+  structured pipeline (extract_reasoning → msg["reasoning"],
+  strip_think_blocks at the storage boundary, stream-consumer suppression)
+  handles them — no natural-language heuristics.
+"""
+
+import pytest
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+from providers import get_provider_profile
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.chat_completions  # noqa: F401
+    return get_transport("chat_completions")
+
+
+def _vertex_kwargs(transport, reasoning_config, model="google/gemini-3.1-pro-preview"):
+    profile = get_provider_profile("vertex")
+    return transport.build_kwargs(
+        model=model,
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=[],
+        reasoning_config=reasoning_config,
+        supports_reasoning=True,
+        provider_profile=profile,
+        provider_name="vertex",
+        base_url="https://aiplatform.googleapis.com/v1beta1/projects/p/locations/global/endpoints/openapi",
+    )
+
+
+def _google_extra(kw):
+    return kw["extra_body"]["extra_body"]["google"]
+
+
+class TestVertexRequestVisibility:
+    """Request-body assertions for the Vertex OpenAI-compat surface."""
+
+    def test_medium_effort_display_off_keeps_thinking_hides_thoughts(self, transport):
+        kw = _vertex_kwargs(
+            transport,
+            {"enabled": True, "effort": "medium", "include_thoughts": False},
+        )
+        google = _google_extra(kw)
+        # Thinking stays ON at the effort-mapped level (medium → low for
+        # Gemini 3.x Pro); only the summary return is suppressed.
+        assert google["thinking_config"] == {
+            "include_thoughts": False,
+            "thinking_level": "low",
+        }
+        # No tags needed when no thoughts are returned.
+        assert "thought_tag_marker" not in google
+
+    def test_high_effort_display_off_preserves_high_level(self, transport):
+        kw = _vertex_kwargs(
+            transport,
+            {"enabled": True, "effort": "high", "include_thoughts": False},
+        )
+        assert _google_extra(kw)["thinking_config"] == {
+            "include_thoughts": False,
+            "thinking_level": "high",
+        }
+
+    def test_display_on_requests_thoughts_with_tag_marker(self, transport):
+        kw = _vertex_kwargs(
+            transport,
+            {"enabled": True, "effort": "medium", "include_thoughts": True},
+        )
+        google = _google_extra(kw)
+        assert google["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "low",
+        }
+        # Structured separation: without the marker the compat layer returns
+        # summaries as untagged content text (Vertex docs: "If not specified,
+        # no tags will be returned around the model's thoughts").
+        assert google["thought_tag_marker"] == "think"
+
+    def test_missing_visibility_key_keeps_legacy_behavior(self, transport):
+        """Callers that don't resolve visibility (old configs, third-party
+        embedders) keep the pre-fix request shape."""
+        kw = _vertex_kwargs(transport, {"enabled": True, "effort": "medium"})
+        google = _google_extra(kw)
+        assert google["thinking_config"]["include_thoughts"] is True
+        assert google["thought_tag_marker"] == "think"
+
+    def test_reasoning_disabled_still_omits_thoughts(self, transport):
+        kw = _vertex_kwargs(
+            transport, {"enabled": False, "include_thoughts": True}
+        )
+        assert _google_extra(kw)["thinking_config"] == {"include_thoughts": False}
+
+    def test_visibility_does_not_leak_into_openrouter_reasoning(self, transport):
+        """Non-Gemini providers must not receive the Hermes-internal key."""
+        profile = get_provider_profile("openrouter")
+        kw = transport.build_kwargs(
+            model="deepseek/deepseek-r1",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "high", "include_thoughts": False},
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="openrouter",
+            base_url=profile.base_url,
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
+
+    def test_visibility_does_not_leak_into_nous_reasoning(self, transport):
+        profile = get_provider_profile("nous")
+        kw = transport.build_kwargs(
+            model="hermes-4-405b",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "medium", "include_thoughts": False},
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="nous",
+            base_url=profile.base_url,
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "medium"}
+
+
+class TestGeminiProviderVisibility:
+    """The AI-Studio ``gemini`` profile shares the same builders."""
+
+    def _kwargs(self, transport, reasoning_config, base_url):
+        profile = get_provider_profile("gemini")
+        return transport.build_kwargs(
+            model="gemini-3.1-pro-preview",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config=reasoning_config,
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="gemini",
+            base_url=base_url,
+        )
+
+    def test_openai_compat_display_off(self, transport):
+        kw = self._kwargs(
+            transport,
+            {"enabled": True, "effort": "high", "include_thoughts": False},
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        )
+        google = kw["extra_body"]["extra_body"]["google"]
+        assert google["thinking_config"] == {
+            "include_thoughts": False,
+            "thinking_level": "high",
+        }
+        assert "thought_tag_marker" not in google
+
+    def test_openai_compat_display_on_adds_marker(self, transport):
+        kw = self._kwargs(
+            transport,
+            {"enabled": True, "effort": "high", "include_thoughts": True},
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        )
+        google = kw["extra_body"]["extra_body"]["google"]
+        assert google["thinking_config"]["include_thoughts"] is True
+        assert google["thought_tag_marker"] == "think"
+
+    def test_native_path_display_off_no_marker_key(self, transport):
+        """The native REST client marks thought parts structurally
+        (``part.thought``); it gets includeThoughts=False and never a marker."""
+        kw = self._kwargs(
+            transport,
+            {"enabled": True, "effort": "medium", "include_thoughts": False},
+            "https://generativelanguage.googleapis.com/v1beta",
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": False,
+            "thinkingLevel": "low",
+        }
+        assert "thought_tag_marker" not in kw["extra_body"]
+
+
+class TestThoughtSignaturesUnaffected:
+    """Hiding summaries must not break Gemini tool-call signature replay."""
+
+    def test_normalize_response_preserves_tool_call_signature(self, transport):
+        tc = SimpleNamespace(
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name="t", arguments="{}"),
+            extra_content={"google": {"thought_signature": "SIG_999"}},
+        )
+        msg = SimpleNamespace(content=None, tool_calls=[tc], reasoning=None)
+        resp = SimpleNamespace(
+            choices=[SimpleNamespace(message=msg, finish_reason="tool_calls")],
+            usage=None,
+        )
+        norm = transport.normalize_response(resp)
+        assert norm.tool_calls[0].provider_data == {
+            "extra_content": {"google": {"thought_signature": "SIG_999"}}
+        }
+
+    def test_convert_messages_replays_signature_for_gemini_target(self, transport):
+        msgs = [{
+            "role": "assistant", "content": "ok",
+            "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "extra_content": {"google": {"thought_signature": "SIG_999"}},
+                "function": {"name": "t", "arguments": "{}"},
+            }],
+        }]
+        out = transport.convert_messages(msgs, model="google/gemini-3.1-pro-preview")
+        assert out[0]["tool_calls"][0]["extra_content"] == {
+            "google": {"thought_signature": "SIG_999"}
+        }
+
+
+# ── Response-side regression fixture ─────────────────────────────────────
+# What the leak looked like in production: repeated near-identical summary
+# blocks. With thought_tag_marker set, the compat layer wraps each in
+# <think> tags — the structured signal the pipeline keys on.
+_TAGGED_SUMMARIES = (
+    "<think>**Recalling User Details**\nI'm recalling...</think>"
+    "<think>**Synthesizing User Data**\nI'm synthesizing...</think>"
+)
+_LEGIT_ANSWER = (
+    "**Victor Chun**\n\nVictor is a Berkeley student who builds AI systems.\n\n"
+    "**Highlights**\n- NutriScan\n- RushOS"
+)
+
+
+class _FakeAgent:
+    """Minimal agent stub for build_assistant_message."""
+    verbose_logging = False
+    reasoning_callback = None
+    stream_delta_callback = None
+    _stream_callback = None
+
+    def _extract_reasoning(self, assistant_message):
+        from agent.agent_runtime_helpers import extract_reasoning
+        return extract_reasoning(self, assistant_message)
+
+    def _strip_think_blocks(self, content):
+        from agent.agent_runtime_helpers import strip_think_blocks
+        return strip_think_blocks(self, content)
+
+
+class TestThoughtContentSeparation:
+    def _build(self, content):
+        from agent.chat_completion_helpers import build_assistant_message
+        msg = SimpleNamespace(
+            content=content, tool_calls=None,
+            reasoning=None, reasoning_content=None, reasoning_details=None,
+        )
+        return build_assistant_message(_FakeAgent(), msg, "stop")
+
+    def test_tagged_summaries_removed_from_content_captured_once_as_reasoning(self):
+        built = self._build(_TAGGED_SUMMARIES + _LEGIT_ANSWER)
+        # Structured thought content is gone from user-visible content …
+        assert "Recalling User Details" not in built["content"]
+        assert "Synthesizing User Data" not in built["content"]
+        # … the legitimate bold-markdown answer is untouched …
+        assert built["content"] == _LEGIT_ANSWER
+        # … and the reasoning is captured exactly once for the display gate.
+        assert built["reasoning"].count("Recalling User Details") == 1
+        assert built["reasoning"].count("Synthesizing User Data") == 1
+
+    def test_untagged_bold_paragraphs_are_never_stripped(self):
+        """Guard against natural-language heuristics: a legitimate answer that
+        *looks* like a thought summary (leading bold headers) must survive
+        verbatim when there is no structured thought marker."""
+        lookalike = (
+            "**Crafting Victor's Description**\n\n"
+            "Here is the requested description, formatted as asked.\n\n"
+            + _LEGIT_ANSWER
+        )
+        built = self._build(lookalike)
+        assert built["content"] == lookalike
+        assert built["reasoning"] is None
+
+    def test_reasoning_only_content_yields_empty_visible_text(self):
+        """Dozens of summaries with no answer → nothing user-visible leaks;
+        the loop's empty-response recovery takes over instead."""
+        many = "".join(
+            f"<think>**Recalling User Details {i}**\nI'm recalling...</think>"
+            for i in range(24)
+        )
+        built = self._build(many)
+        assert built["content"].strip() == ""
+        assert "Recalling User Details 0" in built["reasoning"]
+
+
+class TestStreamingSuppression:
+    """Streaming path: tagged summaries never reach the platform buffer."""
+
+    def _consumer(self):
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+        return GatewayStreamConsumer(
+            adapter=SimpleNamespace(),
+            chat_id="c1",
+            config=StreamConsumerConfig(),
+        )
+
+    def test_tagged_summary_fixture_suppressed_mid_stream(self):
+        c = self._consumer()
+        c._filter_and_accumulate(
+            "<think>**Recalling User Details**\nI'm recalling...</think>"
+        )
+        c._filter_and_accumulate(_LEGIT_ANSWER)
+        assert "Recalling User Details" not in c._accumulated
+        assert c._accumulated == _LEGIT_ANSWER
+
+    def test_tag_split_across_deltas_still_suppressed(self):
+        c = self._consumer()
+        for delta in ("<thi", "nk>**Synthesizing User Data**", " I'm synthesizing...", "</think>", "Final answer."):
+            c._filter_and_accumulate(delta)
+        assert "Synthesizing" not in c._accumulated
+        assert c._accumulated == "Final answer."

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -58,10 +58,18 @@ class TestHandleReasoningCommand(unittest.TestCase):
 
     def _make_cli(self, reasoning_config=None, show_reasoning=False):
         """Create a minimal CLI stub with the reasoning attributes."""
+        import types as _types
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
         stub = SimpleNamespace(
             reasoning_config=reasoning_config,
             show_reasoning=show_reasoning,
             agent=MagicMock(),
+        )
+        # Effort changes carry reasoning VISIBILITY (include_thoughts) along
+        # via this mixin method — bind the real one so the stub exercises it.
+        stub._sync_reasoning_visibility = _types.MethodType(
+            CLICommandsMixin._sync_reasoning_visibility, stub
         )
         return stub
 
@@ -163,7 +171,10 @@ class TestHandleReasoningCommand(unittest.TestCase):
             CLICommandsMixin._handle_reasoning_command(stub, "/reasoning high")
 
         save_config.assert_not_called()
-        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
+        self.assertEqual(
+            stub.reasoning_config,
+            {"enabled": True, "effort": "high", "include_thoughts": False},
+        )
         self.assertIsNone(stub.agent)
 
     def test_effort_global_flag_persists_config(self):
@@ -179,7 +190,10 @@ class TestHandleReasoningCommand(unittest.TestCase):
             self.assertEqual(CLI_CONFIG["agent"]["reasoning_effort"], "high")
 
         save_config.assert_called_once_with("agent.reasoning_effort", "high")
-        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
+        self.assertEqual(
+            stub.reasoning_config,
+            {"enabled": True, "effort": "high", "include_thoughts": False},
+        )
         self.assertIsNone(stub.agent)
 
     def test_effort_session_flag_does_not_persist_config(self):
@@ -191,7 +205,10 @@ class TestHandleReasoningCommand(unittest.TestCase):
             CLICommandsMixin._handle_reasoning_command(stub, "/reasoning high --session")
 
         save_config.assert_not_called()
-        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
+        self.assertEqual(
+            stub.reasoning_config,
+            {"enabled": True, "effort": "high", "include_thoughts": False},
+        )
         self.assertIsNone(stub.agent)
 
     def test_new_session_clears_session_reasoning_override(self):

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -105,7 +105,8 @@ class TestReasoningCommand:
 
         assert "**Effort:** `none (disabled)`" in result
         assert "**Display:** on ✓" in result
-        assert runner._reasoning_config == {"enabled": False}
+        # include_thoughts mirrors the resolved display state (on here).
+        assert runner._reasoning_config == {"enabled": False, "include_thoughts": True}
         assert runner._show_reasoning is True
 
     @pytest.mark.asyncio
@@ -225,7 +226,13 @@ class TestReasoningCommand:
         session_key = runner._session_key_for_source(source)
         runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "xhigh"}
 
-        assert runner._resolve_session_reasoning_config(source=source) == {"enabled": True, "effort": "xhigh"}
+        # Session override wins for effort; include_thoughts carries the
+        # resolved reasoning VISIBILITY (display off in this runner).
+        assert runner._resolve_session_reasoning_config(source=source) == {
+            "enabled": True,
+            "effort": "xhigh",
+            "include_thoughts": False,
+        }
 
     def test_run_agent_reloads_reasoning_config_per_message(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -274,7 +281,11 @@ class TestReasoningCommand:
 
         assert result["final_response"] == "ok"
         assert _CapturingAgent.last_init is not None
-        assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "low"}
+        assert _CapturingAgent.last_init["reasoning_config"] == {
+            "enabled": True,
+            "effort": "low",
+            "include_thoughts": False,
+        }
 
     def test_run_agent_prefers_session_reasoning_override(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -324,7 +335,11 @@ class TestReasoningCommand:
 
         assert result["final_response"] == "ok"
         assert _CapturingAgent.last_init is not None
-        assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "high"}
+        assert _CapturingAgent.last_init["reasoning_config"] == {
+            "enabled": True,
+            "effort": "high",
+            "include_thoughts": False,
+        }
 
     def test_run_agent_includes_enabled_mcp_servers_in_gateway_toolsets(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -434,6 +449,136 @@ class TestReasoningCommand:
         assert result["final_response"] == "ok"
         assert _CapturingAgent.last_init is not None
         assert "homeassistant" in set(_CapturingAgent.last_init["enabled_toolsets"])
+
+
+class TestReasoningVisibilityResolution:
+    """Reasoning effort vs. visibility separation at the gateway boundary.
+
+    include_thoughts (resolved from display.show_reasoning, per-platform
+    overrides, and /reasoning show|hide) rides on the reasoning config so
+    Gemini/Vertex can suppress thought summaries at the REQUEST — effort is
+    never touched by visibility changes.
+    """
+
+    def _home(self, tmp_path, monkeypatch, yaml_body: str):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml_body, encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        return hermes_home
+
+    def test_platform_overrides_beat_global_for_weixin_and_discord(self, tmp_path, monkeypatch):
+        self._home(
+            tmp_path, monkeypatch,
+            "agent:\n  reasoning_effort: medium\n"
+            "display:\n"
+            "  show_reasoning: true\n"
+            "  platforms:\n"
+            "    weixin:\n      show_reasoning: false\n"
+            "    discord:\n      show_reasoning: false\n",
+        )
+        runner = _make_runner()
+        runner._show_reasoning = True
+
+        for platform in (Platform.WEIXIN, Platform.DISCORD):
+            source = _make_event(platform=platform).source
+            resolved = runner._resolve_session_reasoning_config(source=source)
+            assert resolved == {
+                "enabled": True,
+                "effort": "medium",
+                "include_thoughts": False,
+            }, platform
+
+        # A platform WITHOUT an override follows the global display flag.
+        telegram = _make_event(platform=Platform.TELEGRAM).source
+        assert runner._resolve_session_reasoning_config(source=telegram)[
+            "include_thoughts"
+        ] is True
+
+    def test_platform_override_can_reenable_over_global_off(self, tmp_path, monkeypatch):
+        self._home(
+            tmp_path, monkeypatch,
+            "agent:\n  reasoning_effort: high\n"
+            "display:\n"
+            "  show_reasoning: false\n"
+            "  platforms:\n"
+            "    discord:\n      show_reasoning: true\n",
+        )
+        runner = _make_runner()
+        discord = _make_event(platform=Platform.DISCORD).source
+        weixin = _make_event(platform=Platform.WEIXIN).source
+        assert runner._resolve_session_reasoning_config(source=discord) == {
+            "enabled": True,
+            "effort": "high",
+            "include_thoughts": True,
+        }
+        assert runner._resolve_session_reasoning_config(source=weixin)[
+            "include_thoughts"
+        ] is False
+
+    @pytest.mark.asyncio
+    async def test_reasoning_hide_changes_visibility_not_effort(self, tmp_path, monkeypatch):
+        home = self._home(
+            tmp_path, monkeypatch,
+            "agent:\n  reasoning_effort: medium\n"
+            "display:\n  show_reasoning: true\n",
+        )
+        runner = _make_runner()
+        runner._show_reasoning = True
+        event = _make_event("/reasoning hide", platform=Platform.WEIXIN)
+
+        await runner._handle_reasoning_command(event)
+
+        saved = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+        # Visibility persisted per-platform; effort untouched.
+        assert saved["display"]["platforms"]["weixin"]["show_reasoning"] is False
+        assert saved["agent"]["reasoning_effort"] == "medium"
+
+        resolved = runner._resolve_session_reasoning_config(source=event.source)
+        assert resolved == {
+            "enabled": True,
+            "effort": "medium",
+            "include_thoughts": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_reasoning_show_reenables_visibility(self, tmp_path, monkeypatch):
+        self._home(
+            tmp_path, monkeypatch,
+            "agent:\n  reasoning_effort: high\n"
+            "display:\n  show_reasoning: false\n",
+        )
+        runner = _make_runner()
+        event = _make_event("/reasoning show", platform=Platform.DISCORD)
+
+        await runner._handle_reasoning_command(event)
+
+        resolved = runner._resolve_session_reasoning_config(source=event.source)
+        assert resolved == {
+            "enabled": True,
+            "effort": "high",
+            "include_thoughts": True,
+        }
+
+    def test_session_override_dict_not_mutated_by_resolution(self, tmp_path, monkeypatch):
+        self._home(tmp_path, monkeypatch, "agent:\n  reasoning_effort: low\n")
+        runner = _make_runner()
+        source = _make_event().source
+        session_key = runner._session_key_for_source(source)
+        override = {"enabled": True, "effort": "xhigh"}
+        runner._session_reasoning_overrides[session_key] = override
+
+        runner._resolve_session_reasoning_config(source=source)
+
+        assert override == {"enabled": True, "effort": "xhigh"}
+
+    def test_no_reasoning_config_stays_none(self, tmp_path, monkeypatch):
+        """No effort configured → no thinking_config at all (Gemini's default
+        is include_thoughts=false, so nothing leaks) — unchanged behavior."""
+        self._home(tmp_path, monkeypatch, "display:\n  show_reasoning: true\n")
+        runner = _make_runner()
+        source = _make_event().source
+        assert runner._resolve_session_reasoning_config(source=source) is None
 
 
 class TestLoadShowReasoningCoercion:

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -173,4 +173,10 @@ class TestGatewaySessionEffectiveModel:
         result = runner._resolve_session_reasoning_config(
             session_key="agent:main:telegram:private:1", model="claude-opus-4.5"
         )
-        assert result == {"enabled": True, "effort": "minimal"}
+        # include_thoughts carries the resolved reasoning VISIBILITY
+        # (display off in this runner) alongside the effort override.
+        assert result == {
+            "enabled": True,
+            "effort": "minimal",
+            "include_thoughts": False,
+        }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4685,7 +4685,12 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
         }
     )
     assert resp_effort["result"]["value"] == "low"
-    assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+    assert agent.reasoning_config == {
+        "enabled": True,
+        "effort": "low",
+        # visibility rides along, resolved from display.show_reasoning
+        "include_thoughts": True,
+    }
     assert server._sessions["sid"]["create_reasoning_override"] == {"enabled": True, "effort": "low"}
     assert server._load_cfg()["agent"]["reasoning_effort"] == "medium"
 
@@ -9446,7 +9451,12 @@ def test_make_agent_uses_session_runtime_overrides(monkeypatch):
     assert resolved == {"requested": "openai-codex", "target_model": "gpt-5.4"}
     assert mock_agent.call_args.kwargs["model"] == "gpt-5.4"
     assert mock_agent.call_args.kwargs["provider"] == "openai-codex"
-    assert mock_agent.call_args.kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert mock_agent.call_args.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+        # visibility rides along, resolved from display.show_reasoning
+        "include_thoughts": True,
+    }
     assert mock_agent.call_args.kwargs["service_tier"] == "priority"
 
 

--- a/tests/tui_gateway/test_reasoning_session_scope.py
+++ b/tests/tui_gateway/test_reasoning_session_scope.py
@@ -71,7 +71,11 @@ class TestConfigSetReasoningSessionScope:
                 {"key": "reasoning", "session_id": "s1", "value": "none"}
             )
         assert resp["result"]["value"] == "none"
-        assert agent.reasoning_config == {"enabled": False}
+        assert agent.reasoning_config == {
+            "enabled": False,
+            # visibility rides along, resolved from display.show_reasoning
+            "include_thoughts": True,
+        }
         write_key.assert_not_called()
 
     def test_session_scoped_set_updates_create_override_for_lazy_session(self) -> None:

--- a/tests/tui_gateway/test_reasoning_visibility.py
+++ b/tests/tui_gateway/test_reasoning_visibility.py
@@ -1,0 +1,97 @@
+"""TUI/Desktop reasoning-visibility coverage (PR review follow-up).
+
+The messaging gateway and classic CLI resolve display.show_reasoning into
+``reasoning_config["include_thoughts"]`` so Gemini/Vertex suppress thought
+summaries at the request. The TUI backend must do the same at its
+agent-construction sites, and `/reasoning show|hide` must synchronize the
+live cached agent — otherwise a TUI Gemini/Vertex session with hidden
+reasoning keeps requesting summaries until the agent is rebuilt.
+"""
+
+from types import SimpleNamespace
+
+import tui_gateway.server as tui_server
+
+
+def _cfg(show_reasoning: bool, effort: str = "medium") -> dict:
+    return {
+        "model": {"default": "google/gemini-3.1-pro-preview"},
+        "agent": {"reasoning_effort": effort},
+        "display": {"show_reasoning": show_reasoning},
+    }
+
+
+class TestAnnotateReasoningVisibility:
+    def test_display_off_marks_thoughts_hidden(self, monkeypatch):
+        monkeypatch.setattr(tui_server, "_load_cfg", lambda: _cfg(False))
+        result = tui_server._annotate_reasoning_visibility(
+            tui_server._load_reasoning_config()
+        )
+        assert result == {
+            "enabled": True,
+            "effort": "medium",
+            "include_thoughts": False,
+        }
+
+    def test_display_on_requests_thoughts(self, monkeypatch):
+        monkeypatch.setattr(tui_server, "_load_cfg", lambda: _cfg(True, "high"))
+        result = tui_server._annotate_reasoning_visibility(
+            tui_server._load_reasoning_config()
+        )
+        assert result == {
+            "enabled": True,
+            "effort": "high",
+            "include_thoughts": True,
+        }
+
+    def test_none_stays_none(self, monkeypatch):
+        monkeypatch.setattr(tui_server, "_load_cfg", lambda: _cfg(False))
+        assert tui_server._annotate_reasoning_visibility(None) is None
+
+    def test_session_override_not_mutated(self, monkeypatch):
+        """Stored /reasoning overrides must not accumulate visibility state."""
+        monkeypatch.setattr(tui_server, "_load_cfg", lambda: _cfg(False))
+        override = {"enabled": True, "effort": "xhigh"}
+        annotated = tui_server._annotate_reasoning_visibility(override)
+        assert annotated["include_thoughts"] is False
+        assert override == {"enabled": True, "effort": "xhigh"}
+
+    def test_loader_stays_effort_only(self, monkeypatch):
+        """Parity contract: the loader itself must not grow visibility keys
+        (tests/tui_gateway/test_reasoning_config_per_model.py compares it
+        against the gateway loader verbatim)."""
+        monkeypatch.setattr(tui_server, "_load_cfg", lambda: _cfg(False))
+        assert "include_thoughts" not in (tui_server._load_reasoning_config() or {})
+
+
+class TestLiveToggleSync:
+    def _session_with_agent(self, reasoning_config):
+        agent = SimpleNamespace(reasoning_config=reasoning_config)
+        return {"agent": agent, "show_reasoning": True}, agent
+
+    def test_hide_updates_live_agent_without_touching_effort(self):
+        session, agent = self._session_with_agent(
+            {"enabled": True, "effort": "high", "include_thoughts": True}
+        )
+        tui_server._sync_live_agent_reasoning_visibility(session, False)
+        assert agent.reasoning_config == {
+            "enabled": True,
+            "effort": "high",
+            "include_thoughts": False,
+        }
+
+    def test_show_reenables_thoughts(self):
+        session, agent = self._session_with_agent(
+            {"enabled": True, "effort": "medium", "include_thoughts": False}
+        )
+        tui_server._sync_live_agent_reasoning_visibility(session, True)
+        assert agent.reasoning_config["include_thoughts"] is True
+        assert agent.reasoning_config["effort"] == "medium"
+
+    def test_no_agent_is_a_noop(self):
+        tui_server._sync_live_agent_reasoning_visibility({"agent": None}, False)
+
+    def test_agent_without_reasoning_config_is_a_noop(self):
+        session, agent = self._session_with_agent(None)
+        tui_server._sync_live_agent_reasoning_visibility(session, False)
+        assert agent.reasoning_config is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2892,10 +2892,46 @@ def _load_reasoning_config(model: str = "") -> dict | None:
     :func:`hermes_constants.resolve_reasoning_config` (per-model override >
     global ``agent.reasoning_effort``; YAML boolean False = disabled).
     Closes #21256.
+
+    Effort only — reasoning VISIBILITY (``include_thoughts``) is attached at
+    the agent-construction sites via ``_annotate_reasoning_visibility`` so
+    this loader stays in lockstep with the gateway/CLI loaders (see the
+    parity test in tests/tui_gateway/test_reasoning_config_per_model.py).
     """
     from hermes_constants import resolve_reasoning_config
 
     return resolve_reasoning_config(_load_cfg(), model)
+
+
+def _annotate_reasoning_visibility(config: dict | None) -> dict | None:
+    """Attach the current display visibility to a reasoning config.
+
+    Returns a copy with ``include_thoughts`` set from
+    ``display.show_reasoning`` — never mutates the input, so stored session
+    overrides don't accumulate stale visibility state. ``None`` stays
+    ``None`` (no thinking_config is emitted at all; Gemini's own default is
+    include_thoughts=false, so nothing leaks).
+    """
+    if config is None:
+        return None
+    return {**config, "include_thoughts": _load_show_reasoning()}
+
+
+def _sync_live_agent_reasoning_visibility(session: dict, show: bool) -> None:
+    """Propagate a `/reasoning show|hide` toggle onto the live cached agent.
+
+    Without this, an existing session's agent keeps the include_thoughts
+    value it was built with and the toggle only takes effect after an agent
+    rebuild — the classic-CLI path syncs the live agent the same way.
+    Effort is never touched.
+    """
+    agent = session.get("agent")
+    if agent is None:
+        return
+    config = getattr(agent, "reasoning_config", None)
+    if not isinstance(config, dict):
+        return
+    agent.reasoning_config = {**config, "include_thoughts": bool(show)}
 
 
 def _load_service_tier() -> str | None:
@@ -4661,8 +4697,12 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "provider_data_collection": getattr(agent, "provider_data_collection", None),
         "openrouter_min_coding_score": getattr(agent, "openrouter_min_coding_score", None),
         "session_id": task_id,
-        "reasoning_config": getattr(agent, "reasoning_config", None)
-        or _load_reasoning_config(str(getattr(agent, "model", "") or "")),
+        # Re-annotate visibility either way: the parent agent's config may
+        # predate a /reasoning show|hide toggle, and the loader is effort-only.
+        "reasoning_config": _annotate_reasoning_visibility(
+            getattr(agent, "reasoning_config", None)
+            or _load_reasoning_config(str(getattr(agent, "model", "") or ""))
+        ),
         "service_tier": getattr(agent, "service_tier", None) or _load_service_tier(),
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "platform": "tui",
@@ -5126,7 +5166,11 @@ def _make_agent(
         # display detail).  See cli.py PR (decoupling fix) for the matching
         # change on the classic CLI side.
         verbose_logging=False,
-        reasoning_config=(
+        # Stored /reasoning overrides and the config loader both carry effort
+        # only; visibility (include_thoughts) is resolved here at build time
+        # so neither ever freezes a stale display state. Gemini/Vertex map it
+        # onto thinking_config so hidden thought summaries are never returned.
+        reasoning_config=_annotate_reasoning_visibility(
             reasoning_config_override
             if reasoning_config_override is not None
             else _load_reasoning_config(str(model or ""))
@@ -11626,6 +11670,7 @@ def _(rid, params: dict) -> dict:
                 _save_cfg(cfg)
                 if session:
                     session["show_reasoning"] = True
+                    _sync_live_agent_reasoning_visibility(session, True)
                 return _ok(rid, {"key": key, "value": "show"})
             if arg in {"hide", "off"}:
                 cfg = _load_cfg()
@@ -11644,6 +11689,7 @@ def _(rid, params: dict) -> dict:
                 _save_cfg(cfg)
                 if session:
                     session["show_reasoning"] = False
+                    _sync_live_agent_reasoning_visibility(session, False)
                 return _ok(rid, {"key": key, "value": "hide"})
 
             # /reasoning full | clamp — parity with the classic CLI's
@@ -11700,7 +11746,10 @@ def _(rid, params: dict) -> dict:
                 # agent.reasoning_effort to the preset default.
                 session["create_reasoning_override"] = parsed
             if session and session.get("agent") is not None:
-                session["agent"].reasoning_config = parsed
+                # Effort changed; visibility rides along unchanged.
+                session["agent"].reasoning_config = (
+                    _annotate_reasoning_visibility(parsed)
+                )
                 _persist_live_session_runtime(session)
                 _emit(
                     "session.info",

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1364,6 +1364,54 @@ There is no `hermes config set` support for `reasoning_overrides` keys — edit 
 4. Provider default
 
 The override applies automatically everywhere: CLI startup, messaging gateway, Desktop/TUI, cron jobs, `/model` mid-session switches, and fallback model activation.
+### Reasoning effort vs. reasoning visibility
+
+These are **independent** controls:
+
+| Control | What it does | What it never does |
+|---------|--------------|--------------------|
+| `agent.reasoning_effort` (or `/reasoning <level>`) | How deeply the model thinks | Show or hide anything |
+| `display.show_reasoning` (or `/reasoning show\|hide`) | Whether thought summaries are returned and displayed | Change how the model thinks |
+
+`/reasoning hide` does **not** disable model reasoning — the model keeps
+thinking at the configured effort; you just receive only the final answer.
+In the messaging gateway, `/reasoning show|hide` persists a per-platform
+override (`display.platforms.<platform>.show_reasoning`), which takes
+precedence over the global `display.show_reasoning` for that platform.
+
+**How Gemini / Vertex map these controls.** Both Google surfaces receive a
+`thinking_config` built from the two knobs separately:
+
+```json
+{
+  "google": {
+    "thinking_config": {
+      "thinking_level": "low",      // from agent.reasoning_effort
+      "include_thoughts": false     // from resolved show_reasoning
+    }
+  }
+}
+```
+
+So with display off, thought summaries are suppressed **at the API** — they
+are never returned, not merely filtered client-side — while internal
+thinking continues at the requested level. When display is on, Hermes also
+sets `thought_tag_marker` so the OpenAI-compat endpoints return summaries
+wrapped in `<think>` tags; Hermes extracts them into the reasoning box and
+strips them from the answer, so reasoning is shown exactly once.
+
+Model-specific notes:
+
+- **Gemini 3.x Pro** accepts only `low`/`high` thinking levels; Hermes clamps
+  `minimal|low|medium` → `low` and `high|xhigh|max|ultra` → `high`.
+- **Gemini 3 Flash** additionally accepts `medium`.
+- **Gemini 2.5** uses thinking budgets instead of levels; Hermes only toggles
+  `include_thoughts` and leaves the budget at the model default.
+- **Gemini 3 models cannot disable thinking** — `/reasoning none` hides
+  thought summaries, but the model still reasons internally (Google-side
+  behavior).
+- Thought signatures on tool calls are unrelated to visibility and are always
+  preserved and replayed, as Gemini requires.
 
 ## Tool-Use Enforcement
 


### PR DESCRIPTION
## What does this PR do?

Fixes a reasoning-visibility leak on Gemini/Vertex: with `display.show_reasoning: false` (and every per-platform override off, streaming off, interim messages off), users still received raw thought-summary blocks in chat — sometimes dozens of near-identical `**Crafting…** / **Synthesizing…**` paragraphs before (or instead of) the answer.

Two stacked causes:

1. **Effort and visibility were coupled at the request.** `_build_gemini_thinking_config` (`agent/transports/chat_completions.py`) hardcoded `thinking_config.include_thoughts = true` whenever thinking was enabled, so `agent.reasoning_effort: medium` silently forced summary return. `display.show_reasoning` never reached the request builder.
2. **The compat surfaces return summaries untagged.** On Vertex / AI-Studio `/openai` endpoints, thought summaries arrive as plain text inside `message.content` unless `thought_tag_marker` is set (per Google's Vertex OpenAI-compat docs: "If not specified, no tags will be returned around the model's thoughts"). Untagged, they're indistinguishable from the answer — `extract_reasoning`, `strip_think_blocks`, and the gateway display gate all had nothing to key on.

The fix makes the two knobs independent, matching Google's own API split:

- `agent.reasoning_effort` → `thinking_config.thinking_level` (unchanged mapping)
- resolved `show_reasoning` (global → `display.platforms.<plat>.show_reasoning` → `/reasoning show|hide`) → `thinking_config.include_thoughts`, resolved **per turn** by the gateway so `/reasoning hide` applies on the next message without evicting cached agents

So "high effort, final answer only" now works: hidden summaries are suppressed **at the API**, not filtered client-side. When display is ON, the request also sets `extra_body.google.thought_tag_marker: "think"`, so summaries come back `<think>`-wrapped and the existing structured pipeline handles them: captured once into `msg["reasoning"]` (shown once by the gateway/CLI reasoning display), stripped from stored content at the storage boundary, and suppressed live by the stream consumer. No natural-language heuristics anywhere — a legitimate answer that merely *looks* like a thought summary is never touched (there's a test for exactly that).

## Related Issue

Fixes #64035

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py` — `_build_gemini_thinking_config` honors `reasoning_config["include_thoughts"]` (absent = legacy `true`, so existing configs/sessions keep the old request shape); new `_gemini_thought_tag_marker()`; legacy path emits the marker on the compat branch.
- `plugins/model-providers/vertex/__init__.py`, `plugins/model-providers/gemini/__init__.py` — emit `thought_tag_marker` alongside `thinking_config` on OpenAI-compat surfaces (native path keeps structural `part.thought` handling, no marker).
- `gateway/run.py` — new `_resolve_reasoning_visibility()` (same precedence rules as the response-side display gate, incl. the Mattermost platform-only opt-in); `_resolve_session_reasoning_config()` annotates each turn's config without mutating stored session overrides.
- `cli.py`, `hermes_cli/cli_commands_mixin.py` — CLI syncs `include_thoughts` from `display.show_reasoning`; `/reasoning show|hide` updates the live agent and now prints that hiding does not disable thinking.
- `gateway/platforms/api_server.py` — annotates from global `display.show_reasoning`.
- `tui_gateway/server.py` + `tests/tui_gateway/test_reasoning_visibility.py` (review follow-up) — visibility annotation at agent build and background-task kwargs, live `/reasoning show|hide` sync, 9 TUI tests (display-off construction, toggle sync both directions, override non-mutation, loader-parity guard).
- `plugins/model-providers/openrouter/__init__.py`, `plugins/model-providers/nous/__init__.py`, `agent/chat_completion_helpers.py` — scrub the Hermes-internal key before wire-verbatim `reasoning` forwards (no behavior change for non-Gemini providers).
- `tests/agent/transports/test_gemini_reasoning_visibility.py` (new, 17 tests) + `tests/gateway/test_reasoning_command.py` (+6 tests, 4 assertions updated for the new key) — request bodies for medium/high × display on/off, legacy-shape compat, Weixin/Discord overrides both directions, `/reasoning hide` leaves effort untouched, repeated-summary regression fixture (tag-marked thoughts stripped, identical-looking legit answer preserved verbatim, reasoning captured exactly once), split-across-deltas streaming suppression, thought-signature preservation on tool calls, OpenRouter/Nous unchanged.
- `cli-config.yaml.example`, `website/docs/user-guide/configuration.md` — document effort vs. visibility independence, the `thinking_config` mapping, and model-specific limits (3.x Pro low/high only; 2.5 budgets; Gemini 3 cannot disable thinking).

## How to Test

1. `pytest tests/agent/transports/test_gemini_reasoning_visibility.py tests/gateway/test_reasoning_command.py -q` — 43 tests, all green.
2. Request-body proof (no live call): `pytest tests/agent/transports/test_gemini_reasoning_visibility.py::TestVertexRequestVisibility -q` asserts the exact Vertex `extra_body`: display off → `{"include_thoughts": false, "thinking_level": "low"}` with no marker; display on → `include_thoughts: true` + `thought_tag_marker: "think"`.
3. Live (Vertex + `google/gemini-3.1-pro-preview`, `reasoning_effort: medium`, `display.show_reasoning: false`): send any message via a messaging platform → final answer only, no bold summary blocks; `/reasoning show` → next reply shows one 💭 Reasoning block; `/reasoning hide` → gone, `/reasoning` still reports the same effort.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest is #59504, unrelated debug-dump fix)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` — all suites touching this change pass (transports, providers, gateway reasoning/display/stream, CLI reasoning: 322 focused tests green on this branch). Full-tree runs on my macOS dev box have pre-existing environment failures; I verified baseline vs. patched failure sets are identical (patched actually ⊆ baseline).
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (dev) / Ubuntu 26.04 GCE (production repro)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (request-shape + config resolution only)
- [x] Tool descriptions/schemas — N/A
