### PR TITLE
fix(serve): bridge terminal.backend config to TERMINAL_ENV in start_server()

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17067,6 +17067,18 @@ def start_server(
     except Exception as exc:
         _log.debug("Nous auth keepalive did not start: %s", exc)
 
+    # Bridge terminal.* config into process environment so the serve
+    # process (and any child processes it spawns) use the configured
+    # terminal backend (e.g. Docker) instead of defaulting to local.
+    # Without this, `hermes serve` ignores terminal.backend and every
+    # tool call runs on the host (#63141).
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+
+        apply_terminal_config_to_env()
+    except Exception as exc:
+        _log.debug("Failed to apply terminal config bridge: %s", exc)
+
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token
     # injection / WS-auth paths can branch on it consistently.  Phase 3.5
     # uses this to decide whether to refuse the bind, log the gate-on


### PR DESCRIPTION
The serve process (used by Hermes Desktop) never called apply_terminal_config_to_env() for its own environment, so `terminal.backend: docker` was silently ignored and every tool call ran in local mode. Add the bridge call early in start_server() so the configured terminal backend is active for the server and all its child tool calls.

Fixes #63141