### PR TITLE
feat(gateway): QQBot group activation modes + C2C native streaming replies

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -991,6 +991,60 @@ platform_toolsets:
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
 #
+#   # QQ Bot (official QQ 频道/群/C2C bot). All QQ-specific knobs live under
+#   # `extra`. Credentials can also come from QQ_APP_ID / QQ_CLIENT_SECRET env.
+#   qqbot:
+#     enabled: true
+#     extra:
+#       # ── Credentials ──
+#       app_id: "102xxxxxx"
+#       client_secret: "your-qq-bot-secret"
+#
+#       # ── Direct-message (C2C) access control ──
+#       dm_policy: pairing            # pairing (default) | open | allowlist | disabled
+#       allow_from: []                # user openids allowed when dm_policy=allowlist
+#
+#       # ── Group access control (mirrors Feishu: open | allowlist | disabled) ──
+#       group_policy: disabled        # disabled (default, safe) | open | allowlist
+#       group_allow_from:             # group openids allowed when group_policy=allowlist
+#         - AC2B08219675D5E1F4A6A9395179F350
+#       group_require_mention: true   # true (default): bot only replies when @-mentioned.
+#                                     # false also needs QQ's "receive all group messages" perm.
+#       # Per-group override of require_mention (the per-group value wins over the global one):
+#       groups:
+#         AC2B08219675D5E1F4A6A9395179F350:
+#           require_mention: false
+#       # Non-@ group messages are buffered and injected as context on the next
+#       # @-reply. <= 0 disables buffering. Default 20.
+#       group_history_limit: 20
+#
+#       # ── Group session sharing (per-platform override of the top-level
+#       #    `group_sessions_per_user`). false = ALL members of a group share ONE
+#       #    conversation session; each inbound message is then auto-prefixed with
+#       #    the sender's name ([Alice] …) so the agent can still tell members
+#       #    apart. This per-platform value drives BOTH the shared session key AND
+#       #    the sender prefix. ──
+#       group_sessions_per_user: false
+#
+#       # ── C2C streaming reply (private chats only; QQ's stream_messages
+#       #    endpoint is C2C-only, so group/guild replies never stream). QQ can
+#       #    edit an in-flight C2C stream bubble in place but cannot edit ordinary
+#       #    already-sent message IDs, so generic tool-progress bubbles are
+#       #    intentionally suppressed on QQ to avoid chat spam. ──
+#       streaming_enabled: true
+#       streaming_session_ttl_seconds: 300
+#
+#       # ── Rendering ──
+#       markdown_support: true        # send native QQ markdown when the bot is allowed to
+#
+#       # ── Voice message transcription (OpenAI-compatible STT; optional) ──
+#       stt:
+#         enabled: true
+#         provider: zai               # zai | glm | openai (picks a default base_url)
+#         # base_url: "https://open.bigmodel.cn/api/coding/paas/v4"
+#         api_key: "your-stt-key"
+#         model: glm-asr
+#
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #
 # discord:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3503,6 +3503,22 @@ class BasePlatformAdapter(ABC):
     # property) so the stream consumer knows not to short-circuit.
     REQUIRES_EDIT_FINALIZE: bool = False
 
