### PR TITLE
feat(acp): honor platform_toolsets.acp config for ACP tool surface

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -831,7 +831,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                getattr(state.agent, "enabled_toolsets", None) or None,
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
@@ -1791,7 +1791,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+                getattr(state.agent, "enabled_toolsets", None) or None
             )
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             tool_view = SimpleNamespace(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1165,7 +1165,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                getattr(state.agent, "enabled_toolsets", None) or None,
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
@@ -2350,7 +2350,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+                getattr(state.agent, "enabled_toolsets", None) or None
             )
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             tool_view = SimpleNamespace(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -126,13 +126,34 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
 
 
+def _acp_base_toolsets() -> List[str]:
+    """Return the base toolsets for ACP sessions.
+
+    Honors an explicit ``platform_toolsets.acp`` list in config.yaml so users
+    can trim the ACP tool surface (e.g. drop ``browser``) the same way they
+    configure other platforms. Falls back to the built-in composite
+    ``hermes-acp`` toolset when no list is configured.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        raw = (load_config().get("platform_toolsets") or {}).get("acp")
+        if isinstance(raw, list):
+            names = [str(t) for t in raw if t]
+            if names:
+                return names
+    except Exception:
+        logger.debug("Failed to read platform_toolsets.acp from config", exc_info=True)
+    return ["hermes-acp"]
+
+
 def _expand_acp_enabled_toolsets(
     toolsets: List[str] | None = None,
     mcp_server_names: List[str] | None = None,
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    for name in list(toolsets or _acp_base_toolsets()):
         if name and name not in expanded:
             expanded.append(name)
 
@@ -617,7 +638,7 @@ class SessionManager:
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                None,  # resolves platform_toolsets.acp or hermes-acp default
                 mcp_server_names=configured_mcp_servers,
             ),
             "quiet_mode": True,

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -129,21 +129,27 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
 def _acp_base_toolsets() -> List[str]:
     """Return the base toolsets for ACP sessions.
 
-    Honors an explicit ``platform_toolsets.acp`` list in config.yaml so users
-    can trim the ACP tool surface (e.g. drop ``browser``) the same way they
-    configure other platforms. Falls back to the built-in composite
-    ``hermes-acp`` toolset when no list is configured.
+    An explicit ``platform_toolsets.acp`` list in config.yaml is resolved
+    through the shared ``_get_platform_tools`` resolver so ACP gets the same
+    explicit-selection semantics as other platforms — including the global
+    ``agent.disabled_toolsets`` subtraction, which a raw config lookup would
+    bypass. Missing, non-list, or empty values fall back to the built-in
+    composite ``hermes-acp`` toolset, so existing installs are unaffected.
+    Config-level MCP servers are excluded here; the per-session MCP append
+    path (``_expand_acp_enabled_toolsets``) adds them.
     """
     try:
         from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
 
-        raw = (load_config().get("platform_toolsets") or {}).get("acp")
-        if isinstance(raw, list):
-            names = [str(t) for t in raw if t]
-            if names:
-                return names
+        config = load_config()
+        raw = (config.get("platform_toolsets") or {}).get("acp")
+        if isinstance(raw, list) and any(t for t in raw):
+            return sorted(
+                _get_platform_tools(config, "acp", include_default_mcp_servers=False)
+            )
     except Exception:
-        logger.debug("Failed to read platform_toolsets.acp from config", exc_info=True)
+        logger.debug("Failed to resolve platform_toolsets.acp", exc_info=True)
     return ["hermes-acp"]
 
 

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -137,13 +137,26 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
 
 
+def _acp_base_toolsets(config: dict | None = None) -> List[str]:
+    """Resolve ACP toolsets through the shared per-platform config resolver."""
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+
+        config = config if isinstance(config, dict) else load_config()
+        return sorted(_get_platform_tools(config, "acp"))
+    except Exception:
+        logger.debug("Failed to resolve ACP platform toolsets", exc_info=True)
+    return ["hermes-acp"]
+
+
 def _expand_acp_enabled_toolsets(
     toolsets: List[str] | None = None,
     mcp_server_names: List[str] | None = None,
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    for name in list(toolsets or _acp_base_toolsets()):
         if name and name not in expanded:
             expanded.append(name)
 
@@ -626,18 +639,9 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers = [
-            name
-            for name, cfg in (config.get("mcp_servers") or {}).items()
-            if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
-        ]
-
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
-            ),
+            "enabled_toolsets": _acp_base_toolsets(config),
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -440,6 +440,45 @@ class TestPersistence:
 
         assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-olympus", "mcp-exa"]
 
+    def test_create_session_honors_platform_toolsets_acp(self, tmp_path, monkeypatch):
+        """platform_toolsets.acp in config replaces the hermes-acp composite."""
+        captured = {}
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), enabled_toolsets=kwargs.get("enabled_toolsets"))
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "platform_toolsets": {"acp": ["web", "terminal", "file"]},
+            "mcp_servers": {"olympus": {"command": "python", "enabled": True}},
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None, **kwargs: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            },
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            manager.create_session(cwd="/work")
+
+        assert captured["enabled_toolsets"] == ["web", "terminal", "file", "mcp-olympus"]
+
+    def test_acp_base_toolsets_fallback_on_empty_or_missing(self, monkeypatch):
+        """Missing, non-list, or empty platform_toolsets.acp falls back to hermes-acp."""
+        for cfg in ({}, {"platform_toolsets": {}}, {"platform_toolsets": {"acp": "web"}},
+                    {"platform_toolsets": {"acp": []}}, {"platform_toolsets": {"acp": ["", None]}}):
+            monkeypatch.setattr("hermes_cli.config.load_config", lambda cfg=cfg: cfg)
+            assert acp_session._acp_base_toolsets() == ["hermes-acp"]
+
     def test_create_session_writes_to_db(self, manager):
         state = manager.create_session(cwd="/project")
         db = manager._get_db()

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -470,7 +470,46 @@ class TestPersistence:
             manager = SessionManager(db=db)
             manager.create_session(cwd="/work")
 
-        assert captured["enabled_toolsets"] == ["web", "terminal", "file", "mcp-olympus"]
+        assert captured["enabled_toolsets"] == ["file", "terminal", "web", "mcp-olympus"]
+
+    def test_create_session_strips_globally_disabled_toolsets(self, tmp_path, monkeypatch):
+        """A toolset listed in platform_toolsets.acp but globally disabled stays off.
+
+        The shared resolver applies agent.disabled_toolsets last; the ACP
+        surface must not re-enable a globally disabled toolset just because
+        it appears in the platform list.
+        """
+        captured = {}
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), enabled_toolsets=kwargs.get("enabled_toolsets"))
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "platform_toolsets": {"acp": ["web", "terminal", "file"]},
+            "agent": {"disabled_toolsets": ["web"]},
+            "mcp_servers": {"olympus": {"command": "python", "enabled": True}},
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None, **kwargs: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            },
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            manager.create_session(cwd="/work")
+
+        assert "web" not in captured["enabled_toolsets"]
+        assert captured["enabled_toolsets"] == ["file", "terminal", "mcp-olympus"]
 
     def test_acp_base_toolsets_fallback_on_empty_or_missing(self, monkeypatch):
         """Missing, non-list, or empty platform_toolsets.acp falls back to hermes-acp."""

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -274,6 +274,46 @@ class TestPersistence:
 
 
 
+    def test_create_session_honors_platform_toolsets_acp(self, tmp_path, monkeypatch):
+        """ACP uses the shared platform resolver, including MCP and global disables."""
+        captured = {}
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), enabled_toolsets=kwargs.get("enabled_toolsets"))
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "platform_toolsets": {"acp": ["web", "terminal", "file"]},
+            "mcp_servers": {"olympus": {"command": "python", "enabled": True}},
+            "agent": {"disabled_toolsets": ["terminal"]},
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None, **kwargs: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            },
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            manager.create_session(cwd="/work")
+
+        assert captured["enabled_toolsets"] == ["file", "olympus", "web"]
+
+    def test_acp_base_toolsets_falls_back_when_resolver_fails(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            MagicMock(side_effect=RuntimeError("bad config")),
+        )
+
+        assert acp_session._acp_base_toolsets({}) == ["hermes-acp"]
 
 
 


### PR DESCRIPTION
## Problem

ACP (editor integration) sessions hard-code the `hermes-acp` composite toolset in three places (`acp_adapter/session.py` agent construction, `acp_adapter/server.py` MCP-registration tool refresh and `/tools` command). As a result, `platform_toolsets` in config.yaml — the mechanism every other platform uses — is silently ignored for ACP, and users cannot trim the ACP tool surface (e.g. drop `browser` automation to save ~10 tool schemas of context per request in VS Code/Zed sessions).

## Change

- New `_acp_base_toolsets()` helper in `acp_adapter/session.py`: reads `platform_toolsets.acp` from config; an explicit non-empty list wins, anything else (missing key, non-list, empty) falls back to the `hermes-acp` composite.
- `_expand_acp_enabled_toolsets(None, ...)` now resolves through the helper; the three hard-coded `["hermes-acp"]` call sites pass `None` instead.
- Backward compatible: installs without the config key behave exactly as before.

## Usage

```yaml
platform_toolsets:
  acp: [web, terminal, file, code_execution, vision, skills, todo, memory, session_search, delegation]
```

## Testing

- New: `test_create_session_honors_platform_toolsets_acp` (config list replaces composite, MCP toolsets still appended) and `test_acp_base_toolsets_fallback_on_empty_or_missing` (5 fallback shapes).
- `pytest tests/acp tests/acp_adapter` → 327 passed.
- Verified live: an ACP session under a profile with the config key resolves 15 tools with zero `browser_*`; a profile without it falls back to `hermes-acp` unchanged.