### PR TITLE
fix(dashboard): pass backup output path with -o flag instead of positional arg

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11754,7 +11754,7 @@ async def run_backup(body: BackupRequest):
     args = ["backup"]
     archive: Optional[Path] = None
     if body.output:
-        args.append(body.output.strip())
+        args.extend(["-o", body.output.strip()])
     else:
         archive = _new_dashboard_backup_path()
         try:
@@ -11764,7 +11764,7 @@ async def run_backup(body: BackupRequest):
                 status_code=500,
                 detail=f"Could not create backup directory: {exc}",
             )
-        args.append(str(archive))
+        args.extend(["-o", str(archive)])
     try:
         proc = _spawn_hermes_action(args, "backup")
     except Exception as exc:


### PR DESCRIPTION
## Problem

The dashboard backup button (`/api/ops/backup`) calls `hermes backup /path/to/output.zip`, passing the output path as a positional argument. But the CLI `backup` subcommand only accepts the output path via `-o`/`--output` flag.

This causes every backup initiated from the dashboard to fail silently (from the user's perspective) with:
```
hermes: error: unrecognized arguments: /path/to/hermes-backup-....zip
```

## Fix

Changed `args.append(path)` to `args.extend(["-o", path])` in both branches of run_backup():
- Default automatic path (saves to ~/.hermes/backups/)
- User-specified output path

## Root cause

Introduced in commit 476875acb9 (2026-06-29) when the output path logic was added. The original endpoint (b571ec298d) called `hermes backup` without any path arg, which worked but saved to the wrong directory.