### PR TITLE
fix(telegram): escalate persistent 409 Conflict to fatal via wall-clock gate

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -18,6 +18,7 @@ import html as _html
 import re
 import threading
 from contextvars import ContextVar
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -643,6 +644,16 @@ class TelegramAdapter(BasePlatformAdapter):
         self._drop_delayed_deliveries = False
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
+        # Wall-clock timestamp of the first 409 Conflict in the current streak.
+        # `start_polling()` returning does NOT prove the upstream Telegram
+        # getUpdates session was released, so the attempt counter alone cannot
+        # guarantee escalation — #63724. We additionally bound the conflict
+        # state by elapsed time: if conflicts keep recurring past
+        # `_CONFLICT_WALL_CLOCK_LIMIT_SECS` since `_polling_conflict_first_seen`
+        # (regardless of intervening `start_polling()` "successes" that reset
+        # `_polling_conflict_count`), we escalate to retryable-fatal so the
+        # supervisor can restart the gateway instead of looping forever.
+        self._polling_conflict_first_seen: Optional[float] = None
         self._polling_network_error_count: int = 0
         self._polling_generation: int = 0
         self._polling_progress_event = asyncio.Event()
@@ -2679,6 +2690,29 @@ class TelegramAdapter(BasePlatformAdapter):
         # nor fatal — messages are silently dropped.  We schedule another
         # retry attempt instead of returning silently, and only escalate to
         # fatal after all retries are exhausted.
+        #
+        # Wall-clock escalation gate (#63724): a successful `start_polling()`
+        # does NOT prove the upstream Telegram getUpdates session was actually
+        # released — another long-poll may still hold it.  When that is the
+        # case, the next `getUpdates` raises 409 again, the counter starts
+        # from 1 once more, and the ladder never reaches `MAX_CONFLICT_RETRIES`
+        # even though the bot is silently deaf for days.  We anchor an
+        # immutable `_polling_conflict_first_seen` timestamp on the FIRST
+        # conflict of a streak; if conflicts keep recurring past
+        # `_CONFLICT_WALL_CLOCK_LIMIT_SECS` regardless of intervening
+        # `start_polling()` "successes", we escalate to retryable-fatal so
+        # the supervisor can restart the gateway instead of looping forever.
+        # The timestamp is cleared only on durable evidence of resolution
+        # (an update actually being consumed), not on `start_polling()` returning.
+        now_mono = time.monotonic()
+        if self._polling_conflict_first_seen is None:
+            self._polling_conflict_first_seen = now_mono
+        conflict_age = now_mono - self._polling_conflict_first_seen
+        # 5 minutes covers the typical server-side session expiry (~30s) with
+        # ample margin for repeated ladder cycles while still bounding the
+        # silent-deaf window to a tolerable operator-response delay.
+        _CONFLICT_WALL_CLOCK_LIMIT_SECS = 300.0
+
         self._polling_conflict_count += 1
 
         MAX_CONFLICT_RETRIES = 5
@@ -2688,13 +2722,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # hammering the API on fast-restart loops.
         RETRY_DELAY = 10 + (self._polling_conflict_count * 10)  # seconds
 
