### PR TITLE
fix: bump Pillow pin from 12.2.0 to 12.3.0 (5 CVEs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ dependencies = [
   # libs required for the codecs we use, so it's safe to ship in the base
   # install rather than gating it behind an extra + a mid-session lazy install
   # (which deadlocked the CLI under prompt_toolkit — see #40490).
-  "Pillow==12.2.0",
+  "Pillow==12.3.0",
   # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
   # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
   # Windows whenever any other process holds an append-mode handle on

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -228,7 +228,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # for stripped/source-build installs that somehow dropped it. The vision
     # call site uses prompt=False so it can never raise a blocking input()
     # prompt mid-session (#40490).
-    "tool.vision": ("Pillow==12.2.0",),
+    "tool.vision": ("Pillow==12.3.0",),
     # Computer Use (cua-driver) — the MCP client SDK used to spawn and talk
     # to the cua-driver process over stdio. Matches the `mcp` / `computer-use`
     # extras in pyproject.toml. The one-liner installer pulls this in via


### PR DESCRIPTION
**What:** Bump the Pillow version pin from 12.2.0 to 12.3.0 in both pyproject.toml and tools/lazy_deps.py.

**Why:** Pillow 12.2.0 has 5 CVEs (PYSEC-2026-2253 through PYSEC-2026-2257). The venv can be upgraded independently, but the source pins mean a fresh `pip install hermes-agent` would downgrade back to the vulnerable version.

**How:** Two line changes:
- `pyproject.toml:126` — `"Pillow==12.2.0"` → `"Pillow==12.3.0"`
- `tools/lazy_deps.py:231` — `"tool.vision": ("Pillow==12.2.0",)` → `"tool.vision": ("Pillow==12.3.0",)`

Pillow 12.3.0 is a patch release with no breaking API changes. The only changes are security fixes for the 5 CVEs listed above.

**Tests:** No new tests needed — this is a dependency version bump. The existing vision tools test suite covers Pillow integration paths.

**Files Changed:**
- `pyproject.toml` — bump Pillow pin 12.2.0 → 12.3.0
- `tools/lazy_deps.py` — bump lazy vision dep pin 12.2.0 → 12.3.0