### PR TITLE
fix: add UTF-8 encoding to read_text/write_text in Copilot ACP fs handlers

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -703,7 +703,7 @@ class CopilotACPClient:
                 if block_error:
                     raise PermissionError(block_error)
                 try:
-                    content = path.read_text()
+                    content = path.read_text(encoding="utf-8")
                 except FileNotFoundError:
                     content = ""
                 line = params.get("line")
@@ -732,7 +732,7 @@ class CopilotACPClient:
                         f"Write denied: '{path}' is a protected system/credential file."
                     )
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(str(params.get("content") or ""))
+                path.write_text(str(params.get("content") or ""), encoding="utf-8")
                 response = {
                     "jsonrpc": "2.0",
                     "id": message_id,


### PR DESCRIPTION
## Summary

`Path.read_text()` and `Path.write_text()` in the Copilot ACP client's `fs/read_text_file` and `fs/write_text_file` JSON-RPC handlers omit explicit `encoding=`. On Windows, these default to the system locale (typically cp1252), silently corrupting non-ASCII content — source code with unicode identifiers, CJK comments, emoji in strings, etc.

## Changes

| Line | Before | After |
|------|--------|-------|
| 706 | `path.read_text()` | `path.read_text(encoding="utf-8")` |
| 735 | `path.write_text(str(params.get("content") or ""))` | `path.write_text(str(params.get("content") or ""), encoding="utf-8")` |

## Why this matters

The Copilot ACP client acts as a file I/O bridge for external coding agents. Any non-ASCII content written through this bridge on Windows gets silently corrupted. The corruption is invisible until someone reads the file and sees mojibake.

Follows the same pattern as PR #56940 (os.fdopen encoding) and PR #62667 (write_text + ensure_ascii=False).

## Test Plan

- [ ] Existing tests pass: `pytest tests/agent/test_copilot_acp_client.py -xvs`
- [ ] Verified no false positives — these calls have no kwargs dict or encoding on adjacent lines