### PR TITLE
fix(telegram): wrap callback_query handler with resilient_handler to swallow TimedOut (#31066)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -19,7 +19,37 @@ import threading
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
+import functools
+from telegram.error import TimedOut, NetworkError
+
 logger = logging.getLogger(__name__)
+
+
+def resilient_handler(func):
+    """
+    Envuelve handlers de PTB para capturar errores transitorios de red
+    (TimedOut, NetworkError) que no llegan al exception handler del loop
+    principal porque PTB los maneja en su propio polling loop interno.
+
+    Issue #31066 / #31110: unhandled TimedOut from ``query.answer()`` can kill
+    the entire gateway process silently. This decorator restores the safety net
+    for any wrapped handler. Transient errors are logged+swallowed; any other
+    exception is logged via logger.exception so real bugs still surface.
+    """
+    @functools.wraps(func)
+    async def wrapper(update, context, *args, **kwargs):
+        try:
+            return await func(update, context, *args, **kwargs)
+        except (TimedOut, NetworkError) as e:
+            logger.warning(
+                f"[resilient_handler] Transient Telegram error in "
+                f"'{func.__name__}': {type(e).__name__}: {e}"
+            )
+        except Exception:
+            logger.exception(
+                f"[resilient_handler] Unexpected error in '{func.__name__}'"
+            )
+    return wrapper
 
 
 def _redact_telegram_error_text(error: object) -> str:
@@ -5320,6 +5350,7 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    @resilient_handler
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:


### PR DESCRIPTION
## Problem

`telegram.error.TimedOut` raised from `query.answer()` inside the callback_query handler propagates into python-telegram-bot's internal polling loop, not the main asyncio event loop. As a result, `_gateway_loop_exception_handler` (installed via `set_exception_handler` on the main loop) never sees it — PTB's internal loop swallows the polling task silently, killing the gateway process without any traceback in logs.

## Fix

Introduces a `resilient_handler` decorator that wraps `_handle_callback_query`. Transient network errors (`TimedOut`, `NetworkError`) are caught, logged as warnings, and swallowed — restoring the safety net at the handler level instead of relying on the main loop's exception handler, which cannot see PTB-internal loop exceptions.

Any non-transient exception is still logged via `logger.exception` with full traceback, so real bugs are not hidden.

## Validation

- 6/6 unit tests passing (mocked `TimedOut`/`NetworkError`/generic exception scenarios, decorator metadata preservation via `functools.wraps`)
- Live gateway stress test: gateway remained alive and `:8642` responsive after simulated `TimedOut` during callback_query handling
- No regressions: gateway startup, Telegram polling, and other platform adapters unaffected (change is scoped to a single handler + decorator definition, 31 lines total)

Supersedes #64037 (closed because PR head was opened from `polroc22pr-byte:main` instead of a dedicated branch; `head` is immutable after PR creation).

Fixes #31066
