### PR TITLE
fix(telegram): retry native media sends on flood control instead of giving up

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1140,30 +1140,52 @@ class TelegramAdapter(BasePlatformAdapter):
         media_label: str,
         reset_media: Optional[Any] = None,
     ) -> Any:
-        """Retry stale private-topic media replies once without the topic anchor."""
-        try:
-            return await send_fn(**send_kwargs)
-        except Exception as send_err:
-            if not self._should_retry_without_dm_topic_reply_anchor(
-                send_err,
-                metadata,
-                reply_to_message_id,
-            ):
-                raise
-            logger.warning(
-                "[%s] Reply target deleted for Telegram %s, "
-                "retrying without reply/topic anchor: %s",
-                self.name,
-                media_label,
-                send_err,
-            )
-            if reset_media is not None:
-                reset_media()
-            retry_kwargs = dict(send_kwargs)
-            retry_kwargs["reply_to_message_id"] = None
-            retry_kwargs.pop("message_thread_id", None)
-            retry_kwargs.pop("direct_messages_topic_id", None)
-            return await send_fn(**retry_kwargs)
+        """Send native media, retrying on flood control and stale reply anchors.
+
+        Mirrors the flood-control backoff that plain text send() already has
+        (see the "Telegram flood control on send" loop above) — without this,
+        RetryAfter on a document/video/image/voice send fell straight through
+        to the "couldn't deliver the file attachment" text fallback instead of
+        just waiting out Telegram's cooldown like text messages do.
+        """
+        kwargs = send_kwargs
+        for attempt in range(3):
+            try:
+                return await send_fn(**kwargs)
+            except Exception as send_err:
+                retry_after = getattr(send_err, "retry_after", None)
+                if (retry_after is not None or "retry after" in str(send_err).lower()) and attempt < 2:
+                    wait = float(retry_after) if retry_after is not None else 1.0
+                    safe_send_error = _redact_telegram_error_text(send_err)
+                    logger.warning(
+                        "[%s] Telegram flood control on %s send (attempt %d/3), retrying in %.1fs: %s",
+                        self.name, media_label, attempt + 1, wait, safe_send_error,
+                    )
+                    await asyncio.sleep(wait)
+                    if reset_media is not None:
+                        reset_media()
+                    continue
+
+                if not self._should_retry_without_dm_topic_reply_anchor(
+                    send_err,
+                    metadata,
+                    reply_to_message_id,
+                ):
+                    raise
+                logger.warning(
+                    "[%s] Reply target deleted for Telegram %s, "
+                    "retrying without reply/topic anchor: %s",
+                    self.name,
+                    media_label,
+                    send_err,
+                )
+                if reset_media is not None:
+                    reset_media()
+                kwargs = dict(kwargs)
+                kwargs["reply_to_message_id"] = None
+                kwargs.pop("message_thread_id", None)
+                kwargs.pop("direct_messages_topic_id", None)
+                return await send_fn(**kwargs)
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -805,6 +805,69 @@ class TestSendDocument:
         assert result.message_id == "fallback"
 
     @pytest.mark.asyncio
+    async def test_send_document_retries_on_flood_control(self, connected_adapter, tmp_path):
+        """RetryAfter (flood control) is retried with backoff, not an immediate fallback.
+
+        Regression for the bug where send_document gave up on the first
+        RetryAfter and silently degraded to a text-only "couldn't deliver
+        the file attachment" apology instead of delivering the file once
+        Telegram's flood-control window passed.
+        """
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+
+        class _RetryAfter(Exception):
+            def __init__(self, retry_after):
+                super().__init__(f"Flood control exceeded. Retry in {retry_after} seconds")
+                self.retry_after = retry_after
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 104
+        connected_adapter._bot.send_document = AsyncMock(
+            side_effect=[_RetryAfter(1), mock_msg]
+        )
+
+        with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await connected_adapter.send_document(
+                chat_id="12345",
+                file_path=str(test_file),
+                caption="Here's the report",
+            )
+
+        assert result.success is True
+        assert result.message_id == "104"
+        assert connected_adapter._bot.send_document.await_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_send_document_falls_back_after_flood_control_exhausted(self, connected_adapter, tmp_path):
+        """After 3 flood-controlled attempts, still falls back to the text notice."""
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+
+        class _RetryAfter(Exception):
+            def __init__(self, retry_after):
+                super().__init__(f"Flood control exceeded. Retry in {retry_after} seconds")
+                self.retry_after = retry_after
+
+        connected_adapter._bot.send_document = AsyncMock(
+            side_effect=[_RetryAfter(1), _RetryAfter(1), _RetryAfter(1)]
+        )
+        connected_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="fallback")
+        )
+
+        with patch("plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()):
+            result = await connected_adapter.send_document(
+                chat_id="12345",
+                file_path=str(test_file),
+            )
+
+        assert connected_adapter._bot.send_document.await_count == 3
+        assert result.success is True
+        assert result.message_id == "fallback"
+
+    @pytest.mark.asyncio
     async def test_send_document_reply_to(self, connected_adapter, tmp_path):
         """reply_to parameter is forwarded as reply_to_message_id."""
         test_file = tmp_path / "spec.md"


### PR DESCRIPTION
## Summary
- `send_document`/`send_video`/`send_image`/`send_voice` all go through `_send_with_dm_topic_reply_anchor_retry`, which previously only retried stale reply-anchor errors. Any other exception — including `RetryAfter` (Telegram flood control) — was re-raised immediately, and the caller's `except Exception` fallback then sends a text-only "⚠️ Couldn't deliver the file attachment" notice instead of the actual file.
- Plain text `send()` already retries on `RetryAfter` with backoff (the "Telegram flood control on send (attempt N/3)..." loop). This PR gives native media sends the same resilience: back off for `retry_after` seconds (up to 3 attempts, re-seeking the open file via the existing `reset_media` hook) before falling through to the text-notice fallback.
- In production this showed up as a daily voucher PDF permanently failing to attach in a busy Telegram chat that was already near the flood-control threshold from other bot activity — the PDF existed on disk and was valid, but the send path gave up on the very first `RetryAfter` instead of waiting out Telegram's stated cooldown.

Fixes #64137.

## Test plan
- [x] Added `test_send_document_retries_on_flood_control` — verifies a `RetryAfter` on the first attempt is retried and the second attempt succeeds, without falling back to the text notice.
- [x] Added `test_send_document_falls_back_after_flood_control_exhausted` — verifies that after 3 flood-controlled attempts it still falls back to the text notice (no infinite retry / no crash).
- [x] `uv run pytest tests/gateway/test_telegram_documents.py -q` — 46 passed.
- [x] `uv run pytest tests/gateway/ tests/plugins/ tests/tools/ -k "telegram or send_document" ...` — same 9 pre-existing failures as on `main` (unrelated test-order/mock pollution, verified via `git stash`), no new failures; +2 passing from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)