### PR TITLE
fix(cron): isolate profile stores and deduplicate failures

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -99,14 +99,19 @@ _jobs_lock_state = threading.local()
 # worst-case stall well under one status-alarm threshold.
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
+_COMPAT_CRON_DIR = CRON_DIR
+_COMPAT_JOBS_FILE = JOBS_FILE
+_COMPAT_OUTPUT_DIR = OUTPUT_DIR
 ONESHOT_GRACE_SECONDS = 120
 
 
 @dataclass(frozen=True)
 class _CronStorePaths:
+    home: Path
     cron_dir: Path
     jobs_file: Path
     output_dir: Path
+    owner_profile: str
 
 
 _cron_store_override: ContextVar[Optional[_CronStorePaths]] = ContextVar(
@@ -115,23 +120,63 @@ _cron_store_override: ContextVar[Optional[_CronStorePaths]] = ContextVar(
 )
 
 
+def _profile_name_for_home(home: Path) -> str:
+    """Return the canonical cron owner represented by a Hermes home path."""
+    return home.name if home.parent.name == "profiles" else "default"
+
+
 def _current_cron_store() -> _CronStorePaths:
     """Return paths pinned to this execution context's profile."""
     override = _cron_store_override.get()
     if override is not None:
         return override
-    return _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
+    home = get_hermes_home().expanduser().resolve()
+    if (
+        CRON_DIR != _COMPAT_CRON_DIR
+        or JOBS_FILE != _COMPAT_JOBS_FILE
+        or OUTPUT_DIR != _COMPAT_OUTPUT_DIR
+    ):
+        # Preserve the documented test/integration override globals. Production
+        # profile routing uses context-local use_cron_store(); explicit global
+        # monkeypatches remain an opt-in compatibility path.
+        return _CronStorePaths(
+            home=home,
+            cron_dir=Path(CRON_DIR),
+            jobs_file=Path(JOBS_FILE),
+            output_dir=Path(OUTPUT_DIR),
+            owner_profile=_profile_name_for_home(home),
+        )
+    cron_dir = home / "cron"
+    return _CronStorePaths(
+        home=home,
+        cron_dir=cron_dir,
+        jobs_file=cron_dir / "jobs.json",
+        output_dir=cron_dir / "output",
+        owner_profile=_profile_name_for_home(home),
+    )
 
 
 @contextlib.contextmanager
-def use_cron_store(home: Union[str, Path]):
+def use_cron_store(
+    home: Union[str, Path], *, owner_profile: Optional[str] = None
+):
     """Route cron storage to ``home`` without mutating process globals."""
-    cron_dir = Path(home).expanduser().resolve() / "cron"
+    resolved_home = Path(home).expanduser().resolve()
+    path_owner = _profile_name_for_home(resolved_home)
+    requested_owner = str(owner_profile or path_owner).strip() or "default"
+    if requested_owner != path_owner:
+        raise ValueError(
+            f"Cron owner_profile {requested_owner!r} does not match store path "
+            f"{resolved_home} (owner {path_owner!r})"
+        )
+    cron_dir = resolved_home / "cron"
     token = _cron_store_override.set(
         _CronStorePaths(
+            home=resolved_home,
             cron_dir=cron_dir,
             jobs_file=cron_dir / "jobs.json",
             output_dir=cron_dir / "output",
+            owner_profile=requested_owner,
         )
     )
     try:
@@ -239,6 +284,13 @@ def _jobs_lock():
     """
     depth = getattr(_jobs_lock_state, "depth", 0)
     if depth:
+        current_lock_path = _jobs_lock_file().resolve()
+        held_lock_path = getattr(_jobs_lock_state, "lock_path", None)
+        if held_lock_path != current_lock_path:
+            raise RuntimeError(
+                "Nested cron jobs lock attempted for a different cron store: "
+                f"held {held_lock_path}, requested {current_lock_path}"
+            )
         _jobs_lock_state.depth = depth + 1
         try:
             yield
@@ -248,6 +300,7 @@ def _jobs_lock():
 
     with _jobs_file_lock:
         _jobs_lock_state.depth = 1
+        _jobs_lock_state.lock_path = _jobs_lock_file().resolve()
         lock_fd = None
         try:
             try:
@@ -279,8 +332,8 @@ def _jobs_lock():
                                 logger.error(
                                     "Timed out after %.0fs waiting for the cron "
                                     "jobs lock (%s) — another process is holding "
-                                    "it. Proceeding with in-process locking only "
-                                    "so the scheduler stays alive (#60703).",
+                                    "it. Refusing to continue without the "
+                                    "cross-process lock.",
                                     _JOBS_LOCK_TIMEOUT_SECONDS,
                                     _jobs_lock_file(),
                                 )
@@ -289,13 +342,36 @@ def _jobs_lock():
                                 except OSError:
                                     pass
                                 lock_fd = None
-                                break
+                                raise TimeoutError(
+                                    f"Timed out waiting for cron jobs lock: "
+                                    f"{_jobs_lock_file()}"
+                                )
                             time.sleep(0.1)
                 elif msvcrt is not None:
-                    getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    _deadline = time.monotonic() + _JOBS_LOCK_TIMEOUT_SECONDS
+                    while True:
+                        try:
+                            getattr(msvcrt, "locking")(
+                                lock_fd.fileno(), getattr(msvcrt, "LK_NBLCK"), 1
+                            )
+                            break
+                        except (OSError, IOError):
+                            if time.monotonic() >= _deadline:
+                                try:
+                                    lock_fd.close()
+                                except OSError:
+                                    pass
+                                lock_fd = None
+                                raise TimeoutError(
+                                    f"Timed out waiting for cron jobs lock: {_jobs_lock_file()}"
+                                )
+                            time.sleep(0.1)
             except (OSError, IOError) as e:
-                # Never let a locking failure take down cron writes — fall back to
-                # in-process-only protection (still held via _jobs_file_lock).
+                if isinstance(e, TimeoutError):
+                    raise
+                # If advisory locking is unavailable on this platform, retain
+                # the historical in-process protection. A real contention
+                # timeout above is different: it must fail closed.
                 logger.warning("jobs.json cross-process lock unavailable (%s); "
                                "proceeding with in-process lock only", e)
             try:
@@ -313,12 +389,33 @@ def _jobs_lock():
                         lock_fd.close()
         finally:
             _jobs_lock_state.depth = 0
+            _jobs_lock_state.lock_path = None
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
-_IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_IMMUTABLE_JOB_FIELDS = frozenset({"id", "owner_profile"})
+
+
+def _validate_job_owners(jobs: List[Dict[str, Any]]) -> None:
+    """Fail closed when explicit job ownership disagrees with the active store.
+
+    Jobs written before owner metadata was introduced remain readable. Once an
+    owner is present, however, a profile-scoped reader/writer may not silently
+    operate on a record from another profile.
+    """
+    expected = _current_cron_store().owner_profile
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        owner = job.get("owner_profile")
+        if owner is not None and str(owner).strip() != expected:
+            raise RuntimeError(
+                f"Cron job {job.get('id', '<unknown>')!r} owner_profile "
+                f"{owner!r} does not match active store owner {expected!r} "
+                f"({_current_cron_store().jobs_file})"
+            )
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -782,13 +879,14 @@ def record_ticker_heartbeat(success: bool = False) -> None:
 
     Best-effort: a write failure must never disrupt the tick loop.
     """
+    store = _current_cron_store()
     try:
-        _atomic_write_epoch(TICKER_HEARTBEAT_FILE)
+        _atomic_write_epoch(store.cron_dir / "ticker_heartbeat")
     except Exception:
         pass
     if success:
         try:
-            _atomic_write_epoch(TICKER_SUCCESS_FILE)
+            _atomic_write_epoch(store.cron_dir / "ticker_last_success")
         except Exception:
             pass
 
@@ -807,12 +905,12 @@ def get_ticker_heartbeat_age() -> Optional[float]:
     None = heartbeat file missing/unreadable (older build, never ran, or a
     torn read). Callers treat None as "cannot determine", not "dead".
     """
-    return _epoch_file_age(TICKER_HEARTBEAT_FILE)
+    return _epoch_file_age(_current_cron_store().cron_dir / "ticker_heartbeat")
 
 
 def get_ticker_success_age() -> Optional[float]:
     """Seconds since the ticker last completed a tick WITHOUT raising, or None."""
-    return _epoch_file_age(TICKER_SUCCESS_FILE)
+    return _epoch_file_age(_current_cron_store().cron_dir / "ticker_last_success")
 
 
 # =============================================================================
@@ -854,6 +952,7 @@ def load_jobs() -> List[Dict[str, Any]]:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)
             logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+        _validate_job_owners(jobs)
         return jobs
     if isinstance(data, list):
         # Bare array — likely saved/edited outside save_jobs(). Wrap it back
@@ -861,6 +960,7 @@ def load_jobs() -> List[Dict[str, Any]]:
         if data:
             save_jobs(data)
             logger.warning("Auto-repaired jobs.json (bare list wrapped as dict)")
+        _validate_job_owners(data)
         return data
 
     raise RuntimeError(
@@ -870,6 +970,7 @@ def load_jobs() -> List[Dict[str, Any]]:
 
 def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
+    _validate_job_owners(jobs)
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
     fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
@@ -1177,6 +1278,7 @@ def create_job(
 
     job = {
         "id": job_id,
+        "owner_profile": _current_cron_store().owner_profile,
         "name": name or label_source[:50].strip(),
         "prompt": prompt_text,
         "skills": normalized_skills,
@@ -1466,7 +1568,8 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 alert_state: Optional[Dict[str, Any]] = None):
     """
     Mark a job as having been run.
     
@@ -1475,6 +1578,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+
+    ``alert_state`` is scheduler-owned incident lifecycle metadata. ``None``
+    preserves the existing state, an empty dict clears it after recovery, and
+    a non-empty dict replaces it. Raw error text is never stored there.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1486,6 +1593,11 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                if alert_state is not None:
+                    if alert_state:
+                        job["failure_alert_state"] = dict(alert_state)
+                    else:
+                        job.pop("failure_alert_state", None)
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,6 +12,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
@@ -46,6 +47,10 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
+
+
+_DEFAULT_FAILURE_ALERT_AFTER = 1
+_DEFAULT_FAILURE_ALERT_COOLDOWN_SECONDS = 86_400
 
 
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
@@ -99,6 +104,107 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     if len(cleaned) > 180:
         cleaned = cleaned[:177].rstrip() + "..."
     return f"⚠️ Cron '{job_name}' failed: {cleaned}"
+
+
+def _bounded_job_int(job: dict, key: str, default: int, *, minimum: int, maximum: int) -> int:
+    """Return a bounded integer alert-policy value from a job record."""
+    try:
+        value = int(job.get(key, default))
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def _cron_failure_notification(
+    job: dict,
+    error: str | None,
+    *,
+    now: float | None = None,
+) -> tuple[str, dict, str]:
+    """Return edge-triggered failure content and the next persisted state.
+
+    Cron historically delivered every non-zero script result on every tick.
+    A five-minute job could therefore send 288 identical alerts per day.  The
+    scheduler is the only layer that sees every job, so deduplication belongs
+    here rather than in an optional per-script wrapper.
+
+    The persisted state contains hashes and counters only; raw errors remain in
+    the normal cron output file and ``last_error`` field.
+    """
+    ts = float(time.time() if now is None else now)
+    summary = _summarize_cron_failure_for_delivery(job, error)
+    fingerprint = hashlib.sha256(summary.encode("utf-8", errors="replace")).hexdigest()
+    prior = job.get("failure_alert_state")
+    prior = prior if isinstance(prior, dict) else {}
+
+    same_incident = (
+        prior.get("fingerprint") == fingerprint
+        and prior.get("status") in {"observing", "open"}
+    )
+    count = int(prior.get("count") or 0) + 1 if same_incident else 1
+    first_seen = float(prior.get("first_seen") or ts) if same_incident else ts
+    last_alert = prior.get("last_alert") if same_incident else None
+    try:
+        last_alert = float(last_alert) if last_alert is not None else None
+    except (TypeError, ValueError):
+        last_alert = None
+
+    open_after = _bounded_job_int(
+        job,
+        "alert_after_failures",
+        _DEFAULT_FAILURE_ALERT_AFTER,
+        minimum=1,
+        maximum=100,
+    )
+    cooldown = _bounded_job_int(
+        job,
+        "alert_cooldown_seconds",
+        _DEFAULT_FAILURE_ALERT_COOLDOWN_SECONDS,
+        minimum=60,
+        maximum=30 * 86_400,
+    )
+
+    action = "silent"
+    status = "observing"
+    if count >= open_after:
+        status = "open"
+        if not same_incident or prior.get("status") != "open":
+            action = "opened"
+            last_alert = ts
+        elif last_alert is None or ts - last_alert >= cooldown:
+            action = "reminder"
+            last_alert = ts
+
+    state = {
+        "status": status,
+        "fingerprint": fingerprint,
+        "count": count,
+        "first_seen": first_seen,
+        "last_seen": ts,
+        "last_alert": last_alert,
+    }
+    return (summary if action != "silent" else ""), state, action
+
+
+def _cron_recovery_notification(
+    job: dict,
+    *,
+    now: float | None = None,
+) -> tuple[str, dict | None, str]:
+    """Return one recovery message for an open scheduler failure incident."""
+    prior = job.get("failure_alert_state")
+    if not isinstance(prior, dict) or not prior:
+        return "", None, "silent"
+    if prior.get("status") != "open":
+        # A sub-threshold observing streak disappears silently on success.
+        return "", {}, "silent"
+    job_name = job.get("name") or job.get("id") or "cron job"
+    count = max(1, int(prior.get("count") or 1))
+    return (
+        f"✅ Cron '{job_name}' recovered after {count} failed run(s).",
+        {},
+        "recovery",
+    )
 
 
 class CronPromptInjectionBlocked(Exception):
@@ -3529,6 +3635,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
+        alert_state_update = None
+        alert_action = "silent"
         try:
             output_file = save_job_output(job["id"], output)
             if verbose:
@@ -3548,23 +3656,32 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     "(tool subprocess was killed mid-flight)."
                 )
 
