### PR TITLE
fix: hashlib FIPS crash in qqbot, wecom, yuanbao_media (md5/sha1 without usedforsecurity=False)

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -366,7 +366,7 @@ class ChunkedUploader:
         data = await asyncio.get_running_loop().run_in_executor(
             None, _read_file_chunk, file_path, offset, length
         )
-        md5_hex = hashlib.md5(data).hexdigest()
+        md5_hex = hashlib.md5(data, usedforsecurity=False).hexdigest()
 
         logger.debug(
             "[%s] Part %d/%d: uploading %s (offset=%d md5=%s)",
@@ -558,9 +558,9 @@ def _read_file_chunk(file_path: str, offset: int, length: int) -> bytes:
 
 def _compute_file_hashes(file_path: str, file_size: int) -> Dict[str, str]:
     """Compute md5, sha1, and md5_10m in a single pass."""
-    md5 = hashlib.md5()
-    sha1 = hashlib.sha1()
-    md5_10m = hashlib.md5()
+    md5 = hashlib.md5(usedforsecurity=False)
+    sha1 = hashlib.sha1(usedforsecurity=False)
+    md5_10m = hashlib.md5(usedforsecurity=False)
 
     need_10m = file_size > _MD5_10M_SIZE
     bytes_read = 0

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -107,7 +107,7 @@ def get_image_format(mime_type: str) -> int:
 
 def md5_hex(data: bytes) -> str:
     """计算 MD5 十六进制摘要。"""
-    return hashlib.md5(data).hexdigest()
+    return hashlib.md5(data, usedforsecurity=False).hexdigest()
 
 
 def generate_file_id() -> str:
@@ -328,7 +328,7 @@ def _cos_sign(
     ])
 
     # Step 3: StringToSign = sha1 hash of HttpString
-    sha1_of_http = hashlib.sha1(http_string.encode("utf-8")).hexdigest()
+    sha1_of_http = hashlib.sha1(http_string.encode("utf-8"), usedforsecurity=False).hexdigest()
     string_to_sign = "\n".join([
         "sha1",
         q_sign_time,

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1207,7 +1207,7 @@ class WeComAdapter(BasePlatformAdapter):
                 "filename": filename,
                 "total_size": total_size,
                 "total_chunks": total_chunks,
-                "md5": hashlib.md5(data).hexdigest(),
+                "md5": hashlib.md5(data, usedforsecurity=False).hexdigest(),
             },
         )
         self._raise_for_wecom_error(init_response, "media upload init")

--- a/plugins/platforms/wecom/wecom_crypto.py
+++ b/plugins/platforms/wecom/wecom_crypto.py
@@ -60,7 +60,7 @@ class PKCS7Encoder:
 
 def _sha1_signature(token: str, timestamp: str, nonce: str, encrypt: str) -> str:
     parts = sorted([token, timestamp, nonce, encrypt])
-    return hashlib.sha1("".join(parts).encode("utf-8")).hexdigest()
+    return hashlib.sha1("".join(parts).encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 class WXBizMsgCrypt:


### PR DESCRIPTION
## Summary

`hashlib.md5()` and `hashlib.sha1()` without `usedforsecurity=False` crash on FIPS-enabled systems (RHEL 8/9, Ubuntu FIPS mode) with `ValueError: EVP_DigestInit_ex disabled for FIPS`.

All uses are non-security: file integrity checksums for uploads, cache keys, and API request signatures.

## Changes (4 files, 8 calls)

| File | Calls | Purpose |
|------|-------|---------|
| `gateway/platforms/qqbot/chunked_upload.py` | md5 x3, sha1 x1 | Chunk upload integrity hashes |
| `plugins/platforms/wecom/adapter.py` | md5 x1 | Media upload chunk checksum |
| `plugins/platforms/wecom/wecom_crypto.py` | sha1 x1 | Callback signature verification |
| `gateway/platforms/yuanbao_media.py` | md5 x1, sha1 x1 | File hash + COS signing |

## Pattern

Same fix as PRs #56715, #56716, #56719, #62654 which covered other gateway/platform files. These 4 files were missed in those batches.

## Test Plan

- [ ] `python -c "import hashlib; hashlib.md5(b'test', usedforsecurity=False).hexdigest()"` succeeds
- [ ] Existing tests pass
- [ ] Verified no `hmac.new(hashlib.sha1, ...)` false positives — all calls are direct invocations