### PR TITLE
fix(oidc): add User-Agent header to PyJWKClient for Cloudflare/WAF compatibility

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -601,6 +601,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 disco["jwks_uri"],
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={"User-Agent": "Hermes-Dashboard/1.0"},
             )
         return self._jwks_client
 


### PR DESCRIPTION
Fixes #63273

## Problem
SelfHostedOIDCProvider's JWKS key fetch uses Python `urllib` default User-Agent, which Cloudflare and other WAFs block (HTTP 403 / error 1010). The browser successfully completes the OIDC flow but Hermes fails to retrieve the signing key.

## Root Cause
`PyJWKClient` at `_get_jwks_client()` is constructed without any `headers` parameter, so `urllib` sends its default User-Agent (`Python-urllib/3.x`) which is commonly blocked by WAF policies.

## Fix
Add `headers={"User-Agent": "Hermes-Dashboard/1.0"}` to the `PyJWKClient` constructor. This makes the JWKS request pass standard WAF checks while retaining full TLS and JWT signature verification.