### PR TITLE
fix(cli): fail loudly when gateway setup runs on non-TTY terminals

### DIFF
--- a/hermes_cli/secret_prompt.py
+++ b/hermes_cli/secret_prompt.py
@@ -63,7 +63,13 @@ def masked_secret_prompt(prompt: str, *, mask: str = "*") -> str:
     stdout = sys.stdout
 
     if not _stream_is_tty(stdin) or not _stream_is_tty(stdout):
-        return getpass.getpass(prompt)
+        # Cannot control echo — getpass.getpass() will fail silently on non-TTY.
+        # Raise an explicit error so the caller can provide actionable guidance.
+        raise RuntimeError(
+            "Secret input requires an interactive terminal. "
+            "Run this command in a native terminal (not a multiplexer, IDE, or piped input), "
+            "or configure platforms non-interactively via `hermes config set` and .env files."
+        )
 
     if os.name == "nt":
         try:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -212,6 +212,11 @@ def prompt(question: str, default: str = None, password: bool = False) -> str:
 
         cleaned = _sanitize_pasted_input(value)
         return cleaned.strip() or default or ""
+    except RuntimeError as e:
+        # Secret prompt requires TTY — provide actionable guidance
+        print()
+        print_error(str(e))
+        sys.exit(1)
     except (KeyboardInterrupt, EOFError):
         print()
         sys.exit(1)

--- a/tests/hermes_cli/test_secret_prompt.py
+++ b/tests/hermes_cli/test_secret_prompt.py
@@ -50,13 +50,13 @@ def test_collect_masked_input_raises_keyboard_interrupt():
     assert "".join(output) == "API key: \r\n"
 
 
-def test_masked_secret_prompt_falls_back_to_getpass_for_non_tty(monkeypatch):
+def test_masked_secret_prompt_raises_on_non_tty(monkeypatch):
     class NonTty:
         def isatty(self):
             return False
 
     monkeypatch.setattr("sys.stdin", NonTty())
     monkeypatch.setattr("sys.stdout", NonTty())
-    monkeypatch.setattr("getpass.getpass", lambda prompt: f"value from {prompt}")
 
-    assert masked_secret_prompt("API key: ") == "value from API key: "
+    with pytest.raises(RuntimeError, match="Secret input requires an interactive terminal"):
+        masked_secret_prompt("API key: ")

--- a/tests/hermes_cli/test_secret_prompt_tty.py
+++ b/tests/hermes_cli/test_secret_prompt_tty.py
@@ -1,0 +1,29 @@
+"""Tests for masked_secret_prompt TTY detection and error handling."""
+
+import pytest
+import sys
+from unittest.mock import patch, MagicMock
+
+from hermes_cli.secret_prompt import masked_secret_prompt
+
+
+def test_non_tty_raises_runtime_error():
+    """masked_secret_prompt raises RuntimeError on non-TTY stdin/stdout."""
+    with patch("hermes_cli.secret_prompt._stream_is_tty", return_value=False):
+        with pytest.raises(RuntimeError) as exc_info:
+            masked_secret_prompt("Test: ")
+
+        error_msg = str(exc_info.value)
+        assert "interactive terminal" in error_msg
+        assert "hermes config set" in error_msg or ".env" in error_msg
+
+
+def test_tty_stream_isatty_exception():
+    """_stream_is_tty handles exceptions gracefully."""
+    # Simulate isatty() raising an exception
+    fake_stream = MagicMock()
+    fake_stream.isatty.side_effect = OSError("Mock TTY error")
+
+    from hermes_cli.secret_prompt import _stream_is_tty
+
+    assert _stream_is_tty(fake_stream) is False

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -510,8 +510,8 @@ class TestPostSetup:
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
-        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
+        monkeypatch.setattr("hermes_cli.secret_prompt.masked_secret_prompt", lambda prompt="": "sk-local-test")
+        monkeypatch.setattr("sys.stdin", type("F", (), {"isatty": lambda self: True, "readline": lambda self: ""})())
         saved_configs = []
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
 
@@ -544,8 +544,8 @@ class TestPostSetup:
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
-        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
+        monkeypatch.setattr("hermes_cli.secret_prompt.masked_secret_prompt", lambda prompt="": "***")
+        monkeypatch.setattr("sys.stdin", type("F", (), {"isatty": lambda self: True, "readline": lambda self: ""})())
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
 
         provider = HindsightMemoryProvider()
@@ -567,8 +567,8 @@ class TestPostSetup:
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
-        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+        monkeypatch.setattr("hermes_cli.secret_prompt.masked_secret_prompt", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin", type("F", (), {"isatty": lambda self: True, "readline": lambda self: ""})())
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
 
         env_path = hermes_home / ".env"
@@ -612,8 +612,8 @@ class TestPostSetup:
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: kwargs.get("default", 0))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
-        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+        monkeypatch.setattr("hermes_cli.secret_prompt.masked_secret_prompt", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin", type("F", (), {"isatty": lambda self: True, "readline": lambda self: ""})())
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
 
         provider = HindsightMemoryProvider()


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes gateway setup` silently no-opping on terminals without echo control. On terminals where Python cannot control echo (tmux/screen in some configs, certain SSH/pty setups, IDE-embedded terminals), `getpass.getpass()` emits a GetPassWarning and falls back to `fallback_getpass()`, which cannot read from non-interactive stdin. This causes the setup wizard to silently skip every field and return to the menu, appearing as an instant flash/no-op.

The fix makes `masked_secret_prompt()` raise a clear RuntimeError with actionable guidance when stdin/stdout are not TTY, instead of falling back to `getpass.getpass()`. The `prompt()` caller catches RuntimeError and prints the error message before exiting, so users see an actionable error instead of a silent no-op.

## Related Issue

Fixes #64093

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/secret_prompt.py`: In `masked_secret_prompt()`, raise RuntimeError with actionable guidance when stdin/stdout are not TTY, instead of falling back to `getpass.getpass()`.
- `hermes_cli/setup.py`: In `prompt()`, catch RuntimeError and print the error message before exiting.
- `tests/hermes_cli/test_secret_prompt_tty.py`: Add regression tests for TTY detection and RuntimeError handling.

## How to Test

1. On a native terminal, run `hermes gateway setup` and select a platform (e.g., Telegram). The prompt should work normally.
2. On a non-TTY terminal (e.g., `printf '1\n\n' | hermes gateway setup`), the command should fail with a clear error message:
   ```
   RuntimeError: Secret input requires an interactive terminal. Run this command in a native terminal (not a multiplexer, IDE, or piped input), or configure platforms non-interactively via `hermes config set` and .env files.
   ```
3. Run `pytest tests/hermes_cli/test_secret_prompt_tty.py -q` — both tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A