### PR TITLE
feat(cli): show local llama.cpp residency

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -998,6 +998,19 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
             except Exception as exc:
                 _probe_failed(exc)
             if result is None:
+                # llama.cpp exposes /v1/props (older builds used /props without the /v1 prefix)
+                # Probe this before /api/tags: modern llama.cpp builds expose
+                # that Ollama-compatible endpoint too and would otherwise be
+                # misclassified as Ollama.
+                try:
+                    r = client.get(f"{server_url}/v1/props")
+                    if r.status_code != 200:
+                        r = client.get(f"{server_url}/props")  # fallback for older builds
+                    if r.status_code == 200 and "default_generation_settings" in r.text:
+                        result = "llamacpp"
+                except Exception:
+                    pass
+            if result is None:
                 # Ollama exposes /api/tags and responds with {"models": [...]}
                 # LM Studio returns {"error": "Unexpected endpoint"} with status 200
                 # on this path, so we must verify the response contains "models".
@@ -1010,16 +1023,6 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
                                 result = "ollama"
                         except Exception:
                             pass
-                except Exception as exc:
-                    _probe_failed(exc)
-            if result is None:
-                # llama.cpp exposes /v1/props (older builds used /props without the /v1 prefix)
-                try:
-                    r = client.get(f"{server_url}/v1/props")
-                    if r.status_code != 200:
-                        r = client.get(f"{server_url}/props")  # fallback for older builds
-                    if r.status_code == 200 and "default_generation_settings" in r.text:
-                        result = "llamacpp"
                 except Exception as exc:
                     _probe_failed(exc)
             if result is None:

--- a/cli.py
+++ b/cli.py
@@ -55,6 +55,12 @@ from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
 from agent.interrupt_compat import request_hard_interrupt
+from hermes_cli.local_model_status import (
+    LocalModelStatusMonitor,
+    build_local_model_display,
+    build_local_model_route,
+    canonicalize_route_url,
+)
 
 # prompt_toolkit for fixed input area TUI
 from prompt_toolkit.history import FileHistory
@@ -504,6 +510,11 @@ def load_cli_config() -> Dict[str, Any]:
             # Print a one-line summary of resolved modal prompts (approval /
             # clarify) into scrollback so the decision survives the repaint.
             "persist_prompts": True,
+
+            "local_model_status": {
+                "enabled": True,
+                "idle_timeout_seconds": None,
+            },
 
             "skin": "default",
         },
@@ -4792,6 +4803,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Battery read-out in the status bar (toggled via /battery, off by
         # default). Persisted to display.battery so it survives restarts.
         self._battery_visible = bool(CLI_CONFIG["display"].get("battery", False))
+        local_status_config = CLI_CONFIG.get("display", {}).get("local_model_status", {})
+        if not isinstance(local_status_config, dict):
+            local_status_config = {}
+        local_status_enabled = local_status_config.get("enabled", True) is not False
+        idle_timeout = local_status_config.get("idle_timeout_seconds")
+        try:
+            idle_timeout = float(idle_timeout) if idle_timeout is not None else None
+            if idle_timeout is not None and idle_timeout <= 0:
+                idle_timeout = None
+        except (TypeError, ValueError):
+            idle_timeout = None
+        self._local_model_idle_timeout_seconds = idle_timeout
+        self._last_local_model_activity_at = None
+        self._last_local_model_activity_route = None
+        self._local_model_status_monitor = (
+            LocalModelStatusMonitor(auto_poll=True) if local_status_enabled else None
+        )
+        if self._local_model_status_monitor is not None:
+            atexit.register(self._local_model_status_monitor.close)
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that
@@ -5281,6 +5311,69 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         idle = max(0.0, time.time() - last_finished_at)
         return f"✓ {format_duration_compact(idle)}"
 
+    def _get_active_local_model_route(self):
+        agent = getattr(self, "agent", None)
+        if agent is None:
+            return None
+        client = getattr(agent, "client", None)
+        client_kwargs = getattr(agent, "_client_kwargs", None)
+        if client is None or not isinstance(client_kwargs, dict):
+            return None
+
+        # The client reference is published only after its kwargs are fully
+        # built. Require all three endpoint views to agree so a concurrent
+        # provider/fallback transition can never form a hybrid route carrying
+        # credentials from the previous host.
+        agent_base_url = canonicalize_route_url(getattr(agent, "base_url", None))
+        client_base_url = canonicalize_route_url(getattr(client, "base_url", None))
+        kwargs_base_url = canonicalize_route_url(client_kwargs.get("base_url"))
+        if not agent_base_url or not (
+            agent_base_url == client_base_url == kwargs_base_url
+        ):
+            return None
+
+        api_key = client_kwargs.get("api_key")
+        if not isinstance(api_key, str):
+            api_key = ""
+        return build_local_model_route(
+            provider=getattr(agent, "provider", None) or "",
+            base_url=kwargs_base_url,
+            model=getattr(agent, "model", None) or "",
+            api_key=api_key,
+            extra_headers=client_kwargs.get("default_headers"),
+            ssl_ca_cert=client_kwargs.get("ssl_ca_cert") or "",
+            ssl_verify=client_kwargs.get("ssl_verify"),
+        )
+
+    def _record_local_model_activity(self) -> None:
+        route = self._get_active_local_model_route()
+        if route is not None:
+            self._last_local_model_activity_route = route.key
+            self._last_local_model_activity_at = time.monotonic()
+
+    def _get_local_model_status_display(self):
+        """Return the cached active-route residency display without blocking."""
+
+        monitor = getattr(self, "_local_model_status_monitor", None)
+        if monitor is None:
+            return None
+
+        route = self._get_active_local_model_route()
+        result = monitor.observe(route)
+        if route is None or result is None:
+            return None
+
+        last_activity_at = None
+        if getattr(self, "_last_local_model_activity_route", None) == route.key:
+            last_activity_at = getattr(self, "_last_local_model_activity_at", None)
+        return build_local_model_display(
+            result,
+            idle_timeout_seconds=getattr(self, "_local_model_idle_timeout_seconds", None),
+            last_activity_at=last_activity_at,
+            now=time.monotonic(),
+            turn_live=getattr(self, "_prompt_start_time", None) is not None,
+        )
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -5339,6 +5432,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Focus view badge (/focus). Persistent indicator so the reduced
             # output mode is never invisible. Display-only.
             "focus_label": "",
+            "local_model_status": self._get_local_model_status_display(),
         }
 
         try:
@@ -6123,6 +6217,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 parts.append(idle_since)
             if focus_label:
                 parts.append(focus_label)
