### PR TITLE
fix(moa): fall back to runtime Codex credentials

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2507,14 +2507,32 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
         else:
             codex_token = _read_codex_access_token()
-            if not codex_token:
-                return None, None
             base_url = _CODEX_AUX_BASE_URL
     else:
         codex_token = _read_codex_access_token()
-        if not codex_token:
-            return None, None
         base_url = _CODEX_AUX_BASE_URL
+
+    # A selected pool entry can be temporarily unavailable even when the
+    # canonical runtime resolver can refresh or choose a usable Codex OAuth
+    # credential. MoA slots arrive here through ``call_llm`` and must share the
+    # main runtime's resolver rather than degrading to an env-key-only failure.
+    if not codex_token:
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(
+                requested="openai-codex", target_model=model
+            )
+            codex_token = str(runtime.get("api_key") or "").strip()
+            base_url = (
+                str(runtime.get("base_url") or "").strip().rstrip("/")
+                or _CODEX_AUX_BASE_URL
+            )
+        except Exception as exc:
+            logger.debug("Auxiliary client: Codex runtime resolution failed: %s", exc)
+
+    if not codex_token:
+        return None, None
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", model)
     real_client = _create_openai_client(
         api_key=codex_token,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -676,6 +676,52 @@ class TestBuildCodexClient:
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
 
+    def test_pool_without_token_uses_canonical_runtime_resolver(self):
+        """A stale pool selection must not mask usable runtime Codex auth."""
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
+            patch("agent.auxiliary_client._read_codex_access_token", return_value=""),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "runtime-codex-token",
+                    "base_url": "https://runtime.example.test/codex/",
+                },
+            ) as resolve_runtime,
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _build_codex_client
+
+            client, model = _build_codex_client("gpt-5.4")
+
+        assert client is not None
+        assert model == "gpt-5.4"
+        resolve_runtime.assert_called_once_with(
+            requested="openai-codex", target_model="gpt-5.4"
+        )
+        assert mock_openai.call_args.kwargs["api_key"] == "runtime-codex-token"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://runtime.example.test/codex"
+
+    def test_codex_runtime_resolver_absence_fails_cleanly(self):
+        """No selected, direct, or runtime credential remains an unavailable client."""
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
+            patch("agent.auxiliary_client._read_codex_access_token", return_value=""),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={"api_key": "", "base_url": ""},
+            ),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            from agent.auxiliary_client import _build_codex_client
+
+            client, model = _build_codex_client("gpt-5.4")
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+
     def test_rejects_missing_model(self):
         """Callers must pass an explicit model; no hardcoded default."""
         from agent.auxiliary_client import _build_codex_client


### PR DESCRIPTION
## Problem

An MoA `openai-codex` auxiliary slot could report no API key even when canonical Codex OAuth/runtime authentication was available. A credential pool can contain entries but yield no usable selected entry; the auxiliary resolver returned unavailable before canonical runtime resolution could recover credentials.

## Fix

Preserve existing precedence: a usable selected pool entry, then a direct Codex auth-store token, then `resolve_runtime_provider(requested="openai-codex", target_model=model)`. The fallback uses the resolved runtime base URL when present and otherwise retains the Codex endpoint. If all sources are unavailable, no client is constructed.

No credential is copied into configuration, logged, or persisted.

## Validation

- 315 focused auxiliary-client and Codex-header tests passed.
- Ruff check and Python compilation passed for the changed source/tests.
- A real MoA Codex reference request completed through the repaired auxiliary path.

## Regression coverage

- An unusable selected pool entry falls through to canonical runtime Codex resolution.
- Absence of pool, direct, and runtime credentials returns unavailable cleanly.

No merge is requested by this draft PR.
