### PR TITLE
feat(desktop): add Smart, WSL2, and Windows Native terminal modes

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -936,6 +936,16 @@ _WINDOWS_BASH_SHELL_HINT = (
 )
 
 
+_WINDOWS_POWERSHELL_SHELL_HINT = (
+    "Shell: on this Windows host your `terminal` tool runs commands through "
+    "PowerShell, NOT bash or cmd.exe. Use PowerShell syntax (e.g. `Get-ChildItem`, "
+    "`$env:FOO`, `Select-String`, single-quoted or double-quoted strings appropriately) "
+    "inside terminal calls. Native Windows paths (like `C:\\Users\\<user>\\...`) work "
+    "normally. Bash/POSIX commands and syntax (`export VAR=val`, `ls`, `grep`, `&&` "
+    "unless using PowerShell 7+) will NOT work — use their PowerShell equivalents."
+)
+
+
 def _probe_remote_backend(env_type: str) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
 
@@ -1123,7 +1133,16 @@ def build_environment_hints() -> str:
         # Windows-local terminal runs bash, not PowerShell — the model must
         # know this or it will issue PowerShell syntax and fail.
         if sys.platform == "win32" and not is_wsl():
-            hints.append(_WINDOWS_BASH_SHELL_HINT)
+            from tools.environments.windows_execution_mode import resolve_windows_execution_mode
+            try:
+                mode_cwd = resolve_agent_cwd()
+            except OSError:
+                mode_cwd = ""
+            mode = resolve_windows_execution_mode(mode_cwd)
+            if mode.resolved == "windows-native":
+                hints.append(_WINDOWS_POWERSHELL_SHELL_HINT)
+            else:
+                hints.append(_WINDOWS_BASH_SHELL_HINT)
     else:
         # --- Remote backend block (host info suppressed) ---
         probe = _probe_remote_backend(backend)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -104,6 +104,13 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
