### PR TITLE
fix(dashboard): scope PTY keep-alive token to profile+resume

### DIFF
--- a/web/src/lib/pty-token.test.ts
+++ b/web/src/lib/pty-token.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { ptyAttachToken, PTY_ATTACH_TOKEN_BASE } from "./pty-token";
+import type { PtyTokenStorage, PtyTokenCrypto } from "./pty-token";
+
+/** Predictable "random" that returns sequential bytes: 0,1,2,3,... */
+function sequentialCrypto(): PtyTokenCrypto {
+  let next = 0;
+  return {
+    getRandomValues<T extends Uint8Array>(array: T): T {
+      for (let i = 0; i < array.length; i++) {
+        array[i] = (next++ & 0xff) as number;
+      }
+      return array;
+    },
+  };
+}
+
+/** Simple in-memory storage for tests. */
+class MemoryStorage implements PtyTokenStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+describe("ptyAttachToken", () => {
+  let storage: MemoryStorage;
+  let crypto: PtyTokenCrypto;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    crypto = sequentialCrypto();
+  });
+
+  it("returns the same token for the same scope (keep-alive preserved)", () => {
+    const scope = "default\0session-123";
+
+    const first = ptyAttachToken(false, scope, storage, crypto);
+    const second = ptyAttachToken(false, scope, storage, crypto);
+
+    expect(first).toBe(second);
+    expect(first).toHaveLength(32); // 16 bytes hex = 32 chars
+    expect(storage.getItem(`${PTY_ATTACH_TOKEN_BASE}.${scope}`)).toBe(first);
+  });
+
+  it("returns different tokens when scope differs — profile changes", () => {
+    const tokenA = ptyAttachToken(false, "profile-a\0s1", storage, crypto);
+    const tokenB = ptyAttachToken(
+      false,
+      "profile-b\0s1",
+      // Use fresh storage so the old key doesn't collide
+      new MemoryStorage(),
+      crypto,
+    );
+
+    expect(tokenA).not.toBe(tokenB);
+  });
+
+  it("returns different tokens when scope differs — resume changes", () => {
+    const tokenA = ptyAttachToken(false, "default\0session-1", storage, crypto);
+    const tokenB = ptyAttachToken(
+      false,
+      "default\0session-2",
+      new MemoryStorage(),
+      crypto,
+    );
+
+    expect(tokenA).not.toBe(tokenB);
+  });
+
+  it("returns different tokens when scope differs — both profile and resume change", () => {
+    const tokenA = ptyAttachToken(false, "p1\0s1", storage, crypto);
+    // Use the same crypto instance so it continues the sequence from where
+    // the first call left off, producing different bytes for tokenB.
+    const tokenB = ptyAttachToken(
+      false,
+      "p2\0s2",
+      new MemoryStorage(),
+      crypto,
+    );
+
+    expect(tokenA).not.toBe(tokenB);
+  });
+
+  it("rotates the token when rotate=true, even with same scope", () => {
+    const scope = "default\0s1";
+
+    const first = ptyAttachToken(false, scope, storage, crypto);
+    const fresh = ptyAttachToken(true, scope, storage, crypto);
+
+    expect(first).not.toBe(fresh);
+    // The new token should now be persisted
+    expect(storage.getItem(`${PTY_ATTACH_TOKEN_BASE}.${scope}`)).toBe(fresh);
+  });
+
+  it("scoped token does not collide with unscoped (legacy) key", () => {
+    const scoped = ptyAttachToken(false, "default\0s1", storage, crypto);
+    const unscoped = ptyAttachToken(false, "", new MemoryStorage(), crypto);
+
+    expect(scoped).not.toBe(unscoped);
+
+    const scopedKey = `${PTY_ATTACH_TOKEN_BASE}.default\0s1`;
+    const unscopedKey = `${PTY_ATTACH_TOKEN_BASE}.chat`;
+    expect(scopedKey).not.toBe(unscopedKey);
+  });
+
+  it("persists to the scoped key", () => {
+    const scope = "my-profile\0resume-42";
+    const token = ptyAttachToken(false, scope, storage, crypto);
+
+    expect(storage.getItem(`${PTY_ATTACH_TOKEN_BASE}.${scope}`)).toBe(token);
+  });
+
+  it("reuses stored token without calling getRandomValues again", () => {
+    const scope = "sticky\0test";
+    const first = ptyAttachToken(false, scope, storage, crypto);
+    // Create a fresh crypto that would produce different bytes — if the
+    // function re-mints the token, we'd see a different value.
+    const differentCrypto = sequentialCrypto();
+    const second = ptyAttachToken(false, scope, storage, differentCrypto);
+
+    expect(second).toBe(first);
+  });
+
+  it("rotate=true + empty storage mints a fresh 32-char hex token", () => {
+    const token = ptyAttachToken(true, "any\0scope", storage, crypto);
+
+    expect(token).toHaveLength(32);
+    expect(/^[0-9a-f]{32}$/.test(token)).toBe(true);
+  });
+});

