### PR TITLE
fix(acp): preserve custom provider namespace in session persist/restore

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -423,6 +423,11 @@ class SessionManager:
         model_str = str(state.model) if state.model else None
         session_meta = {"cwd": state.cwd}
         provider = getattr(state.agent, "provider", None)
+        # Use the original requested provider (e.g. "custom:anthropic") instead
+        # of the normalized "custom" so ACP session restore can match named
+        # custom_providers entries. Falls back to agent.provider for agents
+        # that were not created via ACP _make_agent.
+        provider = getattr(state.agent, "_acp_requested_provider", None) or provider
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
         if isinstance(provider, str) and provider.strip():
@@ -650,4 +655,10 @@ class SessionManager:
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
         # Route any incidental human-readable agent output to stderr instead.
         agent._print_fn = _acp_stderr_print
+        # Preserve the original requested provider name (e.g. "custom:anthropic")
+        # so ACP session persist stores the full namespace-qualified name, not
+        # the normalized "custom" — fixes restore of named custom providers.
+        _req_prov = runtime.get("requested_provider", "")
+        if _req_prov:
+            agent._acp_requested_provider = _req_prov
         return agent


### PR DESCRIPTION
Fixes #63681

## Problem
ACP session persistence stores `agent.provider` (normalized to `"custom"`) into the DB metadata, losing the namespace qualifier (`"custom:anthropic"`). On restore, `resolve_runtime_provider(requested="custom")` cannot find the named custom provider entry, causing auth failures.

## Root cause chain
1. `_make_agent()` resolves `custom:anthropic` → result has `provider="custom"` (normalized)
2. `agent.provider = "custom"` → persist stores `"custom"` in metadata
3. `_restore()` reads `"custom"` back → passes to `resolve_runtime_provider("custom")` → no match for `custom:anthropic`

## Fix
Save the original `requested_provider` (e.g. `"custom:anthropic"`) from the runtime dict onto the agent instance as `_acp_requested_provider`. Use it during persist instead of the normalized `agent.provider` field.

## Testing
- Agent instantiated outside ACP (no `_acp_requested_provider`) falls back to `agent.provider` — no behavior change.
- TUI/CLI path reads config.yaml directly every time — unaffected.