### PR TITLE
fix: replace assert with runtime guard in Slack block_kit _rich_text_list_block

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -205,7 +205,11 @@ def _list_block(items: List[Tuple[int, bool, str]]) -> Block:
             }
             elements.append(cur)
             cur_key = key
-        assert cur is not None
+        if cur is None:
+            # Defensive: should never happen (first iteration always enters
+            # the ``if key != cur_key`` block above), but guard explicitly
+            # so ``python -O`` doesn't silently drop the check.
+            continue
         cur["elements"].append(
             {"type": "rich_text_section", "elements": _inline_elements(text)}
         )


### PR DESCRIPTION
## Summary

Replace `assert cur is not None` in `plugins/platforms/slack/block_kit.py` `_rich_text_list_block()` with an explicit `if cur is None: continue` guard.

## Why

`assert` statements are stripped by `python -O`, silently removing the invariant check. While this particular assert is technically unreachable (the first loop iteration always enters the `if key != cur_key` block and sets `cur`), using `assert` for runtime invariant checking in production code is fragile.

Follows the same pattern as PRs #56736, #56866, #61983, #62001, #62006, #62659, #64063.

## Test Plan

- [ ] Existing Slack tests pass
- [ ] `python -O -c "from plugins.platforms.slack.block_kit import _rich_text_list_block"` succeeds