### PR TITLE
fix(agent): normalize list-type delta.content on streaming follow-up

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1946,6 +1946,35 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 
 
 
+def _normalize_stream_delta_content(raw_content: Any) -> str:
+    """Normalise a streaming ``delta.content`` value to a plain string.
+
+    Most OpenAI-compatible providers send ``delta.content`` as a string.
+    A few — observed on Mistral ``mistral-small-latest`` and NVIDIA custom
+    endpoints serving ``mistralai/mistral-large-3`` — return
+    ``delta.content`` as a *list of content-block dicts* on the streaming
+    request that follows a completed tool call. Passing that list
+    verbatim to ``agent._fire_stream_delta`` /
+    ``agent._record_streamed_assistant_text`` raises
+    ``AttributeError: 'list' object has no attribute 'strip'`` and
+    fails the whole streaming request. See issue #63734.
+
+    Recognised shapes:
+      - ``str`` → returned unchanged
+      - ``list`` → blocks joined by their ``text`` field (``str(block)``
+        fallback for non-dict items); missing ``text`` → empty string
+      - anything else → ``str(raw_content)`` (defensive)
+    """
+    if isinstance(raw_content, str):
+        return raw_content
+    if isinstance(raw_content, list):
+        return "".join(
+            (block.get("text", "") if isinstance(block, dict) else str(block))
+            for block in raw_content
+        )
+    return str(raw_content)
+
+
 def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=None):
     """Streaming variant of _interruptible_api_call for real-time token delivery.
 
@@ -2360,10 +2389,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
-                content_parts.append(delta.content)
+                # Normalise delta.content to a string. Mistral and NVIDIA
+                # custom providers can return ``delta.content`` as a list of
+                # content-block dicts on the streaming request that follows
+                # a completed tool call.  The downstream API
+                # (``_fire_stream_delta``, ``_record_streamed_assistant_text``)
+                # expects a plain string and crashes with
+                # ``AttributeError: 'list' object has no attribute 'strip'``.
+                # See issue #63734.
+                _delta_text = _normalize_stream_delta_content(delta.content)
+                content_parts.append(_delta_text)
                 if not tool_calls_acc:
                     _fire_first_delta()
-                    agent._fire_stream_delta(delta.content)
+                    agent._fire_stream_delta(_delta_text)
                     deltas_were_sent["yes"] = True
                 # Tool calls suppress regular content streaming (avoids
                 # displaying chatty "I'll use the tool..." text alongside
@@ -2378,8 +2416,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # box is already closed (tool boundary flush).
                 elif agent.stream_delta_callback:
                     try:
-                        agent.stream_delta_callback(delta.content)
-                        agent._record_streamed_assistant_text(delta.content)
+                        agent.stream_delta_callback(_delta_text)
+                        agent._record_streamed_assistant_text(_delta_text)
                     except Exception:
                         pass
 

--- a/tests/agent/test_chat_completion_stream_delta_normalize_63734.py
+++ b/tests/agent/test_chat_completion_stream_delta_normalize_63734.py
@@ -1,0 +1,58 @@
+"""Tests for ``_normalize_stream_delta_content`` (issue #63734).
+
+Mistral and NVIDIA custom providers can return ``delta.content`` as a
+list of content-block dicts on the streaming request follows a completed
+tool call. The downstream ``_fire_stream_delta`` /
+``_record_streamed_assistant_text`` expects a plain string. This suite
+pins the normalisation helper that prevents the
+``AttributeError: 'list' object has no attribute 'strip'`` crash.
+"""
+
+from agent.chat_completion_helpers import _normalize_stream_delta_content
+
+
+class TestNormalizeStreamDeltaContent:
+    """``_normalize_stream_delta_content`` contract."""
+
+    def test_string_passthrough(self):
+        """Plain string returns unchanged."""
+        assert _normalize_stream_delta_content("hello") == "hello"
+        assert _normalize_stream_delta_content("") == ""
+
+    def test_list_of_text_blocks(self):
+        """List of content-block dicts with ``text`` keys -> joined text."""
+        chunks = [
+            {"type": "text", "text": "Hello"},
+            {"type": "text", "text": "World"},
+        ]
+        assert _normalize_stream_delta_content(chunks) == "HelloWorld"
+
+    def test_list_mixed_types(self):
+        """Non-dict items in list are str()-converted."""
+        chunks = [
+            {"type": "text", "text": "Score: "},
+            42,
+            {"type": "text", "text": " points"},
+        ]
+        assert _normalize_stream_delta_content(chunks) == "Score: 42 points"
+
+    def test_list_missing_text_key(self):
+        """Dicts without ``text`` key contribute empty string."""
+        chunks = [
+            {"type": "text", "text": "A"},
+            {"type": "image_url", "image_url": {"url": "..."}},
+            {"type": "text", "text": "B"},
+        ]
+        assert _normalize_stream_delta_content(chunks) == "AB"
+
+    def test_list_empty(self):
+        """Empty list gives empty string."""
+        assert _normalize_stream_delta_content([]) == ""
+
+    def test_none_converted_to_string(self):
+        """``None`` is str()-converted (defensive)."""
+        assert _normalize_stream_delta_content(None) == "None"
+
+    def test_integer_converted_to_string(self):
+        """Integer is str()-converted (defensive)."""
+        assert _normalize_stream_delta_content(42) == "42"


### PR DESCRIPTION
## What

Fixes #63734 — the streaming request that follows a completed tool call crashed with `AttributeError: 'list' object has no attribute 'strip'` for some OpenAI-compatible providers (Mistral `mistral-small-latest`, NVIDIA custom endpoint serving `mistralai/mistral-large-3`).

## Why

In `agent/chat_completion_helpers.py`, the per-chunk delta handler inside `interruptible_streaming_api_call` called downstream APIs with the raw `delta.content`:

- `agent._fire_stream_delta(delta.content)` — **not** wrapped in try/except, so the exception propagates up and fails the whole streaming request
- `agent.stream_delta_callback(delta.content)` — wrapped, but still serialises the wrong type
- `agent._record_streamed_assistant_text(delta.content)` — wrapped in the same `except: pass`

Some OpenAI-compatible providers return `delta.content` as a *list of content-block dicts* on the streaming request that follows a completed tool call (e.g. `[{"type": "text", "text": "..."}]`). The downstream `_fire_stream_delta` / `_record_streamed_assistant_text` expect a plain string. They hit `.strip()` on the list and raise.

All 3 retries fail identically; the agent silently switches to the configured fallback provider; the only visible symptom in the gateway log is repeated `error_type=AttributeError ... summary='list' object has no attribute 'strip'` with no traceback — confusing to diagnose.

Per the reporter's local debugging, the initial streaming request already handled non-string `delta.content` correctly; only the post-tool-call path was broken.

## How

Extract the normalisation logic into a pure helper, `_normalize_stream_delta_content(raw_content) -> str`:

- `str` -> returned unchanged
- `list` -> blocks joined by their `text` field (`str(block)` fallback for non-dict items; missing `text` key -> empty string)
- anything else -> `str(raw_content)` (defensive)

Route all three downstream call sites through the helper. Pure-function helper keeps the diff small (touches one code path, not a streaming request graph) and the behaviour unit-testable.

The fix mirrors what the issue reporter already verified locally.

## Where

- `agent/chat_completion_helpers.py` — add `_normalize_stream_delta_content` near the top of the streaming section; change 4 lines in `interruptible_streaming_api_call` (the `content_parts.append` and the three downstream calls now use `_delta_text` instead of `delta.content`).
- `tests/agent/test_chat_completion_stream_delta_normalize_63734.py` — 7 new regression tests pinning the helper contract: string passthrough, list of text-block dicts, mixed types (text+int+text), missing `text` key, empty list, `None`, integer.

## Verification

- `pytest tests/agent/test_chat_completion_stream_delta_normalize_63734.py -v` — 7 passed
- Surrounding streaming tests (`test_chat_completion_helpers_provider_sort`, `test_streaming_context_scrubber`, `test_moa_trace_streamed_capture`) — 28 passed, no regressions
- `python -c "import agent.conversation_loop; import agent.chat_completion_helpers"` — import succeeds

## Risk

- **Low surface area** — only the streaming delta handler in one function, three call sites.
- **Behaviour change is strictly more permissive** — providers that already sent string `delta.content` see no change; providers that sent list `delta.content` no longer crash. The normalisation is idempotent for strings.
- **`max_keep`-style coupling**: none — this is a local normalisation, no shared state with the Anthropic adapter or any other eviction path.
- The `try: ... except Exception: pass` around `stream_delta_callback` / `_record_streamed_assistant_text` is preserved. The bug it was masking (list-type content) is now fixed at the source, but the defensive `except` is left in place — removing it would be a separate refactor.

## Out of scope (deliberately)

- Not touching the non-streaming path (already correct per the issue).
- Not touching the Anthropic adapter / `_evict_old_screenshots` — orthogonal eviction path.
- Not extracting a shared content-normalisation utility across modules — `_normalize_stream_delta_content` is local to the streaming site; if a second consumer appears later we can promote it then.