+    @property
+    def SUPPORTS_STREAM_EDITING(self) -> bool:
+        """Whether this adapter can edit an *in-flight streaming* bubble.
+
+        Split from ``SUPPORTS_MESSAGE_EDITING`` (which advertises editing of
+        arbitrary already-sent message IDs, e.g. for tool-progress bubbles).
+        Some adapters support one but not the other: QQBot can update a native
+        C2C stream session in place but cannot edit ordinary sent message IDs.
+
+        Defaults to ``SUPPORTS_MESSAGE_EDITING`` so every existing adapter
+        keeps its current streaming behaviour. Subclasses may override with a
+        plain class attribute (e.g. ``SUPPORTS_STREAM_EDITING = True``), which
+        shadows this property in the subclass namespace.
+        """
+        return getattr(self, "SUPPORTS_MESSAGE_EDITING", True)
+
     async def create_handoff_thread(
         self,
         parent_chat_id: str,

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -60,7 +60,10 @@ except ImportError:
     HTTPX_AVAILABLE = False
     httpx = None  # type: ignore[assignment]
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import (
+    Platform,
+    PlatformConfig,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -143,6 +146,12 @@ from gateway.platforms.qqbot.group_context import (
     GroupContextBuffer,
     summarize_attachments,
 )
+from gateway.platforms.qqbot.streaming import (
+    DEFAULT_SESSION_TTL_SECONDS,
+    MAX_STREAM_CONTENT_LEN,
+    StreamManager,
+    StreamSession,
+)
 
 
 def check_qq_requirements() -> bool:
@@ -163,8 +172,28 @@ def _coerce_list(value: Any) -> List[str]:
 class QQAdapter(BasePlatformAdapter):
     """QQ Bot adapter backed by the official QQ Bot WebSocket Gateway + REST API."""
 
-    # QQ Bot API does not support editing sent messages.
-    SUPPORTS_MESSAGE_EDITING = False
+    # QQ Bot API does not support editing regular sent messages, but the
+    # C2C stream_messages endpoint (used for streaming replies to private
+    # chats) DOES accept in-place updates for the same ``stream_msg_id``.
+    #
+    # We advertise ``SUPPORTS_MESSAGE_EDITING = True`` so the gateway
+    # stream consumer is willing to attach for C2C sessions.  The actual
+    # gating happens inside :meth:`edit_message`: if no C2C stream
+    # session is registered for the given ``message_id`` (which is the
+    # case for group / guild replies), we return
+    # ``SendResult(success=False, error="stream session not found …")``
+    # and the stream consumer falls back to a fresh ``send()`` — so
+    # non-C2C paths still get plain "send new message" semantics.
+    SUPPORTS_MESSAGE_EDITING = True
+
+    # Streaming replies to QQ AI-assistant surfaces stay in a "generating"
+    # visual state until the caller sends ``input_state=10 (DONE)``.  The
+    # stream consumer honours this flag by routing a final edit through
+    # even when content is unchanged, ensuring the UI transitions out of
+    # the streaming indicator.  Group / guild replies fall back to plain
+    # sends so this only affects C2C, where it's required.
+    REQUIRES_EDIT_FINALIZE = True
+
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     _TYPING_INPUT_SECONDS = 60  # input_notify duration reported to QQ
     _TYPING_DEBOUNCE_SECONDS = 50  # refresh before it expires
@@ -264,6 +293,60 @@ class QQAdapter(BasePlatformAdapter):
         # group_history_limit <= 0 disables buffering.
         self._group_history_limit = int(extra.get("group_history_limit", 20))
         self._group_context = GroupContextBuffer(limit=self._group_history_limit)
+
+        # ── C2C streaming reply ─────────────────────────────────────────
+        # QQ's official ``stream_messages`` endpoint is C2C-only (see
+        # openclaw ``shouldUseOfficialC2cStream`` which hard-rejects
+        # non-C2C targets).  We enable it by default because failures
+        # gracefully fall back to fresh sends via the stream consumer's
+        # own error-handling; a config knob is exposed for operators who
+        # want to force the legacy path (e.g. during incident triage).
+        self._streaming_enabled = bool(extra.get("streaming_enabled", True))
+        self._stream_session_ttl = float(
+            extra.get("streaming_session_ttl_seconds", DEFAULT_SESSION_TTL_SECONDS)
+        )
+        self._stream_manager = StreamManager(ttl_seconds=self._stream_session_ttl)
+
+        # Deferred streaming sessions for group / guild chats.
+        #
+        # QQ has no editable-message API for group or guild targets, and
+        # its ``stream_messages`` endpoint is C2C-only.  To avoid the
+        # "two messages per turn" symptom described in
+        # ``send()``/``edit_message()``, we intercept the streaming
+        # first-send for group/guild chats: we don't hit the QQ API on
+        # ``send()``, we hand out a sentinel ``message_id``, and we
+        # buffer subsequent ``edit_message()`` updates locally until the
+        # stream consumer calls with ``finalize=True`` — at that point
+        # we deliver ONE complete reply via the normal legacy path.
+        #
+        # After the first successful ``finalize=True`` edit, the session
+        # entry is **kept but flagged as finalized** and the delivered
+        # ``SendResult`` is memoised on it.  This is intentional: the
+        # ``stream_consumer`` occasionally issues a second finalize edit
+        # after the mid-stream tick already finalized (adapters with
+        # ``REQUIRES_EDIT_FINALIZE=True`` skip the "final edit already
+        # delivered content" fast path — see the ``got_done`` branch in
+        # ``gateway/stream_consumer.py``).  Without idempotence that
+        # second call would re-enter the "session missing → recover via
+        # fresh send" branch below and post the reply a second time
+        # (the "two identical messages per group turn" bug this comment
+        # is guarding against).  We evict finalized entries only when
+        # they exceed the LRU cap to bound memory.
+        #
+        # ``sentinel_id -> {
+        #     "chat_id",
+        #     "chat_type",
+        #     "reply_to",
+        #     "finalized": bool,          # True after first finalize
+        #     "finalized_result": SendResult | None,  # memoised delivery
+        # }``
+        self._group_defer_sessions: Dict[str, Dict[str, Any]] = {}
+        # LRU cap on finalized-session bookkeeping — a single QQ bot
+        # rarely holds more than a handful of concurrent group replies,
+        # so 1024 is comfortably above any realistic burst but low
+        # enough to bound memory even if some pathological consumer
+        # never issues finalize edits.
+        self._group_defer_sessions_cap: int = 1024
 
         # Connection state
         self._session: Optional[aiohttp.ClientSession] = None
@@ -1448,16 +1531,26 @@ class QQAdapter(BasePlatformAdapter):
             image_urls = image_urls + quoted["image_urls"]
             image_media_types = image_media_types + quoted["image_media_types"]
 
-        # (6) mention-mode @-activation: prepend any buffered non-@ messages as
-        # CONTEXT ONLY, then clear the group's buffer (2.2.1). Done BEFORE the
-        # empty check so an @-message with no body (e.g. a bare @) still flushes
-        # and injects the pending context. In always mode the buffer is empty
+        # (6) mention-mode @-activation: drain any buffered non-@ messages and
+        # carry them as CONTEXT ONLY via ``channel_context`` — NOT merged into
+        # ``text``. Keeping the buffered history out of ``text`` leaves the
+        # trigger message at the start of ``text`` so slash-command detection
+        # (event.get_command) and sender-prefix logic in run.py operate on the
+        # current message alone; run.py prepends channel_context afterwards.
+        # This fixes ``/stop``-style commands failing to match in mention/context
+        # modes where the buffered block previously sat ahead of the command.
+        # Done BEFORE the empty check so a bare @ (no body) still flushes and
+        # injects the pending context. In always mode the buffer is empty
         # (nothing was recorded), so drain is a harmless no-op.
         pending = self._group_context.drain(group_openid)
-        if pending:
-            text = GroupContextBuffer.format_context(pending, text)
+        channel_context = (
+            GroupContextBuffer.format_context_block(pending) if pending else None
+        )
 
-        if not text.strip() and not image_urls:
+        # An empty trigger with no media is normally dropped, but a bare @ that
+        # flushes pending context must still produce a turn — otherwise the
+        # buffered context would be stranded.
+        if not text.strip() and not image_urls and not channel_context:
             return
 
         self._chat_type_map[group_openid] = "group"
@@ -1468,6 +1561,7 @@ class QQAdapter(BasePlatformAdapter):
                 chat_type="group",
             ),
             text=text,
+            channel_context=channel_context,
             message_type=self._detect_message_type(image_urls, image_media_types),
             raw_message=d,
             message_id=msg_id,
@@ -2525,6 +2619,27 @@ class QQAdapter(BasePlatformAdapter):
     # How often (seconds) to poll is_connected while waiting.
     _RECONNECT_POLL_INTERVAL = 0.5
 
+    def _evict_group_defer_sessions_if_needed(self) -> None:
+        """Bound ``_group_defer_sessions`` size by dropping the oldest
+        finalized entries (LRU on insertion order) when the map exceeds
+        its cap.  Non-finalized entries are preserved — dropping one
+        would silently discard an in-flight reply and force the fallback
+        "session missing → fresh send" path.
+        """
+        cap = self._group_defer_sessions_cap
+        if len(self._group_defer_sessions) <= cap:
+            return
+        # Dicts preserve insertion order (Py 3.7+); walk oldest → newest
+        # and evict finalized entries first.  If everything is still
+        # pending we bail — capacity is best-effort, correctness wins.
+        to_drop = len(self._group_defer_sessions) - cap
+        stale_keys = [
+            k for k, v in self._group_defer_sessions.items()
+            if v.get("finalized")
+        ][:to_drop]
+        for k in stale_keys:
+            self._group_defer_sessions.pop(k, None)
+
     async def _wait_for_reconnection(self) -> bool:
         """Wait for the WebSocket listener to reconnect.
 
@@ -2558,15 +2673,86 @@ class QQAdapter(BasePlatformAdapter):
 
         Applies format_message(), splits long messages via truncate_message(),
         and retries transient failures with exponential backoff.
-        """
-        del metadata
 
+        When the caller signals a streaming reply (``metadata.expect_edits``)
+        and the target is a C2C chat, the first chunk is delivered through
+        QQ's native ``stream_messages`` endpoint instead of the regular
+        ``/messages`` API.  The returned ``SendResult.message_id`` is an
+        adapter-generated opaque handle (``StreamSession.logical_id``); the
+        stream consumer uses it in follow-up ``edit_message`` calls.  On
+        streaming-start failure we log a warning and fall through to the
+        legacy path so the user still receives an answer.
+        """
         if not self.is_connected:
             if not await self._wait_for_reconnection():
                 return SendResult(success=False, error="Not connected", retryable=True)
 
         if not content or not content.strip():
             return SendResult(success=True)
+
+        expect_edits = bool((metadata or {}).get("expect_edits"))
+        chat_type = self._guess_chat_type(chat_id)
+
+        # Streaming fast-path: C2C + expect_edits + globally enabled.
+        # QQ's ``stream_messages`` endpoint only accepts C2C targets, so
+        # group / guild replies take a different route (see below).
+        if (
+                self._streaming_enabled
+                and expect_edits
+                and chat_type == "c2c"
+        ):
+            stream_result = await self._start_stream_reply(chat_id, content, reply_to)
+            if stream_result is not None:
+                return stream_result
+            # Falls through to the legacy path on start failure — the
+            # helper has already emitted a warning log.
+
+        # Group / guild streaming: no editable message id on QQ side.
+        #
+        # For group and guild targets QQ does not support in-place
+        # message edits, and the ``stream_messages`` endpoint is C2C
+        # only.  If we let the streaming first-send deliver a real
+        # message here, the stream consumer would try ``edit_message``
+        # on it for every subsequent tick — each edit fails, and the
+        # consumer's fallback re-sends the full accumulated text as a
+        # brand-new message.  Users then see the first chunk followed
+        # by the complete answer, i.e. two messages per turn.
+        #
+        # To collapse that to a single complete reply we:
+        #
+        #   1. buffer the streaming session inside the adapter,
+        #   2. hand out a sentinel ``message_id`` so the consumer
+        #      stays on its edit path (avoiding the multi-send
+        #      fallback machinery — including its lossy prefix-based
+        #      continuation logic which would drop the first chunk),
+        #   3. no-op every ``edit_message`` (see ``edit_message``
+        #      below), and
+        #   4. on the final ``edit_message(finalize=True)``, send ONE
+        #      complete message via the regular legacy path (which
+        #      handles chunking, keyboards, retries etc. correctly).
+        #      Subsequent ``finalize=True`` edits on the same sentinel
+        #      are idempotent — the stream consumer may issue a second
+        #      finalize tick on ``REQUIRES_EDIT_FINALIZE`` adapters
+        #      (see the ``got_done`` branch in
+        #      ``gateway/stream_consumer.py``), and re-delivering the
+        #      reply would surface as duplicate messages on screen.
+        if expect_edits and chat_type in ("group", "guild"):
+            sentinel_id = f"__qqbot_group_defer_{uuid.uuid4().hex}__"
+            self._group_defer_sessions[sentinel_id] = {
+                "chat_id": chat_id,
+                "chat_type": chat_type,
+                "reply_to": reply_to,
+                "finalized": False,
+                "finalized_result": None,
+            }
+            self._evict_group_defer_sessions_if_needed()
+            logger.debug(
+                "[%s] streaming first-send buffered for %s chat %s "
+                "(sentinel=%s): the complete reply will be delivered "
+                "on finalize",
+                self._log_tag, chat_type, chat_id, sentinel_id,
+            )
+            return SendResult(success=True, message_id=sentinel_id)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -2687,6 +2873,387 @@ class QQAdapter(BasePlatformAdapter):
         data = await self._api_request("POST", f"/channels/{channel_id}/messages", body)
         msg_id = str(data.get("id", uuid.uuid4().hex[:12]))
         return SendResult(success=True, message_id=msg_id, raw_response=data)
+
+    # ------------------------------------------------------------------
+    # C2C streaming reply (POST /v2/users/{openid}/stream_messages)
+    # ------------------------------------------------------------------
+
+    async def _start_stream_reply(
+            self,
+            openid: str,
+            content: str,
+            reply_to: Optional[str],
+    ) -> Optional[SendResult]:
+        """Open a C2C streaming session and send the first chunk.
+
+        Returns a successful :class:`SendResult` whose ``message_id`` is
+        the adapter's opaque ``logical_id`` on success.  On failure
+        returns ``None`` (a warning is logged) so the caller can fall
+        back to the legacy send path — per user requirement (d): first
+        chunk failure degrades to a normal message within the same
+        ``send()`` call to minimise user-visible latency.
+        """
+        # QQ's stream_messages endpoint requires a valid passive-reply
+        # msg_id (event_id is the same value in openclaw's mapping).  If
+        # the consumer hasn't provided reply_to, fall back to the most
+        # recent inbound id we've seen for this chat.  With no passive
+        # id we cannot start streaming — return None to trigger legacy
+        # fallback rather than making a request we know will fail.
+        passive_msg_id = reply_to or self._last_msg_id.get(openid)
+        if not passive_msg_id:
+            logger.warning(
+                "[%s] Streaming reply skipped for %s: no passive msg_id available; "
+                "falling back to regular send",
+                self._log_tag, openid,
+            )
+            return None
+
+        session = self._stream_manager.create(
+            openid=openid,
+            passive_msg_id=passive_msg_id,
+            msg_seq=self._next_msg_seq(passive_msg_id),
+        )
+        # First chunk has no prior text to reconcile against and the
+        # gateway suppresses the typewriter cursor for QQBOT (see
+        # ``gateway/run.py`` ``_effective_cursor`` handling), so we
+        # forward ``content`` verbatim.
+        try:
+            resp = await self._call_stream_api(
+                session, content, input_state=1,
+            )
+        except Exception as exc:
+            # Purge the abandoned session so its logical_id can't leak
+            # into an ``edit_message`` lookup later.
+            self._stream_manager.drop(session.logical_id)
+            logger.warning(
+                "[%s] Failed to start C2C streaming reply for %s "
+                "(passive_msg_id=%s): %s — falling back to regular send",
+                self._log_tag, openid, passive_msg_id, exc,
+            )
+            return None
+
+        stream_msg_id = resp.get("id") if isinstance(resp, dict) else None
+        if not stream_msg_id:
+            self._stream_manager.drop(session.logical_id)
+            logger.warning(
+                "[%s] Streaming reply for %s: response missing 'id' field "
+                "(resp=%r); falling back to regular send",
+                self._log_tag, openid, resp,
+            )
+            return None
+
+        session.stream_msg_id = str(stream_msg_id)
+        session.last_sent_index = session.next_index
+        session.last_sent_content = content[:MAX_STREAM_CONTENT_LEN]
+        session.next_index += 1
+        logger.debug(
+            "[%s] C2C streaming reply started: logical_id=%s stream_msg_id=%s",
+            self._log_tag, session.logical_id, session.stream_msg_id,
+        )
+        return SendResult(
+            success=True,
+            message_id=session.logical_id,
+            raw_response=resp,
+        )
+
+    async def edit_message(
+            self,
+            chat_id: str,
+            message_id: str,
+            content: str,
+            *,
+            finalize: bool = False,
+    ) -> SendResult:
+        """Edit a streamed reply.
+
+        Two flavours are supported:
+
+        * **C2C streaming sessions** (``message_id`` matches an entry
+          in ``_stream_manager``): forwarded to QQ's ``stream_messages``
+          endpoint as an append.
+        * **Group / guild deferred sessions** (``message_id`` starts
+          with ``__qqbot_group_defer_``): buffered locally.  Non-final
+          edits are silent no-ops; on ``finalize=True`` the accumulated
+          text is delivered as ONE complete message via the regular
+          legacy send path (chunking, keyboards, retries all handled by
+          the standard ``send()``).  This collapses what would otherwise
+          become two-plus messages per turn — see ``send()`` for the
+          full rationale.  A **second** ``finalize=True`` edit on the
+          same sentinel is idempotent: we memoise the delivery result
+          and replay it instead of re-sending (the stream consumer's
+          ``REQUIRES_EDIT_FINALIZE`` code path can issue a redundant
+          second finalize tick).
+
+        For any other unrecognised ``message_id`` we return
+        ``success=False`` so the stream consumer falls back to a fresh
+        ``send()``.  Content is treated as the full accumulated text
+        (``input_mode=replace`` semantics on the QQ side), matching the
+        hermes base ``edit_message`` contract of "replace the message
+        with this content".
+
+        For the simplified out-of-order policy agreed for this release,
+        the adapter tracks the last successfully-sent ``index`` and
+        silently drops any edit that arrives out of sequence (reports
+        ``success=True`` without invoking QQ, so the consumer keeps its
+        internal cursor advancing).  In practice the consumer awaits
+        each edit serially, so this branch is defensive only.
+        """
+        # Group / guild deferred session: accumulate silently, flush
+        # on finalize.  ``content`` here is the FULL accumulated text
+        # for this tick (per the base edit_message contract).
+        if message_id and message_id.startswith("__qqbot_group_defer_"):
+            defer = self._group_defer_sessions.get(message_id)
+            if defer is None:
+                # Session expired or already flushed — fresh-send the
+                # content so the user still gets a reply.  Falls
+                # through to the regular ``send()`` path (no
+                # expect_edits → legacy chunked delivery).
+                logger.warning(
+                    "[%s] deferred group session %s missing on edit "
+                    "(finalize=%s); recovering via fresh send to %s",
+                    self._log_tag, message_id, finalize, chat_id,
+                )
+                if not finalize:
+                    # Nothing to do until finalize — the consumer will
+                    # call us again with the full text.
+                    return SendResult(success=True, message_id=message_id)
+                return await self.send(chat_id, content, reply_to=None)
+
+            if not finalize:
+                # Silent no-op: the next edit (or the finalize edit)
+                # will carry the newer accumulated text.  We do NOT
+                # store ``content`` here — the consumer always sends
+                # the full text on every edit call, so the finalize
+                # payload is authoritative.
+                #
+                # If a previous finalize already delivered the reply,
+                # any lingering non-final edits (e.g. cancellation
+                # cleanup) are silent no-ops as well — the message is
+                # already out.
+                return SendResult(success=True, message_id=message_id)
+
+            # ``finalize=True`` re-entry guard.
+            #
+            # The stream consumer's ``got_done`` branch may issue TWO
+            # ``_send_or_edit(..., finalize=True)`` calls per turn on
+            # adapters that set ``REQUIRES_EDIT_FINALIZE=True`` — the
+            # mid-stream flush (line 742 in ``stream_consumer.py``)
+            # plus the explicit final tick right below (line 792).
+            # The first call already delivered the complete reply via
+            # ``self.send(...)``, so re-delivering here would post a
+            # second identical message ("two full events per group
+            # turn").  Idempotently return the memoised result.
+            if defer.get("finalized"):
+                logger.debug(
+                    "[%s] deferred group finalize replayed for %s "
+                    "(sentinel=%s); returning memoised result",
+                    self._log_tag, defer.get("chat_id"), message_id,
+                )
+                cached = defer.get("finalized_result")
+                if isinstance(cached, SendResult):
+                    return cached
+                return SendResult(success=True, message_id=message_id)
+
+            # Finalize: deliver ONE complete reply via the legacy
+            # (non-streaming) send path, using the reply_to captured
+            # at ``send()`` time so threading is preserved.
+            defer_chat_id = defer.get("chat_id") or chat_id
+            reply_to = defer.get("reply_to")
+            # Flip the flag BEFORE the send so a re-entrant edit
+            # (shouldn't happen, but defensive) hits the memoised
+            # branch above and can't double-send even if the send
+            # itself awaits at an ``await`` boundary.
+            defer["finalized"] = True
+            result = await self.send(
+                defer_chat_id, content, reply_to=reply_to,
+            )
+            defer["finalized_result"] = result
+            if not result.success:
+                logger.warning(
+                    "[%s] deferred group finalize failed for %s "
+                    "(sentinel=%s): %s",
+                    self._log_tag, defer_chat_id, message_id, result.error,
+                )
+            return result
+
+        del chat_id  # Session lookup is by logical_id, chat is implied.
+
+        session = self._stream_manager.get(message_id)
+        if session is None:
+            # Unknown / expired session: the consumer will re-send from
+            # scratch on the next tick.  This also covers group / guild
+            # ``edit_message`` calls — those never have a matching
+            # session because ``send()`` never opened one for them.
+            return SendResult(
+                success=False,
+                error="stream session not found or expired",
+            )
+
+        if session.finalized:
+            # Idempotent no-op — protects against double-DONE which
+            # would confuse QQ (index would regress from its POV).
+            logger.debug(
+                "[%s] edit_message on already-finalized session %s ignored",
+                self._log_tag, message_id,
+            )
+            return SendResult(success=True, message_id=message_id)
+
+        # Defensive out-of-order guard.  next_index tracks what we're
+        # about to send; last_sent_index tracks what QQ has already
+        # accepted.  next_index <= last_sent_index means we've already
+        # sent something at or past this position, which shouldn't
+        # happen with a serial consumer — treat as a no-op success.
+        my_index = session.next_index
+        if my_index <= session.last_sent_index:
+            logger.debug(
+                "[%s] out-of-order stream chunk dropped: my_index=%d last_sent=%d",
+                self._log_tag, my_index, session.last_sent_index,
+            )
+            return SendResult(success=True, message_id=message_id)
+
+        input_state = 10 if finalize else 1
+        outgoing = self._enforce_stream_prefix(session, content)
+        try:
+            resp = await self._call_stream_api(
+                session, outgoing, input_state=input_state,
+            )
+        except Exception as exc:
+            error_str = str(exc)
+            retryable = not any(
+                kw in error_str.lower()
+                for kw in ("invalid", "forbidden", "not found", "bad request")
+            )
+            logger.warning(
+                "[%s] Stream edit failed (logical_id=%s stream_msg_id=%s "
+                "index=%d finalize=%s): %s",
+                self._log_tag, message_id, session.stream_msg_id,
+                my_index, finalize, exc,
+            )
+            # On terminal failures purge the session so subsequent edits
+            # get a fresh ``success=False`` fast instead of retrying
+            # against a broken stream.
+            if not retryable:
+                self._stream_manager.drop(message_id)
+            return SendResult(success=False, error=error_str, retryable=retryable)
+
+        session.last_sent_index = my_index
+        session.last_sent_content = outgoing[:MAX_STREAM_CONTENT_LEN]
+        session.next_index += 1
+        if finalize:
+            session.finalized = True
+            self._stream_manager.drop(message_id)
+        return SendResult(
+            success=True,
+            message_id=message_id,
+            raw_response=resp,
+        )
+
+    # ------------------------------------------------------------------
+    # Stream content prefix guard
+    # ------------------------------------------------------------------
+    #
+    # QQ's ``stream_messages`` endpoint uses ``input_mode=replace`` which
+    # means each chunk carries the FULL accumulated text and QQ verifies
+    # that the new text starts with the previously accepted text.  Two
+    # upstream behaviours can break that invariant:
+    #
+    # 1. **Typewriter cursor.**  ``GatewayStreamConsumer`` appends a
+    #    configurable "typing" cursor (``streaming.cursor``) to every
+    #    intermediate frame.  On QQBOT we suppress that injection at
+    #    the source — ``gateway/run.py`` sets ``_effective_cursor = ""``
+    #    for ``Platform.QQBOT`` (same treatment as ``Platform.MATRIX``),
+    #    so no cursor glyph ever reaches this adapter and there is
+    #    nothing to reverse-strip here.
+    #
+    # 2. **Occasional shorter frames / trims.**  A rare edge is a
+    #    frame that is shorter than the previous one (retries, dedupe
+    #    after a re-emit, model backtrack).  Sending that verbatim
+    #    triggers "系统繁忙" (HTTP 500) and permanently breaks the
+    #    stream — QQ won't accept any further chunk on the same
+    #    ``stream_msg_id``.  We defend against that by forcing each new
+    #    chunk to start with ``session.last_sent_content``; if it does
+    #    not, we replay the previously-accepted text so QQ sees a
+    #    no-op-shaped chunk instead of a rejection.
+
+    def _enforce_stream_prefix(
+            self, session: StreamSession, content: str,
+    ) -> str:
+        """Return a version of ``content`` safe to send on this session.
+
+        The returned text is guaranteed to start with
+        ``session.last_sent_content`` (the prefix invariant QQ enforces
+        server-side).  If ``content`` does not satisfy that invariant
+        (upstream trimmed the frame or the model backtracked), we log a
+        warning and fall back to the previously-accepted text — QQ will
+        treat the resulting chunk as a stylistic no-op and the stream
+        stays alive for the next real update.
+        """
+        last = session.last_sent_content
+        if not last:
+            # First edit after the initial send failed to record content
+            # (shouldn't happen — ``_start_stream_reply`` always writes
+            # ``last_sent_content`` on success), just forward as-is.
+            return content
+        if content.startswith(last):
+            return content
+        # Divergence: either the new frame is shorter (upstream trimmed
+        # or replayed a smaller partial) or its prefix drifted.  Replay
+        # ``last`` so we don't get rejected — the next tick will bring a
+        # longer frame that properly extends it.
+        logger.warning(
+            "[%s] stream prefix divergence on session %s "
+            "(last_len=%d new_len=%d); replaying last chunk to keep "
+            "QQ session alive",
+            self._log_tag, session.logical_id,
+            len(last), len(content),
+        )
+        return last
+
+    async def _call_stream_api(
+            self,
+            session: StreamSession,
+            content: str,
+            *,
+            input_state: int,
+    ) -> Dict[str, Any]:
+        """POST one chunk to ``/v2/users/{openid}/stream_messages``.
+
+        Body fields mirror the shape openclaw uses (see
+        ``streaming-c2c.ts`` ``sendStreamChunk``):
+
+        - ``input_mode="replace"`` — every call carries the full
+          accumulated text.  QQ's Go backend unmarshals this into a
+          ``string`` field, so numeric enum values (``1``) are rejected
+          with ``json: cannot unmarshal number into Go value of type
+          string``.  Use the string form.
+        - ``content_type="markdown"`` — fixed per operator requirement;
+          same string-vs-number caveat as ``input_mode``.  QQ markdown
+          gracefully renders plain-text bodies too.
+        - ``event_id`` reuses ``passive_msg_id`` (matches openclaw's
+          ``eventId: event.messageId``)
+        - ``msg_seq`` is session-wide constant; ``index`` post-increments
+
+        First-chunk requests omit ``stream_msg_id`` — the response body
+        carries the platform-assigned id.  Subsequent chunks must include
+        it or QQ will treat them as a new stream.
+        """
+        body: Dict[str, Any] = {
+            "input_mode": "replace",  # REPLACE — string, not numeric enum.
+            "input_state": input_state,
+            "content_type": "markdown",  # MARKDOWN — string, not numeric enum.
+            "content_raw": content[:MAX_STREAM_CONTENT_LEN],
+            "event_id": session.passive_msg_id,
+            "msg_id": session.passive_msg_id,
+            "msg_seq": session.msg_seq,
+            "index": session.next_index,
+        }
+        if session.stream_msg_id:
+            body["stream_msg_id"] = session.stream_msg_id
+        return await self._api_request(
+            "POST",
+            f"/v2/users/{session.openid}/stream_messages",
+            body,
+        )
 
     # ------------------------------------------------------------------
     # Inline-keyboard outbound helpers (approval / update-prompt flows)
@@ -3190,21 +3757,55 @@ class QQAdapter(BasePlatformAdapter):
         The QQ API requires the originating message ID — retrieved from
         ``_last_msg_id`` which is populated by ``_on_message``.
         """
+        logger.debug(
+            "[%s] send_typing called: chat_id=%s connected=%s",
+            self._log_tag,
+            chat_id,
+            self.is_connected,
+        )
+
         if not self.is_connected:
+            logger.debug(
+                "[%s] send_typing skipped: adapter not connected, chat_id=%s",
+                self._log_tag,
+                chat_id,
+            )
             return
 
         chat_type = self._guess_chat_type(chat_id)
         if chat_type != "c2c":
+            logger.debug(
+                "[%s] send_typing skipped: chat_type=%s (only c2c supported), chat_id=%s",
+                self._log_tag,
+                chat_type,
+                chat_id,
+            )
             return
 
         msg_id = self._last_msg_id.get(chat_id)
         if not msg_id:
+            logger.debug(
+                "[%s] send_typing skipped: no passive msg_id available, chat_id=%s "
+                "(user has not sent a message yet or _last_msg_id was cleared)",
+                self._log_tag,
+                chat_id,
+            )
             return
 
         # Debounce — skip if we sent recently
         now = time.time()
         last_sent = self._typing_sent_at.get(chat_id, 0.0)
-        if now - last_sent < self._TYPING_DEBOUNCE_SECONDS:
+        elapsed = now - last_sent
+        if elapsed < self._TYPING_DEBOUNCE_SECONDS:
+            logger.debug(
+                "[%s] send_typing skipped: debounced, chat_id=%s elapsed=%.1fs "
+                "debounce=%ds (last sent %.1fs ago, will refresh after debounce window)",
+                self._log_tag,
+                chat_id,
+                elapsed,
+                self._TYPING_DEBOUNCE_SECONDS,
+                elapsed,
+            )
             return
 
         try:
@@ -3218,10 +3819,34 @@ class QQAdapter(BasePlatformAdapter):
                 },
                 "msg_seq": msg_seq,
             }
+            logger.debug(
+                "[%s] send_typing sending input_notify: chat_id=%s msg_id=%s "
+                "msg_seq=%s input_second=%d",
+                self._log_tag,
+                chat_id,
+                msg_id,
+                msg_seq,
+                self._TYPING_INPUT_SECONDS,
+            )
             await self._api_request("POST", f"/v2/users/{chat_id}/messages", body)
             self._typing_sent_at[chat_id] = now
+            logger.debug(
+                "[%s] send_typing succeeded: chat_id=%s msg_id=%s msg_seq=%s "
+                "(indicator will auto-expire in %ds)",
+                self._log_tag,
+                chat_id,
+                msg_id,
+                msg_seq,
+                self._TYPING_INPUT_SECONDS,
+            )
         except Exception as exc:
-            logger.debug("[%s] send_typing failed: %s", self._log_tag, exc)
+            logger.debug(
+                "[%s] send_typing failed: chat_id=%s msg_id=%s err=%s",
+                self._log_tag,
+                chat_id,
+                msg_id,
+                exc,
+            )
 
     # ------------------------------------------------------------------
     # Format

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -172,19 +172,27 @@ def _coerce_list(value: Any) -> List[str]:
 class QQAdapter(BasePlatformAdapter):
     """QQ Bot adapter backed by the official QQ Bot WebSocket Gateway + REST API."""
 
-    # QQ Bot API does not support editing regular sent messages, but the
-    # C2C stream_messages endpoint (used for streaming replies to private
+    # QQ Bot API does not support editing regular already-sent messages, but
+    # the C2C stream_messages endpoint (used for streaming replies to private
     # chats) DOES accept in-place updates for the same ``stream_msg_id``.
     #