-        if self._polling_conflict_count <= MAX_CONFLICT_RETRIES:
+        if self._polling_conflict_count <= MAX_CONFLICT_RETRIES and conflict_age < _CONFLICT_WALL_CLOCK_LIMIT_SECS:
             logger.warning(
-                "[%s] Telegram polling conflict (%d/%d) — previous session still "
+                "[%s] Telegram polling conflict (%d/%d, age=%.0fs) — previous session still "
                 "held open on Telegram's servers. Waiting %ds for it to expire. "
                 "Error: %s",
                 self.name, self._polling_conflict_count, MAX_CONFLICT_RETRIES,
-                RETRY_DELAY, error,
+                conflict_age, RETRY_DELAY, error,
             )
             # Stop the local updater cleanly before sleeping.  If it's already
             # stopped (e.g. PTB raised before updater.running was set) this is

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -294,6 +294,108 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_polling_conflict_becomes_fatal_after_wall_clock_limit(monkeypatch):
+    """A persistent 409 must escalate to fatal even when `start_polling()`
+    keeps returning successfully and resetting the attempt counter.
+
+    Regression test for #63724: when a competing long-poll holds the
+    Telegram getUpdates session, `start_polling()` returning does NOT prove
+    the conflict is resolved.  The next `getUpdates` raises 409 again, the
+    counter resets to 0 on each `start_polling()` "success", and the ladder
+    never reaches `MAX_CONFLICT_RETRIES` — the bot stays silently deaf for
+    days while the gateway reports healthy.  The wall-clock escalation gate
+    bounds the silent-deaf window so a stuck conflict state escalates to
+    retryable-fatal instead of looping forever.
+    """
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    captured = {}
+
+    async def fake_start_polling(**kwargs):
+        # `start_polling()` "succeeds" every time — but a competing long-poll
+        # is still holding the upstream getUpdates session, so the next poll
+        # will raise 409 again.  This is the heart of #63724.
+        captured["error_callback"] = kwargs["error_callback"]
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.Application", SimpleNamespace(builder=MagicMock(return_value=builder)))
+
+    # Speed up retries for testing
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    # Drive `time.monotonic()` so each successive `_handle_polling_conflict`
+    # call sees a later wall-clock.  The first call anchors
+    # `_polling_conflict_first_seen`; subsequent calls advance past the
+    # 5-minute wall-clock limit while `start_polling()` keeps "succeeding"
+    # (which resets `_polling_conflict_count` to 0 each time).
+    fake_now = {"t": 0.0}
+
+    def fake_monotonic():
+        return fake_now["t"]
+
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.time.monotonic", fake_monotonic)
+
+    ok = await adapter.connect()
+    assert ok is True
+
+    conflict = type("Conflict", (Exception,), {})
+
+    # First conflict at t=0 — anchors `_polling_conflict_first_seen`.
+    # `start_polling()` then succeeds, counter resets to 0.
+    await adapter._handle_polling_conflict(
+        conflict("Conflict: terminated by other getUpdates request")
+    )
+    assert adapter.has_fatal_error is False, "First conflict must not be fatal"
+    assert adapter._polling_conflict_count == 0, "Counter resets on start_polling success"
+    assert adapter._polling_conflict_first_seen is not None
+
+    # Second conflict well past the 5-minute wall-clock limit (t=400s).
+    # Even though `_polling_conflict_count` was reset to 0 by the previous
+    # `start_polling()` "success", the wall-clock gate must escalate to
+    # retryable-fatal instead of letting the ladder restart from 1/5.
+    fake_now["t"] = 400.0
+    await adapter._handle_polling_conflict(
+        conflict("Conflict: terminated by other getUpdates request")
+    )
+
+    assert adapter.fatal_error_code == "telegram_polling_conflict", (
+        f"Expected fatal after wall-clock escalation, got "
+        f"code={adapter.fatal_error_code}, count={adapter._polling_conflict_count}"
+    )
+    assert adapter.has_fatal_error is True
+    fatal_handler.assert_awaited_once()
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
 async def test_connect_marks_retryable_fatal_error_for_startup_network_failure(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 


### PR DESCRIPTION
Closes #63724.

## Problem

A persistent Telegram `409 Conflict` puts the adapter into an infinite
retry loop that **never escalates to the fatal/restart path**. The bot
silently stops receiving messages while the gateway reports itself
healthy. Reported real-world impact: a gateway stayed in this state for
**4 days** — every incoming DM queued in the Bot API and was never
handled.

_root cause_: `_polling_conflict_count` is reset whenever
`start_polling()` *returns*, but `start_polling()` returning only proves
the updater object started — **not** that this client won the
server-side `getUpdates` session. If another long-poll still holds the
session, the very next `getUpdates` raises `409 Conflict` again, the
error callback re-enters `_handle_polling_conflict`, the counter starts
from 1 once more, and the ladder can never reach `MAX_CONFLICT_RETRIES`.
The retryable-fatal path is unreachable in exactly the scenario it
exists for.

The heartbeat doesn't help either: `_heartbeat_loop` probes with
`bot.get_me()`, which uses the general request path and stays healthy
during a `getUpdates` conflict — nothing escalates. From the outside
everything looks fine: container healthy, `getMe` OK, "connection
verified" in any UI that tests the token that way. Only the missing
replies reveal it.

## Fix

Two-line idea, but with carefully designed semantics:

1. Anchor an immutable **wall-clock timestamp**
   `_polling_conflict_first_seen` on the FIRST 409 of a streak.
2. Add `_CONFLICT_WALL_CLOCK_LIMIT_SECS = 300.0` (5 minutes): if
   conflicts keep recurring past this window — regardless of any
   intervening `start_polling()` "successes" that reset the attempt
   counter — the next 409 short-circuits past the retry branch and
   falls through to the existing retryable-fatal escalation path so
   the supervisor can restart the gateway.

To clear the timestamp, durable evidence of resolution is required
(actual update consumption) — **not** `start_polling()` returning. This
patch conservatively never clears it inside the conflict path; future
work can clear it from the update handler if desired.

Critical flow under the failure scenario:
```
409 → counter=1 → start_polling "succeeds" → counter=0
409 → counter=1 → start_polling "succeeds" → counter=0
... ad infinitum, but now:
409 (after wall-clock elapsed 5 min) → conflict_age >= 300
   if `counter <= 5 AND conflict_age < 300`: false → skip retry branch
   → fall through to fatal escalation
```

The existing 5-attempt ladder still handles transient conflicts (e.g.,
gateway restart handoff) the same way it always did — it just isn't the
only safety net anymore.

## Why wall-clock and not just an attempt counter ceiling

The issue suggests several alternative fixes (require observed update
drain to reset counter; bound by wall-clock; ensure no duplicate
long-poll tasks survive `updater.stop()` timeout; surface conflict
state to health checks). Wall-clock is the smallest, most-rigorous
intervention: it tolerates counter resets without requiring changes to
the update-consumption path or the supervisor's health surface, it
cannot be tricked by a second competing poll task spraying 409s, and it
degrades cleanly — if `_polling_conflict_first_seen` is never cleared
in the conflict path (this patch), the only consequence is escalation
after 5 minutes of persistent conflict, which is exactly the desired
behavior.

## Verification

### New regression test
`test_polling_conflict_becomes_fatal_after_wall_clock_limit` mocks
`time.monotonic()` to drive the wall-clock past the 5-minute limit
across two `_handle_polling_conflict` calls where `start_polling()`
"successfully" returns and resets the counter in between — exactly the
scenario in #63724. Without the fix the test would hang in an infinite
ladder of 1/5 attempts; with the fix the second 409 escalates directly
to retryable-fatal.

### Existing test suite
\`\`\`
tests/gateway/test_telegram_conflict.py  14 passed (13 existing + 1 new)
+ tests/gateway/test_telegram_status_indicator.py  23 passed total
\`\`\`

No regressions in surrounding telegram tests.

## Files changed
- \`plugins/platforms/telegram/adapter.py\` (+37, −3): new
  \`_polling_conflict_first_seen\` field; wall-clock gate in
  \`_handle_polling_conflict\`.
- \`tests/gateway/test_telegram_conflict.py\` (+102): new regression
  test (\`test_polling_conflict_becomes_fatal_after_wall_clock_limit\`).

## Notes for reviewer

- The wall-clock constant (5 min) is a judgment call: long enough to
  cover the typical server-side session expiry (~30s) with ample margin
  for repeated ladder cycles; short enough to bound the silent-deaf
  window to a tolerable operator-response delay. Issue specifies
  "say 5 minutes" as the example — match it.
- The import of \`time\` was added at the module level (was previously
  only used transitively). It is already used elsewhere in the codebase
  so this doesn't introduce a new dependency.
- The new field is initialized in \`__init__\` next to the existing
  \`_polling_conflict_count\` block for locality.
- I did **not** remove the existing attempt-counter ladder — it
  remains the primary path for transient conflicts. The wall-clock
  gate is a strict safety net for the stuck-forever case the ladder
  cannot reach.

Happy to follow up on clearing \`_polling_conflict_first_seen\` from the
update-consumption path if maintainers want the timestamp reset on
genuine recovery — I left it conservative on purpose.