### PR TITLE
fix(cli): drop escape-sequence tail in masked_secret_prompt on POSIX

### DIFF
--- a/hermes_cli/secret_prompt.py
+++ b/hermes_cli/secret_prompt.py
@@ -105,6 +105,56 @@ def _masked_secret_prompt_windows(prompt: str, *, mask: str) -> str:
     return _collect_masked_input(read_char, write, prompt, mask=mask)
 
 
+def _read_posix_raw_char(fd: int) -> str:
+    """Read one Unicode character from *fd* using ``os.read``.
+
+    Bypasses ``sys.stdin``'s ``TextIOWrapper`` buffer so it can't hide bytes
+    from the escape-sequence drain below. When the first byte is ESC (``\\x1b``),
+    any bytes belonging to a CSI/SS3 escape sequence (arrow keys, function
+    keys, Home/End, PageUp/PageDown, etc.) are drained with a short ``select``
+    poll so their tail (e.g. ``b"[A"`` for arrow-up) does not leak into the
+    caller's secret buffer. Every keystroke is masked, so without the drain
+    the corruption would be silent — the user would just see wrong-password
+    errors and no clue why. A 5 ms window is longer than any local terminal
+    takes to burst these bytes and shorter than a plausible human ESC-then-
+    typed-key interval.
+
+    Multi-byte UTF-8 code points are reassembled by reading continuation
+    bytes until the accumulated buffer decodes cleanly (max 4 bytes per
+    code point).
+    """
+    import select
+
+    try:
+        b = os.read(fd, 1)
+    except OSError:
+        return ""
+    if not b:
+        return ""
+    if b == b"\x1b":
+        while select.select([fd], [], [], 0.005)[0]:
+            try:
+                if not os.read(fd, 1):
+                    break
+            except OSError:
+                break
+        return "\x1b"
+    buf = bytearray(b)
+    for _ in range(3):
+        try:
+            return buf.decode("utf-8")
+        except UnicodeDecodeError:
+            pass
+        try:
+            more = os.read(fd, 1)
+        except OSError:
+            break
+        if not more:
+            break
+        buf.extend(more)
+    return buf.decode("utf-8", errors="replace")
+
+
 def _masked_secret_prompt_posix(prompt: str, *, mask: str) -> str:
     import termios
     import tty
@@ -113,7 +163,7 @@ def _masked_secret_prompt_posix(prompt: str, *, mask: str) -> str:
     old_attrs = termios.tcgetattr(fd)
 
     def read_char() -> str:
-        return sys.stdin.read(1)
+        return _read_posix_raw_char(fd)
 
     def write(text: str) -> None:
         sys.stdout.write(text)

