### PR TITLE
fix: add CREATE_NO_WINDOW to env_probe and lazy_deps subprocess calls on Windows

### DIFF
--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -37,6 +37,8 @@ import sys
 import threading
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # Module-level cache.  The probe result is deterministic for the
@@ -66,6 +68,7 @@ def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
             timeout=timeout,
             check=False,
             stdin=subprocess.DEVNULL,
+            **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}),
         )
         return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
     except FileNotFoundError:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -79,6 +79,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -668,6 +670,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
                     capture_output=True, text=True, timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
+                    **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}),
                 )
                 if r.returncode == 0:
                     if target is not None:
@@ -684,6 +687,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["--version"],
                 capture_output=True, text=True, timeout=15,
                 stdin=subprocess.DEVNULL,
+                **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}),
             )
             if probe.returncode != 0:
                 raise FileNotFoundError("pip not in venv")
@@ -693,6 +697,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                     capture_output=True, text=True, timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
+                    **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 return _InstallResult(False, "",
@@ -703,6 +708,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
                 capture_output=True, text=True, timeout=timeout,
                 stdin=subprocess.DEVNULL,
+                **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}),
             )
             if r.returncode == 0 and target is not None:
                 _activate_target_on_syspath(target)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1999,7 +1999,8 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
         "--device", device,
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL,
+                            **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}))
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr
@@ -2083,6 +2084,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
              "--download-dir", str(download_dir)],
             capture_output=True, text=True, timeout=300,
             stdin=subprocess.DEVNULL,
+            **({"creationflags": windows_hide_flags()} if _sys.platform == "win32" else {}),
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(


### PR DESCRIPTION
## Summary

Fixes #63698 — console windows flash on Windows despite `windows_hide_console: true` because several subprocess calls in tools spawn without `CREATE_NO_WINDOW` creation flag.

The main terminal execution path (`tools/environments/local.py`) already applies `windows_hide_flags()` (which returns `CREATE_NO_WINDOW` on Windows), but these files were missing it:

| File | Calls fixed | Purpose |
|------|------------|---------|
| `tools/env_probe.py` | 1 | Environment version probes (python, pip, node) |
| `tools/lazy_deps.py` | 4 | `uv pip install`, `pip --version`, `ensurepip`, `pip install` |
| `tools/tts_tool.py` | 2 | NeuTTS synthesis, Piper voice download |

## Why this matters

On Windows, every `subprocess.run()` / `subprocess.Popen()` without `CREATE_NO_WINDOW` spawns a visible console window (cmd.exe / conhost.exe) that flashes on screen. The env_probe runs during agent startup and the lazy_deps runs during package installation — both happen frequently enough to be disruptive.

The fix uses the existing `windows_hide_flags()` helper from `hermes_cli._subprocess_compat`, which is a no-op on non-Windows platforms. Pattern matches the 20+ other call sites already using this helper.

## Test Plan

- [ ] On Windows: verify no console flash when running terminal commands
- [ ] On Linux/macOS: `windows_hide_flags()` returns 0, no behavior change
- [ ] Existing tests pass