+import {
+  detectWslDistributions,
+  readTerminalMode,
+  resolveWindowsTerminalMode,
+  toWslPath,
+  writeTerminalMode
+} from './terminal-mode'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
@@ -8223,7 +8230,50 @@ function windowsShellSpec() {
 
 // Resolve the interactive shell for the embedded terminal: an explicit user
 // override wins, otherwise auto-detect the best one installed for the platform.
-function terminalShellCommand() {
+function desktopTerminalModeInfo(cwd = '') {
+  const configuredMode = readTerminalMode(HERMES_HOME)
+  const wslDistributions = IS_WINDOWS ? detectWslDistributions() : []
+
+  const resolution = resolveWindowsTerminalMode({
+    configuredMode,
+    cwd,
+    isWindows: IS_WINDOWS,
+    wslDistributions
+  })
+
+  return {
+    configuredMode,
+    distribution: resolution.distribution,
+    resolvedMode: resolution.mode,
+    supported: IS_WINDOWS,
+    wslDistributions
+  }
+}
+
+function terminalShellCommand(cwd) {
+  const modeInfo = desktopTerminalModeInfo(cwd)
+  const withMode = spec => ({ ...spec, ...modeInfo })
+
+  if (IS_WINDOWS && modeInfo.resolvedMode === 'wsl2') {
+    if (!modeInfo.distribution) {
+      throw new Error('WSL2 mode is selected, but no WSL2 distribution is installed.')
+    }
+
+    return withMode({
+      args: [
+        '--distribution',
+        modeInfo.distribution,
+        '--cd',
+        toWslPath(cwd, modeInfo.distribution),
+        '--exec',
+        'bash',
+        '-l'
+      ],
+      command: 'wsl.exe',
+      name: `wsl2:${modeInfo.distribution}`
+    })
+  }
+
   // HERMES_DESKTOP_SHELL is the cross-platform escape hatch (a path or a bare
   // name on PATH); $SHELL is honored on POSIX, where it's the user's canonical
   // choice, but ignored on Windows, where it's usually a stray MSYS/Git path
@@ -8234,17 +8284,17 @@ function terminalShellCommand() {
     const resolved = isExecutableFile(override) ? override : findOnPath(override)
 
     if (resolved) {
-      return shellSpecFor(resolved)
+      return withMode(shellSpecFor(resolved))
     }
   }
 
   if (IS_WINDOWS) {
-    return windowsShellSpec()
+    return withMode(windowsShellSpec())
   }
 
   const shellPath = ['/bin/zsh', '/bin/bash', '/bin/sh'].find(candidate => isExecutableFile(candidate))
 
-  return posixShellSpec(shellPath || '/bin/sh')
+  return withMode(posixShellSpec(shellPath || '/bin/sh'))
 }
 
 function safeTerminalCwd(cwd) {
@@ -8522,16 +8572,26 @@ ipcMain.handle('hermes:git:scanRepos', async (_event, roots, options) => {
   }
 })
 
+ipcMain.handle('hermes:terminal-mode:get', (_event, cwd) => desktopTerminalModeInfo(safeTerminalCwd(cwd)))
+ipcMain.handle('hermes:terminal-mode:set', (_event, mode, cwd) => {
+  writeTerminalMode(HERMES_HOME, mode)
+
+  return desktopTerminalModeInfo(safeTerminalCwd(cwd))
+})
+
 ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   const id = crypto.randomUUID()
-  const { args, command, name } = terminalShellCommand()
   const cwd = safeTerminalCwd(payload?.cwd)
+  const { args, command, configuredMode, distribution, name, resolvedMode } = terminalShellCommand(cwd)
+  // wsl.exe receives the real Linux cwd through --cd. Keep CreateProcess/node-pty
+  // on a native host directory so WSL UNC projects do not fail before wsl.exe starts.
+  const ptyCwd = resolvedMode === 'wsl2' ? app.getPath('home') : cwd
   const cols = Math.max(2, Number.parseInt(String(payload?.cols || 80), 10) || 80)
   const rows = Math.max(2, Number.parseInt(String(payload?.rows || 24), 10) || 24)
 
   const ptyProcess = nodePty.spawn(command, args, {
     cols,
-    cwd,
+    cwd: ptyCwd,
     env: terminalShellEnv(),
     name: 'xterm-256color',
     rows
@@ -8554,7 +8614,7 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   })
   event.sender.once('destroyed', () => disposeTerminalSession(id))
 
-  return { cwd, id, shell: name }
+  return { configuredMode, cwd, distribution, id, mode: resolvedMode, shell: name }
 })
 
 ipcMain.handle('hermes:terminal:write', (_event, id, data) => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -106,6 +106,7 @@ import {
 } from './session-windows'
 import {
   detectWslDistributions,
+  detectWslDistributionsAsync,
   readTerminalMode,
   resolveWindowsTerminalMode,
   toWslPath,
@@ -8230,9 +8231,9 @@ function windowsShellSpec() {
 
 // Resolve the interactive shell for the embedded terminal: an explicit user
 // override wins, otherwise auto-detect the best one installed for the platform.
-function desktopTerminalModeInfo(cwd = '') {
+async function desktopTerminalModeInfo(cwd = '') {
   const configuredMode = readTerminalMode(HERMES_HOME)
-  const wslDistributions = IS_WINDOWS ? detectWslDistributions() : []
+  const wslDistributions = IS_WINDOWS ? await detectWslDistributionsAsync() : []
 
   const resolution = resolveWindowsTerminalMode({
     configuredMode,
@@ -8250,8 +8251,8 @@ function desktopTerminalModeInfo(cwd = '') {
   }
 }
 
-function terminalShellCommand(cwd) {
-  const modeInfo = desktopTerminalModeInfo(cwd)
+async function terminalShellCommand(cwd) {
+  const modeInfo = await desktopTerminalModeInfo(cwd)
   const withMode = spec => ({ ...spec, ...modeInfo })
 
   if (IS_WINDOWS && modeInfo.resolvedMode === 'wsl2') {
@@ -8572,17 +8573,17 @@ ipcMain.handle('hermes:git:scanRepos', async (_event, roots, options) => {
   }
 })
 
-ipcMain.handle('hermes:terminal-mode:get', (_event, cwd) => desktopTerminalModeInfo(safeTerminalCwd(cwd)))
-ipcMain.handle('hermes:terminal-mode:set', (_event, mode, cwd) => {
+ipcMain.handle('hermes:terminal-mode:get', async (_event, cwd) => await desktopTerminalModeInfo(safeTerminalCwd(cwd)))
+ipcMain.handle('hermes:terminal-mode:set', async (_event, mode, cwd) => {
   writeTerminalMode(HERMES_HOME, mode)
 
-  return desktopTerminalModeInfo(safeTerminalCwd(cwd))
+  return await desktopTerminalModeInfo(safeTerminalCwd(cwd))
 })
 
 ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   const id = crypto.randomUUID()
   const cwd = safeTerminalCwd(payload?.cwd)
-  const { args, command, configuredMode, distribution, name, resolvedMode } = terminalShellCommand(cwd)
+  const { args, command, configuredMode, distribution, name, resolvedMode } = await terminalShellCommand(cwd)
   // wsl.exe receives the real Linux cwd through --cd. Keep CreateProcess/node-pty
   // on a native host directory so WSL UNC projects do not fail before wsl.exe starts.
   const ptyCwd = resolvedMode === 'wsl2' ? app.getPath('home') : cwd

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -137,6 +137,10 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     }
   },
   terminal: {
+    mode: {
+      get: cwd => ipcRenderer.invoke('hermes:terminal-mode:get', cwd),
+      set: (mode, cwd) => ipcRenderer.invoke('hermes:terminal-mode:set', mode, cwd)
+    },
     cwd: id => ipcRenderer.invoke('hermes:terminal:cwd', id),
     dispose: id => ipcRenderer.invoke('hermes:terminal:dispose', id),
     resize: (id, size) => ipcRenderer.invoke('hermes:terminal:resize', id, size),

--- a/apps/desktop/electron/terminal-mode.test.ts
+++ b/apps/desktop/electron/terminal-mode.test.ts
@@ -28,7 +28,15 @@ describe('terminal mode', () => {
     try {
       fs.writeFileSync(
         configPath,
-        ['model:', '  provider: test', '', 'terminal:', '  timeout: 120', '  windows_execution_mode: smart', ''].join('\n'),
+        [
+          'model:',
+          '  provider: test',
+          '',
+          'terminal:',
+          '  timeout: 120',
+          '  windows_execution_mode: smart',
+          ''
+        ].join('\n'),
         'utf8'
       )
 
@@ -58,7 +66,13 @@ describe('terminal mode', () => {
     }
   })
 
-  it('parses the null-padded output returned by wsl.exe', () => {
+  it('parses UTF-16LE output returned by wsl.exe', () => {
+    const output = Buffer.from('Ubuntu\r\nDébian\r\n', 'utf16le')
+
+    expect(parseWslDistributions(output)).toEqual(['Ubuntu', 'Débian'])
+  })
+
+  it('parses null-padded string output returned by wsl.exe', () => {
     expect(
       parseWslDistributions(
         'U\u0000b\u0000u\u0000n\u0000t\u0000u\u0000\r\u0000\n\u0000D\u0000e\u0000b\u0000i\u0000a\u0000n\u0000'

--- a/apps/desktop/electron/terminal-mode.test.ts
+++ b/apps/desktop/electron/terminal-mode.test.ts
@@ -55,6 +55,17 @@ describe('terminal mode', () => {
     ).toEqual({ distribution: 'Ubuntu', mode: 'wsl2' })
   })
 
+  it('returns wsl2 with null distribution when configured as wsl2 but no distributions are installed', () => {
+    expect(
+      resolveWindowsTerminalMode({
+        configuredMode: 'wsl2',
+        cwd: 'C:\\Users\\shay\\project',
+        isWindows: true,
+        wslDistributions: []
+      })
+    ).toEqual({ distribution: null, mode: 'wsl2' })
+  })
+
   it('maps Windows and WSL UNC paths', () => {
     expect(toWslPath('C:\\Users\\shay\\project', 'Ubuntu')).toBe('/mnt/c/Users/shay/project')
     expect(toWslPath('\\\\wsl$\\Ubuntu\\home\\shay\\project', 'Ubuntu')).toBe('/home/shay/project')

--- a/apps/desktop/electron/terminal-mode.test.ts
+++ b/apps/desktop/electron/terminal-mode.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  distributionFromWslPath,
+  normalizeTerminalMode,
+  parseWslDistributions,
+  resolveWindowsTerminalMode,
+  toWslPath
+} from './terminal-mode'
+
+describe('terminal mode', () => {
+  it('normalizes unknown values to smart', () => {
+    expect(normalizeTerminalMode('wsl2')).toBe('wsl2')
+    expect(normalizeTerminalMode('bad')).toBe('smart')
+  })
+
+  it('parses the null-padded output returned by wsl.exe', () => {
+    expect(
+      parseWslDistributions(
+        'U\u0000b\u0000u\u0000n\u0000t\u0000u\u0000\r\u0000\n\u0000D\u0000e\u0000b\u0000i\u0000a\u0000n\u0000'
+      )
+    ).toEqual(['Ubuntu', 'Debian'])
+  })
+
+  it('uses WSL for a matching UNC project in smart mode', () => {
+    expect(
+      resolveWindowsTerminalMode({
+        configuredMode: 'smart',
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\shay\\project',
+        isWindows: true,
+        wslDistributions: ['Ubuntu']
+      })
+    ).toEqual({ distribution: 'Ubuntu', mode: 'wsl2' })
+  })
+
+  it('keeps ordinary Windows projects native in smart mode', () => {
+    expect(
+      resolveWindowsTerminalMode({
+        configuredMode: 'smart',
+        cwd: 'C:\\Users\\shay\\project',
+        isWindows: true,
+        wslDistributions: ['Ubuntu']
+      })
+    ).toEqual({ distribution: null, mode: 'windows-native' })
+  })
+
+  it('forces the first installed distro in WSL2 mode', () => {
+    expect(
+      resolveWindowsTerminalMode({
+        configuredMode: 'wsl2',
+        cwd: 'C:\\Users\\shay\\project',
+        isWindows: true,
+        wslDistributions: ['Ubuntu', 'Debian']
+      })
+    ).toEqual({ distribution: 'Ubuntu', mode: 'wsl2' })
+  })
+
+  it('maps Windows and WSL UNC paths', () => {
+    expect(toWslPath('C:\\Users\\shay\\project', 'Ubuntu')).toBe('/mnt/c/Users/shay/project')
+    expect(toWslPath('\\\\wsl$\\Ubuntu\\home\\shay\\project', 'Ubuntu')).toBe('/home/shay/project')
+    expect(distributionFromWslPath('\\\\wsl.localhost\\Ubuntu\\home\\shay')).toBe('Ubuntu')
+  })
+})

--- a/apps/desktop/electron/terminal-mode.test.ts
+++ b/apps/desktop/electron/terminal-mode.test.ts
@@ -1,17 +1,61 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import {
   distributionFromWslPath,
   normalizeTerminalMode,
   parseWslDistributions,
+  readTerminalMode,
   resolveWindowsTerminalMode,
-  toWslPath
+  terminalModeConfigPath,
+  toWslPath,
+  writeTerminalMode
 } from './terminal-mode'
 
 describe('terminal mode', () => {
   it('normalizes unknown values to smart', () => {
     expect(normalizeTerminalMode('wsl2')).toBe('wsl2')
     expect(normalizeTerminalMode('bad')).toBe('smart')
+  })
+
+  it('reads and updates terminal.windows_execution_mode in config.yaml', () => {
+    const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-terminal-mode-'))
+    const configPath = terminalModeConfigPath(hermesHome)
+
+    try {
+      fs.writeFileSync(
+        configPath,
+        ['model:', '  provider: test', '', 'terminal:', '  timeout: 120', '  windows_execution_mode: smart', ''].join('\n'),
+        'utf8'
+      )
+
+      expect(readTerminalMode(hermesHome)).toBe('smart')
+      expect(writeTerminalMode(hermesHome, 'wsl2')).toBe('wsl2')
+      expect(readTerminalMode(hermesHome)).toBe('wsl2')
+      expect(fs.readFileSync(configPath, 'utf8')).toContain('  windows_execution_mode: wsl2')
+      expect(fs.readFileSync(configPath, 'utf8')).toContain('  timeout: 120')
+    } finally {
+      fs.rmSync(hermesHome, { force: true, recursive: true })
+    }
+  })
+
+  it('creates the terminal section when config.yaml does not contain one', () => {
+    const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-terminal-mode-'))
+
+    try {
+      fs.writeFileSync(terminalModeConfigPath(hermesHome), 'model:\n  provider: test\n', 'utf8')
+      writeTerminalMode(hermesHome, 'windows-native')
+
+      expect(readTerminalMode(hermesHome)).toBe('windows-native')
+      expect(fs.readFileSync(terminalModeConfigPath(hermesHome), 'utf8')).toContain(
+        'terminal:\n  windows_execution_mode: windows-native'
+      )
+    } finally {
+      fs.rmSync(hermesHome, { force: true, recursive: true })
+    }
   })
 
   it('parses the null-padded output returned by wsl.exe', () => {

--- a/apps/desktop/electron/terminal-mode.ts
+++ b/apps/desktop/electron/terminal-mode.ts
@@ -23,31 +23,96 @@ export function normalizeTerminalMode(value: unknown): TerminalMode {
 }
 
 export function terminalModeConfigPath(hermesHome: string): string {
-  return path.join(hermesHome, 'desktop-terminal.json')
+  return path.join(hermesHome, 'config.yaml')
+}
+
+function stripYamlScalar(value: string): string {
+  const withoutComment = value.replace(/\s+#.*$/, '').trim()
+  const quote = withoutComment[0]
+
+  if ((quote === '"' || quote === "'") && withoutComment.endsWith(quote)) {
+    return withoutComment.slice(1, -1)
+  }
+
+  return withoutComment
 }
 
 export function readTerminalMode(hermesHome: string): TerminalMode {
-  const envMode = normalizeTerminalMode(process.env.HERMES_WINDOWS_EXECUTION_MODE)
-
-  if (process.env.HERMES_WINDOWS_EXECUTION_MODE) {
-    return envMode
-  }
-
   try {
-    const parsed = JSON.parse(fs.readFileSync(terminalModeConfigPath(hermesHome), 'utf8'))
+    const lines = fs.readFileSync(terminalModeConfigPath(hermesHome), 'utf8').split(/\r?\n/)
+    let inTerminal = false
 
-    return normalizeTerminalMode(parsed?.mode)
+    for (const line of lines) {
+      if (!/^\s/.test(line)) {
+        inTerminal = /^terminal\s*:\s*(?:#.*)?$/.test(line)
+        continue
+      }
+
+      if (inTerminal) {
+        const match = /^\s+windows_execution_mode\s*:\s*(.*?)\s*$/.exec(line)
+        if (match) {
+          return normalizeTerminalMode(stripYamlScalar(match[1]))
+        }
+      }
+    }
   } catch {
-    return 'smart'
+    // Missing or unreadable config falls back to the documented default.
   }
+
+  return 'smart'
 }
 
 export function writeTerminalMode(hermesHome: string, value: unknown): TerminalMode {
   const mode = normalizeTerminalMode(value)
   const target = terminalModeConfigPath(hermesHome)
   fs.mkdirSync(path.dirname(target), { recursive: true })
-  fs.writeFileSync(target, `${JSON.stringify({ mode }, null, 2)}\n`, 'utf8')
 
+  let text = ''
+  try {
+    text = fs.readFileSync(target, 'utf8')
+  } catch {
+    // A fresh install may not have config.yaml yet.
+  }
+
+  const lines = text ? text.split(/\r?\n/) : []
+  let terminalStart = -1
+  let terminalEnd = lines.length
+  let modeLine = -1
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (!/^\s/.test(line)) {
+      if (/^terminal\s*:\s*(?:#.*)?$/.test(line)) {
+        terminalStart = index
+        terminalEnd = lines.length
+      } else if (terminalStart >= 0) {
+        terminalEnd = index
+        break
+      }
+      continue
+    }
+
+    if (terminalStart >= 0 && /^\s+windows_execution_mode\s*:/.test(line)) {
+      modeLine = index
+    }
+  }
+
+  if (modeLine >= 0) {
+    const indent = /^\s*/.exec(lines[modeLine])?.[0] || '  '
+    lines[modeLine] = `${indent}windows_execution_mode: ${mode}`
+  } else if (terminalStart >= 0) {
+    lines.splice(terminalEnd, 0, `  windows_execution_mode: ${mode}`)
+  } else {
+    while (lines.length && lines[lines.length - 1] === '') {
+      lines.pop()
+    }
+    if (lines.length) {
+      lines.push('')
+    }
+    lines.push('terminal:', `  windows_execution_mode: ${mode}`)
+  }
+
+  fs.writeFileSync(target, `${lines.join('\n').replace(/\n+$/, '')}\n`, 'utf8')
   return mode
 }
 
@@ -145,7 +210,6 @@ export function resolveWindowsTerminalMode({
       : { distribution: null, mode: 'windows-native' }
   }
 
-  // configuredMode === 'wsl2'
   const distribution = pathDistribution || wslDistributions[0] || null
 
   return { distribution, mode: 'wsl2' }

--- a/apps/desktop/electron/terminal-mode.ts
+++ b/apps/desktop/electron/terminal-mode.ts
@@ -1,0 +1,150 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const TERMINAL_MODES = ['smart', 'wsl2', 'windows-native'] as const
+
+export type TerminalMode = (typeof TERMINAL_MODES)[number]
+
+interface ResolveTerminalModeOptions {
+  configuredMode: TerminalMode
+  cwd?: string
+  isWindows: boolean
+  wslDistributions: string[]
+}
+
+export function normalizeTerminalMode(value: unknown): TerminalMode {
+  return TERMINAL_MODES.includes(value as TerminalMode) ? (value as TerminalMode) : 'smart'
+}
+
+export function terminalModeConfigPath(hermesHome: string): string {
+  return path.join(hermesHome, 'desktop-terminal.json')
+}
+
+export function readTerminalMode(hermesHome: string): TerminalMode {
+  const envMode = normalizeTerminalMode(process.env.HERMES_WINDOWS_EXECUTION_MODE)
+
+  if (process.env.HERMES_WINDOWS_EXECUTION_MODE) {
+    return envMode
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(terminalModeConfigPath(hermesHome), 'utf8'))
+
+    return normalizeTerminalMode(parsed?.mode)
+  } catch {
+    return 'smart'
+  }
+}
+
+export function writeTerminalMode(hermesHome: string, value: unknown): TerminalMode {
+  const mode = normalizeTerminalMode(value)
+  const target = terminalModeConfigPath(hermesHome)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, `${JSON.stringify({ mode }, null, 2)}\n`, 'utf8')
+
+  return mode
+}
+
+export function parseWslDistributions(output: unknown): string[] {
+  const text = Buffer.isBuffer(output) ? output.toString('utf8') : String(output || '')
+  const seen = new Set<string>()
+
+  return text
+    .split('\u0000')
+    .join('')
+    .split(/\r?\n/)
+    .map(line => line.replace(/^\*\s*/, '').trim())
+    .filter(name => {
+      const key = name.toLowerCase()
+
+      if (!name || seen.has(key)) {
+        return false
+      }
+
+      seen.add(key)
+
+      return true
+    })
+}
+
+export function detectWslDistributions(run: typeof execFileSync = execFileSync): string[] {
+  try {
+    const output = run('wsl.exe', ['--list', '--quiet'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true
+    })
+
+    return parseWslDistributions(output)
+  } catch {
+    return []
+  }
+}
+
+export function distributionFromWslPath(cwd: string): string | null {
+  const match = /^\\\\(?:wsl\.localhost|wsl\$)\\([^\\/]+)(?:[\\/]|$)/i.exec(String(cwd || ''))
+
+  return match?.[1] || null
+}
+
+function matchingDistribution(distributions: string[], requested: string | null): string | null {
+  if (!requested) {
+    return null
+  }
+
+  return distributions.find(name => name.toLowerCase() === requested.toLowerCase()) || null
+}
+
+export function resolveWindowsTerminalMode({
+  configuredMode,
+  cwd = '',
+  isWindows,
+  wslDistributions
+}: ResolveTerminalModeOptions): { distribution: string | null; mode: 'windows-native' | 'wsl2' } {
+  if (!isWindows || configuredMode === 'windows-native') {
+    return { distribution: null, mode: 'windows-native' }
+  }
+
+  const pathDistribution = matchingDistribution(wslDistributions, distributionFromWslPath(cwd))
+
+  if (configuredMode === 'smart') {
+    return pathDistribution
+      ? { distribution: pathDistribution, mode: 'wsl2' }
+      : { distribution: null, mode: 'windows-native' }
+  }
+
+  const distribution = pathDistribution || wslDistributions[0] || null
+
+  return distribution ? { distribution, mode: 'wsl2' } : { distribution: null, mode: 'windows-native' }
+}
+
+export function toWslPath(cwd: string, distribution?: string | null): string {
+  const value = String(cwd || '').trim()
+
+  if (!value) {
+    return '~'
+  }
+
+  const unc = /^\\\\(?:wsl\.localhost|wsl\$)\\([^\\/]+)(?:[\\/](.*))?$/i.exec(value)
+
+  if (unc) {
+    if (!distribution || unc[1].toLowerCase() === distribution.toLowerCase()) {
+      return (
+        `/${String(unc[2] || '')
+          .replace(/\\/g, '/')
+          .replace(/^\/+/, '')}`.replace(/\/$/, '') || '/'
+      )
+    }
+  }
+
+  const drive = /^([a-zA-Z]):[\\/]*(.*)$/.exec(value)
+
+  if (drive) {
+    const tail = drive[2].replace(/\\/g, '/').replace(/^\/+/, '')
+
+    return `/mnt/${drive[1].toLowerCase()}${tail ? `/${tail}` : ''}`
+  }
+
+  return value.replace(/\\/g, '/')
+}

--- a/apps/desktop/electron/terminal-mode.ts
+++ b/apps/desktop/electron/terminal-mode.ts
@@ -1,6 +1,11 @@
-import { execFileSync } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+let cachedDistributions: string[] | null = null
 
 export const TERMINAL_MODES = ['smart', 'wsl2', 'windows-native'] as const
 
@@ -47,7 +52,12 @@ export function writeTerminalMode(hermesHome: string, value: unknown): TerminalM
 }
 
 export function parseWslDistributions(output: unknown): string[] {
-  const text = Buffer.isBuffer(output) ? output.toString('utf8') : String(output || '')
+  let text = ''
+  if (Buffer.isBuffer(output)) {
+    text = output.toString('utf16le')
+  } else {
+    text = String(output || '')
+  }
   const seen = new Set<string>()
 
   return text
@@ -71,7 +81,7 @@ export function parseWslDistributions(output: unknown): string[] {
 export function detectWslDistributions(run: typeof execFileSync = execFileSync): string[] {
   try {
     const output = run('wsl.exe', ['--list', '--quiet'], {
-      encoding: 'utf8',
+      encoding: 'buffer' as any,
       stdio: ['ignore', 'pipe', 'ignore'],
       windowsHide: true
     })
@@ -80,6 +90,27 @@ export function detectWslDistributions(run: typeof execFileSync = execFileSync):
   } catch {
     return []
   }
+}
+
+export async function detectWslDistributionsAsync(): Promise<string[]> {
+  if (cachedDistributions !== null) {
+    return cachedDistributions
+  }
+  try {
+    const { stdout } = await execFileAsync('wsl.exe', ['--list', '--quiet'], {
+      encoding: 'buffer',
+      windowsHide: true
+    })
+    cachedDistributions = parseWslDistributions(stdout)
+    return cachedDistributions
+  } catch {
+    cachedDistributions = []
+    return []
+  }
+}
+
+export function clearWslDistributionCache(): void {
+  cachedDistributions = null
 }
 
 export function distributionFromWslPath(cwd: string): string | null {
@@ -114,9 +145,10 @@ export function resolveWindowsTerminalMode({
       : { distribution: null, mode: 'windows-native' }
   }
 
+  // configuredMode === 'wsl2'
   const distribution = pathDistribution || wslDistributions[0] || null
 
-  return distribution ? { distribution, mode: 'wsl2' } : { distribution: null, mode: 'windows-native' }
+  return { distribution, mode: 'wsl2' }
 }
 
 export function toWslPath(cwd: string, distribution?: string | null): string {

--- a/apps/desktop/electron/terminal-mode.ts
+++ b/apps/desktop/electron/terminal-mode.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
+const WSL_DETECTION_TIMEOUT_MS = 10_000
 
 let cachedDistributions: string[] | null = null
 
@@ -48,11 +49,13 @@ export function readTerminalMode(hermesHome: string): TerminalMode {
         continue
       }
 
-      if (inTerminal) {
-        const match = /^\s+windows_execution_mode\s*:\s*(.*?)\s*$/.exec(line)
-        if (match) {
-          return normalizeTerminalMode(stripYamlScalar(match[1]))
-        }
+      if (!inTerminal) {
+        continue
+      }
+
+      const match = /^\s+windows_execution_mode\s*:\s*(.*?)\s*$/.exec(line)
+      if (match) {
+        return normalizeTerminalMode(stripYamlScalar(match[1] || ''))
       }
     }
   } catch {
@@ -80,7 +83,8 @@ export function writeTerminalMode(hermesHome: string, value: unknown): TerminalM
   let modeLine = -1
 
   for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]
+    const line = lines[index] || ''
+
     if (!/^\s/.test(line)) {
       if (/^terminal\s*:\s*(?:#.*)?$/.test(line)) {
         terminalStart = index
@@ -98,7 +102,8 @@ export function writeTerminalMode(hermesHome: string, value: unknown): TerminalM
   }
 
   if (modeLine >= 0) {
-    const indent = /^\s*/.exec(lines[modeLine])?.[0] || '  '
+    const currentLine = lines[modeLine] || ''
+    const indent = /^\s*/.exec(currentLine)?.[0] || '  '
     lines[modeLine] = `${indent}windows_execution_mode: ${mode}`
   } else if (terminalStart >= 0) {
     lines.splice(terminalEnd, 0, `  windows_execution_mode: ${mode}`)
@@ -118,16 +123,20 @@ export function writeTerminalMode(hermesHome: string, value: unknown): TerminalM
 
 export function parseWslDistributions(output: unknown): string[] {
   let text = ''
+
   if (Buffer.isBuffer(output)) {
-    text = output.toString('utf16le')
+    const hasUtf16LeBom = output.length >= 2 && output[0] === 0xff && output[1] === 0xfe
+    const looksUtf16Le = output.length >= 2 && output[1] === 0
+    text = output.toString(hasUtf16LeBom || looksUtf16Le ? 'utf16le' : 'utf8')
   } else {
     text = String(output || '')
   }
+
   const seen = new Set<string>()
 
   return text
-    .split('\u0000')
-    .join('')
+    .replace(/\u0000/g, '')
+    .replace(/^\ufeff/, '')
     .split(/\r?\n/)
     .map(line => line.replace(/^\*\s*/, '').trim())
     .filter(name => {
@@ -138,7 +147,6 @@ export function parseWslDistributions(output: unknown): string[] {
       }
 
       seen.add(key)
-
       return true
     })
 }
@@ -148,6 +156,7 @@ export function detectWslDistributions(run: typeof execFileSync = execFileSync):
     const output = run('wsl.exe', ['--list', '--quiet'], {
       encoding: 'buffer' as any,
       stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: WSL_DETECTION_TIMEOUT_MS,
       windowsHide: true
     })
 
@@ -161,17 +170,19 @@ export async function detectWslDistributionsAsync(): Promise<string[]> {
   if (cachedDistributions !== null) {
     return cachedDistributions
   }
+
   try {
     const { stdout } = await execFileAsync('wsl.exe', ['--list', '--quiet'], {
       encoding: 'buffer',
+      timeout: WSL_DETECTION_TIMEOUT_MS,
       windowsHide: true
     })
     cachedDistributions = parseWslDistributions(stdout)
-    return cachedDistributions
   } catch {
     cachedDistributions = []
-    return []
   }
+
+  return cachedDistributions
 }
 
 export function clearWslDistributionCache(): void {
@@ -224,14 +235,12 @@ export function toWslPath(cwd: string, distribution?: string | null): string {
 
   const unc = /^\\\\(?:wsl\.localhost|wsl\$)\\([^\\/]+)(?:[\\/](.*))?$/i.exec(value)
 
-  if (unc) {
-    if (!distribution || unc[1].toLowerCase() === distribution.toLowerCase()) {
-      return (
-        `/${String(unc[2] || '')
-          .replace(/\\/g, '/')
-          .replace(/^\/+/, '')}`.replace(/\/$/, '') || '/'
-      )
-    }
+  if (unc && (!distribution || unc[1].toLowerCase() === distribution.toLowerCase())) {
+    return (
+      `/${String(unc[2] || '')
+        .replace(/\\/g, '/')
+        .replace(/^\/+/, '')}`.replace(/\/$/, '') || '/'
+    )
   }
 
   const drive = /^([a-zA-Z]):[\\/]*(.*)$/.exec(value)

--- a/apps/desktop/src/app/right-sidebar/terminal/rail.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/rail.tsx
@@ -43,9 +43,9 @@ const RAIL_ACTION =
   'grid size-6 place-items-center rounded text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring [-webkit-app-region:no-drag]'
 
 const TERMINAL_MODE_LABELS: Record<TerminalMode, string> = {
-  smart: 'Smart',
-  wsl2: 'WSL2',
-  'windows-native': 'Windows Native'
+  smart: 'Smart (AI Choice)',
+  wsl2: 'WSL2 (Bash)',
+  'windows-native': 'Windows Native (PowerShell)'
 }
 
 const TERMINAL_MODE_ICONS: Record<TerminalMode, string> = {
@@ -138,12 +138,12 @@ export function TerminalRail() {
         {modeInfo?.supported && (
           <DropdownMenu>
             <Tip
-              label={`Terminal mode: ${TERMINAL_MODE_LABELS[modeInfo.configuredMode]} (new terminals; agent commands update immediately)`}
+              label={`Agent Execution Environment: ${TERMINAL_MODE_LABELS[modeInfo.configuredMode]} (controls where the agent executes tools/commands)`}
               side="left"
             >
               <DropdownMenuTrigger asChild>
                 <button
-                  aria-label={`Terminal mode: ${TERMINAL_MODE_LABELS[modeInfo.configuredMode]}`}
+                  aria-label={`Agent Execution Environment: ${TERMINAL_MODE_LABELS[modeInfo.configuredMode]}`}
                   className={RAIL_ACTION}
                   type="button"
                 >
@@ -165,7 +165,7 @@ export function TerminalRail() {
               ))}
               {modeInfo.configuredMode === 'smart' && (
                 <div className="max-w-56 px-2 py-1 text-[0.65rem] text-(--ui-text-tertiary)">
-                  Smart uses WSL2 for projects opened through a WSL UNC path; other projects stay Windows native.
+                  Smart mode executes agent commands in WSL2 for projects under a WSL UNC path, and uses PowerShell for native Windows projects.
                 </div>
               )}
             </DropdownMenuContent>

--- a/apps/desktop/src/app/right-sidebar/terminal/rail.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/rail.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import {
@@ -8,6 +9,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Tip, TipHintLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { formatCombo } from '@/lib/keybinds/combo'
@@ -27,8 +29,30 @@ import {
   type TerminalEntry
 } from './terminals'
 
+type TerminalMode = 'smart' | 'wsl2' | 'windows-native'
+
+interface TerminalModeInfo {
+  configuredMode: TerminalMode
+  distribution: null | string
+  resolvedMode: 'windows-native' | 'wsl2'
+  supported: boolean
+  wslDistributions: string[]
+}
+
 const RAIL_ACTION =
   'grid size-6 place-items-center rounded text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring [-webkit-app-region:no-drag]'
+
+const TERMINAL_MODE_LABELS: Record<TerminalMode, string> = {
+  smart: 'Smart',
+  wsl2: 'WSL2',
+  'windows-native': 'Windows Native'
+}
+
+const TERMINAL_MODE_ICONS: Record<TerminalMode, string> = {
+  smart: 'server-environment',
+  wsl2: 'terminal-linux',
+  'windows-native': 'terminal-powershell'
+}
 
 /** Thin icon "bookmark" strip blended into the terminal surface, shown whenever a
  *  terminal exists. Each square is a tab (name + hotkey on hover); close via the
@@ -40,6 +64,34 @@ export function TerminalRail() {
   const bindings = useStore($bindings)
   const toggleHint = bindings['view.showTerminal']?.[0]
   const newHint = bindings['view.newTerminal']?.[0]
+
+  const [modeInfo, setModeInfo] = useState<TerminalModeInfo | null>(null)
+
+  useEffect(() => {
+    const api = window.hermesDesktop?.terminal?.mode
+
+    if (!api) {
+      return
+    }
+
+    void api
+      .get()
+      .then(setModeInfo)
+      .catch(() => setModeInfo(null))
+  }, [])
+
+  const selectMode = (mode: TerminalMode) => {
+    const api = window.hermesDesktop?.terminal?.mode
+
+    if (!api) {
+      return
+    }
+
+    void api
+      .set(mode)
+      .then(setModeInfo)
+      .catch(() => undefined)
+  }
 
   return (
     <div
@@ -82,7 +134,43 @@ export function TerminalRail() {
         </li>
       </ul>
 
-      <div className="flex shrink-0 flex-col items-center pb-1.5">
+      <div className="flex shrink-0 flex-col items-center gap-0.5 pb-1.5">
+        {modeInfo?.supported && (
+          <DropdownMenu>
+            <Tip
+              label={`Terminal mode: ${TERMINAL_MODE_LABELS[modeInfo.configuredMode]} (new terminals; agent commands update immediately)`}
+              side="left"
+            >
+              <DropdownMenuTrigger asChild>
+                <button
+                  aria-label={`Terminal mode: ${TERMINAL_MODE_LABELS[modeInfo.configuredMode]}`}
+                  className={RAIL_ACTION}
+                  type="button"
+                >
+                  <Codicon name={TERMINAL_MODE_ICONS[modeInfo.configuredMode]} size="0.8125rem" />
+                </button>
+              </DropdownMenuTrigger>
+            </Tip>
+            <DropdownMenuContent align="end" side="left">
+              {(Object.keys(TERMINAL_MODE_LABELS) as TerminalMode[]).map(mode => (
+                <DropdownMenuItem
+                  disabled={mode === 'wsl2' && modeInfo.wslDistributions.length === 0}
+                  key={mode}
+                  onSelect={() => selectMode(mode)}
+                >
+                  <Codicon name={TERMINAL_MODE_ICONS[mode]} />
+                  <span className="flex-1">{TERMINAL_MODE_LABELS[mode]}</span>
+                  {modeInfo.configuredMode === mode && <Codicon name="check" />}
+                </DropdownMenuItem>
+              ))}
+              {modeInfo.configuredMode === 'smart' && (
+                <div className="max-w-56 px-2 py-1 text-[0.65rem] text-(--ui-text-tertiary)">
+                  Smart uses WSL2 for projects opened through a WSL UNC path; other projects stay Windows native.
+                </div>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         <Tip label={t.rightSidebar.terminalHide} side="left">
           <button
             aria-label={t.rightSidebar.terminalHide}

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -469,7 +469,17 @@ export function ConfigSettings({
                     : enumOptionsFor(key, getNested(config, key), config)
                 }
                 onChange={value => updateConfig(setNested(config, key, value))}
-                optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
+                optionLabels={
+                  key === 'tts.elevenlabs.voice_id'
+                    ? elevenLabsVoiceLabels
+                    : key === 'terminal.windows_execution_mode'
+                      ? {
+                          smart: 'Smart (AI Choice)',
+                          wsl2: 'WSL2 (Bash)',
+                          'windows-native': 'Windows Native (PowerShell)'
+                        }
+                      : undefined
+                }
                 schema={field}
                 schemaKey={key}
                 value={getNested(config, key)}

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -243,6 +243,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   // tools/terminal_tool.py::_create_environment (local/docker/singularity/
   // modal/daytona/ssh). Remote backends need extra env (image, tokens, host).
   'terminal.backend': ['local', 'docker', 'singularity', 'modal', 'daytona', 'ssh'],
+  'terminal.windows_execution_mode': ['smart', 'wsl2', 'windows-native'],
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
   'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
   // Speech-to-text backends — kept in sync with the stt block in
@@ -291,6 +292,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     toolUseEnforcement: 'Tool-Use Enforcement'
   },
   terminal: {
+    windowsExecutionMode: 'Agent Execution Environment',
     cwd: 'Working Directory',
     backend: 'Execution Backend',
     timeout: 'Command Timeout',
@@ -441,6 +443,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     maxTurns: 'Upper bound for tool-calling turns before Hermes stops a run.'
   },
   terminal: {
+    windowsExecutionMode: 'Determines where the agent executes tools and commands (WSL2 Bash, Windows Native PowerShell, or Smart selection based on project directory).',
     cwd: 'Default project folder for tool and terminal work.',
     persistentShell: 'Keep shell state between commands when the backend supports it.',
     envPassthrough: 'Environment variables to pass into tool execution.',
@@ -524,6 +527,7 @@ export const SECTIONS: DesktopConfigSection[] = [
     icon: Monitor,
     keys: [
       'terminal.cwd',
+      'terminal.windows_execution_mode',
       'code_execution.mode',
       'terminal.persistent_shell',
       'terminal.env_passthrough',

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -167,6 +167,10 @@ declare global {
         scanRepos: (roots: string[], options?: { maxDepth?: number }) => Promise<{ root: string; label: string }[]>
       }
       terminal: {
+        mode: {
+          get: (cwd?: string) => Promise<DesktopTerminalModeInfo>
+          set: (mode: DesktopTerminalMode, cwd?: string) => Promise<DesktopTerminalModeInfo>
+        }
         /** Best-effort current working directory of the live PTY child (POSIX
          *  only; null on Windows or when unavailable). Used to reopen a tab
          *  where the user last `cd`'d. */
@@ -222,6 +226,16 @@ declare global {
       }
     }
   }
+}
+
+export type DesktopTerminalMode = 'smart' | 'wsl2' | 'windows-native'
+
+export interface DesktopTerminalModeInfo {
+  configuredMode: DesktopTerminalMode
+  distribution: null | string
+  resolvedMode: 'windows-native' | 'wsl2'
+  supported: boolean
+  wslDistributions: string[]
 }
 
 export interface DesktopMarketplaceSearchItem {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1169,6 +1169,7 @@ DEFAULT_CONFIG = {
 
     "terminal": {
         "backend": "local",
+        "windows_execution_mode": "smart",
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
         "timeout": 180,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,7 @@ AUTHOR_MAP = {
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "2024104039@mails.szu.edu.cn": "pixel4039",  # PR #64420 salvage (streaming: retry zero-chunk streams)
+    "ntun7729@users.noreply.github.com": "ntun7729",  # PR #64066 (desktop: Agent Execution Environment selector and Windows Native PowerShell execution mode)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -50,6 +50,7 @@ AUTHOR_MAP = {
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "2024104039@mails.szu.edu.cn": "pixel4039",  # PR #64420 salvage (streaming: retry zero-chunk streams)
     "ntun7729@users.noreply.github.com": "ntun7729",  # PR #64066 (desktop: Agent Execution Environment selector and Windows Native PowerShell execution mode)
+    "ntun77.19@gmail.com": "ntun7729",  # PR #64066 (desktop: Agent Execution Environment selector and Windows Native PowerShell execution mode)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -20,6 +20,13 @@ on the real OS.
 
 import os
 from unittest.mock import patch
+import pytest
+from tools.environments.windows_execution_mode import WindowsExecutionMode
+
+@pytest.fixture(autouse=True)
+def mock_resolved_mode():
+    with patch("tools.environments.local.resolve_windows_execution_mode", return_value=WindowsExecutionMode("smart", "windows-bash")):
+        yield
 
 from tools.environments.base import BaseEnvironment
 from tools.environments import local as local_mod
@@ -507,3 +514,47 @@ class TestWrapCommandWindowsNativeCwd:
         script = captured["script"]
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-deadbeef.sh" in script
         assert r"C:\Users\Alexander\AppData" not in script
+
+    def test_powershell_execution_args_and_wrapping(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        from tools.environments.windows_execution_mode import WindowsExecutionMode
+        from unittest.mock import MagicMock
+        with patch("tools.environments.local.resolve_windows_execution_mode", return_value=WindowsExecutionMode("windows-native", "windows-native")):
+            with patch.object(LocalEnvironment, "__init__", lambda self, **kw: None):
+                env = LocalEnvironment.__new__(LocalEnvironment)
+                BaseEnvironment.__init__(
+                    env,
+                    cwd=r"C:\Users\Alexander\Documents",
+                    timeout=10,
+                )
+                env._snapshot_path = r"C:\Users\Alexander\AppData\Local\Temp\hermes-snap-deadbeef.ps1"
+                env._cwd_file = r"C:\Users\Alexander\AppData\Local\Temp\hermes-snap-deadbeef.cwd"
+                env.cwd = r"C:\Users\Alexander\Documents"
+                env._cwd_marker = "__HERMES_CWD__"
+
+                # Check path quoting
+                assert env._quote_cwd_for_cd(r"C:\Users\Alexander\Documents") == "'C:\\Users\\Alexander\\Documents'"
+                assert env._quote_shell_path(r"C:\Users\Alexander\Documents") == "'C:\\Users\\Alexander\\Documents'"
+
+                # Check wrap command
+                wrapped = env._wrap_command("echo hello", r"C:\Users\Alexander\Documents")
+                assert "Set-Location -LiteralPath 'C:\\Users\\Alexander\\Documents'" in wrapped
+                assert "echo hello" in wrapped
+                assert "Get-ChildItem env:" in wrapped
+
+                # Check run args
+                captured_args = []
+                def fake_popen(args, *args2, **kwargs):
+                    captured_args.append(args)
+                    mock_proc = MagicMock()
+                    mock_proc.pid = 1234
+                    return mock_proc
+
+                monkeypatch.setattr(local_mod.subprocess, "Popen", fake_popen)
+                env._run_bash("echo hello", login=False)
+
+                assert len(captured_args) == 1
+                cmd_args = captured_args[0]
+                assert any(p in cmd_args[0].lower() for p in ("powershell", "pwsh"))
+                assert "-EncodedCommand" in cmd_args

--- a/tests/tools/test_windows_execution_mode.py
+++ b/tests/tools/test_windows_execution_mode.py
@@ -1,0 +1,58 @@
+from tools.environments.windows_execution_mode import (
+    distribution_from_wsl_path,
+    normalize_mode,
+    parse_wsl_distributions,
+    resolve_windows_execution_mode,
+    windows_to_wsl_path,
+    wsl_to_windows_path,
+)
+
+
+def test_normalize_mode_defaults_to_smart():
+    assert normalize_mode("wsl2") == "wsl2"
+    assert normalize_mode("unknown") == "smart"
+
+
+def test_parse_utf16_wsl_output():
+    raw = "Ubuntu\r\nDebian\r\n".encode("utf-16-le")
+    assert parse_wsl_distributions(raw) == ["Ubuntu", "Debian"]
+
+
+def test_smart_mode_uses_wsl_unc_project():
+    result = resolve_windows_execution_mode(
+        r"\\wsl.localhost\Ubuntu\home\shay\project",
+        configured="smart",
+        distributions=["Ubuntu"],
+        is_windows=True,
+    )
+    assert result.resolved == "wsl2"
+    assert result.distribution == "Ubuntu"
+
+
+def test_smart_mode_keeps_drive_project_native():
+    result = resolve_windows_execution_mode(
+        r"C:\Users\shay\project",
+        configured="smart",
+        distributions=["Ubuntu"],
+        is_windows=True,
+    )
+    assert result.resolved == "windows-native"
+
+
+def test_explicit_wsl_uses_first_distribution():
+    result = resolve_windows_execution_mode(
+        r"C:\Users\shay\project",
+        configured="wsl2",
+        distributions=["Ubuntu", "Debian"],
+        is_windows=True,
+    )
+    assert result.resolved == "wsl2"
+    assert result.distribution == "Ubuntu"
+
+
+def test_path_bridges():
+    assert windows_to_wsl_path(r"C:\Users\shay\project", "Ubuntu") == "/mnt/c/Users/shay/project"
+    assert windows_to_wsl_path(r"\\wsl$\Ubuntu\home\shay", "Ubuntu") == "/home/shay"
+    assert wsl_to_windows_path("/mnt/c/Users/shay", "Ubuntu") == r"C:\Users\shay"
+    assert wsl_to_windows_path("/home/shay", "Ubuntu") == r"\\wsl.localhost\Ubuntu\home\shay"
+    assert distribution_from_wsl_path(r"\\wsl.localhost\Ubuntu\home") == "Ubuntu"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -14,6 +14,12 @@ from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
+from tools.environments.windows_execution_mode import (
+    build_wsl_bash_args,
+    resolve_windows_execution_mode,
+    windows_to_wsl_path,
+    wsl_to_windows_path,
+)
 
 _IS_WINDOWS = platform.system() == "Windows"
 
@@ -1105,6 +1111,19 @@ class LocalEnvironment(BaseEnvironment):
         if cwd:
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        self._windows_execution = resolve_windows_execution_mode(self.cwd) if _IS_WINDOWS else None
+        self.init_session()
+
+    def _before_execute(self) -> None:
+        if not _IS_WINDOWS:
+            return
+        current = resolve_windows_execution_mode(self.cwd)
+        previous = self._windows_execution
+        if previous and (current.resolved, current.distribution) == (previous.resolved, previous.distribution):
+            return
+        self._windows_execution = current
+        self._snapshot_ready = False
+        self._prefer_nonlogin = False
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -1157,45 +1176,31 @@ class LocalEnvironment(BaseEnvironment):
 
     @staticmethod
     def _quote_cwd_for_cd(cwd: str) -> str:
-        """Use native paths for Python, but Git Bash-friendly paths for cd."""
+        """Translate the host cwd for the currently selected Windows environment."""
+        if _IS_WINDOWS:
+            mode = resolve_windows_execution_mode(cwd)
+            if mode.resolved == "wsl2":
+                return BaseEnvironment._quote_cwd_for_cd(windows_to_wsl_path(cwd, mode.distribution))
         return BaseEnvironment._quote_cwd_for_cd(_windows_to_msys_path(cwd))
 
     def _quote_shell_path(self, path: str) -> str:
-        """Rewrite native/mixed Windows paths before quoting for Git Bash."""
+        """Rewrite host paths for Git Bash or WSL2 before shell interpolation."""
+        if _IS_WINDOWS:
+            mode = resolve_windows_execution_mode(self.cwd)
+            if mode.resolved == "wsl2":
+                import shlex
+                return shlex.quote(windows_to_wsl_path(path, mode.distribution))
         return _quote_bash_path(path)
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
-        bash = _find_bash()
-        # For login-shell invocations (used by init_session to build the
-        # environment snapshot), prepend sources for the user's bashrc /
-        # custom init files so tools registered outside bash_profile
-        # (nvm, asdf, pyenv, …) end up on PATH in the captured snapshot.
-        # Non-login invocations are already sourcing the snapshot and
-        # don't need this.
-        if login:
-            init_files = _resolve_shell_init_files()
-            if init_files:
-                cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
-        run_env = _make_run_env(self.env)
+        mode = resolve_windows_execution_mode(self.cwd) if _IS_WINDOWS else None
 
         # Recover when the cwd has been deleted out from under us — usually by
-        # a previous tool call that ran ``rm -rf`` on its own working dir
-        # (issue #17558).  Popen would otherwise raise FileNotFoundError on
-        # the cwd before bash starts, wedging every subsequent call until the
-        # gateway restarts.
-        #
-        # On Windows, ``_resolve_safe_cwd`` also normalises Git Bash-style
-        # POSIX paths (``/c/Users/...``) to native form so a perfectly valid
-        # ``pwd -P`` result from bash isn't mistakenly treated as "missing"
-        # and spammed as a warning on every command.
+        # a previous tool call that ran ``rm -rf`` on its own working dir.
         safe_cwd = _resolve_safe_cwd(self.cwd)
         if safe_cwd != self.cwd:
-            # MSYS → Windows translation alone shouldn't surface as a warning
-            # (it's a benign normalization, not a recovery). Only warn when
-            # the directory really doesn't exist on disk.
             normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
             if safe_cwd != normalized:
                 logger.warning(
@@ -1206,7 +1211,31 @@ class LocalEnvironment(BaseEnvironment):
                 )
             self.cwd = safe_cwd
 
+        if mode and mode.resolved == "wsl2":
+            if not mode.distribution:
+                raise RuntimeError("WSL2 mode is selected, but no WSL2 distribution is installed")
+            args = build_wsl_bash_args(
+                cmd_string,
+                self.cwd,
+                login=login,
+                distribution=mode.distribution,
+            )
+        else:
+            bash = _find_bash()
+            # For native login-shell invocations, source the user's configured
+            # shell init files so nvm/asdf/pyenv additions reach the snapshot.
+            if login:
+                init_files = _resolve_shell_init_files()
+                if init_files:
+                    cmd_string = _prepend_shell_init(cmd_string, init_files)
+            args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+
+        run_env = _make_run_env(self.env)
         _popen_cwd = self.cwd
+        if mode and mode.resolved == "wsl2" and self.cwd.startswith("\\"):
+            # CreateProcess cannot reliably use a WSL UNC directory as the host
+            # working directory. wsl.exe --cd still enters the requested path.
+            _popen_cwd = tempfile.gettempdir()
 
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
@@ -1332,7 +1361,12 @@ class LocalEnvironment(BaseEnvironment):
             with open(self._cwd_file, encoding="utf-8") as f:
                 cwd_path = f.read().strip()
             if _IS_WINDOWS:
-                cwd_path = _msys_to_windows_path(cwd_path)
+                mode = resolve_windows_execution_mode(self.cwd)
+                cwd_path = (
+                    wsl_to_windows_path(cwd_path, mode.distribution)
+                    if mode.resolved == "wsl2"
+                    else _msys_to_windows_path(cwd_path)
+                )
             if cwd_path and os.path.isdir(cwd_path):
                 self.cwd = cwd_path
         except (OSError, FileNotFoundError):
@@ -1357,7 +1391,15 @@ class LocalEnvironment(BaseEnvironment):
         prev_cwd = self.cwd
         super()._extract_cwd_from_output(result)
         if self.cwd != prev_cwd:
-            normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
+            if _IS_WINDOWS:
+                mode = resolve_windows_execution_mode(prev_cwd)
+                normalized = (
+                    wsl_to_windows_path(self.cwd, mode.distribution)
+                    if mode.resolved == "wsl2"
+                    else _msys_to_windows_path(self.cwd)
+                )
+            else:
+                normalized = self.cwd
             if normalized and os.path.isdir(normalized):
                 self.cwd = normalized
             else:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -72,6 +72,27 @@ def _windows_to_msys_path(cwd: str) -> str:
     return f"/{drive}/{tail}" if tail else f"/{drive}/"
 
 
+def _powershell_quote(s: str) -> str:
+    """Quote a string for safe use in PowerShell single-quoted strings."""
+    return "'" + s.replace("'", "''") + "'"
+
+
+def _find_powershell() -> str:
+    """Find powershell or pwsh executable on Windows."""
+    pwsh = shutil.which("pwsh")
+    if pwsh:
+        return pwsh
+    powershell = shutil.which("powershell")
+    if powershell:
+        return powershell
+    # Fallback to standard location
+    system32 = os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "System32")
+    powershell_path = os.path.join(system32, "WindowsPowerShell", "v1.0", "powershell.exe")
+    if os.path.isfile(powershell_path):
+        return powershell_path
+    return "powershell.exe"
+
+
 def _bash_safe_path(path: str) -> str:
     """Return *path* in a form safe to embed in a Git Bash script.
 
@@ -1181,16 +1202,89 @@ class LocalEnvironment(BaseEnvironment):
             mode = resolve_windows_execution_mode(cwd)
             if mode.resolved == "wsl2":
                 return BaseEnvironment._quote_cwd_for_cd(windows_to_wsl_path(cwd, mode.distribution))
+            elif mode.resolved == "windows-native":
+                if cwd == "~" or cwd == "~/":
+                    return "~"
+                if cwd.startswith("~/"):
+                    suffix = cwd[2:].replace("/", "\\")
+                    return f"$HOME\\{_powershell_quote(suffix)}"
+                return _powershell_quote(cwd.replace("/", "\\"))
         return BaseEnvironment._quote_cwd_for_cd(_windows_to_msys_path(cwd))
 
     def _quote_shell_path(self, path: str) -> str:
-        """Rewrite host paths for Git Bash or WSL2 before shell interpolation."""
+        """Rewrite host paths for Git Bash, WSL2 or PowerShell before shell interpolation."""
         if _IS_WINDOWS:
             mode = resolve_windows_execution_mode(self.cwd)
             if mode.resolved == "wsl2":
                 import shlex
                 return shlex.quote(windows_to_wsl_path(path, mode.distribution))
+            elif mode.resolved == "windows-native":
+                return _powershell_quote(path)
         return _quote_bash_path(path)
+
+    def init_session(self):
+        if _IS_WINDOWS:
+            mode = resolve_windows_execution_mode(self.cwd)
+            if mode.resolved == "windows-native":
+                try:
+                    with open(self._snapshot_path, "w", encoding="utf-8") as f:
+                        for k, v in os.environ.items():
+                            f.write(f"{k}={v}\n")
+                    self._snapshot_ready = True
+                    logger.info("PowerShell local session initialized (cwd=%s)", self.cwd)
+                except Exception as exc:
+                    self._snapshot_ready = False
+                    logger.warning("Failed to initialize PowerShell local session: %s", exc)
+                return
+        super().init_session()
+
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        if _IS_WINDOWS:
+            mode = resolve_windows_execution_mode(cwd)
+            if mode.resolved == "windows-native":
+                snapshot_path = self._snapshot_path
+                cwd_file = self._cwd_file
+                cwd_marker = self._cwd_marker
+                return f"""$ErrorActionPreference = 'Stop'
+if (Test-Path {_powershell_quote(cwd)}) {{
+    Set-Location -LiteralPath {_powershell_quote(cwd)}
+}}
+$ErrorActionPreference = 'Continue'
+
+if (Test-Path {_powershell_quote(snapshot_path)}) {{
+    Get-Content -LiteralPath {_powershell_quote(snapshot_path)} | ForEach-Object {{
+        if ($_ -match '^([^=]+)=(.*)$') {{
+            [System.Environment]::SetEnvironmentVariable($Matches[1], $Matches[2], 'Process')
+        }}
+    }}
+}}
+
+# Run command
+$__hermes_ec = 0
+try {{
+    {command}
+    if ($LASTEXITCODE -ne $null) {{ $__hermes_ec = $LASTEXITCODE }}
+    elif (-not $?) {{ $__hermes_ec = 1 }}
+}} catch {{
+    $__hermes_ec = 1
+}}
+
+# Dump env vars
+try {{
+    Get-ChildItem env: | ForEach-Object {{ "$($_.Name)=$($_.Value)" }} | Out-File -LiteralPath {_powershell_quote(snapshot_path)} -Encoding utf8 -Force
+}} catch {{}}
+
+# Write CWD and markers
+try {{
+    $current_cwd = (Get-Location).Path
+    [System.IO.File]::WriteAllText({_powershell_quote(cwd_file)}, $current_cwd)
+    [Console]::WriteLine("")
+    [Console]::WriteLine("{cwd_marker}" + $current_cwd + "{cwd_marker}")
+}} catch {{}}
+
+exit $__hermes_ec
+"""
+        return super()._wrap_command(command, cwd)
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
@@ -1211,7 +1305,12 @@ class LocalEnvironment(BaseEnvironment):
                 )
             self.cwd = safe_cwd
 
-        if mode and mode.resolved == "wsl2":
+        if mode and mode.resolved == "windows-native":
+            powershell = _find_powershell()
+            import base64
+            encoded_cmd = base64.b64encode(cmd_string.encode('utf-16-le')).decode('ascii')
+            args = [powershell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", encoded_cmd]
+        elif mode and mode.resolved == "wsl2":
             if not mode.distribution:
                 raise RuntimeError("WSL2 mode is selected, but no WSL2 distribution is installed")
             args = build_wsl_bash_args(
@@ -1362,11 +1461,12 @@ class LocalEnvironment(BaseEnvironment):
                 cwd_path = f.read().strip()
             if _IS_WINDOWS:
                 mode = resolve_windows_execution_mode(self.cwd)
-                cwd_path = (
-                    wsl_to_windows_path(cwd_path, mode.distribution)
-                    if mode.resolved == "wsl2"
-                    else _msys_to_windows_path(cwd_path)
-                )
+                if mode.resolved == "wsl2":
+                    cwd_path = wsl_to_windows_path(cwd_path, mode.distribution)
+                elif mode.resolved == "windows-native":
+                    cwd_path = os.path.normpath(cwd_path)
+                else:
+                    cwd_path = _msys_to_windows_path(cwd_path)
             if cwd_path and os.path.isdir(cwd_path):
                 self.cwd = cwd_path
         except (OSError, FileNotFoundError):
@@ -1393,11 +1493,12 @@ class LocalEnvironment(BaseEnvironment):
         if self.cwd != prev_cwd:
             if _IS_WINDOWS:
                 mode = resolve_windows_execution_mode(prev_cwd)
-                normalized = (
-                    wsl_to_windows_path(self.cwd, mode.distribution)
-                    if mode.resolved == "wsl2"
-                    else _msys_to_windows_path(self.cwd)
-                )
+                if mode.resolved == "wsl2":
+                    normalized = wsl_to_windows_path(self.cwd, mode.distribution)
+                elif mode.resolved == "windows-native":
+                    normalized = os.path.normpath(self.cwd)
+                else:
+                    normalized = _msys_to_windows_path(self.cwd)
             else:
                 normalized = self.cwd
             if normalized and os.path.isdir(normalized):

--- a/tools/environments/windows_execution_mode.py
+++ b/tools/environments/windows_execution_mode.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import os
 import re
 import shutil
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -26,32 +24,13 @@ def normalize_mode(value: object) -> str:
     return value if isinstance(value, str) and value in VALID_MODES else "smart"
 
 
-def _config_path() -> Path:
-    try:
-        from hermes_constants import get_hermes_home
-
-        return get_hermes_home() / "desktop-terminal.json"
-    except Exception:
-        return Path.home() / ".hermes" / "desktop-terminal.json"
-
-
 def read_configured_mode() -> str:
-    override = os.environ.get("HERMES_WINDOWS_EXECUTION_MODE")
-    if override:
-        return normalize_mode(override)
-
+    """Read the mode from the repository-wide config.yaml source of truth."""
     try:
         from hermes_cli.config import load_config
-        config = load_config()
-        val = config.get("terminal", {}).get("windows_execution_mode")
-        if val:
-            return normalize_mode(val)
-    except Exception:
-        pass
 
-    try:
-        data = json.loads(_config_path().read_text(encoding="utf-8"))
-        return normalize_mode(data.get("mode"))
+        config = load_config()
+        return normalize_mode(config.get("terminal", {}).get("windows_execution_mode"))
     except Exception:
         return "smart"
 

--- a/tools/environments/windows_execution_mode.py
+++ b/tools/environments/windows_execution_mode.py
@@ -41,6 +41,15 @@ def read_configured_mode() -> str:
         return normalize_mode(override)
 
     try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        val = config.get("terminal", {}).get("windows_execution_mode")
+        if val:
+            return normalize_mode(val)
+    except Exception:
+        pass
+
+    try:
         data = json.loads(_config_path().read_text(encoding="utf-8"))
         return normalize_mode(data.get("mode"))
     except Exception:

--- a/tools/environments/windows_execution_mode.py
+++ b/tools/environments/windows_execution_mode.py
@@ -1,0 +1,180 @@
+"""Shared Windows execution-mode selection for Desktop PTYs and agent commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermes_cli._subprocess_compat import windows_hide_flags
+
+VALID_MODES = frozenset({"smart", "wsl2", "windows-native"})
+
+
+@dataclass(frozen=True)
+class WindowsExecutionMode:
+    configured: str
+    resolved: str
+    distribution: str | None = None
+
+
+def normalize_mode(value: object) -> str:
+    return value if isinstance(value, str) and value in VALID_MODES else "smart"
+
+
+def _config_path() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "desktop-terminal.json"
+    except Exception:
+        return Path.home() / ".hermes" / "desktop-terminal.json"
+
+
+def read_configured_mode() -> str:
+    override = os.environ.get("HERMES_WINDOWS_EXECUTION_MODE")
+    if override:
+        return normalize_mode(override)
+
+    try:
+        data = json.loads(_config_path().read_text(encoding="utf-8"))
+        return normalize_mode(data.get("mode"))
+    except Exception:
+        return "smart"
+
+
+def _decode_wsl_output(raw: bytes) -> str:
+    if b"\x00" in raw:
+        for encoding in ("utf-16-le", "utf-8"):
+            try:
+                return raw.decode(encoding).replace("\x00", "")
+            except UnicodeError:
+                pass
+    return raw.decode("utf-8", errors="replace").replace("\x00", "")
+
+
+def parse_wsl_distributions(raw: bytes | str) -> list[str]:
+    text = _decode_wsl_output(raw) if isinstance(raw, bytes) else raw.replace("\x00", "")
+    result: list[str] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        name = re.sub(r"^\*\s*", "", line).strip()
+        key = name.casefold()
+        if name and key not in seen:
+            seen.add(key)
+            result.append(name)
+    return result
+
+
+def wsl_executable() -> str | None:
+    return shutil.which("wsl.exe") or shutil.which("wsl")
+
+
+def list_wsl_distributions() -> list[str]:
+    executable = wsl_executable()
+    if not executable:
+        return []
+    try:
+        completed = subprocess.run(
+            [executable, "--list", "--quiet"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+    except OSError:
+        return []
+    return parse_wsl_distributions(completed.stdout) if completed.returncode == 0 else []
+
+
+def distribution_from_wsl_path(cwd: str) -> str | None:
+    match = re.match(r"^\\\\(?:wsl\.localhost|wsl\$)\\([^\\/]+)(?:[\\/]|$)", cwd or "", re.I)
+    return match.group(1) if match else None
+
+
+def _matching_distribution(distributions: list[str], requested: str | None) -> str | None:
+    if not requested:
+        return None
+    requested_key = requested.casefold()
+    return next((name for name in distributions if name.casefold() == requested_key), None)
+
+
+def resolve_windows_execution_mode(
+    cwd: str = "",
+    *,
+    configured: str | None = None,
+    distributions: list[str] | None = None,
+    is_windows: bool | None = None,
+) -> WindowsExecutionMode:
+    if is_windows is None:
+        is_windows = os.name == "nt"
+    configured_mode = normalize_mode(configured if configured is not None else read_configured_mode())
+    available = list_wsl_distributions() if distributions is None and is_windows else (distributions or [])
+
+    if not is_windows or configured_mode == "windows-native":
+        return WindowsExecutionMode(configured_mode, "windows-native")
+
+    path_distribution = _matching_distribution(available, distribution_from_wsl_path(cwd))
+    if configured_mode == "smart":
+        if path_distribution:
+            return WindowsExecutionMode(configured_mode, "wsl2", path_distribution)
+        return WindowsExecutionMode(configured_mode, "windows-native")
+
+    distribution = path_distribution or (available[0] if available else None)
+    if distribution:
+        return WindowsExecutionMode(configured_mode, "wsl2", distribution)
+    return WindowsExecutionMode(configured_mode, "windows-native")
+
+
+def windows_to_wsl_path(value: str, distribution: str | None = None) -> str:
+    raw = (value or "").strip()
+    if not raw:
+        return "~"
+
+    unc = re.match(r"^\\\\(?:wsl\.localhost|wsl\$)\\([^\\/]+)(?:[\\/](.*))?$", raw, re.I)
+    if unc and (not distribution or unc.group(1).casefold() == distribution.casefold()):
+        tail = (unc.group(2) or "").replace("\\", "/").lstrip("/")
+        return f"/{tail}" if tail else "/"
+
+    drive = re.match(r"^([a-zA-Z]):[\\/]*(.*)$", raw)
+    if drive:
+        tail = (drive.group(2) or "").replace("\\", "/").lstrip("/")
+        suffix = f"/{tail}" if tail else ""
+        return f"/mnt/{drive.group(1).lower()}{suffix}"
+
+    return raw.replace("\\", "/")
+
+
+def wsl_to_windows_path(value: str, distribution: str | None) -> str:
+    raw = (value or "").strip()
+    mount = re.match(r"^/mnt/([a-zA-Z])(?:/(.*))?$", raw)
+    if mount:
+        tail = (mount.group(2) or "").replace("/", "\\")
+        return f"{mount.group(1).upper()}:\\{tail}" if tail else f"{mount.group(1).upper()}:\\"
+    if raw.startswith("/") and distribution:
+        tail = raw.lstrip("/").replace("/", "\\")
+        base = f"\\\\wsl.localhost\\{distribution}"
+        return f"{base}\\{tail}" if tail else base
+    return raw
+
+
+def build_wsl_bash_args(command: str, cwd: str, *, login: bool, distribution: str) -> list[str]:
+    executable = wsl_executable()
+    if not executable:
+        raise RuntimeError("WSL2 mode is selected, but wsl.exe is not available")
+    shell_flag = "-lc" if login else "-c"
+    return [
+        executable,
+        "--distribution",
+        distribution,
+        "--cd",
+        windows_to_wsl_path(cwd, distribution),
+        "--exec",
+        "bash",
+        shell_flag,
+        command,
+    ]


### PR DESCRIPTION
## Summary

Add a Windows execution-mode selector to Hermes Desktop with three modes:

- **Smart** — uses WSL2 when the project is opened through a `\\wsl$` / `\\wsl.localhost` path; otherwise stays Windows native.
- **WSL2** — runs new embedded terminal sessions and local agent terminal commands through an installed WSL2 distribution.
- **Windows Native** — preserves the native Windows execution path.

Closes #63783.

## What changed

- Adds a compact mode selector to the embedded terminal rail.
- Persists the selected mode in `${HERMES_HOME}/desktop-terminal.json`.
- Detects installed WSL distributions through `wsl.exe --list --quiet`.
- Maps Windows drive paths to `/mnt/<drive>/...` and WSL UNC paths to Linux paths.
- Launches WSL-backed embedded terminals with `wsl.exe --distribution <name> --cd <path> --exec bash -l`.
- Keeps the host `node-pty` cwd native so WSL UNC projects cannot fail before `wsl.exe` starts.
- Makes the Python `LocalEnvironment` read the same persisted mode before agent commands and refresh its shell snapshot when the selected environment changes.
- Adds TypeScript and Python unit coverage for mode resolution, distribution parsing, and path translation.

## Behavior notes

- Changing the mode affects **new interactive terminal tabs**. Existing tabs keep their already-running shell.
- Agent terminal commands pick up the selected mode on the next execution without restarting Hermes.
- In this initial scope, **Windows Native** retains the existing agent-side Bash execution adapter; the visible embedded terminal continues to use Hermes' existing native Windows shell selection (PowerShell 7, Windows PowerShell, then cmd fallback).
- Explicit WSL2 mode uses the WSL distribution matching a WSL UNC project path, or otherwise the first installed distribution.

## Validation

Validated through GitHub Actions on Ubuntu and `windows-latest`:

- Python compilation
- Python unit tests: `tests/tools/test_windows_execution_mode.py`
- Desktop TypeScript typecheck
- Electron unit tests: `electron/terminal-mode.test.ts`
- Targeted ESLint
- Full Desktop production build on Windows

All checks passed.

## Remaining manual validation

This is a draft because it still needs hands-on verification on a Windows machine with WSL2 installed, particularly:

- opening projects under both `C:\...` and `\\wsl.localhost\...`
- switching modes while Hermes Desktop is running
- long-running command cancellation through `wsl.exe`
- multiple installed WSL distributions
