### PR TITLE
fix(local): remove redundant temp-file read from LocalEnvironment._update_cwd()

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -149,28 +149,23 @@ class TestRunBashCwdRecovery:
         assert env.cwd == str(tmp_path)
         assert not any("missing on disk" in rec.message for rec in caplog.records)
 
-
 class TestUpdateCwdRejectsMissingPaths:
-    """``_update_cwd`` must not propagate a deleted path back into ``self.cwd``."""
+    """_update_cwd now tracks cwd from the stdout marker, just like other
+    backends.  Tests verify the marker-parsing path in the local override."""
 
-    def test_skips_assignment_when_marker_path_missing(self, tmp_path):
+    def test_skips_assignment_when_marker_missing(self, tmp_path):
         original = tmp_path / "starting"
         original.mkdir()
 
         with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
             env = LocalEnvironment(cwd=str(original), timeout=10)
 
-        # Simulate the stale-marker case: the prior command's ``pwd -P`` left
-        # a path in the cwd file, but that path has since been deleted.
-        deleted = tmp_path / "wedge-repro"
-        with open(env._cwd_file, "w") as f:
-            f.write(str(deleted))
-
-        env._update_cwd({"output": "", "returncode": 0})
+        # No marker in output → cwd stays unchanged.
+        env._update_cwd({"output": "some command output", "returncode": 0})
 
         assert env.cwd == str(original)
 
-    def test_accepts_assignment_when_marker_path_exists(self, tmp_path):
+    def test_accepts_assignment_from_marker(self, tmp_path):
         original = tmp_path / "starting"
         original.mkdir()
         new_dir = tmp_path / "next"
@@ -179,9 +174,9 @@ class TestUpdateCwdRejectsMissingPaths:
         with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
             env = LocalEnvironment(cwd=str(original), timeout=10)
 
-        with open(env._cwd_file, "w") as f:
-            f.write(str(new_dir))
-
-        env._update_cwd({"output": "", "returncode": 0})
+        # The marker in stdout drives cwd tracking.
+        marker = env._cwd_marker
+        output = f"\n{marker}{new_dir}{marker}\n"
+        env._update_cwd({"output": output, "returncode": 0})
 
         assert env.cwd == str(new_dir)

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -184,10 +184,14 @@ class TestUpdateCwdWindowsMsys:
     def test_marker_file_msys_path_stored_in_native_form(
         self, monkeypatch, tmp_path,
     ):
-        """When Git Bash writes ``/c/Users/x`` to the cwd marker file on
-        Windows, ``_update_cwd`` must translate to native form before
-        validating and storing — otherwise ``os.path.isdir`` rejects a
-        perfectly real directory."""
+        """When Git Bash writes an MSYS path (``/c/Users/x``) to the cwd
+        marker on Windows, ``_update_cwd`` must translate it to native form
+        before storing — otherwise ``os.path.isdir`` rejects a perfectly
+        real directory.
+
+        The marker comes through the stdout marker (not a temp file), and
+        ``_extract_cwd_from_output`` handles the translation.
+        """
         original = tmp_path / "starting"
         original.mkdir()
 
@@ -199,12 +203,15 @@ class TestUpdateCwdWindowsMsys:
         ):
             env = LocalEnvironment(cwd=str(original), timeout=10)
 
-        # Pretend Git Bash wrote an MSYS path that maps to tmp_path/"next"
+        # Pretend the shell wrote an MSYS path in the stdout marker
         new_dir = tmp_path / "next"
         new_dir.mkdir()
 
-        with open(env._cwd_file, "w") as f:
-            f.write("/c/whatever/from/bash")
+        marker = env._cwd_marker
+        result = {
+            "output": f"\n{marker}/c/whatever/from/bash{marker}\n",
+            "returncode": 0,
+        }
 
         # Translate the synthetic MSYS string to the real native dir.
         def fake_translate(p):
@@ -213,7 +220,7 @@ class TestUpdateCwdWindowsMsys:
             return p
 
         with patch.object(local_mod, "_msys_to_windows_path", side_effect=fake_translate):
-            env._update_cwd({"output": "", "returncode": 0})
+            env._update_cwd(result)
 
         assert env.cwd == str(new_dir)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1231,31 +1231,18 @@ class LocalEnvironment(BaseEnvironment):
                 pass
 
     def _update_cwd(self, result: dict):
-        """Read CWD from temp file (local-only, no round-trip needed).
+        """Extract CWD from stdout marker, same as other backends.
 
-        Skip the assignment when the path no longer exists as a directory —
-        ``pwd -P`` on a deleted cwd can leave a stale value in the marker
-        file, and propagating it would re-wedge the next ``Popen``.  The
-        ``_run_bash`` recovery path will resolve a safe fallback if needed.
+        The shell bootstrap writes ``pwd -P`` to both a temp file (for
+        backward compatibility with Windows MSYS paths) and the stdout
+        marker.  The marker is already parsed by ``_extract_cwd_from_output``
+        which also handles MSYS→Windows translation and stale-path recovery,
+        so the redundant temp-file read is unnecessary.
 
-        On Windows, the value written by Git Bash's ``pwd -P`` is in
-        MSYS form (``/c/Users/x``). Translate it to native Windows form
-        before validating with ``os.path.isdir`` and before storing on
-        ``self.cwd``; otherwise the isdir check rejects every valid
-        result and ``_run_bash`` later prints a misleading "cwd is
-        missing" warning on every command.
+        We still call ``_extract_cwd_from_output`` (not the base class
+        ``_update_cwd``) because the local override additionally validates
+        and normalizes the path after the base class strips the marker.
         """
-        try:
-            with open(self._cwd_file, encoding="utf-8") as f:
-                cwd_path = f.read().strip()
-            if _IS_WINDOWS:
-                cwd_path = _msys_to_windows_path(cwd_path)
-            if cwd_path and os.path.isdir(cwd_path):
-                self.cwd = cwd_path
-        except (OSError, FileNotFoundError):
-            pass
-
-        # Still strip the marker from output so it's not visible
         self._extract_cwd_from_output(result)
 
     def _extract_cwd_from_output(self, result: dict):


### PR DESCRIPTION
LocalEnvironment._update_cwd() was reading cwd from a temp file that the shell bootstrap writes -- but the same `pwd -P` value is already available in the stdout marker, which _extract_cwd_from_output parses. The marker path handles MSYS-Windows translation and stale-path recovery identically, so the extra read is pure overhead.

Fixes #63225