### PR TITLE
Fail closed when cron pre-run scripts fail

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -58,6 +58,25 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     job_name = job.get("name") or job.get("id") or "cron job"
     text = (error or "unknown error").strip()
     lower = text.lower()
+    script_failure_detail = "script-only job failed" if job.get("no_agent") else "agent was not started"
+
+    # Agent-backed pre-run failures are scheduler/runtime failures, not model
+    # provider failures. Classify them before the generic timeout/auth rules so
+    # a script timeout never tells the operator to inspect the fallback chain.
+    if lower.startswith("script timed out"):
+        return (
+            f"⚠️ Cron '{job_name}' failed: pre-run script timeout; {script_failure_detail}. "
+            "Full details saved in cron output."
+        )
+    if lower.startswith((
+        "script not found", "script path is not a file", "script exited with code",
+        "script execution failed", "cannot run .sh/.bash script",
+        "blocked: script path resolves outside",
+    )):
+        return (
+            f"⚠️ Cron '{job_name}' failed: pre-run script error; {script_failure_detail}. "
+            "Full details saved in cron output."
+        )
 
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
@@ -2039,8 +2058,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             are also validated to ensure they stay within the scripts dir.
 
     Returns:
-        (success, output) — on failure *output* contains the error message so the
-        LLM can report the problem to the user.
+        (success, output) — on failure *output* contains a redacted error for
+        the scheduler to persist and deliver. Agent-backed jobs fail before the
+        LLM is initialized; no-agent jobs use the same result directly.
     """
     scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
@@ -2607,11 +2627,50 @@ def run_job(
         )
         return True, doc, output, None
 
+    # Run an agent-backed job's pre-run script before initializing any agent
+    # machinery. A script failure means its required context was not produced;
+    # asking the model to explain that failure can turn an execution failure
+    # into a false-green scheduler result. Fail closed and let run_one_job
+    # record/deliver the scheduler error instead.
+    prerun_script = None
+    script_path = job.get("script")
+    if script_path:
+        prerun_script = _run_job_script(script_path)
+        _ran_ok, _script_output = prerun_script
+        if not _ran_ok:
+            logger.error(
+                "Job '%s' (ID: %s): pre-run script failed; agent not started: %s",
+                job_name, job_id, _script_output,
+            )
+            failed_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                "**Status:** pre-run script failed\n\n"
+                f"{_script_output}\n"
+            )
+            return False, failed_doc, "", _script_output
+        if not _parse_wake_gate(_script_output):
+            logger.info(
+                "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
+                job_name, job_id,
+            )
+            silent_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                "Script gate returned `wakeAgent=false` — agent skipped.\n"
+            )
+            return True, silent_doc, SILENT_MARKER, None
+        if not _script_output.strip():
+            logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+            return True, "", SILENT_MARKER, None
+
     # ---------------------------------------------------------------
     # Default (LLM) path — import and construct the agent machinery now
     # that we know we actually need it. Doing these imports here instead of
-    # at module top keeps no_agent ticks from paying for AIAgent / SessionDB
-    # construction costs.
+    # at module top keeps no_agent and pre-run short-circuit ticks from paying
+    # for AIAgent / SessionDB construction costs.
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
@@ -2681,28 +2740,6 @@ def run_job(
         )
     except Exception as e:
         logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
-
-    # Wake-gate: if this job has a pre-check script, run it BEFORE building
-    # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
-    # the whole agent run. We pass the result into _build_job_prompt so
-    # the script is only executed once.
-    prerun_script = None
-    script_path = job.get("script")
-    if script_path:
-        prerun_script = _run_job_script(script_path)
-        _ran_ok, _script_output = prerun_script
-        if _ran_ok and not _parse_wake_gate(_script_output):
-            logger.info(
-                "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
-                job_name, job_id,
-            )
-            silent_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-                "Script gate returned `wakeAgent=false` — agent skipped.\n"
-            )
-            return True, silent_doc, SILENT_MARKER, None
 
     try:
         prompt = _build_job_prompt(job, prerun_script=prerun_script)

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -100,6 +100,47 @@ def test_run_one_job_failed_job_delivers_error(monkeypatch):
     assert mark == ("mark", "j5", False)
 
 
+def test_run_one_job_persists_exact_prerun_script_error(monkeypatch):
+    """The scheduler's last_error keeps the exact redacted pre-run failure."""
+    script_error = "Script timed out after 30s: /tmp/slow.py"
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None: (False, "failure doc", "", script_error),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *args, **kwargs: None)
+    marks = []
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok, err)),
+    )
+
+    ok = s.run_one_job({"id": "script-failure", "name": "script failure"})
+
+    assert ok is True  # processed; the job outcome itself is recorded as failed
+    assert marks == [("script-failure", False, script_error)]
+
+
+def test_prerun_script_timeout_delivery_is_not_provider_timeout():
+    message = s._summarize_cron_failure_for_delivery(
+        {"id": "j", "name": "script job"},
+        "Script timed out after 30s: /tmp/slow.py",
+    )
+
+    assert "pre-run script timeout" in message
+    assert "provider timeout" not in message
+    assert "fallback" not in message.lower()
+
+    no_agent_message = s._summarize_cron_failure_for_delivery(
+        {"id": "j", "name": "script job", "no_agent": True},
+        "Script timed out after 30s: /tmp/slow.py",
+    )
+    assert "script-only job failed" in no_agent_message
+    assert "agent was not started" not in no_agent_message
+
+
 def test_run_one_job_exception_marks_failure(monkeypatch):
     """If run_job raises, the helper marks the run failed and returns False
     rather than propagating."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2830,7 +2830,8 @@ class TestRunJobWakeGate:
 
         with patch.object(scheduler, "_run_job_script",
                           return_value=(True, '{"wakeAgent": false}')), \
-             patch("run_agent.AIAgent") as agent_cls:
+             patch("run_agent.AIAgent") as agent_cls, \
+             patch("hermes_state.SessionDB") as session_db_cls:
             success, doc, final, err = scheduler.run_job(self._make_job())
 
         assert success is True
@@ -2838,6 +2839,24 @@ class TestRunJobWakeGate:
         assert final == SILENT_MARKER
         assert "Script gate returned `wakeAgent=false`" in doc
         agent_cls.assert_not_called()
+        session_db_cls.assert_not_called()
+
+    def test_empty_script_output_is_silent_before_runtime_init(self):
+        """A successful empty script remains a normal no-op without runtime init."""
+        from cron.scheduler import SILENT_MARKER
+        import cron.scheduler as scheduler
+
+        with patch.object(scheduler, "_run_job_script", return_value=(True, "")), \
+             patch("run_agent.AIAgent") as agent_cls, \
+             patch("hermes_state.SessionDB") as session_db_cls:
+            success, doc, final, err = scheduler.run_job(self._make_job())
+
+        assert success is True
+        assert doc == ""
+        assert final == SILENT_MARKER
+        assert err is None
+        agent_cls.assert_not_called()
+        session_db_cls.assert_not_called()
 
     def test_wake_true_runs_agent_with_injected_output(self):
         """When the script returns {wakeAgent: true, data: ...}, the agent is