-    # We advertise ``SUPPORTS_MESSAGE_EDITING = True`` so the gateway
-    # stream consumer is willing to attach for C2C sessions.  The actual
-    # gating happens inside :meth:`edit_message`: if no C2C stream
-    # session is registered for the given ``message_id`` (which is the
-    # case for group / guild replies), we return
-    # ``SendResult(success=False, error="stream session not found …")``
-    # and the stream consumer falls back to a fresh ``send()`` — so
-    # non-C2C paths still get plain "send new message" semantics.
-    SUPPORTS_MESSAGE_EDITING = True
+    # These are two distinct capabilities, and the gateway consumes them at
+    # separate call sites, so we advertise them separately:
+    #
+    #   * ``SUPPORTS_MESSAGE_EDITING = False`` — we cannot edit an arbitrary
+    #     already-sent message ID.  This keeps the generic tool-progress editor
+    #     (gateway.run.send_progress_messages) from repeatedly calling
+    #     :meth:`edit_message` with ordinary QQ message IDs — those always fail
+    #     (``"stream session not found …"``) and would degrade to a fresh
+    #     ``send()`` per progress tick, spamming the chat.
+    #   * ``SUPPORTS_STREAM_EDITING = True`` — we CAN update an in-flight C2C
+    #     stream bubble in place.  The stream consumer reads this flag to decide
+    #     whether to attach & suppress the typewriter cursor.  The actual gating
+    #     still happens inside :meth:`edit_message`: only C2C stream-session
+    #     handles are accepted; group / guild replies (which have no stream
+    #     session) return failure and fall back to plain ``send()`` semantics.
+    SUPPORTS_MESSAGE_EDITING = False
+    SUPPORTS_STREAM_EDITING = True
 
     # Streaming replies to QQ AI-assistant surfaces stay in a "generating"
     # visual state until the caller sends ``input_state=10 (DONE)``.  The

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -14,7 +14,7 @@ Configuration in config.yaml:
           markdown_support: true           # enable QQ markdown (msg_type 2)
           dm_policy: "pairing"             # open | allowlist | disabled | pairing
           allow_from: ["openid_1"]
-          group_policy: "pairing"          # open | allowlist | disabled | pairing
+          group_policy: "disabled"         # open | allowlist | disabled
           group_allow_from: ["group_openid_1"]
           stt:                             # Voice-to-text config (optional)
             provider: "zai"                # zai (GLM-ASR), openai (Whisper), etc.
@@ -135,6 +135,14 @@ from gateway.platforms.qqbot.keyboards import (
     parse_interaction_event,
     parse_update_prompt_button_data,
 )
+from gateway.platforms.qqbot.group_activation import (
+    detect_mentioned,
+    resolve_require_mention,
+)
+from gateway.platforms.qqbot.group_context import (
+    GroupContextBuffer,
+    summarize_attachments,
+)
 
 
 def check_qq_requirements() -> bool:
@@ -213,10 +221,49 @@ class QQAdapter(BasePlatformAdapter):
         self._allow_from = _coerce_list(
             extra.get("allow_from") or extra.get("allowFrom")
         )
-        self._group_policy = str(extra.get("group_policy", "pairing")).strip().lower()
+        # Group ACL policy — mirrors Feishu (open | allowlist | disabled).
+        # Default is "disabled" (safe-by-default: no group receives replies
+        # until explicitly enabled). QQ does not implement a group "pairing"
+        # handshake, so pairing is intentionally not offered for groups
+        # (unlike dm_policy, where QQ C2C supports pairing).
+        raw_group_policy = str(extra.get("group_policy", "disabled")).strip().lower()
+        if raw_group_policy not in {"open", "allowlist", "disabled"}:
+            logger.warning(
+                "[%s] Unknown group_policy=%r; falling back to 'disabled'. "
+                "Supported: open | allowlist | disabled.",
+                self._log_tag, raw_group_policy,
+            )
+            raw_group_policy = "disabled"
+        self._group_policy = raw_group_policy
         self._group_allow_from = _coerce_list(
             extra.get("group_allow_from") or extra.get("groupAllowFrom")
         )
+
+        # Group activation mode (always vs mention). Default: mention — the bot
+        # only replies when @-ed (aligns with openclaw requireMention default).
+        # always mode (require_mention=False) lets any group message trigger a
+        # reply; it also needs the "receive all group messages" permission on
+        # the QQ platform to actually receive GROUP_MESSAGE_CREATE events.
+        self._group_require_mention = bool(extra.get("group_require_mention", True))
+        # Per-group override: groups.{group_openid}.require_mention (group > global).
+        self._group_mode_overrides: Dict[str, bool] = {}
+        _groups_cfg = extra.get("groups")
+        if isinstance(_groups_cfg, dict):
+            for _gid, _gcfg in _groups_cfg.items():
+                if isinstance(_gcfg, dict) and "require_mention" in _gcfg:
+                    self._group_mode_overrides[str(_gid)] = bool(
+                        _gcfg["require_mention"]
+                    )
+        # Reserved for a future runtime mode-switch command (solution 2.2.3):
+        # a /-command would write here and persist via cli.save_config_value.
+        # Empty in this release.
+        self._group_mode_runtime_overrides: Dict[str, bool] = {}
+
+        # Group context buffer (mention mode): non-@ messages are remembered per
+        # group and injected as CONTEXT ONLY on the next @-reply. Default 20;
+        # group_history_limit <= 0 disables buffering.
+        self._group_history_limit = int(extra.get("group_history_limit", 20))
+        self._group_context = GroupContextBuffer(limit=self._group_history_limit)
 
         # Connection state
         self._session: Optional[aiohttp.ClientSession] = None
@@ -852,6 +899,7 @@ class QQAdapter(BasePlatformAdapter):
             elif t in {
                     "C2C_MESSAGE_CREATE",
                     "GROUP_AT_MESSAGE_CREATE",
+                    "GROUP_MESSAGE_CREATE",
                     "DIRECT_MESSAGE_CREATE",
                     "GUILD_MESSAGE_CREATE",
                     "GUILD_AT_MESSAGE_CREATE",
@@ -951,8 +999,10 @@ class QQAdapter(BasePlatformAdapter):
         # Route by event type
         if event_type == "C2C_MESSAGE_CREATE":
             await self._handle_c2c_message(d, msg_id, content, author, timestamp)
-        elif event_type in {"GROUP_AT_MESSAGE_CREATE",}:
-            await self._handle_group_message(d, msg_id, content, author, timestamp)
+        elif event_type in {"GROUP_AT_MESSAGE_CREATE", "GROUP_MESSAGE_CREATE"}:
+            await self._handle_group_message(
+                d, msg_id, content, author, timestamp, event_type
+            )
         elif event_type in {"GUILD_MESSAGE_CREATE", "GUILD_AT_MESSAGE_CREATE"}:
             await self._handle_guild_message(d, msg_id, content, author, timestamp)
         elif event_type == "DIRECT_MESSAGE_CREATE":
@@ -1314,18 +1364,64 @@ class QQAdapter(BasePlatformAdapter):
             content: str,
             author: Dict[str, Any],
             timestamp: str,
+            event_type: str = "GROUP_AT_MESSAGE_CREATE",
     ) -> None:
-        """Handle a group @-message event."""
+        """Handle a group message event.
+
+        Handles both ``GROUP_AT_MESSAGE_CREATE`` (bot @-ed) and, when the QQ
+        platform pushes full group traffic and/or the bot runs in always mode,
+        ``GROUP_MESSAGE_CREATE`` (any group message). The activation decision
+        is:
+
+        1. group-level ACL (``_is_group_allowed``; user_id is intentionally not
+           used — per-user filtering is out of scope);
+        2. mention detection (``detect_mentioned``);
+        3. mode resolution (``resolve_require_mention``: global +
+           per-group override);
+        4. gate: mention mode + not-mentioned → skip (no reply); otherwise
+           process and reply.
+        """
         group_openid = str(d.get("group_openid", ""))
         if not group_openid:
             return
-        if not self._is_group_allowed(
-                group_openid, str(author.get("member_openid", ""))
-        ):
+        member_openid = str(author.get("member_openid", ""))
+        # (1) ACL — group-level (per-user filtering intentionally out of scope).
+        if not self._is_group_allowed(group_openid, member_openid):
+            logger.debug(
+                "[%s] Group message blocked by ACL: group=%r "
+                "policy=%s (set platforms.qqbot.extra.group_policy=open, or "
+                "'allowlist' with this group in group_allow_from, to enable).",
+                self._log_tag, group_openid, self._group_policy,
+            )
             return
 
-        # Strip the @bot mention prefix from content
-        text = self._strip_at_mention(content)
+        # (2) mention detection + (3) mode resolution + (4) activation gate.
+        mentioned = detect_mentioned(event_type, d, content, self._app_id)
+        require_mention = resolve_require_mention(
+            group_openid,
+            global_default=self._group_require_mention,
+            per_group=self._group_mode_overrides,
+            runtime_overrides=self._group_mode_runtime_overrides,
+        )
+        if require_mention and not mentioned:
+            # mention mode + message not addressed to the bot → do not reply,
+            # but remember it as pending context for the next @-reply (2.2.1).
+            self._group_context.record(
+                group_openid,
+                sender=member_openid,
+                text=content,
+                msg_id=msg_id,
+                attachment_tag=summarize_attachments(d.get("attachments")),
+            )
+            logger.debug(
+                "[%s] Group %s: buffered non-mention message (mention mode, event=%s)",
+                self._log_tag, group_openid, event_type,
+            )
+            return
+
+        # (5) pass: assemble the message (reuse the existing media / quote /
+        # markdown path). Only strip the @bot prefix when actually mentioned.
+        text = self._strip_at_mention(content) if mentioned else content
         att_result = await self._process_attachments(d.get("attachments"))
         image_urls = att_result["image_urls"]
         image_media_types = att_result["image_media_types"]
@@ -1351,6 +1447,15 @@ class QQAdapter(BasePlatformAdapter):
         if quoted["image_urls"]:
             image_urls = image_urls + quoted["image_urls"]
             image_media_types = image_media_types + quoted["image_media_types"]
+
+        # (6) mention-mode @-activation: prepend any buffered non-@ messages as
+        # CONTEXT ONLY, then clear the group's buffer (2.2.1). Done BEFORE the
+        # empty check so an @-message with no body (e.g. a bare @) still flushes
+        # and injects the pending context. In always mode the buffer is empty
+        # (nothing was recorded), so drain is a harmless no-op.
+        pending = self._group_context.drain(group_openid)
+        if pending:
+            text = GroupContextBuffer.format_context(pending, text)
 
         if not text.strip() and not image_urls:
             return
@@ -3160,12 +3265,39 @@ class QQAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _strip_at_mention(content: str) -> str:
-        """Strip the @bot mention prefix from group message content."""
-        # QQ group @-messages may have the bot's QQ/ID as prefix
+        """Strip @bot mention markers from group message content.
+
+        Handles both forms QQ may deliver:
+
+        - the explicit ``<@!123>`` mention tag (full-push GROUP_MESSAGE_CREATE),
+          aligning with openclaw ``MENTION_TAG_RE``;
+        - the legacy leading ``@name `` prefix (GROUP_AT_MESSAGE_CREATE where the
+          platform already rendered the tag as plain text).
+        """
         import re
 
-        stripped = re.sub(r"^@\S+\s*", "", content.strip())
-        return stripped
+        # Remove explicit mention tags anywhere in the content.
+        stripped = re.sub(r"<@!?\d+>", "", content).strip()
+        # Remove a leading "@name " prefix if present.
+        stripped = re.sub(r"^@\S+\s*", "", stripped)
+        return stripped.strip()
+
+    def _set_group_mode_override(
+        self, group_openid: str, require_mention: bool
+    ) -> None:
+        """Set an in-memory activation-mode override for a single group.
+
+        Reserved integration point for a future runtime mode-switch command
+        (solution 2.2.3). It updates the highest-priority override consulted by
+        :func:`resolve_require_mention`. A command handler would call this and
+        then persist the change via ``cli.save_config_value`` — persistence and
+        the command wiring are intentionally out of scope this round because a
+        ``/``-command requires changes to the shared command framework.
+        """
+        if group_openid:
+            self._group_mode_runtime_overrides[str(group_openid)] = bool(
+                require_mention
+            )
 
     def _open_dm_opted_in(self) -> bool:
         if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
@@ -3200,8 +3332,6 @@ class QQAdapter(BasePlatformAdapter):
             return False
         if self._group_policy == "allowlist":
             return self._entry_matches(self._group_allow_from, group_id)
-        if self._group_policy == "pairing":
-            return False
         if self._group_policy == "open":
             return True
         return False

--- a/gateway/platforms/qqbot/group_activation.py
+++ b/gateway/platforms/qqbot/group_activation.py
@@ -1,0 +1,95 @@
+"""Group activation-mode helpers for the QQ Bot adapter.
+
+Pure, side-effect-free functions that decide whether an inbound group message
+should trigger a bot reply. Kept separate from ``adapter.py`` so the
+mention/mode logic is independently testable and so a future runtime
+mode-switch command can reuse :func:`resolve_require_mention` without touching
+adapter internals (see solution 2.2.3).
+
+Aligns with openclaw ``extensions/qqbot/src/engine/group/`` — ``mention.ts``
+(detectWasMentioned), ``message-gating.ts`` (resolveMentionGating) and
+``activation.ts`` (resolveGroupActivation / requireMention fallback).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional
+
+# QQ open-platform group event names.
+GROUP_AT_MESSAGE_CREATE = "GROUP_AT_MESSAGE_CREATE"
+GROUP_MESSAGE_CREATE = "GROUP_MESSAGE_CREATE"
+
+# Matches an explicit @bot mention tag in raw content, e.g. ``<@!1903885637>``.
+# Aligns with openclaw MENTION_TAG_RE. The captured group is the mentioned id;
+# we only treat it as "the bot" when it equals our own app_id, so an @ of some
+# other member never counts as addressing the bot.
+_MENTION_TAG_RE = re.compile(r"<@!?(\d+)>")
+
+
+def detect_mentioned(
+    event_type: str,
+    payload: Dict[str, Any],
+    content: str,
+    app_id: str = "",
+) -> bool:
+    """Return True when the bot was @-mentioned in a group message.
+
+    Aligns with openclaw ``detectWasMentioned``:
+
+    1. ``GROUP_AT_MESSAGE_CREATE`` always means the bot was @-ed (the QQ
+       platform only emits it for bot-directed messages).
+    2. Full-mode ``GROUP_MESSAGE_CREATE`` carries a ``mentions`` array; an
+       entry with ``is_you: true`` marks the bot (authoritative).
+    3. Fallback: an explicit ``<@!{app_id}>`` tag for *our* app id in the raw
+       content.
+
+    Conservative by design (see solution D1): when none of the above match we
+    treat the message as NOT addressed to the bot. We intentionally do NOT use
+    a generic ``^@word`` prefix here — in full-push mode that would misfire on
+    messages that @ another member.
+    """
+    if event_type == GROUP_AT_MESSAGE_CREATE:
+        return True
+
+    mentions = payload.get("mentions")
+    if isinstance(mentions, list):
+        for entry in mentions:
+            # Explicit ``is True`` (not truthy): keeps the conservative contract
+            # if the platform ever returns a string like "false".
+            if isinstance(entry, dict) and entry.get("is_you") is True:
+                return True
+
+    if app_id and content:
+        target = str(app_id)
+        for match in _MENTION_TAG_RE.finditer(content):
+            if match.group(1) == target:
+                return True
+
+    return False
+
+
+def resolve_require_mention(
+    group_openid: str,
+    *,
+    global_default: bool,
+    per_group: Optional[Dict[str, bool]] = None,
+    runtime_overrides: Optional[Dict[str, bool]] = None,
+) -> bool:
+    """Resolve the effective ``require_mention`` for a group.
+
+    Priority (highest first), aligned with openclaw ``resolveGroupConfig``:
+
+    * runtime override — in-memory, reserved for a future ``/``-command
+      (solution 2.2.3); empty in this release.
+    * per-group config — ``groups.{group_openid}.require_mention``.
+    * global default — ``group_require_mention`` (defaults to True = mention).
+
+    Returns True for mention mode (reply only when @-ed), False for always
+    mode (every group message may trigger a reply).
+    """
+    if runtime_overrides and group_openid in runtime_overrides:
+        return bool(runtime_overrides[group_openid])
+    if per_group and group_openid in per_group:
+        return bool(per_group[group_openid])
+    return bool(global_default)

--- a/gateway/platforms/qqbot/group_context.py
+++ b/gateway/platforms/qqbot/group_context.py
@@ -1,0 +1,140 @@
+"""Per-group pending-message context buffer for the QQ Bot adapter.
+
+In **mention mode**, group messages that do not address the bot are not replied
+to, but they are remembered per group. When the bot is next @-ed in that group,
+the buffered messages are injected into the turn as CONTEXT ONLY so the agent
+can follow the conversation it was pulled into. This mirrors openclaw
+``extensions/qqbot/src/engine/group/history.ts`` (recordPendingHistoryEntry +
+buildPendingHistoryContext).
+
+**always mode** does not use this buffer — every group message is already its
+own turn, so there is nothing pending to inject.
+
+Memory is bounded on both axes: entries per group (``deque(maxlen=limit)``) and
+number of groups tracked (LRU-capped at :data:`MAX_GROUPS`). ``limit <= 0``
+disables buffering entirely.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict, deque
+from dataclasses import dataclass, field
+from typing import Any, Deque, List, Optional, OrderedDict as OrderedDictT
+
+# Upper bound on the number of groups tracked (aligns with openclaw
+# MAX_HISTORY_KEYS). Prevents unbounded growth across many groups.
+MAX_GROUPS = 1000
+
+# Context envelope tags (align with openclaw HISTORY_CTX_START / HISTORY_CTX_END).
+# Wrapping the buffered messages as "context only" keeps the agent from treating
+# them as instructions (solution R5).
+HISTORY_CTX_START = "[Chat messages since your last reply \u2014 CONTEXT ONLY]"
+HISTORY_CTX_END = "[CURRENT MESSAGE \u2014 reply to this]"
+
+
+@dataclass
+class HistoryEntry:
+    """A single buffered group message."""
+
+    sender: str
+    text: str
+    ts: float = field(default_factory=time.time)
+    msg_id: str = ""
+
+
+def summarize_attachments(attachments: Any) -> str:
+    """Return a short, network-free tag describing message attachments.
+
+    Used to record what a buffered message carried without downloading or
+    transcribing it (that would be far too expensive for every passing group
+    message). Aligns with openclaw ``inferAttachmentType``.
+    """
+    if not isinstance(attachments, list) or not attachments:
+        return ""
+    tags: List[str] = []
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        ctype = str(att.get("content_type", "")).lower()
+        name = str(att.get("filename", "")).strip()
+        if ctype.startswith("image") or att.get("type") == 1:
+            tags.append("[image]")
+        elif ctype.startswith("audio") or ctype.startswith("voice") or att.get("type") == 3:
+            tags.append("[voice]")
+        elif ctype.startswith("video") or att.get("type") == 2:
+            tags.append("[video]")
+        else:
+            tags.append(f"[file: {name}]" if name else "[file]")
+    return " ".join(tags)
+
+
+class GroupContextBuffer:
+    """Bounded per-group buffer of non-@ messages awaiting an @-activation."""
+
+    def __init__(self, limit: int = 50, max_groups: int = MAX_GROUPS) -> None:
+        self._limit = int(limit)
+        self._max_groups = max(1, int(max_groups))
+        self._buffers: "OrderedDictT[str, Deque[HistoryEntry]]" = OrderedDict()
+
+    @property
+    def enabled(self) -> bool:
+        """Buffering is active only when the per-group limit is positive."""
+        return self._limit > 0
+
+    def record(
+        self,
+        group_openid: str,
+        *,
+        sender: str,
+        text: str,
+        msg_id: str = "",
+        attachment_tag: str = "",
+    ) -> None:
+        """Append a non-@ message to a group's pending buffer (no-op if disabled)."""
+        if not self.enabled or not group_openid:
+            return
+        body = text or ""
+        if attachment_tag:
+            body = (body + " " + attachment_tag).strip() if body.strip() else attachment_tag
+        if not body.strip():
+            return
+        buf = self._buffers.get(group_openid)
+        if buf is None:
+            buf = deque(maxlen=self._limit)
+            self._buffers[group_openid] = buf
+            self._evict_if_needed()
+        buf.append(
+            HistoryEntry(sender=sender or "unknown", text=body.strip(), msg_id=msg_id)
+        )
+        self._buffers.move_to_end(group_openid)
+
+    def drain(self, group_openid: str) -> List[HistoryEntry]:
+        """Return and remove all buffered entries for a group (empty if none)."""
+        buf = self._buffers.pop(group_openid, None)
+        if not buf:
+            return []
+        return list(buf)
+
+    def clear(self, group_openid: str) -> None:
+        """Drop a group's buffer without returning it."""
+        self._buffers.pop(group_openid, None)
+
+    def _evict_if_needed(self) -> None:
+        while len(self._buffers) > self._max_groups:
+            self._buffers.popitem(last=False)  # drop least-recently-used group
+
+    @staticmethod
+    def format_context(entries: List[HistoryEntry], current_text: str) -> str:
+        """Wrap buffered entries + current message into a tagged context block."""
+        if not entries:
+            return current_text
+        lines: List[str] = [HISTORY_CTX_START]
+        for entry in entries:
+            # Collapse newlines so a buffered message cannot forge the
+            # CONTEXT/CURRENT envelope tags on its own line (R5 hardening).
+            body = " ".join(entry.text.splitlines()).strip()
+            lines.append(f"{entry.sender}: {body}")
+        lines.append(HISTORY_CTX_END)
+        lines.append(current_text)
+        return "\n".join(lines)

