### PR TITLE
fix(cron): guard lock_fd.close() against OSError in tick() finally

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3862,7 +3862,10 @@ def tick(
                 msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
             except (OSError, IOError):
                 pass
-        lock_fd.close()
+        try:
+            lock_fd.close()
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Guard `lock_fd.close()` in the `tick()` finally block against `OSError`.

## Problem

In `cron/scheduler.py`'s `tick()` function, the finally block properly
guards the `fcntl.flock(LOCK_UN)` and `msvcrt.locking(UNLCK)` calls with
try/except, but calls `lock_fd.close()` on line 3865 without any error
handling. If `close()` raises (e.g. bad file descriptor, interrupted system
call), the exception propagates out of the finally block and crashes the cron
tick — potentially preventing subsequent scheduled jobs from firing.

`cron/jobs.py` already does this correctly: its lock release wraps
`lock_fd.close()` in a try/finally inside a try/except.

## Fix

Wrap `lock_fd.close()` in the same `try/except OSError: pass` pattern used
for the unlock calls above it.

## Testing
- Syntax check passed (py_compile)
- Behavior verified