### PR TITLE
fix(cron): apply output transforms before delivery

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -368,12 +368,15 @@ def finalize_turn(
     if final_response and not interrupted:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _transform_platform = getattr(agent, "_transform_llm_output_platform", None)
+            if not isinstance(_transform_platform, str) or not _transform_platform.strip():
+                _transform_platform = getattr(agent, "platform", None) or ""
             _transform_results = _invoke_hook(
                 "transform_llm_output",
                 response_text=final_response,
                 session_id=agent.session_id or "",
                 model=agent.model,
-                platform=getattr(agent, "platform", None) or "",
+                platform=_transform_platform,
             )
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1346,6 +1346,47 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
+def _apply_cron_delivery_output_transform(
+    job: dict,
+    content: str,
+    *,
+    platform_name: str,
+) -> str:
+    """Apply final-output plugin transforms for the concrete delivery platform.
+
+    Cron agents run with ``platform="cron"``, but auto-delivery may send the
+    final text to Slack, Telegram, etc.  Gateway replies run
+    ``transform_llm_output`` before platform send, so cron delivery needs the
+    same hook at the delivery boundary with the actual target platform.
+    """
+    if not content:
+        return content
+
+    try:
+        from hermes_cli.plugins import discover_plugins, invoke_hook
+
+        discover_plugins()
+        transform_results = invoke_hook(
+            "transform_llm_output",
+            response_text=content,
+            session_id=f"cron:{job.get('id', '')}" if job.get("id") else "",
+            model=str(job.get("model") or ""),
+            platform=str(platform_name or "").lower(),
+        )
+        for hook_result in transform_results:
+            if isinstance(hook_result, str) and hook_result:
+                return hook_result
+    except Exception as exc:
+        logger.warning(
+            "Job '%s': transform_llm_output hook failed for %s delivery: %s",
+            job.get("id", "?"),
+            platform_name,
+            exc,
+        )
+
+    return content
+
+
 def _is_channel_dm_topic(
     runtime_adapter: Any,
     chat_id: Any,
@@ -1462,10 +1503,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
+    # MEDIA extraction happens per target below, after the target-platform
+    # output transform hook has run.  That lets Slack-specific plugins adjust
+    # cron output before Slack delivery while preserving attachment handling.
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session
@@ -1535,6 +1576,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue
+
+        transformed_delivery_content = delivery_content
+        if not job.get("no_agent"):
+            transformed_delivery_content = _apply_cron_delivery_output_transform(
+                job,
+                delivery_content,
+                platform_name=platform_name,
+            )
+        media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(
+            transformed_delivery_content
+        )
+        media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1263,6 +1263,22 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
     return targets[0] if targets else None
 
 
+def _resolve_transform_output_platform(job: dict) -> str:
+    """Resolve the platform exposed to the once-per-turn output transform.
+
+    When a cron job has exactly one delivery platform, let
+    ``transform_llm_output`` see that concrete platform. Cross-platform fan-out
+    has no single target-platform contract, so keep the cron platform instead
+    of formatting once for one target and sending that result everywhere.
+    """
+    platforms = {
+        str(target.get("platform") or "").lower()
+        for target in _resolve_delivery_targets(job)
+        if target.get("platform")
+    }
+    return next(iter(platforms)) if len(platforms) == 1 else "cron"
+
+
 # Media extension sets — audio routing is centralized in gateway.platforms.base
 # via should_send_media_as_audio() so Telegram-specific rules stay in one place.
 _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
@@ -3151,13 +3167,8 @@ def run_job(
         # Keep ``agent.platform`` as cron: request dispatch, prompt construction,
         # and approvals rely on it.  Only transform_llm_output should see the
         # concrete delivery platform, and the existing finalizer invokes that
-        # hook exactly once per turn. For fan-out, the first resolved target is
-        # the canonical output format and every target receives the same result.
-        agent._transform_llm_output_platform = (
-            str(delivery_target.get("platform") or "").lower()
-            if delivery_target
-            else "cron"
-        )
+        # hook exactly once per turn.
+        agent._transform_llm_output_platform = _resolve_transform_output_platform(job)
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1346,47 +1346,6 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
-def _apply_cron_delivery_output_transform(
-    job: dict,
-    content: str,
-    *,
-    platform_name: str,
-) -> str:
-    """Apply final-output plugin transforms for the concrete delivery platform.
-
-    Cron agents run with ``platform="cron"``, but auto-delivery may send the
-    final text to Slack, Telegram, etc.  Gateway replies run
-    ``transform_llm_output`` before platform send, so cron delivery needs the
-    same hook at the delivery boundary with the actual target platform.
-    """
-    if not content:
-        return content
-
-    try:
-        from hermes_cli.plugins import discover_plugins, invoke_hook
-
-        discover_plugins()
-        transform_results = invoke_hook(
-            "transform_llm_output",
-            response_text=content,
-            session_id=f"cron:{job.get('id', '')}" if job.get("id") else "",
-            model=str(job.get("model") or ""),
-            platform=str(platform_name or "").lower(),
-        )
-        for hook_result in transform_results:
-            if isinstance(hook_result, str) and hook_result:
-                return hook_result
-    except Exception as exc:
-        logger.warning(
-            "Job '%s': transform_llm_output hook failed for %s delivery: %s",
-            job.get("id", "?"),
-            platform_name,
-            exc,
-        )
-
-    return content
-
-
 def _is_channel_dm_topic(
     runtime_adapter: Any,
     chat_id: Any,
@@ -1503,10 +1462,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
-    # MEDIA extraction happens per target below, after the target-platform
-    # output transform hook has run.  That lets Slack-specific plugins adjust
-    # cron output before Slack delivery while preserving attachment handling.
+    # Extract MEDIA: tags after the agent finalizer's output transform so
+    # attachments added by a transform are forwarded as files, not raw text.
     from gateway.platforms.base import BasePlatformAdapter
+    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
     # Resolve the delivery-mirror gate ONCE (default off). When on, each
     # successful delivery is also appended to the target chat's gateway session
@@ -1576,18 +1536,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue
-
-        transformed_delivery_content = delivery_content
-        if not job.get("no_agent"):
-            transformed_delivery_content = _apply_cron_delivery_output_transform(
-                job,
-                delivery_content,
-                platform_name=platform_name,
-            )
-        media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(
-            transformed_delivery_content
-        )
-        media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
@@ -3154,6 +3102,20 @@ def run_job(
                 job_id, _mcp_exc,
             )
 
+        # Ensure output hooks are registered before the agent finalizer runs.
+        # This stays on the agent path so no_agent script output is never
+        # transformed or made to pay plugin-discovery cost.
+        try:
+            from hermes_cli.plugins import discover_plugins
+
+            discover_plugins()
+        except Exception as _plugin_exc:
+            logger.warning(
+                "Job '%s': plugin discovery failed (non-fatal): %s",
+                job_id,
+                _plugin_exc,
+            )
+
         agent = AIAgent(
             model=model,
             api_key=runtime.get("api_key"),
@@ -3185,6 +3147,16 @@ def run_job(
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
+        )
+        # Keep ``agent.platform`` as cron: request dispatch, prompt construction,
+        # and approvals rely on it.  Only transform_llm_output should see the
+        # concrete delivery platform, and the existing finalizer invokes that
+        # hook exactly once per turn. For fan-out, the first resolved target is
+        # the canonical output format and every target receives the same result.
+        agent._transform_llm_output_platform = (
+            str(delivery_target.get("platform") or "").lower()
+            if delivery_target
+            else "cron"
         )
         
         # Run the agent with an *inactivity*-based timeout: the job can run

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -669,6 +669,80 @@ class TestDeliverResultWrapping:
         # Media files should be forwarded separately
         assert kwargs["media_files"] == [(str(media_path), False)]
 
+    def test_slack_delivery_applies_transform_llm_output_before_send(self):
+        """Cron Slack delivery should run final-output hooks for Slack."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("hermes_cli.plugins.discover_plugins") as discover_mock, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=["spaced slack text"]) as hook_mock, \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "slack-job",
+                "model": "test-model",
+                "deliver": "origin",
+                "origin": {"platform": "slack", "chat_id": "C123456789"},
+            }
+            _deliver_result(job, "raw cron text")
+
+        discover_mock.assert_called_once()
+        hook_mock.assert_called_once_with(
+            "transform_llm_output",
+            response_text="raw cron text",
+            session_id="cron:slack-job",
+            model="test-model",
+            platform="slack",
+        )
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        assert args[0] == Platform.SLACK
+        assert args[3] == "spaced slack text"
+        assert kwargs["media_files"] == []
+
+    def test_transform_runs_before_media_extraction_and_preserves_wrap_response(
+        self, tmp_path, monkeypatch
+    ):
+        """Hook output should still go through MEDIA extraction after wrapping."""
+        from gateway.config import Platform
+
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "chart.png")
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        def transform_hook(_hook_name, **kwargs):
+            return [f"{kwargs['response_text']}\nPlugin footer\nMEDIA:{media_path}"]
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}), \
+             patch("hermes_cli.plugins.discover_plugins"), \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=transform_hook), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "wrapped-slack-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "slack", "chat_id": "C123456789"},
+            }
+            _deliver_result(job, "Original body")
+
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        sent_content = args[3]
+        assert "Cronjob Response: daily-report" in sent_content
+        assert "Original body" in sent_content
+        assert "Plugin footer" in sent_content
+        assert "MEDIA:" not in sent_content
+        assert kwargs["media_files"] == [(str(media_path), False)]
+
     def test_live_adapter_sends_media_as_attachments(self, tmp_path, monkeypatch):
         """When a live adapter is available, MEDIA files should be sent as native
         platform attachments (e.g., Discord voice, Telegram audio) rather than
@@ -2838,6 +2912,41 @@ class TestRunJobWakeGate:
         assert final == SILENT_MARKER
         assert "Script gate returned `wakeAgent=false`" in doc
         agent_cls.assert_not_called()
+
+    def test_no_agent_delivery_skips_transform_hook(self):
+        """Script-only cron output is delivered verbatim without LLM transforms."""
+        from gateway.config import Platform
+        import cron.scheduler as scheduler
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        job = self._make_job(name="script-only")
+        job.update({
+            "no_agent": True,
+            "deliver": "origin",
+            "origin": {"platform": "slack", "chat_id": "C123456789"},
+        })
+
+        with patch.object(scheduler, "claim_dispatch", return_value=True), \
+             patch.object(scheduler, "_run_job_script", return_value=(True, "raw script text")), \
+             patch.object(scheduler, "save_job_output", return_value="/tmp/out.md"), \
+             patch.object(scheduler, "mark_job_run"), \
+             patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("hermes_cli.plugins.discover_plugins"), \
+             patch("hermes_cli.plugins.invoke_hook", return_value=["spaced script text"]) as hook_mock, \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            assert scheduler.run_one_job(job) is True
+
+        hook_mock.assert_not_called()
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        assert args[0] == Platform.SLACK
+        assert args[3] == "raw script text"
+        assert kwargs["media_files"] == []
 
     def test_wake_true_runs_agent_with_injected_output(self):
         """When the script returns {wakeAgent: true, data: ...}, the agent is

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -670,15 +670,24 @@ class TestDeliverResultWrapping:
         # Media files should be forwarded separately
         assert kwargs["media_files"] == [(str(media_path), False)]
 
-    def test_agent_cron_transform_runs_once_before_fanout(self, tmp_path):
-        """The agent finalizer transforms once before delivery fan-out."""
+    def _run_agent_cron_transform_case(
+        self,
+        tmp_path,
+        *,
+        deliver,
+        platforms,
+        expected_platform,
+        expected_sends,
+    ):
         from gateway.config import Platform
         from run_agent import AIAgent as RealAIAgent
 
-        pconfig = MagicMock()
-        pconfig.enabled = True
         mock_cfg = MagicMock()
-        mock_cfg.platforms = {Platform.SLACK: pconfig}
+        mock_cfg.platforms = {}
+        for platform in platforms:
+            pconfig = MagicMock()
+            pconfig.enabled = True
+            mock_cfg.platforms[Platform(platform)] = pconfig
 
         transform_calls = []
 
@@ -723,7 +732,7 @@ class TestDeliverResultWrapping:
             "name": "Slack report",
             "prompt": "make a report",
             "model": "test-model",
-            "deliver": "slack:C123456789,slack:C987654321",
+            "deliver": deliver,
         }
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
@@ -753,14 +762,35 @@ class TestDeliverResultWrapping:
         assert len(transform_calls) == 1
         assert transform_calls[0]["response_text"] == "raw cron text"
         assert transform_calls[0]["model"] == "test-model"
-        assert transform_calls[0]["platform"] == "slack"
+        assert transform_calls[0]["platform"] == expected_platform
         assert transform_calls[0]["session_id"].startswith("cron_slack-job_")
-        assert send_mock.call_count == 2
+        assert send_mock.call_count == expected_sends
+        sent_platforms = {call.args[0] for call in send_mock.call_args_list}
+        assert sent_platforms == {Platform(platform) for platform in platforms}
         for call in send_mock.call_args_list:
             args, kwargs = call
-            assert args[0] == Platform.SLACK
             assert args[3] == "raw cron text|transformed"
             assert kwargs["media_files"] == []
+
+    def test_agent_cron_transform_runs_once_before_same_platform_fanout(self, tmp_path):
+        """Same-platform fan-out can expose the concrete delivery platform."""
+        self._run_agent_cron_transform_case(
+            tmp_path,
+            deliver="slack:C123456789,slack:C987654321",
+            platforms=["slack"],
+            expected_platform="slack",
+            expected_sends=2,
+        )
+
+    def test_agent_cron_transform_uses_cron_for_cross_platform_fanout(self, tmp_path):
+        """Cross-platform fan-out has no single concrete output platform."""
+        self._run_agent_cron_transform_case(
+            tmp_path,
+            deliver="slack:C123456789,discord:987654321",
+            platforms=["slack", "discord"],
+            expected_platform="cron",
+            expected_sends=2,
+        )
 
     def test_transformed_agent_output_preserves_wrap_and_media_extraction(
         self, tmp_path, monkeypatch

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import logging
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -669,46 +670,102 @@ class TestDeliverResultWrapping:
         # Media files should be forwarded separately
         assert kwargs["media_files"] == [(str(media_path), False)]
 
-    def test_slack_delivery_applies_transform_llm_output_before_send(self):
-        """Cron Slack delivery should run final-output hooks for Slack."""
+    def test_agent_cron_transform_runs_once_before_fanout(self, tmp_path):
+        """The agent finalizer transforms once before delivery fan-out."""
         from gateway.config import Platform
+        from run_agent import AIAgent as RealAIAgent
 
         pconfig = MagicMock()
         pconfig.enabled = True
         mock_cfg = MagicMock()
         mock_cfg.platforms = {Platform.SLACK: pconfig}
 
-        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
-             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
-             patch("hermes_cli.plugins.discover_plugins") as discover_mock, \
-             patch("hermes_cli.plugins.invoke_hook", return_value=["spaced slack text"]) as hook_mock, \
-             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
-            job = {
-                "id": "slack-job",
-                "model": "test-model",
-                "deliver": "origin",
-                "origin": {"platform": "slack", "chat_id": "C123456789"},
-            }
-            _deliver_result(job, "raw cron text")
+        transform_calls = []
 
-        discover_mock.assert_called_once()
-        hook_mock.assert_called_once_with(
-            "transform_llm_output",
-            response_text="raw cron text",
-            session_id="cron:slack-job",
+        def invoke_hook(hook_name, **kwargs):
+            if hook_name != "transform_llm_output":
+                return []
+            transform_calls.append(kwargs)
+            return [f"{kwargs['response_text']}|transformed"]
+
+        def make_agent(*_args, **kwargs):
+            with patch("run_agent.get_tool_definitions", return_value=[]), \
+                 patch("run_agent.check_toolset_requirements", return_value={}), \
+                 patch("run_agent.OpenAI"):
+                agent = RealAIAgent(*_args, **kwargs)
+            agent.client = MagicMock()
+            agent._cached_system_prompt = "You are helpful."
+            agent._use_prompt_caching = False
+            agent.compression_enabled = False
+            agent.save_trajectories = False
+            agent.tool_delay = 0
+            agent._fallback_chain = []
+            return agent
+
+        model_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="raw cron text",
+                        tool_calls=None,
+                        reasoning=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
             model="test-model",
-            platform="slack",
+            usage=None,
         )
-        send_mock.assert_called_once()
-        args, kwargs = send_mock.call_args
-        assert args[0] == Platform.SLACK
-        assert args[3] == "spaced slack text"
-        assert kwargs["media_files"] == []
 
-    def test_transform_runs_before_media_extraction_and_preserves_wrap_response(
+        fake_db = MagicMock()
+        job = {
+            "id": "slack-job",
+            "name": "Slack report",
+            "prompt": "make a report",
+            "model": "test-model",
+            "deliver": "slack:C123456789,slack:C987654321",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             }), \
+             patch("run_agent.AIAgent", side_effect=make_agent), \
+             patch("agent.chat_completion_helpers.direct_api_call", return_value=model_response), \
+             patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("hermes_cli.plugins.discover_plugins"), \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=invoke_hook), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            success, _output, final_response, error = run_job(job)
+            delivery_error = _deliver_result(job, final_response)
+
+        assert success is True
+        assert error is None
+        assert delivery_error is None
+        assert len(transform_calls) == 1
+        assert transform_calls[0]["response_text"] == "raw cron text"
+        assert transform_calls[0]["model"] == "test-model"
+        assert transform_calls[0]["platform"] == "slack"
+        assert transform_calls[0]["session_id"].startswith("cron_slack-job_")
+        assert send_mock.call_count == 2
+        for call in send_mock.call_args_list:
+            args, kwargs = call
+            assert args[0] == Platform.SLACK
+            assert args[3] == "raw cron text|transformed"
+            assert kwargs["media_files"] == []
+
+    def test_transformed_agent_output_preserves_wrap_and_media_extraction(
         self, tmp_path, monkeypatch
     ):
-        """Hook output should still go through MEDIA extraction after wrapping."""
+        """Finalizer-transformed output still uses normal delivery handling."""
         from gateway.config import Platform
 
         media_path = self._safe_media_path(tmp_path, monkeypatch, "chart.png")
@@ -718,13 +775,8 @@ class TestDeliverResultWrapping:
         mock_cfg = MagicMock()
         mock_cfg.platforms = {Platform.SLACK: pconfig}
 
-        def transform_hook(_hook_name, **kwargs):
-            return [f"{kwargs['response_text']}\nPlugin footer\nMEDIA:{media_path}"]
-
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
              patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}), \
-             patch("hermes_cli.plugins.discover_plugins"), \
-             patch("hermes_cli.plugins.invoke_hook", side_effect=transform_hook), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
             job = {
                 "id": "wrapped-slack-job",
@@ -732,7 +784,10 @@ class TestDeliverResultWrapping:
                 "deliver": "origin",
                 "origin": {"platform": "slack", "chat_id": "C123456789"},
             }
-            _deliver_result(job, "Original body")
+            _deliver_result(
+                job,
+                f"Original body\nPlugin footer\nMEDIA:{media_path}",
+            )
 
         send_mock.assert_called_once()
         args, kwargs = send_mock.call_args


### PR DESCRIPTION
## Summary
- apply `transform_llm_output` hooks at the cron delivery boundary using the concrete target platform
- run MEDIA extraction after the target-platform transform so transformed output still sends attachments correctly
- add cron delivery regression coverage for Slack transforms, wrapping, and media extraction

## Why
Gateway final responses run `transform_llm_output` before platform delivery, but cron auto-delivery sent the cleaned content directly to the platform sender. That meant platform-specific final-output plugins, such as Slack markdown spacing transforms, were skipped for cron delivery.

## Tests
- `uv run --extra dev pytest tests/cron/test_scheduler.py`
- `uv run --extra dev pytest tests/test_transform_llm_output_hook.py`
- `uv run --extra dev ruff check cron/scheduler.py tests/cron/test_scheduler.py`
- `git diff --check`