--- a/gateway/platforms/qqbot/group_context.py
+++ b/gateway/platforms/qqbot/group_context.py
@@ -125,16 +125,33 @@ class GroupContextBuffer:
             self._buffers.popitem(last=False)  # drop least-recently-used group
 
     @staticmethod
-    def format_context(entries: List[HistoryEntry], current_text: str) -> str:
-        """Wrap buffered entries + current message into a tagged context block."""
+    def format_context_block(entries: List[HistoryEntry]) -> str:
+        """Render buffered entries as a standalone CONTEXT-ONLY block.
+
+        Unlike :meth:`format_context`, the current/trigger message is **not**
+        appended and the ``HISTORY_CTX_END`` tag is omitted. The block is meant
+        for :attr:`MessageEvent.channel_context`, which run.py prepends to the
+        trigger message *after* slash-command detection and sender-prefix logic
+        have already operated on the trigger message alone. This keeps
+        ``/stop``-style commands matchable in mention/context modes where the
+        command must remain at the start of ``text``. The gateway supplies its
+        own ``[New message]`` boundary, so a trailing envelope tag here would be
+        redundant. Returns "" when there are no entries.
+        """
         if not entries:
-            return current_text
+            return ""
         lines: List[str] = [HISTORY_CTX_START]
         for entry in entries:
             # Collapse newlines so a buffered message cannot forge the
             # CONTEXT/CURRENT envelope tags on its own line (R5 hardening).
             body = " ".join(entry.text.splitlines()).strip()
             lines.append(f"{entry.sender}: {body}")
-        lines.append(HISTORY_CTX_END)
-        lines.append(current_text)
         return "\n".join(lines)
+
+    @staticmethod
+    def format_context(entries: List[HistoryEntry], current_text: str) -> str:
+        """Wrap buffered entries + current message into a tagged context block."""
+        if not entries:
+            return current_text
+        block = GroupContextBuffer.format_context_block(entries)
+        return f"{block}\n{HISTORY_CTX_END}\n{current_text}"

--- a/gateway/platforms/qqbot/streaming.py
+++ b/gateway/platforms/qqbot/streaming.py
@@ -1,0 +1,220 @@
+"""
+QQ Bot C2C streaming state management.
+
+Backs :class:`QQAdapter`'s streaming-reply implementation.  The QQ Official
+Bot API exposes ``POST /v2/users/{openid}/stream_messages`` for private
+(C2C) chats: the caller sends the first chunk without ``stream_msg_id``,
+the response body carries the platform-assigned ``id`` (aka
+``stream_msg_id``), and every subsequent chunk must reuse that id together
+with a monotonically increasing ``index``.  When the response is done the
+caller sends a final chunk with ``input_state=10`` (``DONE``).
+
+Hermes' stream consumer expresses this lifecycle through the standard
+adapter surface — a single ``send()`` for the first chunk followed by
+``edit_message()`` for each subsequent update (``finalize=True`` for the
+last).  Consumers reference the streaming reply solely via
+``SendResult.message_id``.
+
+To bridge those two protocols the adapter keeps an in-memory
+:class:`StreamSession` per outgoing streaming reply.  The consumer sees an
+opaque adapter-generated ``logical_id`` as ``SendResult.message_id`` and
+uses it for every ``edit_message`` call.  Internally the adapter uses
+:class:`StreamManager` to look up the session and translate the edit into a
+``stream_messages`` call with the correct ``stream_msg_id`` / ``msg_seq`` /
+``index`` triple.
+
+The manager also enforces a bounded lifetime — sessions are cleaned up on
+``finalize=True``, on an explicit ``drop``, on TTL expiry, or by an LRU
+cap.  When the consumer hands back a ``logical_id`` for which no session
+exists (e.g. after adapter restart or QQ's ~5 min passive-message window
+expired), the adapter returns ``SendResult(success=False)`` and the
+consumer falls back to a fresh ``send()`` naturally.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# QQ Bot stream_messages content_raw hard limit — the platform accepts
+# larger payloads on regular POST /messages, but streaming replies are
+# capped tighter.  Value chosen to align with openclaw's practical
+# ceiling; keep well below the doc-stated maximum.
+MAX_STREAM_CONTENT_LEN = 4096
+
+# Default session TTL — QQ's passive-message window is ~5 min, so any
+# session older than that will fail server-side anyway.  We give a little
+# extra headroom for slow generation runs.
+DEFAULT_SESSION_TTL_SECONDS = 600.0
+
+# Bounded session table to prevent runaway growth if adapters somehow
+# leak sessions (e.g. consumer crashes mid-stream without finalize).
+DEFAULT_MAX_SESSIONS = 1000
+
+
+@dataclass
+class StreamSession:
+    """In-memory state for a single QQ C2C streaming reply.
+
+    A session is created on the adapter's first ``send()`` for a
+    streaming-capable outbound reply and destroyed on finalize / TTL /
+    LRU eviction.  All fields are managed by :class:`StreamManager` and
+    the adapter — callers should treat instances as opaque.
+    """
+
+    # Adapter-generated id exposed to the stream consumer as
+    # ``SendResult.message_id``.  Consumers echo this back on every
+    # ``edit_message`` call so the adapter can look the session up.
+    logical_id: str
+
+    # QQ target user openid (C2C chats only — group / guild are not
+    # supported by the stream_messages endpoint).
+    openid: str
+
+    # Inbound message id used as the ``msg_id`` (passive-reply id) AND
+    # ``event_id`` for every stream_messages call in this session.
+    # openclaw uses the inbound message id for both fields (see
+    # ``outbound-dispatch.ts`` where ``eventId: event.messageId``), so
+    # hermes matches that behaviour and avoids a separate event_id cache.
+    passive_msg_id: str
+
+    # Session-wide ``msg_seq`` — QQ requires the same value across all
+    # chunks of one stream (openclaw ``streaming-c2c.ts`` reuses a single
+    # ``this.msgSeq`` after the first chunk).  Generated lazily on first
+    # send inside the adapter.
+    msg_seq: int
+
+    # QQ-assigned stream identifier.  ``None`` until the first
+    # stream_messages POST returns; every subsequent call must include
+    # this value.
+    stream_msg_id: Optional[str] = None
+
+    # Next ``index`` to send.  Starts at 0 for the first chunk and
+    # increments after each successful send.
+    next_index: int = 0
+
+    # Highest ``index`` that has been successfully sent to QQ.  Used by
+    # the adapter to defensively drop out-of-order edits (per the "if id
+    # arrives out of order, ignore" simplification agreed for this
+    # release).  ``-1`` = nothing sent yet.
+    last_sent_index: int = -1
+
+    # Sticky flag: True once we've sent ``input_state=10 (DONE)`` so
+    # the adapter can defend against duplicate finalize calls.
+    finalized: bool = False
+
+    # The exact ``content_raw`` string QQ last accepted for this stream.
+    # QQ enforces a "each chunk's full text MUST start with the previous
+    # chunk's full text" invariant for ``input_mode=replace`` — any
+    # violation is rejected as ``系统繁忙`` (HTTP 500) and permanently
+    # breaks the session.  We keep the last-accepted text here so the
+    # adapter can enforce that invariant even when the upstream stream
+    # consumer's per-frame content isn't strictly monotonic (e.g. a
+    # trailing typewriter cursor character that disappears on the next
+    # frame, or an occasional short retry frame).  Empty string until
+    # the first successful send.
+    last_sent_content: str = ""
+
+    # Monotonic timestamp at creation — used by the LRU/TTL sweeper.
+    created_at: float = field(default_factory=time.monotonic)
+
+
+class StreamManager:
+    """Bounded LRU + TTL table of active :class:`StreamSession`s.
+
+    Not thread-safe: the QQ adapter is asyncio-driven and every mutation
+    happens on the single event loop.  Concurrent ``edit_message`` calls
+    against the same ``logical_id`` are already serialised by the stream
+    consumer (it awaits each edit before issuing the next), so no lock
+    is required here.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_sessions: int = DEFAULT_MAX_SESSIONS,
+        ttl_seconds: float = DEFAULT_SESSION_TTL_SECONDS,
+    ) -> None:
+        self._sessions: "OrderedDict[str, StreamSession]" = OrderedDict()
+        self._max_sessions = max_sessions
+        self._ttl_seconds = ttl_seconds
+
+    # ------------------------------------------------------------------
+    # Public API — used by QQAdapter
+    # ------------------------------------------------------------------
+
+    def create(
+        self,
+        *,
+        openid: str,
+        passive_msg_id: str,
+        msg_seq: int,
+    ) -> StreamSession:
+        """Create and register a new streaming session.
+
+        Sweeps expired sessions first, then enforces the LRU cap by
+        evicting the least-recently-used entry when full.  Returns the
+        freshly registered session; caller mutates ``stream_msg_id`` /
+        ``next_index`` / ``last_sent_index`` after each successful API
+        call.
+        """
+        self._sweep_expired()
+        while len(self._sessions) >= self._max_sessions:
+            # popitem(last=False) drops the LRU entry.
+            self._sessions.popitem(last=False)
+
+        session = StreamSession(
+            logical_id=uuid.uuid4().hex,
+            openid=openid,
+            passive_msg_id=passive_msg_id,
+            msg_seq=msg_seq,
+        )
+        self._sessions[session.logical_id] = session
+        return session
+
+    def get(self, logical_id: str) -> Optional[StreamSession]:
+        """Fetch a session and mark it as most-recently-used.
+
+        Returns ``None`` when the session is unknown or has expired.
+        Expired entries are removed as a side effect so callers don't
+        keep hitting them.
+        """
+        session = self._sessions.get(logical_id)
+        if session is None:
+            return None
+        if self._is_expired(session):
+            self._sessions.pop(logical_id, None)
+            return None
+        # Refresh LRU ordering — recently-accessed sessions stay warm.
+        self._sessions.move_to_end(logical_id)
+        return session
+
+    def drop(self, logical_id: str) -> None:
+        """Remove a session from the table (idempotent)."""
+        self._sessions.pop(logical_id, None)
+
+    def __len__(self) -> int:  # pragma: no cover - convenience
+        return len(self._sessions)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _is_expired(self, session: StreamSession) -> bool:
+        return (time.monotonic() - session.created_at) > self._ttl_seconds
+
+    def _sweep_expired(self) -> None:
+        # Snapshot the keys since we mutate during iteration.  Sessions
+        # are stored in insertion order, so the first non-expired entry
+        # marks the boundary — everything before it can go.  We still
+        # iterate defensively in case the TTL clock is non-monotonic in
+        # a mocked test environment.
+        expired = [
+            key for key, session in self._sessions.items() if self._is_expired(session)
+        ]
+        for key in expired:
+            self._sessions.pop(key, None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3621,8 +3621,16 @@ class TurnRunner:
         # getattr, not attribute access: duck-typed adapters (test fakes,
         # minimal plugin adapters) may not define edit_message at all —
         # "missing" means the same thing as "base no-op": can't edit.
+        # The SUPPORTS_MESSAGE_EDITING check is also required: an adapter may
+        # override edit_message for in-flight stream handles only (QQBot), so
+        # overriding it does NOT imply arbitrary sent-message editing works.
         _adapter_edit = getattr(type(adapter), "edit_message", None)
-        if _adapter_edit is None or _adapter_edit is BasePlatformAdapter.edit_message:
+        _generic_editing = (
+            _adapter_edit is not None
+            and _adapter_edit is not BasePlatformAdapter.edit_message
+            and getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)
+        )
+        if not _generic_editing:
             while not ctx.progress_queue.empty():
                 try:
                     ctx.progress_queue.get_nowait()
@@ -6322,11 +6330,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        _group_spu, _thread_spu = self._effective_session_sharing(source)
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=_group_spu,
+            thread_sessions_per_user=_thread_spu,
             profile=_profile,
+        )
+
+    def _effective_session_sharing(self, source: SessionSource) -> tuple[bool, bool]:
+        """Resolve the per-platform effective (group, thread) session-sharing flags.
+
+        Single source of truth shared by session-key construction and sender
+        attribution. Mirrors the values ``BasePlatformAdapter`` uses to build
+        the session key (``self.config.extra.get(...)``): a per-platform
+        override (e.g. QQ ``platforms.qqbot.extra.group_sessions_per_user:
+        false``) therefore drives BOTH the shared key namespace AND the
+        ``[user_name]`` sender prefix in ``_prepare_inbound_message_text``.
+
+        Without this, attribution read only the global ``GatewayConfig`` value,
+        so a QQ-only shared session merged different users into one session
+        with no sender prefix.
+        """
+        config = getattr(self, "config", None)
+        group_default = getattr(config, "group_sessions_per_user", True)
+        thread_default = getattr(config, "thread_sessions_per_user", False)
+        platform_cfg = None
+        try:
+            platform_cfg = config.platforms.get(source.platform)
+        except Exception:
+            platform_cfg = None
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg is not None else None
+        if not isinstance(extra, dict):
+            return (group_default, thread_default)
+        return (
+            extra.get("group_sessions_per_user", group_default),
+            extra.get("thread_sessions_per_user", thread_default),
         )
 
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
@@ -15017,8 +15056,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _pending_stt_prepared
             else event.text
         ) or ""
-        _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
-        _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
+        # Resolve sharing flags via the same per-platform effective value used
+        # to build the session key (see _effective_session_sharing). Using the
+        # global GatewayConfig here would desync attribution from the key: a
+        # QQ-only shared session (extra.group_sessions_per_user=false) would
+        # merge users into one key yet skip the [user_name] sender prefix.
+        _group_sessions_per_user, _thread_sessions_per_user = self._effective_session_sharing(source)
         # Prefer the already resolved session key from the caller so this write
         # key matches the consume key at the run_conversation site. Fall back
         # to deriving it here for tests and legacy standalone callers.
@@ -22625,9 +22668,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Build the shared ``StreamConsumerConfig`` and the optional
         Telegram pause-typing closure used by both agent-run paths.
 
-        ``on_missing_cursor`` controls how platforms whose adapter sets
-        ``SUPPORTS_MESSAGE_EDITING = False`` are handled — both semantics
-        are preserved verbatim from the pre-refactor call sites:
+        ``on_missing_cursor`` controls how platforms whose adapter cannot
+        edit an in-flight streaming bubble (``SUPPORTS_STREAM_EDITING``,
+        falling back to ``SUPPORTS_MESSAGE_EDITING``) are handled — both
+        semantics are preserved verbatim from the pre-refactor call sites:
 
         - ``"fallback"`` (proxy path): stream anyway with an empty cursor.
         - ``"raise"`` (in-process agent path): raise ``RuntimeError`` so
@@ -22651,7 +22695,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # duplicate messages (partial + final).
         # (The proxy path instead opts into a cursorless fallback
         # via on_missing_cursor="fallback".)
-        _adapter_supports_edit = getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)
+        _adapter_supports_edit = getattr(
+            adapter,
+            "SUPPORTS_STREAM_EDITING",
+            getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True),
+        )
         if not _adapter_supports_edit and on_missing_cursor == "raise":
             raise RuntimeError("skip streaming for non-editable platform")
         _effective_cursor = scfg.cursor if _adapter_supports_edit else ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22662,6 +22662,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if source.platform == Platform.MATRIX:
             _effective_cursor = ""
             _buffer_only = True
+        # QQBot's stream_messages endpoint enforces a strict
+        # "new full text MUST prefix previous full text" invariant.
+        # Any cursor glyph appended to intermediate frames breaks that
+        # invariant the moment the next (cursor-less, extended) frame
+        # arrives, so we suppress cursor injection at the source instead
+        # of trying to peel it back off inside the QQ adapter.
+        if source.platform == Platform.QQBOT:
+            _effective_cursor = ""
         # Fresh-final applies to Telegram only — other
         # platforms either edit in place cheaply (Discord,
         # Slack) or don't have the timestamp-on-edit /

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6089,12 +6089,27 @@ def _configure_qqbot_extra_settings() -> None:
     Writes to ``platforms.qqbot.extra`` under keys the QQBot adapter reads
     at startup (see ``gateway/platforms/qqbot/adapter.py``):
 