+            local_model_status = snapshot.get("local_model_status")
+            if local_model_status:
+                parts.append(local_model_status.text)
             if yolo_active:
                 parts.append("⚠ YOLO")
             return self._right_align_status_title(" │ ".join(parts), session_title, width)
@@ -6147,6 +6244,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             battery_style = self._battery_status_style(snapshot.get("battery_category", "dim"))
             focus_label = snapshot.get("focus_label") or ""
             session_title = snapshot.get("session_title") or ""
+            local_model_fragment_range = None
 
             if width < 52:
                 frags = [
@@ -6262,6 +6360,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if focus_label:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", focus_label))
+                    local_model_status = snapshot.get("local_model_status")
+                    if local_model_status:
+                        local_model_fragment_start = len(frags)
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((
+                            f"class:status-bar-local-{local_model_status.style}",
+                            local_model_status.bar,
+                        ))
+                        frags.append(("class:status-bar-local-label", f" {local_model_status.label}"))
+                        local_model_fragment_range = (local_model_fragment_start, len(frags))
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -6296,10 +6404,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     (battery_style, battery_label),
                     ("class:status-bar-dim", " │"),
                 ]
+                if local_model_fragment_range is not None:
+                    start, end = local_model_fragment_range
+                    local_model_fragment_range = (start + 3, end + 3)
 
             frags = self._right_align_status_title_fragments(frags, session_title, width)
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
+            if total_width > width and local_model_fragment_range is not None:
+                start, end = local_model_fragment_range
+                del frags[start:end]
+                total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
                 plain_text = "".join(text for _, text in frags)
                 trimmed = self._trim_status_bar_text(plain_text, width)
@@ -14392,6 +14507,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Record when this agent loop finished so the status bar can show
             # idle time since the last final response.
             self._last_turn_finished_at = time.time()
+            self._record_local_model_activity()
 
             # Proactively clean up async clients whose event loop is dead.
             # The agent thread may have created AsyncOpenAI clients bound
@@ -17347,6 +17463,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             'status-bar-critical': 'bg:#1a1a2e #FF6B6B bold',
             'status-bar-yolo': 'bg:#1a1a2e #FF4444 bold',
             'status-bar-session-title': 'bg:#FFD700 #1a1a2e bold',
