### PR TITLE
fix(agent): evict old tool-result screenshots on OpenAI-compatible path (#63849)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -586,6 +586,80 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     return result if changed else messages
 
 
+def _evict_old_tool_result_images(
+    messages: List[Dict[str, Any]], max_keep: int = 3
+) -> List[Dict[str, Any]]:
+    """Evict old tool-result screenshot images on the OpenAI-compatible path.
+
+    Anthropic adapter runs its own eviction (``_evict_old_screenshots`` in
+    ``agent/anthropic_adapter.py``). The chat.completions path had no
+    equivalent, so browser_vision / vision_analyze screenshots accumulated
+    in conversation history forever and OOM'd local VLMs on long browser
+    sessions. See issue #63849.
+
+    Walks ``messages`` backward, counting tool-role messages whose ``content``
+    list carries at least one image part. Once the running count exceeds
+    ``max_keep``, older image parts on those messages are replaced with a
+    short text placeholder. Only ``tool``-role messages are touched — user
+    images are preserved (the Anthropic eviction mirrors this scoping).
+
+    Shallow copies of touched messages only; the input list and any
+    untouched message are never mutated. If no eviction was needed, the
+    original list reference is returned unchanged.
+    """
+    if not messages:
+        return messages
+
+    placeholder = {"type": "text", "text": "[screenshot removed to save context]"}
+
+    # First pass: locate tool-role image-bearing messages, counting newest
+    # => oldest. We need the indices whose running count > max_keep.
+    tool_image_indices: List[int] = []
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "tool":
+            continue
+        if _content_has_images(msg.get("content")):
+            tool_image_indices.append(i)
+
+    # tool_image_indices is newest-first (highest index first). The first
+    # max_keep entries are kept; everything older (the rest of the list) is
+    # evicted. If total count <= max_keep, nothing to do.
+    if len(tool_image_indices) <= max_keep:
+        return messages
+
+    evict_set = set(tool_image_indices[max_keep:])
+
+    changed = False
+    result: List[Dict[str, Any]] = []
+    for i, msg in enumerate(messages):
+        if i not in evict_set:
+            result.append(msg)
+            continue
+        # Shallow copy and replace image parts with placeholder.
+        new_msg = msg.copy()
+        new_content = []
+        content = msg.get("content")
+        if isinstance(content, list):
+            for p in content:
+                if _is_image_part(p):
+                    new_content.append(placeholder)
+                else:
+                    new_content.append(p)
+            new_msg["content"] = new_content
+        else:
+            # Defensive: content isn't a list — shouldn't happen because
+            # _content_has_images already filtered, but leave untouched
+            # rather than risk corrupting an unexpected shape.
+            new_content = content
+        result.append(new_msg)
+        changed = True
+
+    return result if changed else messages
+
+
 def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) -> str:
     """Create an informative 1-line summary of a tool call + result.
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -35,6 +35,7 @@ from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
+from agent.context_compressor import _evict_old_tool_result_images
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
@@ -955,6 +956,15 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Evict old tool-result screenshots on the OpenAI-compatible path
+        # to bound memory pressure on local VLMs (LM Studio / Ollama / vLLM).
+        # The Anthropic adapter does its own eviction in
+        # ``convert_messages_to_anthropic`` via ``_evict_old_screenshots``;
+        # this is the chat.completions equivalent. Operates on the per-call
+        # copy only — stored conversation history is never mutated, matching
+        # the per-conversation prompt-caching invariant. See issue #63849.
+        api_messages = _evict_old_tool_result_images(api_messages)
 
         # Calculate approximate request size for logging and pressure checks.
         # estimate_messages_tokens_rough(api_messages) includes the system

--- a/tests/agent/test_evict_tool_result_images_63849.py
+++ b/tests/agent/test_evict_tool_result_images_63849.py
@@ -1,0 +1,247 @@
+"""Tests for ``_evict_old_tool_result_images`` (issue #63849).
+
+Tool-result images (browser_vision / vision_analyze screenshots) accumulated
+forever on the OpenAI-compatible request path because the only eviction lived
+in the Anthropic adapter. This test suite pins the per-call eviction that
+replaces old tool-role image parts with text placeholders.
+"""
+
+import copy
+
+from agent.context_compressor import _evict_old_tool_result_images
+
+
+def _make_tool_msg(content_type: str = "image_url") -> dict:
+    """Helper: a tool-role message with one image part."""
+    return {
+        "role": "tool",
+        "content": [
+            {"type": content_type, "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ],
+    }
+
+
+def _make_user_msg(content_type: str = "image_url") -> dict:
+    """Helper: a user-role message with one image part."""
+    return {
+        "role": "user",
+        "content": [
+            {"type": content_type, "image_url": {"url": "data:image/png;base64,BBBB"}},
+        ],
+    }
+
+
+def _make_tool_msg_no_image() -> dict:
+    """Helper: a tool-role message with text-only content."""
+    return {
+        "role": "tool",
+        "content": [
+            {"type": "text", "text": "command output"},
+        ],
+    }
+
+
+class TestEvictOldToolResultImages:
+    """Regression suite for _evict_old_tool_result_images."""
+
+    def test_no_images_returns_unchanged(self):
+        """No image-bearing messages => returns the same list reference."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "tool", "content": [{"type": "text", "text": "output"}]},
+        ]
+        result = _evict_old_tool_result_images(messages)
+        assert result is messages, "Should return the same list when no eviction"
+
+    def test_empty_list_returns_empty(self):
+        """Empty input => empty output."""
+        assert _evict_old_tool_result_images([]) == []
+
+    def test_messages_below_threshold_unchanged(self):
+        """≤3 tool screenshots stays unchanged (same reference)."""
+        messages = [_make_tool_msg() for _ in range(3)]
+        messages.insert(0, {"role": "user", "content": "look at this"})
+        result = _evict_old_tool_result_images(messages)
+        assert result is messages, "≤3 tool images should not trigger eviction"
+
+    def test_keeps_last_n_images(self):
+        """5 tool screenshots → keep the newest 3, evict the oldest 2."""
+        messages = [_make_tool_msg() for _ in range(5)]
+        result = _evict_old_tool_result_images(messages, max_keep=3)
+
+        # We should get 5 messages back (same length)
+        assert len(result) == 5
+
+        # The first 2 (oldest) tool messages should have their image parts
+        # replaced with text placeholders.
+        for i in range(2):
+            parts = result[i]["content"]
+            assert isinstance(parts, list)
+            for p in parts:
+                assert p["type"] == "text", f"Msg {i}: expected text placeholder"
+                assert "screenshot removed" in p["text"]
+
+        # The last 3 (newest) tool messages should keep their original images.
+        for i in range(2, 5):
+            parts = result[i]["content"]
+            assert isinstance(parts, list)
+            for p in parts:
+                assert p["type"] != "text" or "screenshot" not in p.get("text", ""), (
+                    f"Msg {i}: newest should keep image parts"
+                )
+
+    def test_does_not_mutate_input(self):
+        """Input list and its messages must not be mutated."""
+        messages = [_make_tool_msg() for _ in range(5)]
+        original = copy.deepcopy(messages)
+
+        _evict_old_tool_result_images(messages, max_keep=3)
+
+        # Input list should be unchanged
+        assert messages == original, "Input list was mutated"
+
+    def test_input_not_mutated_when_count_exceeds(self):
+        """Even when eviction triggers, original list is unmodified."""
+        messages = [_make_tool_msg() for _ in range(5)]
+        original = copy.deepcopy(messages)
+
+        _evict_old_tool_result_images(messages, max_keep=3)
+
+        assert messages == original, (
+            "Input list was mutated even though eviction occurred"
+        )
+        # Verify the content parts are still image type
+        for msg in messages:
+            for p in msg["content"]:
+                # OpenAI tool-image parts are type "image_url"
+                assert p["type"] != "text" or "screenshot" not in p.get("text", "")
+
+    def test_user_images_not_touched(self):
+        """User-role images should never be evicted."""
+        messages = [
+            _make_user_msg(),
+            _make_tool_msg(),
+            _make_user_msg(),
+            _make_tool_msg(),
+            _make_tool_msg(),
+            _make_tool_msg(),
+            _make_tool_msg(),
+        ]
+        result = _evict_old_tool_result_images(messages, max_keep=2)
+
+        # User messages should keep their images
+        assert result[0]["content"] == messages[0]["content"]
+        assert result[2]["content"] == messages[2]["content"]
+
+        # Tool messages beyond max_keep should have placeholders
+        for i in [1, 3]:  # tool messages at positions 1 and 3
+            parts = result[i]["content"]
+            assert parts[0]["type"] == "text"
+            assert "screenshot removed" in parts[0]["text"]
+
+    def test_anthropic_image_type_also_evicted(self):
+        """Anthropic 'image' type inside tool messages is also evicted.
+
+        This covers the scenario where an Anthropic native image block
+        ends up in an OpenAI-format tool message (rare but possible
+        during format conversion).
+        """
+        messages = []
+        for _ in range(5):
+            messages.append({
+                "role": "tool",
+                "content": [
+                    {"type": "image", "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "AAAA",
+                    }},
+                ],
+            })
+        result = _evict_old_tool_result_images(messages, max_keep=3)
+
+        # First 2 should be replaced
+        for i in range(2):
+            parts = result[i]["content"]
+            assert parts[0]["type"] == "text"
+            assert "screenshot removed" in parts[0]["text"]
+
+        # Last 3 should keep original
+        for i in range(2, 5):
+            assert result[i]["content"] == messages[i]["content"]
+
+    def test_mixed_text_and_image_in_tool_message(self):
+        """A tool message with both text and image parts — only the image
+        part is replaced; text parts survive."""
+        multi_msg = {
+            "role": "tool",
+            "content": [
+                {"type": "text", "text": "stdout: done"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,CCCC"}},
+                {"type": "text", "text": "stderr: none"},
+            ],
+        }
+        # multi_msg is the oldest, so it gets evicted (max_keep=1).
+        messages = [multi_msg, _make_tool_msg(), _make_tool_msg(), _make_tool_msg()]
+        result = _evict_old_tool_result_images(messages, max_keep=1)
+
+        # The evicted message (the oldest beyond max_keep)
+        evicted = result[0]
+        parts = evicted["content"]
+        assert len(parts) == 3
+        assert parts[0]["type"] == "text" and parts[0]["text"] == "stdout: done"
+        assert parts[1]["type"] == "text" and "screenshot removed" in parts[1]["text"]
+        assert parts[2]["type"] == "text" and parts[2]["text"] == "stderr: none"
+
+        # The other evicted (pos 1, 2) are single-image → 1 placeholder part
+        for i in (1, 2):
+            parts_i = result[i]["content"]
+            assert len(parts_i) == 1
+            assert parts_i[0]["type"] == "text"
+            assert "screenshot removed" in parts_i[0]["text"]
+
+    def test_input_image_type_recognized(self):
+        """OpenAI Responses API 'input_image' type is also evicted."""
+        messages = []
+        for _ in range(5):
+            messages.append({
+                "role": "tool",
+                "content": [
+                    {"type": "input_image", "image_url": "data:image/png;base64,DDDD"},
+                ],
+            })
+        result = _evict_old_tool_result_images(messages, max_keep=2)
+
+        assert len(result) == 5
+        # First 3 should be replaced
+        for i in range(3):
+            assert result[i]["content"][0]["type"] == "text"
+        # Last 2 keep original
+        for i in range(3, 5):
+            assert result[i]["content"] == messages[i]["content"]
+
+    def test_tool_messages_without_images_not_counted(self):
+        """Tool messages that have no image parts don't count toward max_keep."""
+        messages = [
+            _make_tool_msg(),           # image-bearing (counted)
+            _make_tool_msg_no_image(),  # not image-bearing (not counted)
+            _make_tool_msg(),           # image-bearing (counted)
+            _make_tool_msg_no_image(),  # not image-bearing (not counted)
+            _make_tool_msg(),           # image-bearing (counted)
+            _make_tool_msg(),           # image-bearing (exceeds max_keep)
+        ]
+        result = _evict_old_tool_result_images(messages, max_keep=3)
+
+        # Position 0 (oldest image) should be evicted
+        assert result[0]["content"][0]["type"] == "text"
+        assert "screenshot removed" in result[0]["content"][0]["text"]
+
+        # Non-image-bearing messages at 1 and 3 should be untouched
+        assert result[1] is messages[1]
+        assert result[3] is messages[3]
+
+        # Newest images at 2, 4, 5 should be untouched
+        assert result[2]["content"] == messages[2]["content"]
+        assert result[4]["content"] == messages[4]["content"]
+        assert result[5]["content"] == messages[5]["content"]


### PR DESCRIPTION
## What

Fixes #63849 — adds tool-result screenshot eviction on the OpenAI-compatible (chat.completions) request-build path, mirroring the eviction the Anthropic adapter already runs.

## Why

`browser_vision` / `vision_analyze` screenshots accumulate forever in conversation history on the chat.completions path. The only existing eviction is `_evict_old_screenshots` in `agent/anthropic_adapter.py`, which never runs for OpenAI-compatible providers (LM Studio, Ollama, vLLM, OpenRouter, …). The other safety nets each miss the case:

- `_strip_historical_media` anchors on the last *user* message that carries images. A typical `browser_vision` flow has no user-image message — `user → assistant(tool_calls) → tool(screenshot)` — so `anchor = -1` and the function returns the transcript unchanged.
- `_strip_images_from_messages` fires only after a recognisable image-rejection 4xx; the gate at `conversation_loop.py:2548-2551` excludes 5xx/timeouts, so a local-server OOM crash never triggers it.

Reporter's repro: 36 GB M4 Mac Studio running `qwen3.6-27b` (MLX 4-bit VLM) via LM Studio; a long browser session forced the model into four consecutive OOM crashes, each Hermes retry re-sent the same image-laden context.

## How

Port the Anthropic adapter's request-build-time eviction to the chat.completions path. New `_evict_old_tool_result_images(messages, max_keep=3)` in `agent/context_compressor.py` walks `api_messages` backward, keeps the most recent 3 tool-role images, and replaces older image parts with a short text placeholder.

- Stored conversation history is never mutated (per-conversation prompt-caching invariant preserved); only the per-call payload changes — same pattern as `_sanitize_api_messages`, `_drop_thinking_only_and_merge_users`, etc.
- Scope limited to `tool`-role messages — user images untouched (mirrors the Anthropic adapter).
- Image part types recognized via the existing `_IMAGE_PART_TYPES` set: `image_url` (OpenAI chat.completions), `input_image` (OpenAI Responses API), `image` (Anthropic native).
- `max_keep=3` hard-coded, matching `_evict_old_screenshots._MAX_KEEP_IMAGES`. Not configurable to keep the surface area minimal — both call sites should evolve together.

## Where

- `agent/context_compressor.py` — add `_evict_old_tool_result_images` next to `_is_image_part` / `_content_has_images` / `_strip_historical_media` so the module's image-handling primitives stay co-located.
- `agent/conversation_loop.py` — add the import, plus one call site right after `_sanitize_messages_surrogates(api_messages)` (around line 957), before request-size estimation. Eviction runs after every message-shape normalization (whitespace, tool-call JSON, surrogate stripping) and before any token math / prompt-caching layout decisions.
- `tests/agent/test_evict_tool_result_images_63849.py` — 11 new regression tests covering: no-op paths return the input list unchanged (same `id()`), last-N keep semantics, input immutability (both branches), user-role images preserved, all three image part types recognized, mixed text+image tool message (only image parts replaced, text parts survive), non-image-bearing tool messages don't count toward `max_keep`.

## Verification

- `pytest tests/agent/test_evict_tool_result_images_63849.py -v` — 11 passed
- `pytest tests/agent/test_context_compressor.py -v` — 151 passed (no regressions)
- Full `tests/agent/` sweep: 1756 passed, 1 unrelated failure (`test_copilot_acp_client::test_run_prompt_preserves_real_home_when_profile_home_available`, also fails on `main` — pytest-home-fixture sandbox issue, not caused by this PR)
- `python -c "import agent.conversation_loop"` — import succeeds

## Risk

- **Low surface area** — touches only the request-build copy (`api_messages`), not stored history. A bug in this function cannot corrupt the on-disk transcript (same invariant already relied on by the existing per-call passes).
- **Behavior change visible to users**: on long browser sessions the agent will no longer have access to screenshots older than 3 turns in the *outgoing* request, even though they remain in the displayed transcript. This matches the Anthropic adapter's existing behavior — no new user-visible contract, just closing the gap for the other half of providers.
- **max_keep coupling**: hard-coded to match `_evict_old_screenshots._MAX_KEEP_IMAGES`. If anyone bumps one without the other, the two paths will diverge. Left a comment but did not extract a constant — the Anthropic adapter's local `_MAX_KEEP_IMAGES = 3` is closure-scoped and promoting it crosses module boundaries for limited payoff. Happy to extract if the reviewer prefers.

## Out of scope (deliberately)

- Not touching `agent/anthropic_adapter.py` (`_evict_old_screenshots` already works there).
- Not touching `agent/message_sanitization.py` (`_strip_images_from_messages` is the 4xx-fallback path, orthogonal to this proactive eviction).
- Not changing `max_keep` to be configurable — keeping the surface area minimal.

Closes #63849.