+    * ``streaming_enabled``     — C2C streaming via /stream_messages.
     * ``group_policy``          — open | allowlist | disabled (ACL gate).
     * ``group_allow_from``      — allow-list of group openids (list[str]).
     * ``group_require_mention`` — True: only respond when @-ed; False:
       respond to every group message (requires the "receive all group
       messages" permission on the QQ platform).
     """
+    # ── Streaming replies (C2C) ────────────────────────────────────────
+    print()
+    print_info(
+        "  Streaming replies use QQ's official /stream_messages endpoint"
+    )
+    print_info(
+        "  for C2C chats. Recommended for a smoother 'typing → reply' feel."
+    )
+    streaming_enabled = prompt_yes_no("  Enable streaming replies?", True)
+    _write_qqbot_extra("streaming_enabled", bool(streaming_enabled))
+    print_success(
+        f"  streaming_enabled = {'true' if streaming_enabled else 'false'}"
+    )
+
     # ── Group policy ───────────────────────────────────────────────────
     print()
     group_choices = [

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6039,9 +6039,110 @@ def _setup_qqbot():
             save_env_value("QQBOT_HOME_CHANNEL", home_channel.strip())
             print_success(f"  Home channel set to {home_channel.strip()}")
 
+    # ── QQBot-only feature knobs (persist under platforms.qqbot.extra.*) ──
+    # Unlike DM ACL / home channel (env-var driven), the QQBot adapter reads
+    # group_policy / group_require_mention / streaming_enabled ONLY from
+    # config.yaml under ``platforms.qqbot.extra``. We write there directly.
+    _configure_qqbot_extra_settings()
+
     print()
     print_success("🐧 QQ Bot configured!")
     print_info(f"  App ID: {credentials['app_id']}")
+
+
+def _write_qqbot_extra(field: str, value) -> None:
+    """Persist a single field under ``platforms.qqbot.extra.<field>``.
+
+    Uses the raw config file (not the merged loaded config) so we only
+    touch values the user explicitly asked us to change — preserving any
+    existing hand-edited keys under ``platforms.qqbot`` verbatim.
+    """
+    from hermes_cli.config import (
+        ensure_hermes_home,
+        get_config_path,
+        read_raw_config,
+    )
+    from utils import atomic_yaml_write
+
+    cfg = read_raw_config() or {}
+    platforms = cfg.setdefault("platforms", {})
+    if not isinstance(platforms, dict):
+        platforms = {}
+        cfg["platforms"] = platforms
+    qqbot_cfg = platforms.setdefault("qqbot", {})
+    if not isinstance(qqbot_cfg, dict):
+        qqbot_cfg = {}
+        platforms["qqbot"] = qqbot_cfg
+    extra = qqbot_cfg.setdefault("extra", {})
+    if not isinstance(extra, dict):
+        extra = {}
+        qqbot_cfg["extra"] = extra
+    extra[field] = value
+
+    ensure_hermes_home()
+    atomic_yaml_write(get_config_path(), cfg, sort_keys=False)
+
+
+def _configure_qqbot_extra_settings() -> None:
+    """Interactive prompts for QQBot's config.yaml-only feature knobs.
+
+    Writes to ``platforms.qqbot.extra`` under keys the QQBot adapter reads
+    at startup (see ``gateway/platforms/qqbot/adapter.py``):
+
+    * ``group_policy``          — open | allowlist | disabled (ACL gate).
+    * ``group_allow_from``      — allow-list of group openids (list[str]).
+    * ``group_require_mention`` — True: only respond when @-ed; False:
+      respond to every group message (requires the "receive all group
+      messages" permission on the QQ platform).
+    """
+    # ── Group policy ───────────────────────────────────────────────────
+    print()
+    group_choices = [
+        "Disable group chats (default, safest)",
+        "Allow all groups the bot is in",
+        "Only allow listed group OpenIDs",
+    ]
+    group_idx = prompt_choice(
+        "  How should group chats be handled?", group_choices, 0
+    )
+    if group_idx == 0:
+        _write_qqbot_extra("group_policy", "disabled")
+        _write_qqbot_extra("group_allow_from", [])
+        print_info("  Group chats disabled.")
+        return  # mention/allow-list irrelevant when disabled
+    elif group_idx == 1:
+        _write_qqbot_extra("group_policy", "open")
+        _write_qqbot_extra("group_allow_from", [])
+        print_warning("  Open group access enabled for QQ Bot.")
+    else:
+        allow_groups_raw = prompt(
+            "  Allowed group OpenIDs (comma-separated)", password=False
+        ).replace(" ", "")
+        allow_groups = [g for g in allow_groups_raw.split(",") if g]
+        _write_qqbot_extra("group_policy", "allowlist")
+        _write_qqbot_extra("group_allow_from", allow_groups)
+        print_success(
+            f"  Group allowlist saved ({len(allow_groups)} entries)."
+        )
+
+    # ── @-mention requirement (only meaningful when groups are enabled) ─
+    print()
+    print_info(
+        "  Mention mode: bot only replies when explicitly @-ed."
+    )
+    print_info(
+        "  Always mode: bot may reply to every group message (requires"
+    )
+    print_info(
+        "  the 'receive all group messages' permission on q.qq.com)."
+    )
+    require_mention = prompt_yes_no(
+        "  Require @mention to trigger replies?", True
+    )
+    _write_qqbot_extra("group_require_mention", bool(require_mention))
+    print_success(
+        f"  group_require_mention = {'true' if require_mention else 'false'}"
+    )
 
 
 def _setup_signal():

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -55,7 +55,7 @@ class TestQQAdapterInit:
 
     def test_group_policy_default(self):
         adapter = self._make(app_id="a", client_secret="b")
-        assert adapter._group_policy == "pairing"
+        assert adapter._group_policy == "disabled"
 
     def test_allow_from_parsing_string(self):
         adapter = self._make(app_id="a", client_secret="b", allow_from="x, y , z")
@@ -229,6 +229,153 @@ class TestStripAtMention:
         result = self._fn("@BotUser hello there")
         assert result == "hello there"
 
+    def test_only_mention(self):
+        assert self._fn("@Someone  ") == ""
+
+    def test_strips_explicit_mention_tag(self):
+        # Full-push GROUP_MESSAGE_CREATE may carry the <@!id> tag form.
+        assert self._fn("<@!1903885637> hello there") == "hello there"
+
+    def test_strips_tag_midstring(self):
+        assert self._fn("hey <@!123> how are you") == "hey  how are you"
+
+
+# ---------------------------------------------------------------------------
+# Group rich media / markdown parity (2.3)
+# ---------------------------------------------------------------------------
+
+class TestGroupMediaMarkdown:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        extra.setdefault("app_id", "1903885637")
+        extra.setdefault("client_secret", "b")
+        extra.setdefault("group_policy", "open")
+        return QQAdapter(_make_config(**extra))
+
+    @pytest.mark.asyncio
+    async def test_group_inbound_image_populates_media_urls(self):
+        adapter = self._make_adapter(group_require_mention=False)  # always
+        captured = []
+
+        async def fake_process(_a):
+            return {"image_urls": ["/tmp/x.jpg"],
+                    "image_media_types": ["image/jpeg"],
+                    "voice_transcripts": [], "attachment_info": ""}
+
+        async def fake_quote(_d):
+            return {"quote_block": "", "image_urls": [], "image_media_types": []}
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+        adapter._process_quoted_context = fake_quote  # type: ignore[assignment]
+        adapter.handle_message = fake_handle  # type: ignore[assignment]
+
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "look",
+             "attachments": [{"content_type": "image/jpeg", "url": "u"}]},
+            "m1", "look", {"member_openid": "u1"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        assert captured[0].media_urls == ["/tmp/x.jpg"]
+        assert captured[0].media_types == ["image/jpeg"]
+
+    @pytest.mark.asyncio
+    async def test_group_markdown_send_routes_to_group_endpoint(self):
+        adapter = self._make_adapter(markdown_support=True)
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["g1"] = "group"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "sent1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send("g1", "**bold** reply")
+        assert result.success
+        assert calls and calls[0][1] == "/v2/groups/g1/messages"
+        # markdown_support=True → markdown msg_type (2).
+        assert calls[0][2]["msg_type"] == 2
+        assert calls[0][2]["markdown"]["content"] == "**bold** reply"
+
+    @pytest.mark.asyncio
+    async def test_group_plaintext_send_routes_to_group_endpoint(self):
+        # Default markdown_support=False → plain text msg_type (0).
+        adapter = self._make_adapter(markdown_support=False)
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["g1"] = "group"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "sent2"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send("g1", "plain reply", reply_to="mm1")
+        assert result.success
+        assert calls[0][1] == "/v2/groups/g1/messages"
+        assert calls[0][2]["msg_type"] == 0
+        assert calls[0][2]["content"] == "plain reply"
+        assert calls[0][2].get("msg_id") == "mm1"
+
+    @pytest.mark.asyncio
+    async def test_group_media_send_posts_msg_type_media(self):
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["g1"] = "group"
+        calls = []
+
+        async def fake_upload(chat_type, chat_id, file_type, **kw):
+            return {"file_info": "FILEINFO"}
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "media1"}
+
+        adapter._upload_media = fake_upload  # type: ignore[assignment]
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter._send_media(
+            "g1", "https://example.com/x.jpg", 1, "image",
+        )
+        assert result.success
+        assert calls and calls[0][1] == "/v2/groups/g1/messages"
+        assert calls[0][2]["msg_type"] == 7  # MSG_TYPE_MEDIA
+        assert calls[0][2]["media"]["file_info"] == "FILEINFO"
+
+
+# ---------------------------------------------------------------------------
+# Reserved runtime mode-switch hook (2.2.3)
+# ---------------------------------------------------------------------------
+
+class TestGroupModeRuntimeOverride:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        extra.setdefault("app_id", "a")
+        extra.setdefault("client_secret", "b")
+        return QQAdapter(_make_config(**extra))
+
+    def test_override_takes_effect(self):
+        from gateway.platforms.qqbot.group_activation import resolve_require_mention
+        adapter = self._make_adapter(group_require_mention=True)
+        adapter._set_group_mode_override("g1", require_mention=False)
+        assert adapter._group_mode_runtime_overrides == {"g1": False}
+        # resolve should now honour the runtime override for g1.
+        eff = resolve_require_mention(
+            "g1",
+            global_default=adapter._group_require_mention,
+            per_group=adapter._group_mode_overrides,
+            runtime_overrides=adapter._group_mode_runtime_overrides,
+        )
+        assert eff is False
+
 
 # ---------------------------------------------------------------------------
 # _is_dm_allowed
@@ -268,8 +415,17 @@ class TestGroupAllowed:
 
 
     def test_pairing_default_blocks_groups(self):
+        # group_policy default is now "disabled" (Feishu-aligned: no
+        # "pairing" mode for groups). Any group message is denied by default.
         adapter = self._make_adapter(app_id="a", client_secret="b")
-        assert adapter._group_policy == "pairing"
+        assert adapter._group_policy == "disabled"
+        assert adapter._is_group_allowed("grp1", "user1") is False
+
+    def test_unknown_group_policy_falls_back_to_disabled(self):
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", group_policy="pairing",  # no longer valid
+        )
+        assert adapter._group_policy == "disabled"
         assert adapter._is_group_allowed("grp1", "user1") is False
 
 
@@ -1222,3 +1378,483 @@ class TestReadEventsClosedWsGuard:
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
 
+
+
+# ---------------------------------------------------------------------------
+# Group activation mode — mention detection (group_activation.detect_mentioned)
+# ---------------------------------------------------------------------------
+
+class TestDetectMentioned:
+    def test_group_at_event_always_mentioned(self):
+        from gateway.platforms.qqbot.group_activation import detect_mentioned
+        assert detect_mentioned("GROUP_AT_MESSAGE_CREATE", {}, "hi", "app1") is True
+
+    def test_mentions_is_you_true(self):
+        from gateway.platforms.qqbot.group_activation import detect_mentioned
+        d = {"mentions": [{"member_openid": "x"}, {"is_you": True}]}
+        assert detect_mentioned("GROUP_MESSAGE_CREATE", d, "hi", "app1") is True
+
+    def test_explicit_tag_for_our_app_id(self):
+        from gateway.platforms.qqbot.group_activation import detect_mentioned
+        assert detect_mentioned(
+            "GROUP_MESSAGE_CREATE", {}, "<@!1903885637> hello", "1903885637"
+        ) is True
+
+    def test_tag_for_other_member_not_mentioned(self):
+        from gateway.platforms.qqbot.group_activation import detect_mentioned
+        # @ of a different member must NOT count as addressing the bot.
+        assert detect_mentioned(
+            "GROUP_MESSAGE_CREATE", {}, "<@!99999> hello", "1903885637"
+        ) is False
+
+    def test_plain_message_not_mentioned(self):
+        from gateway.platforms.qqbot.group_activation import detect_mentioned
+        assert detect_mentioned(
+            "GROUP_MESSAGE_CREATE", {}, "just chatting", "1903885637"
+        ) is False
+
+    def test_generic_at_prefix_not_treated_as_bot(self):
+        from gateway.platforms.qqbot.group_activation import detect_mentioned
+        # Conservative: a bare "@alice " prefix is NOT a bot mention.
+        assert detect_mentioned(
+            "GROUP_MESSAGE_CREATE", {}, "@alice look here", "1903885637"
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Group activation mode — require_mention resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveRequireMention:
+    def test_global_default_true(self):
+        from gateway.platforms.qqbot.group_activation import resolve_require_mention
+        assert resolve_require_mention("g1", global_default=True) is True
+
+    def test_global_default_false(self):
+        from gateway.platforms.qqbot.group_activation import resolve_require_mention
+        assert resolve_require_mention("g1", global_default=False) is False
+
+    def test_per_group_overrides_global(self):
+        from gateway.platforms.qqbot.group_activation import resolve_require_mention
+        # global always, but g1 forced to mention.
+        assert resolve_require_mention(
+            "g1", global_default=False, per_group={"g1": True}
+        ) is True
+        # other group still follows global.
+        assert resolve_require_mention(
+            "g2", global_default=False, per_group={"g1": True}
+        ) is False
+
+    def test_runtime_override_wins(self):
+        from gateway.platforms.qqbot.group_activation import resolve_require_mention
+        assert resolve_require_mention(
+            "g1", global_default=True, per_group={"g1": True},
+            runtime_overrides={"g1": False},
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Group activation mode — config parsing + gate (_handle_group_message)
+# ---------------------------------------------------------------------------
+
+class TestGroupActivationMode:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        extra.setdefault("app_id", "1903885637")
+        extra.setdefault("client_secret", "b")
+        extra.setdefault("group_policy", "open")
+        return QQAdapter(_make_config(**extra))
+
+    def test_default_mode_is_mention(self):
+        adapter = self._make_adapter()
+        assert adapter._group_require_mention is True
+
+    def test_always_mode_from_config(self):
+        adapter = self._make_adapter(group_require_mention=False)
+        assert adapter._group_require_mention is False
+
+    def test_per_group_override_parsed(self):
+        adapter = self._make_adapter(
+            group_require_mention=False,
+            groups={"grp_a": {"require_mention": True}},
+        )
+        assert adapter._group_mode_overrides == {"grp_a": True}
+
+    def _drive(self, adapter):
+        """Stub the assembly path and capture handle_message events."""
+        captured = []
+
+        async def fake_process(_a):
+            return {"image_urls": [], "image_media_types": [],
+                    "voice_transcripts": [], "attachment_info": ""}
+
+        async def fake_quote(_d):
+            return {"quote_block": "", "image_urls": [], "image_media_types": []}
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+        adapter._process_quoted_context = fake_quote  # type: ignore[assignment]
+        adapter.handle_message = fake_handle  # type: ignore[assignment]
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_mention_mode_skips_non_mention_group_message(self):
+        adapter = self._make_adapter()  # default mention
+        captured = self._drive(adapter)
+        d = {"group_openid": "g1", "content": "hello everyone"}
+        await adapter._handle_group_message(
+            d, "m1", "hello everyone", {"member_openid": "u1"}, "",
+            "GROUP_MESSAGE_CREATE",
+        )
+        assert captured == []  # skipped, no reply
+
+    @pytest.mark.asyncio
+    async def test_mention_mode_handles_at_message(self):
+        adapter = self._make_adapter()  # default mention
+        captured = self._drive(adapter)
+        d = {"group_openid": "g1", "content": "hi bot"}
+        await adapter._handle_group_message(
+            d, "m1", "hi bot", {"member_openid": "u1"}, "",
+            "GROUP_AT_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        assert captured[0].source.chat_id == "g1"
+        assert captured[0].source.chat_type == "group"
+
+    @pytest.mark.asyncio
+    async def test_always_mode_handles_non_mention_group_message(self):
+        adapter = self._make_adapter(group_require_mention=False)  # always
+        captured = self._drive(adapter)
+        d = {"group_openid": "g1", "content": "just chatting"}
+        await adapter._handle_group_message(
+            d, "m1", "just chatting", {"member_openid": "u1"}, "",
+            "GROUP_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        assert captured[0].text == "just chatting"
+
+    @pytest.mark.asyncio
+    async def test_per_group_mention_override_blocks_in_always_global(self):
+        adapter = self._make_adapter(
+            group_require_mention=False,
+            groups={"g1": {"require_mention": True}},
+        )
+        captured = self._drive(adapter)
+        # g1 forced to mention -> non-@ skipped.
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "hey"}, "m1", "hey",
+            {"member_openid": "u1"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        assert captured == []
+        # g2 follows global always -> handled.
+        await adapter._handle_group_message(
+            {"group_openid": "g2", "content": "hey"}, "m2", "hey",
+            {"member_openid": "u1"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_group_acl_blocks_before_gate(self):
+        adapter = self._make_adapter(group_policy="disabled",
+                                     group_require_mention=False)
+        captured = self._drive(adapter)
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "hi"}, "m1", "hi",
+            {"member_openid": "u1"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_group_acl_reject_emits_debug_log(self, caplog):
+        # ACL rejection must leave an operator-visible breadcrumb explaining
+        # both the cause (policy=disabled) and how to unblock it.
+        import logging
+        adapter = self._make_adapter(group_policy="disabled")
+        self._drive(adapter)
+        with caplog.at_level(logging.DEBUG, logger="gateway.platforms.qqbot"):
+            await adapter._handle_group_message(
+                {"group_openid": "gX", "content": "hi"}, "m1", "hi",
+                {"member_openid": "u1"}, "", "GROUP_AT_MESSAGE_CREATE",
+            )
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "blocked by ACL" in log_text
+        assert "gX" in log_text
+        assert "policy=disabled" in log_text
+        assert "group_policy" in log_text  # hint on how to unblock
+
+    def test_default_history_limit_is_20(self):
+        adapter = self._make_adapter()
+        assert adapter._group_history_limit == 20
+
+
+# ---------------------------------------------------------------------------
+# Group shared session (2.1) — group_sessions_per_user key behaviour
+# ---------------------------------------------------------------------------
+
+class TestGroupSharedSession:
+    def _source(self):
+        from gateway.session import SessionSource
+        from gateway.config import Platform
+        return SessionSource(
+            platform=Platform.QQBOT,
+            chat_id="group_openid_1",
+            chat_type="group",
+            user_id="member_openid_1",
+        )
+
+    def test_isolated_key_includes_participant_by_default(self):
+        from gateway.session import build_session_key
+        key = build_session_key(self._source(), group_sessions_per_user=True)
+        assert key.endswith(":member_openid_1")
+
+    def test_shared_key_excludes_participant(self):
+        from gateway.session import build_session_key
+        key = build_session_key(self._source(), group_sessions_per_user=False)
+        assert "member_openid_1" not in key
+        assert key.endswith(":group_openid_1")
+
+
+# ---------------------------------------------------------------------------
+# Group context buffer (2.2.1) — GroupContextBuffer unit tests
+# ---------------------------------------------------------------------------
+
+class TestGroupContextBuffer:
+    def _buf(self, **kw):
+        from gateway.platforms.qqbot.group_context import GroupContextBuffer
+        return GroupContextBuffer(**kw)
+
+    def test_record_and_drain_in_order(self):
+        buf = self._buf(limit=10)
+        buf.record("g1", sender="u1", text="first")
+        buf.record("g1", sender="u2", text="second")
+        entries = buf.drain("g1")
+        assert [e.text for e in entries] == ["first", "second"]
+        assert [e.sender for e in entries] == ["u1", "u2"]
+
+    def test_drain_clears(self):
+        buf = self._buf(limit=10)
+        buf.record("g1", sender="u1", text="hi")
+        assert buf.drain("g1")
+        assert buf.drain("g1") == []
+
+    def test_limit_truncates_oldest(self):
+        buf = self._buf(limit=2)
+        buf.record("g1", sender="u", text="a")
+        buf.record("g1", sender="u", text="b")
+        buf.record("g1", sender="u", text="c")
+        entries = buf.drain("g1")
+        assert [e.text for e in entries] == ["b", "c"]  # oldest "a" dropped
+
+    def test_disabled_when_limit_zero(self):
+        buf = self._buf(limit=0)
+        assert buf.enabled is False
+        buf.record("g1", sender="u", text="hi")
+        assert buf.drain("g1") == []
+
+    def test_group_isolation(self):
+        buf = self._buf(limit=10)
+        buf.record("g1", sender="u", text="a")
+        buf.record("g2", sender="u", text="b")
+        assert [e.text for e in buf.drain("g1")] == ["a"]
+        assert [e.text for e in buf.drain("g2")] == ["b"]
+
+    def test_empty_text_no_attachment_not_recorded(self):
+        buf = self._buf(limit=10)
+        buf.record("g1", sender="u", text="   ")
+        assert buf.drain("g1") == []
+
+    def test_attachment_tag_recorded_when_no_text(self):
+        buf = self._buf(limit=10)
+        buf.record("g1", sender="u", text="", attachment_tag="[image]")
+        entries = buf.drain("g1")
+        assert entries and entries[0].text == "[image]"
+
+    def test_max_groups_lru_eviction(self):
+        buf = self._buf(limit=5, max_groups=2)
+        buf.record("g1", sender="u", text="a")
+        buf.record("g2", sender="u", text="b")
+        buf.record("g3", sender="u", text="c")  # evicts g1 (LRU)
+        assert buf.drain("g1") == []
+        assert [e.text for e in buf.drain("g3")] == ["c"]
+
+    def test_format_context_wraps_with_tags(self):
+        from gateway.platforms.qqbot.group_context import (
+            GroupContextBuffer, HistoryEntry, HISTORY_CTX_START, HISTORY_CTX_END,
+        )
+        entries = [HistoryEntry(sender="u1", text="hello"),
+                   HistoryEntry(sender="u2", text="world")]
+        out = GroupContextBuffer.format_context(entries, "please summarize")
+        assert HISTORY_CTX_START in out
+        assert "u1: hello" in out
+        assert "u2: world" in out
+        assert HISTORY_CTX_END in out
+        assert out.endswith("please summarize")
+
+    def test_format_context_empty_returns_current(self):
+        from gateway.platforms.qqbot.group_context import GroupContextBuffer
+        assert GroupContextBuffer.format_context([], "just this") == "just this"
+
+    def test_summarize_attachments(self):
+        from gateway.platforms.qqbot.group_context import summarize_attachments
+        assert summarize_attachments(None) == ""
+        assert summarize_attachments([]) == ""
+        assert summarize_attachments([{"content_type": "image/png"}]) == "[image]"
+        assert summarize_attachments([{"content_type": "audio/silk"}]) == "[voice]"
+        assert summarize_attachments(
+            [{"content_type": "application/zip", "filename": "a.zip"}]
+        ) == "[file: a.zip]"
+
+
+# ---------------------------------------------------------------------------
+# Group context buffer — integration through _handle_group_message
+# ---------------------------------------------------------------------------
+
+class TestGroupContextIntegration:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        extra.setdefault("app_id", "1903885637")
+        extra.setdefault("client_secret", "b")
+        extra.setdefault("group_policy", "open")
+        return QQAdapter(_make_config(**extra))
+
+    def _drive(self, adapter):
+        captured = []
+
+        async def fake_process(_a):
+            return {"image_urls": [], "image_media_types": [],
+                    "voice_transcripts": [], "attachment_info": ""}
+
+        async def fake_quote(_d):
+            return {"quote_block": "", "image_urls": [], "image_media_types": []}
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+        adapter._process_quoted_context = fake_quote  # type: ignore[assignment]
+        adapter.handle_message = fake_handle  # type: ignore[assignment]
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_mention_mode_buffers_then_injects_on_at(self):
+        adapter = self._make_adapter()  # mention mode, default limit 50
+        captured = self._drive(adapter)
+        # non-@ message → buffered, no reply.
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "the sky is blue"}, "m1",
+            "the sky is blue", {"member_openid": "alice"}, "",
+            "GROUP_MESSAGE_CREATE",
+        )
+        assert captured == []
+        # @ message → reply with buffered context injected.
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "what did she say"}, "m2",
+            "what did she say", {"member_openid": "bob"}, "",
+            "GROUP_AT_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        text = captured[0].text
+        assert "CONTEXT ONLY" in text
+        assert "alice: the sky is blue" in text
+        assert text.endswith("what did she say")
+
+    @pytest.mark.asyncio
+    async def test_buffer_cleared_after_injection(self):
+        adapter = self._make_adapter()
+        captured = self._drive(adapter)
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "ctx"}, "m1", "ctx",
+            {"member_openid": "alice"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "q1"}, "m2", "q1",
+            {"member_openid": "bob"}, "", "GROUP_AT_MESSAGE_CREATE",
+        )
+        # second @ has no stale context.
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "q2"}, "m3", "q2",
+            {"member_openid": "bob"}, "", "GROUP_AT_MESSAGE_CREATE",
+        )
+        assert len(captured) == 2
+        assert "CONTEXT ONLY" not in captured[1].text
+        assert captured[1].text == "q2"
+
+    @pytest.mark.asyncio
+    async def test_always_mode_no_buffering(self):
+        adapter = self._make_adapter(group_require_mention=False)
+        captured = self._drive(adapter)
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "hello"}, "m1", "hello",
+            {"member_openid": "alice"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        assert captured[0].text == "hello"  # no context wrapper
+        # nothing left buffered.
+        assert adapter._group_context.drain("g1") == []
+
+    @pytest.mark.asyncio
+    async def test_history_limit_zero_disables_buffer(self):
+        adapter = self._make_adapter(group_history_limit=0)
+        captured = self._drive(adapter)
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "ctx"}, "m1", "ctx",
+            {"member_openid": "alice"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "q"}, "m2", "q",
+            {"member_openid": "bob"}, "", "GROUP_AT_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        assert "CONTEXT ONLY" not in captured[0].text
+        assert captured[0].text == "q"
+
+    @pytest.mark.asyncio
+    async def test_empty_at_message_still_flushes_context(self):
+        # A bare @ (empty body after strip) must still flush + inject pending
+        # context, not early-return and strand the buffer.
+        adapter = self._make_adapter()
+        captured = self._drive(adapter)
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "background note"}, "m1",
+            "background note", {"member_openid": "alice"}, "",
+            "GROUP_MESSAGE_CREATE",
+        )
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": ""}, "m2", "",
+            {"member_openid": "bob"}, "", "GROUP_AT_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        assert "alice: background note" in captured[0].text
+        # buffer cleared.
+        assert adapter._group_context.drain("g1") == []
+
+    @pytest.mark.asyncio
+    async def test_injection_keeps_current_message_with_attachments_last(self):
+        # Lock the order: buffered context first, current message (incl. its
+        # appended attachment_info) last.
+        adapter = self._make_adapter()
+        captured = self._drive(adapter)
+
+        async def fake_process(_a):
+            return {"image_urls": [], "image_media_types": [],
+                    "voice_transcripts": [], "attachment_info": "[file: doc.pdf]"}
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "earlier"}, "m1", "earlier",
+            {"member_openid": "alice"}, "", "GROUP_MESSAGE_CREATE",
+        )
+        # NB: alice's non-@ message uses the light attachment tag, not the full
+        # processor; the @ message below exercises the full path.
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "see attached"}, "m2",
+            "see attached", {"member_openid": "bob"}, "",
+            "GROUP_AT_MESSAGE_CREATE",
+        )
+        text = captured[0].text
+        assert text.index("earlier") < text.index("see attached")
+        assert text.index("see attached") < text.index("[file: doc.pdf]")
+        assert "CONTEXT ONLY" in text

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1696,6 +1696,34 @@ class TestGroupContextBuffer:
         from gateway.platforms.qqbot.group_context import GroupContextBuffer
         assert GroupContextBuffer.format_context([], "just this") == "just this"
 
+    def test_format_context_block_no_current_message(self):
+        # The block variant renders context only (for channel_context): it must
+        # include the CONTEXT-ONLY header + entries, but NOT the current message
+        # and NOT the CURRENT-MESSAGE end tag (gateway supplies [New message]).
+        from gateway.platforms.qqbot.group_context import (
+            GroupContextBuffer, HistoryEntry, HISTORY_CTX_START, HISTORY_CTX_END,
+        )
+        entries = [HistoryEntry(sender="u1", text="hello"),
+                   HistoryEntry(sender="u2", text="world")]
+        out = GroupContextBuffer.format_context_block(entries)
+        assert HISTORY_CTX_START in out
+        assert "u1: hello" in out
+        assert "u2: world" in out
+        assert HISTORY_CTX_END not in out
+
+    def test_format_context_block_empty_returns_blank(self):
+        from gateway.platforms.qqbot.group_context import GroupContextBuffer
+        assert GroupContextBuffer.format_context_block([]) == ""
+
+    def test_format_context_block_collapses_newlines(self):
+        # R5 hardening: a buffered multi-line message cannot forge envelope tags.
+        from gateway.platforms.qqbot.group_context import (
+            GroupContextBuffer, HistoryEntry,
+        )
+        entries = [HistoryEntry(sender="u1", text="line1\nline2")]
+        out = GroupContextBuffer.format_context_block(entries)
+        assert "u1: line1 line2" in out
+
     def test_summarize_attachments(self):
         from gateway.platforms.qqbot.group_context import summarize_attachments
         assert summarize_attachments(None) == ""
@@ -1755,10 +1783,38 @@ class TestGroupContextIntegration:
             "GROUP_AT_MESSAGE_CREATE",
         )
         assert len(captured) == 1
-        text = captured[0].text
-        assert "CONTEXT ONLY" in text
-        assert "alice: the sky is blue" in text
-        assert text.endswith("what did she say")
+        # Buffered history is carried in channel_context (kept out of text so
+        # slash-command detection + sender-prefix operate on the trigger alone).
+        ctx = captured[0].channel_context
+        assert ctx and "CONTEXT ONLY" in ctx
+        assert "alice: the sky is blue" in ctx
+        # text is the trigger message only.
+        assert captured[0].text == "what did she say"
+
+    @pytest.mark.asyncio
+    async def test_command_at_message_stays_matchable_with_pending_context(self):
+        # Regression: a /stop-style command in an @-message must remain at the
+        # start of text (get_command works) even when pending context exists;
+        # the context goes to channel_context instead of being merged ahead.
+        adapter = self._make_adapter()
+        captured = self._drive(adapter)
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "the sky is blue"}, "m1",
+            "the sky is blue", {"member_openid": "alice"}, "",
+            "GROUP_MESSAGE_CREATE",
+        )
+        await adapter._handle_group_message(
+            {"group_openid": "g1", "content": "/stop"}, "m2",
+            "/stop", {"member_openid": "bob"}, "",
+            "GROUP_AT_MESSAGE_CREATE",
+        )
+        assert len(captured) == 1
+        ev = captured[0]
+        assert ev.text == "/stop"
+        assert ev.is_command() is True
+        assert ev.get_command() == "stop"
+        # context preserved separately, not merged into text.
+        assert ev.channel_context and "alice: the sky is blue" in ev.channel_context
 
     @pytest.mark.asyncio
     async def test_buffer_cleared_after_injection(self):
@@ -1826,7 +1882,12 @@ class TestGroupContextIntegration:
             {"member_openid": "bob"}, "", "GROUP_AT_MESSAGE_CREATE",
         )
         assert len(captured) == 1
-        assert "alice: background note" in captured[0].text
+        # bare @ carries no trigger body; pending context lands in channel_context.
+        assert captured[0].text == ""
+        assert (
+            captured[0].channel_context
+            and "alice: background note" in captured[0].channel_context
+        )
         # buffer cleared.
         assert adapter._group_context.drain("g1") == []
 
@@ -1854,7 +1915,843 @@ class TestGroupContextIntegration:
             "see attached", {"member_openid": "bob"}, "",
             "GROUP_AT_MESSAGE_CREATE",
         )
-        text = captured[0].text
-        assert text.index("earlier") < text.index("see attached")
-        assert text.index("see attached") < text.index("[file: doc.pdf]")
-        assert "CONTEXT ONLY" in text
+        ev = captured[0]
+        # Trigger message + its attachment_info stay in text, in order.
+        assert ev.text.index("see attached") < ev.text.index("[file: doc.pdf]")
+        # Buffered history is separated into channel_context.
+        assert ev.channel_context and "CONTEXT ONLY" in ev.channel_context
+        assert "earlier" in ev.channel_context
+        assert "earlier" not in ev.text
+
+
+# ---------------------------------------------------------------------------
+# C2C streaming reply — StreamManager
+# ---------------------------------------------------------------------------
+
+class TestStreamManager:
+    """Unit tests for the in-memory StreamSession table."""
+
+    def test_create_registers_session_with_generated_logical_id(self):
+        from gateway.platforms.qqbot.streaming import StreamManager
+        mgr = StreamManager()
+        s1 = mgr.create(openid="u1", passive_msg_id="m1", msg_seq=42)
+        s2 = mgr.create(openid="u2", passive_msg_id="m2", msg_seq=43)
+        assert s1.logical_id and s2.logical_id
+        assert s1.logical_id != s2.logical_id
+        assert mgr.get(s1.logical_id) is s1
+        assert mgr.get(s2.logical_id) is s2
+
+    def test_get_returns_none_for_unknown_id(self):
+        from gateway.platforms.qqbot.streaming import StreamManager
+        mgr = StreamManager()
+        assert mgr.get("nonexistent") is None
+
+    def test_drop_is_idempotent(self):
+        from gateway.platforms.qqbot.streaming import StreamManager
+        mgr = StreamManager()
+        s = mgr.create(openid="u", passive_msg_id="m", msg_seq=1)
+        mgr.drop(s.logical_id)
+        mgr.drop(s.logical_id)  # second drop must not raise
+        assert mgr.get(s.logical_id) is None
+
+    def test_ttl_expiry_evicts_stale_session(self):
+        from gateway.platforms.qqbot.streaming import StreamManager
+        mgr = StreamManager(ttl_seconds=60.0)
+        s = mgr.create(openid="u", passive_msg_id="m", msg_seq=1)
+        # Backdate the session past the TTL horizon.
+        s.created_at -= 61.0
+        assert mgr.get(s.logical_id) is None
+        # After the failed lookup the entry should be gone.
+        assert len(mgr) == 0
+
+    def test_lru_eviction_when_full(self):
+        from gateway.platforms.qqbot.streaming import StreamManager
+        mgr = StreamManager(max_sessions=2)
+        a = mgr.create(openid="a", passive_msg_id="m1", msg_seq=1)
+        b = mgr.create(openid="b", passive_msg_id="m2", msg_seq=2)
+        # Touch A to promote it — B becomes LRU.
+        assert mgr.get(a.logical_id) is a
+        mgr.create(openid="c", passive_msg_id="m3", msg_seq=3)
+        assert mgr.get(b.logical_id) is None  # evicted
+        assert mgr.get(a.logical_id) is a  # still present
+
+
+# ---------------------------------------------------------------------------
+# C2C streaming reply — QQAdapter integration
+# ---------------------------------------------------------------------------
+
+class TestC2CStreamingReply:
+    """Streaming-path tests for ``send()`` + ``edit_message()`` on C2C chats."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        extra.setdefault("app_id", "a")
+        extra.setdefault("client_secret", "b")
+        adapter = QQAdapter(_make_config(**extra))
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._http_client = mock.MagicMock()
+        return adapter
+
+    def test_requires_edit_finalize_class_attr_is_true(self):
+        from gateway.platforms.qqbot import QQAdapter
+        assert QQAdapter.REQUIRES_EDIT_FINALIZE is True
+
+    def test_streaming_defaults_enabled(self):
+        adapter = self._make_adapter()
+        assert adapter._streaming_enabled is True
+
+    def test_streaming_can_be_disabled_via_config(self):
+        adapter = self._make_adapter(streaming_enabled=False)
+        assert adapter._streaming_enabled is False
+
+    @pytest.mark.asyncio
+    async def test_c2c_first_send_opens_stream_session(self):
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "stream-xyz-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send(
+            "user_a", "hello",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert result.success
+        # message_id must be the adapter's logical_id (opaque uuid hex),
+        # NOT the QQ-assigned stream_msg_id — the consumer echoes this
+        # back on edit_message and we translate internally.
+        assert result.message_id is not None
+        assert result.message_id != "stream-xyz-1"
+        assert len(calls) == 1
+        method, path, body = calls[0]
+        assert method == "POST"
+        assert path == "/v2/users/user_a/stream_messages"
+        assert body["input_mode"] == "replace"
+        assert body["input_state"] == 1  # GENERATING
+        assert body["content_type"] == "markdown"  # MARKDOWN — fixed
+        assert body["content_raw"] == "hello"
+        assert body["event_id"] == "inbound_m1"
+        assert body["msg_id"] == "inbound_m1"
+        assert body["index"] == 0
+        assert "stream_msg_id" not in body  # first chunk omits it
+        # Session should be registered and reference the QQ id.
+        session = adapter._stream_manager.get(result.message_id)
+        assert session is not None
+        assert session.stream_msg_id == "stream-xyz-1"
+
+    @pytest.mark.asyncio
+    async def test_c2c_edit_reuses_stream_msg_id_and_increments_index(self):
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "stream-xyz-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "user_a", "hel",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert first.success
+        logical_id = first.message_id
+
+        second = await adapter.edit_message("user_a", logical_id, "hello")
+        third = await adapter.edit_message("user_a", logical_id, "hello wor")
+        assert second.success and third.success
+        # All three chunks share the same msg_seq and target the same
+        # stream endpoint.
+        assert len({body["msg_seq"] for _, _, body in calls}) == 1
+        assert [body["index"] for _, _, body in calls] == [0, 1, 2]
+        # Second/third chunks carry stream_msg_id from the first response.
+        assert calls[1][2]["stream_msg_id"] == "stream-xyz-1"
+        assert calls[2][2]["stream_msg_id"] == "stream-xyz-1"
+        # content_raw is REPLACE semantics — full accumulated text each time.
+        assert [body["content_raw"] for _, _, body in calls] == [
+            "hel", "hello", "hello wor",
+        ]
+        # Intermediate edits stay in GENERATING state.
+        assert calls[1][2]["input_state"] == 1
+        assert calls[2][2]["input_state"] == 1
+
+    @pytest.mark.asyncio
+    async def test_c2c_finalize_sends_done_and_drops_session(self):
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "stream-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "user_a", "partial",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        result = await adapter.edit_message(
+            "user_a", first.message_id, "final full answer",
+            finalize=True,
+        )
+        assert result.success
+        # Final chunk uses input_state=10 (DONE).
+        assert calls[-1][2]["input_state"] == 10
+        # Session should be cleaned up after finalize.
+        assert adapter._stream_manager.get(first.message_id) is None
+
+    @pytest.mark.asyncio
+    async def test_edit_after_finalize_is_noop_success(self):
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+
+        async def fake_api(method, path, body=None, **kw):
+            return {"id": "stream-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "user_a", "x",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        await adapter.edit_message(
+            "user_a", first.message_id, "final",
+            finalize=True,
+        )
+        # Second call after finalize: session already dropped, treated
+        # as "unknown session" → success=False so the consumer sends a
+        # fresh message rather than corrupting the finalized stream.
+        r = await adapter.edit_message(
+            "user_a", first.message_id, "oops",
+        )
+        assert r.success is False
+        assert "expired" in (r.error or "").lower() or "found" in (r.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_edit_on_unknown_session_returns_failure(self):
+        adapter = self._make_adapter()
+        result = await adapter.edit_message("user_a", "nonexistent-logical-id", "hi")
+        assert result.success is False
+        assert result.error
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_edit_is_dropped_silently(self):
+        """When ``next_index <= last_sent_index`` the edit is treated as a
+        no-op success without hitting the QQ API — matches the simplified
+        out-of-order policy agreed for this release.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "stream-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "user_a", "hi",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        session = adapter._stream_manager.get(first.message_id)
+        # Simulate an out-of-order scenario by regressing next_index.
+        # (Consumer serialisation makes this impossible in practice, so
+        # we assert the defensive guard triggers when it happens.)
+        session.next_index = 0
+        session.last_sent_index = 0
+        api_calls_before = len(calls)
+
+        r = await adapter.edit_message("user_a", first.message_id, "hello")
+        assert r.success is True
+        assert len(calls) == api_calls_before  # no additional API call
+
+    @pytest.mark.asyncio
+    async def test_group_chat_streaming_first_send_defers_delivery(self):
+        """Group targets have no editable message id on QQ, so the
+        streaming first-send is buffered inside the adapter: no QQ API
+        call yet, but ``send()`` returns ``success=True`` with a
+        sentinel ``message_id`` so the stream consumer stays on its
+        edit path (avoiding the lossy prefix-based fallback).  The
+        complete reply is delivered later, on ``edit_message`` with
+        ``finalize=True``.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        paths = []
+
+        async def fake_api(method, path, body=None, **kw):
+            paths.append(path)
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send(
+            "group_a", "hello",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert result.success
+        assert result.message_id is not None
+        assert result.message_id.startswith("__qqbot_group_defer_")
+        # No QQ API call happened — the reply is deferred to finalize.
+        assert paths == []
+        # Session bookkeeping preserves the original reply_to for
+        # threaded delivery on finalize.
+        assert result.message_id in adapter._group_defer_sessions
+        session = adapter._group_defer_sessions[result.message_id]
+        assert session["chat_id"] == "group_a"
+        assert session["chat_type"] == "group"
+        assert session["reply_to"] == "inbound_m1"
+        # Fresh session — not yet finalized.
+        assert session["finalized"] is False
+        assert session["finalized_result"] is None
+
+    @pytest.mark.asyncio
+    async def test_guild_chat_streaming_first_send_defers_delivery(self):
+        """Same deferral as group chats — guild targets are also
+        non-editable, so ``expect_edits`` must not trigger a real send.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["chan1"] = "guild"
+        paths = []
+
+        async def fake_api(method, path, body=None, **kw):
+            paths.append(path)
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send(
+            "chan1", "hello",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert result.success
+        assert result.message_id is not None
+        assert result.message_id.startswith("__qqbot_group_defer_")
+        assert paths == []
+        session = adapter._group_defer_sessions[result.message_id]
+        assert session["chat_type"] == "guild"
+
+    @pytest.mark.asyncio
+    async def test_group_deferred_edit_intermediate_is_noop(self):
+        """Intermediate ``edit_message`` calls on a deferred group
+        session must NOT hit the QQ API — they are silent no-ops that
+        accumulate context until the finalize call arrives.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        paths = []
+
+        async def fake_api(method, path, body=None, **kw):
+            paths.append(path)
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "group_a", "chunk1",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        sentinel = first.message_id
+        assert paths == []
+
+        for partial in ("chunk1 chunk2", "chunk1 chunk2 chunk3"):
+            r = await adapter.edit_message(
+                "group_a", sentinel, partial, finalize=False,
+            )
+            assert r.success
+            assert r.message_id == sentinel
+
+        # Still no QQ API traffic.
+        assert paths == []
+        # Session is still live.
+        assert sentinel in adapter._group_defer_sessions
+
+    @pytest.mark.asyncio
+    async def test_group_deferred_edit_finalize_delivers_full_content(self):
+        """The finalize ``edit_message`` is where the complete reply
+        actually reaches QQ.  It must:
+
+        * hit the regular group messages endpoint exactly once,
+        * carry the FULL accumulated content (not just the tail),
+        * preserve the original ``reply_to`` for threading, and
+        * clear the deferred session bookkeeping.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "group_a", "hello",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        sentinel = first.message_id
+        # A couple of intermediate edits — should not touch QQ.
+        await adapter.edit_message("group_a", sentinel, "hello world")
+        await adapter.edit_message(
+            "group_a", sentinel, "hello world, done",
+        )
+        assert calls == []
+
+        # Finalize with the full accumulated text.
+        final = await adapter.edit_message(
+            "group_a", sentinel,
+            "hello world, done: final answer",
+            finalize=True,
+        )
+        assert final.success
+        assert final.message_id == "regular-1"
+        # One and only one API call — the complete reply.
+        assert len(calls) == 1
+        method, path, body = calls[0]
+        assert method == "POST"
+        assert path == "/v2/groups/group_a/messages"
+        # Full accumulated text (may be under ``content`` or
+        # ``markdown.content`` depending on adapter markdown mode).
+        text = (
+            body.get("content")
+            or body.get("markdown", {}).get("content")
+            or ""
+        )
+        assert text.startswith("hello world, done: final answer")
+        # Threaded to the original inbound message.
+        assert body.get("msg_id") == "inbound_m1"
+        # Session bookkeeping: entry is preserved but flagged so
+        # subsequent finalize edits become idempotent no-ops (see
+        # ``test_group_deferred_edit_finalize_is_idempotent``).
+        assert sentinel in adapter._group_defer_sessions
+        remembered = adapter._group_defer_sessions[sentinel]
+        assert remembered["finalized"] is True
+        assert remembered["finalized_result"] is final
+
+    @pytest.mark.asyncio
+    async def test_group_deferred_edit_finalize_is_idempotent(self):
+        """A second ``finalize=True`` edit on the same sentinel must NOT
+        re-post the reply.
+
+        Regression guard: because the adapter declares
+        ``REQUIRES_EDIT_FINALIZE=True``, the stream consumer's
+        ``got_done`` branch can issue two ``_send_or_edit(...,
+        finalize=True)`` calls per turn — the mid-stream flush plus the
+        explicit final tick.  The first call already delivered the
+        reply via ``self.send(...)``; the second must be an idempotent
+        no-op or the user sees two identical messages in the group.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "group_a", "hello",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        sentinel = first.message_id
+
+        final_a = await adapter.edit_message(
+            "group_a", sentinel, "the full reply",
+            finalize=True,
+        )
+        final_b = await adapter.edit_message(
+            "group_a", sentinel, "the full reply",
+            finalize=True,
+        )
+
+        # First finalize delivered exactly once; the second is a
+        # memoised replay — same result object, no extra API call.
+        assert len(calls) == 1
+        assert final_a.success and final_b.success
+        assert final_a.message_id == "regular-1"
+        assert final_b.message_id == "regular-1"
+        assert final_b is final_a
+
+    @pytest.mark.asyncio
+    async def test_group_deferred_edit_after_finalize_non_final_is_noop(self):
+        """A stray non-final edit arriving after finalize must not
+        re-hit QQ (would happen on cancellation cleanup or an errant
+        mid-stream tick that raced with the final one).
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "group_a", "hi",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        sentinel = first.message_id
+
+        await adapter.edit_message("group_a", sentinel, "final",
+                                    finalize=True)
+        # Simulate a late non-final tick after finalize.
+        stray = await adapter.edit_message(
+            "group_a", sentinel, "final plus more", finalize=False,
+        )
+        assert stray.success
+        # Still exactly one API call — the finalize one.
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_group_deferred_sessions_evict_finalized_over_cap(self):
+        """The finalized-session bookkeeping must not grow without
+        bound: once above the LRU cap, oldest finalized entries are
+        dropped.  Pending (non-finalized) entries are preserved.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        adapter._group_defer_sessions_cap = 3
+
+        async def fake_api(method, path, body=None, **kw):
+            return {"id": "regular"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        # 3 finalized + 1 pending → over cap by 1.
+        finalized_ids = []
+        for _ in range(3):
+            r = await adapter.send(
+                "group_a", "hi",
+                metadata={"expect_edits": True},
+            )
+            await adapter.edit_message("group_a", r.message_id, "x",
+                                        finalize=True)
+            finalized_ids.append(r.message_id)
+
+        pending = await adapter.send(
+            "group_a", "hi",
+            metadata={"expect_edits": True},
+        )
+
+        # Cap enforcement runs on send() insertion — the oldest
+        # finalized entry should have been evicted, the pending one
+        # kept.
+        assert pending.message_id in adapter._group_defer_sessions
+        assert finalized_ids[0] not in adapter._group_defer_sessions
+        # Newer finalized entries remain until they too age out.
+        assert finalized_ids[-1] in adapter._group_defer_sessions
+
+    @pytest.mark.asyncio
+    async def test_group_deferred_edit_after_session_expiry_recovers(self):
+        """If the deferred session is gone (adapter restart, TTL, ...),
+        a finalize edit must still deliver the content via a fresh
+        legacy send instead of dropping the reply silently.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append((method, path, body))
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        # Never called send() first: no session exists.
+        result = await adapter.edit_message(
+            "group_a", "__qqbot_group_defer_missing__",
+            "recovered content", finalize=True,
+        )
+        assert result.success
+        assert len(calls) == 1
+        assert calls[0][1] == "/v2/groups/group_a/messages"
+
+    @pytest.mark.asyncio
+    async def test_group_chat_without_expect_edits_sends_normally(self):
+        """Non-streaming group sends must still hit the regular group
+        messages endpoint and return a real id.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["group_a"] = "group"
+        paths = []
+
+        async def fake_api(method, path, body=None, **kw):
+            paths.append(path)
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send(
+            "group_a", "final answer",
+            reply_to="inbound_m1",
+            metadata={"final": True},
+        )
+        assert result.success
+        assert result.message_id == "regular-1"
+        assert paths == ["/v2/groups/group_a/messages"]
+
+    @pytest.mark.asyncio
+    async def test_group_edit_message_returns_failure(self):
+        """Groups have no stream session — edit_message must return
+        ``success=False`` so the consumer falls back to a fresh send.
+        """
+        adapter = self._make_adapter()
+        result = await adapter.edit_message("group_a", "any-id", "hi")
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_streaming_disabled_falls_back_to_legacy_send(self):
+        adapter = self._make_adapter(streaming_enabled=False)
+        adapter._chat_type_map["user_a"] = "c2c"
+        paths = []
+
+        async def fake_api(method, path, body=None, **kw):
+            paths.append(path)
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send(
+            "user_a", "hi",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert result.success
+        assert all("/stream_messages" not in p for p in paths)
+
+    @pytest.mark.asyncio
+    async def test_c2c_send_without_expect_edits_uses_legacy_path(self):
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        paths = []
+
+        async def fake_api(method, path, body=None, **kw):
+            paths.append(path)
+            return {"id": "regular-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send("user_a", "hi", reply_to="inbound_m1")
+        assert result.success
+        assert paths == ["/v2/users/user_a/messages"]
+
+    @pytest.mark.asyncio
+    async def test_streaming_start_failure_falls_back_to_legacy(self, caplog):
+        """First chunk failure must warn and degrade to a regular send in
+        the same ``send()`` call — user requirement (d).
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append(path)
+            if "/stream_messages" in path:
+                raise RuntimeError("QQ Bot API error [500] boom")
+            return {"id": "legacy-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = await adapter.send(
+                "user_a", "hi",
+                reply_to="inbound_m1",
+                metadata={"expect_edits": True},
+            )
+        assert result.success
+        # Stream attempt happened, then fell back to the regular endpoint.
+        assert calls[0].endswith("/stream_messages")
+        assert calls[-1] == "/v2/users/user_a/messages"
+        assert any(
+            "Failed to start C2C streaming reply" in rec.message
+            for rec in caplog.records
+        )
+        # Abandoned session must not leak into the manager table.
+        assert len(adapter._stream_manager) == 0
+
+    @pytest.mark.asyncio
+    async def test_streaming_start_without_passive_msg_id_falls_back(self, caplog):
+        """No reply_to + no cached inbound id → skip streaming with a
+        warning; the endpoint requires a passive-reply msg_id.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        # _last_msg_id intentionally empty.
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append(path)
+            return {"id": "legacy-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = await adapter.send(
+                "user_a", "hi",
+                metadata={"expect_edits": True},
+            )
+        assert result.success
+        assert all("/stream_messages" not in p for p in calls)
+        assert any("no passive msg_id" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_streaming_uses_cached_inbound_id_when_reply_to_missing(self):
+        """If ``reply_to`` is not supplied, the adapter must use the most
+        recent inbound msg_id it saw for that chat.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        adapter._last_msg_id["user_a"] = "cached_inbound_99"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append(body)
+            return {"id": "stream-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        result = await adapter.send(
+            "user_a", "hi",
+            metadata={"expect_edits": True},
+        )
+        assert result.success
+        assert calls[0]["msg_id"] == "cached_inbound_99"
+        assert calls[0]["event_id"] == "cached_inbound_99"
+
+    @pytest.mark.asyncio
+    async def test_content_truncated_to_stream_content_limit(self):
+        from gateway.platforms.qqbot.streaming import MAX_STREAM_CONTENT_LEN
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        captured = []
+
+        async def fake_api(method, path, body=None, **kw):
+            captured.append(body)
+            return {"id": "stream-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        big = "x" * (MAX_STREAM_CONTENT_LEN + 200)
+        await adapter.send(
+            "user_a", big,
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert len(captured[0]["content_raw"]) == MAX_STREAM_CONTENT_LEN
+
+    @pytest.mark.asyncio
+    async def test_stream_forwards_content_verbatim_when_gateway_suppresses_cursor(self):
+        """With QQBOT-specific cursor suppression in ``gateway/run.py``
+        (analogous to ``Platform.MATRIX``), no typewriter cursor ever
+        reaches the adapter — successive frames are forwarded verbatim
+        and the prefix invariant holds naturally.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append(body)
+            return {"id": "stream-nocursor-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        # All three frames arrive without any trailing cursor glyph,
+        # exactly what the gateway will emit for QQBOT.
+        first = await adapter.send(
+            "user_a", "Hello",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert first.success
+        logical_id = first.message_id
+
+        second = await adapter.edit_message(
+            "user_a", logical_id, "Hello world",
+        )
+        assert second.success
+
+        third = await adapter.edit_message(
+            "user_a", logical_id, "Hello world!", finalize=True,
+        )
+        assert third.success
+
+        seen = [body["content_raw"] for body in calls]
+        assert seen == ["Hello", "Hello world", "Hello world!"]
+        for i in range(len(seen) - 1):
+            assert seen[i + 1].startswith(seen[i]), (
+                f"prefix broken at {i}: {seen[i]!r} -> {seen[i + 1]!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_stream_prefix_divergence_replays_last_chunk(self):
+        """Divergent frames must degrade to a safe replay, not a 500.
+
+        If a subsequent edit's cleaned text does NOT start with the
+        previously-accepted text (e.g. upstream trimmed a segment,
+        replayed a shorter partial, or the model backtracked), we
+        MUST NOT forward it verbatim — that would break the prefix
+        invariant and kill the whole stream.  Instead the adapter
+        replays the last-accepted text so QQ sees a no-op-shaped
+        chunk and the session stays alive for the next real update.
+        """
+        adapter = self._make_adapter()
+        adapter._chat_type_map["user_a"] = "c2c"
+        calls = []
+
+        async def fake_api(method, path, body=None, **kw):
+            calls.append(body)
+            return {"id": "stream-div-1"}
+
+        adapter._api_request = fake_api  # type: ignore[assignment]
+
+        first = await adapter.send(
+            "user_a", "Hello world how are you",
+            reply_to="inbound_m1",
+            metadata={"expect_edits": True},
+        )
+        assert first.success
+        logical_id = first.message_id
+
+        # Divergent frame — shorter and NOT a prefix of the first.
+        result = await adapter.edit_message(
+            "user_a", logical_id, "Different content entirely",
+        )
+        # We report success (from QQ's POV nothing bad happened) but the
+        # payload we actually sent is the previously-accepted text,
+        # keeping the prefix invariant intact.
+        assert result.success
+        assert calls[1]["content_raw"] == "Hello world how are you"
+
+        # A subsequent, properly-extended frame flows through as normal.
+        third = await adapter.edit_message(
+            "user_a", logical_id, "Hello world how are you today",
+        )
+        assert third.success
+        assert calls[2]["content_raw"] == "Hello world how are you today"

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1617,6 +1617,193 @@ class TestGroupSharedSession:
 
 
 # ---------------------------------------------------------------------------
+# Review follow-up (problem 1): per-platform session-sharing must drive BOTH
+# the session key AND the [user_name] sender attribution.
+#
+# Regression: sender attribution in GatewayRunner._prepare_inbound_message_text
+# read only the global GatewayConfig.group_sessions_per_user, while the session
+# key was built from the per-platform extra value. A QQ-only shared session
+# (extra.group_sessions_per_user=false, global default true) therefore merged
+# users into one session key WITHOUT the required sender prefix.
+# ---------------------------------------------------------------------------
+
+def _make_runner_with_qq_extra(**extra):
+    """Bare GatewayRunner: QQ platform carries `extra`, global config stays default."""
+    from gateway.run import GatewayRunner
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.QQBOT: PlatformConfig(enabled=True, extra=dict(extra))}
+    )
+    runner.adapters = {}
+    runner.session_store = None
+    runner._pending_native_image_paths_by_session = {}
+    return runner
+
+
+class TestEffectiveSessionSharing:
+    """GatewayRunner._effective_session_sharing resolves per-platform values."""
+
+    def _source(self):
+        from gateway.session import SessionSource
+        from gateway.config import Platform
+        return SessionSource(
+            platform=Platform.QQBOT,
+            chat_id="group_openid_1",
+            chat_type="group",
+            user_id="member_1",
+        )
+
+    def test_qq_extra_override_beats_global_default(self):
+        # Global default group_sessions_per_user=True, QQ extra says False.
+        runner = _make_runner_with_qq_extra(group_sessions_per_user=False)
+        group_spu, _thread_spu = runner._effective_session_sharing(self._source())
+        assert group_spu is False  # per-platform override wins
+
+    def test_falls_back_to_global_when_no_extra(self):
+        runner = _make_runner_with_qq_extra()  # empty extra
+        group_spu, thread_spu = runner._effective_session_sharing(self._source())
+        assert group_spu is True   # inherits global default (True)
+        assert thread_spu is False
+
+    def test_unknown_platform_uses_global(self):
+        from gateway.session import SessionSource
+        from gateway.config import Platform
+        runner = _make_runner_with_qq_extra(group_sessions_per_user=False)
+        # A source for a platform with no config entry → global defaults.
+        src = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="c",
+            chat_type="group",
+            user_id="u",
+        )
+        group_spu, thread_spu = runner._effective_session_sharing(src)
+        assert group_spu is True
+        assert thread_spu is False
+
+
+class TestGroupSharedSenderAttribution:
+    """Two-sender regression for the shared-session sender prefix."""
+
+    def _event(self, user_id, user_name, text="hello"):
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.session import SessionSource
+        from gateway.config import Platform
+
+        src = SessionSource(
+            platform=Platform.QQBOT,
+            chat_id="group_openid_1",
+            chat_type="group",
+            user_id=user_id,
+            user_name=user_name,
+        )
+        return src, MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=src,
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_senders_share_key_and_get_prefixed(self):
+        # QQ-only shared session; global default stays isolated (True).
+        runner = _make_runner_with_qq_extra(group_sessions_per_user=False)
+
+        src_a, ev_a = self._event("member_1", "Alice")
+        src_b, ev_b = self._event("member_2", "Bob")
+
+        text_a = await runner._prepare_inbound_message_text(
+            event=ev_a, source=src_a, history=[]
+        )
+        text_b = await runner._prepare_inbound_message_text(
+            event=ev_b, source=src_b, history=[]
+        )
+
+        # Both messages carry their own sender prefix …
+        assert text_a == "[Alice] hello"
+        assert text_b == "[Bob] hello"
+
+        # … and both land in the SAME shared session key (user_id excluded).
+        key_a = runner._session_key_for_source(src_a)
+        key_b = runner._session_key_for_source(src_b)
+        assert key_a == key_b
+        assert "member_1" not in key_a and "member_2" not in key_a
+
+    @pytest.mark.asyncio
+    async def test_isolated_default_has_no_prefix(self):
+        # Default (isolated) sessions: each user has its own key, no prefix.
+        runner = _make_runner_with_qq_extra()  # inherits global True (isolated)
+        src_a, ev_a = self._event("member_1", "Alice")
+        text_a = await runner._prepare_inbound_message_text(
+            event=ev_a, source=src_a, history=[]
+        )
+        assert text_a == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up (problem 2): split native C2C stream editing from generic
+# already-sent message editing so the tool-progress editor does not attempt
+# (and fail) edits against ordinary QQ message IDs.
+# ---------------------------------------------------------------------------
+
+class TestStreamEditingCapabilitySplit:
+    def test_qq_message_editing_is_false(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        # QQ cannot edit arbitrary already-sent message IDs.
+        assert QQAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+    def test_qq_stream_editing_is_true(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        # QQ CAN update an in-flight C2C stream bubble in place.
+        assert QQAdapter.SUPPORTS_STREAM_EDITING is True
+
+    def test_base_stream_editing_falls_back_to_message_editing(self):
+        from gateway.platforms.base import BasePlatformAdapter
+        prop = BasePlatformAdapter.__dict__["SUPPORTS_STREAM_EDITING"]
+
+        class _NonEditable:
+            SUPPORTS_MESSAGE_EDITING = False
+
+        class _Editable:
+            SUPPORTS_MESSAGE_EDITING = True
+
+        class _Silent:  # neither attribute set
+            pass
+
+        assert prop.fget(_NonEditable()) is False
+        assert prop.fget(_Editable()) is True
+        assert prop.fget(_Silent()) is True  # default True
+
+    def test_stream_consumer_resolution_for_qq(self):
+        # Mirrors gateway.run stream consumer: prefer stream flag, fall back to
+        # generic message-editing flag.
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        supports = getattr(
+            QQAdapter,
+            "SUPPORTS_STREAM_EDITING",
+            getattr(QQAdapter, "SUPPORTS_MESSAGE_EDITING", True),
+        )
+        assert supports is True  # C2C streaming stays enabled
+
+    def test_tool_progress_gate_skips_qq(self):
+        # Mirrors the gate in gateway.run.send_progress_messages: an adapter is
+        # eligible for generic tool-progress editing ONLY if it overrides
+        # edit_message AND advertises SUPPORTS_MESSAGE_EDITING. QQ overrides
+        # edit_message but is not a generic editor → progress must be skipped.
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        from gateway.platforms.base import BasePlatformAdapter
+
+        overrides_edit = (
+            QQAdapter.edit_message is not BasePlatformAdapter.edit_message
+        )
+        generic_editing = overrides_edit and getattr(
+            QQAdapter, "SUPPORTS_MESSAGE_EDITING", True
+        )
+        assert overrides_edit is True       # QQ does override edit_message
+        assert generic_editing is False     # …but not for generic message IDs
+
+
+# ---------------------------------------------------------------------------
 # Group context buffer (2.2.1) — GroupContextBuffer unit tests
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -73,15 +73,54 @@ platforms:
       dm_policy: "open"          # open | allowlist | disabled
       allow_from:
         - "user_openid_1"
-      group_policy: "open"       # open | allowlist | disabled
+      group_policy: "open"       # open | allowlist | disabled (default: disabled)
       group_allow_from:
         - "group_openid_1"
+      # ── Group activation mode (always vs mention) ──
+      group_require_mention: true  # true = reply only when @-ed (default);
+                                   # false = "always" mode, any group message
+                                   # may trigger a reply (needs the "receive all
+                                   # group messages" permission on the QQ platform)
+      groups:                      # optional per-group override (group > global)
+        "group_openid_1":
+          require_mention: false   # force always mode for this group only
+      # ── Group session sharing ──
+      group_sessions_per_user: true  # true (default) = each member gets an
+                                     # isolated session; set false so ALL members
+                                     # of a group share ONE conversation session
+      group_history_limit: 20        # (mention mode) non-@ messages buffered per
+                                     # group and injected as CONTEXT ONLY on the
+                                     # next @-reply; <=0 disables buffering
       stt:
         provider: "zai"          # zai (GLM-ASR), openai (Whisper), etc.
         baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4"
         apiKey: "your-stt-key"
         model: "glm-asr"
 ```
+
+## Group Activation Mode
+
+QQ groups support two independent axes:
+
+- **Server push mode** (configured on the QQ platform): mention-only, context, or
+  full. Mention-only/context deliver `GROUP_AT_MESSAGE_CREATE`; full delivers
+  `GROUP_MESSAGE_CREATE` for every message (with a per-message "is this bot
+  @-ed" marker). Full mode requires the **"receive all group messages"**
+  permission granted on the QQ platform.
+- **Plugin activation mode** (`group_require_mention`):
+  - **mention** (default): the bot replies only when explicitly @-ed.
+  - **always** (`group_require_mention: false`): any group message may trigger a
+    reply — the agent decides whether to respond.
+
+The two axes are orthogonal, so all six combinations work. Whatever events
+arrive are run through the same pipeline: the bot detects whether it was
+@-mentioned (via the `GROUP_AT` event, a `mentions[].is_you` flag, or an
+`<@!app_id>` tag) and then applies the activation gate. `group_require_mention`
+can be overridden per group under `groups.{group_openid}.require_mention`.
+
+Group ACL (`group_policy` / `group_allow_from`) is a separate, group-level
+concern applied before activation — it decides *which groups* the bot serves,
+not which members.
 
 ## Voice Messages (STT)
 
@@ -113,7 +152,7 @@ This usually means:
 
 - Verify the bot's **intents** are enabled at q.qq.com
 - Check `QQ_ALLOWED_USERS` if DM access is restricted
-- For group messages, ensure the bot is **@mentioned** (group policy may require allowlisting)
+- For group messages, ensure the bot is **@mentioned** (default mention mode), or enable **always mode** via `group_require_mention: false` (group policy may also require allowlisting)
 - Check `QQBOT_HOME_CHANNEL` for cron/notification delivery
 
 ### Connection errors

--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -91,12 +91,64 @@ platforms:
       group_history_limit: 20        # (mention mode) non-@ messages buffered per
                                      # group and injected as CONTEXT ONLY on the
                                      # next @-reply; <=0 disables buffering
+      # ── Streaming replies (C2C only) ──
+      streaming_enabled: true              # true (default) = use QQ's native
+                                           # stream_messages endpoint for C2C
+                                           # replies; false forces the legacy
+                                           # one-shot send path
+      streaming_session_ttl_seconds: 600   # in-memory session TTL; QQ's own
+                                           # passive-reply window is ~5 min, so
+                                           # the default gives modest headroom
       stt:
         provider: "zai"          # zai (GLM-ASR), openai (Whisper), etc.
         baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4"
         apiKey: "your-stt-key"
         model: "glm-asr"
 ```
+
+## Streaming Replies
+
+The adapter renders long-form model output as it's generated, matching the
+experience users get on Feishu / Telegram / Slack.
+
+- **Private (C2C) chats**: streamed **in place** through QQ's official
+  `POST /v2/users/{openid}/stream_messages` endpoint. A single message
+  bubble updates progressively as the model produces tokens, and
+  transitions out of the "generating…" state on the final chunk
+  (`input_state=10`).
+- **Group / guild chats**: **not supported by the QQ platform** — the
+  `stream_messages` endpoint is C2C-only. The adapter transparently
+  falls back to the standard send loop, so users see a small number of
+  appended messages during a long response instead of a single
+  updating bubble. No configuration is required.
+
+### Constraints
+
+- **Passive-reply window**: QQ requires every streamed chunk to carry
+  the inbound `msg_id` as its `event_id` / `msg_id`. That id is only
+  valid for ~5 minutes, so responses that take longer to generate may
+  see the last edits rejected — the adapter logs a warning and the
+  stream consumer will fall back to a fresh send.
+- **Content type is fixed to markdown** (`content_type=2`). Plain text
+  renders correctly under markdown, and rich formatting works
+  end-to-end.
+- **Content length**: each chunk is truncated to 4096 characters
+  (`stream_messages` accepts less than the regular `/messages`
+  endpoint).
+- **Ordering**: the stream consumer serialises edits, so out-of-order
+  updates should not occur in normal operation. As a defensive
+  measure, any edit whose sequence index is not strictly greater than
+  the last one sent is silently dropped.
+- **Restart-safety**: streaming sessions live in memory. After an
+  adapter restart, in-flight edits to a pre-restart message will fail
+  gracefully; the consumer sends the remainder as a new message.
+
+### Config knobs
+
+| Key | Default | Effect |
+|---|---|---|
+| `streaming_enabled` | `true` | Set to `false` to force the legacy send-only path for C2C (useful during incident triage). |
+| `streaming_session_ttl_seconds` | `600` | Upper bound on how long an in-flight streaming session is kept in memory. |
 
 ## Group Activation Mode
 

--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -87,7 +87,10 @@ platforms:
       # ── Group session sharing ──
       group_sessions_per_user: true  # true (default) = each member gets an
                                      # isolated session; set false so ALL members
-                                     # of a group share ONE conversation session
+                                     # of a group share ONE conversation session.
+                                     # In a shared session every message is
+                                     # prefixed with the sender's name ([Alice] …)
+                                     # so the agent can still tell members apart.
       group_history_limit: 20        # (mention mode) non-@ messages buffered per
                                      # group and injected as CONTEXT ONLY on the
                                      # next @-reply; <=0 disables buffering

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
@@ -73,7 +73,7 @@ platforms:
       dm_policy: "open"          # open | allowlist | disabled
       allow_from:
         - "user_openid_1"
-      group_policy: "open"       # open | allowlist | disabled
+      group_policy: "open"       # open | allowlist | disabled（默认：disabled）
       group_allow_from:
         - "group_openid_1"
       stt:


### PR DESCRIPTION
## What does this PR do?

Two related QQBot gateway enhancements that bring the QQ platform closer to
the feature parity we already have on Feishu / Telegram / Slack:

1. **Group activation modes (`always` / `mention`)** — QQBot group chats can now
   be gated by an activation mode instead of replying to every message. This
   routes `GROUP_MESSAGE_CREATE` alongside the existing `GROUP_AT_MESSAGE_CREATE`
   and decides whether to reply based on a conservative mention-detection layer.

2. **C2C streaming replies** — Private-chat (C2C) replies now stream through QQ's
   official `POST /v2/users/{openid}/stream_messages` endpoint, updating a single
   message bubble in place instead of appending new messages for each chunk.

Both are opt-in / backward-compatible: default behaviour (mention mode, per-user
sessions, non-streaming) is unchanged, and group/guild chats transparently fall
back to the standard send loop since `stream_messages` is C2C-only.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**Group activation mode**
- `gateway/platforms/qqbot/group_activation.py` (new): `detect_mentioned()`
  (GROUP_AT event / `mentions[].is_you` / `<@!app_id>` tag — conservative, never
  treats an @ of another member as addressing the bot) and
  `resolve_require_mention()` (runtime > per-group > global precedence).
- `gateway/platforms/qqbot/group_context.py` (new): group session-key /
  context helpers, including per-user vs shared-session resolution.
- `gateway/platforms/qqbot/adapter.py`: read `group_require_mention` (default
  `True` = mention) and per-group `groups.{openid}.require_mention` overrides;
  `_handle_group_message` applies group-level ACL → mention detection → mode gate.
- `hermes_cli/gateway.py`: config wiring for the new group options.

**C2C streaming**
- `gateway/platforms/qqbot/streaming.py` (new): `StreamManager` + `StreamSession`
  primitives (session TTL, `msg_seq` allocation).
- `gateway/platforms/qqbot/adapter.py`: `SUPPORTS_MESSAGE_EDITING=True` (gated
  per-session so non-C2C paths still fresh-send), `REQUIRES_EDIT_FINALIZE=True`,
  and `_start_stream_reply` / `_call_stream_api` / `_enforce_stream_prefix`
  (prefix-invariant guard against upstream trims and model backtracks).
- `gateway/run.py`: add a `Platform.QQBOT` branch (mirrors `Platform.MATRIX`) so
  `_effective_cursor = ''` — the typewriter cursor is suppressed at the source,
  because QQ's `stream_messages` enforces a strict "new full text MUST prefix the
  previous full text" invariant that a trailing cursor glyph would break.

**Docs**
- `website/docs/user-guide/messaging/qqbot.md`: documents the activation modes,
  shared-session option (`platforms.qqbot.extra.group_sessions_per_user`), and a
  new "Streaming Replies" section.

## How to Test

1. Run the QQBot test suite:
   ```bash
   pytest tests/gateway/test_qqbot.py -q
   ```
   All 249 tests pass (adds ~60 new tests: mention detection, mode resolution,
   6-combo activation gate, ACL ordering, session-key sharing, C2C stream
   start/edit/finalize, prefix-divergence replay, session-TTL expiry, non-C2C
   fallback).
2. **Group activation:** with `platforms.qqbot.extra.group_require_mention: true`
   (default), send a plain group message → bot stays silent; @-mention the bot →
   it replies. Set `group_require_mention: false` → bot replies to every group
   message.
3. **C2C streaming:** DM the bot with a prompt that yields a long answer → the
   reply updates in a single bubble in place (no cursor glyph), and the QQ
   "generating" state clears on the final chunk. Send the same prompt in a group
   → it falls back to the normal multi-message send.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the streaming bubble update / group gating in action. -->