+            'status-bar-local-loaded': 'bg:#1a1a2e #8FBC8F bold',
+            'status-bar-local-loading': 'bg:#1a1a2e #FFD700 bold',
+            'status-bar-local-sleeping': 'bg:#1a1a2e #8B8682',
+            'status-bar-local-unknown': 'bg:#1a1a2e #8B8682',
+            'status-bar-local-label': 'bg:#1a1a2e #8B8682',
             # Bronze horizontal rules around the input area
             'input-rule': '#CD7F32',
             # Clipboard image attachment badges

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1202,6 +1202,13 @@ DEFAULT_CONFIG = {
         # failure isn't silent from the UI's perspective.  Set false to suppress.
         "turn_completion_explainer": True,
         "show_cost": False,       # Show $ cost in the status bar (off by default)
+        # Classic CLI: asynchronously show llama.cpp model residency for local
+        # routes. The timeout is only an estimated countdown; /props remains
+        # authoritative for loaded vs sleeping state.
+        "local_model_status": {
+            "enabled": True,
+            "idle_timeout_seconds": None,
+        },
         # Show a color-coded battery read-out as the first status-bar element in
         # the CLI/TUI (off by default). No-op on machines without a battery.
         "battery": False,

--- a/hermes_cli/local_model_status.py
+++ b/hermes_cli/local_model_status.py
@@ -1,0 +1,385 @@
+"""Non-blocking status probes for local llama.cpp runtimes."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import math
+import ssl
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Mapping, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from agent.model_metadata import _auth_headers, _localhost_to_ipv4, _normalize_base_url, is_local_endpoint
+from agent.ssl_verify import resolve_httpx_verify
+
+
+class LocalModelState(str, Enum):
+    """Authoritative residency states reported by a local runtime."""
+
+    LOADED = "loaded"
+    LOADING = "loading"
+    SLEEPING = "sleeping"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class LocalModelRoute:
+    """A probeable local model route. Credentials are never shown in repr."""
+
+    provider: str
+    base_url: str
+    model: str
+    api_key: str = field(default="", repr=False)
+    extra_headers: tuple[tuple[str, str], ...] = field(default_factory=tuple, repr=False)
+    ssl_ca_cert: str = field(default="", repr=False)
+    ssl_verify: Optional[bool] = field(default=None, repr=False)
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.provider, self.base_url, self.model)
+
+
+@dataclass(frozen=True)
+class LocalModelProbeResult:
+    state: LocalModelState
+    supported: Optional[bool]
+    checked_at: float
+
+
+@dataclass(frozen=True)
+class LocalModelDisplay:
+    bar: str
+    label: str
+    style: str
+
+    @property
+    def text(self) -> str:
+        return f"{self.bar} {self.label}"
+
+
+def canonicalize_route_url(value: object) -> str:
+    """Return a stable URL identity for cross-client route comparisons."""
+
+    try:
+        return str(httpx.URL(str(value or ""))).rstrip("/")
+    except Exception:
+        return ""
+
+
+def _format_remaining(seconds: int) -> str:
+    minutes, seconds = divmod(max(0, seconds), 60)
+    if minutes:
+        return f"{minutes}m{seconds:02d}s"
+    return f"{seconds}s"
+
+
+def build_local_model_display(
+    result: LocalModelProbeResult,
+    *,
+    idle_timeout_seconds: Optional[float],
+    last_activity_at: Optional[float],
+    now: float,
+    turn_live: bool,
+) -> LocalModelDisplay:
+    """Build a binary residency bar plus an explicitly estimated countdown."""
+
+    if result.state is LocalModelState.SLEEPING:
+        return LocalModelDisplay("[░░░░░░░░░░]", "off", "sleeping")
+    if result.state is LocalModelState.LOADING:
+        return LocalModelDisplay("[▒▒▒▒▒▒▒▒▒▒]", "load", "loading")
+    if result.state is not LocalModelState.LOADED:
+        return LocalModelDisplay("[░░░░░░░░░░]", "?", "unknown")
+
+    label = "busy" if turn_live else "on"
+    if not turn_live and idle_timeout_seconds and idle_timeout_seconds > 0 and last_activity_at is not None:
+        remaining = math.ceil(idle_timeout_seconds - max(0.0, now - last_activity_at))
+        if remaining > 0:
+            label = f"~{_format_remaining(remaining)}"
+    return LocalModelDisplay("[██████████]", label, "loaded")
+
+
+def build_local_model_route(
+    *,
+    provider: str,
+    base_url: str,
+    model: str,
+    api_key: str = "",
+    extra_headers: Optional[Mapping[str, str]] = None,
+    ssl_ca_cert: str = "",
+    ssl_verify: Optional[bool] = None,
+) -> Optional[LocalModelRoute]:
+    """Return a probe route only for local HTTP(S) endpoints."""
+
+    normalized = canonicalize_route_url(_normalize_base_url(base_url or ""))
+    try:
+        parsed = urlparse(normalized)
+    except Exception:
+        return None
+    # Rewriting localhost avoids slow IPv6 fallback for plain HTTP, but doing
+    # so for HTTPS breaks certificates whose SAN contains localhost, not the IP.
+    if parsed.scheme == "http":
+        normalized = _localhost_to_ipv4(normalized)
+        parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not is_local_endpoint(normalized):
+        return None
+    return LocalModelRoute(
+        provider=str(provider or ""),
+        base_url=normalized,
+        model=str(model or ""),
+        api_key=str(api_key or ""),
+        extra_headers=tuple(
+            sorted(
+                (str(name), str(value))
+                for name, value in (extra_headers or {}).items()
+                if value is not None
+            )
+        ),
+        ssl_ca_cert=str(ssl_ca_cert or ""),
+        ssl_verify=ssl_verify if isinstance(ssl_verify, bool) else None,
+    )
+
+
+def _props_urls(base_url: str) -> tuple[str, ...]:
+    server_url = base_url[:-3] if base_url.endswith("/v1") else base_url
+    # Current llama.cpp serves props at the server root. Keep /v1/props as a
+    # compatibility fallback, but avoid generating a 404 on every poll.
+    return (f"{server_url}/props", f"{server_url}/v1/props")
+
+
+@lru_cache(maxsize=32)
+def _resolve_probe_verify(
+    base_url: str,
+    ca_bundle: str,
+    ssl_verify: Optional[bool],
+) -> bool | ssl.SSLContext:
+    """Resolve and cache the active route's TLS policy."""
+
+    return resolve_httpx_verify(
+        ca_bundle=ca_bundle or None,
+        ssl_verify=ssl_verify,
+        base_url=base_url,
+    )
+
+
+def probe_llamacpp_status(
+    route: LocalModelRoute,
+    *,
+    timeout: float = 1.0,
+) -> LocalModelProbeResult:
+    """Probe llama.cpp's read-only props endpoint without waking the model."""
+
+    checked_at = time.monotonic()
+    try:
+        headers = _auth_headers(route.api_key)
+        headers.update(dict(route.extra_headers))
+        with httpx.Client(
+            timeout=timeout,
+            headers=headers,
+            trust_env=False,
+            verify=_resolve_probe_verify(
+                route.base_url,
+                route.ssl_ca_cert,
+                route.ssl_verify,
+            ),
+        ) as client:
+            for url in _props_urls(route.base_url):
+                response = client.get(url)
+                if response.status_code == 404:
+                    continue
+                if response.status_code == 503:
+                    return LocalModelProbeResult(
+                        state=LocalModelState.LOADING,
+                        supported=None,
+                        checked_at=checked_at,
+                    )
+                if response.status_code != 200:
+                    return LocalModelProbeResult(
+                        state=LocalModelState.UNKNOWN,
+                        supported=None,
+                        checked_at=checked_at,
+                    )
+                try:
+                    payload = response.json()
+                except Exception:
+                    return LocalModelProbeResult(
+                        state=LocalModelState.UNKNOWN,
+                        supported=None,
+                        checked_at=checked_at,
+                    )
+                if not isinstance(payload, dict) or "default_generation_settings" not in payload:
+                    return LocalModelProbeResult(
+                        state=LocalModelState.UNKNOWN,
+                        supported=False,
+                        checked_at=checked_at,
+                    )
+                is_sleeping = payload.get("is_sleeping")
+                if not isinstance(is_sleeping, bool):
+                    return LocalModelProbeResult(
+                        state=LocalModelState.UNKNOWN,
+                        supported=True,
+                        checked_at=checked_at,
+                    )
+                return LocalModelProbeResult(
+                    state=LocalModelState.SLEEPING if is_sleeping else LocalModelState.LOADED,
+                    supported=True,
+                    checked_at=checked_at,
+                )
+    except Exception:
+        return LocalModelProbeResult(
+            state=LocalModelState.UNKNOWN,
+            supported=None,
+            checked_at=checked_at,
+        )
+
+    return LocalModelProbeResult(
+        state=LocalModelState.UNKNOWN,
+        supported=False,
+        checked_at=checked_at,
+    )
+
+
+class LocalModelStatusMonitor:
+    """Single-flight background probe cache for the active local route."""
+
+    def __init__(
+        self,
+        *,
+        probe: Callable[[LocalModelRoute], LocalModelProbeResult] = probe_llamacpp_status,
+        poll_interval: float = 5.0,
+        max_backoff: float = 30.0,
+        unsupported_interval: float = 300.0,
+        auto_poll: bool = False,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._probe = probe
+        self._poll_interval = max(0.1, float(poll_interval))
+        self._max_backoff = max(self._poll_interval, float(max_backoff))
+        self._unsupported_interval = max(self._poll_interval, float(unsupported_interval))
+        self._auto_poll = bool(auto_poll)
+        self._failure_delay = self._poll_interval
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._route: Optional[LocalModelRoute] = None
+        self._generation = 0
+        self._closed = False
+        self._probe_in_flight = False
+        self._next_probe_at = 0.0
+        self._snapshot = LocalModelProbeResult(
+            state=LocalModelState.UNKNOWN,
+            supported=None,
+            checked_at=0.0,
+        )
+
+    def observe(self, route: Optional[LocalModelRoute]) -> Optional[LocalModelProbeResult]:
+        """Return cached status and schedule a due probe without blocking."""
+
+        worker: Optional[threading.Thread] = None
+        with self._lock:
+            if self._closed:
+                return None
+            if route != self._route:
+                self._generation += 1
+                self._route = route
+                self._next_probe_at = 0.0
+                self._failure_delay = self._poll_interval
+                self._snapshot = LocalModelProbeResult(
+                    state=LocalModelState.UNKNOWN,
+                    supported=None,
+                    checked_at=0.0,
+                )
+            if route is None:
+                return None
+
+            now = self._clock()
+            if not self._probe_in_flight and now >= self._next_probe_at:
+                self._probe_in_flight = True
+                generation = self._generation
+                worker = threading.Thread(
+                    target=self._run_probe,
+                    args=(route, generation),
+                    daemon=True,
+                    name="hermes-local-model-status",
+                )
+            snapshot = self._snapshot
+
+        if worker is not None:
+            worker.start()
+        if snapshot.supported is False:
+            return None
+        return snapshot
+
+    def _run_probe(self, route: LocalModelRoute, generation: int) -> None:
+        try:
+            result = self._probe(route)
+        except Exception:
+            result = LocalModelProbeResult(
+                state=LocalModelState.UNKNOWN,
+                supported=None,
+                checked_at=self._clock(),
+            )
+
+        timer: Optional[threading.Timer] = None
+        replacement_worker: Optional[threading.Thread] = None
+        with self._lock:
+            if generation != self._generation or route != self._route:
+                self._probe_in_flight = False
+                if not self._closed and self._route is not None:
+                    self._probe_in_flight = True
+                    replacement_worker = threading.Thread(
+                        target=self._run_probe,
+                        args=(self._route, self._generation),
+                        daemon=True,
+                        name="hermes-local-model-status",
+                    )
+            else:
+                self._snapshot = result
+                self._probe_in_flight = False
+                if result.supported is False:
+                    delay = self._unsupported_interval
+                    self._failure_delay = self._poll_interval
+                elif result.state is LocalModelState.UNKNOWN and result.supported is None:
+                    delay = self._failure_delay
+                    self._failure_delay = min(self._failure_delay * 2, self._max_backoff)
+                else:
+                    delay = self._poll_interval
+                    self._failure_delay = self._poll_interval
+                self._next_probe_at = self._clock() + delay
+                if self._auto_poll and not self._closed:
+                    timer = threading.Timer(
+                        delay,
+                        self._run_scheduled_probe,
+                        args=(route, generation),
+                    )
+                    timer.daemon = True
+                    timer.name = "hermes-local-model-status-timer"
+
+        if replacement_worker is not None:
+            replacement_worker.start()
+        if timer is not None:
+            timer.start()
+
+    def _run_scheduled_probe(self, route: LocalModelRoute, generation: int) -> None:
+        with self._lock:
+            if (
+                self._closed
+                or generation != self._generation
+                or route != self._route
+                or self._probe_in_flight
+            ):
+                return
+            self._probe_in_flight = True
+        self._run_probe(route, generation)
+
+    def close(self) -> None:
+        """Invalidate in-flight work; daemon probes never delay process exit."""
+
+        with self._lock:
+            self._generation += 1
+            self._closed = True
+            self._route = None
+            self._probe_in_flight = False

--- a/tests/agent/test_probe_cache_followups.py
+++ b/tests/agent/test_probe_cache_followups.py
@@ -80,6 +80,35 @@ class TestOllamaApiShowCaching:
 class TestDetectLocalServerTypeCache:
     """#29988: detect_local_server_type memoized with a bounded TTL."""
 
+    def test_llamacpp_compat_tags_do_not_misclassify_as_ollama(self):
+        """Modern llama.cpp also exposes /api/tags for Ollama compatibility."""
+        miss = MagicMock(status_code=404)
+        tags = MagicMock(status_code=200)
+        tags.json.return_value = {"models": [{"name": "local.gguf"}]}
+        props = MagicMock(status_code=200)
+        props.text = '{"default_generation_settings": {}, "is_sleeping": false}'
+
+        client = MagicMock()
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+
+        def _get(url, *args, **kwargs):
+            if url.endswith("/api/tags"):
+                return tags
+            if url.endswith("/v1/props"):
+                return props
+            return miss
+
+        client.get.side_effect = _get
+
+        from agent.model_metadata import detect_local_server_type
+
+        with patch("httpx.Client", return_value=client):
+            detected = detect_local_server_type("http://127.0.0.1:8080/v1")
+
+        assert detected == "llamacpp"
+        assert any(call.args[0].endswith("/v1/props") for call in client.get.call_args_list)
+
     def _get_client(self, server_type="ollama"):
         ollama_resp = MagicMock()
         ollama_resp.status_code = 200

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import cli as cli_mod
 from cli import HermesCLI
+from hermes_cli.local_model_status import LocalModelDisplay, LocalModelProbeResult, LocalModelState
 
 
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
@@ -74,6 +75,89 @@ class TestCLIStatusBar:
 
         assert snapshot["session_title"] == "user-profiles"
 
+    def test_local_model_display_observes_only_the_active_local_route(self):
+        cli_obj = _make_cli("local.gguf")
+        cli_obj.provider = "custom"
+        cli_obj.base_url = "http://127.0.0.1:8080/v1"
+        cli_obj.api_key = "test-secret"
+        cli_obj.agent = SimpleNamespace(
+            provider="custom",
+            base_url="http://127.0.0.1:8080/v1",
+            model="local.gguf",
+            api_key="test-secret",
+            client=SimpleNamespace(base_url="http://127.0.0.1:8080/v1"),
+            _client_kwargs={
+                "api_key": "test-secret",
+                "base_url": "http://127.0.0.1:8080/v1",
+                "default_headers": {"X-Local-Proxy": "header-secret"},
+                "ssl_ca_cert": "/tmp/test-ca.pem",
+                "ssl_verify": False,
+            },
+        )
+        cli_obj._local_model_idle_timeout_seconds = 300
+        cli_obj._last_local_model_activity_at = 100.0
+        cli_obj._last_local_model_activity_route = (
+            "custom",
+            "http://127.0.0.1:8080/v1",
+            "local.gguf",
+        )
+        cli_obj._turn_live = False
+        cli_obj._local_model_status_monitor = MagicMock()
+        cli_obj._local_model_status_monitor.observe.return_value = LocalModelProbeResult(
+            state=LocalModelState.LOADED,
+            supported=True,
+            checked_at=116.0,
+        )
+
+        with patch.object(cli_mod.time, "monotonic", return_value=117.0):
+            display = cli_obj._get_local_model_status_display()
+
+        route = cli_obj._local_model_status_monitor.observe.call_args.args[0]
+        assert route.key == cli_obj._last_local_model_activity_route
+        assert "test-secret" not in repr(route)
+        assert "header-secret" not in repr(route)
+        assert dict(route.extra_headers) == {"X-Local-Proxy": "header-secret"}
+        assert route.ssl_ca_cert == "/tmp/test-ca.pem"
+        assert route.ssl_verify is False
+        assert display.label == "~4m43s"
+
+        cli_obj.agent.base_url = "https://api.example.com/v1"
+        assert cli_obj._get_local_model_status_display() is None
+        cli_obj._local_model_status_monitor.observe.assert_called_with(None)
+
+    def test_local_route_never_falls_back_to_cli_or_mixed_agent_credentials(self):
+        cli_obj = _make_cli("local.gguf")
+        cli_obj.provider = "custom"
+        cli_obj.base_url = "http://127.0.0.1:8080/v1"
+        cli_obj.api_key = "unrelated-cloud-secret"
+
+        assert cli_obj._get_active_local_model_route() is None
+
+        cli_obj.agent = SimpleNamespace(
+            provider="custom",
+            base_url="http://127.0.0.1:8080/v1",
+            model="local.gguf",
+            api_key="",
+            client=SimpleNamespace(base_url="http://127.0.0.1:8080/v1"),
+            _client_kwargs={
+                "api_key": "",
+                "base_url": "http://127.0.0.1:8080/v1",
+            },
+        )
+        route = cli_obj._get_active_local_model_route()
+        assert route is not None
+        assert route.api_key == ""
+
+        cli_obj.agent.client = SimpleNamespace(base_url="https://remote.example/v1")
+        assert cli_obj._get_active_local_model_route() is None
+
+        cli_obj.agent.base_url = "http://LOCALHOST:80/v1"
+        cli_obj.agent._client_kwargs["base_url"] = "http://LOCALHOST:80/v1"
+        cli_obj.agent.client = SimpleNamespace(base_url="http://localhost/v1/")
+        route = cli_obj._get_active_local_model_route()
+        assert route is not None
+        assert route.base_url == "http://127.0.0.1/v1"
+
     def test_context_style_thresholds(self):
         cli_obj = _make_cli()
 
@@ -102,6 +186,116 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
 
+    def test_local_model_residency_follows_idle_time_and_precedes_yolo(self):
+        cli_obj = _attach_agent(
+            _make_cli("local.gguf"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+        cli_obj._last_turn_finished_at = time.time() - 17
+        snapshot = cli_obj._get_status_bar_snapshot()
+        snapshot["local_model_status"] = LocalModelDisplay(
+            bar="[██████████]",
+            label="~4m43s",
+            style="loaded",
+        )
+
+        with patch.object(cli_obj, "_get_status_bar_snapshot", return_value=snapshot), \
+             patch.object(cli_obj, "_get_tui_terminal_width", return_value=200), \
+             patch.object(cli_obj, "_is_session_yolo_active", return_value=True):
+            fragments = cli_obj._get_status_bar_fragments()
+
+        plain = "".join(text for _style, text in fragments)
+        assert plain.index("✓ 17s") < plain.index("[██████████]") < plain.index("⚠ YOLO")
+        assert ("class:status-bar-local-loaded", "[██████████]") in fragments
+        assert ("class:status-bar-local-label", " ~4m43s") in fragments
+
+        with patch.object(cli_obj, "_get_status_bar_snapshot", return_value=snapshot), \
+             patch.object(cli_obj, "_get_tui_terminal_width", return_value=200), \
+             patch.object(cli_obj, "_is_session_yolo_active", return_value=True):
+            text = cli_obj._build_status_bar_text(width=200)
+
+        assert "✓ 17s │ [██████████] ~4m43s │ ⚠ YOLO" in text
+
+        full_width = sum(cli_obj._status_bar_display_width(value) for _style, value in fragments)
+        constrained_width = full_width - 5
+        with patch.object(cli_obj, "_get_status_bar_snapshot", return_value=snapshot), \
+             patch.object(cli_obj, "_get_tui_terminal_width", return_value=constrained_width), \
+             patch.object(cli_obj, "_is_session_yolo_active", return_value=True):
+            constrained = cli_obj._get_status_bar_fragments()
+
+        constrained_plain = "".join(value for _style, value in constrained)
+        assert "[██████████]" not in constrained_plain
+        assert "~4m43s" not in constrained_plain
+        assert "⚠ YOLO" in constrained_plain
+
+    def test_local_model_fragment_removal_keeps_prepended_battery(self):
+        """Width fallback removes the local widget, not battery fragments."""
+        cli_obj = _attach_agent(
+            _make_cli("local.gguf"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+        snapshot = cli_obj._get_status_bar_snapshot()
+        snapshot["battery_label"] = "BAT 50%"
+        snapshot["battery_category"] = "good"
+        snapshot["local_model_status"] = LocalModelDisplay(
+            bar="[██████████]",
+            label="~4m43s",
+            style="loaded",
+        )
+
+        with patch.object(cli_obj, "_get_status_bar_snapshot", return_value=snapshot), \
+             patch.object(cli_obj, "_get_tui_terminal_width", return_value=200), \
+             patch.object(cli_obj, "_is_session_yolo_active", return_value=True):
+            wide = cli_obj._get_status_bar_fragments()
+
+        constrained_width = sum(
+            cli_obj._status_bar_display_width(value) for _style, value in wide
+        ) - 5
+        with patch.object(cli_obj, "_get_status_bar_snapshot", return_value=snapshot), \
+             patch.object(cli_obj, "_get_tui_terminal_width", return_value=constrained_width), \
+             patch.object(cli_obj, "_is_session_yolo_active", return_value=True):
+            constrained = cli_obj._get_status_bar_fragments()
+
+        constrained_plain = "".join(value for _style, value in constrained)
+        assert "BAT 50%" in constrained_plain
+        assert "[██████████]" not in constrained_plain
+        assert "~4m43s" not in constrained_plain
+        assert "⚠ YOLO" in constrained_plain
+
+    def test_post_compression_sentinel_does_not_render_negative(self):
+        """Right after a compression, last_prompt_tokens is parked at the -1
+        sentinel until the next API call reports real usage. The status bar
+        must clamp it to 0 instead of rendering "-1/200K" / "-1%".
+        """
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=-1,
+            context_length=200_000,
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert snapshot["context_tokens"] == 0
+        assert snapshot["context_percent"] == 0
+
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "-1" not in text
+        assert "0/200K" in text
 
     def test_input_height_counts_prompt_only_on_first_wrapped_row(self):
         # Regression for prompt_toolkit classic CLI resize glitches: the prompt
@@ -350,5 +544,3 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 5.0
         snapshot = cli_obj._get_status_bar_snapshot()
         assert snapshot["idle_since"].startswith("✓ ")
-
-

--- a/tests/cli/test_local_model_status.py
+++ b/tests/cli/test_local_model_status.py
@@ -1,0 +1,603 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from hermes_cli.local_model_status import (
+    LocalModelProbeResult,
+    LocalModelStatusMonitor,
+    LocalModelState,
+    build_local_model_display,
+    build_local_model_route,
+    probe_llamacpp_status,
+    _resolve_probe_verify,
+)
+
+
+class _PropsHandler(BaseHTTPRequestHandler):
+    payload = {
+        "default_generation_settings": {"n_ctx": 131072},
+        "is_sleeping": False,
+    }
+    expected_auth = "Bearer test-secret"
+    expected_extra_header: tuple[str, str] | None = None
+    response_status = 200
+    raw_body: bytes | None = None
+    paths: list[str] = []
+
+    def do_GET(self):
+        type(self).paths.append(self.path)
+        if self.headers.get("Authorization") != self.expected_auth:
+            self.send_response(401)
+            self.end_headers()
+            return
+        if self.expected_extra_header is not None:
+            name, value = self.expected_extra_header
+            if self.headers.get(name) != value:
+                self.send_response(403)
+                self.end_headers()
+                return
+        if self.path not in {"/v1/props", "/props"}:
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.response_status != 200:
+            self.send_response(self.response_status)
+            self.end_headers()
+            return
+        body = self.raw_body if self.raw_body is not None else json.dumps(self.payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+        return
+
+
+def test_probe_reads_loaded_state_from_authenticated_llamacpp():
+    _PropsHandler.response_status = 200
+    _PropsHandler.payload = {
+        "default_generation_settings": {"n_ctx": 131072},
+        "is_sleeping": False,
+    }
+    _PropsHandler.paths = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PropsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        route = build_local_model_route(
+            provider="custom",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            model="local.gguf",
+            api_key="test-secret",
+        )
+        assert route is not None
+
+        result = probe_llamacpp_status(route)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert result.state is LocalModelState.LOADED
+    assert result.supported is True
+    assert _PropsHandler.paths == ["/props"]
+    assert "test-secret" not in repr(route)
+    assert "test-secret" not in repr(result)
+
+
+def test_probe_includes_configured_route_headers_without_exposing_them():
+    _PropsHandler.response_status = 200
+    _PropsHandler.expected_extra_header = ("X-Local-Proxy", "header-secret")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PropsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        route = build_local_model_route(
+            provider="custom",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            model="local.gguf",
+            api_key="test-secret",
+            extra_headers={"X-Local-Proxy": "header-secret"},
+        )
+        assert route is not None
+        result = probe_llamacpp_status(route)
+    finally:
+        _PropsHandler.expected_extra_header = None
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert result.state is LocalModelState.LOADED
+    assert "header-secret" not in repr(route)
+
+
+def test_probe_reports_sleeping_only_when_llamacpp_confirms_it():
+    _PropsHandler.response_status = 200
+    _PropsHandler.payload = {
+        "default_generation_settings": {"n_ctx": 131072},
+        "is_sleeping": True,
+    }
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PropsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        route = build_local_model_route(
+            provider="custom",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            model="local.gguf",
+            api_key="test-secret",
+        )
+        assert route is not None
+
+        result = probe_llamacpp_status(route)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert result.state is LocalModelState.SLEEPING
+    assert result.supported is True
+
+
+def test_probe_reports_loading_on_props_service_unavailable():
+    _PropsHandler.response_status = 503
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PropsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        route = build_local_model_route(
+            provider="custom",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            model="local.gguf",
+            api_key="test-secret",
+        )
+        assert route is not None
+        result = probe_llamacpp_status(route)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert result.state is LocalModelState.LOADING
+    assert result.supported is None
+
+
+def test_probe_failures_never_report_sleeping():
+    _PropsHandler.response_status = 200
+    _PropsHandler.raw_body = None
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PropsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base_url = f"http://127.0.0.1:{server.server_port}/v1"
+        unauthorized_route = build_local_model_route(
+            provider="custom",
+            base_url=base_url,
+            model="local.gguf",
+            api_key="wrong-secret",
+        )
+        assert unauthorized_route is not None
+        unauthorized = probe_llamacpp_status(unauthorized_route)
+
+        _PropsHandler.raw_body = b"{not-json"
+        valid_auth_route = build_local_model_route(
+            provider="custom",
+            base_url=base_url,
+            model="local.gguf",
+            api_key="test-secret",
+        )
+        assert valid_auth_route is not None
+        invalid_json = probe_llamacpp_status(valid_auth_route)
+
+        _PropsHandler.raw_body = None
+        _PropsHandler.payload = {"default_generation_settings": {"n_ctx": 131072}}
+        missing_sleep_flag = probe_llamacpp_status(valid_auth_route)
+    finally:
+        _PropsHandler.raw_body = None
+        _PropsHandler.payload = {
+            "default_generation_settings": {"n_ctx": 131072},
+            "is_sleeping": False,
+        }
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    unavailable_route = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:1/v1",
+        model="local.gguf",
+    )
+    assert unavailable_route is not None
+    transport_error = probe_llamacpp_status(unavailable_route, timeout=0.1)
+
+    failures = (unauthorized, invalid_json, missing_sleep_flag, transport_error)
+    assert all(result.state is LocalModelState.UNKNOWN for result in failures)
+    assert all(result.state is not LocalModelState.SLEEPING for result in failures)
+
+
+def test_monitor_probes_off_thread_and_keeps_one_request_in_flight():
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def _probe(_route):
+        nonlocal calls
+        calls += 1
+        started.set()
+        assert release.wait(timeout=2)
+        return LocalModelProbeResult(
+            state=LocalModelState.LOADED,
+            supported=True,
+            checked_at=time.monotonic(),
+        )
+
+    route = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="local.gguf",
+        api_key="test-secret",
+    )
+    assert route is not None
+    monitor = LocalModelStatusMonitor(probe=_probe, poll_interval=60)
+
+    before = time.monotonic()
+    initial = monitor.observe(route)
+    elapsed = time.monotonic() - before
+    assert elapsed < 0.1
+    assert initial is not None
+    assert initial.state is LocalModelState.UNKNOWN
+    assert started.wait(timeout=1)
+
+    monitor.observe(route)
+    assert calls == 1
+
+    release.set()
+    deadline = time.monotonic() + 2
+    current = monitor.observe(route)
+    assert current is not None
+    while current.state is not LocalModelState.LOADED and time.monotonic() < deadline:
+        time.sleep(0.01)
+        current = monitor.observe(route)
+        assert current is not None
+
+    assert current.state is LocalModelState.LOADED
+    assert calls == 1
+
+
+def test_monitor_auto_polls_without_additional_render_observations():
+    second_probe = threading.Event()
+    calls = 0
+
+    def _probe(_route):
+        nonlocal calls
+        calls += 1
+        if calls >= 2:
+            second_probe.set()
+        return LocalModelProbeResult(
+            state=LocalModelState.LOADED,
+            supported=True,
+            checked_at=time.monotonic(),
+        )
+
+    route = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="local.gguf",
+    )
+    assert route is not None
+    monitor = LocalModelStatusMonitor(
+        probe=_probe,
+        poll_interval=0.1,
+        auto_poll=True,
+    )
+    try:
+        monitor.observe(route)
+        assert second_probe.wait(timeout=1)
+    finally:
+        monitor.close()
+
+    assert calls >= 2
+
+
+def test_monitor_uses_exponential_backoff_after_probe_failures():
+    now = [100.0]
+    calls = 0
+
+    def _probe(_route):
+        nonlocal calls
+        calls += 1
+        return LocalModelProbeResult(
+            state=LocalModelState.UNKNOWN,
+            supported=None,
+            checked_at=now[0],
+        )
+
+    route = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="local.gguf",
+    )
+    assert route is not None
+    monitor = LocalModelStatusMonitor(
+        probe=_probe,
+        poll_interval=5,
+        max_backoff=30,
+        clock=lambda: now[0],
+    )
+
+    def _wait_for_calls(expected):
+        deadline = time.monotonic() + 1
+        while calls < expected and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert calls == expected
+
+    monitor.observe(route)
+    _wait_for_calls(1)
+
+    now[0] = 105.0
+    monitor.observe(route)
+    _wait_for_calls(2)
+
+    now[0] = 110.0
+    monitor.observe(route)
+    time.sleep(0.05)
+    assert calls == 2
+
+    now[0] = 115.0
+    monitor.observe(route)
+    _wait_for_calls(3)
+
+    switched_route = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="other-local.gguf",
+    )
+    assert switched_route is not None
+    now[0] = 116.0
+    monitor.observe(switched_route)
+    _wait_for_calls(4)
+
+    # A new route gets a fresh backoff budget instead of inheriting the old
+    # route's 30-second failure delay.
+    now[0] = 121.0
+    monitor.observe(switched_route)
+    _wait_for_calls(5)
+
+
+def test_monitor_uses_a_long_negative_cache_for_unsupported_routes():
+    now = [100.0]
+    calls = 0
+
+    def _probe(_route):
+        nonlocal calls
+        calls += 1
+        return LocalModelProbeResult(
+            state=LocalModelState.UNKNOWN,
+            supported=False,
+            checked_at=now[0],
+        )
+
+    route = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="local.gguf",
+    )
+    assert route is not None
+    monitor = LocalModelStatusMonitor(
+        probe=_probe,
+        poll_interval=5,
+        unsupported_interval=300,
+        clock=lambda: now[0],
+    )
+
+    monitor.observe(route)
+    deadline = time.monotonic() + 1
+    while calls < 1 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert calls == 1
+
+    now[0] = 105.0
+    assert monitor.observe(route) is None
+    time.sleep(0.05)
+    assert calls == 1
+
+    now[0] = 400.0
+    assert monitor.observe(route) is None
+    deadline = time.monotonic() + 1
+    while calls < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert calls == 2
+
+
+def test_loaded_display_uses_binary_bar_and_estimated_five_minute_countdown():
+    loaded = LocalModelProbeResult(
+        state=LocalModelState.LOADED,
+        supported=True,
+        checked_at=100.0,
+    )
+
+    active = build_local_model_display(
+        loaded,
+        idle_timeout_seconds=300,
+        last_activity_at=100.0,
+        now=117.0,
+        turn_live=False,
+    )
+    expired_but_still_loaded = build_local_model_display(
+        loaded,
+        idle_timeout_seconds=300,
+        last_activity_at=100.0,
+        now=401.0,
+        turn_live=False,
+    )
+
+    assert active.bar == "[██████████]"
+    assert active.label == "~4m43s"
+    assert expired_but_still_loaded.bar == "[██████████]"
+    assert expired_but_still_loaded.label == "on"
+
+
+def test_monitor_discards_a_stale_result_after_route_change():
+    started = {"a": threading.Event(), "b": threading.Event()}
+    release = {"a": threading.Event(), "b": threading.Event()}
+
+    def _probe(route):
+        suffix = route.model
+        started[suffix].set()
+        assert release[suffix].wait(timeout=2)
+        return LocalModelProbeResult(
+            state=LocalModelState.LOADED if suffix == "a" else LocalModelState.SLEEPING,
+            supported=True,
+            checked_at=time.monotonic(),
+        )
+
+    route_a = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="a",
+    )
+    route_b = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="b",
+    )
+    assert route_a is not None
+    assert route_b is not None
+    monitor = LocalModelStatusMonitor(probe=_probe, poll_interval=60)
+
+    monitor.observe(route_a)
+    assert started["a"].wait(timeout=1)
+    monitor.observe(route_b)
+    assert not started["b"].wait(timeout=0.05)
+
+    release["a"].set()
+    assert started["b"].wait(timeout=1)
+    stale_snapshot = monitor.observe(route_b)
+    assert stale_snapshot is not None
+    assert stale_snapshot.state is LocalModelState.UNKNOWN
+
+    release["b"].set()
+    deadline = time.monotonic() + 2
+    result = monitor.observe(route_b)
+    assert result is not None
+    while result.state is not LocalModelState.SLEEPING and time.monotonic() < deadline:
+        time.sleep(0.01)
+        result = monitor.observe(route_b)
+        assert result is not None
+    assert result.state is LocalModelState.SLEEPING
+
+
+def test_monitor_serializes_an_a_b_a_route_cycle():
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls: list[str] = []
+    active = 0
+    max_active = 0
+
+    def _probe(route):
+        nonlocal active, max_active
+        calls.append(route.model)
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            if len(calls) == 1:
+                first_started.set()
+                assert release_first.wait(timeout=2)
+            return LocalModelProbeResult(
+                state=LocalModelState.LOADED,
+                supported=True,
+                checked_at=time.monotonic(),
+            )
+        finally:
+            active -= 1
+
+    route_a = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="a",
+    )
+    route_b = build_local_model_route(
+        provider="custom",
+        base_url="http://127.0.0.1:8080/v1",
+        model="b",
+    )
+    assert route_a is not None
+    assert route_b is not None
+    monitor = LocalModelStatusMonitor(probe=_probe, poll_interval=60)
+
+    monitor.observe(route_a)
+    assert first_started.wait(timeout=1)
+    monitor.observe(route_b)
+    monitor.observe(route_a)
+    time.sleep(0.05)
+    assert calls == ["a"]
+
+    release_first.set()
+    deadline = time.monotonic() + 1
+    while len(calls) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert calls == ["a", "a"]
+    assert max_active == 1
+
+
+def test_route_builder_rejects_cloud_and_non_http_endpoints():
+    assert build_local_model_route(
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model="gpt-5",
+    ) is None
+    assert build_local_model_route(
+        provider="moa",
+        base_url="moa://local",
+        model="ensemble",
+    ) is None
+
+
+def test_route_builder_preserves_localhost_for_https_certificates():
+    route = build_local_model_route(
+        provider="custom",
+        base_url="https://localhost:8443/v1",
+        model="local.gguf",
+    )
+
+    assert route is not None
+    assert route.base_url == "https://localhost:8443/v1"
+
+
+def test_probe_verify_uses_the_shared_provider_tls_resolution(monkeypatch):
+    _resolve_probe_verify.cache_clear()
+    calls = 0
+    captured = {}
+
+    def _resolve_httpx_verify(*, ca_bundle, ssl_verify, base_url):
+        nonlocal calls
+        calls += 1
+        captured.update(
+            ca_bundle=ca_bundle,
+            ssl_verify=ssl_verify,
+            base_url=base_url,
+        )
+        return False
+
+    monkeypatch.setattr(
+        "hermes_cli.local_model_status.resolve_httpx_verify",
+        _resolve_httpx_verify,
+    )
+
+    args = ("https://localhost:8443/v1", "/tmp/test-ca.pem", False)
+    assert _resolve_probe_verify(*args) is False
+    assert _resolve_probe_verify(*args) is False
+    assert calls == 1
+    assert captured == {
+        "ca_bundle": "/tmp/test-ca.pem",
+        "ssl_verify": False,
+        "base_url": "https://localhost:8443/v1",
+    }
+    _resolve_probe_verify.cache_clear()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -985,6 +985,13 @@ class TestCliRefreshIntervalConfig:
         assert DEFAULT_CONFIG["display"]["cli_refresh_interval"] == 1.0
 
 
