### PR TITLE
fix(desktop): isolate process notifications by session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15186,8 +15186,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             # and watch pattern matches) while agent is idle.
                             try:
                                 from tools.process_registry import process_registry
-                                from tools.approval import get_current_session_key
-                                _drain_sk = get_current_session_key(default="")
+                                _drain_sk = str(
+                                    getattr(getattr(self, "agent", None), "session_id", "")
+                                    or getattr(self, "session_id", "")
+                                    or ""
+                                ).strip()
                                 for _evt, _synth in process_registry.drain_notifications(session_key=_drain_sk):
                                     from tools.async_delegation import (
                                         claim_event_delivery, complete_event_delivery,
@@ -15357,7 +15360,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         # that arrived while the agent was running.
                         try:
                             from tools.process_registry import process_registry
-                            for _evt, _synth in process_registry.drain_notifications():
+                            _drain_sk = str(
+                                getattr(getattr(self, "agent", None), "session_id", "")
+                                or getattr(self, "session_id", "")
+                                or ""
+                            ).strip()
+                            for _evt, _synth in process_registry.drain_notifications(
+                                session_key=_drain_sk
+                            ):
                                 from tools.async_delegation import (
                                     claim_event_delivery, complete_event_delivery,
                                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15450,6 +15450,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 entry = self.session_store._entries.get(session_key)
                 if entry and getattr(entry, "origin", None):
                     return entry.origin
+
+                # Tool worker threads can lose the stable gateway ContextVar
+                # and fall back to the AIAgent's internal session_id. Reverse-
+                # map that durable ID to the owning conversation instead of
+                # guessing from whichever chat is active now.
+                internal_ids = {
+                    value
+                    for value in (
+                        session_key,
+                        str(evt.get("parent_session_id") or "").strip(),
+                    )
+                    if value
+                }
+                for candidate in self.session_store._entries.values():
+                    if (
+                        candidate.session_id in internal_ids
+                        and getattr(candidate, "origin", None)
+                    ):
+                        return candidate.origin
             except Exception as exc:
                 logger.debug(
                     "Synthetic process-event session-store lookup failed for %s: %s",

--- a/tests/gateway/test_async_delivery_capability.py
+++ b/tests/gateway/test_async_delivery_capability.py
@@ -159,7 +159,12 @@ class TestTerminalNotifyGate:
         from tools.terminal_tool import terminal_tool
 
         return json.loads(
-            terminal_tool(command=command, background=True, notify_on_complete=True)
+            terminal_tool(
+                command=command,
+                session_id="cli-origin-session",
+                background=True,
+                notify_on_complete=True,
+            )
         )
 
     def test_api_server_skips_watcher_and_notes(self):
@@ -177,6 +182,10 @@ class TestTerminalNotifyGate:
         assert d.get("notify_unsupported"), "must explain the limitation"
         assert "poll" in d["notify_unsupported"].lower()
         assert len(process_registry.pending_watchers) == 0
+        session = process_registry.get(d["session_id"])
+        assert session is not None
+        assert session.notify_on_complete is False
+        assert not session.watch_patterns
 
     def test_gateway_registers_watcher(self):
         from tools.process_registry import process_registry

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -515,6 +515,32 @@ def test_build_process_event_source_returns_none_for_short_session_key(monkeypat
     assert source is None
 
 
+def test_build_process_event_source_resolves_internal_agent_session_id(
+    monkeypatch, tmp_path
+):
+    """Tool-thread fallback IDs must map back to their gateway conversation."""
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    origin = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="owner",
+    )
+    entry = runner.session_store.get_or_create_session(origin)
+    entry.session_id = "20260714_internal_agent_id"
+
+    resolved = runner._build_process_event_source(
+        {
+            "session_id": "proc_fallback",
+            "session_key": "20260714_internal_agent_id",
+        }
+    )
+
+    assert resolved == origin
+
+
 # ---------------------------------------------------------------------------
 # _parse_session_key helper
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7799,14 +7799,9 @@ def test_notification_poller_delivers_completion(monkeypatch):
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
-    # Isolate the completion queue for the duration of this test. The poller
-    # reads process_registry.completion_queue by attribute at runtime; the
-    # event below carries no session_key, so any *other* poller (a leaked
-    # daemon thread from another test, or a concurrent one in the same xdist
-    # worker) is allowed to dequeue and dispatch it to its own session — whose
-    # agent may be a fixture double without run_conversation. A fresh Queue
-    # here fully isolates this test; monkeypatch restores the original on
-    # teardown. (Same pattern as test_notification_poller_requeues_when_busy.)
+    # Isolate the completion queue for the duration of this test. The event
+    # carries the matching session key because ownerless notification events
+    # must fail closed instead of being adopted by whichever poller wakes first.
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_poller_test")
@@ -7818,6 +7813,7 @@ def test_notification_poller_delivers_completion(monkeypatch):
     isolated_queue.put({
         "type": "completion",
         "session_id": "proc_poller_test",
+        "session_key": sess["session_key"],
         "command": "echo hello",
         "exit_code": 0,
         "output": "hello",
@@ -7867,10 +7863,8 @@ def test_notification_poller_skips_consumed(monkeypatch):
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
-    # Isolate the completion queue so a concurrent/leaked poller in the same
-    # xdist worker can't dequeue this session_key-less event before our poller
-    # does. monkeypatch restores the shared singleton on teardown. (Same
-    # pattern as test_notification_poller_requeues_when_busy.)
+    # Isolate the completion queue and bind the event to this session so this
+    # test exercises consumed-event suppression rather than orphan rejection.
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
 
@@ -7878,6 +7872,7 @@ def test_notification_poller_skips_consumed(monkeypatch):
     isolated_queue.put({
         "type": "completion",
         "session_id": "proc_already_done",
+        "session_key": sess["session_key"],
         "command": "echo x",
         "exit_code": 0,
         "output": "x",
@@ -7920,6 +7915,7 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
     evt = {
         "type": "completion",
         "session_id": "proc_busy_test",
+        "session_key": sess["session_key"],
         "command": "make build",
         "exit_code": 0,
         "output": "ok",
@@ -8051,6 +8047,7 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
     base = {
         "type": "watch_match",
         "session_id": "proc_watch_dedup",
+        "session_key": sess["session_key"],
         "command": "tail -f app.log",
         "pattern": "READY",
         "output": "READY on port 8000",

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -345,6 +345,110 @@ def test_submit_failure_removes_durable_running_record(tmp_path, monkeypatch):
         assert conn.execute("SELECT COUNT(*) FROM async_delegations").fetchone()[0] == 0
 
 
+@pytest.mark.parametrize("batch", [False, True])
+def test_persist_failure_rejects_without_phantom_running_record(
+    tmp_path, monkeypatch, batch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def _fail_persist(_record):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(ad, "_persist_dispatch", _fail_persist)
+    ran = threading.Event()
+    runner = lambda: ran.set() or {}
+    if batch:
+        result = ad.dispatch_async_delegation_batch(
+            goals=["never ran"],
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="owner",
+            runner=runner,
+        )
+    else:
+        result = ad.dispatch_async_delegation(
+            goal="never ran",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="owner",
+            runner=runner,
+        )
+
+    assert result["status"] == "rejected"
+    assert "persist" in result["error"].lower()
+    assert not ran.is_set()
+    assert ad.active_count() == 0
+    assert ad.list_async_delegations() == []
+
+
+@pytest.mark.parametrize(
+    ("durable_owner", "event_owner"),
+    [("", ""), ("owner-a", "owner-b")],
+)
+def test_restore_quarantines_ownerless_or_mismatched_completion(
+    tmp_path, monkeypatch, durable_owner, event_owner
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record = {
+        "delegation_id": "deleg_quarantine",
+        "session_key": "owner-a",
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+    }
+    ad._persist_dispatch(record)
+    ad._persist_completion(
+        {
+            "type": "async_delegation",
+            "delegation_id": "deleg_quarantine",
+            "session_key": event_owner,
+            "status": "completed",
+            "completed_at": 2.0,
+        },
+        {"status": "completed", "summary": "unsafe"},
+    )
+    with ad._DB_LOCK, ad._connect() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET origin_session=? WHERE delegation_id=?",
+            (durable_owner, "deleg_quarantine"),
+        )
+
+    restored = queue.Queue()
+    assert ad.restore_undelivered_completions(restored) == 0
+    assert restored.empty()
+    durable = ad.get_durable_delegation("deleg_quarantine")
+    assert durable["delivery_state"] == "quarantined"
+
+
+def test_recover_quarantines_ownerless_abandoned_record(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    record = {
+        "delegation_id": "deleg_ownerless_abandoned",
+        "session_key": "owner",
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+    }
+    ad._persist_dispatch(record)
+    with ad._DB_LOCK, ad._connect() as conn:
+        conn.execute(
+            """UPDATE async_delegations
+               SET origin_session=?, owner_pid=?, owner_started_at=NULL
+               WHERE delegation_id=?""",
+            ("", 99999999, "deleg_ownerless_abandoned"),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+    durable = ad.get_durable_delegation("deleg_ownerless_abandoned")
+    assert durable["state"] == "unknown"
+    assert durable["delivery_state"] == "quarantined"
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+
+
 def test_pending_retention_prunes_delivered_before_undelivered(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 2)

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -30,13 +30,34 @@ def _clean_state():
         process_registry.completion_queue.get_nowait()
 
 
-def _drain_one(timeout=5.0):
+def _drain_one(timeout=5.0, *, goal=None):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if not process_registry.completion_queue.empty():
-            return process_registry.completion_queue.get_nowait()
+            event = process_registry.completion_queue.get_nowait()
+            if goal is None or event.get("goal") == goal:
+                return event
         time.sleep(0.02)
     return None
+
+
+def test_dispatch_rejects_missing_origin_session_without_starting_runner():
+    ran = threading.Event()
+
+    result = ad.dispatch_async_delegation(
+        goal="ownerless",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="  ",
+        runner=lambda: ran.set() or {"status": "completed"},
+        max_async_children=3,
+    )
+
+    assert result["status"] == "rejected"
+    assert "origin session" in result["error"].lower()
+    assert not ran.is_set()
 
 
 def test_dispatch_returns_immediately_without_blocking():
@@ -50,7 +71,7 @@ def test_dispatch_returns_immediately_without_blocking():
     t0 = time.monotonic()
     res = ad.dispatch_async_delegation(
         goal="g", context=None, toolsets=None, role="leaf", model="m",
-        session_key="", runner=runner, max_async_children=3,
+        session_key="test-origin-session", runner=runner, max_async_children=3,
     )
     elapsed = time.monotonic() - t0
 
@@ -75,7 +96,7 @@ def test_async_executor_workers_are_daemon_threads():
 
     res = ad.dispatch_async_delegation(
         goal="daemon check", context=None, toolsets=None, role="leaf", model="m",
-        session_key="", runner=runner, max_async_children=1,
+        session_key="test-origin-session", runner=runner, max_async_children=1,
     )
     assert res["status"] == "dispatched"
 
@@ -126,7 +147,7 @@ def test_rich_reinjection_block_is_self_contained():
         goal="Compute the meaning of life",
         context="User is a philosopher. Respond tersely.",
         toolsets=["web"], role="leaf", model="test-model",
-        session_key="", runner=runner, max_async_children=3,
+        session_key="test-origin-session", runner=runner, max_async_children=3,
     )
     evt = _drain_one()
     assert evt is not None
@@ -154,13 +175,13 @@ def test_dispatch_rejected_at_capacity():
     for i in range(2):
         r = ad.dispatch_async_delegation(
             goal=f"task{i}", context=None, toolsets=None, role="leaf",
-            model="m", session_key="", runner=blocker, max_async_children=2,
+            model="m", session_key="test-origin-session", runner=blocker, max_async_children=2,
         )
         assert r["status"] == "dispatched"
 
     r3 = ad.dispatch_async_delegation(
         goal="task3", context=None, toolsets=None, role="leaf", model="m",
-        session_key="", runner=blocker, max_async_children=2,
+        session_key="test-origin-session", runner=blocker, max_async_children=2,
     )
     assert r3["status"] == "rejected"
     assert "capacity reached" in r3["error"]
@@ -173,10 +194,10 @@ def test_crashed_runner_produces_error_completion():
 
     r = ad.dispatch_async_delegation(
         goal="risky", context=None, toolsets=None, role="leaf", model="m",
-        session_key="", runner=boom, max_async_children=3,
+        session_key="test-origin-session", runner=boom, max_async_children=3,
     )
     assert r["status"] == "dispatched"
-    evt = _drain_one()
+    evt = _drain_one(goal="risky")
     assert evt is not None
     assert evt["status"] == "error"
     text = format_process_notification(evt)
@@ -200,7 +221,7 @@ def test_interrupt_all_signals_running_children():
 
     ad.dispatch_async_delegation(
         goal="long task", context=None, toolsets=None, role="leaf",
-        model="m", session_key="", runner=blocker,
+        model="m", session_key="test-origin-session", runner=blocker,
         interrupt_fn=interrupt_fn, max_async_children=3,
     )
     n = ad.interrupt_all(reason="test")
@@ -217,7 +238,7 @@ def test_completed_records_pruned_to_cap():
     for i in range(ad._MAX_RETAINED_COMPLETED + 10):
         ad.dispatch_async_delegation(
             goal=f"t{i}", context=None, toolsets=None, role="leaf", model="m",
-            session_key="", runner=lambda: {"status": "completed", "summary": "ok"},
+            session_key="test-origin-session", runner=lambda: {"status": "completed", "summary": "ok"},
             max_async_children=ad._MAX_RETAINED_COMPLETED + 20,
         )
     # let workers finish
@@ -751,7 +772,7 @@ def test_concurrent_dispatch_respects_capacity():
         results.append(
             ad.dispatch_async_delegation(
                 goal="race", context=None, toolsets=None, role="leaf",
-                model="m", session_key="", runner=blocker,
+                model="m", session_key="test-origin-session", runner=blocker,
                 max_async_children=1,
             )
         )
@@ -846,8 +867,8 @@ def test_gateway_builds_routable_source_from_enriched_event():
     assert src.chat_id == "12345"
 
 
-def test_gateway_cli_origin_event_left_unrouted():
-    """An empty session_key (CLI origin) is left without routing fields."""
+def test_gateway_legacy_ownerless_event_left_unrouted():
+    """A legacy ownerless event is left without routing fields."""
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -35,6 +35,7 @@ from tools.delegate_tool import (
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
     _inherit_parent_base_url,
+    _resolve_async_origin_session_key,
 )
 
 
@@ -52,6 +53,7 @@ def _make_mock_parent(depth=0):
     parent.providers_order = None
     parent.provider_sort = None
     parent._session_db = None
+    parent.session_id = "parent-origin-session"
     parent._delegate_depth = depth
     parent._active_children = []
     parent._active_children_lock = threading.Lock()
@@ -62,6 +64,25 @@ def _make_mock_parent(depth=0):
 
 
 class TestDelegateRequirements(unittest.TestCase):
+    def test_async_origin_uses_parent_session_when_worker_context_is_missing(self):
+        parent = _make_mock_parent()
+        with patch("tools.approval.get_current_session_key", return_value=""):
+            self.assertEqual(
+                _resolve_async_origin_session_key(parent),
+                "parent-origin-session",
+            )
+
+    def test_async_origin_prefers_gateway_session_context(self):
+        parent = _make_mock_parent()
+        with patch(
+            "tools.approval.get_current_session_key",
+            return_value="gateway-origin-session",
+        ):
+            self.assertEqual(
+                _resolve_async_origin_session_key(parent),
+                "gateway-origin-session",
+            )
+
     def test_always_available(self):
         self.assertTrue(check_delegate_requirements())
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -83,6 +83,15 @@ class TestDelegateRequirements(unittest.TestCase):
                 "gateway-origin-session",
             )
 
+    def test_async_origin_uses_parent_gateway_key_before_internal_session_id(self):
+        parent = _make_mock_parent()
+        parent._gateway_session_key = "agent:main:telegram:dm:123"
+        with patch("tools.approval.get_current_session_key", return_value=""):
+            self.assertEqual(
+                _resolve_async_origin_session_key(parent),
+                "agent:main:telegram:dm:123",
+            )
+
     def test_always_available(self):
         self.assertTrue(check_delegate_requirements())
 

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -238,6 +238,7 @@ class TestCheckpointNotify:
             "command": "sleep 999",
             "pid": os.getpid(),
             "task_id": "t1",
+            "session_key": "test-origin-session",
             "notify_on_complete": True,
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
@@ -278,6 +279,7 @@ class TestCheckpointNotify:
             "command": "sleep 999",
             "pid": os.getpid(),
             "task_id": "t1",
+            "session_key": "test-origin-session",
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             recovered = registry.recover_from_checkpoint()
@@ -510,6 +512,7 @@ def test_background_without_notify_emits_silent_process_hint(monkeypatch, tmp_pa
         result = json.loads(
             tt.terminal_tool(
                 command="while true; do gh pr checks 999; sleep 30; done",
+                session_id="test-origin-session",
                 background=True,
             )
         )
@@ -535,6 +538,7 @@ def test_background_with_notify_does_not_emit_hint(monkeypatch, tmp_path):
         result = json.loads(
             tt.terminal_tool(
                 command="pytest tests/",
+                session_id="test-origin-session",
                 background=True,
                 notify_on_complete=True,
             )
@@ -556,6 +560,7 @@ def test_background_with_watch_patterns_does_not_emit_hint(monkeypatch, tmp_path
         result = json.loads(
             tt.terminal_tool(
                 command="uvicorn app:server --port 8080",
+                session_id="test-origin-session",
                 background=True,
                 watch_patterns=["Application startup complete"],
             )
@@ -628,6 +633,7 @@ def test_homebrew_ci_poller_via_statusCheckRollup_emits_hint(monkeypatch, tmp_pa
                     "| group_by(.) | map({k:.[0],v:length}) | from_entries'); "
                     "echo \"$status\"; sleep 30; done"
                 ),
+                session_id="test-origin-session",
                 background=True,
                 notify_on_complete=True,
             )
@@ -660,6 +666,7 @@ def test_homebrew_ci_poller_via_gh_pr_checks_piped_to_jq_emits_hint(monkeypatch,
                     "gh pr checks $PR | jq -R 'split(\"\\t\")[1]'; "
                     "sleep 30; done"
                 ),
+                session_id="test-origin-session",
                 background=True,
                 notify_on_complete=True,
             )
@@ -692,6 +699,7 @@ def test_canonical_column2_awk_poller_does_not_emit_homebrew_hint(monkeypatch, t
                     "fi; sleep 30; "
                     "done"
                 ),
+                session_id="test-origin-session",
                 background=True,
                 notify_on_complete=True,
             )
@@ -719,6 +727,7 @@ def test_canonical_gh_pr_checks_exit_code_loop_does_not_emit_hint(monkeypatch, t
                     "case $rc in 0) exit 0;; 8) sleep 30;; *) exit 1;; esac; "
                     "done"
                 ),
+                session_id="test-origin-session",
                 background=True,
                 notify_on_complete=True,
             )
@@ -743,6 +752,7 @@ def test_non_ci_background_command_does_not_emit_homebrew_hint(monkeypatch, tmp_
         result = json.loads(
             tt.terminal_tool(
                 command="cat /var/log/syslog | awk '/error/ {print}' > /tmp/errs.log",
+                session_id="test-origin-session",
                 background=True,
                 notify_on_complete=True,
             )

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1345,6 +1345,7 @@ def test_drain_notifications_returns_pending_events():
     process_registry.completion_queue.put({
         "type": "completion",
         "session_id": "proc_drain1",
+        "session_key": "owner-session",
         "command": "echo hi",
         "exit_code": 0,
         "output": "hi",
@@ -1352,6 +1353,7 @@ def test_drain_notifications_returns_pending_events():
     process_registry.completion_queue.put({
         "type": "watch_match",
         "session_id": "proc_drain2",
+        "session_key": "owner-session",
         "command": "tail -f x",
         "pattern": "ERR",
         "output": "ERR found",
@@ -1359,7 +1361,7 @@ def test_drain_notifications_returns_pending_events():
     })
 
     try:
-        results = process_registry.drain_notifications()
+        results = process_registry.drain_notifications(session_key="owner-session")
         assert len(results) == 2
         assert results[0][0]["session_id"] == "proc_drain1"
         assert "proc_drain1 completed normally" in results[0][1]
@@ -1538,12 +1540,8 @@ def test_drain_notifications_ownership_callback_filters_process_completion():
             process_registry.completion_queue.get_nowait()
 
 
-def test_drain_notifications_no_filter_passes_all_async_delegation():
-    """Without a session_key filter, all async-delegation events are consumed.
-
-    This ensures backward compatibility — the default (session_key="") permits
-    all events, matching pre-fix behavior.
-    """
+def test_drain_notifications_without_owner_fails_closed():
+    """An unowned drain must never adopt events from the global queue."""
     from tools.process_registry import process_registry
 
     while not process_registry.completion_queue.empty():
@@ -1571,13 +1569,9 @@ def test_drain_notifications_no_filter_passes_all_async_delegation():
             "duration_seconds": 0.3,
         })
 
-        # No filter — both should be consumed
         results = process_registry.drain_notifications()
-        assert len(results) == 2, (
-            f"Expected 2 events without filter, got {len(results)}"
-        )
-        ids = {r[0]["delegation_id"] for r in results}
-        assert ids == {"deleg_1", "deleg_2"}
+        assert results == []
+        assert process_registry.completion_queue.qsize() == 2
     finally:
         while not process_registry.completion_queue.empty():
             process_registry.completion_queue.get_nowait()

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -65,6 +65,36 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
     return False
 
 
+def test_quick_background_process_is_registered_and_armed_before_exit(
+    registry, tmp_path
+):
+    """A zero-duration child must still publish one owned completion event."""
+    with patch.object(registry, "_write_checkpoint"):
+        session = registry.spawn_local(
+            f'{sys.executable} -c "print(\'done\')"',
+            cwd=str(tmp_path),
+            session_key="origin-session",
+            notify_on_complete=True,
+        )
+
+        assert _wait_until(lambda: session.exited)
+        assert session.id not in registry._running
+        assert session.id in registry._finished
+
+        event = registry.completion_queue.get(timeout=2)
+        assert event["type"] == "completion"
+        assert event["session_id"] == session.id
+        assert event["session_key"] == "origin-session"
+
+
+def test_registry_rejects_ownerless_local_and_remote_spawns(registry):
+    with pytest.raises(ValueError, match="origin session"):
+        registry.spawn_local("echo nope", cwd="/tmp")
+
+    with pytest.raises(ValueError, match="origin session"):
+        registry.spawn_via_env(MagicMock(), "echo nope")
+
+
 def test_write_stdin_uses_str_for_windows_pty(monkeypatch, registry):
     """pywinpty expects str input; bytes raises a PyString conversion error."""
     written = []
@@ -481,6 +511,7 @@ class TestStdinHelpers:
         session = registry.spawn_local(
             'python3 -c "import sys; print(sys.stdin.read().strip())"',
             cwd=str(tmp_path),
+            session_key="test-origin-session",
             use_pty=True,
         )
 
@@ -685,6 +716,7 @@ class TestSpawnEnvSanitization:
             registry.spawn_local(
                 "echo hello",
                 cwd="/tmp",
+                session_key="test-origin-session",
                 env_vars={
                     "MY_CUSTOM_VAR": "keep-me",
                     "TELEGRAM_BOT_TOKEN": "drop-me",
@@ -716,7 +748,7 @@ class TestSpawnEnvSanitization:
 
         with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
             patch.object(registry, "_write_checkpoint"):
-            session = registry.spawn_via_env(env, "echo hello")
+            session = registry.spawn_via_env(env, "echo hello", session_key="test-origin-session")
 
         bg_command = env.commands[0][0]
         assert session.pid == 4321
@@ -741,7 +773,7 @@ class TestSpawnEnvSanitization:
 
         with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
             patch.object(registry, "_write_checkpoint"):
-            session = registry.spawn_via_env(env, "echo hello")
+            session = registry.spawn_via_env(env, "echo hello", session_key="test-origin-session")
 
         assert session.exited is True
         assert session.exit_code == 2
@@ -768,7 +800,7 @@ class TestSpawnEnvSanitization:
 
         with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
             patch.object(registry, "_write_checkpoint"):
-            registry.spawn_via_env(env, "echo hello")
+            registry.spawn_via_env(env, "echo hello", session_key="test-origin-session")
 
         args, kwargs = env.commands[0]
         assert kwargs.get("rewrite_compound_background") is False
@@ -847,7 +879,7 @@ class TestPopenLeakOnSetupFailure:
              patch("os.getpgid", side_effect=ProcessLookupError), \
              patch.object(registry, "_write_checkpoint"):
             with pytest.raises(RuntimeError, match="Thread creation failed"):
-                registry.spawn_local("echo hello", cwd="/tmp")
+                registry.spawn_local("echo hello", cwd="/tmp", session_key="test-origin-session")
 
         assert killed, "proc.kill() must be called when post-Popen setup raises"
 
@@ -879,7 +911,7 @@ class TestPopenLeakOnSetupFailure:
              patch("os.getpgid", side_effect=ProcessLookupError), \
              patch.object(registry, "_write_checkpoint", side_effect=OSError("disk full")):
             with pytest.raises(OSError, match="disk full"):
-                registry.spawn_local("echo hello", cwd="/tmp")
+                registry.spawn_local("echo hello", cwd="/tmp", session_key="test-origin-session")
 
         assert killed, "proc.kill() must be called when _write_checkpoint raises"
 
@@ -905,7 +937,7 @@ class TestPopenLeakOnSetupFailure:
              patch("subprocess.Popen", return_value=proc), \
              patch("threading.Thread", return_value=fake_thread), \
              patch.object(registry, "_write_checkpoint"):
-            session = registry.spawn_local("echo hello", cwd="/tmp")
+            session = registry.spawn_local("echo hello", cwd="/tmp", session_key="test-origin-session")
 
         assert not killed, "proc.kill() must NOT be called on successful spawn"
         assert session.pid == 7777
@@ -919,16 +951,37 @@ class TestCheckpoint:
     def test_write_checkpoint(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
             s = _make_session()
+            s.session_key = "origin-session"
+            s.notify_on_complete = True
+            s.watch_patterns = ["READY"]
             registry._running[s.id] = s
             registry._write_checkpoint()
 
             data = json.loads((tmp_path / "procs.json").read_text())
             assert len(data) == 1
             assert data[0]["session_id"] == s.id
+            assert data[0]["session_key"] == "origin-session"
+            assert data[0]["notify_on_complete"] is True
+            assert data[0]["watch_patterns"] == ["READY"]
 
     def test_recover_no_file(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "missing.json"):
             assert registry.recover_from_checkpoint() == 0
+
+    def test_recovery_quarantines_ownerless_live_process(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_ownerless",
+            "command": "legacy command",
+            "pid": os.getpid(),
+            "task_id": "legacy-task",
+            "session_key": "",
+        }]))
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 0
+            assert registry.get("proc_ownerless") is None
+            assert json.loads(checkpoint.read_text()) == []
 
     def test_recover_dead_pid(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
@@ -998,6 +1051,7 @@ class TestCheckpoint:
             "command": "sleep 999",
             "pid": os.getpid(),
             "task_id": "t1",
+            "session_key": "test-origin-session",
             "watcher_interval": 0,
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
@@ -1013,12 +1067,18 @@ class TestCheckpoint:
             "pid": os.getpid(),
             "task_id": "t1",
             "session_key": "sk1",
+            "notify_on_complete": True,
+            "watch_patterns": ["READY"],
         }]))
 
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             recovered = registry.recover_from_checkpoint()
             assert recovered == 1
-            assert registry.get("proc_live") is not None
+            recovered_session = registry.get("proc_live")
+            assert recovered_session is not None
+            assert recovered_session.session_key == "sk1"
+            assert recovered_session.notify_on_complete is True
+            assert recovered_session.watch_patterns == ["READY"]
 
             data = json.loads(checkpoint.read_text())
             assert len(data) == 1
@@ -1836,6 +1896,7 @@ class TestPidReuseGuard:
             "pid_scope": "host",
             "host_start_time": real_start,
             "task_id": "t1",
+            "session_key": "test-origin-session",
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             assert registry.recover_from_checkpoint() == 1
@@ -1849,6 +1910,7 @@ class TestPidReuseGuard:
             "pid": os.getpid(),
             "pid_scope": "host",
             "task_id": "t1",
+            "session_key": "test-origin-session",
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             assert registry.recover_from_checkpoint() == 1

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1404,6 +1404,80 @@ def test_drain_notifications_filters_async_delegation_by_session_key():
             process_registry.completion_queue.get_nowait()
 
 
+def test_drain_notifications_filters_process_completions_by_session_key():
+    """A terminal completion must only become a turn in its owning session.
+
+    Regression for the cross-project context switch where a frontend chat
+    drained a model-router review process completion from the process-global
+    queue. The old filter only covered async_delegation events.
+    """
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    try:
+        process_registry.completion_queue.put({
+            "type": "completion",
+            "session_id": "proc_session_a",
+            "session_key": "desktop-session-a",
+            "command": "review project A",
+            "exit_code": 0,
+            "output": "A done",
+        })
+        process_registry.completion_queue.put({
+            "type": "completion",
+            "session_id": "proc_session_b",
+            "session_key": "desktop-session-b",
+            "command": "build project B",
+            "exit_code": 0,
+            "output": "B done",
+        })
+
+        results_a = process_registry.drain_notifications(
+            session_key="desktop-session-a"
+        )
+        assert [r[0]["session_id"] for r in results_a] == ["proc_session_a"]
+        assert "A done" in results_a[0][1]
+
+        results_b = process_registry.drain_notifications(
+            session_key="desktop-session-b"
+        )
+        assert [r[0]["session_id"] for r in results_b] == ["proc_session_b"]
+        assert "B done" in results_b[0][1]
+        assert process_registry.completion_queue.empty()
+    finally:
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_drain_notifications_ownership_callback_filters_process_completion():
+    """The desktop's chain-aware callback must gate terminal completions too."""
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    try:
+        process_registry.completion_queue.put({
+            "type": "completion",
+            "session_id": "proc_foreign",
+            "session_key": "foreign-key",
+            "command": "foreign review",
+            "exit_code": 1,
+            "output": "failed",
+        })
+        results = process_registry.drain_notifications(
+            session_key="current-key",
+            owns_event=lambda e: e.get("session_key") == "current-key",
+        )
+        assert results == []
+        assert process_registry.completion_queue.get_nowait()["session_id"] == "proc_foreign"
+    finally:
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
 def test_drain_notifications_no_filter_passes_all_async_delegation():
     """Without a session_key filter, all async-delegation events are consumed.
 

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -157,6 +157,8 @@ def test_background_command_prefers_live_env_cwd_over_init_time_cwd(monkeypatch)
         "cwd": "/workspace/live",
         "task_id": task_id,
         "session_key": task_id,
+        "notify_on_complete": False,
+        "watch_patterns": None,
         "env_vars": {},
         "use_pty": False,
     }]

--- a/tests/tools/test_terminal_tool_pty_fallback.py
+++ b/tests/tools/test_terminal_tool_pty_fallback.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import tools.terminal_tool as terminal_tool_module
 from tools import process_registry as process_registry_module
@@ -31,6 +32,11 @@ def test_terminal_background_disables_pty_for_gh_with_token(monkeypatch, tmp_pat
     dummy_env = SimpleNamespace(env={})
     captured = {}
 
+    monkeypatch.setattr(
+        "tools.approval.get_current_session_key",
+        lambda default="": "gateway-origin-session",
+    )
+
     def fake_spawn_local(**kwargs):
         captured.update(kwargs)
         return SimpleNamespace(id="proc_test", pid=1234, notify_on_complete=False)
@@ -48,6 +54,7 @@ def test_terminal_background_disables_pty_for_gh_with_token(monkeypatch, tmp_pat
                 command="gh auth login --hostname github.com --git-protocol https --with-token",
                 background=True,
                 pty=True,
+                session_id="session-explicit",
             )
         )
     finally:
@@ -55,6 +62,7 @@ def test_terminal_background_disables_pty_for_gh_with_token(monkeypatch, tmp_pat
         terminal_tool_module._last_activity.pop("default", None)
 
     assert captured["use_pty"] is False
+    assert captured["session_key"] == "gateway-origin-session"
     assert result["session_id"] == "proc_test"
     assert "PTY disabled" in result["pty_note"]
 
@@ -81,6 +89,7 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
                 command="python3 -c \"print(input())\"",
                 background=True,
                 pty=True,
+                session_id="session-explicit",
             )
         )
     finally:
@@ -88,4 +97,42 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
         terminal_tool_module._last_activity.pop("default", None)
 
     assert captured["use_pty"] is True
+    assert captured["session_key"] == "session-explicit"
     assert "pty_note" not in result
+
+
+def test_terminal_background_rejects_missing_origin_session(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(env={})
+    spawn_local = MagicMock()
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(
+        process_registry_module.process_registry, "spawn_local", spawn_local
+    )
+    monkeypatch.setattr(
+        "tools.approval.get_current_session_key", lambda default="": default
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="python3 -c \"print('done')\"",
+                background=True,
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert result["exit_code"] == -1
+    assert "origin session" in result["error"].lower()
+    spawn_local.assert_not_called()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -470,6 +470,16 @@ def dispatch_async_delegation(
         ``{"status": "dispatched", "delegation_id": ...}`` on success, or
         ``{"status": "rejected", "error": ...}`` when at capacity.
     """
+    session_key = str(session_key or "").strip()
+    if not session_key:
+        return {
+            "status": "rejected",
+            "error": (
+                "Background delegation requires an origin session ID; "
+                "refusing to start ownerless work."
+            ),
+        }
+
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
     record: Dict[str, Any] = {
@@ -598,7 +608,7 @@ def _push_completion_event(
         "type": "async_delegation",
         "delegation_id": record.get("delegation_id"),
         # session_key routes the completion back to the originating gateway
-        # session; empty string => CLI (single-session) path.
+        # session and is required at dispatch time.
         "session_key": record.get("session_key", ""),
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
@@ -663,6 +673,16 @@ def dispatch_async_delegation_batch(
     ``{"status": "rejected", "error": ...}`` when the async pool is at
     capacity.
     """
+    session_key = str(session_key or "").strip()
+    if not session_key:
+        return {
+            "status": "rejected",
+            "error": (
+                "Background delegation requires an origin session ID; "
+                "refusing to start ownerless work."
+            ),
+        }
+
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
     n = len(goals)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -157,6 +157,21 @@ def _delete_durable_delegation(delegation_id: str) -> None:
         conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
 
 
+def _cleanup_rejected_dispatch(delegation_id: str) -> None:
+    """Remove in-memory and durable state after a dispatch setup failure."""
+    with _records_lock:
+        _records.pop(delegation_id, None)
+    try:
+        _delete_durable_delegation(delegation_id)
+    except Exception:
+        # Persistence itself may be unavailable. The in-memory slot must still
+        # be released, and a partially committed row will be recovered later.
+        logger.exception(
+            "Failed to remove durable state for rejected async delegation %s",
+            delegation_id,
+        )
+
+
 def _prune_durable_records() -> None:
     """Bound terminal history, preferring delivered records for deletion."""
     now = time.time()
@@ -241,40 +256,90 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            owner_session = str(session_key or "").strip()
+            error = (
+                "Delegation owner exited before recording a terminal result; "
+                "outcome unknown."
+            )
+            delivery_state = "pending"
+            if not owner_session:
+                error += " Origin session is missing; result quarantined."
+                delivery_state = "quarantined"
+                logger.warning(
+                    "Quarantining abandoned ownerless async delegation %s",
+                    delegation_id,
+                )
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
-                "session_key": session_key, "origin_ui_session_id": origin_ui,
+                "session_key": owner_session, "origin_ui_session_id": origin_ui,
                 "parent_session_id": parent_id, "goal": task.get("goal", ""),
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
                 "status": "unknown", "summary": None,
-                "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
+                "error": error,
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
             result = {"status": "unknown", "summary": None, "error": event["error"]}
             conn.execute(
                 """UPDATE async_delegations SET state='unknown', completed_at=?,
-                   updated_at=?, event_json=?, result_json=?, delivery_state='pending'
+                   updated_at=?, event_json=?, result_json=?, delivery_state=?
                    WHERE delegation_id=?""",
-                (now, now, json.dumps(event), json.dumps(result), delegation_id),
+                (
+                    now,
+                    now,
+                    json.dumps(event),
+                    json.dumps(result),
+                    delivery_state,
+                    delegation_id,
+                ),
             )
             recovered += 1
     return recovered
 
 
 def restore_undelivered_completions(target_queue) -> int:
-    """Enqueue durable pending completions as fresh turns after process start."""
+    """Restore only completions with a non-empty, exact durable owner."""
     recover_abandoned_delegations()
+    restored = 0
+    now = time.time()
     with _DB_LOCK, _connect() as conn:
         rows = conn.execute(
-            """SELECT delegation_id, event_json FROM async_delegations
-               WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
+            """SELECT delegation_id, origin_session, event_json
+               FROM async_delegations
+               WHERE state != 'running' AND delivery_state='pending'
+                 AND event_json IS NOT NULL
                ORDER BY completed_at, delegation_id"""
         ).fetchall()
-        for _delegation_id, payload in rows:
-            target_queue.put(json.loads(payload))
-    return len(rows)
+        for delegation_id, durable_owner, payload in rows:
+            owner = str(durable_owner or "").strip()
+            try:
+                event = json.loads(payload)
+            except (TypeError, ValueError):
+                event = None
+            event_owner = (
+                str(event.get("session_key") or "").strip()
+                if isinstance(event, dict)
+                else ""
+            )
+            if not owner or event_owner != owner:
+                conn.execute(
+                    """UPDATE async_delegations
+                       SET delivery_state='quarantined', updated_at=?
+                       WHERE delegation_id=? AND delivery_state='pending'""",
+                    (now, delegation_id),
+                )
+                logger.warning(
+                    "Quarantining async delegation completion %s: durable "
+                    "owner=%r event owner=%r",
+                    delegation_id,
+                    owner,
+                    event_owner,
+                )
+                continue
+            target_queue.put(event)
+            restored += 1
+    return restored
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:
@@ -517,8 +582,15 @@ def dispatch_async_delegation(
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
-    executor = _get_executor(max_async_children)
+    try:
+        _persist_dispatch(record)
+        executor = _get_executor(max_async_children)
+    except Exception as exc:
+        _cleanup_rejected_dispatch(delegation_id)
+        return {
+            "status": "rejected",
+            "error": f"Failed to persist or prepare async delegation: {exc}",
+        }
 
     def _worker() -> None:
         result: Dict[str, Any] = {}
@@ -544,9 +616,7 @@ def dispatch_async_delegation(
         # get_hermes_home() under the right profile.
         executor.submit(propagate_context_to_thread(_worker))
     except Exception as exc:  # pragma: no cover — pool submit failure is rare
-        with _records_lock:
-            _records.pop(delegation_id, None)
-        _delete_durable_delegation(delegation_id)
+        _cleanup_rejected_dispatch(delegation_id)
         return {
             "status": "rejected",
             "error": f"Failed to schedule async delegation: {exc}",
@@ -723,8 +793,18 @@ def dispatch_async_delegation_batch(
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
-    executor = _get_executor(max_async_children)
+    try:
+        _persist_dispatch(record)
+        executor = _get_executor(max_async_children)
+    except Exception as exc:
+        _cleanup_rejected_dispatch(delegation_id)
+        return {
+            "status": "rejected",
+            "error": (
+                "Failed to persist or prepare async delegation batch: "
+                f"{exc}"
+            ),
+        }
 
     def _worker() -> None:
         combined: Dict[str, Any] = {}
@@ -755,9 +835,7 @@ def dispatch_async_delegation_batch(
         # Propagate the dispatching profile to the detached batch children.
         executor.submit(propagate_context_to_thread(_worker))
     except Exception as exc:  # pragma: no cover
-        with _records_lock:
-            _records.pop(delegation_id, None)
-        _delete_durable_delegation(delegation_id)
+        _cleanup_rejected_dispatch(delegation_id)
         return {
             "status": "rejected",
             "error": f"Failed to schedule async delegation batch: {exc}",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2366,6 +2366,20 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_async_origin_session_key(parent_agent) -> str:
+    """Return the durable owner for an async delegation.
+
+    Gateway context is preferred when available. Worker threads may not inherit
+    that ContextVar, so the parent agent's durable session id is the mandatory
+    fallback instead of allowing an ownerless dispatch.
+    """
+    from tools.approval import get_current_session_key
+
+    gateway_key = str(get_current_session_key(default="") or "").strip()
+    parent_key = str(getattr(parent_agent, "session_id", "") or "").strip()
+    return gateway_key or parent_key
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -2794,7 +2808,6 @@ def delegate_task(
     # keep chatting, get the combined summaries back together at the end.
     if background:
         from tools.async_delegation import dispatch_async_delegation_batch
-        from tools.approval import get_current_session_key
 
         # Stateless request/response sessions (the API server / WebUI path)
         # cannot route a detached subagent result back to the agent after the
@@ -2824,7 +2837,11 @@ def delegate_task(
                 )
             return json.dumps(_sync_result, ensure_ascii=False)
 
-        _session_key = get_current_session_key(default="")
+        # Gateway conversation keys win when present. The parent agent's
+        # durable session id is the fail-safe when tool-worker contextvars are
+        # unavailable, so an async delegation is never dispatched ownerless.
+        _parent_session_id = getattr(parent_agent, "session_id", None)
+        _session_key = _resolve_async_origin_session_key(parent_agent)
         _origin_ui_session_id = ""
         try:
             from gateway.session_context import get_session_env
@@ -2844,7 +2861,6 @@ def delegate_task(
                     _session_key = _agent_session_id
         except Exception:
             _origin_ui_session_id = ""
-        _parent_session_id = getattr(parent_agent, "session_id", None)
         _child_agents = [c for (_, _, c) in children]
 
         # Detach every child from the parent's interrupt-propagation list — the

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2376,8 +2376,14 @@ def _resolve_async_origin_session_key(parent_agent) -> str:
     from tools.approval import get_current_session_key
 
     gateway_key = str(get_current_session_key(default="") or "").strip()
+    parent_gateway_raw = getattr(parent_agent, "_gateway_session_key", None)
+    parent_gateway_key = (
+        parent_gateway_raw.strip()
+        if isinstance(parent_gateway_raw, str)
+        else ""
+    )
     parent_key = str(getattr(parent_agent, "session_id", "") or "").strip()
-    return gateway_key or parent_key
+    return gateway_key or parent_gateway_key or parent_key
 
 
 def delegate_task(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1212,10 +1212,11 @@ class ProcessRegistry:
           a post-compression session still claims its own pre-compression
           dispatches.
         - ``session_key``: plain key equality (CLI and other single-session
-          callers). Non-matching async-delegation events are re-queued.
+          callers). Non-matching events are re-queued.
 
-        With neither set, all events are consumed (legacy single-session
-        behavior, backward compatible).
+        With neither set, fail closed and re-queue every event. An unowned
+        consumer must never adopt a synthetic turn from this process-global
+        queue.
         """
         results: "list[tuple[dict, str]]" = []
         requeue: "list[dict]" = []
@@ -1237,15 +1238,17 @@ class ProcessRegistry:
                 try:
                     owned = bool(owns_event(evt))
                 except Exception:
-                    owned = False  # fail closed — never leak on a broken check
+                    owned = False
                 if not owned:
                     requeue.append(evt)
                     continue
             elif session_key:
-                evt_session_key = evt.get("session_key", "") or ""
-                if evt_session_key != session_key:
+                if evt.get("session_key") != session_key:
                     requeue.append(evt)
                     continue
+            else:
+                requeue.append(evt)
+                continue
             text = format_process_notification(evt)
             if text:
                 results.append((evt, text))

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -692,6 +692,8 @@ class ProcessRegistry:
         cwd: str = None,
         task_id: str = "",
         session_key: str = "",
+        notify_on_complete: bool = False,
+        watch_patterns: Optional[List[str]] = None,
         env_vars: dict = None,
         use_pty: bool = False,
     ) -> ProcessSession:
@@ -705,11 +707,18 @@ class ProcessRegistry:
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
         """
+        session_key = str(session_key or "").strip()
+        if not session_key:
+            raise ValueError(
+                "Background process requires a non-empty origin session ID"
+            )
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
             session_key=session_key,
+            notify_on_complete=bool(notify_on_complete),
+            watch_patterns=list(watch_patterns or []),
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
@@ -743,18 +752,27 @@ class ProcessRegistry:
                     name=f"proc-pty-reader-{session.id}",
                 )
                 session._reader_thread = reader
-                reader.start()
 
                 with self._lock:
                     self._prune_if_needed()
                     self._running[session.id] = session
 
+                reader.start()
                 self._write_checkpoint()
                 return session
 
             except ImportError:
                 logger.warning("ptyprocess not installed, falling back to pipe mode")
             except Exception as e:
+                with self._lock:
+                    self._running.pop(session.id, None)
+                try:
+                    if session._pty is not None:
+                        session._pty.terminate(force=True)
+                except Exception:
+                    pass
+                session._pty = None
+                session.pid = None
                 logger.warning("PTY spawn failed (%s), falling back to pipe mode", e)
 
         # Standard Popen path (non-PTY or PTY fallback)
@@ -795,17 +813,19 @@ class ProcessRegistry:
                 name=f"proc-reader-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
 
             with self._lock:
                 self._prune_if_needed()
                 self._running[session.id] = session
 
+            reader.start()
             self._write_checkpoint()
         except Exception:
             # Post-Popen setup failed — kill the orphaned subprocess (and any
             # descendants spawned via setsid) before re-raising so they do not
             # leak as untracked background processes.
+            with self._lock:
+                self._running.pop(session.id, None)
             try:
                 if not _IS_WINDOWS:
                     try:
@@ -832,6 +852,8 @@ class ProcessRegistry:
         cwd: str = None,
         task_id: str = "",
         session_key: str = "",
+        notify_on_complete: bool = False,
+        watch_patterns: Optional[List[str]] = None,
         timeout: int = 10,
     ) -> ProcessSession:
         """
@@ -845,11 +867,18 @@ class ProcessRegistry:
         This is less capable than local spawn (no live stdout pipe, no stdin),
         but it ensures the command runs in the correct sandbox context.
         """
+        session_key = str(session_key or "").strip()
+        if not session_key:
+            raise ValueError(
+                "Background process requires a non-empty origin session ID"
+            )
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
             session_key=session_key,
+            notify_on_complete=bool(notify_on_complete),
+            watch_patterns=list(watch_patterns or []),
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,
@@ -904,8 +933,14 @@ class ProcessRegistry:
             session.termination_source = "failed_start"
             session.output_buffer = f"Failed to start: {e}"
 
+        with self._lock:
+            self._prune_if_needed()
+            if not session.exited:
+                self._running[session.id] = session
+
         if not session.exited:
-            # Start a poller thread that periodically reads the log file
+            # Register the fully-owned, fully-armed session before the poller
+            # can observe process exit. This mirrors spawn_local's ordering.
             reader = threading.Thread(
                 target=self._env_poller_loop,
                 args=(session, env, log_path, pid_path, exit_path),
@@ -913,15 +948,13 @@ class ProcessRegistry:
                 name=f"proc-poller-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
-
-        with self._lock:
-            self._prune_if_needed()
-            if not session.exited:
-                self._running[session.id] = session
-
-        if not session.exited:
-            self._write_checkpoint()
+            try:
+                reader.start()
+                self._write_checkpoint()
+            except Exception:
+                with self._lock:
+                    self._running.pop(session.id, None)
+                raise
 
         return session
 
@@ -1919,6 +1952,15 @@ class ProcessRegistry:
                 )
                 continue
 
+            session_key = str(entry.get("session_key", "") or "").strip()
+            if not session_key:
+                logger.warning(
+                    "Quarantining recovered background process %s: missing "
+                    "origin session ID",
+                    entry.get("session_id", "?"),
+                )
+                continue
+
             # The PID must be alive AND still the same process we spawned. A
             # bare liveness check is unsafe: across a restart (especially a
             # reboot or long uptime) the kernel may have recycled this number
@@ -1940,7 +1982,7 @@ class ProcessRegistry:
                 id=entry["session_id"],
                 command=entry.get("command", "unknown"),
                 task_id=entry.get("task_id", ""),
-                session_key=entry.get("session_key", ""),
+                session_key=session_key,
                 pid=pid,
                 host_start_time=recorded_start,
                 pid_scope=pid_scope,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1168,13 +1168,13 @@ class ProcessRegistry:
         Skips completion events the agent already consumed via wait/log or
         observed inline via poll() (see ``_drain_should_skip``).
 
-        Async-delegation events carry a conversation payload, so draining one
-        into the wrong session is a cross-chat leak (#58684, #55578). Two
-        filter modes, strongest wins:
+        Every notification event becomes a synthetic conversation turn, so
+        draining even an ordinary process completion into the wrong session is
+        a cross-chat context leak. Two filter modes, strongest wins:
 
         - ``owns_event(evt) -> bool``: positive-proof ownership callback.
-          When provided, an async-delegation event is consumed ONLY if the
-          callback returns True; everything else is re-queued for its owner.
+          When provided, an event is consumed ONLY if the callback returns
+          True; everything else is re-queued for its owner.
           The TUI passes its compression-chain-aware ownership check here so
           a post-compression session still claims its own pre-compression
           dispatches.
@@ -1194,23 +1194,25 @@ class ProcessRegistry:
             _evt_sid = evt.get("session_id", "")
             if evt.get("type") == "completion" and self._drain_should_skip(_evt_sid):
                 continue
-            # Filter async-delegation events so they are not delivered to the
-            # wrong session/thread (#58684). Positive-proof callback beats
-            # bare key equality when the caller can provide one.
-            if evt.get("type") == "async_delegation":
-                if owns_event is not None:
-                    try:
-                        owned = bool(owns_event(evt))
-                    except Exception:
-                        owned = False  # fail closed — never leak on a broken check
-                    if not owned:
-                        requeue.append(evt)
-                        continue
-                elif session_key:
-                    evt_session_key = evt.get("session_key", "") or ""
-                    if evt_session_key != session_key:
-                        requeue.append(evt)
-                        continue
+            # Filter ALL notification events, not only async delegations.
+            # Process completions and watch matches are also injected as
+            # synthetic user turns; letting whichever chat drains this global
+            # queue first consume them can replace that chat's active task with
+            # another project's background work. Positive-proof ownership beats
+            # bare key equality when the caller can provide it.
+            if owns_event is not None:
+                try:
+                    owned = bool(owns_event(evt))
+                except Exception:
+                    owned = False  # fail closed — never leak on a broken check
+                if not owned:
+                    requeue.append(evt)
+                    continue
+            elif session_key:
+                evt_session_key = evt.get("session_key", "") or ""
+                if evt_session_key != session_key:
+                    requeue.append(evt)
+                    continue
             text = format_process_notification(evt)
             if text:
                 results.append((evt, text))

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2372,6 +2372,7 @@ def terminal_tool(
             pass
 
         notification_conflict_note = None
+        notification_unsupported_note = None
         if background:
             # Resolve mutually-exclusive notification modes before spawn so a
             # fast child cannot observe a transient, invalid configuration.
@@ -2382,6 +2383,22 @@ def terminal_tool(
                     background=True,
                 )
             )
+            # Stateless request/response sessions have no destination after
+            # the turn ends. Disable the promise BEFORE spawn so even a child
+            # that exits immediately cannot enqueue an undeliverable event.
+            if notify_on_complete or watch_patterns:
+                from gateway.session_context import async_delivery_supported
+
+                if not async_delivery_supported():
+                    notify_on_complete = False
+                    watch_patterns = None
+                    notification_unsupported_note = (
+                        "notify_on_complete / watch_patterns are not available on "
+                        "this endpoint (stateless HTTP API — no channel to deliver "
+                        "an async completion after the turn ends). The process is "
+                        "running in the background; retrieve its result with "
+                        "process(action='poll') or process(action='wait')."
+                    )
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
@@ -2429,6 +2446,14 @@ def terminal_tool(
                     result_data["approval"] = approval_note
                 if pty_disabled_reason:
                     result_data["pty_note"] = pty_disabled_reason
+                if notification_unsupported_note:
+                    result_data["notify_on_complete"] = False
+                    result_data["notify_unsupported"] = notification_unsupported_note
+                    logger.info(
+                        "background proc %s: async delivery unsupported on this "
+                        "session; notify_on_complete/watch_patterns disabled",
+                        proc_session.id,
+                    )
 
                 # Nudge: background=True without notify_on_complete=True OR
                 # watch_patterns is a silent process. The agent has NO way to
@@ -2442,7 +2467,12 @@ def terminal_tool(
                 # surface the result. Cheap nudge here costs ~one read for
                 # server cases (false positive) and prevents silent
                 # blindness for bounded-task cases (false negative).
-                if background and not notify_on_complete and not watch_patterns:
+                if (
+                    background
+                    and not notify_on_complete
+                    and not watch_patterns
+                    and not notification_unsupported_note
+                ):
                     result_data["hint"] = (
                         "background=true without notify_on_complete=true means "
                         "this process runs SILENTLY — you will not be told when "
@@ -2539,47 +2569,21 @@ def terminal_tool(
                 # watch-pattern and completion notifications can be
                 # routed back to the correct chat/thread.
                 if background and (notify_on_complete or watch_patterns):
-                    from gateway.session_context import (
-                        async_delivery_supported as _async_ok,
-                        get_session_env as _gse,
-                    )
+                    from gateway.session_context import get_session_env as _gse
 
-                    # Stateless request/response sessions (the API server /
-                    # WebUI path) cannot route a completion back to the agent
-                    # after the turn ends — there is no persistent channel and
-                    # send() is a no-op. Registering a watcher there silently
-                    # no-ops (issue #10760). Refuse the promise instead: drop
-                    # the flags and tell the agent to poll.
-                    if not _async_ok():
-                        notify_on_complete = False
-                        watch_patterns = None
-                        result_data["notify_on_complete"] = False
-                        result_data["notify_unsupported"] = (
-                            "notify_on_complete / watch_patterns are not available on "
-                            "this endpoint (stateless HTTP API — no channel to deliver "
-                            "an async completion after the turn ends). The process is "
-                            "running in the background; retrieve its result with "
-                            "process(action='poll') or process(action='wait')."
-                        )
-                        logger.info(
-                            "background proc %s: async delivery unsupported on this "
-                            "session; notify_on_complete/watch_patterns disabled",
-                            proc_session.id,
-                        )
-                    else:
-                        _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
-                        if _gw_platform:
-                            _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
-                            _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
-                            _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
-                            _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
-                            _gw_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
-                            proc_session.watcher_platform = _gw_platform
-                            proc_session.watcher_chat_id = _gw_chat_id
-                            proc_session.watcher_user_id = _gw_user_id
-                            proc_session.watcher_user_name = _gw_user_name
-                            proc_session.watcher_thread_id = _gw_thread_id
-                            proc_session.watcher_message_id = _gw_message_id
+                    _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
+                    if _gw_platform:
+                        _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
+                        _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
+                        _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
+                        _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
+                        _gw_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
+                        proc_session.watcher_platform = _gw_platform
+                        proc_session.watcher_chat_id = _gw_chat_id
+                        proc_session.watcher_user_id = _gw_user_id
+                        proc_session.watcher_user_name = _gw_user_name
+                        proc_session.watcher_thread_id = _gw_thread_id
+                        proc_session.watcher_message_id = _gw_message_id
 
                 # Mutual exclusion: if both notify_on_complete and watch_patterns
                 # are set, drop watch_patterns. The combination produces duplicate

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2345,21 +2345,43 @@ def terminal_tool(
             )
 
         # Claim the (shared "default") terminal env for the session driving this
-        # command. File tools read env.cwd_owner to decide whether the env's live
-        # cwd is THIS session's `cd` or a different worktree session's — without
-        # it, two open worktree sessions sharing the env route each other's edits
-        # to the wrong checkout. get_current_session_key()'s contextvar doesn't
-        # cross tool-worker threads, so fall back to the raw task_id (which IS the
-        # session_key for the top-level agent) — a stable, thread-safe anchor.
+        # command. Prefer the gateway's stable conversation key when present;
+        # contextvars do not reliably cross tool-worker threads, so the
+        # dispatcher's explicit durable AIAgent session id is the mandatory
+        # fallback that prevents an ownerless background process.
         from tools.approval import get_current_session_key
 
-        session_key = get_current_session_key(default="") or (task_id or "")
+        session_key = (
+            str(get_current_session_key(default="") or "").strip()
+            or str(session_id or "").strip()
+            or str(task_id or "").strip()
+        )
+        if background and not session_key:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": (
+                    "Background process requires an origin session ID. The tool "
+                    "dispatcher must pass session_id; refusing to start ownerless "
+                    "work because its output could not be delivered safely."
+                ),
+            }, ensure_ascii=False)
         try:
             env.cwd_owner = session_key
         except Exception:
             pass
 
+        notification_conflict_note = None
         if background:
+            # Resolve mutually-exclusive notification modes before spawn so a
+            # fast child cannot observe a transient, invalid configuration.
+            watch_patterns, notification_conflict_note = (
+                _resolve_notification_flag_conflict(
+                    notify_on_complete=bool(notify_on_complete),
+                    watch_patterns=watch_patterns,
+                    background=True,
+                )
+            )
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
@@ -2377,6 +2399,8 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        notify_on_complete=bool(notify_on_complete),
+                        watch_patterns=watch_patterns,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
                     )
@@ -2387,6 +2411,8 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        notify_on_complete=bool(notify_on_complete),
+                        watch_patterns=watch_patterns,
                     )
 
                 result_data = {
@@ -2562,11 +2588,7 @@ def terminal_tool(
                 # notify_on_complete is the more useful signal for "let me know
                 # when the task finishes"; watch_patterns should be reserved for
                 # standalone mid-process signals on long-lived processes.
-                watch_patterns, conflict_note = _resolve_notification_flag_conflict(
-                    notify_on_complete=bool(notify_on_complete),
-                    watch_patterns=watch_patterns,
-                    background=bool(background),
-                )
+                conflict_note = notification_conflict_note
                 if conflict_note:
                     logger.warning("background proc %s: %s", proc_session.id, conflict_note)
                     result_data["watch_patterns_ignored"] = conflict_note

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8638,9 +8638,9 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
     minus its orphan-adoption fallback. An event owns-matches when its
     ``origin_ui_session_id`` is this live session, or its ``session_key``
     (raw or resolved through the compression chain) matches this session's
-    key/lineage. Used as a fail-closed gate for async-delegation payloads:
-    "not provably elsewhere" is NOT good enough to inject a conversation
-    payload into this chat (#55578).
+    key/lineage. Used as a fail-closed gate for every notification payload:
+    "not provably elsewhere" is NOT good enough to inject a synthetic
+    conversation turn into this chat (#55578).
     """
     if session.get("_finalized"):
         return False
@@ -8735,26 +8735,23 @@ def _notification_poller_loop(
             time.sleep(0.1)
             continue
 
-        # Fail closed for async-delegation results (#55578): these carry a
-        # conversation payload, and injecting one into any chat other than the
-        # one that commissioned it is a hard cross-session leak. The
+        # Fail closed for every notification result (#55578): process
+        # completions and watch matches also become synthetic conversation
+        # turns, so injecting any of them into a chat other than the one that
+        # commissioned it is a hard cross-session context leak. The
         # belongs-elsewhere check above already re-queued events owned by
-        # another LIVE session; what reaches here is either ours or an
-        # orphan whose owner is gone. Orphaned delegation payloads are
-        # DROPPED, not adopted — the subagent's summary is already persisted
-        # in the delegation records/output store, so nothing is lost, whereas
-        # a wrong-chat injection is unrecoverable. Non-delegation events
-        # (background process completions etc.) keep the historical
-        # adopt-orphans behavior.
-        if evt.get("type") == "async_delegation" and not _session_owns_notification_event(
-            sid, session, evt
-        ):
+        # another LIVE session; what reaches here is either ours or an orphan
+        # whose owner is gone. Orphaned events are DROPPED from auto-injection,
+        # not adopted. Delegation results remain in the delegation records;
+        # process output remains in the process registry/status terminal. A
+        # missed notification is recoverable, while a wrong-chat injection is
+        # not.
+        if not _session_owns_notification_event(sid, session, evt):
             logger.warning(
-                "async-delegation completion %s has no live owner "
+                "notification %s has no live owner "
                 "(origin=%r key=%r); dropping from injection instead of "
-                "delivering to session %s (#55578 fail-closed; result "
-                "remains in the delegation records)",
-                evt.get("delegation_id", "?"),
+                "delivering to session %s (#55578 fail-closed)",
+                evt.get("delegation_id") or evt.get("session_id", "?"),
                 str(evt.get("origin_ui_session_id") or ""),
                 str(evt.get("session_key") or ""),
                 sid,
@@ -8825,13 +8822,10 @@ def _notification_poller_loop(
         if _notification_event_belongs_elsewhere(sid, session, evt):
             deferred.append(evt)
             continue
-        # Same fail-closed rule as the live loop: an orphaned async-delegation
-        # payload is never adopted by a foreign session — defer it (a later
-        # resume of the owner's lineage can still claim it) rather than
-        # injecting another chat's conversation here (#55578).
-        if evt.get("type") == "async_delegation" and not _session_owns_notification_event(
-            sid, session, evt
-        ):
+        # Same fail-closed rule as the live loop: an orphaned notification is
+        # never adopted by a foreign session. Defer it rather than injecting
+        # another chat's synthetic turn during shutdown (#55578).
+        if not _session_owns_notification_event(sid, session, evt):
             deferred.append(evt)
             continue
         _evt_sid = evt.get("session_id", "")


### PR DESCRIPTION
## Summary

- require a non-empty durable owner for every agent-created terminal background process and detached subagent batch
- prefer the gateway conversation key, then fall back to the dispatcher's explicit `AIAgent.session_id` when worker context is unavailable
- persist the owner and notification mode in process checkpoints; quarantine legacy ownerless recovery records
- register and arm process notifications before reader/poller threads start, closing the zero-duration completion race
- exact-match all queued notification events at delivery, not only async-delegation completions
- preserve compression-chain-aware routing for legitimate continuations

## Root cause

`ProcessRegistry.drain_notifications(session_key=..., owns_event=...)` previously applied ownership checks only to async-delegation events. Ordinary terminal completions share the same process-global queue and also become synthetic user turns, so another desktop chat could consume a stale completion first.

A second creation-side gap made the issue possible: `terminal_tool()` received an explicit `session_id` from tool dispatch but ignored it when worker-thread context and `task_id` were empty. That produced ownerless processes. Notification flags were also armed after process start, allowing very short commands to finish before registration or notification setup.

This PR now enforces ownership at both boundaries:

1. creation rejects ownerless terminal and delegation work;
2. the durable owner and notification mode are stored before execution can complete;
3. restart recovery restores owned records and quarantines ownerless legacy records;
4. delivery requires positive ownership, including continuation-lineage resolution.

Losing an invalid legacy notification is safer than guessing an owner and contaminating another session. Legitimate terminal output remains available through the process registry, and delegation records remain queryable.

## Incident evidence

At 2026-07-13 18:43, the desktop transport emitted terminal output for `proc_af1041e85102` with an empty session ID. Its completion was persisted as a synthetic user turn in session `20260713_162533_199471`, which had no matching process-launch record. That unrelated Scribe chat consequently began responding to a Fleet Model Router audit.

## Verification

- `python -m pytest -q tests/tools/test_process_registry.py` -> **108 passed**
- `python -m pytest -q tests/tools/test_async_delegation.py tests/tools/test_delegate.py` -> **186 passed**
- terminal ownership/notification/dispatch suites -> **82 passed**
- focused desktop notification routing -> **8 passed**
- full `tests/test_tui_gateway_server.py` -> **319 passed, 3 unrelated existing failures** around stale `tui` versus `desktop` expectations
- Ruff, `py_compile`, and `git diff --check` passed