--- a/web/src/lib/pty-token.ts
+++ b/web/src/lib/pty-token.ts
@@ -1,0 +1,88 @@
+/**
+ * PTY attach-token helpers — scoped per-browser keep-alive identity.
+ *
+ * A stable token lets a page refresh or transient WebSocket drop reattach
+ * to the same live PTY process instead of spawning a fresh one. The token
+ * is stored in localStorage so other devices cannot grab it.
+ *
+ * ``rotate`` mints a new token — used when the user explicitly starts a
+ * fresh session so the old keep-alive PTY is NOT reattached.
+ *
+ * ``scope`` (e.g. "profile\0resume") scopes the token to a profile+session
+ * combination so switching either one forces a new PTY spawn instead of
+ * reattaching to a stale PTY with the wrong HERMES_HOME / session.
+ */
+
+export const PTY_ATTACH_TOKEN_BASE = "hermes.pty.token";
+
+export interface PtyTokenStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface PtyTokenCrypto {
+  getRandomValues<T extends Uint8Array>(array: T): T;
+}
+
+const DEFAULT_STORAGE: PtyTokenStorage =
+  typeof window !== "undefined"
+    ? {
+        getItem(key: string) {
+          return window.localStorage.getItem(key);
+        },
+        setItem(key: string, value: string) {
+          window.localStorage.setItem(key, value);
+        },
+      }
+    : { getItem: () => null, setItem: () => {} };
+
+const DEFAULT_CRYPTO: PtyTokenCrypto =
+  typeof crypto !== "undefined" && "getRandomValues" in crypto
+    ? (crypto as PtyTokenCrypto)
+    : {
+        getRandomValues<T extends Uint8Array>(array: T): T {
+          for (let i = 0; i < array.length; i++) {
+            array[i] = Math.floor(Math.random() * 256);
+          }
+          return array;
+        },
+      };
+
+/**
+ * Returns a stable hex token for PTY attach.
+ *
+ * @param rotate  — if true, always mint a fresh token.
+ * @param scope   — scoping suffix (e.g. "profile\0resume").
+ * @param storage — injectable localStorage-like storage (defaults to window.localStorage).
+ * @param crypto  — injectable crypto (defaults to globalThis.crypto).
+ */
+export function ptyAttachToken(
+  rotate = false,
+  scope = "",
+  storage: PtyTokenStorage = DEFAULT_STORAGE,
+  rand: PtyTokenCrypto = DEFAULT_CRYPTO,
+): string {
+  const key = scope
+    ? `${PTY_ATTACH_TOKEN_BASE}.${scope}`
+    : `${PTY_ATTACH_TOKEN_BASE}.chat`;
+
+  let t = "";
+  if (!rotate) {
+    try {
+      t = storage.getItem(key) ?? "";
+    } catch {
+      /* private mode / storage blocked */
+    }
+  }
+  if (!t) {
+    const a = new Uint8Array(16);
+    rand.getRandomValues(a);
+    t = Array.from(a, (b) => b.toString(16).padStart(2, "0")).join("");
+    try {
+      storage.setItem(key, t);
+    } catch {
+      /* ignore */
+    }
+  }
+  return t;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -63,12 +63,18 @@ import { useProfileScope } from "@/contexts/useProfileScope";
 // instead of spawning a fresh one. Per-localStorage, so other devices can't grab it.
 // ``rotate`` mints a new token — used when the user explicitly starts a fresh
 // session so the old keep-alive PTY is NOT reattached (the registry reaps it).
-const PTY_ATTACH_TOKEN_KEY = "hermes.pty.token.chat";
-function ptyAttachToken(rotate = false): string {
+// ``scope`` (e.g. "profile\0resume") scopes the token to a profile+session
+// combination so switching either one forces a new PTY spawn instead of
+// reattaching to a stale PTY with the wrong HERMES_HOME / session.
+const PTY_ATTACH_TOKEN_BASE = "hermes.pty.token";
+function ptyAttachToken(rotate = false, scope = ""): string {
+  const key = scope
+    ? `${PTY_ATTACH_TOKEN_BASE}.${scope}`
+    : `${PTY_ATTACH_TOKEN_BASE}.chat`;
   let t = "";
   if (!rotate) {
     try {
-      t = window.localStorage.getItem(PTY_ATTACH_TOKEN_KEY) ?? "";
+      t = window.localStorage.getItem(key) ?? "";
     } catch {
       /* private mode / storage blocked */
     }
@@ -78,7 +84,7 @@ function ptyAttachToken(rotate = false): string {
     crypto.getRandomValues(a);
     t = Array.from(a, (b) => b.toString(16).padStart(2, "0")).join("");
     try {
-      window.localStorage.setItem(PTY_ATTACH_TOKEN_KEY, t);
+      window.localStorage.setItem(key, t);
     } catch {
       /* ignore */
     }
@@ -907,7 +913,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Keep-alive identity: reattach to this tab's living PTY across
       // refresh/transient drops. A forced-fresh start rotates the token so
       // the previous keep-alive PTY is not reattached (registry reaps it).
-      params.attach = ptyAttachToken(forceFresh);
+      // Token is scoped to profile+resume so switching either one forces a
+      // fresh PTY spawn with the correct HERMES_HOME / session ID.
+      params.attach = ptyAttachToken(forceFresh, `${scopedProfile ?? "default"}\0${resumeParam ?? "fresh"}`);
       // Profile-scoped chat: the PTY child gets HERMES_HOME pointed at the
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -54,43 +54,10 @@ import {
   transferMayContainImage,
   uploadChatImage,
 } from "@/lib/chatImagePaste";
+import { ptyAttachToken } from "@/lib/pty-token";
 import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
 import { useProfileScope } from "@/contexts/useProfileScope";
-
-// Stable per-browser token identifying THIS chat tab's keep-alive PTY session.
-// Sent as ?attach=; lets a refresh/disconnect reattach to the same live process
-// instead of spawning a fresh one. Per-localStorage, so other devices can't grab it.
-// ``rotate`` mints a new token — used when the user explicitly starts a fresh
-// session so the old keep-alive PTY is NOT reattached (the registry reaps it).
-// ``scope`` (e.g. "profile\0resume") scopes the token to a profile+session
-// combination so switching either one forces a new PTY spawn instead of
-// reattaching to a stale PTY with the wrong HERMES_HOME / session.
-const PTY_ATTACH_TOKEN_BASE = "hermes.pty.token";
-function ptyAttachToken(rotate = false, scope = ""): string {
-  const key = scope
-    ? `${PTY_ATTACH_TOKEN_BASE}.${scope}`
-    : `${PTY_ATTACH_TOKEN_BASE}.chat`;
-  let t = "";
-  if (!rotate) {
-    try {
-      t = window.localStorage.getItem(key) ?? "";
-    } catch {
-      /* private mode / storage blocked */
-    }
-  }
-  if (!t) {
-    const a = new Uint8Array(16);
-    crypto.getRandomValues(a);
-    t = Array.from(a, (b) => b.toString(16).padStart(2, "0")).join("");
-    try {
-      window.localStorage.setItem(key, t);
-    } catch {
-      /* ignore */
-    }
-  }
-  return t;
-}
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar
 // (subscriber).  Generated once per mount so a tab refresh starts a fresh


### PR DESCRIPTION
## Problem

When switching profiles or selecting a different session in the dashboard Chat tab, the embedded TUI always reattaches to the same PTY — ignoring the new profile and session selection. This happens because the PTY keep-alive attach token is stored under a single global `localStorage` key, so `PtySessionRegistry.attach_or_spawn()` finds the old PTY still alive and returns it, never applying the new `HERMES_HOME` or `HERMES_TUI_RESUME`.

Fixes #64154.

## Root Cause

- **Frontend** (`ChatPage.tsx:67`): `ptyAttachToken()` uses one global key `hermes.pty.token.chat` — not scoped to profile or resume
- **Backend** (`pty_session.py:148`): `attach_or_spawn()` matches by token only, ignoring the WebSocket query params when the PTY is already alive

When the user switches profiles, `channel` regenerates → WebSocket reconnects → but the attach token is unchanged → old PTY reused → new `HERMES_HOME` never applied.

## Fix

Scope the `attach_token` localStorage key to the `profile + resume` combination:

```ts
// Before: global key
const PTY_ATTACH_TOKEN_KEY = "hermes.pty.token.chat";
params.attach = ptyAttachToken(forceFresh);

// After: scoped key
const PTY_ATTACH_TOKEN_BASE = "hermes.pty.token";
params.attach = ptyAttachToken(forceFresh, `${scopedProfile ?? "default"}\0${resumeParam ?? "fresh"}`);
```

- Switching profiles/sessions → different key → new token → fresh PTY spawn
- Browser refresh on same profile+session → same key → existing token → keep-alive preserved
- Explicit "New chat" → `forceFresh=true` → token rotated (unchanged behavior)

## Verification

- TypeScript: `tsc -p . --noEmit` — no errors
- Tests: `vitest run` — 72/72 passed (11 files)