+class TestLocalModelStatusConfig:
+    def test_default_config_enables_local_probe_without_guessing_idle_timeout(self):
+        status = DEFAULT_CONFIG["display"]["local_model_status"]
+        assert status["enabled"] is True
+        assert status["idle_timeout_seconds"] is None
+
+
 class TestDiscordChannelPromptsConfig:
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1695,6 +1695,9 @@ display:
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar
+  local_model_status:     # Classic CLI: llama.cpp residency bar for local routes
+    enabled: true
+    idle_timeout_seconds: null  # Match llama.cpp --sleep-idle-seconds for estimated countdown
   timestamps: false       # When true, prefixes user and assistant labels with timestamps in the CLI / TUI transcript
   timestamp_format: "%H:%M"  # strftime format for those timestamps (e.g. "%b-%d %H:%M" for month-day)
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
@@ -1734,6 +1737,18 @@ The tally is observed from the tool-progress feed the CLI already receives, so i
 The count is per-turn (session totals are baselined at turn start) and updates as each API call in the turn reports usage. Nothing renders before the first usage report lands, so you never see a misleading `↓ 0 tok`.
 
 Both keys are display-only and CLI-only: they are suppressed in quiet mode, when `display.tool_progress` is `off`, in single-query/`-Q` batch runs, and in gateway/messaging surfaces (those use `display.runtime_footer` instead). Set either key to `false` to turn it off.
