### PR TITLE
fix(qqbot): handle GROUP_MESSAGE_CREATE event (QQ changed event format)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -850,6 +850,7 @@ class QQAdapter(BasePlatformAdapter):
             elif t in {
                     "C2C_MESSAGE_CREATE",
                     "GROUP_AT_MESSAGE_CREATE",
+                    "GROUP_MESSAGE_CREATE",
                     "DIRECT_MESSAGE_CREATE",
                     "GUILD_MESSAGE_CREATE",
                     "GUILD_AT_MESSAGE_CREATE",
@@ -949,7 +950,7 @@ class QQAdapter(BasePlatformAdapter):
         # Route by event type
         if event_type == "C2C_MESSAGE_CREATE":
             await self._handle_c2c_message(d, msg_id, content, author, timestamp)
-        elif event_type in {"GROUP_AT_MESSAGE_CREATE",}:
+        elif event_type in {"GROUP_AT_MESSAGE_CREATE", "GROUP_MESSAGE_CREATE",}:
             await self._handle_group_message(d, msg_id, content, author, timestamp)
         elif event_type in {"GUILD_MESSAGE_CREATE", "GUILD_AT_MESSAGE_CREATE"}:
             await self._handle_guild_message(d, msg_id, content, author, timestamp)


### PR DESCRIPTION
Fixes #63761

QQ changed the group message event from `GROUP_AT_MESSAGE_CREATE` to `GROUP_MESSAGE_CREATE`. The gateway log showed:

```
[QQBot:102929556] Unhandled dispatch: GROUP_MESSAGE_CREATE
```

This adds `GROUP_MESSAGE_CREATE` alongside `GROUP_AT_MESSAGE_CREATE` in both the dispatch handler and the message routing handler, so group messages continue to work with QQ's updated API while retaining backward compatibility with the old event name.