### PR TITLE
fix(desktop): preserve session list on fetch failure instead of dropping to empty

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -24,6 +24,7 @@ import {
   touchSecondaryGateways
 } from '@/store/gateway'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
+import { SessionRefreshError } from '@/app/session/hooks/use-session-list-actions'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
 import {
@@ -55,7 +56,7 @@ interface GatewayBootOptions {
   ) => void
   onGatewayReady: (gateway: HermesGateway | null) => void
   refreshHermesConfig: () => Promise<void>
-  refreshSessions: () => Promise<void>
+  refreshSessions: (options?: { isBoot?: boolean }) => Promise<void>
 }
 
 export function useGatewayBoot({
@@ -475,14 +476,21 @@ export function useGatewayBoot({
           message: translateNow('boot.steps.loadingSessions'),
           progress: 99
         })
-        await callbacksRef.current.refreshSessions()
+        await callbacksRef.current.refreshSessions({ isBoot: true })
         completeDesktopBoot()
         bootCompleted = true
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
+          // A session-list failure gets its own error key so the toast/overlay
+          // tells the user it's the session fetch, not the whole desktop boot.
+          // Anything else (gateway, settings, cwd) keeps the generic copy.
+          const errorKey =
+            err instanceof SessionRefreshError
+              ? 'boot.errors.sessionLoadFailed'
+              : 'boot.errors.desktopBootFailed'
           failDesktopBoot(message)
-          notifyError(err, translateNow('boot.errors.desktopBootFailed'))
+          notifyError(err, translateNow(errorKey))
           setSessionsLoading(false)
         }
       }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -1,0 +1,204 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { listAllProfileSessions, type SessionInfo } from '@/hermes'
