### PR TITLE
fix(conversation_loop): invalidate stale housekeeping fallback on substantive tool-only turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4664,6 +4664,23 @@ def run_conversation(
                 # answer and calls memory/skill tools as a side-effect in the same
                 # turn. If the follow-up turn after tools is empty, we use this.
                 turn_content = assistant_message.content or ""
+                # Determine whether every tool call in THIS turn is housekeeping
+                # (memory, todo, skill_manage, session_search). Substantive tools
+                # (search_files, read_file, write_file, terminal, ...) signal that
+                # the model has moved into real task execution; any earlier
+                # housekeeping-only narration captured as a fallback candidate is
+                # now stale and must not be reused as a final answer if a later
+                # turn goes empty. See issue #63860: without this invalidation a
+                # cached `_last_content_with_tools` from a prior housekeeping-only
+                # turn survived a substantive tool-only turn and was incorrectly
+                # surfaced as the final response, suppressing the post-tool nudge.
+                _HOUSEKEEPING_TOOLS = frozenset({
+                    "memory", "todo", "skill_manage", "session_search",
+                })
+                _all_housekeeping = bool(assistant_message.tool_calls) and all(
+                    tc.function.name in _HOUSEKEEPING_TOOLS
+                    for tc in assistant_message.tool_calls
+                )
                 if turn_content and agent._has_content_after_think_block(turn_content):
                     agent._last_content_with_tools = turn_content
                     # Only mute subsequent output when EVERY tool call in
@@ -4671,13 +4688,6 @@ def run_conversation(
                     # skill_manage, etc.).  If any substantive tool is present
                     # (search_files, read_file, write_file, terminal, ...),
                     # keep output visible so the user sees progress.
-                    _HOUSEKEEPING_TOOLS = frozenset({
-                        "memory", "todo", "skill_manage", "session_search",
-                    })
-                    _all_housekeeping = all(
-                        tc.function.name in _HOUSEKEEPING_TOOLS
-                        for tc in assistant_message.tool_calls
-                    )
                     agent._last_content_tools_all_housekeeping = _all_housekeeping
                     if _all_housekeeping and agent._has_stream_consumers():
                         agent._mute_post_response = True
@@ -4685,6 +4695,18 @@ def run_conversation(
                         clean = agent._strip_think_blocks(turn_content).strip()
                         if clean:
                             agent._vprint(f"  ┊ 💬 {clean}")
+                elif not _all_housekeeping and assistant_message.tool_calls:
+                    # Substantive tool-only turn (no usable content, but at
+                    # least one non-housekeeping tool call). The earlier
+                    # `_last_content_with_tools` was captured from a prior
+                    # housekeeping-only turn and is now stale narration —
+                    # e.g. "I'll begin the work." uttered alongside a `todo`
+                    # call should not be reused as the final answer if a
+                    # later substantive tool turn goes empty. Drop it so the
+                    # post-tool empty-response nudge path runs instead.
+                    # Fixes #63860.
+                    agent._last_content_with_tools = None
+                    agent._last_content_tools_all_housekeeping = False
                 
                 # Pop thinking-only prefill message(s) before appending
                 # (tool-call path — same rationale as the final-response path).

--- a/tests/run_agent/test_stale_housekeeping_fallback_63860.py
+++ b/tests/run_agent/test_stale_housekeeping_fallback_63860.py
@@ -1,0 +1,172 @@
+"""Regression test for issue #63860.
+
+A cached ``_last_content_with_tools`` from a prior housekeeping-only turn
+(content + todo/memory/etc.) must not survive a later substantive tool-only
+turn (content="" + web_search/terminal/etc.). Previously the substantive
+turn neither updated nor cleared the old fallback candidate, so when the
+model returned empty after the tool result, the conversation loop emitted
+the old narration ("I'll begin the work.") as the final answer instead of
+entering the post-tool nudge path — wasting the full tool round.
+
+The fix: when a turn has at least one substantive (non-housekeeping) tool
+call and no usable content, clear ``_last_content_with_tools`` and
+``_last_content_tools_all_housekeeping`` so the downstream fallback check
+at line ~4893 skips the prior-turn shortcut and enters the nudge path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import run_agent
+from run_agent import AIAgent
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _tool_call(name: str, call_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+
+
+def _response(
+    *, content: str | None, finish_reason: str, tool_calls: list | None = None
+) -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+class TestSubstantiveToolOnlyTurnClearsStaleHousekeepingFallback:
+    """Issue #63860 — regression guard."""
+
+    def test_substantive_tool_only_turn_invalidates_older_housekeeping(self):
+        """Turn sequence:
+
+          1. content + todo (housekeeping)    → saves fallback content
+          2. content="" + web_search (subst.)  → should INVALIDATE old fallback
+          3. content="" + stop                 → should enter nudge, not use stale content
+          4. content="Recovered after nudge."  → final answer
+        """
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_tool_defs("todo", "web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.valid_tool_names = {"todo", "web_search"}
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.side_effect = [
+            _response(
+                content="I'll begin the work.",
+                finish_reason="tool_calls",
+                tool_calls=[_tool_call("todo", "todo1")],
+            ),
+            _response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_tool_call("web_search", "search1")],
+            ),
+            _response(content="", finish_reason="stop"),
+            _response(content="Recovered after nudge.", finish_reason="stop"),
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("do the full task")
+
+        assert result["final_response"] == "Recovered after nudge.", (
+            f"Expected nudge recovery, got: {result['final_response']!r}"
+        )
+        assert result["api_calls"] == 4, (
+            f"Expected 4 API calls (3 + 1 nudge follow-up), got {result['api_calls']}"
+        )
+        assert result["turn_exit_reason"].startswith("text_response"), (
+            f"Expected text_response exit, got: {result['turn_exit_reason']}"
+        )
+
+    def test_housekeeping_only_turn_still_sets_fallback_content(self):
+        """Pure housekeeping turns with content should still set the fallback.
+
+        A turn with content + only housekeeping tools (e.g. "You're welcome!"
+        + memory save) should behave exactly as before.
+        """
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_tool_defs("memory", "todo")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.valid_tool_names = {"memory", "todo"}
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.side_effect = [
+            _response(
+                content="You're welcome!",
+                finish_reason="tool_calls",
+                tool_calls=[_tool_call("memory", "mem1")],
+            ),
+            _response(content="", finish_reason="stop"),
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("thanks")
+
+        # Housekeeping-only fallback should still fire — the "You're welcome!"
+        # answer + memory save is the exact use case the fallback was designed for.
+        assert result["final_response"] == "You're welcome!", (
+            f"Expected housekeeping fallback to fire, got: {result['final_response']!r}"
+        )
+        assert result["api_calls"] == 2, (
+            f"Expected 2 API calls, got {result['api_calls']}"
+        )


### PR DESCRIPTION
## Summary

Fixes #63860 (P1, sweeper:risk-session-state).

A cached `_last_content_with_tools` from a prior **housekeeping-only** turn (content + `todo`/`memory`/`skill_manage`/`session_search`) survived a later **substantive tool-only** turn (content="" + `web_search`/`terminal`/`read_file`/etc.). When the model then returned an empty follow-up response, the conversation loop emitted the stale narration (e.g. "I'll begin the work.") as the final answer with exit reason `fallback_prior_turn_content`, suppressing the post-tool empty-response nudge and skipping the recovery round.

Observed production impact (reported in the issue): a scheduled daily-report cron job ran `todo`, then two `terminal` calls, received an empty model completion, returned only "I'll begin the daily report pipeline…", and was marked successful without producing the report artifact.

## Root cause

The update guard at the top of the tool-call branch (`agent/conversation_loop.py:4667`) only ran when the current turn had usable content. So a substantive tool-only turn (no content) neither updated nor cleared the older housekeeping fallback candidate — `_last_content_with_tools` and `_last_content_tools_all_housekeeping` were left untouched, and the downstream fallback check at line ~4893 short-circuited to the stale narration instead of entering the existing post-tool nudge path.

## Fix

Two small changes in `agent/conversation_loop.py`:

1. **Hoist** the `_all_housekeeping` computation above the content check, so it is computed for every tool-call turn (not only turns with content).
2. **Add** an `elif not _all_housekeeping and assistant_message.tool_calls:` branch that clears `_last_content_with_tools` and `_last_content_tools_all_housekeeping` whenever the current turn has at least one substantive tool call and no usable content. The downstream fallback check at line ~4893 then skips the prior-turn shortcut and flows into the existing post-tool nudge path, which issues one more API call and recovers the actual final answer.

Pure housekeeping turns (content + only housekeeping tools like "You're welcome!" + memory save) continue to set the fallback exactly as before — covered by the second new test.

## Tests

- New `tests/run_agent/test_stale_housekeeping_fallback_63860.py` with two cases:
  - `test_substantive_tool_only_turn_invalidates_older_housekeeping` — the exact 4-response sequence from the issue: asserts the nudge path runs and the 4th response ("Recovered after nudge.") is returned with `api_calls == 4` and `turn_exit_reason` starting with `text_response`. Previously failed with `assert "I'll begin the work." == "Recovered after nudge."` and `api_calls == 3`.
  - `test_housekeeping_only_turn_still_sets_fallback_content` — pure housekeeping turn (content="You're welcome!" + `memory`) still uses the fallback as before, asserting the regression does not break the original use case the fallback was designed for.
- Existing fallback / partial-stream / empty-response / turn-finalizer tests continue to pass (24 selected, 24 passed).

## Reproduction

The bug reproduces deterministically with the standalone test from the issue:

```
$ HERMES_HOME=/tmp/hermes-repro-home python -m pytest /tmp/test_repro_stale_housekeeping_fallback.py -v
FAILED  assert "I'll begin the work." == "Recovered after nudge."
```

with the patch applied:

```
$ python -m pytest tests/run_agent/test_stale_housekeeping_fallback_63860.py -v
2 passed in 4.14s
```

## Affected component

- Agent Core (conversation loop)
- Gateway (scheduled cron execution exposed the production symptom)

## Version

Reproduced on `af250d84948179834820a62bfd870c0df6f264a1` (latest `origin/main` at the time of the report).
