### PR TITLE
fix: unblock stale active-pr kanban guards

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -57,6 +57,31 @@ def _resolve_auto_decompose_settings(
     return enabled, per_tick
 
 
+def _respawn_guard_summary(results: "list[tuple[str, Optional[object]]]") -> str:
+    counts: dict[str, int] = {}
+    for _slug, res in results or []:
+        if res is None:
+            continue
+        for _task_id, reason in getattr(res, "respawn_guarded", []) or []:
+            counts[str(reason)] = counts.get(str(reason), 0) + 1
+    return ", ".join(
+        f"{reason}×{count}" for reason, count in sorted(counts.items())
+    )
+
+
+def _all_spawnable_ready_deferred_by_respawn_guard(
+    results: "list[tuple[str, Optional[object]]]",
+) -> bool:
+    spawnable = 0
+    guarded = 0
+    for _slug, res in results or []:
+        if res is None:
+            continue
+        spawnable += int(getattr(res, "spawnable_ready", 0) or 0)
+        guarded += len(getattr(res, "respawn_guarded", []) or [])
+    return spawnable > 0 and guarded == spawnable
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -1252,9 +1277,23 @@ class GatewayKanbanWatchersMixin:
                         )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
+                all_ready_guarded = _all_spawnable_ready_deferred_by_respawn_guard(
+                    results or []
+                )
+                if ready_pending and not any_spawned and not all_ready_guarded:
                     bad_ticks += 1
                 else:
+                    if ready_pending and not any_spawned and all_ready_guarded:
+                        summary = _respawn_guard_summary(results or [])
+                        logger.info(
+                            "kanban dispatcher: %d ready deferred by respawn guard: %s",
+                            sum(
+                                int(getattr(res, "spawnable_ready", 0) or 0)
+                                for _slug, res in (results or [])
+                                if res is not None
+                            ),
+                            summary or "unknown",
+                        )
                     bad_ticks = 0
                 if bad_ticks >= HEALTH_WINDOW:
                     now = int(time.time())

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5908,6 +5908,147 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
     re.IGNORECASE,
 )
+_RESPAWN_GUARD_PR_TERMINAL_RE = re.compile(
+    r"\b(merged|closed)\b|머지|닫힘|종결",
+    re.IGNORECASE,
+)
+_RESPAWN_GUARD_PR_NUMBER_RE = re.compile(r"/pull/(\d+)", re.IGNORECASE)
+_RESPAWN_GUARD_PR_STATE_CACHE: dict[str, tuple[int, bool]] = {}
+
+
+def _kanban_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        kanban_cfg = cfg.get("kanban") if isinstance(cfg, dict) else {}
+        return kanban_cfg if isinstance(kanban_cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _resolve_respawn_guard_escalation_threshold() -> int:
+    cfg = _kanban_config()
+    raw_enabled = os.environ.get(
+        "HERMES_KANBAN_RESPAWN_GUARD_ESCALATE",
+        str(cfg.get("respawn_guard_escalate", True)),
+    ).strip().lower()
+    if raw_enabled in {"0", "false", "no", "off"}:
+        return 0
+    raw = os.environ.get(
+        "HERMES_KANBAN_RESPAWN_GUARD_MAX_TICKS",
+        str(cfg.get("respawn_guard_max_ticks", "")),
+    ).strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = 0
+        if parsed >= 0:
+            return parsed
+    return 30
+
+
+def _resolve_respawn_guard_pr_state_cache_seconds() -> int:
+    cfg = _kanban_config()
+    raw = os.environ.get(
+        "HERMES_KANBAN_RESPAWN_GUARD_PR_STATE_CACHE_SECONDS",
+        str(cfg.get("respawn_guard_pr_state_cache_seconds", "")),
+    ).strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = 0
+        if parsed >= 0:
+            return parsed
+    return 600
+
+
+def _pr_number_from_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    m = _RESPAWN_GUARD_PR_NUMBER_RE.search(url)
+    return m.group(1) if m else None
+
+
+def _github_pr_url_is_open(url: str) -> bool:
+    """Return False when GitHub reports the PR is closed/merged.
+
+    Fail closed in favour of duplicate-PR prevention: if the local ``gh`` probe
+    is unavailable or inconclusive, keep treating the recent PR comment as
+    active. Successful and failed probes are cached briefly so dispatcher ticks
+    do not hit GitHub every time.
+    """
+    ttl = _resolve_respawn_guard_pr_state_cache_seconds()
+    now = int(time.time())
+    if ttl > 0:
+        cached = _RESPAWN_GUARD_PR_STATE_CACHE.get(url)
+        if cached is not None and now - cached[0] < ttl:
+            return cached[1]
+    is_open = True
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", url, "--json", "state", "--jq", ".state"],
+            capture_output=True,
+            text=True,
+            timeout=8,
+            check=False,
+        )
+        if proc.returncode == 0:
+            state = (proc.stdout or "").strip().upper()
+            if state in {"CLOSED", "MERGED"}:
+                is_open = False
+            elif state == "OPEN":
+                is_open = True
+    except Exception:
+        is_open = True
+    if ttl > 0:
+        _RESPAWN_GUARD_PR_STATE_CACHE[url] = (now, is_open)
+    return is_open
+
+
+def _active_pr_comment(
+    conn: sqlite3.Connection, task_id: str, cutoff: int
+) -> Optional[dict[str, str]]:
+    for c in conn.execute(
+        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
+        (task_id, cutoff),
+    ).fetchall():
+        body = c["body"] or ""
+        match = _RESPAWN_GUARD_PR_URL_RE.search(body)
+        if not match:
+            continue
+        if _RESPAWN_GUARD_PR_TERMINAL_RE.search(body):
+            continue
+        url = match.group(0)
+        if not _github_pr_url_is_open(url):
+            continue
+        return {"url": url, "number": _pr_number_from_url(url) or ""}
+    return None
+
+
+def _consecutive_respawn_guard_events(
+    conn: sqlite3.Connection, task_id: str, reason: str
+) -> int:
+    count = 0
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "ORDER BY id DESC LIMIT 100",
+        (task_id,),
+    ).fetchall()
+    for row in rows:
+        payload = row["payload"]
+        try:
+            parsed = json.loads(payload) if payload else {}
+        except Exception:
+            parsed = {}
+        if isinstance(parsed, dict) and parsed.get("reason") == reason:
+            count += 1
+            continue
+        break
+    return count
 
 
 @dataclass
