### PR TITLE
fix(serve): bridge terminal.backend config to process environment

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17203,6 +17203,14 @@ def start_server(
         # after the socket is live (ephemeral port discovery).
         if not config.loaded:
             config.load()
+        # Bridge terminal.* config into the process environment so the
+        # terminal tool respects the user's sandbox/backend settings
+        # (TERMINAL_ENV, docker_volumes, etc.) in the serve process.
+        try:
+            from hermes_cli.config import apply_terminal_config_to_env
+            apply_terminal_config_to_env()
+        except Exception:
+            _log.debug("Failed to apply terminal config bridge for serve", exc_info=True)
         server.lifespan = config.lifespan_class(config)
         with server.capture_signals():
             await server.startup()


### PR DESCRIPTION
Fixes #63141

## Problem
`hermes serve` (the headless JSON-RPC/WS backend used by Hermes Desktop) never calls `apply_terminal_config_to_env()`, so `TERMINAL_ENV` is never set in the serve process. The terminal tool always runs in local mode regardless of `terminal.backend: docker` config.

The config bridge was only applied to child processes (TUI, dashboard PTY), never to the serve process itself.

## Fix
Add `apply_terminal_config_to_env()` call to `_serve()` after config is loaded, matching the pattern already used by the dashboard PTY launch path.

## Testing
- TUI and dashboard PTY paths already use this same function — no regression.
- Function reads config file internally (no parameter dependency).