### PR TITLE
fix(kanban): persist creator chat_type so DM/thread wakes route correctly (#56580)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -514,27 +514,12 @@ class GatewayKanbanWatchersMixin:
                                     )
                                     from gateway.session import SessionSource
                                     from gateway.platforms.base import MessageEvent, MessageType
-                                    # KNOWN LIMITATION (tracked follow-up): the
-                                    # subscription row does not persist the
-                                    # creator's chat_type, and it is not carried
-                                    # on the session-context bridge, so we cannot
-                                    # faithfully reconstruct the creator's real
-                                    # session key here. build_session_key() keys
-                                    # DMs (":dm:<chat_id>") on a wholly different
-                                    # shape from group/thread, so any hardcoded
-                                    # value mis-routes some creators. "group" is
-                                    # the least-surprising default for the
-                                    # dashboard/group flows this wake primarily
-                                    # serves; DM-originated creators are handled
-                                    # by the follow-up that stamps + persists
-                                    # chat_type end-to-end. handle_message()
-                                    # get_or_create_session's the target, so a
-                                    # mismatch degrades to "wake lands in a fresh
-                                    # group session" — never an exception.
+                                    # chat_type persisted on sub row (issue #56580). Fall back to
+                                    # "group" for legacy rows; handle_message rebuilds the key.
                                     _source = SessionSource(
                                         platform=plat,
                                         chat_id=sub["chat_id"],
-                                        chat_type="group",
+                                        chat_type=sub.get("chat_type") or "group",
                                         thread_id=sub.get("thread_id") or None,
                                         user_id=sub.get("user_id"),
                                         profile=sub_profile or None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16747,6 +16747,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
+            chat_type=context.source.chat_type or "",
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -77,6 +77,7 @@ _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
+_SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # In-process UI session/window id for multi-session desktop/TUI hosts. This is
@@ -128,6 +129,7 @@ _VAR_MAP = {
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
@@ -162,6 +164,7 @@ def set_session_vars(
     thread_id: str = "",
     user_id: str = "",
     user_name: str = "",
+    chat_type: str = "",
     session_key: str = "",
     session_id: str = "",
     message_id: str = "",
@@ -198,6 +201,7 @@ def set_session_vars(
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_KEY.set(session_key),
         _SESSION_ID.set(session_id),
         _SESSION_UI_SESSION_ID.set(ui_session_id),
@@ -233,6 +237,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
+        _SESSION_CHAT_TYPE,
         _SESSION_KEY,
         _SESSION_ID,
         _SESSION_UI_SESSION_ID,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -478,6 +478,7 @@ class GatewaySlashCommandsMixin:
                         platform.value if hasattr(platform, "value") else str(platform or "")
                     ).lower()
                     chat_id = str(getattr(source, "chat_id", "") or "")
+                    chat_type = str(getattr(source, "chat_type", "") or "")
                     thread_id = str(getattr(source, "thread_id", "") or "")
                     user_id = str(getattr(source, "user_id", "") or "") or None
                     if platform_str and chat_id:
@@ -488,6 +489,7 @@ class GatewaySlashCommandsMixin:
                                 _kb.add_notify_sub(
                                     conn, task_id=task_id,
                                     platform=platform_str, chat_id=chat_id,
+                                    chat_type=chat_type,
                                     thread_id=thread_id or None,
                                     user_id=user_id,
                                     notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -720,6 +720,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_nsub.add_argument("task_id")
     p_nsub.add_argument("--platform", required=True)
     p_nsub.add_argument("--chat-id", required=True)
+    p_nsub.add_argument("--chat-type", default="", help="dm / group / channel (used by wake routing)")
     p_nsub.add_argument("--thread-id", default=None)
     p_nsub.add_argument("--user-id", default=None)
     p_nsub.add_argument(
@@ -2610,6 +2611,7 @@ def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
         kb.add_notify_sub(
             conn, task_id=args.task_id,
             platform=args.platform, chat_id=args.chat_id,
+            chat_type=args.chat_type,
             thread_id=args.thread_id, user_id=args.user_id,
             notifier_profile=args.notifier_profile or _profile_author(),
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1256,6 +1256,7 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     task_id       TEXT NOT NULL,
     platform      TEXT NOT NULL,
     chat_id       TEXT NOT NULL,
+    chat_type     TEXT NOT NULL DEFAULT '',
     thread_id     TEXT NOT NULL DEFAULT '',
     user_id       TEXT,
     notifier_profile TEXT,
@@ -2361,6 +2362,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
+        # chat_type (issue #56580): wake needs creator's chat_type to rebuild
+        # the session key — DM keys differ in shape from group/thread. Default
+        # "" keeps legacy rows working; watchers fall back to "group".
+        if "chat_type" not in notify_cols:
+            _add_column_if_missing(
+                conn, "kanban_notify_subs", "chat_type", "chat_type TEXT NOT NULL DEFAULT ''"
+            )
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -2483,8 +2491,8 @@ _REBUILD_SPECS = {
     "kanban_notify_subs": (
         "CREATE TABLE kanban_notify_subs ("
         " task_id TEXT NOT NULL, platform TEXT NOT NULL, chat_id TEXT NOT NULL,"
-        " thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,"
-        " notifier_profile TEXT, created_at INTEGER NOT NULL,"
+        " chat_type TEXT NOT NULL DEFAULT '', thread_id TEXT NOT NULL DEFAULT '',"
+        " user_id TEXT, notifier_profile TEXT, created_at INTEGER NOT NULL,"
         " last_event_id INTEGER NOT NULL DEFAULT 0,"
         " PRIMARY KEY (task_id, platform, chat_id, thread_id))",
         ("CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id)",),
@@ -9103,6 +9111,7 @@ def add_notify_sub(
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
     notifier_profile: Optional[str] = None,
+    chat_type: str = "",
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
@@ -9111,10 +9120,10 @@ def add_notify_sub(
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (task_id, platform, chat_id, chat_type, thread_id, user_id, notifier_profile, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (task_id, platform, chat_id, chat_type or "", thread_id or "", user_id, notifier_profile, now),
         )
         if notifier_profile:
             # Self-heal legacy rows that predate notifier ownership by
@@ -9127,6 +9136,18 @@ def add_notify_sub(
                    AND (notifier_profile IS NULL OR notifier_profile = '')
                 """,
                 (notifier_profile, task_id, platform, chat_id, thread_id or ""),
+            )
+        if chat_type:
+            # Self-heal legacy rows that predate chat_type persistence (#56580):
+            # backfill empty values so wake routing can use the right chat_type.
+            conn.execute(
+                """
+                UPDATE kanban_notify_subs
+                   SET chat_type = ?
+                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                   AND chat_type = ''
+                """,
+                (chat_type, task_id, platform, chat_id, thread_id or ""),
             )
 
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -307,3 +307,109 @@ def _unseen_terminal_events_for(tid, chat_id):
         return events
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# chat_type persistence + wake routing (issue #56580)
+# ---------------------------------------------------------------------------
+
+
+class WakeCapturingAdapter:
+    """Records both notification sends and wake-up handle_message calls so a
+    test can assert the synthetic wake SessionSource carries the right
+    chat_type (the bug: hardcoded "group" mis-routed DM/thread creators)."""
+
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def _task_with_session(session_id: str, chat_type: str = "") -> str:
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="wake-route task", assignee="worker",
+            session_id=session_id,
+        )
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram",
+            chat_id="dm-123", chat_type=chat_type,
+        )
+        kb.complete_task(conn, tid, summary="done")
+        return tid
+    finally:
+        conn.close()
+
+
+def test_wake_uses_persisted_dm_chat_type(tmp_path, monkeypatch):
+    """DM-originated sub must wake a SessionSource with chat_type='dm', not
+    the legacy hardcoded 'group' (issue #56580)."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake.db"))
+    kb.init_db()
+
+    _task_with_session(
+        session_id="agent:main:telegram:dm:dm-123", chat_type="dm",
+    )
+
+    adapter = WakeCapturingAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.handled) == 1, "wake handle_message should fire once"
+    wake_source = adapter.handled[0].source
+    assert wake_source.chat_type == "dm", (
+        f"DM sub wake must preserve chat_type='dm' (got {wake_source.chat_type!r})"
+    )
+    assert wake_source.chat_id == "dm-123"
+
+
+def test_wake_falls_back_to_group_for_legacy_rows(tmp_path, monkeypatch):
+    """Sub rows written before the chat_type column existed (or with empty
+    chat_type) must keep degrading to 'group' so existing flows don't break."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-legacy.db"))
+    kb.init_db()
+
+    _task_with_session(
+        session_id="agent:main:telegram:group:legacy", chat_type="",
+    )
+
+    adapter = WakeCapturingAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.handled) == 1
+    assert adapter.handled[0].source.chat_type == "group", (
+        "empty chat_type on sub row must fall back to 'group'"
+    )
+
+
+def test_add_notify_sub_persists_and_self_heals_chat_type(tmp_path, monkeypatch):
+    """add_notify_sub writes chat_type on insert and backfills it on a later
+    call if the row predated the column (self-heal for legacy rows)."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "chat-type.db"))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="persist test", assignee="worker")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c1",
+        )
+        row = kb.list_notify_subs(conn, tid)[0]
+        assert row["chat_type"] == ""
+
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c1", chat_type="dm",
+        )
+        row = kb.list_notify_subs(conn, tid)[0]
+        assert row["chat_type"] == "dm"
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1258,6 +1258,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             chat_id = session_key
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+        chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "")
         notifier_profile = (
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
@@ -1270,6 +1271,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             platform=platform, chat_id=chat_id,
             thread_id=thread_id, user_id=user_id,
             notifier_profile=notifier_profile,
+            chat_type=chat_type,
         )
         return True
     except Exception as _exc:


### PR DESCRIPTION
## Summary

Implements the 4-step fix proposed in #56580. The kanban creator-agent wake was building a synthetic `SessionSource` with hardcoded `chat_type="group"`, but `build_session_key()` shapes DM keys (`":dm:<chat_id>"`) on a wholly different template than group/thread keys. For tasks created from a DM (the common case for a personal agent) or a thread, the wake resolved to a different session key and silently landed in a fresh/empty session instead of the creator's actual conversation.

Per @agautam's production measurement on the issue, every mis-routed wake also paid a full-context prompt-cache re-write on the premium model (~10× cost penalty), because the forked session started at 0% cache hit.

## Changes

| File | What |
|------|------|
| `gateway/session_context.py` | Add `HERMES_SESSION_CHAT_TYPE` ContextVar + `_VAR_MAP` entry + `set_session_vars`/`clear_session_vars` kwargs (backward-compatible default `""`). |
| `gateway/run.py::_set_session_env` | Stamp `chat_type` from `context.source.chat_type` at session-bind time. |
| `hermes_cli/kanban_db.py` | Add `chat_type` column to `kanban_notify_subs`: `CREATE TABLE` + `_REBUILD_SPECS` + additive `_add_column_if_missing` migration + self-heal backfill in `add_notify_sub`. New `chat_type` kwarg on `add_notify_sub`. |
| `tools/kanban_tools.py::_maybe_auto_subscribe` | Read `HERMES_SESSION_CHAT_TYPE` from session context and pass it to `add_notify_sub`. |
| `gateway/kanban_watchers.py` | Use `sub["chat_type"]` (fall back to `"group"` for legacy rows written before the column existed) when building the wake `SessionSource`. `handle_message`'s existing `build_session_key` path then reconstructs the creator's real key. |

## Tests

3 new tests in `tests/gateway/test_kanban_notifier.py`:
- `test_wake_uses_persisted_dm_chat_type` — DM sub produces a wake `SessionSource` with `chat_type="dm"` (regression test for the bug).
- `test_wake_falls_back_to_group_for_legacy_rows` — empty `chat_type` on legacy rows falls back to `"group"` so existing flows don't break.
- `test_add_notify_sub_persists_and_self_heals_chat_type` — `add_notify_sub` writes `chat_type` on insert and self-heals it on later calls when the row predated the column.

Full kanban + session_context suites pass (366 tests, 0 failures).

## Backward compatibility

- Legacy DBs without the `chat_type` column are migrated via `_add_column_if_missing` with `DEFAULT ''`. Legacy rows have empty `chat_type`; the wake site falls back to `"group"` (byte-identical behavior to before).
- `add_notify_sub`'s new `chat_type` kwarg defaults to `""`, so existing callers (e.g. plugins that copy subs) keep working without modification — they just don't persist `chat_type` yet, which the wake site handles via the `"group"` fallback.
- The schema-rebuild test (`test_rebuilt_schema_matches_fresh_db`) caught a `_REBUILD_SPECS` drift; both `SCHEMA_SQL` and `_REBUILD_SPECS` now include `chat_type` in the same position, so rebuilt legacy DBs structurally match fresh DBs.

Closes #56580.