### PR TITLE
fix: guard empty-response continuation to prevent hallucination

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1887,6 +1887,35 @@ def run_conversation(
                                 force=True,
                             )
                         if assistant_message is not None and not _trunc_has_tool_calls:
+                            # Guard: if the truncated response has no actual content
+                            # (empty string or None), sending a "continue where you
+                            # left off" prompt causes the model to hallucinate about
+                            # unrelated topics because there is literally nothing to
+                            # continue from. Treat this as a hard failure instead.
+                            _trunc_actual_content = str(getattr(assistant_message, 'content', '') or '').strip()
+                            if not _trunc_actual_content and not _is_partial_stream_stub:
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚠️  finish_reason='length' with empty "
+                                    f"response — cannot send continuation (nothing to continue). "
+                                    f"Try reducing ollama_num_ctx in config.",
+                                    force=True,
+                                )
+                                agent._cleanup_task_resources(effective_task_id)
+                                agent._persist_session(messages, conversation_history)
+                                return {
+                                    "final_response": (
+                                        "⚠️ The model produced an empty response (finish_reason='length'). "
+                                        "This usually means the context window is too large for this model "
+                                        "or the reasoning trace consumed all available tokens. "
+                                        "Try reducing `ollama_num_ctx` in ~/.hermes/config.yaml."
+                                    ),
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": False,
+                                    "failed": True,
+                                    "error": "Empty response with finish_reason='length' — cannot continue without content",
+                                }
+
                             length_continue_retries += 1
                             interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                             messages.append(interim_msg)


### PR DESCRIPTION
## Problem

When a model hits `finish_reason='length'` with an **empty** response (i.e. the entire token budget was consumed by reasoning/thinking and no visible text was produced), the agent loop injected a continuation prompt:

```
[System: Your previous response was truncated by the output length limit.
Continue exactly where you left off. Do not restart or repeat prior text.
Finish the answer directly.]
```

Because the assistant message was empty there was nothing to continue from. The model hallucinated a completely unrelated topic in response to this prompt — in the observed case, the user asked about fiber optic ISP tooling and received an answer about AI smartphone voice control.

## Fix

Add a guard in the `finish_reason='length'` handler, before the continuation retry counter is incremented:

```python
_trunc_actual_content = str(getattr(assistant_message, 'content', '') or '').strip()
if not _trunc_actual_content and not _is_partial_stream_stub:
    # Nothing to continue from — return a hard failure with an
    # actionable message instead of hallucinating.
    return {
        'final_response': (
            '⚠️ The model produced an empty response (finish_reason=length). '
            'Try reducing ollama_num_ctx in ~/.hermes/config.yaml.'
        ),
        ...
        'error': "Empty response with finish_reason='length' — cannot continue",
    }
```

Normal truncation with partial content is unaffected: if `assistant_message.content` is non-empty, all four continuation retry attempts fire as before.

The partial-stream-stub path (`_is_partial_stream_stub`) is also excluded from the guard because a stub with an empty content field represents a network drop, not a token exhaustion — the stub's tool calls or other metadata may still be worth retrying.

## Root cause context

The empty response scenario occurs most commonly with small reasoning models (≤ 8B) running under large Ollama `num_ctx` values (≥ 32K). The model spends all its output tokens on the `<think>...</think>` reasoning trace before producing any visible text, leaving the response content empty. The existing `_thinking_exhausted` guard does not catch this case because it requires `<think>` tags to be visible in `_trunc_content`, which is `None` when the model context window is configured at the Ollama layer and the thinking trace is stripped by the GGUF renderer before reaching the API response.

## Testing

Verified by code inspection: the guard fires before `length_continue_retries += 1`, so it cannot increment the retry counter or append a continuation message. Normal truncation (non-empty partial content) falls through to the existing retry logic unchanged.

---
*This PR was developed with [Warp](https://app.warp.dev/conversation/bbab6f58-7dad-40d4-8344-df9b4436749a)*

Co-Authored-By: Oz <oz-agent@warp.dev>