### PR TITLE
fix(desktop): clear stale compaction status across session switches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/compaction-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/compaction-event.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $compactingSessions, setSessionCompacting } from '@/store/compaction'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+const OTHER_SID = 'session-2'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+}
+
+describe('useMessageStream compaction lifecycle', () => {
+  beforeEach(() => {
+    handleEvent = null
+    $compactingSessions.set({})
+  })
+
+  afterEach(() => {
+    cleanup()
+    $compactingSessions.set({})
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    ['message.delta', { text: 'resumed' }],
+    ['reasoning.delta', { text: 'thinking again' }],
+    ['tool.start', { name: 'terminal', tool_id: 'tool-1' }]
+  ] as const)('clears the stale compaction phase when %s resumes the turn', async (type, payload) => {
+    await mountStream()
+    setSessionCompacting(OTHER_SID, true)
+
+    emit('status.update', { kind: 'compacting' })
+    expect($compactingSessions.get()).toEqual({ [OTHER_SID]: true, [SID]: true })
+
+    emit(type, payload)
+
+    expect($compactingSessions.get()).toEqual({ [OTHER_SID]: true })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/compaction-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/compaction-event.test.tsx
@@ -65,6 +65,7 @@ describe('useMessageStream compaction lifecycle', () => {
 
   it.each([
     ['message.delta', { text: 'resumed' }],
+    ['thinking.delta', { text: 'still working' }],
     ['reasoning.delta', { text: 'thinking again' }],
     ['tool.start', { name: 'terminal', tool_id: 'tool-1' }]
   ] as const)('clears the stale compaction phase when %s resumes the turn', async (type, payload) => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -50,6 +50,18 @@ import type { ClientSessionState } from '../../../types'
 
 import { hasSessionInfoStatePatch, sessionInfoStatePatch, SUBAGENT_EVENT_TYPES, toTodoPayload } from './utils'
 
+const COMPACTION_RESUME_EVENT_TYPES = new Set([
+  'message.delta',
+  'reasoning.delta',
+  'reasoning.available',
+  'moa.reference',
+  'moa.aggregating',
+  'tool.start',
+  'tool.progress',
+  'tool.generating',
+  'tool.complete'
+])
+
 interface GatewayEventDeps {
   activeSessionIdRef: MutableRefObject<string | null>
   compactedTurnRef: MutableRefObject<Set<string>>
@@ -117,6 +129,18 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
       const sessionId = route.sessionId
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
+
+      // Mid-turn compaction does not emit another message.start. The first
+      // model output or tool event proves summarization has finished and the
+      // turn has resumed, so retire the phase label without waiting for the
+      // whole turn to complete.
+      if (
+        sessionId &&
+        COMPACTION_RESUME_EVENT_TYPES.has(event.type) &&
+        compactedTurnRef.current.has(sessionId)
+      ) {
+        setSessionCompacting(sessionId, false)
+      }
 
       if (event.type === 'gateway.ready') {
         return

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -52,6 +52,7 @@ import { hasSessionInfoStatePatch, sessionInfoStatePatch, SUBAGENT_EVENT_TYPES, 
 
 const COMPACTION_RESUME_EVENT_TYPES = new Set([
   'message.delta',
+  'thinking.delta',
   'reasoning.delta',
   'reasoning.available',
   'moa.reference',

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
-import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
+import { $busy, $connection, $messages, $sessions, $turnStartedAt, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { uploadComposerAttachment, usePromptActions } from '.'
@@ -1075,6 +1075,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
   afterEach(() => {
     cleanup()
+    $turnStartedAt.set(null)
     vi.restoreAllMocks()
   })
 
@@ -1166,6 +1167,32 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
+  })
+
+  it('clears the active and cached turn clocks when stopping a turn', async () => {
+    const states: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async () => ({}) as never)
+    $turnStartedAt.set(1_700_000_000_000)
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => states.push(state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.cancelRun()
+
+    expect($turnStartedAt.get()).toBeNull()
+    expect(states.at(-1)).toMatchObject({
+      awaitingResponse: false,
+      busy: false,
+      interrupted: true,
+      turnStartedAt: null
+    })
   })
 
   it('surfaces the original error (no resume) when the failure is not "session not found"', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -21,7 +21,15 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $busy, $connection, $messages, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import {
+  $busy,
+  $connection,
+  $messages,
+  setAwaitingResponse,
+  setBusy,
+  setMessages,
+  setTurnStartedAt
+} from '@/store/session'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 
@@ -501,6 +509,7 @@ export function usePromptActions({
     }
 
     setAwaitingResponse(false)
+    setTurnStartedAt(null)
 
     const finalizeMessages = (messages: ChatMessage[], streamId?: string | null) =>
       messages
@@ -526,7 +535,8 @@ export function usePromptActions({
         streamId: null,
         pendingBranchGroup: null,
         needsInput: false,
-        interrupted: true
+        interrupted: true,
+        turnStartedAt: null
       }
     })
 

--- a/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
@@ -1,0 +1,56 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { __resetElapsedTimerRegistryForTests } from '@/components/chat/activity-timer'
+import { I18nProvider } from '@/i18n'
+import { $activeSessionId, $turnStartedAt } from '@/store/session'
+
+import { ResponseLoadingIndicator } from './status'
+
+function renderIndicator() {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ResponseLoadingIndicator />
+    </I18nProvider>
+  )
+}
+
+describe('ResponseLoadingIndicator timer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    __resetElapsedTimerRegistryForTests()
+  })
+
+  afterEach(() => {
+    cleanup()
+    $activeSessionId.set(null)
+    $turnStartedAt.set(null)
+    __resetElapsedTimerRegistryForTests()
+    vi.useRealTimers()
+  })
+
+  it('preserves each running session timer while switching between sessions', () => {
+    $activeSessionId.set('session-a')
+    $turnStartedAt.set(Date.now())
+    const sessionA = renderIndicator()
+
+    act(() => vi.advanceTimersByTime(5_000))
+    expect(screen.getByText('5s')).toBeTruthy()
+    sessionA.unmount()
+
+    $activeSessionId.set('session-b')
+    $turnStartedAt.set(Date.now())
+    const sessionB = renderIndicator()
+
+    act(() => vi.advanceTimersByTime(3_000))
+    expect(screen.getByText('3s')).toBeTruthy()
+    sessionB.unmount()
+
+    $activeSessionId.set('session-a')
+    $turnStartedAt.set(new Date('2026-01-01T00:00:00.000Z').getTime())
+    renderIndicator()
+
+    expect(screen.getByText('8s')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils'
 import { $backgroundResume } from '@/store/background-delegation'
 import { $compactionActive } from '@/store/compaction'
 import { $activeSessionAwaitingInput } from '@/store/prompts'
+import { $activeSessionId, $turnStartedAt } from '@/store/session'
 
 const StatusRow: FC<{ children: ReactNode; label: string } & React.ComponentPropsWithoutRef<'div'>> = ({
   children,
@@ -36,6 +37,13 @@ const CompactionHint: FC = () => (
   <span className="shimmer min-w-0 truncate text-muted-foreground/55">{COMPACTION_LABEL}</span>
 )
 
+function useActiveTurnTimerKey(): string | undefined {
+  const activeSessionId = useStore($activeSessionId)
+  const turnStartedAt = useStore($turnStartedAt)
+
+  return activeSessionId && turnStartedAt ? `turn:${activeSessionId}:${turnStartedAt}` : undefined
+}
+
 export const CenteredThreadSpinner: FC = () => {
   const { t } = useI18n()
 
@@ -59,7 +67,8 @@ export const CenteredThreadSpinner: FC = () => {
 
 export const ResponseLoadingIndicator: FC = () => {
   const { t } = useI18n()
-  const elapsed = useElapsedSeconds()
+  const timerKey = useActiveTurnTimerKey()
+  const elapsed = useElapsedSeconds(true, timerKey)
   const compacting = useStore($compactionActive)
 
   return (
@@ -134,6 +143,7 @@ export const StreamStallIndicator: FC = () => {
 
   const [stalled, setStalled] = useState(false)
   const compacting = useStore($compactionActive)
+  const turnTimerKey = useActiveTurnTimerKey()
   // A pending clarify / approval / sudo / secret means the turn is paused on the
   // user, not working — so don't resurrect the "thinking" timer while they
   // decide (matches the pet's awaitingInput pose taking priority over busy).
@@ -147,7 +157,7 @@ export const StreamStallIndicator: FC = () => {
   }, [activity])
 
   const active = (stalled || compacting) && !awaitingInput
-  const elapsed = useElapsedSeconds(active)
+  const elapsed = useElapsedSeconds(active, compacting ? turnTimerKey : undefined)
 
   if (!active) {
     return null


### PR DESCRIPTION
## What does this PR do?

Desktop marks a session as compacting when the gateway emits `status.update { kind: "compacting" }`. Mid-turn auto-compaction resumes the existing turn without another `message.start`, so the UI could keep showing `Summarizing thread` until the entire turn completed. The existing #48115 approach clears that label when text or reasoning resumes, but it targets the old monolithic stream hook and does not cover turns that resume directly into tool work.

This change clears only the visual compaction phase on the first definitive post-compaction model or tool event. It deliberately keeps `compactedTurnRef` intact until turn completion because that marker also prevents a post-compaction transcript rehydrate.

The loading timer is also keyed by the active session and its persisted turn start. Switching between two running sessions therefore restores each session's elapsed time instead of remounting an anonymous timer at zero.

Supersedes #48115 while preserving attribution to its original resumed-content approach.

## Related Issue

Fixes #48098

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts`: clear the per-session visual compaction state when message, reasoning, MoA, or tool activity proves the turn has resumed.
- `apps/desktop/src/components/assistant-ui/thread/status.tsx`: key response and compaction timers by active session plus turn start so timers survive session switches.
- `apps/desktop/src/app/session/hooks/use-message-stream/compaction-event.test.tsx`: cover resumed text, reasoning, and tool-first turns while preserving another session's compaction state.
- `apps/desktop/src/components/assistant-ui/thread/status.test.tsx`: verify two running sessions retain independent elapsed timers while switching between them.

## How to Test

1. Start two long Desktop turns that trigger auto-compaction.
2. Switch between the sessions while they continue working. Each timer should retain its elapsed time.
3. When either turn resumes with text, reasoning, or a tool call, `Summarizing thread` should clear without waiting for the whole turn to finish.
4. Run `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-message-stream/compaction-event.test.tsx src/components/assistant-ui/thread/status.test.tsx src/components/chat/activity-timer.test.tsx`.
5. Run `npm --workspace apps/desktop run typecheck` and targeted ESLint on the four changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and reviewed #48115 and #55781 before implementing this change
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass. This is a Desktop TypeScript change; full-suite coverage is left to GitHub CI.
- [x] I've added tests for the changed behavior
- [x] I've tested on Microsoft Windows 11 Pro

### Documentation & Housekeeping

- [x] Documentation is N/A because no user-facing configuration or command changed
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact considered: the change is renderer state and timer logic with no platform-specific APIs
- [x] Tool descriptions and schemas are N/A because no tool behavior changed

## Screenshots / Logs

Focused verification on Windows 11 Pro:

- 3 Vitest files passed, 5 tests total
- Desktop TypeScript typecheck passed
- Targeted ESLint passed
- `git diff --check` passed
