### PR TITLE
fix(cron): reject one-shot+repeat>1 (HARNESS-P1 finite-repeat)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -473,6 +473,162 @@ def parse_duration(s: str) -> int:
     return value * multipliers[unit]
 
 
+def validate_repeat_for_schedule(
+    schedule: Dict[str, Any],
+    times: Optional[int],
+) -> None:
+    """Reject schedule+repeat combinations that can never satisfy the count.
+
+    Bare relative durations (``20m``, ``2h``) and ISO timestamps are one-shot
+    delays (``kind == "once"``). They fire at most once, so ``repeat > 1`` can
+    never complete N times — the scheduler runs once, records ``1/N``, then
+    marks the job completed with no ``next_run_at`` (HARNESS-P1 / fleet-update
+    drop). Recurring forms (``every 20m``, cron expressions) support finite
+    ``repeat`` correctly.
+
+    ``times is None`` means forever (recurring only). ``times <= 1`` is fine
+    for one-shots. Callers should normalize ``repeat <= 0`` to ``None`` first.
+    """
+    if times is None or times <= 1:
+        return
+    kind = (schedule or {}).get("kind")
+    if kind != "once":
+        return
+    display = (
+        (schedule or {}).get("display")
+        or (schedule or {}).get("run_at")
+        or "once"
+    )
+    raise ValueError(
+        f"repeat={times} cannot be satisfied by one-shot schedule ({display}). "
+        "Bare relative durations like '20m'/'2h' and ISO timestamps are one-shot "
+        "delays, not intervals. Use 'every 20m' (or a cron expression) with "
+        f"repeat={times} for N periodic executions, or omit/set repeat=1 for a "
+        "single run."
+    )
+
+
+def describe_schedule_semantics(
+    schedule: Dict[str, Any],
+    times: Optional[int] = None,
+) -> str:
+    """Human-readable interpretation of a parsed schedule + optional repeat."""
+    schedule = schedule or {}
+    kind = schedule.get("kind")
+    display = schedule.get("display") or kind or "unknown"
+    if kind == "once":
+        return (
+            f"one-shot ({display}); fires once then completes "
+            "(not an interval — use 'every …' for recurring)"
+        )
+    if kind == "interval":
+        base = f"recurring interval ({display})"
+    elif kind == "cron":
+        base = f"recurring cron ({display})"
+    else:
+        base = f"schedule ({display})"
+    if times is None:
+        return f"{base}; runs forever until removed/paused"
+    if times == 1:
+        return f"{base}; runs once then auto-removes"
+    return f"{base}; finite repeat {times} times then auto-removes"
+
+
+def preview_next_runs(
+    schedule: Dict[str, Any],
+    n: int = 2,
+    last_run_at: Optional[str] = None,
+) -> List[str]:
+    """Return up to ``n`` expected next fire timestamps for a schedule.
+
+    Used by tool/CLI responses so callers see the interpreted semantics
+    (e.g. one-shot has one tick; ``every 20m`` has two successive ticks).
+    """
+    if n <= 0:
+        return []
+    ticks: List[str] = []
+    cursor = last_run_at
+    for _ in range(n):
+        nxt = compute_next_run(schedule, cursor)
+        if not nxt:
+            break
+        ticks.append(nxt)
+        # Advance the cursor so the next preview tick is after this one.
+        # For one-shots, a non-None last_run makes compute_next_run return None.
+        cursor = nxt
+    return ticks
+
+
+def find_unsatisfiable_repeat_jobs(
+    jobs: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Operator diagnostic: jobs whose schedule can never reach repeat N.
+
+    Detects the stuck ``1/N`` completed shape from one-shot + ``repeat>1``
+    (and any still-scheduled legacy jobs with that illegal combo). Safe /
+    read-only — does not mutate the job store. Existing jobs are preserved
+    for migration compatibility; this only surfaces warnings.
+    """
+    if jobs is None:
+        jobs = load_jobs()
+    issues: List[Dict[str, Any]] = []
+    for job in jobs:
+        schedule = job.get("schedule") or {}
+        repeat = job.get("repeat") or {}
+        times = repeat.get("times")
+        if times is None or times <= 1:
+            continue
+        kind = schedule.get("kind")
+        completed = int(repeat.get("completed") or 0)
+        state = job.get("state") or (
+            "scheduled" if job.get("enabled", True) else "paused"
+        )
+        if kind == "once":
+            issues.append(
+                {
+                    "job_id": job.get("id"),
+                    "name": job.get("name"),
+                    "schedule": job.get("schedule_display")
+                    or schedule.get("display")
+                    or kind,
+                    "completed": completed,
+                    "times": times,
+                    "state": state,
+                    "enabled": job.get("enabled", True),
+                    "warning": (
+                        f"one-shot schedule cannot satisfy repeat "
+                        f"{completed}/{times}; use 'every …' (or a cron "
+                        "expression) for N periodic executions"
+                    ),
+                }
+            )
+        elif (
+            state == "completed"
+            and completed > 0
+            and completed < times
+            and not job.get("next_run_at")
+        ):
+            # Defensive: completed early with remaining count and no next tick.
+            issues.append(
+                {
+                    "job_id": job.get("id"),
+                    "name": job.get("name"),
+                    "schedule": job.get("schedule_display")
+                    or schedule.get("display")
+                    or kind,
+                    "completed": completed,
+                    "times": times,
+                    "state": state,
+                    "enabled": job.get("enabled", True),
+                    "warning": (
+                        f"job completed at {completed}/{times} with no "
+                        "next_run_at — finite repeat was not fully satisfied"
+                    ),
+                }
+            )
+    return issues
+
+
 def parse_schedule(schedule: str) -> Dict[str, Any]:
     """
     Parse schedule string into structured format.
@@ -484,12 +640,15 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         - For "cron": "expr" (cron expression)
     
     Examples:
-        "30m"              → once in 30 minutes
+        "30m"              → once in 30 minutes  (NOT every 30 minutes)
         "2h"               → once in 2 hours
         "every 30m"        → recurring every 30 minutes
         "every 2h"         → recurring every 2 hours
         "0 9 * * *"        → cron expression
         "2026-02-03T14:00" → once at timestamp
+
+    Note: bare relative durations are one-shot delays. For N periodic
+    executions use ``every 30m`` (or a cron expression) with ``repeat=N``.
     """
     schedule = schedule.strip()
     original = schedule
@@ -1106,6 +1265,10 @@ def create_job(
     if parsed_schedule["kind"] == "once" and repeat is None:
         repeat = 1
 
+    # Reject one-shot + repeat>1 before anything is persisted. Bare '20m' is a
+    # one-shot delay; it can never satisfy N periodic executions (HARNESS-P1).
+    validate_repeat_for_schedule(parsed_schedule, repeat)
+
     # Default delivery to origin if available, otherwise local
     if deliver is None:
         deliver = "origin" if origin else "local"
@@ -1357,6 +1520,37 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                             f"{ONESHOT_GRACE_SECONDS}s in the past and cannot be scheduled."
                         )
                     updated["next_run_at"] = updated_next_run
+
+            # Reject one-shot + repeat>1 on update too (schedule and/or repeat
+            # may have changed independently). Normalize repeat<=0 like create.
+            if "repeat" in updates or schedule_changed:
+                repeat_state = updated.get("repeat")
+                if not isinstance(repeat_state, dict):
+                    repeat_state = {"times": None, "completed": 0}
+                times = repeat_state.get("times")
+                if times is not None and isinstance(times, (int, float)) and times <= 0:
+                    times = None
+                    repeat_state = {**repeat_state, "times": None}
+                    updated["repeat"] = repeat_state
+                # One-shots default to repeat=1 when times is unset so we
+                # don't leave a forever-once ghost after schedule edits.
+                if (
+                    (updated.get("schedule") or {}).get("kind") == "once"
+                    and times is None
+                ):
+                    times = 1
+                    updated["repeat"] = {
+                        **repeat_state,
+                        "times": 1,
+                        "completed": int(repeat_state.get("completed") or 0),
+                    }
+                else:
+                    updated["repeat"] = {
+                        **repeat_state,
+                        "times": times,
+                        "completed": int(repeat_state.get("completed") or 0),
+                    }
+                validate_repeat_for_schedule(updated.get("schedule") or {}, times)
 
             if inference_fields_changed:
                 provider_snapshot, model_snapshot = _compute_provider_model_snapshots(

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -98,13 +98,27 @@ def _warn_if_gateway_not_running() -> None:
 
 def cron_list(show_all: bool = False):
     """List all scheduled jobs."""
-    from cron.jobs import list_jobs
+    from cron.jobs import find_unsatisfiable_repeat_jobs, list_jobs
 
     jobs = list_jobs(include_disabled=show_all)
 
     if not jobs:
         print(color("No scheduled jobs.", Colors.DIM))
         print(color("Create one with 'hermes cron create ...' or the /cron command in chat.", Colors.DIM))
+        # Still surface stuck legacy jobs even if none are "active".
+        warnings = find_unsatisfiable_repeat_jobs()
+        if warnings:
+            print()
+            print(color(
+                f"⚠ {len(warnings)} job(s) have unsatisfiable one-shot+repeat "
+                "(e.g. completed at 1/N). Use 'every …' for finite periodic runs.",
+                Colors.YELLOW,
+            ))
+            for w in warnings:
+                print(color(
+                    f"  - {w.get('job_id')} {w.get('name')}: {w.get('warning')}",
+                    Colors.YELLOW,
+                ))
         return
 
     print()
@@ -178,6 +192,20 @@ def cron_list(show_all: bool = False):
         if delivery_err:
             print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
 
+        print()
+
+    warnings = find_unsatisfiable_repeat_jobs()
+    if warnings:
+        print(color(
+            f"⚠ {len(warnings)} job(s) have unsatisfiable one-shot+repeat "
+            "(e.g. completed at 1/N). Use 'every …' for finite periodic runs.",
+            Colors.YELLOW,
+        ))
+        for w in warnings:
+            print(color(
+                f"  - {w.get('job_id')} {w.get('name')}: {w.get('warning')}",
+                Colors.YELLOW,
+            ))
         print()
 
     _warn_if_gateway_not_running()
@@ -317,6 +345,11 @@ def cron_create(args):
     print(color(f"Created job: {result['job_id']}", Colors.GREEN))
     print(f"  Name: {result['name']}")
     print(f"  Schedule: {result['schedule']}")
+    if result.get("semantics"):
+        print(f"  Semantics: {result['semantics']}")
+    if result.get("expected_next_ticks"):
+        ticks = result["expected_next_ticks"]
+        print(f"  Next ticks: {', '.join(ticks)}")
     if result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
     job_data = result.get("job", {})
@@ -326,6 +359,8 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if result.get("repeat"):
+        print(f"  Repeat: {result['repeat']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0

--- a/tests/cron/test_finite_repeat_semantics.py
+++ b/tests/cron/test_finite_repeat_semantics.py
@@ -1,0 +1,431 @@
+"""HARNESS-P1: cron finite-repeat / schedule semantics.
+
+Bare relative durations ('20m') are one-shot delays. Combining them with
+repeat>1 previously created a job that fired once, recorded 1/N, then
+completed with no next_run_at — silently dropping the remaining N-1 runs.
+
+These tests pin the rejection, correct recurring finite-repeat behavior,
+tool response semantics, diagnostics, and related edge cases.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cron.jobs import (
+    claim_dispatch,
+    compute_next_run,
+    create_job,
+    describe_schedule_semantics,
+    find_unsatisfiable_repeat_jobs,
+    get_job,
+    load_jobs,
+    mark_job_run,
+    parse_schedule,
+    pause_job,
+    preview_next_runs,
+    resume_job,
+    save_jobs,
+    update_job,
+    validate_repeat_for_schedule,
+)
+
+
+@pytest.fixture
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Parser + validation
+# ---------------------------------------------------------------------------
+
+
+class TestRelativeVsEverySemantics:
+    def test_bare_duration_is_once_not_interval(self):
+        result = parse_schedule("20m")
+        assert result["kind"] == "once"
+        assert "run_at" in result
+
+    def test_every_duration_is_interval(self):
+        result = parse_schedule("every 20m")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == 20
+
+    def test_iso_timestamp_is_once(self, monkeypatch):
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        future = (now + timedelta(hours=1)).isoformat()
+        result = parse_schedule(future)
+        assert result["kind"] == "once"
+
+
+class TestValidateRepeatForSchedule:
+    def test_rejects_once_with_repeat_gt_1(self):
+        schedule = parse_schedule("20m")
+        with pytest.raises(ValueError, match="cannot be satisfied by one-shot"):
+            validate_repeat_for_schedule(schedule, 8)
+
+    def test_allows_once_with_repeat_1(self):
+        validate_repeat_for_schedule(parse_schedule("20m"), 1)
+
+    def test_allows_once_with_none(self):
+        # create_job will auto-set times=1; validator itself permits None.
+        validate_repeat_for_schedule(parse_schedule("20m"), None)
+
+    def test_allows_interval_with_finite_repeat(self):
+        validate_repeat_for_schedule(parse_schedule("every 20m"), 8)
+
+    def test_allows_cron_with_finite_repeat(self):
+        validate_repeat_for_schedule(
+            {"kind": "cron", "expr": "*/5 * * * *", "display": "*/5 * * * *"},
+            3,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Create / update rejection (incident reproduction)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRejectsUnsatisfiableRepeat:
+    def test_incident_shape_20m_repeat_8_rejected(self, tmp_cron_dir):
+        """Reproduce Blazar's edd042027e2b shape: schedule='20m', repeat=8."""
+        with pytest.raises(ValueError, match="every 20m"):
+            create_job(prompt="fleet update", schedule="20m", repeat=8)
+        assert load_jobs() == []
+
+    def test_iso_oneshot_repeat_gt_1_rejected(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        future = (now + timedelta(minutes=10)).isoformat()
+        with pytest.raises(ValueError, match="one-shot"):
+            create_job(prompt="iso", schedule=future, repeat=3)
+        assert load_jobs() == []
+
+    def test_once_repeat_1_still_ok(self, tmp_cron_dir):
+        job = create_job(prompt="once", schedule="30m", repeat=1)
+        assert job["schedule"]["kind"] == "once"
+        assert job["repeat"]["times"] == 1
+
+    def test_every_20m_repeat_8_accepted(self, tmp_cron_dir):
+        job = create_job(prompt="fleet", schedule="every 20m", repeat=8)
+        assert job["schedule"]["kind"] == "interval"
+        assert job["schedule"]["minutes"] == 20
+        assert job["repeat"]["times"] == 8
+        assert job["next_run_at"] is not None
+
+
+class TestUpdateRejectsUnsatisfiableRepeat:
+    def test_update_repeat_on_oneshot_rejected(self, tmp_cron_dir):
+        job = create_job(prompt="once", schedule="30m")
+        with pytest.raises(ValueError, match="one-shot"):
+            update_job(job["id"], {"repeat": {"times": 5, "completed": 0}})
+        assert get_job(job["id"])["repeat"]["times"] == 1
+
+    def test_update_schedule_to_oneshot_with_finite_repeat_rejected(self, tmp_cron_dir):
+        job = create_job(prompt="recurring", schedule="every 1h", repeat=5)
+        with pytest.raises(ValueError, match="one-shot"):
+            update_job(job["id"], {"schedule": parse_schedule("45m")})
+        # Unchanged
+        fetched = get_job(job["id"])
+        assert fetched["schedule"]["kind"] == "interval"
+        assert fetched["repeat"]["times"] == 5
+
+    def test_update_interval_finite_repeat_ok(self, tmp_cron_dir):
+        job = create_job(prompt="recurring", schedule="every 1h")
+        updated = update_job(job["id"], {"repeat": {"times": 4, "completed": 0}})
+        assert updated["repeat"]["times"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Finite recurring repeat tracking
+# ---------------------------------------------------------------------------
+
+
+class TestIntervalFiniteRepeat:
+    def test_every_duration_finite_repeat_counts_and_removes(self, tmp_cron_dir):
+        job = create_job(prompt="finite", schedule="every 20m", repeat=3)
+        jid = job["id"]
+
+        mark_job_run(jid, success=True)
+        j1 = get_job(jid)
+        assert j1 is not None
+        assert j1["repeat"]["completed"] == 1
+        assert j1["next_run_at"] is not None
+        assert j1["state"] == "scheduled"
+
+        mark_job_run(jid, success=True)
+        j2 = get_job(jid)
+        assert j2["repeat"]["completed"] == 2
+        assert j2["next_run_at"] is not None
+
+        mark_job_run(jid, success=True)
+        assert get_job(jid) is None  # auto-removed at limit
+
+    def test_delivery_failure_still_counts_toward_repeat(self, tmp_cron_dir):
+        job = create_job(prompt="deliv", schedule="every 5m", repeat=2)
+        mark_job_run(job["id"], success=True, delivery_error="platform down")
+        mid = get_job(job["id"])
+        assert mid["repeat"]["completed"] == 1
+        assert mid["last_delivery_error"] == "platform down"
+        assert mid["next_run_at"] is not None
+        mark_job_run(job["id"], success=True)
+        assert get_job(job["id"]) is None
+
+
+class TestCronFiniteRepeat:
+    def test_cron_expr_finite_repeat(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="cron finite", schedule="*/5 * * * *", repeat=2)
+        assert job["schedule"]["kind"] == "cron"
+        assert job["repeat"]["times"] == 2
+        assert job["next_run_at"] is not None
+
+        mark_job_run(job["id"], success=True)
+        mid = get_job(job["id"])
+        assert mid["repeat"]["completed"] == 1
+        assert mid["next_run_at"] is not None
+
+        mark_job_run(job["id"], success=True)
+        assert get_job(job["id"]) is None
+
+
+class TestIsoOneshot:
+    def test_iso_oneshot_fires_once_and_completes(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        future = (now + timedelta(minutes=5)).isoformat()
+        job = create_job(prompt="iso once", schedule=future)
+        assert job["repeat"]["times"] == 1
+        # claim + mark path for finite oneshot
+        assert claim_dispatch(job["id"]) is True
+        mark_job_run(job["id"], success=True)
+        # times=1 → removed after claim+mark
+        assert get_job(job["id"]) is None
+
+
+# ---------------------------------------------------------------------------
+# Pause / resume / restart / catch-up
+# ---------------------------------------------------------------------------
+
+
+class TestPauseResumeFinite:
+    def test_pause_resume_preserves_finite_count(self, tmp_cron_dir):
+        job = create_job(prompt="p", schedule="every 10m", repeat=5)
+        mark_job_run(job["id"], success=True)
+        paused = pause_job(job["id"], reason="ops")
+        assert paused["state"] == "paused"
+        assert paused["repeat"]["completed"] == 1
+        resumed = resume_job(job["id"])
+        assert resumed["state"] == "scheduled"
+        assert resumed["repeat"]["completed"] == 1
+        assert resumed["repeat"]["times"] == 5
+        assert resumed["next_run_at"] is not None
+
+
+class TestProcessRestartPreservesState:
+    def test_reload_jobs_preserves_completed_count(self, tmp_cron_dir):
+        job = create_job(prompt="r", schedule="every 15m", repeat=4)
+        mark_job_run(job["id"], success=True)
+        # Simulate process restart: re-load from disk via get_job/load_jobs
+        reloaded = load_jobs()
+        assert len(reloaded) == 1
+        assert reloaded[0]["repeat"]["completed"] == 1
+        assert reloaded[0]["repeat"]["times"] == 4
+        assert reloaded[0]["next_run_at"] is not None
+
+
+class TestMissedTickCatchup:
+    def test_stale_interval_still_advances_and_counts(self, tmp_cron_dir, monkeypatch):
+        """A stale next_run_at still consumes one finite-repeat slot on fire."""
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="stale", schedule="every 5m", repeat=3)
+        # Backdate next_run_at far into the past (missed ticks)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (now - timedelta(hours=2)).isoformat()
+        save_jobs(jobs)
+
+        mark_job_run(job["id"], success=True)
+        after = get_job(job["id"])
+        assert after["repeat"]["completed"] == 1
+        # next_run_at re-anchored from last_run (now), not forever-stuck
+        assert after["next_run_at"] is not None
+        next_dt = datetime.fromisoformat(after["next_run_at"])
+        assert next_dt > now - timedelta(seconds=1)
+
+
+# ---------------------------------------------------------------------------
+# Preview / semantics / diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticsAndPreview:
+    def test_describe_once(self):
+        s = parse_schedule("20m")
+        text = describe_schedule_semantics(s, 1)
+        assert "one-shot" in text
+        assert "every" in text.lower() or "not an interval" in text
+
+    def test_describe_interval_finite(self):
+        s = parse_schedule("every 20m")
+        text = describe_schedule_semantics(s, 8)
+        assert "finite repeat 8" in text
+
+    def test_preview_once_has_single_tick(self, monkeypatch):
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        s = parse_schedule("20m")
+        ticks = preview_next_runs(s, n=2)
+        assert len(ticks) == 1
+
+    def test_preview_interval_has_two_ticks(self, monkeypatch):
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        s = parse_schedule("every 20m")
+        ticks = preview_next_runs(s, n=2)
+        assert len(ticks) == 2
+        t0 = datetime.fromisoformat(ticks[0])
+        t1 = datetime.fromisoformat(ticks[1])
+        assert t1 - t0 == timedelta(minutes=20)
+
+
+class TestDiagnosticUnsatisfiable:
+    def test_finds_legacy_oneshot_repeat_n(self, tmp_cron_dir, monkeypatch):
+        """Legacy jobs already on disk are NOT mutated — only warned about."""
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        # Bypass create_job validation by writing a legacy record directly.
+        save_jobs(
+            [
+                {
+                    "id": "legacydeadbe",
+                    "name": "stuck-fleet",
+                    "prompt": "update",
+                    "schedule": {
+                        "kind": "once",
+                        "run_at": (now + timedelta(minutes=20)).isoformat(),
+                        "display": "once in 20m",
+                    },
+                    "schedule_display": "once in 20m",
+                    "repeat": {"times": 8, "completed": 1},
+                    "enabled": False,
+                    "state": "completed",
+                    "next_run_at": None,
+                    "last_run_at": now.isoformat(),
+                }
+            ]
+        )
+        issues = find_unsatisfiable_repeat_jobs()
+        assert len(issues) == 1
+        assert issues[0]["job_id"] == "legacydeadbe"
+        assert "1/8" in issues[0]["warning"] or "1/8" in f"{issues[0]['completed']}/{issues[0]['times']}"
+        # Store preserved
+        assert load_jobs()[0]["repeat"]["times"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Tool response surface
+# ---------------------------------------------------------------------------
+
+
+class TestToolResponseSemantics:
+    def test_create_response_includes_semantics_and_ticks(self, tmp_cron_dir, monkeypatch):
+        from tools.cronjob_tools import cronjob
+        import json
+
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        raw = cronjob(
+            action="create",
+            prompt="fleet",
+            schedule="every 20m",
+            repeat=8,
+            deliver="local",
+            name="fleet-updates",
+        )
+        data = json.loads(raw)
+        assert data["success"] is True
+        assert data["schedule_kind"] == "interval"
+        assert "finite repeat 8" in data["semantics"]
+        assert len(data["expected_next_ticks"]) == 2
+        assert data["repeat"] == "8 times"
+
+    def test_create_tool_rejects_20m_repeat_8(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+        import json
+
+        raw = cronjob(
+            action="create",
+            prompt="fleet",
+            schedule="20m",
+            repeat=8,
+            deliver="local",
+        )
+        data = json.loads(raw)
+        assert data["success"] is False
+        assert "one-shot" in data["error"].lower() or "cannot be satisfied" in data["error"]
+
+    def test_list_warns_on_legacy_stuck(self, tmp_cron_dir, monkeypatch):
+        from tools.cronjob_tools import cronjob
+        import json
+
+        now = datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        save_jobs(
+            [
+                {
+                    "id": "legacywarn01",
+                    "name": "stuck",
+                    "prompt": "x",
+                    "schedule": {
+                        "kind": "once",
+                        "run_at": now.isoformat(),
+                        "display": "once in 20m",
+                    },
+                    "schedule_display": "once in 20m",
+                    "repeat": {"times": 8, "completed": 1},
+                    "enabled": False,
+                    "state": "completed",
+                    "next_run_at": None,
+                }
+            ]
+        )
+        data = json.loads(cronjob(action="list", include_disabled=True))
+        assert data["success"] is True
+        assert data.get("warnings")
+        assert any(w["job_id"] == "legacywarn01" for w in data["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Final state / count invariants
+# ---------------------------------------------------------------------------
+
+
+class TestFinalStateAndCount:
+    def test_oneshot_default_final_removed(self, tmp_cron_dir):
+        job = create_job(prompt="o", schedule="30m")
+        claim_dispatch(job["id"])
+        mark_job_run(job["id"], success=True)
+        assert get_job(job["id"]) is None
+
+    def test_interval_forever_never_removed(self, tmp_cron_dir):
+        job = create_job(prompt="forever", schedule="every 1h")
+        for _ in range(5):
+            mark_job_run(job["id"], success=True)
+        assert get_job(job["id"]) is not None
+        assert get_job(job["id"])["repeat"]["completed"] == 5
+        assert get_job(job["id"])["repeat"]["times"] is None
+
+    def test_compute_next_run_once_after_last_is_none(self):
+        s = {"kind": "once", "run_at": "2099-01-01T00:00:00+00:00"}
+        assert compute_next_run(s, last_run_at="2099-01-01T00:00:01+00:00") is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -23,11 +23,14 @@ from cron.jobs import (
     AmbiguousJobReference,
     claim_job_for_fire,
     create_job,
+    describe_schedule_semantics,
+    find_unsatisfiable_repeat_jobs,
     get_job,
     list_jobs,
     mark_job_run,
     parse_schedule,
     pause_job,
+    preview_next_runs,
     remove_job,
     resolve_job_ref,
     resume_job,
@@ -355,6 +358,32 @@ def _repeat_display(job: Dict[str, Any]) -> str:
     return f"{completed}/{times}" if completed else f"{times} times"
 
 
+def _job_semantics(job: Dict[str, Any]) -> str:
+    schedule = job.get("schedule") or {}
+    times = (job.get("repeat") or {}).get("times")
+    return describe_schedule_semantics(schedule, times)
+
+
+def _job_expected_ticks(job: Dict[str, Any], n: int = 2) -> List[str]:
+    schedule = job.get("schedule") or {}
+    # From a fresh job (no last_run) or paused job, show upcoming ticks from now.
+    # After a run, last_run_at anchors the next preview.
+    last = job.get("last_run_at")
+    # Prefer the stored next_run_at as the first tick when present so the
+    # response matches the persisted schedule (avoids clock skew between
+    # create and format).
+    next_run = job.get("next_run_at")
+    if next_run and not last:
+        ticks = [next_run]
+        # Second tick: advance as if the first had just fired.
+        more = preview_next_runs(schedule, n=max(0, n - 1), last_run_at=next_run)
+        for t in more:
+            if t not in ticks:
+                ticks.append(t)
+        return ticks[:n]
+    return preview_next_runs(schedule, n=n, last_run_at=last)
+
+
 def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
     if skills is None:
         raw_items = [skill] if skill else []
@@ -579,6 +608,9 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
         "schedule": job.get("schedule_display") or "?",
+        "schedule_kind": (job.get("schedule") or {}).get("kind"),
+        "semantics": _job_semantics(job),
+        "expected_next_ticks": _job_expected_ticks(job, n=2),
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
         "next_run_at": job.get("next_run_at"),
@@ -756,6 +788,8 @@ def cronjob(
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
             if _local_notice:
                 _create_message = f"{_create_message} {_local_notice}"
+            _semantics = _job_semantics(job)
+            _ticks = _job_expected_ticks(job, n=2)
             return json.dumps(
                 {
                     "success": True,
@@ -764,6 +798,9 @@ def cronjob(
                     "skill": job.get("skill"),
                     "skills": job.get("skills", []),
                     "schedule": job["schedule_display"],
+                    "schedule_kind": (job.get("schedule") or {}).get("kind"),
+                    "semantics": _semantics,
+                    "expected_next_ticks": _ticks,
                     "repeat": _repeat_display(job),
                     "deliver": job.get("deliver", "local"),
                     "next_run_at": job["next_run_at"],
@@ -775,7 +812,22 @@ def cronjob(
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
-            return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
+            # Always scan the full store (including disabled/completed) so
+            # operators see stuck 1/N one-shot+repeat legacy jobs.
+            warnings = find_unsatisfiable_repeat_jobs()
+            payload: Dict[str, Any] = {
+                "success": True,
+                "count": len(jobs),
+                "jobs": jobs,
+            }
+            if warnings:
+                payload["warnings"] = warnings
+                payload["message"] = (
+                    f"{len(warnings)} job(s) have unsatisfiable one-shot+repeat "
+                    "combinations (completed early at 1/N). Use 'every …' for "
+                    "finite periodic runs."
+                )
+            return json.dumps(payload, indent=2)
 
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)
@@ -1003,7 +1055,15 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
+                "description": (
+                    "REQUIRED for action=create. Schedule string semantics: "
+                    "'30m'/'2h'/'1d' = ONE-SHOT delay (run once after that delay, NOT recurring); "
+                    "'every 30m'/'every 2h' = recurring interval; "
+                    "'0 9 * * *' = cron expression (recurring); "
+                    "'2026-06-01T09:00:00' = one-shot at absolute time. "
+                    "For N periodic executions use 'every 20m' (or a cron expr) with repeat=N — "
+                    "never bare '20m' with repeat>1 (rejected)."
+                ),
             },
             "name": {
                 "type": "string",
@@ -1011,7 +1071,13 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "repeat": {
                 "type": "integer",
-                "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring)."
+                "description": (
+                    "Optional finite run count for RECURRING schedules only "
+                    "('every …' or cron). Omit for defaults (once for one-shot, "
+                    "forever for recurring). repeat>1 is REJECTED for one-shot "
+                    "schedules (bare '20m', ISO timestamps) because they can "
+                    "only fire once — use 'every 20m' + repeat=N instead."
+                ),
             },
             "deliver": {
                 "type": "string",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -563,16 +563,30 @@ every 1d     → Every day
 | Interval (`every 2h`) | forever | Runs until removed |
 | Cron expression | forever | Runs until removed |
 
-You can override it:
+**Important:** bare relative durations (`20m`, `2h`) are **one-shot delays**, not
+intervals. They are not the same as `every 20m`. Requesting `repeat > 1` with a
+one-shot schedule is rejected at create/update time, because a one-shot can never
+satisfy N periodic executions (it would otherwise run once, record `1/N`, and
+complete with no `next_run_at`).
+
+You can override the default for recurring schedules:
 
 ```python
+# Correct: 8 runs every 20 minutes
 cronjob(
     action="create",
     prompt="...",
-    schedule="every 2h",
-    repeat=5,
+    schedule="every 20m",
+    repeat=8,
 )
+
+# Wrong (rejected): bare '20m' is one-shot, cannot repeat 8 times
+# cronjob(action="create", prompt="...", schedule="20m", repeat=8)
 ```
+
+`hermes cron list` and `cronjob(action='list')` also warn about any legacy jobs
+stuck at `1/N` completed with a one-shot schedule (migration-safe diagnostic;
+existing jobs are not auto-deleted).
 
 ## Managing jobs programmatically
 


### PR DESCRIPTION
## Summary

Bare relative durations like `20m` are **one-shot delays**, not intervals. Combining them with `repeat>1` previously accepted the job, fired once, recorded `1/N`, then marked it completed with no `next_run_at` — silently dropping the remaining N-1 runs (Blazar fleet-update cron `edd042027e2b`).

This PR makes finite-repeat semantics unambiguous and unsatisfiable shapes impossible to create.

## Root cause

| Input | Parsed kind | Can satisfy `repeat=8`? |
|-------|-------------|-------------------------|
| `20m` | `once` | No (fires at most once) |
| `every 20m` | `interval` | Yes |
| `0 */20 * * *` | `cron` | Yes |

The tool schema also incorrectly claimed `'30m' (every 30 minutes)`, which steered agents into the bad shape.

## Changes

1. **Validation** — `create_job` / `update_job` reject one-shot + `repeat>1` with a clear error pointing to `every 20m`.
2. **Tool response** — create/list include `semantics`, `schedule_kind`, and `expected_next_ticks` (up to 2).
3. **Operator diagnostic** — `find_unsatisfiable_repeat_jobs()`; surfaced by `hermes cron list` and `cronjob(action='list')`. Legacy jobs are **not** auto-deleted (migration-safe).
4. **Docs** — `website/docs/user-guide/features/cron.md` distinguishes `20m` vs `every 20m`.
5. **Schema** — cronjob tool description no longer mislabels bare durations as recurring.
6. **Tests** — `tests/cron/test_finite_repeat_semantics.py` (33 cases): reject path, interval/cron finite repeat, ISO one-shot, pause/resume, restart, catch-up, delivery failure, diagnostics, tool surface.

## Local fixture verification (isolated HERMES_HOME)

- Rejected `schedule='20m', repeat=8` at create.
- Created `every 1m` + `repeat=3` + `no_agent` + `deliver=local`; three `mark_job_run` cycles auto-removed the job.
- Timestamps: `2026-07-14T01:32:16.252434+00:00`, `...252900+00:00`, `...253481+00:00`
- Diagnostic detected legacy stuck `1/8` completed one-shot; store cleaned after.

## Test plan

- [x] `pytest tests/cron/test_finite_repeat_semantics.py` — 33 passed
- [x] `pytest tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/cron/test_cronjob_schema.py` — 210 passed
- [ ] CI on this PR

## SELF-REVIEW

1. **Incident reproduction** — `create_job(schedule='20m', repeat=8)` now raises `ValueError` and writes nothing to the job store (`test_incident_shape_20m_repeat_8_rejected`).
2. **Correct path still works** — `every 20m` + `repeat=8` creates interval job; three runs of `every 20m`+`repeat=3` count 1→2→remove (`test_every_duration_finite_repeat_counts_and_removes`).
3. **Legacy safety** — pre-existing one-shot+repeat>1 records are only warned about via `find_unsatisfiable_repeat_jobs`, not mutated (`test_finds_legacy_oneshot_repeat_n`).
4. **Misleading schema fixed** — tool create response includes `semantics` + two ticks; bare `20m`+`repeat=8` tool path returns `success=false` (`TestToolResponseSemantics`).

## Tier

Scheduler create/update validation + tool response: Tier-A (execution/state path). Needs binding `## CTO review` at exact head before merge.

actor: grok-agent
card: t_d808882e