### PR TITLE
feat(whatsapp): persistent lifecycle events for the bridge (bridge-events.jsonl)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -31,6 +31,7 @@ import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { recordBridgeEvent } from './bridge_events.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -427,6 +428,7 @@ async function startSocket() {
       connectionState = 'disconnected';
 
       if (reason === DisconnectReason.loggedOut) {
+        recordBridgeEvent(SESSION_DIR, 'logged_out', { reason: reason ?? null });
         emitPairEvent({ event: 'error', error: 'logged_out', reason });
         if (!PAIR_JSON) {
           console.log('❌ Logged out. Delete session and restart to re-authenticate.');
@@ -434,6 +436,7 @@ async function startSocket() {
         process.exit(1);
       } else {
         // 515 = restart requested (common after pairing). Always reconnect.
+        recordBridgeEvent(SESSION_DIR, 'disconnected', { reason: reason ?? null });
         emitPairEvent({ event: 'disconnected', reason });
         if (!PAIR_JSON) {
           if (reason === 515) {
@@ -446,6 +449,7 @@ async function startSocket() {
       }
     } else if (connection === 'open') {
       connectionState = 'connected';
+      recordBridgeEvent(SESSION_DIR, 'connected', {});
       const connectedUser = sock?.user
         ? {
             id: sock.user.id || null,
@@ -1096,6 +1100,7 @@ if (PAIR_ONLY) {
   });
 } else {
   app.listen(PORT, '127.0.0.1', () => {
+    recordBridgeEvent(SESSION_DIR, 'bridge_started', { mode: WHATSAPP_MODE, port: PORT });
     console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE})`);
     console.log(`📁 Session stored in: ${SESSION_DIR}`);
     if (ALLOWED_USERS.size > 0) {

--- a/scripts/whatsapp-bridge/bridge_events.js
+++ b/scripts/whatsapp-bridge/bridge_events.js
@@ -1,0 +1,42 @@
+/**
+ * Persistent lifecycle events for the WhatsApp bridge.
+ *
+ * The bridge's stdout is redirected by the gateway to a per-profile
+ * `whatsapp/bridge.log` (human prose), which is great for debugging but hard
+ * to consume programmatically. This module appends small structured JSONL
+ * entries (`bridge_started` / `connected` / `disconnected` / `logged_out`)
+ * next to the session dir so operators, health checks, and dashboards can
+ * read the channel's live state without parsing prose logs.
+ *
+ * Design notes:
+ * - Best-effort: never throws; a failed write must never take the bridge down.
+ * - Bounded: rotates to `<file>.1` past ~5MB, so it can run unattended forever.
+ * - Location: `<session>/../bridge-events.jsonl` by default (peer of the
+ *   session dir and media caches), overridable via WHATSAPP_BRIDGE_EVENTS_FILE.
+ */
+import path from 'path';
+import { mkdirSync, appendFileSync, statSync, renameSync } from 'fs';
+
+export function resolveEventsFile(sessionDir) {
+  return (
+    process.env.WHATSAPP_BRIDGE_EVENTS_FILE ||
+    path.join(sessionDir, '..', 'bridge-events.jsonl')
+  );
+}
+
+const EVENTS_MAX_BYTES = 5 * 1024 * 1024;
+
+export function recordBridgeEvent(sessionDir, event, extra = {}) {
+  try {
+    const file = resolveEventsFile(sessionDir);
+    mkdirSync(path.dirname(file), { recursive: true });
+    try {
+      if (statSync(file).size > EVENTS_MAX_BYTES) renameSync(file, `${file}.1`);
+    } catch {
+      // file does not exist yet — fine
+    }
+    appendFileSync(file, `${JSON.stringify({ ts: new Date().toISOString(), event, ...extra })}\n`);
+  } catch (err) {
+    try { console.error('[bridge] event write failed:', err.message); } catch {}
+  }
+}

--- a/scripts/whatsapp-bridge/bridge_events.test.mjs
+++ b/scripts/whatsapp-bridge/bridge_events.test.mjs
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+
+import { recordBridgeEvent, resolveEventsFile } from './bridge_events.js';
+
+function tmp() {
+  return mkdtempSync(path.join(os.tmpdir(), 'bridge-events-test-'));
+}
+
+test('resolveEventsFile defaults to a peer of the session dir and honors env override', () => {
+  const dir = tmp();
+  try {
+    const sessionDir = path.join(dir, 'whatsapp', 'session');
+    assert.equal(resolveEventsFile(sessionDir), path.join(sessionDir, '..', 'bridge-events.jsonl'));
+    process.env.WHATSAPP_BRIDGE_EVENTS_FILE = path.join(dir, 'custom-events.jsonl');
+    assert.equal(resolveEventsFile(sessionDir), path.join(dir, 'custom-events.jsonl'));
+  } finally {
+    delete process.env.WHATSAPP_BRIDGE_EVENTS_FILE;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recordBridgeEvent appends timestamped JSONL entries', () => {
+  const dir = tmp();
+  try {
+    const sessionDir = path.join(dir, 'whatsapp', 'session');
+    mkdirSync(sessionDir, { recursive: true });
+    recordBridgeEvent(sessionDir, 'bridge_started', { mode: 'bot', port: 3000 });
+    recordBridgeEvent(sessionDir, 'connected', {});
+    recordBridgeEvent(sessionDir, 'disconnected', { reason: 428 });
+    const lines = readFileSync(resolveEventsFile(sessionDir), 'utf8').trim().split('\n');
+    assert.equal(lines.length, 3);
+    const first = JSON.parse(lines[0]);
+    assert.equal(first.event, 'bridge_started');
+    assert.equal(first.port, 3000);
+    assert.ok(!Number.isNaN(Date.parse(first.ts)));
+    assert.equal(JSON.parse(lines[2]).reason, 428);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recordBridgeEvent never throws on an unwritable destination', () => {
+  const dir = tmp();
+  try {
+    const blocker = path.join(dir, 'blocker');
+    writeFileSync(blocker, 'x');
+    process.env.WHATSAPP_BRIDGE_EVENTS_FILE = path.join(blocker, 'nested', 'events.jsonl');
+    assert.doesNotThrow(() => recordBridgeEvent(path.join(dir, 's'), 'connected', {}));
+  } finally {
+    delete process.env.WHATSAPP_BRIDGE_EVENTS_FILE;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recordBridgeEvent rotates the file past the size cap', () => {
+  const dir = tmp();
+  try {
+    const sessionDir = path.join(dir, 'whatsapp', 'session');
+    mkdirSync(sessionDir, { recursive: true });
+    const file = resolveEventsFile(sessionDir);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, Buffer.alloc(5 * 1024 * 1024 + 1, 0x61));
+    recordBridgeEvent(sessionDir, 'connected', {});
+    assert.ok(existsSync(`${file}.1`), 'rotated file exists');
+    const lines = readFileSync(file, 'utf8').trim().split('\n');
+    assert.equal(lines.length, 1);
+    assert.equal(JSON.parse(lines[0]).event, 'connected');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What & why

The bridge's stdout is redirected by the gateway to the per-profile `whatsapp/bridge.log` — great for debugging, but **prose**: operators, health checks and dashboards have no structured way to answer *"is this channel up, and since when?"* without parsing emoji log lines.

This PR adds a tiny, best-effort event writer (`scripts/whatsapp-bridge/bridge_events.js`) that appends structured JSONL lifecycle entries next to the session dir:

```json
{"ts":"2026-07-14T00:42:09.811Z","event":"bridge_started","mode":"bot","port":3000}
{"ts":"2026-07-14T00:42:10.986Z","event":"connected"}
{"ts":"2026-07-14T01:03:12.101Z","event":"disconnected","reason":428}
```

- Events: `bridge_started` / `connected` / `disconnected` / `logged_out`, hooked at the four lifecycle points in `bridge.js` (mirrors the existing `emitPairEvent` pattern).
- Default location `<session>/../bridge-events.jsonl`, overridable via `WHATSAPP_BRIDGE_EVENTS_FILE`.
- **Best-effort**: a failed write never takes the bridge down. **Bounded**: rotates to `.1` past ~5MB, safe to run unattended forever.
- Zero new dependencies (node:path / node:fs only); no behavior change for anyone who ignores the file.

## Downstream validation

We run Hermes inside a multi-agent orchestration platform (agents-host containers, one gateway per host). We shipped exactly this mechanism downstream first: the events file feeds a per-profile `channels` field in our host snapshot API, which our console renders as a live WhatsApp badge (green=connected / red=disconnected) on the agent that fronts the channel. It has been running in production against a paired WhatsApp account — the events above are real output. Happy to upstream any of the surrounding pieces if useful.

Related: #50539 (broader runtime event streams) — this is a narrow, file-based first step scoped to the WhatsApp bridge, no gateway/TUI surface changes.

## How to test

```bash
cd scripts/whatsapp-bridge
node --test bridge_events.test.mjs   # 4 tests: default/override path, JSONL shape, no-throw, rotation
node --test allowlist.test.mjs outbound_ids.test.mjs   # existing suites untouched (11 pass)
```

Manual: pair a WhatsApp session, start the gateway, then `tail -f <profile>/whatsapp/bridge-events.jsonl` while toggling connectivity.

## Platforms

Tested on Linux (Ubuntu, node 20). The module uses only `node:path`/`node:fs` — no POSIX-only primitives.
