### PR TITLE
fix: replace assert with RuntimeError in Google Meet RealtimeSession WebSocket guards

### DIFF
--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket is not connected; call connect() first")
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket is not connected; call connect() first")
         try:
             if timeout is None:
                 return self._ws.recv()


### PR DESCRIPTION
## Summary

`assert` statements in `_send_json()` and `_recv()` of `plugins/google_meet/realtime/openai_client.py` are stripped when Python runs with `-O` flag, silently removing the `self._ws is not None` guard. This causes a confusing `AttributeError: 'NoneType' object has no attribute 'send'` instead of a clear error.

## Changes

Replace `assert self._ws is not None` with `if self._ws is None: raise RuntimeError(...)` in:
- `RealtimeSession._send_json()` (line 224)
- `RealtimeSession._recv()` (line 229)

## Why this matters

The `cancel()` method right above already handles `self._ws is None` gracefully (returns False). These two methods should fail clearly rather than crash with an opaque AttributeError.

Follows the same pattern as PRs #56736, #56866, #61983, #62001, #62006, #62659.

## Test Plan

- [ ] Existing tests pass
- [ ] `python -O -c "from plugins.google_meet.realtime.openai_client import RealtimeSession"` succeeds