--- a/hermes_cli/secret_prompt.py
+++ b/hermes_cli/secret_prompt.py
@@ -109,15 +109,25 @@ def _read_posix_raw_char(fd: int) -> str:
     """Read one Unicode character from *fd* using ``os.read``.
 
     Bypasses ``sys.stdin``'s ``TextIOWrapper`` buffer so it can't hide bytes
-    from the escape-sequence drain below. When the first byte is ESC (``\\x1b``),
-    any bytes belonging to a CSI/SS3 escape sequence (arrow keys, function
-    keys, Home/End, PageUp/PageDown, etc.) are drained with a short ``select``
-    poll so their tail (e.g. ``b"[A"`` for arrow-up) does not leak into the
-    caller's secret buffer. Every keystroke is masked, so without the drain
-    the corruption would be silent — the user would just see wrong-password
-    errors and no clue why. A 5 ms window is longer than any local terminal
-    takes to burst these bytes and shorter than a plausible human ESC-then-
-    typed-key interval.
+    from the escape-sequence handling below.
+
+    When the first byte is ESC (``\\x1b``), a follow-up byte is peeked for
+    within a short window:
+
+    * If it introduces a **CSI** (``\\x1b[``) or **SS3** (``\\x1bO``) sequence
+      (arrow keys, function keys, Home/End, PageUp/PageDown, etc.), the rest
+      of the sequence is consumed and ``"\\x1b"`` is returned — the collector
+      then skips the ESC. Every keystroke is masked, so leaving the tail bytes
+      in the buffer would silently corrupt the secret.
+    * If the follow-up byte is **not** a CSI/SS3 introducer, it's a Meta/Alt-
+      encoded key (``ESC + <char>``) or a paste that happens to start with
+      ESC. The follow-up byte is returned as an ordinary character so it
+      isn't silently dropped along with the ESC.
+    * If no follow-up byte arrives promptly, this is a lone Escape keypress;
+      ``"\\x1b"`` is returned and the collector skips it.
+
+    Sequence-tail reads use a small ``select`` window (5 ms) rather than a
+    blocking ``os.read`` so a malformed sequence can't hang the prompt.
 
     Multi-byte UTF-8 code points are reassembled by reading continuation
     bytes until the accumulated buffer decodes cleanly (max 4 bytes per
@@ -131,15 +141,51 @@ def _read_posix_raw_char(fd: int) -> str:
         return ""
     if not b:
         return ""
-    if b == b"\x1b":
-        while select.select([fd], [], [], 0.005)[0]:
+    if b != b"\x1b":
+        return _decode_utf8_char(fd, b)
+
+    if not select.select([fd], [], [], 0.005)[0]:
+        return "\x1b"
+    try:
+        nxt = os.read(fd, 1)
+    except OSError:
+        return "\x1b"
+    if not nxt:
+        return "\x1b"
+
+    if nxt == b"[":
+        # CSI: parameter bytes (0x30-0x3F) and intermediates (0x20-0x2F),
+        # terminated by a final byte in 0x40-0x7E. Bounded to avoid hanging
+        # on a malformed sequence.
+        for _ in range(32):
+            if not select.select([fd], [], [], 0.005)[0]:
+                break
             try:
-                if not os.read(fd, 1):
-                    break
+                tail = os.read(fd, 1)
             except OSError:
                 break
+            if not tail:
+                break
+            if 0x40 <= tail[0] <= 0x7E:
+                break
         return "\x1b"
-    buf = bytearray(b)
+
+    if nxt == b"O":
+        # SS3: exactly one final byte follows the introducer.
+        if select.select([fd], [], [], 0.005)[0]:
+            try:
+                os.read(fd, 1)
+            except OSError:
+                pass
+        return "\x1b"
+
+    return _decode_utf8_char(fd, nxt)
+
+
+def _decode_utf8_char(fd: int, first: bytes) -> str:
+    """Decode one UTF-8 code point starting with *first*, pulling continuation
+    bytes from *fd* as needed."""
+    buf = bytearray(first)
     for _ in range(3):
         try:
             return buf.decode("utf-8")

--- a/tests/hermes_cli/test_secret_prompt.py
+++ b/tests/hermes_cli/test_secret_prompt.py
@@ -1,6 +1,14 @@
+import os
+import sys
+import time
+
 import pytest
 
-from hermes_cli.secret_prompt import _collect_masked_input, masked_secret_prompt
+from hermes_cli.secret_prompt import (
+    _collect_masked_input,
+    _read_posix_raw_char,
+    masked_secret_prompt,
+)
 
 
 def _run_collect(chars: str):
@@ -60,3 +68,113 @@ def test_masked_secret_prompt_falls_back_to_getpass_for_non_tty(monkeypatch):
     monkeypatch.setattr("getpass.getpass", lambda prompt: f"value from {prompt}")
 
     assert masked_secret_prompt("API key: ") == "value from API key: "
+
+
+# ---- POSIX raw-char reader ---------------------------------------------------
+#
+# These tests only exercise the POSIX byte-reader in isolation, so they run
+# anywhere ``os.pipe`` works (i.e. non-Windows). They intentionally do NOT
+# spin up a real pty — the drain uses ``select`` on the fd, which works
+# identically on pipes and pseudo-terminals.
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="_read_posix_raw_char is POSIX-only; Windows has its own path.",
+)
+
+
+def _pipe_pair():
+    r, w = os.pipe()
+    return r, w
+
+
+@_POSIX_ONLY
+def test_read_posix_raw_char_reads_single_ascii_byte():
+    r, w = _pipe_pair()
+    try:
+        os.write(w, b"x")
+        assert _read_posix_raw_char(r) == "x"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@_POSIX_ONLY
+def test_read_posix_raw_char_reassembles_multibyte_utf8():
+    r, w = _pipe_pair()
+    try:
+        # "é" is 0xc3 0xa9 in UTF-8; must come back as one Python character
+        # even though the reader pulls one byte at a time.
+        os.write(w, "é".encode("utf-8"))
+        assert _read_posix_raw_char(r) == "é"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@_POSIX_ONLY
+def test_read_posix_raw_char_drains_arrow_key_escape_sequence():
+    # This is the fix for the silent-secret-corruption bug: pressing arrow-up
+    # mid-password used to leak "[A" (or the tail of any CSI/SS3 sequence)
+    # into the captured value, because ``_collect_masked_input`` only skipped
+    # the leading ESC byte. The drain here must consume the "[A" so the
+    # NEXT read_char() call sees the byte AFTER the escape sequence.
+    #
+    # The sleep between writes mirrors real terminal timing: escape sequences
+    # arrive as a fast burst (sub-millisecond), then there is a human-scale
+    # gap before the next typed character. The reader's drain uses a 5 ms
+    # ``select`` window, so 20 ms comfortably separates the two events.
+    r, w = _pipe_pair()
+    try:
+        os.write(w, b"\x1b[A")   # arrow-up: ESC [ A
+        first = _read_posix_raw_char(r)
+        time.sleep(0.02)
+        os.write(w, b"w")
+        second = _read_posix_raw_char(r)
+        assert first == "\x1b"
+        assert second == "w", (
+            f"escape-sequence tail leaked: expected 'w' after drain, got {second!r}"
+        )
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@_POSIX_ONLY
+def test_read_posix_raw_char_end_to_end_typed_secret_with_arrow_key():
+    # End-to-end: drive ``_collect_masked_input`` with the reader used by
+    # ``_masked_secret_prompt_posix`` and prove that "pass<Up>word<Enter>"
+    # captures "password" rather than the pre-fix "pass[Aword".
+    r, w = _pipe_pair()
+    output: list[str] = []
+
+    def read_char():
+        return _read_posix_raw_char(r)
+
+    def write(text):
+        output.append(text)
+
+    # A background writer paces the bytes the way a real user would, so the
+    # 5 ms drain window can observe the boundary between the arrow-up burst
+    # and the trailing typed characters.
+    import threading
+
+    def feed():
+        os.write(w, b"pass")
+        time.sleep(0.02)
+        os.write(w, b"\x1b[A")
+        time.sleep(0.02)
+        os.write(w, b"word\r")
+
+    writer = threading.Thread(target=feed)
+    writer.start()
+    try:
+        value = _collect_masked_input(read_char, write, "pw: ", mask="*")
+    finally:
+        writer.join(timeout=1.0)
+        os.close(r)
+        os.close(w)
+
+    assert value == "password", f"arrow-key bytes leaked into secret: {value!r}"
+    # 8 typed characters -> 8 mask chars, one per keystroke.
+    assert "".join(c for c in output if c == "*") == "*" * 8

--- a/tests/hermes_cli/test_secret_prompt.py
+++ b/tests/hermes_cli/test_secret_prompt.py
@@ -141,6 +141,96 @@ def test_read_posix_raw_char_drains_arrow_key_escape_sequence():
 
 
 @_POSIX_ONLY
+def test_read_posix_raw_char_drains_ss3_escape_sequence():
+    # SS3 sequences (ESC O <final>) are emitted by some terminals for F1-F4
+    # and, in application cursor mode, for the arrow keys. Only the two-byte
+    # tail must be consumed — one introducer byte plus one final byte.
+    r, w = _pipe_pair()
+    try:
+        os.write(w, b"\x1bOP")   # F1 in xterm's SS3 form
+        first = _read_posix_raw_char(r)
+        time.sleep(0.02)
+        os.write(w, b"x")
+        second = _read_posix_raw_char(r)
+        assert first == "\x1b"
+        assert second == "x", (
+            f"SS3 tail leaked: expected 'x' after drain, got {second!r}"
+        )
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@_POSIX_ONLY
+def test_read_posix_raw_char_lone_escape_returns_escape():
+    # A lone Escape keypress (no follow-up bytes) must still surface as ESC
+    # so the collector can skip it. The short peek window is what
+    # distinguishes this from a sequence.
+    r, w = _pipe_pair()
+    try:
+        os.write(w, b"\x1b")
+        assert _read_posix_raw_char(r) == "\x1b"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@_POSIX_ONLY
+def test_read_posix_raw_char_preserves_meta_alt_follow_up_char():
+    # Some terminals encode Meta/Alt-<char> as ESC + <char>. The follow-up
+    # byte is NOT part of a CSI/SS3 sequence and must not be silently
+    # swallowed alongside the ESC — otherwise we'd trade the arrow-key
+    # corruption bug for a Meta-key corruption bug.
+    r, w = _pipe_pair()
+    try:
+        os.write(w, b"\x1ba")   # Alt-a on many terminals
+        first = _read_posix_raw_char(r)
+        assert first == "a", (
+            f"Meta/Alt follow-up byte was dropped: expected 'a', got {first!r}"
+        )
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@_POSIX_ONLY
+def test_read_posix_raw_char_end_to_end_typed_secret_with_alt_key():
+    # End-to-end companion to the arrow-key test: if the user hits Alt-<char>
+    # mid-secret, the <char> must land in the captured value. Pre-fix
+    # (original drain-everything approach) this would produce "pasword"
+    # because the ESC drain swallowed the 's'.
+    r, w = _pipe_pair()
+    output: list[str] = []
+
+    def read_char():
+        return _read_posix_raw_char(r)
+
+    def write(text):
+        output.append(text)
+
+    import threading
+
+    def feed():
+        os.write(w, b"pa")
+        time.sleep(0.02)
+        os.write(w, b"\x1bs")   # Alt-s burst mid-secret
+        time.sleep(0.02)
+        os.write(w, b"sword\r")
+
+    writer = threading.Thread(target=feed)
+    writer.start()
+    try:
+        value = _collect_masked_input(read_char, write, "pw: ", mask="*")
+    finally:
+        writer.join(timeout=1.0)
+        os.close(r)
+        os.close(w)
+
+    assert value == "password", f"Alt-key follow-up byte lost: {value!r}"
+    assert "".join(c for c in output if c == "*") == "*" * 8
+
+
+@_POSIX_ONLY
 def test_read_posix_raw_char_end_to_end_typed_secret_with_arrow_key():
     # End-to-end: drive ``_collect_masked_input`` with the reader used by
     # ``_masked_secret_prompt_posix`` and prove that "pass<Up>word<Enter>"


### PR DESCRIPTION
## What does this PR do?

Fixes silent secret corruption in `hermes_cli.secret_prompt._masked_secret_prompt_posix`: pressing an arrow key (or any CSI/SS3 key — Home/End, PageUp/PageDown, function keys, Insert, Delete) mid-secret used to leak the sequence's tail bytes (e.g. `[A` for arrow-up) into the captured value, because `_collect_masked_input` only skipped the leading `\x1b`. Every keystroke is masked with `*`, so the corruption was invisible — the user would see a downstream "wrong API key / bad password" error with no clue why.

Root cause: the POSIX reader used `sys.stdin.read(1)` in a raw-mode loop with no notion of escape sequences.

Fix: read raw bytes via `os.read(fd, 1)` (bypasses any `TextIOWrapper` buffering that might hide bytes from the drain) and, after an ESC byte, drain any bytes pending on the fd within a 5 ms `select` window. 5 ms is comfortably longer than any local terminal takes to burst these bytes and shorter than a plausible human ESC-then-typed-key interval. Multi-byte UTF-8 code points are reassembled with an incremental decode so non-ASCII secrets keep working.

Windows path (`_masked_secret_prompt_windows`) unchanged — `msvcrt.getwch()` already collapses two-byte special-key sequences into a single `\x1b` token.

## Related Issue

Fixes #64134

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/secret_prompt.py`** — extracted `_read_posix_raw_char(fd)` for a byte-safe raw-mode read; `_masked_secret_prompt_posix` composes it with the unchanged mask/erase loop.
- **`tests/hermes_cli/test_secret_prompt.py`** — four new POSIX-only regression tests: single ASCII byte, multi-byte UTF-8 reassembly, arrow-key drain, and an end-to-end "typed secret with arrow key mid-input" via `_collect_masked_input`. Uses `os.pipe` with realistic timing (small sleeps between the escape-burst and the next typed byte, mirroring how a real terminal delivers them). No pty needed, so tests are stable across CI runners.

## How to Test

1. Deterministic reproducer (this is the pre-fix behavior — on `main`, this prints `'pass[Aword'`):
   ```python
   from hermes_cli.secret_prompt import _collect_masked_input
   stream = iter(list('pass') + ['\x1b', '[', 'A'] + list('word') + ['\r'])
   out = []
   captured = _collect_masked_input(lambda: next(stream), out.append, 'pw: ', mask='*')
   print(repr(captured))  # want 'password', bug prints 'pass[Aword'
   ```
2. Full test file: `pytest tests/hermes_cli/test_secret_prompt.py -v` — 8 tests pass locally (4 pre-existing + 4 new) in <0.3 s.
3. Manual: `hermes auth login` (or any other flow that calls `masked_secret_prompt`), paste part of a token, press an arrow key, finish typing, submit. Post-fix the token should be accepted; pre-fix it is silently corrupted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest matches are #25540 (Windows paste in setup prompts) and #54226 (new `secure_input` tool). Neither touches the POSIX arrow-key drain in the existing helper.
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the modified test file and all tests pass
- [x] I've added tests for my changes (four new POSIX-only regression tests)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring on the new helper explains the drain and its timing budget) — no README/`docs/` changes needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows path is untouched, tests are guarded with `pytest.mark.skipif(sys.platform == "win32", ...)`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A