@@ -5957,6 +6098,10 @@ class DispatchResult:
     Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
     ``"recent_success"`` (completed run within guard window),
     ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    spawnable_ready: int = 0
+    """Ready, assigned, profile-spawnable tasks considered before guard/claim.
+    Gateway health telemetry uses this to distinguish all-ready-deferred by
+    respawn guard from real spawn stalls."""
     rate_limited: list[str] = field(default_factory=list)
     """Task ids whose workers bailed on a provider rate-limit / quota wall
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
@@ -7104,12 +7249,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    if _active_pr_comment(conn, task_id, pr_cutoff):
+        return "active_pr"
 
     return None
 
@@ -7462,6 +7603,7 @@ def _dispatch_once_locked(
                     (row["id"], row_assignee, current)
                 )
                 continue
+        result.spawnable_ready += 1
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so
@@ -7477,11 +7619,35 @@ def _dispatch_once_locked(
             # skipped when reading `hermes kanban tail` — without
             # this the task appears stuck in ready with no diagnosis.
             if not dry_run:
-                with write_txn(conn):
-                    _append_event(
-                        conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
-                    )
+                threshold = _resolve_respawn_guard_escalation_threshold()
+                should_escalate = (
+                    threshold > 0
+                    and guard_reason in {"active_pr", "recent_success"}
+                    and _consecutive_respawn_guard_events(
+                        conn, row["id"], guard_reason
+                    ) + 1 >= threshold
+                )
+                if should_escalate:
+                    pr_cutoff = int(time.time()) - _RESPAWN_GUARD_PR_WINDOW
+                    pr_info = _active_pr_comment(conn, row["id"], pr_cutoff) or {}
+                    pr_num = pr_info.get("number") or "unknown"
+                    if guard_reason == "active_pr":
+                        block_reason = (
+                            f"PR #{pr_num} open but unmergeable — external rework needed"
+                        )
+                    else:
+                        block_reason = (
+                            "recent successful run kept respawn-guarding this "
+                            "ready task — external review needed"
+                        )
+                    block_task(conn, row["id"], reason=block_reason, kind="capability")
+                    result.auto_blocked.append(row["id"])
+                else:
+                    with write_txn(conn):
+                        _append_event(
+                            conn, row["id"], "respawn_guarded",
+                            {"reason": guard_reason},
+                        )
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -8,6 +8,7 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 from __future__ import annotations
 
 import inspect
+from types import SimpleNamespace
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 
@@ -67,3 +68,23 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+def test_all_ready_deferred_by_respawn_guard_helpers():
+    from gateway.kanban_watchers import (
+        _all_spawnable_ready_deferred_by_respawn_guard,
+        _respawn_guard_summary,
+    )
+
+    guarded = SimpleNamespace(
+        spawnable_ready=2,
+        respawn_guarded=[("t1", "active_pr"), ("t2", "active_pr")],
+    )
+    mixed = SimpleNamespace(
+        spawnable_ready=2,
+        respawn_guarded=[("t1", "active_pr")],
+    )
+
+    assert _all_spawnable_ready_deferred_by_respawn_guard([("default", guarded)])
+    assert not _all_spawnable_ready_deferred_by_respawn_guard([("default", mixed)])
+    assert _respawn_guard_summary([("default", guarded)]) == "active_pr×2"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -17,6 +17,10 @@ import pytest
 from hermes_cli import kanban_db as kb
 
 
+def _cache_pr_state(url: str, is_open: bool = True) -> None:
+    kb._RESPAWN_GUARD_PR_STATE_CACHE[url] = (int(time.time()), is_open)
+
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with an empty kanban DB."""
@@ -1919,14 +1923,45 @@ def test_respawn_guard_stale_success_not_guarded(kanban_home):
 
 def test_respawn_guard_active_pr_in_comment(kanban_home):
     """A GitHub PR URL in a recent comment triggers active_pr."""
