### PR TITLE
fix(desktop): prevent agent suspension on lock screen

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -20,6 +20,7 @@ import {
   nativeTheme,
   Notification,
   powerMonitor,
+  powerSaveBlocker,
   protocol,
   safeStorage,
   screen,
@@ -65,7 +66,6 @@ import {
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
-import { resolvePickerDefaultPath } from './wsl-path-bridge'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
 import {
@@ -96,6 +96,11 @@ import {
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import {
+  createPowerLifecycleGuard,
+  registerPowerLifecycleListeners,
+  stopPowerLifecycleGuardSafely
+} from './power-lifecycle'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import {
   buildSessionWindowUrl,
@@ -131,6 +136,7 @@ import { buildPathExtCandidates, chooseUpdaterArgs, getVenvSitePackagesEntries, 
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
+import { resolvePickerDefaultPath } from './wsl-path-bridge'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 
@@ -1007,6 +1013,8 @@ function rememberLog(chunk) {
 
   scheduleDesktopLogFlush()
 }
+
+const appSuspensionGuard = createPowerLifecycleGuard(powerSaveBlocker, rememberLog)
 
 function openExternalUrl(rawUrl) {
   const raw = String(rawUrl || '').trim()
@@ -4491,10 +4499,10 @@ function registerPowerResumeListeners() {
   powerResumeRegistered = true
 
   try {
-    // 'resume' covers sleep/wake; 'unlock-screen' covers lock/unlock without a
-    // full suspend. Either can drop an idle socket.
-    powerMonitor.on('resume', sendPowerResume)
-    powerMonitor.on('unlock-screen', sendPowerResume)
+    // Keep in-flight work alive while the operating system's login screen is
+    // showing, then release the assertion as soon as the user returns. Resume
+    // and unlock also tell the renderer to reconnect any socket the OS dropped.
+    registerPowerLifecycleListeners(powerMonitor, appSuspensionGuard, sendPowerResume, rememberLog)
   } catch {
     // powerMonitor is unavailable before app 'ready' on some platforms; the
     // caller registers after 'ready', so this should not normally throw.
@@ -9071,6 +9079,8 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  stopPowerLifecycleGuardSafely(appSuspensionGuard, rememberLog)
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()

--- a/apps/desktop/electron/power-lifecycle.test.ts
+++ b/apps/desktop/electron/power-lifecycle.test.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  createPowerLifecycleGuard,
+  registerPowerLifecycleListeners,
+  stopPowerLifecycleGuardSafely
+} from './power-lifecycle'
+
+test('power lifecycle guard holds an app-suspension blocker only once', () => {
+  const calls: Array<[string, string | number]> = []
+  const active = new Set<number>()
+
+  const blocker = {
+    start(type: 'prevent-app-suspension') {
+      calls.push(['start', type])
+      active.add(42)
+
+      return 42
+    },
+    isStarted(id: number) {
+      return active.has(id)
+    },
+    stop(id: number) {
+      calls.push(['stop', id])
+      active.delete(id)
+    }
+  }
+
+  const logs: string[] = []
+  const guard = createPowerLifecycleGuard(blocker, line => logs.push(line))
+
+  assert.equal(guard.start(), 42)
+  assert.equal(guard.start(), 42, 'start must be idempotent')
+  assert.equal(guard.active, true)
+  assert.deepEqual(calls, [['start', 'prevent-app-suspension']])
+
+  assert.equal(guard.stop(), true)
+  assert.equal(guard.stop(), false, 'stop must be idempotent')
+  assert.equal(guard.active, false)
+  assert.deepEqual(calls, [
+    ['start', 'prevent-app-suspension'],
+    ['stop', 42]
+  ])
+  assert.deepEqual(logs, ['[power] app-suspension guard started id=42', '[power] app-suspension guard stopped id=42'])
+})
+
+test('power lifecycle guard retains its blocker id when the native status check fails', () => {
+  let isStartedCalls = 0
+  const stoppedIds: number[] = []
+
+  const guard = createPowerLifecycleGuard({
+    start() {
+      return 42
+    },
+    isStarted(id) {
+      assert.equal(id, 42)
+      isStartedCalls += 1
+
+      if (isStartedCalls === 1) {
+        throw new Error('status failed')
+      }
+
+      return true
+    },
+    stop(id) {
+      stoppedIds.push(id)
+    }
+  })
+
+  assert.equal(guard.start(), 42)
+  assert.throws(() => guard.stop(), /status failed/)
+  assert.equal(guard.stop(), true, 'a failed native status check must be retryable')
+  assert.equal(guard.stop(), false, 'a successful retry must clear the blocker id')
+  assert.deepEqual(stoppedIds, [42])
+})
+
+test('power lifecycle guard retains its blocker id when the native stop fails', () => {
+  let stopCalls = 0
+
+  const guard = createPowerLifecycleGuard({
+    start() {
+      return 42
+    },
+    isStarted(id) {
+      assert.equal(id, 42)
+
+      return true
+    },
+    stop(id) {
+      assert.equal(id, 42)
+      stopCalls += 1
+
+      if (stopCalls === 1) {
+        throw new Error('stop failed')
+      }
+    }
+  })
+
+  assert.equal(guard.start(), 42)
+  assert.throws(() => guard.stop(), /stop failed/)
+  assert.equal(guard.stop(), true, 'a failed native stop must be retryable')
+  assert.equal(guard.stop(), false, 'a successful retry must clear the blocker id')
+  assert.equal(stopCalls, 2)
+})
+
+test('safe power lifecycle cleanup catches and logs guard failures', () => {
+  const logs: string[] = []
+
+  const guard = {
+    get active() {
+      return true
+    },
+    start() {
+      return 42
+    },
+    stop() {
+      throw new Error('native cleanup failed')
+    }
+  }
+
+  assert.equal(
+    stopPowerLifecycleGuardSafely(guard, line => logs.push(line)),
+    false
+  )
+  assert.deepEqual(logs, ['[power] app-suspension guard cleanup failed: Error: native cleanup failed'])
+})
+
+test('power lifecycle listeners guard lock-screen work and release on unlock', () => {
+  const listeners = new Map<string, () => void>()
+
+  const powerMonitor = {
+    on(event: string, listener: () => void) {
+      listeners.set(event, listener)
+    }
+  }
+
+  const calls: string[] = []
+
+  const guard = {
+    start() {
+      calls.push('start')
+
+      return 1
+    },
+    stop() {
+      calls.push('stop')
+
+      return true
+    },
+    get active() {
+      return calls.at(-1) === 'start'
+    }
+  }
+
+  registerPowerLifecycleListeners(powerMonitor, guard, () => calls.push('resume'))
+
+  listeners.get('lock-screen')?.()
+  assert.deepEqual(calls, ['start'])
+
+  listeners.get('unlock-screen')?.()
+  assert.deepEqual(calls, ['start', 'stop', 'resume'])
+
+  listeners.get('resume')?.()
+  assert.deepEqual(calls, ['start', 'stop', 'resume', 'resume'])
+})
+
+test('unlock still signals the renderer when blocker cleanup throws', () => {
+  const listeners = new Map<string, () => void>()
+  const logs: string[] = []
+  let resumeSignals = 0
+
+  registerPowerLifecycleListeners(
+    {
+      on(event, listener) {
+        listeners.set(event, listener)
+      }
+    },
+    {
+      get active() {
+        return true
+      },
+      start() {
+        return 42
+      },
+      stop() {
+        throw new Error('stop failed')
+      }
+    },
+    () => {
+      resumeSignals += 1
+    },
+    line => logs.push(line)
+  )
+
+  assert.doesNotThrow(() => listeners.get('unlock-screen')?.())
+  assert.equal(resumeSignals, 1)
+  assert.deepEqual(logs, ['[power] app-suspension guard cleanup failed: Error: stop failed'])
+})

--- a/apps/desktop/electron/power-lifecycle.ts
+++ b/apps/desktop/electron/power-lifecycle.ts
@@ -1,0 +1,89 @@
+type BlockerKind = 'prevent-app-suspension'
+
+export interface PowerSaveBlockerLike {
+  start(type: BlockerKind): number
+  isStarted(id: number): boolean
+  stop(id: number): void
+}
+
+export interface PowerMonitorLike {
+  on(event: 'lock-screen' | 'unlock-screen' | 'resume', listener: () => void): unknown
+}
+
+export interface PowerLifecycleGuard {
+  readonly active: boolean
+  start(): number | null
+  stop(): boolean
+}
+
+export function createPowerLifecycleGuard(
+  powerSaveBlocker: PowerSaveBlockerLike,
+  log: (line: string) => void = () => undefined
+): PowerLifecycleGuard {
+  let blockerId: number | null = null
+
+  return {
+    get active() {
+      return blockerId !== null && powerSaveBlocker.isStarted(blockerId)
+    },
+    start() {
+      if (blockerId !== null && powerSaveBlocker.isStarted(blockerId)) {
+        return blockerId
+      }
+
+      blockerId = powerSaveBlocker.start('prevent-app-suspension')
+      log(`[power] app-suspension guard started id=${blockerId}`)
+
+      return blockerId
+    },
+    stop() {
+      if (blockerId === null) {
+        return false
+      }
+
+      const id = blockerId
+
+      if (powerSaveBlocker.isStarted(id)) {
+        powerSaveBlocker.stop(id)
+      }
+
+      blockerId = null
+      log(`[power] app-suspension guard stopped id=${id}`)
+
+      return true
+    }
+  }
+}
+
+export function stopPowerLifecycleGuardSafely(
+  guard: PowerLifecycleGuard,
+  log: (line: string) => void = () => undefined
+): boolean {
+  try {
+    return guard.stop()
+  } catch (error) {
+    try {
+      log(`[power] app-suspension guard cleanup failed: ${String(error)}`)
+    } catch {
+      // Cleanup and its failure reporting must never interrupt lifecycle events.
+    }
+
+    return false
+  }
+}
+
+export function registerPowerLifecycleListeners(
+  powerMonitor: PowerMonitorLike,
+  guard: PowerLifecycleGuard,
+  onResume: () => void,
+  log: (line: string) => void = () => undefined
+): void {
+  powerMonitor.on('resume', onResume)
+  powerMonitor.on('lock-screen', () => {
+    guard.start()
+  })
+  powerMonitor.on('unlock-screen', () => {
+    stopPowerLifecycleGuardSafely(guard, log)
+    onResume()
+  })
+}


### PR DESCRIPTION
## What does this PR do?

Keeps Hermes Desktop's in-flight agent work alive while the macOS login/lock screen is showing.

Chromium renderer backgrounding is already disabled, but that does not prevent Electron's native app process from being suspended after the session locks. This change acquires Electron's `prevent-app-suspension` power blocker on `lock-screen`, releases it on `unlock-screen` or app quit, and preserves the existing renderer reconnect signal on resume/unlock.

The blocker is scoped to the locked interval rather than the entire app lifetime, so ordinary unlocked idle behavior is unchanged.

## Related Issue

No existing issue or PR found after searching for `powerSaveBlocker` and `lock screen`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a small, testable Electron power-lifecycle guard.
- Acquire `prevent-app-suspension` on `lock-screen`.
- Release the assertion on `unlock-screen` and `before-quit`.
- Keep the existing `hermes:power-resume` reconnect behavior.
- Retain blocker ownership when native cleanup fails so a later lifecycle event can retry it.
- Contain and log cleanup failures so unlock reconnect and quit teardown still complete.
- Add regressions for idempotence, native cleanup failures, retries, and lifecycle listener ordering.

## How to Test

1. `cd apps/desktop && npm run check`
2. Start an agent response, lock macOS with Control-Command-Q, wait, then unlock and confirm the turn continued rather than pausing at the login screen.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and merged PRs/issues and found no duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` (not run: desktop-only TypeScript/Electron change).
- [x] I've added tests for my changes.
- [x] I've tested on macOS 15.7.3.

### Documentation & Housekeeping

- [x] Documentation update: N/A (internal lifecycle bug fix).
- [x] `cli-config.yaml.example`: N/A (no config changes).
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no workflow or architecture change).
- [x] Cross-platform impact considered: the implementation uses Electron APIs and leaves unlocked behavior unchanged.
- [x] Tool descriptions/schemas: N/A.

## Verification

- `npm run check`: passed on the committed snapshot.
- Vitest: 199 files passed; 1,694 tests passed, 1 skipped.
- TypeScript typecheck: passed.
- macOS DMG packaging and production build: passed; `assert-dist-built` confirmed renderer assets.
- Focused lint for the new module/tests: passed.
- Full desktop lint still reports unrelated errors already present on upstream `main` in `wsl-path-bridge.test.ts`, `src/app/cron/index.tsx`, `clarify-tool.test.tsx`, and `src/lib/icons.ts`.