+
+### Local llama.cpp residency status
+
+For an active local HTTP(S) route, the classic CLI probes llama.cpp's read-only `/props` endpoint on a background thread and can show model residency in the status bar:
+
+- `[██████████] on` — llama.cpp reports the model loaded.
+- `[██████████] ~4m43s` — loaded, with an estimated idle countdown.
+- `[▒▒▒▒▒▒▒▒▒▒] load` — the runtime is temporarily unavailable while loading.
+- `[░░░░░░░░░░] off` — llama.cpp explicitly reports `is_sleeping: true`.
+- `[░░░░░░░░░░] ?` — the local runtime cannot be confirmed.
+
+Set `idle_timeout_seconds` to the same value passed to llama.cpp as `--sleep-idle-seconds`. The `~` prefix is intentional: the countdown is an estimate based on the last completed Hermes turn. The runtime's `is_sleeping` value remains authoritative, so reaching zero never makes Hermes claim that the model has unloaded. Cloud routes and non-HTTP local transports are not probed, and the entire widget is omitted when the terminal is too narrow.
 
 ### File-mutation verifier
 


### PR DESCRIPTION
## Summary

- add a non-blocking llama.cpp residency monitor for the classic `prompt_toolkit` CLI, backed by an asynchronous `/props` probe with single-flight caching, route invalidation, short timeouts, and exponential backoff
- keep polling independent of prompt redraws, preserve configured TLS/default headers, and serialize probes across rapid route changes without exposing route credentials
- show loaded, sleeping, loading, and unknown states in the status bar with a binary residency bar and an optional estimated idle countdown
- prefer the llama.cpp `/props` contract over Ollama-compatible endpoints during local server detection, avoiding false Ollama classification
- document `display.local_model_status.enabled` and `display.local_model_status.idle_timeout_seconds`

