### PR TITLE
feat(lsp): add Swift SourceKit-LSP support

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -97,6 +97,8 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
     # Rust — too heavy (hundreds of MB to bootstrap).  We do NOT
     # auto-install rust-analyzer; users install via rustup.
     "rust-analyzer": {"strategy": "manual", "pkg": "", "bin": "rust-analyzer"},
+    # Swift — sourcekit-lsp ships with the Swift/Xcode toolchain.
+    "sourcekit-lsp": {"strategy": "manual", "pkg": "", "bin": "sourcekit-lsp"},
     # C/C++ — manual (clangd ships with LLVM, very heavy)
     "clangd": {"strategy": "manual", "pkg": "", "bin": "clangd"},
     # Lua — manual (LuaLS is platform-specific binaries from GitHub

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -323,6 +323,22 @@ def _spawn_rust_analyzer(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
+def _spawn_sourcekit_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+    bin_path = _resolve_override(ctx, "sourcekit-lsp") or _which("sourcekit-lsp")
+    if bin_path is None:
+        from agent.lsp.install import try_install
+        bin_path = try_install("sourcekit-lsp", ctx.install_strategy)
+        if bin_path is None:
+            return None
+    return SpawnSpec(
+        command=[bin_path],
+        workspace_root=root,
+        cwd=root,
+        env=ctx.env_overrides.get("sourcekit-lsp", {}),
+        initialization_options=ctx.init_overrides.get("sourcekit-lsp", {}),
+    )
+
+
 def _spawn_clangd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "clangd") or _which("clangd")
     if bin_path is None:
@@ -854,6 +870,10 @@ def _root_rust(file_path: str, workspace: str) -> Optional[str]:
     return _root_or_workspace(file_path, workspace, ["Cargo.toml", "Cargo.lock"])
 
 
+def _root_swift(file_path: str, workspace: str) -> Optional[str]:
+    return _root_or_workspace(file_path, workspace, ["Package.swift"])
+
+
 def _root_ruby(file_path: str, workspace: str) -> Optional[str]:
     return _root_or_workspace(file_path, workspace, ["Gemfile"])
 