-            # Deliver the final response to the origin/target chat.
-            # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
-            deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            # Deliver the final response to the origin/target chat. Successful
+            # business output keeps its historical behavior. Scheduler failures
+            # are edge-triggered: one opening alert, one cooldown reminder, and
+            # one recovery instead of one alert per scheduled attempt.
+            if success:
+                normal_content = final_response
+                if normal_content.strip() and _is_cron_silence_response(normal_content):
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    normal_content = ""
+                recovery_content, alert_state_update, alert_action = _cron_recovery_notification(job)
+                if recovery_content and normal_content.strip():
+                    deliver_content = f"{recovery_content}\n\n{normal_content}"
+                else:
+                    deliver_content = recovery_content or normal_content
+            else:
+                deliver_content, alert_state_update, alert_action = _cron_failure_notification(job, error)
+                if not deliver_content:
+                    logger.info(
+                        "Job '%s': repeated failure suppressed by incident cooldown",
+                        job["id"],
+                    )
+
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
-            # Cron silence suppression — see _is_cron_silence_response.  Replaces the
-            # old `SILENT_MARKER in ...upper()` substring check, which both leaked
-            # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
-            # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
-            # #46917).  Keeps the intentional bracketed-prefix / trailing-line
-            # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
-                logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                should_deliver = False
 
             if should_deliver:
                 try:
@@ -3586,8 +3703,20 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
+        # If a recovery notification itself could not be delivered, keep the
+        # incident open so a later successful tick can retry the recovery.
+        if alert_action == "recovery" and delivery_error:
+            prior_state = job.get("failure_alert_state")
+            alert_state_update = prior_state if isinstance(prior_state, dict) else None
+
         if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            mark_job_run(
+                job["id"],
+                success,
+                error,
+                delivery_error=delivery_error,
+                alert_state=alert_state_update,
+            )
         return True
 
     except Exception as e:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -161,6 +161,13 @@ class InProcessCronScheduler(CronScheduler):
     for the next allowed tick.
     """
 
+    def __init__(self) -> None:
+        self._should_tick = lambda: True
+
+    def set_tick_predicate(self, predicate) -> None:
+        """Install the Desktop ownership gate without changing start()'s ABC."""
+        self._should_tick = predicate
+
     @property
     def name(self) -> str:
         return "builtin"
@@ -172,10 +179,16 @@ class InProcessCronScheduler(CronScheduler):
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info("In-process cron scheduler started (interval=%ds)", interval)
-        # Heartbeat once before the first sleep so `hermes cron status` sees a
-        # live ticker immediately after startup, not only after the first tick.
-        record_ticker_heartbeat()
+        may_tick = getattr(self, "_should_tick", None) or (lambda: True)
+        if may_tick():
+            # Heartbeat once before the first sleep so `hermes cron status` sees
+            # a live ticker immediately after startup. A desktop fallback that
+            # currently yields to a gateway must not impersonate its owner.
+            record_ticker_heartbeat()
         while not stop_event.is_set():
+            if not may_tick():
+                stop_event.wait(interval if interval > 0 else 0.01)
+                continue
             ok = False
             try:
                 if can_dispatch is not None and not can_dispatch():

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -271,8 +271,13 @@ def build_top_level_parser():
         help="Interactive chat with the agent",
         description="Start an interactive chat session with Hermes Agent",
     )