@@ -2885,23 +2904,28 @@ class TestRunJobWakeGate:
 
         assert call_count == 1, f"script ran {call_count}x, expected exactly 1"
 
-    def test_script_failure_does_not_trigger_gate(self):
-        """If _run_job_script returns success=False, the gate is NOT evaluated
-        and the agent still runs (the failure is reported as context)."""
+    @pytest.mark.parametrize("script_error", [
+        "Script not found: /tmp/missing.py",
+        "Script timed out after 30s: /tmp/slow.py",
+        "Script exited with code 7\nstderr:\nbroken",
+    ])
+    def test_script_failure_fails_closed_before_runtime_init(self, script_error):
+        """Missing, timed-out, and non-zero scripts fail without runtime init."""
         import cron.scheduler as scheduler
 
-        # Malicious or broken script whose stderr happens to contain the
-        # gate JSON — we must NOT honor it because ran_ok is False.
-        agent = MagicMock()
-        agent.run_conversation = MagicMock(return_value={
-            "final_response": "ok", "messages": []
-        })
         with patch.object(scheduler, "_run_job_script",
-                          return_value=(False, '{"wakeAgent": false}')), \
-             patch("run_agent.AIAgent", return_value=agent) as agent_cls:
+                          return_value=(False, script_error)) as script_runner, \
+             patch("run_agent.AIAgent") as agent_cls, \
+             patch("hermes_state.SessionDB") as session_db_cls:
             success, doc, final, err = scheduler.run_job(self._make_job())
 
-        agent_cls.assert_called_once()  # Agent DID wake despite the gate-like text
+        assert success is False
+        assert final == ""
+        assert err == script_error
+        assert "pre-run script failed" in doc
+        script_runner.assert_called_once_with("check.py")
+        agent_cls.assert_not_called()
+        session_db_cls.assert_not_called()
 
     def test_no_script_path_runs_agent_normally(self):
         """Regression: jobs without a script still work."""


### PR DESCRIPTION
## Summary

- Run agent-backed cron pre-run scripts before AIAgent/SessionDB initialization.
- Record missing, timed-out, and non-zero scripts as scheduler failures instead of waking the agent.
- Preserve wakeAgent=false and empty-output no-op behavior.
- Classify pre-run failures separately from provider timeouts in delivery messages.

## Tests

- `uv run --extra dev pytest -q tests/cron/test_scheduler.py::TestRunJobWakeGate tests/cron/test_run_one_job.py tests/cron/test_cron_script.py`
- 58 passed.

This is intentionally limited to the existing cron scheduler path; it adds no plugin, observer, or generic receipt framework.
