### PR TITLE
fix(skills): prefer fallbacks before requesting credentials

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -894,6 +894,12 @@ class TestSkillViewPrerequisites:
                 "prompt": "Enter value for MISSING_KEY_XYZ",
             }
         ]
+        assert "skill is still loaded and may have documented fallback paths" in result[
+            "setup_note"
+        ]
+        assert "Only ask the user for credentials if the requested task requires them" in result[
+            "setup_note"
+        ]
 
     def test_no_setup_needed_when_legacy_prereqs_are_met(self, tmp_path, monkeypatch):
         monkeypatch.setenv("PRESENT_KEY", "value")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -537,7 +537,12 @@ def _build_setup_note(
 ) -> str | None:
     if readiness_status == SkillReadinessStatus.SETUP_NEEDED:
         missing_str = ", ".join(missing) if missing else "required prerequisites"
-        note = f"Setup needed before using this skill: missing {missing_str}."
+        note = (
+            f"Optional setup is incomplete: missing {missing_str}. The skill is still "
+            "loaded and may have documented fallback paths or reduced functionality. "
+            "Continue with an available path. Only ask the user for credentials if the "
+            "requested task requires them and no documented fallback works."
+        )
         if setup_help:
             return f"{note} {setup_help}"
         return note

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -151,6 +151,9 @@ Each entry supports:
 - `prompt` (optional) — prompt text when asking the user for the value
 - `help` (optional) — help text or URL for obtaining the value
 - `required_for` (optional) — describes which feature needs this variable
+- `optional` (optional, default `false`) — when `true`, register the variable for sandbox passthrough if present without prompting or marking the skill as needing setup. Use this when the credential enables only one path and the skill documents a working fallback.
+
+A missing required variable does not make the skill unusable: `skill_view` still returns the full skill and tells the agent to try documented fallback or degraded paths before asking the user for credentials.
 
 Users can also manually configure passthrough variables in `config.yaml`:
 


### PR DESCRIPTION
## Summary

- clarify that a skill remains usable when setup metadata reports missing credentials
- direct agents to try documented fallback or degraded paths before asking users for secrets
- document `optional: true` for credentials that only enable one of several supported paths
- add regression coverage for the model-facing setup note

## Why

`skill_view` currently emits `Setup needed before using this skill` whenever a declared environment variable is absent. That wording makes agents treat credentials as a hard blocker even though Hermes deliberately still loads the full skill and the skill may document a working alternative (for example, an existing authenticated CLI/session). As a result, agents can ask for API keys unnecessarily instead of using the available fallback.

## Tests

- `python -m pytest tests/tools/test_skills_tool.py tests/tools/test_skill_env_passthrough.py -o addopts= -q` (93 passed)
- `python -m ruff check tools/skills_tool.py tests/tools/test_skills_tool.py`