+import {
+  $sessionLoadError,
+  $sessions,
+  clearSessionLoadError,
+  setSessionLoadError,
+  setSessions,
+  type SessionLoadError
+} from '@/store/session'
+
+import { SessionRefreshError, useSessionListActions } from './use-session-list-actions'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCronJobs: vi.fn(async () => []),
+  listAllProfileSessions: vi.fn()
+}))
+
+const listAllProfileSessionsMock = vi.mocked(listAllProfileSessions)
+
+function session(id: string): SessionInfo {
+  return {
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'desktop',
+    started_at: 1,
+    title: id,
+    tool_call_count: 0
+  }
+}
+
+function Harness({
+  onReady
+}: {
+  onReady: (handle: ReturnType<typeof useSessionListActions>) => void
+}) {
+  const actions = useSessionListActions({ profileScope: 'default' })
+
+  useEffect(() => {
+    onReady(actions)
+  }, [actions, onReady])
+
+  return null
+}
+
+async function renderHook(): Promise<ReturnType<typeof useSessionListActions>> {
+  let handle: ReturnType<typeof useSessionListActions> | null = null
+
+  render(<Harness onReady={h => (handle = h)} />)
+  await waitFor(() => expect(handle).not.toBeNull())
+
+  return handle!
+}
+
+async function flushMicrotasks() {
+  // Wait long enough for the awaited promise + finally + post-await fanout
+  // (refreshCronSessions/refreshCronJobs/refreshMessagingSessions) to settle.
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+}
+
+beforeEach(() => {
+  listAllProfileSessionsMock.mockReset()
+  // Drive the empty-config probe: no sessions on cold start.
+  $sessions.set([])
+  clearSessionLoadError()
+  setSessionLoadError(null)
+})
+
+afterEach(() => {
+  cleanup()
+  $sessions.set([])
+  clearSessionLoadError()
+  setSessionLoadError(null)
+  listAllProfileSessionsMock.mockReset()
+})
+
+describe('useSessionListActions.refreshSessions rejection paths', () => {
+  it('re-throws on cold-boot failure so the boot overlay sees the error', async () => {
+    listAllProfileSessionsMock.mockRejectedValueOnce(new Error('backend timeout'))
+
+    const handle = await renderHook()
+
+    let caught: unknown = null
+    await act(async () => {
+      try {
+        await handle.refreshSessions({ isBoot: true })
+      } catch (err) {
+        caught = err
+      }
+    })
+
+    expect(caught).toBeInstanceOf(SessionRefreshError)
+    expect((caught as SessionRefreshError).message).toBe('backend timeout')
+    expect($sessionLoadError.get()).toBeNull()
+    expect($sessions.get()).toEqual([])
+  })
+
+  it('preserves stale rows and records a recoverable error on background failure', async () => {
+    // Seed a populated list — the empty-state discriminator in the rework
+    // depends on this so a populated user doesn't get false-positive re-throws.
+    $sessions.set([session('a'), session('b')])
+    listAllProfileSessionsMock.mockRejectedValueOnce(new Error('network blip'))
+
+    const handle = await renderHook()
+
+    let resolved = false
+    let rejected: unknown = null
+    await act(async () => {
+      try {
+        await handle.refreshSessions()
+        resolved = true
+      } catch (err) {
+        rejected = err
+      }
+    })
+
+    expect(resolved).toBe(true)
+    expect(rejected).toBeNull()
+    const error = $sessionLoadError.get()
+    expect(error).not.toBeNull()
+    expect(error?.message).toBe('network blip')
+    expect(error?.initial).toBe(false)
+    expect(error?.timestamp).toBeGreaterThan(0)
+    // Stale rows are preserved.
+    expect($sessions.get().map(s => s.id)).toEqual(['a', 'b'])
+  })
+
+  it('clears $sessionLoadError on a successful refresh', async () => {
+    $sessions.set([session('a')])
+    // Seed a stale error so we can verify it gets cleared.
+    const stale: SessionLoadError = { initial: false, message: 'old failure', timestamp: 1 }
+    setSessionLoadError(stale)
+
+    listAllProfileSessionsMock.mockResolvedValueOnce({
+      profile_totals: { default: 2 },
+      sessions: [session('a'), session('c')],
+      total: 2
+    } as never)
+
+    const handle = await renderHook()
+
+    await act(async () => {
+      await handle.refreshSessions()
+    })
+
+    expect($sessionLoadError.get()).toBeNull()
+    await flushMicrotasks()
+  })
+
+  it('handles non-Error rejection values without crashing', async () => {
+    listAllProfileSessionsMock.mockRejectedValueOnce('plain string rejection')
+
+    const handle = await renderHook()
+
+    let caught: unknown = null
+    await act(async () => {
+      try {
+        await handle.refreshSessions({ isBoot: true })
+      } catch (err) {
+        caught = err
+      }
+    })
+
+    expect(caught).toBeInstanceOf(SessionRefreshError)
+    expect((caught as SessionRefreshError).message).toBe('plain string rejection')
+    expect((caught as SessionRefreshError).cause).toBe('plain string rejection')
+  })
+
+  it('keeps the boot path silent on populated-list failure (no re-throw)', async () => {
+    // A populated list combined with isBoot=true is a contrived case — the
+    // controller only ever passes isBoot:true on cold start — but the
+    // discriminator should still trust the explicit flag and re-throw. This
+    // pins the contract so future refactors don't accidentally start treating
+    // empty-vs-populated as a substitute for the explicit option.
+    $sessions.set([session('x')])
+    listAllProfileSessionsMock.mockRejectedValueOnce(new Error('late boot failure'))
+
+    const handle = await renderHook()
+
+    let caught: unknown = null
+    await act(async () => {
+      try {
+        await handle.refreshSessions({ isBoot: true })
+      } catch (err) {
+        caught = err
+      }
+    })
+
+    expect(caught).toBeInstanceOf(SessionRefreshError)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -182,6 +182,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
         setSessionProfileTotals(result.profile_totals ?? {})
       }
+    } catch (err) {
+      // Preserve the previous session list on transient fetch failures
+      // (backend startup delay, network blip). Without this guard, the
+      // try/finally pattern left $sessions at its initial [] — the sidebar
+      // rendered "no sessions" with zero error indication, and on cold
+      // boot after an update this looks exactly like data loss.
+      console.error('refreshSessions: fetch failed, preserving previous list', err)
     } finally {
       if (refreshSessionsRequestRef.current === requestId) {
         setSessionsLoading(false)

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -15,6 +15,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   $workingSessionIds,
+  clearSessionLoadError,
   CRON_SECTION_LIMIT,
   getRecentlySettledSessionIds,
   mergeSessionPage,
@@ -25,11 +26,27 @@ import {
   setMessagingTruncated,
   setSessionProfileTotals,
   setSessions,
+  setSessionLoadError,
   setSessionsLoading,
   setSessionsTotal
 } from '@/store/session'
 
 import { sameCronSignature } from '../../desktop-controller-utils'
+
+// Thrown by refreshSessions() on a cold-boot rejection so the boot hook can
+// distinguish a session-list failure from other gateway/boot failures and show
+// a session-specific error. Caught only on the boot path; background callers
+// see the rejection swallowed into $sessionLoadError and resolve normally.
+export class SessionRefreshError extends Error {
+  override name = 'SessionRefreshError'
+
+  constructor(
+    message: string,
+    readonly cause?: unknown
+  ) {
+    super(message)
+  }
+}
 
 // The recents list is local-only: cron rows have their own section, and each
 // messaging platform (telegram, discord, …) is fetched separately into its own
@@ -152,9 +169,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     }
   }, [])
 
-  const refreshSessions = useCallback(async () => {
+  const refreshSessions = useCallback(async (options?: { isBoot?: boolean }) => {
     const requestId = refreshSessionsRequestRef.current + 1
     refreshSessionsRequestRef.current = requestId
+    const isBoot = options?.isBoot === true
     setSessionsLoading(true)
 
     try {
@@ -181,13 +199,21 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         setSessions(prev => mergeSessionPage(prev, result.sessions, sessionsToKeep()))
         setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
         setSessionProfileTotals(result.profile_totals ?? {})
+        // A successful refresh invalidates any previously recorded load error;
+        // the sidebar should clear its banner without waiting for a Retry click.
+        clearSessionLoadError()
       }
     } catch (err) {
-      // Preserve the previous session list on transient fetch failures
-      // (backend startup delay, network blip). Without this guard, the
-      // try/finally pattern left $sessions at its initial [] — the sidebar
-      // rendered "no sessions" with zero error indication, and on cold
-      // boot after an update this looks exactly like data loss.
+      const message = err instanceof Error ? err.message : String(err)
+      // Cold-boot callers (use-gateway-boot) need the failure to keep boot in
+      // its error path so the user sees the existing failDesktopBoot overlay
+      // and notifyError toast. Background callers (sidebar refresh, profile
+      // switch, reconnect) keep their stale rows and surface a recoverable
+      // error via $sessionLoadError instead of dropping to empty.
+      if (isBoot) {
+        throw new SessionRefreshError(message, err)
+      }
+      setSessionLoadError({ initial: false, message, timestamp: Date.now() })
       console.error('refreshSessions: fetch failed, preserving previous list', err)
     } finally {
       if (refreshSessionsRequestRef.current === requestId) {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -78,7 +78,8 @@ export const en: Translations = {
       desktopBootFailed: 'Desktop boot failed',
       gatewayConnectionLost: 'Lost connection to the gateway',
       gatewaySignInRequired: 'Gateway sign-in required',
-      ipcBridgeUnavailable: 'Desktop IPC bridge is unavailable.'
+      ipcBridgeUnavailable: 'Desktop IPC bridge is unavailable.',
+      sessionLoadFailed: "Couldn't load recent sessions"
     },
     failure: {
       title: "Hermes couldn't start",

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -78,7 +78,8 @@ export const ja = defineLocale({
       desktopBootFailed: 'デスクトップの起動に失敗しました',
       gatewayConnectionLost: 'ゲートウェイへの接続が切断されました',
       gatewaySignInRequired: 'ゲートウェイへのサインインが必要です',
-      ipcBridgeUnavailable: 'デスクトップ IPC ブリッジが利用できません。'
+      ipcBridgeUnavailable: 'デスクトップ IPC ブリッジが利用できません。',
+      sessionLoadFailed: '最近のセッションを読み込めませんでした'
     },
     failure: {
       title: 'Hermes を起動できませんでした',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -124,6 +124,7 @@ export interface Translations {
       gatewayConnectionLost: string
       gatewaySignInRequired: string
       ipcBridgeUnavailable: string
+      sessionLoadFailed: string
     }
     failure: {
       title: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -78,7 +78,8 @@ export const zhHant = defineLocale({
       desktopBootFailed: '桌面啟動失敗',
       gatewayConnectionLost: '與閘道的連線已中斷',
       gatewaySignInRequired: '需要閘道登入',
-      ipcBridgeUnavailable: '桌面 IPC 橋接器不可用。'
+      ipcBridgeUnavailable: '桌面 IPC 橋接器不可用。',
+      sessionLoadFailed: '無法載入最近工作階段'
     },
     failure: {
       title: 'Hermes 無法啟動',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -78,7 +78,8 @@ export const zh: Translations = {
       desktopBootFailed: '桌面启动失败',
       gatewayConnectionLost: '与网关的连接已断开',
       gatewaySignInRequired: '需要登录网关',
-      ipcBridgeUnavailable: '桌面 IPC 桥不可用。'
+      ipcBridgeUnavailable: '桌面 IPC 桥不可用。',
+      sessionLoadFailed: '无法加载最近会话'
     },
     failure: {
       title: 'Hermes 无法启动',

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -199,6 +199,26 @@ export const $connection = atom<HermesConnection | null>(null)
 export const $gatewayState = atom('idle')
 export const $sessions = atom<SessionInfo[]>([])
 export const $sessionsTotal = atom<number>(0)
+// Latest refreshSessions() rejection surfaced to the sidebar. `initial` is true
+// only when the failure happened before any successful fetch in this window
+// (see useSessionListActions.refreshSessions). The boot path surfaces this via
+// failDesktopBoot with a session-specific message; the sidebar reads it on
+// subsequent failures to offer recovery without dropping existing rows.
+export interface SessionLoadError {
+  initial: boolean
+  message: string
+  timestamp: number
+}
+
+export const $sessionLoadError = atom<SessionLoadError | null>(null)
+
+export function setSessionLoadError(error: SessionLoadError | null) {
+  $sessionLoadError.set(error)
+}
+
+export function clearSessionLoadError() {
+  $sessionLoadError.set(null)
+}
 // Cron-job sessions (source === 'cron') are fetched as their own list so the
 // scheduler's always-newest sessions never crowd recents out of the page
 // budget. Powers the collapsed "Cron jobs" sidebar section.


### PR DESCRIPTION
## Summary

Fixes #64157: `refreshSessions()` silently drops the session list to empty on transient fetch failures, making the sidebar appear as if all sessions are gone.

## What this PR does

Adds a `catch` block to `refreshSessions()` in `apps/desktop/src/app/session/hooks/use-session-list-actions.ts`. Previously the function used `try`/`finally` with no `catch` — when `listAllProfileSessions()` threw (backend timeout on cold start after update, network error), `$sessions` stayed at its initial atom value of `[]` and `$sessionsLoading` flipped to `false`. The sidebar rendered "no sessions" with zero error indication.

The catch block preserves the previous session list on transient failure. The spinner still stops (finally), but the sidebar keeps whatever was loaded before the failure instead of dropping to empty.

## Notes

- A follow-up could add an explicit error state atom + retry affordance in the sidebar. This PR is the minimal fix to prevent the silent data-loss appearance.
- The missing `active-profile.json` migration (separate issue) compounds this — on first boot after update, the Desktop defaults to the "default" profile, and if that profile's session fetch times out, the user sees an empty sidebar and assumes everything is gone.