-    chat_parser.add_argument(
+    query_group = chat_parser.add_mutually_exclusive_group()
+    query_group.add_argument(
         "-q", "--query", help="Single query (non-interactive mode)"
+    )
+    query_group.add_argument(
+        "--query-file",
+        help="Read the single query from a UTF-8 file instead of process argv",
     )
     chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2407,6 +2407,21 @@ def cmd_chat(args):
 
     _pin_kanban_board_env()
 
+    query_file = getattr(args, "query_file", None)
+    if query_file:
+        query_path = Path(query_file).expanduser()
+        if not query_path.is_file():
+            print(f"Error: query file not found: {query_path}", file=sys.stderr)
+            raise SystemExit(2)
+        if query_path.stat().st_size > 1_048_576:
+            print("Error: query file exceeds 1 MiB", file=sys.stderr)
+            raise SystemExit(2)
+        try:
+            args.query = query_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            print(f"Error: unable to read query file: {type(exc).__name__}", file=sys.stderr)
+            raise SystemExit(2) from None
+
     if use_tui:
         _launch_tui(
             getattr(args, "resume", None),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -152,9 +152,34 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     real gateway on the same HERMES_HOME — whichever process grabs the lock
     first wins the tick.
     """
-    from cron.scheduler_provider import resolve_cron_scheduler
+    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
+    from gateway.status import is_gateway_running
 
-    provider = resolve_cron_scheduler()
+    resolved_provider = resolve_cron_scheduler()
+    if not isinstance(resolved_provider, InProcessCronScheduler):
+        _log.info(
+            "Desktop will keep a local fallback ticker while gateway owns provider %s",
+            resolved_provider.name,
+        )
+    provider = (
+        resolved_provider
+        if isinstance(resolved_provider, InProcessCronScheduler)
+        else InProcessCronScheduler()
+    )
+
+    # The gateway is authoritative whenever it exists. Re-check every loop so
+    # Desktop can yield when a gateway starts and resume standalone cron after
+    # it stops. For external providers, Desktop intentionally uses the built-in
+    # local ticker only as the failover path; it never provisions a second
+    # external scheduler. Probe failure falls back to tick-lock mediation.
+    def desktop_may_tick() -> bool:
+        try:
+            return not is_gateway_running(cleanup_stale=False)
+        except Exception:
+            _log.exception("Gateway status probe failed; Desktop cron will use tick locking")
+            return True
+
+    provider.set_tick_predicate(desktop_may_tick)
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
     provider.start(stop_event, interval=interval)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,78 @@ test runner at ``scripts/run_tests.sh``.
 """
 
 import asyncio
+import atexit
+import json
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
+
+
+# Install a session sandbox before pytest imports any test modules. Autouse
+# fixtures run after collection, which is too late for modules that resolve
+# cron paths at import time. Preserve a structural snapshot of the real
+# registry as a final blast-radius assertion. Runtime fields legitimately move
+# while the production gateway ticks, so byte equality would be a false alarm.
+_ORIGINAL_HERMES_HOME = os.environ.get("HERMES_HOME")
+_LIVE_HERMES_HOME = Path(
+    _ORIGINAL_HERMES_HOME or (Path.home() / ".hermes")
+).expanduser().resolve()
+_LIVE_CRON_REGISTRY = _LIVE_HERMES_HOME / "cron" / "jobs.json"
+_CRON_RUNTIME_FIELDS = {
+    "last_run_at",
+    "next_run_at",
+    "last_status",
+    "last_error",
+    "last_output",
+    "fire_claim",
+}
+
+
+def _stable_cron_job(job):
+    stable = {key: value for key, value in job.items() if key not in _CRON_RUNTIME_FIELDS}
+    repeat = job.get("repeat")
+    if isinstance(repeat, dict):
+        stable["repeat"] = {
+            key: value for key, value in repeat.items() if key != "completed"
+        }
+    return stable
+
+
+def _cron_registry_structure(path: Path):
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload.get("jobs", []) if isinstance(payload, dict) else payload
+    return tuple(sorted(
+        json.dumps(_stable_cron_job(job), sort_keys=True)
+        for job in rows if isinstance(job, dict)
+    ))
+
+
+_LIVE_CRON_REGISTRY_BEFORE = _cron_registry_structure(_LIVE_CRON_REGISTRY)
+_PRECOLLECTION_HERMES_HOME = Path(
+    tempfile.mkdtemp(prefix="hermes-pytest-home-")
+).resolve()
+for _name in ("sessions", "cron", "memories", "skills"):
+    (_PRECOLLECTION_HERMES_HOME / _name).mkdir(parents=True, exist_ok=True)
+os.environ["HERMES_HOME"] = str(_PRECOLLECTION_HERMES_HOME)
+atexit.register(shutil.rmtree, _PRECOLLECTION_HERMES_HOME, ignore_errors=True)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    after = _cron_registry_structure(_LIVE_CRON_REGISTRY)
+    if after != _LIVE_CRON_REGISTRY_BEFORE:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if reporter is not None:
+            reporter.write_line(
+                f"ERROR: tests modified live cron registry: {_LIVE_CRON_REGISTRY}",
+                red=True,
+            )
 
 # Ensure project root is importable
 PROJECT_ROOT = Path(__file__).parent.parent

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -281,6 +281,115 @@ def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
 
 
 # ---------------------------------------------------------------------------
+# scheduler incident lifecycle: edge-triggered failure/recovery delivery
+# ---------------------------------------------------------------------------
+
+
+def test_failure_notification_opens_suppresses_and_reminds():
+    from cron.scheduler import _cron_failure_notification
+
+    job = {"id": "job-1", "name": "Five Minute Watchdog"}
+    first, state, action = _cron_failure_notification(job, "boom", now=1000)
+    assert action == "opened"
+    assert "failed" in first
+    assert state["count"] == 1
+
+    job["failure_alert_state"] = state
+    repeated, state, action = _cron_failure_notification(job, "boom", now=1300)
+    assert action == "silent"
+    assert repeated == ""
+    assert state["count"] == 2
+
+    job["failure_alert_state"] = state
+    reminder, state, action = _cron_failure_notification(job, "boom", now=1000 + 86_401)
+    assert action == "reminder"
+    assert "failed" in reminder
+    assert state["count"] == 3
+
+
+def test_failure_notification_supports_consecutive_failure_threshold():
+    from cron.scheduler import _cron_failure_notification
+
+    job = {
+        "id": "job-1",
+        "name": "High Frequency Pull",
+        "alert_after_failures": 3,
+    }
+    for index in range(2):
+        content, state, action = _cron_failure_notification(job, "transient", now=1000 + index)
+        assert content == ""
+        assert action == "silent"
+        assert state["status"] == "observing"
+        job["failure_alert_state"] = state
+
+    content, state, action = _cron_failure_notification(job, "transient", now=1002)
+    assert action == "opened"
+    assert content
+    assert state["status"] == "open"
+    assert state["count"] == 3
+
+
+def test_recovery_notification_is_once_and_clears_state():
+    from cron.scheduler import _cron_recovery_notification
+
+    job = {
+        "id": "job-1",
+        "name": "Watchdog",
+        "failure_alert_state": {
+            "status": "open",
+            "fingerprint": "abc",
+            "count": 7,
+            "first_seen": 1,
+            "last_seen": 2,
+            "last_alert": 1,
+        },
+    }
+    content, state, action = _cron_recovery_notification(job, now=3)
+    assert action == "recovery"
+    assert "recovered after 7 failed run(s)" in content
+    assert state == {}
+
+    job.pop("failure_alert_state")
+    content, state, action = _cron_recovery_notification(job, now=4)
+    assert (content, state, action) == ("", None, "silent")
+
+
+def test_run_one_job_delivers_one_failure_then_one_recovery(hermes_env):
+    from cron.jobs import create_job, get_job
+    from cron.scheduler import run_one_job
+
+    script_path = hermes_env / "scripts" / "flaky.sh"
+    script_path.write_text("#!/bin/bash\necho broken >&2\nexit 2\n")
+    job = create_job(
+        prompt=None,
+        name="Flaky watchdog",
+        schedule="every 5m",
+        script="flaky.sh",
+        no_agent=True,
+        deliver="telegram:123",
+    )
+
+    with patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock:
+        assert run_one_job(job) is True
+        assert deliver_mock.call_count == 1
+
+        reloaded = get_job(job["id"])
+        assert reloaded["failure_alert_state"]["status"] == "open"
+        assert reloaded["failure_alert_state"]["count"] == 1
+
+        assert run_one_job(reloaded) is True
+        assert deliver_mock.call_count == 1  # identical failure is suppressed
+
+        script_path.write_text("#!/bin/bash\n# healthy and silent\n")
+        reloaded = get_job(job["id"])
+        assert run_one_job(reloaded) is True
+        assert deliver_mock.call_count == 2
+        assert "recovered after 2 failed run(s)" in deliver_mock.call_args.args[1]
+
+    assert "failure_alert_state" not in get_job(job["id"])
+
+
+# ---------------------------------------------------------------------------
 # _run_job_script: shell-script support
 # ---------------------------------------------------------------------------
 

--- a/tests/cron/test_cron_phase1_hardening.py
+++ b/tests/cron/test_cron_phase1_hardening.py
@@ -1,0 +1,139 @@
+"""Phase 1 cron isolation and ownership hardening regressions."""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import cron.jobs as jobs
+import cron.scheduler_provider as scheduler_provider
+
+
+def profile_home(root: Path, name: str) -> Path:
+    home = root / "profiles" / name
+    (home / "cron").mkdir(parents=True)
+    return home
+
+
+def test_dynamic_store_follows_hermes_home_after_import(monkeypatch, tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    monkeypatch.setenv("HERMES_HOME", str(first))
+    jobs.ensure_dirs()
+    jobs.create_job(name="first", prompt="x", schedule="0 1 * * *")
+    assert (first / "cron" / "jobs.json").is_file()
+
+    monkeypatch.setenv("HERMES_HOME", str(second))
+    jobs.ensure_dirs()
+    created = jobs.create_job(name="second", prompt="x", schedule="0 2 * * *")
+    assert (second / "cron" / "jobs.json").is_file()
+    assert created["owner_profile"] == "default"
+    first_names = [j["name"] for j in json.loads((first / "cron" / "jobs.json").read_text())["jobs"]]
+    second_names = [j["name"] for j in json.loads((second / "cron" / "jobs.json").read_text())["jobs"]]
+    assert first_names == ["first"]
+    assert second_names == ["second"]
+
+
+def test_explicit_compatibility_path_globals_remain_honored(monkeypatch, tmp_path):
+    cron_dir = tmp_path / "legacy-cron"
+    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "custom-jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "custom-output")
+    created = jobs.create_job(name="compat", prompt="x", schedule="0 3 * * *")
+    assert created["name"] == "compat"
+    assert (cron_dir / "custom-jobs.json").is_file()
+
+
+def test_profile_owner_is_written_and_mismatch_fails_closed(tmp_path):
+    alpha = profile_home(tmp_path, "alpha")
+    beta = profile_home(tmp_path, "beta")
+    with jobs.use_cron_store(alpha, owner_profile="alpha"):
+        created = jobs.create_job(name="owned", prompt="x", schedule="0 1 * * *")
+        assert created["owner_profile"] == "alpha"
+
+    with pytest.raises(ValueError, match="does not match store path"):
+        with jobs.use_cron_store(alpha, owner_profile="beta"):
+            pass
+
+    (beta / "cron" / "jobs.json").write_text(json.dumps({"jobs": [created]}))
+    with jobs.use_cron_store(beta, owner_profile="beta"):
+        with pytest.raises(RuntimeError, match="owner_profile"):
+            jobs.load_jobs()
+
+
+def test_legacy_job_without_owner_remains_readable(tmp_path):
+    alpha = profile_home(tmp_path, "alpha")
+    legacy = {"id": "legacy", "name": "legacy", "prompt": "x", "schedule": {"kind": "cron", "expr": "0 1 * * *"}}
+    (alpha / "cron" / "jobs.json").write_text(json.dumps({"jobs": [legacy]}))
+    with jobs.use_cron_store(alpha, owner_profile="alpha"):
+        loaded = jobs.load_jobs()
+    assert loaded == [legacy]
+
+
+def test_nested_lock_rejects_different_store(tmp_path):
+    alpha = profile_home(tmp_path, "alpha")
+    beta = profile_home(tmp_path, "beta")
+    with jobs.use_cron_store(alpha, owner_profile="alpha"):
+        with jobs._jobs_lock():
+            with jobs.use_cron_store(beta, owner_profile="beta"):
+                with pytest.raises(RuntimeError, match="different cron store"):
+                    with jobs._jobs_lock():
+                        pass
+
+
+def test_windows_lock_contention_times_out_without_entering_critical_section(
+    monkeypatch, tmp_path
+):
+    class ContendedMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(_fd, _mode, _count):
+            raise OSError("contended")
+
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr(jobs, "fcntl", None)
+    monkeypatch.setattr(jobs, "msvcrt", ContendedMsvcrt)
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0)
+    entered = False
+    with pytest.raises(TimeoutError):
+        with jobs._jobs_lock():
+            entered = True
+    assert entered is False
+
+
+def test_ticker_heartbeat_uses_current_store(monkeypatch, tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    monkeypatch.setenv("HERMES_HOME", str(first))
+    jobs.record_ticker_heartbeat(success=True)
+    monkeypatch.setenv("HERMES_HOME", str(second))
+    jobs.record_ticker_heartbeat(success=True)
+    assert (first / "cron" / "ticker_heartbeat").is_file()
+    assert (first / "cron" / "ticker_last_success").is_file()
+    assert (second / "cron" / "ticker_heartbeat").is_file()
+    assert (second / "cron" / "ticker_last_success").is_file()
+
+
+def test_builtin_scheduler_predicate_can_yield_without_ticking(monkeypatch):
+    import cron.scheduler as scheduler_module
+
+    calls = []
+    monkeypatch.setattr(scheduler_module, "tick", lambda **kwargs: calls.append(kwargs))
+    scheduler = scheduler_provider.InProcessCronScheduler()
+    scheduler.set_tick_predicate(lambda: False)
+    stop = threading.Event()
+    thread = threading.Thread(target=scheduler.start, args=(stop,), kwargs={"interval": 0.01}, daemon=True)
+    thread.start()
+    time.sleep(0.04)
+    stop.set()
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert calls == []

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -20,18 +20,12 @@ class TestCronFilePermissions(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    @patch("cron.jobs.CRON_DIR")
-    @patch("cron.jobs.OUTPUT_DIR")
-    @patch("cron.jobs.JOBS_FILE")
-    def test_ensure_dirs_sets_0700(self, mock_jobs_file, mock_output, mock_cron):
-        mock_cron.__class__ = Path
-        # Use real paths
+    def test_ensure_dirs_sets_0700(self):
         cron_dir = Path(self.tmpdir) / "cron"
         output_dir = cron_dir / "output"
 
-        with patch("cron.jobs.CRON_DIR", cron_dir), \
-             patch("cron.jobs.OUTPUT_DIR", output_dir):
-            from cron.jobs import ensure_dirs
+        from cron.jobs import ensure_dirs, use_cron_store
+        with use_cron_store(Path(self.tmpdir)):
             ensure_dirs()
 
             cron_mode = stat.S_IMODE(os.stat(cron_dir).st_mode)
@@ -39,30 +33,21 @@ class TestCronFilePermissions(unittest.TestCase):
             self.assertEqual(cron_mode, 0o700)
             self.assertEqual(output_mode, 0o700)
 
-    @patch("cron.jobs.CRON_DIR")
-    @patch("cron.jobs.OUTPUT_DIR")
-    @patch("cron.jobs.JOBS_FILE")
-    def test_save_jobs_sets_0600(self, mock_jobs_file, mock_output, mock_cron):
+    def test_save_jobs_sets_0600(self):
         cron_dir = Path(self.tmpdir) / "cron"
-        output_dir = cron_dir / "output"
         jobs_file = cron_dir / "jobs.json"
 
-        with patch("cron.jobs.CRON_DIR", cron_dir), \
-             patch("cron.jobs.OUTPUT_DIR", output_dir), \
-             patch("cron.jobs.JOBS_FILE", jobs_file):
-            from cron.jobs import save_jobs
+        from cron.jobs import save_jobs, use_cron_store
+        with use_cron_store(Path(self.tmpdir)):
             save_jobs([{"id": "test", "prompt": "hello"}])
 
             file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
             self.assertEqual(file_mode, 0o600)
 
     def test_save_job_output_sets_0600(self):
-        output_dir = Path(self.tmpdir) / "output"
-        with patch("cron.jobs.OUTPUT_DIR", output_dir), \
-             patch("cron.jobs.CRON_DIR", Path(self.tmpdir)), \
-             patch("cron.jobs.ensure_dirs"):
-            output_dir.mkdir(parents=True, exist_ok=True)
-            from cron.jobs import save_job_output
+        output_dir = Path(self.tmpdir) / "cron" / "output"
+        from cron.jobs import save_job_output, use_cron_store
+        with use_cron_store(Path(self.tmpdir)):
             output_file = save_job_output("test-job", "test output content")
 
             file_mode = stat.S_IMODE(os.stat(output_file).st_mode)

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -31,7 +31,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None):
+    def fake_mark(jid, ok, err=None, delivery_error=None, alert_state=None):
         calls.append(("mark", jid, ok))
 
     monkeypatch.setattr(s, "run_job", fake_run_job)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2645,6 +2645,7 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            alert_state=None,
         )
 
 

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -489,26 +489,21 @@ def test_heartbeat_roundtrip_and_age(tmp_path, monkeypatch):
     getters read them back as small positive ages."""
     import cron.jobs as jobs
 
-    cron_dir = tmp_path / "cron"
-    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
-    monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "output")
-    monkeypatch.setattr(jobs, "TICKER_HEARTBEAT_FILE", cron_dir / "ticker_heartbeat")
-    monkeypatch.setattr(jobs, "TICKER_SUCCESS_FILE", cron_dir / "ticker_last_success")
+    with jobs.use_cron_store(tmp_path):
+        # No files yet -> unknown (None), NOT "dead"
+        assert jobs.get_ticker_heartbeat_age() is None
+        assert jobs.get_ticker_success_age() is None
 
-    # No files yet -> unknown (None), NOT "dead"
-    assert jobs.get_ticker_heartbeat_age() is None
-    assert jobs.get_ticker_success_age() is None
+        # liveness-only: heartbeat set, success still unknown
+        jobs.record_ticker_heartbeat(success=False)
+        hb = jobs.get_ticker_heartbeat_age()
+        assert hb is not None and 0.0 <= hb < 5.0
+        assert jobs.get_ticker_success_age() is None
 
-    # liveness-only: heartbeat set, success still unknown
-    jobs.record_ticker_heartbeat(success=False)
-    hb = jobs.get_ticker_heartbeat_age()
-    assert hb is not None and 0.0 <= hb < 5.0
-    assert jobs.get_ticker_success_age() is None
-
-    # success: both set
-    jobs.record_ticker_heartbeat(success=True)
-    ok = jobs.get_ticker_success_age()
-    assert ok is not None and 0.0 <= ok < 5.0
+        # success: both set
+        jobs.record_ticker_heartbeat(success=True)
+        ok = jobs.get_ticker_success_age()
+        assert ok is not None and 0.0 <= ok < 5.0
 
 
 def test_heartbeat_age_detects_staleness(tmp_path, monkeypatch):
@@ -518,12 +513,11 @@ def test_heartbeat_age_detects_staleness(tmp_path, monkeypatch):
     cron_dir = tmp_path / "cron"
     cron_dir.mkdir(parents=True)
     hb = cron_dir / "ticker_heartbeat"
-    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
-    monkeypatch.setattr(jobs, "TICKER_HEARTBEAT_FILE", hb)
 
     import time as _t
     hb.write_text(str(_t.time() - 10_000), encoding="utf-8")
-    age = jobs.get_ticker_heartbeat_age()
+    with jobs.use_cron_store(tmp_path):
+        age = jobs.get_ticker_heartbeat_age()
     assert age is not None and age > 9_000
 
 
@@ -538,16 +532,11 @@ def test_heartbeat_write_failure_is_silent(tmp_path, monkeypatch):
 
     blocker = tmp_path / "not_a_dir"
     blocker.write_text("i am a file, not a directory")
-    bad_cron_dir = blocker / "cron"  # parent is a file -> mkdir/mkstemp fail
-    monkeypatch.setattr(jobs, "CRON_DIR", bad_cron_dir)
-    monkeypatch.setattr(jobs, "OUTPUT_DIR", bad_cron_dir / "output")
-    monkeypatch.setattr(jobs, "TICKER_HEARTBEAT_FILE", bad_cron_dir / "ticker_heartbeat")
-    monkeypatch.setattr(jobs, "TICKER_SUCCESS_FILE", bad_cron_dir / "ticker_last_success")
+    with jobs.use_cron_store(blocker):
+        jobs.record_ticker_heartbeat(success=True)  # must not raise
 
-    jobs.record_ticker_heartbeat(success=True)  # must not raise
-
-    # The write never succeeded, so no heartbeat is recorded...
-    assert jobs.get_ticker_heartbeat_age() is None
+        # The write never succeeded, so no heartbeat is recorded...
+        assert jobs.get_ticker_heartbeat_age() is None
     # ...and no stray temp file leaked anywhere under tmp_path.
     assert not list(tmp_path.rglob(".hb_*.tmp")), "atomic write leaked a temp file on failure"
 

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -3,9 +3,8 @@
 Three fixes under test:
 
 1. ``_jobs_lock()`` bounds its cross-process flock: when another process holds
-   ``.jobs.lock`` indefinitely, acquisition times out, logs at ERROR, and falls
-   through to in-process-only locking — instead of blocking the calling thread
-   (and, transitively, the cron ticker heartbeat) forever.
+   ``.jobs.lock`` indefinitely, acquisition times out and fails closed instead
+   of performing an unlocked write or blocking the ticker forever.
 
 2. Claim freshness checks are bounded on both sides (``0 <= age < ttl``): a
    ``fire_claim``/``run_claim`` stamped in the FUTURE (clock/TZ skew across a
@@ -65,8 +64,8 @@ def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event
 
 
 class TestBoundedJobsLock:
-    def test_lock_acquisition_times_out_and_degrades(self, monkeypatch, caplog):
-        """A foreign holder of .jobs.lock must NOT block _jobs_lock forever."""
+    def test_lock_acquisition_times_out_and_fails_closed(self, monkeypatch, caplog):
+        """A foreign holder must bound the wait without entering unlocked."""
         jobs_mod.ensure_dirs()
         lock_path = jobs_mod._jobs_lock_file()
         lock_path.touch()
@@ -83,16 +82,15 @@ class TestBoundedJobsLock:
 
         try:
             start = time.monotonic()
-            entered = False
             with caplog.at_level("ERROR", logger="cron.jobs"):
-                with _jobs_lock():
-                    entered = True
+                with pytest.raises(TimeoutError):
+                    with _jobs_lock():
+                        pytest.fail("critical section must not run without the flock")
             elapsed = time.monotonic() - start
 
-            assert entered, "critical section must still run in degraded mode"
             assert elapsed < 10, f"lock wait was not bounded (took {elapsed:.1f}s)"
             assert any("Timed out" in r.message for r in caplog.records), (
-                "degraded-mode fallback must be logged at ERROR"
+                "lock timeout must be logged at ERROR"
             )
         finally:
             release.set()

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -22,6 +22,7 @@ def isolated_profiles(tmp_path, monkeypatch):
         (home / "cron").mkdir(parents=True, exist_ok=True)
         (home / "config.yaml").write_text("model: test-model\n", encoding="utf-8")
 
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
     monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
     monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
     return {"default": default_home, "worker_alpha": worker_home}
@@ -34,6 +35,92 @@ def _drain_queue(q):
             values.append(q.get_nowait())
         except Empty:
             return values
+
+
+@pytest.mark.parametrize("gateway_running,expected", [(True, False), (False, True)])
+def test_desktop_builtin_ticker_yields_to_gateway(
+    monkeypatch, gateway_running, expected
+):
+    from cron import scheduler_provider
+    from gateway import status as gateway_status
+    from hermes_cli import web_server
+
+    provider = scheduler_provider.InProcessCronScheduler()
+    decisions = []
+    monkeypatch.setattr(scheduler_provider, "resolve_cron_scheduler", lambda: provider)
+    monkeypatch.setattr(
+        gateway_status,
+        "is_gateway_running",
+        lambda cleanup_stale=False: gateway_running,
+    )
+    monkeypatch.setattr(
+        provider,
+        "start",
+        lambda stop_event, interval=60: decisions.append(provider._should_tick()),
+    )
+
+    web_server._start_desktop_cron_ticker(threading.Event(), interval=1)
+    assert decisions == [expected]
+
+
+def test_desktop_builtin_ticker_status_probe_failure_falls_back_to_locking(monkeypatch):
+    from cron import scheduler_provider
+    from gateway import status as gateway_status
+    from hermes_cli import web_server
+
+    provider = scheduler_provider.InProcessCronScheduler()
+    decisions = []
+    monkeypatch.setattr(scheduler_provider, "resolve_cron_scheduler", lambda: provider)
+
+    def broken_probe(cleanup_stale=False):
+        raise RuntimeError("probe unavailable")
+
+    monkeypatch.setattr(gateway_status, "is_gateway_running", broken_probe)
+    monkeypatch.setattr(
+        provider,
+        "start",
+        lambda stop_event, interval=60: decisions.append(provider._should_tick()),
+    )
+
+    web_server._start_desktop_cron_ticker(threading.Event(), interval=1)
+    assert decisions == [True]
+
+
+def test_desktop_external_provider_keeps_dynamic_builtin_failover(monkeypatch):
+    from cron import scheduler_provider
+    from gateway import status as gateway_status
+    from hermes_cli import web_server
+
+    class ExternalProvider:
+        name = "external"
+
+        def start(self, *_args, **_kwargs):
+            raise AssertionError("Desktop must not provision a second external scheduler")
+
+    decisions = []
+
+    class FallbackProvider:
+        name = "builtin"
+
+        def set_tick_predicate(self, predicate):
+            self.predicate = predicate
+
+        def start(self, _stop_event, interval=60):
+            decisions.extend([self.predicate(), self.predicate()])
+
+    states = iter([True, False])
+    monkeypatch.setattr(
+        scheduler_provider, "resolve_cron_scheduler", lambda: ExternalProvider()
+    )
+    monkeypatch.setattr(scheduler_provider, "InProcessCronScheduler", FallbackProvider)
+    monkeypatch.setattr(
+        gateway_status,
+        "is_gateway_running",
+        lambda cleanup_stale=False: next(states),
+    )
+
+    web_server._start_desktop_cron_ticker(threading.Event(), interval=1)
+    assert decisions == [False, True]
 
 
 def test_call_cron_for_profile_routes_storage_without_mutating_globals(isolated_profiles):
@@ -135,9 +222,6 @@ def test_profile_call_cannot_retarget_ticker_store_mid_write(
     default_file.write_text(json.dumps({"jobs": [default_job]}), encoding="utf-8")
     worker_file.write_text(json.dumps({"jobs": [worker_job]}), encoding="utf-8")
 
-    monkeypatch.setattr(cron_jobs, "CRON_DIR", default_cron)
-    monkeypatch.setattr(cron_jobs, "JOBS_FILE", default_file)
-    monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", default_cron / "output")
     monkeypatch.setattr(
         cron_jobs,
         "compute_next_run",


### PR DESCRIPTION
## What changed

- resolve cron storage dynamically from the active Hermes profile instead of relying on process-global paths that can be retargeted by dashboard requests
- add profile ownership metadata and fail closed on cross-profile registry access
- prevent nested locks from crossing stores and bound lock acquisition without entering an unprotected critical section
- coordinate the built-in Desktop scheduler with profile gateways
- persist failure incident state so repeated identical failures are suppressed, reminders are bounded, and recovery is delivered once
- add deterministic profile-race, locking, heartbeat, scheduler, and failure-lifecycle coverage

## Root cause

The multi-profile dashboard temporarily retargeted cron module globals while scheduler threads used those same globals. A scheduler could load one profile's registry and save it through another profile's path. Lock contention also degraded to an unlocked critical section, and repeated failures had no durable incident state.

## User impact

This prevents one Hermes profile from overwriting another profile's cron registry and reduces repeated failure-message floods without hiding the first failure or the eventual recovery.

## Validation

`scripts/run_tests.sh tests/cron/test_cron_phase1_hardening.py tests/cron/test_file_permissions.py tests/cron/test_scheduler_provider.py tests/cron/test_ticker_stall_60703.py tests/hermes_cli/test_web_server_cron_profiles.py tests/cron/test_cron_no_agent.py tests/cron/test_run_one_job.py tests/cron/test_scheduler.py -q`

Result: **336 passed, 0 failed**.