### PR TITLE
fix: emit chat_template_kwargs for llama.cpp/vLLM thinking control

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -30,12 +30,15 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Disable thinking when reasoning is turned off
+        # Disable thinking when reasoning is turned off.
+        # Ollama honours extra_body.think=False; llama.cpp and vLLM
+        # require chat_template_kwargs={"enable_thinking": false} instead.
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
+                extra_body["chat_template_kwargs"] = {"enable_thinking": False}
 
         return extra_body, {}
 


### PR DESCRIPTION
## Summary

The custom provider's `build_api_kwargs_extras()` emits `extra_body.think=False` when reasoning is disabled. This is an Ollama-only flag — llama.cpp and vLLM ignore it entirely, defaulting to thinking-on, which results in empty content responses and retry storms.

## Fix

Emit `chat_template_kwargs={enable_thinking: false}` alongside the existing `think=False` so each backend picks up the flag it understands:

- **Ollama** — reads `extra_body.think` (unchanged)
- **llama.cpp / vLLM** — reads `chat_template_kwargs.enable_thinking` (new)

Both flags are sent in `extra_body`, which the OpenAI Python client serialises into the top-level request body. No conditional provider detection needed.

## Testing

Verified against llama.cpp server (Qwen3.6-35B-A3B-MTP) running on both Vulkan and ROCm backends:

| Parameter | Thinking | Content |
|-----------|----------|---------|
| *(default, no params)* | ON | Empty |
| `chat_template_kwargs.enable_thinking: false` | OFF | Answer |
| `reasoning_effort: none` | ON (ignored) | Empty |

`chat_template_kwargs` is the only parameter that reliably disables thinking on llama.cpp.

## Motivation

Without this fix, Hermes configured with the custom provider against llama.cpp/vLLM backends produces empty responses when thinking is disabled (`agent.reasoning_effort: none`), because the server still produces reasoning tokens that consume the entire token budget.