### PR TITLE
fix(local): remove redundant temp-file read in _update_cwd

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -160,13 +160,11 @@ class TestUpdateCwdRejectsMissingPaths:
         with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
             env = LocalEnvironment(cwd=str(original), timeout=10)
 
-        # Simulate the stale-marker case: the prior command's ``pwd -P`` left
-        # a path in the cwd file, but that path has since been deleted.
+        # Simulate the stale-marker case: the prior command's output embeds
+        # a path in the CWD marker, but that path has since been deleted.
         deleted = tmp_path / "wedge-repro"
-        with open(env._cwd_file, "w") as f:
-            f.write(str(deleted))
-
-        env._update_cwd({"output": "", "returncode": 0})
+        output = f"\n{env._cwd_marker}{deleted}{env._cwd_marker}\n"
+        env._update_cwd({"output": output, "returncode": 0})
 
         assert env.cwd == str(original)
 
@@ -179,9 +177,8 @@ class TestUpdateCwdRejectsMissingPaths:
         with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
             env = LocalEnvironment(cwd=str(original), timeout=10)
 
-        with open(env._cwd_file, "w") as f:
-            f.write(str(new_dir))
-
-        env._update_cwd({"output": "", "returncode": 0})
+        # Simulate the cwd path being updated in the stdout marker
+        output = f"\n{env._cwd_marker}{new_dir}{env._cwd_marker}\n"
+        env._update_cwd({"output": output, "returncode": 0})
 
         assert env.cwd == str(new_dir)

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -184,7 +184,7 @@ class TestUpdateCwdWindowsMsys:
     def test_marker_file_msys_path_stored_in_native_form(
         self, monkeypatch, tmp_path,
     ):
-        """When Git Bash writes ``/c/Users/x`` to the cwd marker file on
+        """When Git Bash writes ``/c/Users/x`` to the cwd marker in stdout on
         Windows, ``_update_cwd`` must translate to native form before
         validating and storing — otherwise ``os.path.isdir`` rejects a
         perfectly real directory."""
@@ -199,12 +199,11 @@ class TestUpdateCwdWindowsMsys:
         ):
             env = LocalEnvironment(cwd=str(original), timeout=10)
 
-        # Pretend Git Bash wrote an MSYS path that maps to tmp_path/"next"
+        # Pretend Git Bash wrote an MSYS path in the stdout marker
         new_dir = tmp_path / "next"
         new_dir.mkdir()
 
-        with open(env._cwd_file, "w") as f:
-            f.write("/c/whatever/from/bash")
+        output = f"\n{env._cwd_marker}/c/whatever/from/bash{env._cwd_marker}\n"
 
         # Translate the synthetic MSYS string to the real native dir.
         def fake_translate(p):
@@ -213,7 +212,7 @@ class TestUpdateCwdWindowsMsys:
             return p
 
         with patch.object(local_mod, "_msys_to_windows_path", side_effect=fake_translate):
-            env._update_cwd({"output": "", "returncode": 0})
+            env._update_cwd({"output": output, "returncode": 0})
 
         assert env.cwd == str(new_dir)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1231,31 +1231,16 @@ class LocalEnvironment(BaseEnvironment):
                 pass
 
     def _update_cwd(self, result: dict):
-        """Read CWD from temp file (local-only, no round-trip needed).
+        """Read CWD from stdout marker (already emitted by shell bootstrap).
 
-        Skip the assignment when the path no longer exists as a directory —
-        ``pwd -P`` on a deleted cwd can leave a stale value in the marker
-        file, and propagating it would re-wedge the next ``Popen``.  The
-        ``_run_bash`` recovery path will resolve a safe fallback if needed.
-
-        On Windows, the value written by Git Bash's ``pwd -P`` is in
-        MSYS form (``/c/Users/x``). Translate it to native Windows form
-        before validating with ``os.path.isdir`` and before storing on
-        ``self.cwd``; otherwise the isdir check rejects every valid
-        result and ``_run_bash`` later prints a misleading "cwd is
-        missing" warning on every command.
+        The shell bootstrap writes the working directory to both a temp file
+        and a ``__HERMES_CWD_<session>__`` stdout marker.  The base class
+        already parses the marker via ``_extract_cwd_from_output`` — reading
+        the temp file back is redundant I/O.  Delegate entirely to the
+        marker parser instead.
         """
-        try:
-            with open(self._cwd_file, encoding="utf-8") as f:
-                cwd_path = f.read().strip()
-            if _IS_WINDOWS:
-                cwd_path = _msys_to_windows_path(cwd_path)
-            if cwd_path and os.path.isdir(cwd_path):
-                self.cwd = cwd_path
-        except (OSError, FileNotFoundError):
-            pass
-
-        # Still strip the marker from output so it's not visible
+        # Delegate to the base marker-parser which is already used by every
+        # remote backend — no need for an extra temp-file read.
         self._extract_cwd_from_output(result)
 
     def _extract_cwd_from_output(self, result: dict):


### PR DESCRIPTION
Fixes #63225

## Problem
Every `terminal()` call triggers a redundant file read: the shell bootstrap writes the CWD to both a temp file (`/tmp/hermes-cwd-<session>.txt`) and a `__HERMES_CWD_<session>__` stdout marker, but `_update_cwd` was reading the temp file back in Python AND then calling `_extract_cwd_from_output` which parses the same value from the marker.

With ~2-3 terminal calls/second, this is ~12,000 redundant file I/O operations per hour.

## Fix
Remove the temp-file read block and delegate entirely to `_extract_cwd_from_output`, which already handles:
- Parsing the `__HERMES_CWD_<session>__` marker from stdout
- Windows MSYS → native path translation (via local override)
- Directory-existence validation
- Stripping the marker from output text

## Testing
All 45 tests in `test_local_env_cwd_recovery.py`, `test_local_env_windows_msys.py`, and `test_local_tempdir.py` pass. Updated the two tests that were simulating temp-file writes to instead embed the stdout marker.