+    url = "https://github.com/totemx-AI/subsidysmart/pull/42"
+    _cache_pr_state(url, True)
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
         kb.add_comment(
             conn, t, "worker",
-            "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
+            f"PR created: {url}",
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "active_pr"
+
+
+def test_respawn_guard_closed_pr_comment_not_guarded(kanban_home):
+    """A recent PR comment with a closed/merged signal is not active."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="closed-pr", assignee="alice")
+        kb.add_comment(
+            conn, t, "reviewer",
+            "CLOSED PR https://github.com/totemx-AI/subsidysmart/pull/967",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_closed_pr_state_not_guarded(kanban_home, monkeypatch):
+    """If GitHub reports the referenced PR is closed, active_pr is released."""
+    url = "https://github.com/totemx-AI/subsidysmart/pull/123"
+    kb._RESPAWN_GUARD_PR_STATE_CACHE.clear()
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[:4] == ["gh", "pr", "view", url]
+        return subprocess.CompletedProcess(cmd, 0, stdout="CLOSED\n", stderr="")
+
+    monkeypatch.setattr(kb.subprocess, "run", fake_run)
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="closed-pr-state", assignee="alice")
+        kb.add_comment(conn, t, "worker", f"PR created: {url}")
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
 
 
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
@@ -2019,6 +2054,8 @@ def test_dispatch_respawn_guard_skips_active_pr(
     kanban_home, all_assignees_spawnable
 ):
     """dispatch_once skips (but does not block) a task with an active PR comment."""
+    url = "https://github.com/totemx-AI/subsidysmart/pull/99"
+    _cache_pr_state(url, True)
     spawned_ids = []
 
     def fake_spawn(task, workspace):
@@ -2028,7 +2065,7 @@ def test_dispatch_respawn_guard_skips_active_pr(
         t = kb.create_task(conn, title="has-pr", assignee="alice")
         kb.add_comment(
             conn, t, "worker",
-            "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
+            f"Opened {url}",
         )
         res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
 
@@ -2037,6 +2074,38 @@ def test_dispatch_respawn_guard_skips_active_pr(
     assert t not in res.auto_blocked
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_respawn_guard_escalates_active_pr_after_threshold(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Repeated active_pr deferrals transition to blocked instead of livelocking."""
+    monkeypatch.setenv("HERMES_KANBAN_RESPAWN_GUARD_MAX_TICKS", "2")
+    url = "https://github.com/totemx-AI/subsidysmart/pull/99"
+    _cache_pr_state(url, True)
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="stale-pr", assignee="alice")
+        kb.add_comment(
+            conn, t, "worker",
+            f"Opened {url}",
+        )
+        first = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        assert (t, "active_pr") in first.respawn_guarded
+        first_task = kb.get_task(conn, t)
+        assert first_task is not None
+        assert first_task.status == "ready"
+
+        second = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert (t, "active_pr") in second.respawn_guarded
+    assert t in second.auto_blocked
+    assert task is not None
+    assert task.status == "blocked"
+    blocked = [e for e in events if e.kind == "blocked"][-1]
+    assert blocked.payload is not None
+    assert "PR #99 open but unmergeable" in blocked.payload["reason"]
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane (claude lane) — framework-bug item t_65c04de7.

## Change
Fixes the dispatcher respawn guard livelock for ready cards with stale active PR references. Closed/merged PR comments now release the active_pr guard, repeated active_pr/recent_success deferrals escalate to blocked, and gateway health telemetry logs all-ready respawn-guard deferrals as INFO instead of profile-health warnings.

## Evidence
Tests: `/Users/sweetheart/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_pre_gateway_dispatch.py tests/hermes_cli/test_gateway_s6_dispatch.py -q` → 32 passed. Tests: `/Users/sweetheart/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/gateway/test_kanban_watchers_mixin.py -q` → 238 passed. Diff: 4 files changed, 309 insertions(+), 14 deletions(-).

## Auth-only Proof
N/A
