### PR TITLE
fix(gemini): prune required entries missing from properties in tool schemas (port kilocode#11955)

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -87,6 +87,30 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
         if any(not isinstance(item, str) for item in enum_val):
             cleaned.pop("enum", None)
 
+    # Gemini validates ``required`` strictly against the same node's
+    # ``properties`` — GenerateContentRequest fails with HTTP 400
+    # "...items.required[0]: property is not defined" when a required name
+    # has no matching property in that node.  MCP servers routinely emit
+    # this shape (e.g. the GitHub remote MCP's array item schemas carry
+    # ``required`` without ``properties``), and one bad tool schema fails
+    # the ENTIRE request before any model output.  Filter ``required`` to
+    # names that exist in this node's ``properties`` and drop it when
+    # nothing valid remains.  The tool handler still validates required
+    # fields at execution time, so this only removes what Gemini couldn't
+    # accept anyway.  (Port of Kilo-Org/kilocode#11955.)
+    required_val = cleaned.get("required")
+    if isinstance(required_val, list):
+        props_val = cleaned.get("properties")
+        prop_names = set(props_val.keys()) if isinstance(props_val, dict) else set()
+        valid_required = [
+            name for name in required_val
+            if isinstance(name, str) and name in prop_names
+        ]
+        if not valid_required:
+            cleaned.pop("required", None)
+        elif len(valid_required) != len(required_val):
+            cleaned["required"] = valid_required
+
     return cleaned
 
 

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -108,6 +108,93 @@ class TestSanitizeGeminiSchema:
         assert sanitize_gemini_schema([1, 2, 3]) == {}
 
 
+class TestRequiredPropertyPruning:
+    """Gemini rejects ``required`` names missing from the node's ``properties``.
+
+    Regression for the Kilo-Org/kilocode#11955 bug class: MCP servers (e.g.
+    the GitHub remote MCP) emit array item schemas whose ``required`` lists
+    reference properties that don't exist in the same node — Google fails the
+    entire GenerateContentRequest with HTTP 400 "property is not defined".
+    """
+
+    def test_drops_required_when_node_has_no_properties(self):
+        schema = {"type": "object", "required": ["a", "b"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert "required" not in cleaned
+
+    def test_filters_ghost_required_entries(self):
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": ["x", "ghost"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["required"] == ["x"]
+
+    def test_prunes_inside_array_items(self):
+        """The exact shape from the GitHub MCP report — nested in items."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "issue_fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["field_id", "value"],
+                    },
+                },
+            },
+            "required": ["issue_fields"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        items = cleaned["properties"]["issue_fields"]["items"]
+        assert "required" not in items
+        # Top-level required is valid and survives.
+        assert cleaned["required"] == ["issue_fields"]
+
+    def test_prunes_node_without_explicit_type(self):
+        """Nodes carrying properties+required but no ``type`` key still prune."""
+        schema = {
+            "properties": {"x": {"type": "string"}},
+            "required": ["x", "ghost"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["required"] == ["x"]
+
+    def test_valid_required_untouched(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["required"] == ["a", "b"]
+
+    def test_drops_non_string_required_entries(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a", 42, None],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["required"] == ["a"]
+
+    def test_prunes_inside_anyof_branches(self):
+        schema = {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                    "required": ["x", "ghost"],
+                },
+                {"type": "object", "required": ["orphan"]},
+            ]
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["anyOf"][0]["required"] == ["x"]
+        assert "required" not in cleaned["anyOf"][1]
+
+
 class TestSanitizeGeminiToolParameters:
     def test_empty_parameters_return_valid_object_schema(self):
         """Gemini requires ``parameters`` to be a valid object schema."""


### PR DESCRIPTION
## Summary

The native Gemini path no longer fails whole requests when an MCP tool schema carries `required` names that don't exist in the same node's `properties`. Port of [Kilo-Org/kilocode#11955](https://github.com/Kilo-Org/kilocode/pull/11955).

Google validates every object schema's `required` list strictly against that node's `properties` and rejects the **entire** `GenerateContentRequest` with HTTP 400 `...items.required[0]: property is not defined` — the model can't respond at all, not even with text. MCP servers routinely emit this shape (the GitHub remote MCP's array item schemas carry `required` with no `properties`), so a single bad tool schema bricked every Gemini-native session with that server connected.

## Changes

- `agent/gemini_schema.py`: `sanitize_gemini_schema()` now filters each node's `required` to names present in that node's `properties` and drops the keyword when nothing valid remains (including nodes with no `properties` at all). Applies recursively through `properties` / `items` / `anyOf`. Non-string entries are dropped too. Tool handlers still validate required fields at execution time, so nothing usable is lost.
- `tests/agent/test_gemini_schema.py`: 7 regression tests — no-properties nodes, ghost entries, the exact array-`items` shape from the upstream report, untyped nodes, valid lists untouched, non-string entries, `anyOf` branches.

## Adaptation notes

Kilo fixed this in their `transform.ts` Gemini provider transform; hermes's equivalent surface is the native-Gemini adapter's schema sanitizer (`sanitize_gemini_tool_parameters` → `sanitize_gemini_schema`), which previously did no `required` validation at all (probed live before implementing). Scoped deliberately to the Gemini-facing sanitizer: the universal `tools/schema_sanitizer.py` already prunes ghost `required` on explicitly-typed object nodes, and its remaining gap (untyped nodes) overlaps open PR #20151, so this PR doesn't touch it.

## Validation

| | Before | After |
|---|---|---|
| `{"type":"object","required":["a"]}` (no properties) via `build_gemini_request` | `required` reaches wire → Gemini HTTP 400 | `required` dropped, request valid |
| Ghost entry `required:["x","ghost"]` | forwarded verbatim | filtered to `["x"]` |
| Valid `required` lists | pass through | pass through (unchanged) |

`tests/agent/test_gemini_schema.py` + `test_gemini_native_adapter.py` + `tests/tools/test_schema_sanitizer.py`: 87 passed. E2E probe through the real `build_gemini_request()` asserted no node in the final wire declaration carries a `required` name missing from its `properties`.

## Infographic

![gemini-required-pruning](https://v3b.fal.media/files/b/0aa226ab/M2_OKKfaCZ3U_wA87zXxq_gGBiM8ug.png)