## Behavior

- `is_sleeping: false` is shown as resident; `is_sleeping: true` is the only condition shown as unloaded
- HTTP 503 is shown as loading; transport/auth/JSON/contract failures remain unknown
- the renderer only reads cached state; all HTTP work runs on daemon workers
- route changes immediately clear the previous display and stale responses are discarded
- local-model status is omitted atomically before more important status-bar fields are truncated
- `/slots` is never queried
- the countdown is explicitly approximate and reaching zero does not claim the model has unloaded

## Configuration

```yaml
display:
  local_model_status:
    enabled: true
    idle_timeout_seconds: 300  # Match llama-server --sleep-idle-seconds
```

The timeout defaults to `null`; Hermes does not guess the server's idle policy.

## Test plan

- [x] `python -m pytest tests/cli/test_local_model_status.py tests/cli/test_cli_status_bar.py tests/agent/test_probe_cache_followups.py tests/hermes_cli/test_config.py -q -o 'addopts='` — 232 passed
- [x] `ruff check .`
- [x] `ty check hermes_cli/local_model_status.py tests/cli/test_local_model_status.py`
- [x] `python scripts/check-windows-footguns.py --all`
- [x] `uv lock --check`
- [x] `npm run lint:diagrams && npm run build` in `website/`
- [x] manual llama.cpp validation with `--sleep-idle-seconds 300`: `/props` polling did not prevent sleep; sleep observed after 305.7s; inference woke the model in 4.4s; a second residency cycle slept after 301.2s and released 7,642 MiB of GPU memory