@@ -1018,6 +1038,13 @@ SERVERS: List[ServerDef] = [
         resolve_root=_root_rust,
         build_spawn=_spawn_rust_analyzer,
         description="Rust — rust-analyzer",
+    ),
+    ServerDef(
+        server_id="sourcekit-lsp",
+        extensions=(".swift",),
+        resolve_root=_root_swift,
+        build_spawn=_spawn_sourcekit_lsp,
+        description="Swift — SourceKit-LSP",
     ),
     ServerDef(
         server_id="clangd",

--- a/tests/agent/lsp/test_sourcekit_server.py
+++ b/tests/agent/lsp/test_sourcekit_server.py
@@ -1,0 +1,70 @@
+"""Tests for Swift SourceKit-LSP registration and spawn behavior."""
+from __future__ import annotations
+
+import agent.lsp.servers as srv
+from agent.lsp.install import detect_status
+from agent.lsp.servers import ServerContext, find_server_for_file
+
+
+def test_swift_files_route_to_sourcekit_lsp():
+    server = find_server_for_file("Sources/App/Main.swift")
+    assert server is not None
+    assert server.server_id == "sourcekit-lsp"
+
+
+def test_sourcekit_install_status_is_manual_or_installed():
+    assert detect_status("sourcekit-lsp") in {"manual-only", "installed"}
+
+
+def test_sourcekit_root_prefers_package_manifest(tmp_path):
+    package = tmp_path / "Package"
+    sources = package / "Sources" / "App"
+    sources.mkdir(parents=True)
+    (package / "Package.swift").write_text("// swift-tools-version: 6.0\n")
+    file_path = sources / "Main.swift"
+    file_path.write_text("print(\"hello\")\n")
+
+    assert srv._root_swift(str(file_path), str(tmp_path)) == str(package)
+
+
+def test_sourcekit_spawn_uses_path_binary_and_config_overrides(monkeypatch, tmp_path):
+    monkeypatch.setattr(srv, "_which", lambda *names: "/usr/bin/sourcekit-lsp")
+    ctx = ServerContext(
+        workspace_root=str(tmp_path),
+        install_strategy="manual",
+        env_overrides={"sourcekit-lsp": {"SOURCEKIT_LOGGING": "1"}},
+        init_overrides={"sourcekit-lsp": {"backgroundIndexing": True}},
+    )
+
+    spec = srv._spawn_sourcekit_lsp(str(tmp_path), ctx)
+
+    assert spec is not None
+    assert spec.command == ["/usr/bin/sourcekit-lsp"]
+    assert spec.cwd == str(tmp_path)
+    assert spec.workspace_root == str(tmp_path)
+    assert spec.env == {"SOURCEKIT_LOGGING": "1"}
+    assert spec.initialization_options == {"backgroundIndexing": True}
+
+
+def test_sourcekit_spawn_prefers_binary_override(monkeypatch, tmp_path):
+    override = tmp_path / "sourcekit-lsp"
+    override.write_text("")
+    monkeypatch.setattr(srv, "_which", lambda *names: "/usr/bin/sourcekit-lsp")
+    ctx = ServerContext(
+        workspace_root=str(tmp_path),
+        binary_overrides={"sourcekit-lsp": [str(override)]},
+    )
+
+    spec = srv._spawn_sourcekit_lsp(str(tmp_path), ctx)
+
+    assert spec is not None
+    assert spec.command == [str(override)]
+
+
+def test_sourcekit_spawn_skips_when_binary_missing(monkeypatch, tmp_path):
+    import agent.lsp.install as install
+
+    monkeypatch.setattr(srv, "_which", lambda *names: None)
+    monkeypatch.setattr(install, "try_install", lambda *args: None)
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    assert srv._spawn_sourcekit_lsp(str(tmp_path), ctx) is None

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -67,6 +67,7 @@ agent sees a syntax-clean file with semantic problems as
 | Astro | `@astrojs/language-server` | npm |
 | Go | `gopls` | `go install` |
 | Rust | `rust-analyzer` | manual (rustup) |
+| Swift | `sourcekit-lsp` | manual (Swift/Xcode toolchain) |
 | C / C++ | `clangd` | manual (LLVM) |
 | Bash / Zsh | `bash-language-server` | npm |
 | YAML | `yaml-language-server` | npm |


### PR DESCRIPTION
## What does this PR do?

Adds Swift support to Hermes's existing LSP integration by registering `sourcekit-lsp` for `.swift` files.

SourceKit-LSP is bundled with Swift toolchains and Xcode. The integration follows the existing manual-server pattern: Hermes detects an available binary, resolves SwiftPM projects from the nearest `Package.swift`, passes through configured command/environment/initialization overrides, and safely skips the server when it is unavailable.

## Related Issue

None. I found no existing SourceKit/Swift LSP issue or pull request.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/lsp/install.py`: register `sourcekit-lsp` as a manual server bundled with the Swift/Xcode toolchain.
- `agent/lsp/servers.py`: add SourceKit spawning, SwiftPM root resolution, and `.swift` server registration.
- `tests/agent/lsp/test_sourcekit_server.py`: cover routing, install status, SwiftPM roots, configuration overrides, binary-override precedence, and missing-binary behavior.
- `website/docs/user-guide/features/lsp.md`: document Swift/SourceKit-LSP support.

## How to Test

1. Run the focused tests:
   ```bash
   scripts/run_tests.sh tests/agent/lsp/test_sourcekit_server.py -- -q
   ```
   Expected: 6 passed.
2. Run the complete LSP suite:
   ```bash
   scripts/run_tests.sh tests/agent/lsp/ -- -q
   ```
   Expected: 165 passed.
3. Run changed-file lint and whitespace checks:
   ```bash
   ruff check agent/lsp/install.py agent/lsp/servers.py tests/agent/lsp/test_sourcekit_server.py
   git diff --check HEAD^
   ```
4. On a machine with a Swift toolchain, run `hermes lsp status` and confirm `sourcekit-lsp` is installed/registered for `.swift`.
5. Open a SwiftPM source file containing a syntax or type error through Hermes's LSP service and confirm SourceKit-LSP returns diagnostics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - The canonical full-suite wrapper was run. Untouched `origin/main` reproduces the same 31 unrelated failures across 13 gateway/service/macOS-environment files. The complete LSP suite passes.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Apple Swift 6.3.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — manual detection safely skips unavailable binaries
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool/schema changed

## Screenshots / Logs

`hermes lsp status` on macOS:

```text
✓ sourcekit-lsp [installed] .swift
    Swift — SourceKit-LSP
```

Live syntax diagnostic round trip:

```text
diagnostic_count: 2
expected ')' to end parameter clause
expected expression in variable
```

Live warmed semantic diagnostic round trip:

```text
Cannot convert value of type 'String' to specified type 'Int'
```
