### PR TITLE
perf(gateway): single-row routing UPSERT fast path for metadata-only saves

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1026,6 +1026,11 @@ class SessionStore:
         self._save_lock = threading.Lock()
         self._routing_generation = 0
         self._persisted_routing_generation = 0
+        # Single-entry upserts persisted since the last full rewrite:
+        # session_key -> (revision, entry_json). Revisions are allocated
+        # from _routing_generation, so fast and full snapshots are totally
+        # ordered; guarded by _save_lock (see _save_entry).
+        self._fast_persisted_entries: Dict[str, tuple[int, str]] = {}
         self._inflight_lock = threading.Lock()
         self._inflight_sessions: Dict[str, _SessionFlight] = {}
         self._has_active_processes_fn = has_active_processes_fn
@@ -1255,6 +1260,16 @@ class SessionStore:
         with save_lock:
             if generation <= getattr(self, "_persisted_routing_generation", 0):
                 return
+            # Fold in single-entry upserts with a newer revision than this
+            # snapshot (see _save_entry): revisions share the routing
+            # generation counter, so a fast record numbered above us was
+            # serialized after us and a delayed full rewrite must not
+            # regress it.
+            fast_persisted = getattr(self, "_fast_persisted_entries", None)
+            if fast_persisted:
+                for key, (revision, entry_json) in fast_persisted.items():
+                    if revision > generation:
+                        data[key] = json.loads(entry_json)
             db_saved = False
             _db = getattr(self, "_db", None)
             if _db:
@@ -1273,6 +1288,14 @@ class SessionStore:
             if getattr(self, "_write_sessions_json", True) or not db_saved:
                 self._save_sessions_json(data)
             self._persisted_routing_generation = generation
+            # This rewrite supersedes fast records at or below its
+            # generation; newer ones stay for the next delayed full writer.
+            if fast_persisted:
+                for key in [
+                    k for k, (rev, _) in fast_persisted.items()
+                    if rev <= generation
+                ]:
+                    del fast_persisted[key]
 
     def _save_sessions_json(self, data: Dict[str, Any]) -> None:
         """Write the legacy sessions.json mirror of the routing index."""
@@ -1319,6 +1342,85 @@ class SessionStore:
         with self._lock:
             data, generation = self._snapshot_routing_locked()
         self._persist_routing_data(data, generation)
+
+    def _save_entry(self, session_key: str) -> None:
+        """Persist ONE routing entry via UPSERT — the per-turn fast path.
+
+        The steady-state turn only bumps ``updated_at`` /
+        ``last_prompt_tokens`` on one entry; routing that through the
+        full index rewrite re-serializes every entry, DELETE+INSERTs
+        every gateway_routing row, and dumps+fsyncs a multi-MB
+        sessions.json — ~50ms p50 at ~1100 routing keys, and it runs
+        twice per turn.  A single-row UPSERT keeps the durable state.db
+        mapping current in well under a millisecond.
+
+        Correctness constraints this path relies on:
+
+        - The key -> session_id mapping never changes here.  Structural
+          transitions (create/recover/reset/switch/prune, and
+          compression-tip heals — see get_or_create_session) still use
+          the full-rewrite path, which also refreshes the legacy
+          sessions.json mirror.  Between structural saves the mirror may
+          lag in metadata only; every remaining sessions.json reader is
+          a legacy fallback and state.db stays primary, so restart
+          rebinding is unaffected.
+
+        - Ordering vs concurrent writers: the entry is serialized under
+          ``_lock`` together with a revision allocated from the routing
+          generation counter, so every snapshot — fast or full — carries
+          a unique, monotonically increasing number, and a higher number
+          always means same-or-newer data for this key.  Under
+          ``_save_lock`` the upsert is skipped when a snapshot numbered
+          above ours already persisted this key: a FULL snapshot
+          (``_persisted_routing_generation``) or another fast save of
+          the same key (``_fast_persisted_entries``).  Either contains a
+          same-or-newer copy, so writing ours would regress it.  The
+          reverse interaction — a delayed full rewrite landing after a
+          later-serialized fast save — is handled in
+          ``_persist_routing_data``, which folds fast records numbered
+          above its snapshot into the rewrite.  An older snapshot can
+          therefore never overwrite a newer one, in either direction.
+
+        - No DB, or a failed upsert, falls back to the full rewrite so
+          DB-less installs keep sessions.json — their primary store —
+          durable every turn.
+        """
+        with self._lock:
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return
+            entry_json = json.dumps(entry.to_dict())
+            self._routing_generation = getattr(self, "_routing_generation", 0) + 1
+            revision = self._routing_generation
+        _db = getattr(self, "_db", None)
+        saver = getattr(_db, "save_gateway_routing_entry", None) if _db else None
+        if callable(saver):
+            save_lock = getattr(self, "_save_lock", None)
+            if save_lock is None:
+                save_lock = threading.Lock()
+                self._save_lock = save_lock
+            try:
+                with save_lock:
+                    if getattr(self, "_persisted_routing_generation", 0) >= revision:
+                        return
+                    fast_persisted = getattr(self, "_fast_persisted_entries", None)
+                    if fast_persisted is None:
+                        fast_persisted = {}
+                        self._fast_persisted_entries = fast_persisted
+                    persisted = fast_persisted.get(session_key)
+                    if persisted is not None and persisted[0] >= revision:
+                        return
+                    saver(session_key, entry_json, scope=self._routing_scope())
+                    fast_persisted[session_key] = (revision, entry_json)
+                return
+            except Exception as exc:
+                logger.warning(
+                    "gateway.session: single-entry routing save failed for %r "
+                    "(%s); falling back to full index rewrite",
+                    session_key, exc,
+                )
+        self._save_entries()
+
     def _resolve_profile_for_key(self, source: Optional[SessionSource] = None) -> Optional[str]:
         """Return the profile namespace for session keys, or None when off.
 
@@ -1907,6 +2009,11 @@ class SessionStore:
 
         # ---- Phase 2: lock write -- apply decisions to _entries ----
         _needs_save = False
+        # Healthy-path saves only bump updated_at on one entry; they take
+        # the single-row UPSERT fast path instead of the full index rewrite
+        # (see _save_entry). Structural transitions (recover/create below)
+        # keep the full rewrite.
+        _metadata_only_save = False
         _needs_recover = False
         entry: Optional[SessionEntry] = None
         was_auto_reset = False
@@ -1918,7 +2025,10 @@ class SessionStore:
 
             if session_key in self._entries and not force_new:
                 entry = self._entries[session_key]
-                self._heal_compression_tip_locked(
+                # A heal rewrites entry.session_id, so it must reach the
+                # sessions.json mirror too: force the full-rewrite save
+                # below (the fast path persists state.db only).
+                _healed = self._heal_compression_tip_locked(
                     entry, existing_session_id, canonical_existing_session_id
                 )
 
@@ -1945,6 +2055,7 @@ class SessionStore:
                     # window.  Treat as healthy -- bump updated_at and save.
                     entry.updated_at = now
                     _needs_save = True
+                    _metadata_only_save = not _healed
                 else:
                     # Stale check clean.  Apply reset decision.
                     if _reset_reason:
@@ -1958,6 +2069,7 @@ class SessionStore:
                     else:
                         entry.updated_at = now
                         _needs_save = True
+                        _metadata_only_save = not _healed
             else:
                 if not force_new:
                     _needs_recover = True
@@ -2019,7 +2131,10 @@ class SessionStore:
                 }
 
         if _needs_save:
-            self._save_entries()
+            if _metadata_only_save:
+                self._save_entry(session_key)
+            else:
+                self._save_entries()
 
         # SQLite operations outside the lock (unchanged).
         if self._db and db_end_session_id:
@@ -2050,19 +2165,28 @@ class SessionStore:
         """Update lightweight session metadata after an interaction."""
         with self._lock:
             self._ensure_loaded_locked()
-
-            if session_key in self._entries:
-                entry = self._entries[session_key]
-                entry.updated_at = _now()
-                if last_prompt_tokens is not None:
-                    entry.last_prompt_tokens = last_prompt_tokens
-                self._save()
-                self._record_gateway_session_peer(
-                    entry.session_id,
-                    session_key,
-                    entry.origin,
-                    display_name=entry.display_name,
-                )
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return
+            entry.updated_at = _now()
+            if last_prompt_tokens is not None:
+                entry.last_prompt_tokens = last_prompt_tokens
+            # Snapshot peer fields while still holding _lock: a concurrent
+            # reset/heal may rewrite the entry, and mixing old and new
+            # fields would record a torn peer row.
+            peer_session_id = entry.session_id
+            peer_origin = entry.origin
+            peer_display_name = entry.display_name
+        # Metadata-only change on one entry: single-row UPSERT instead of
+        # the full index rewrite (see _save_entry). Both writes run outside
+        # ``_lock`` so the SQLite commit never blocks routing lookups.
+        self._save_entry(session_key)
+        self._record_gateway_session_peer(
+            peer_session_id,
+            session_key,
+            peer_origin,
+            display_name=peer_display_name,
+        )
 
     def set_model_override(
         self, session_key: str, override: Optional[Dict[str, Any]]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -68,6 +68,7 @@ AUTHOR_MAP = {
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "2024104039@mails.szu.edu.cn": "pixel4039",  # PR #64420 salvage (streaming: retry zero-chunk streams)
     "marceloparra.hm@gmail.com": "marcelohildebrand",  # PR #42346 salvage (lmstudio: JIT load mode)
+    "qlskssk@gmail.com": "Soju06",  # agent turn-latency perf PRs
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)

--- a/tests/gateway/test_routing_save_fast_path.py
+++ b/tests/gateway/test_routing_save_fast_path.py
@@ -1,0 +1,445 @@
+"""Single-row routing save fast path.
+
+Metadata-only per-turn writes (get_or_create_session's healthy-path
+``updated_at`` bump, ``update_session``) persist through a single-row
+UPSERT instead of rewriting the whole routing index. These tests prove
+the write-skipping never loses a NEEDED write: changed values always
+land in state.db, and restart rebinding works even when the legacy
+sessions.json mirror lagged behind (or never existed).
+"""
+from __future__ import annotations
+
+import json
+import threading
+
+import hermes_state
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore
+
+
+def _source(user_id: str = "user-1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="cli",
+        chat_name="CLI",
+        chat_type="dm",
+        user_id=user_id,
+    )
+
+
+def _make_store(tmp_path, monkeypatch, **config_kwargs) -> SessionStore:
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    return SessionStore(
+        sessions_dir=tmp_path / "sessions",
+        config=GatewayConfig(**config_kwargs),
+    )
+
+
+def _routing_row(store: SessionStore, session_key: str) -> dict:
+    rows = store._db.load_gateway_routing_entries(scope=store._routing_scope())
+    return json.loads(rows[session_key])
+
+
+class TestChangedValuesAlwaysPersist:
+    def test_update_session_persists_last_prompt_tokens_to_db(
+        self, tmp_path, monkeypatch
+    ):
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        store.update_session(entry.session_key, last_prompt_tokens=54321)
+
+        durable = _routing_row(store, entry.session_key)
+        assert durable["last_prompt_tokens"] == 54321
+        store._db.close()
+
+    def test_healthy_path_bump_persists_updated_at_to_db(
+        self, tmp_path, monkeypatch
+    ):
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+        before = _routing_row(store, entry.session_key)["updated_at"]
+
+        # Second lookup takes the healthy-path metadata-only save.
+        again = store.get_or_create_session(_source())
+        assert again.session_id == entry.session_id
+
+        after = _routing_row(store, entry.session_key)["updated_at"]
+        assert after >= before
+        # The row reflects the in-memory bump, not a stale copy.
+        assert after == again.updated_at.isoformat()
+        store._db.close()
+
+    def test_fast_path_survives_restart_across_stores(
+        self, tmp_path, monkeypatch
+    ):
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+        store.update_session(entry.session_key, last_prompt_tokens=777)
+        store._db.close()
+
+        restarted = _make_store(tmp_path, monkeypatch)
+        rebound = restarted.get_or_create_session(_source())
+        assert rebound.session_id == entry.session_id
+        assert rebound.last_prompt_tokens == 777
+        restarted._db.close()
+
+
+class TestRestartRebindWithoutMirror:
+    def test_rebind_works_when_mirror_lagged_fast_path_writes(
+        self, tmp_path, monkeypatch
+    ):
+        """The fast path skips sessions.json; state.db alone must rebind."""
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+        sessions_json = tmp_path / "sessions" / "sessions.json"
+        assert sessions_json.exists()  # structural save wrote the mirror
+
+        # Remove the mirror, then do fast-path-only writes: they must NOT
+        # recreate it (proves the fast path ran) and must not need it.
+        sessions_json.unlink()
+        store.update_session(entry.session_key, last_prompt_tokens=42)
+        again = store.get_or_create_session(_source())
+        assert again.session_id == entry.session_id
+        assert not sessions_json.exists()
+        store._db.close()
+
+        restarted = _make_store(tmp_path, monkeypatch)
+        rebound = restarted.get_or_create_session(_source())
+        assert rebound.session_id == entry.session_id
+        assert rebound.last_prompt_tokens == 42
+        restarted._db.close()
+
+    def test_compression_heal_takes_full_path_and_updates_mirror(
+        self, tmp_path, monkeypatch
+    ):
+        """A heal rewrites session_id, so it must bypass the fast path.
+
+        The fast path persists state.db only; if a heal took it, the
+        sessions.json mirror would keep the ended parent id until the
+        next structural save (indefinitely on a healthy key).
+        """
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+        healed_id = entry.session_id + "_child"
+        monkeypatch.setattr(
+            store,
+            "_compression_tip_for_session_id",
+            lambda sid: healed_id if sid == entry.session_id else sid,
+        )
+
+        again = store.get_or_create_session(_source())
+        assert again.session_id == healed_id
+
+        assert _routing_row(store, entry.session_key)["session_id"] == healed_id
+        sessions_json = tmp_path / "sessions" / "sessions.json"
+        data = json.loads(sessions_json.read_text(encoding="utf-8"))
+        assert data[entry.session_key]["session_id"] == healed_id
+        store._db.close()
+
+    def test_structural_save_still_rewrites_mirror(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch)
+        first = store.get_or_create_session(_source())
+        fresh = store.get_or_create_session(_source(), force_new=True)
+        assert fresh.session_id != first.session_id
+
+        sessions_json = tmp_path / "sessions" / "sessions.json"
+        data = json.loads(sessions_json.read_text(encoding="utf-8"))
+        assert data[fresh.session_key]["session_id"] == fresh.session_id
+        store._db.close()
+
+
+class TestFallbacks:
+    def test_no_db_falls_back_to_full_rewrite(self, tmp_path, monkeypatch):
+        """DB-less installs keep sessions.json durable every turn."""
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+        store._db.close()
+        store._db = None
+
+        store.update_session(entry.session_key, last_prompt_tokens=99)
+
+        sessions_json = tmp_path / "sessions" / "sessions.json"
+        data = json.loads(sessions_json.read_text(encoding="utf-8"))
+        assert data[entry.session_key]["last_prompt_tokens"] == 99
+
+    def test_failed_upsert_falls_back_to_full_rewrite(
+        self, tmp_path, monkeypatch
+    ):
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("disk on fire")
+
+        monkeypatch.setattr(store._db, "save_gateway_routing_entry", boom)
+        store.update_session(entry.session_key, last_prompt_tokens=1234)
+
+        # The full rewrite carried the change to both stores.
+        sessions_json = tmp_path / "sessions" / "sessions.json"
+        data = json.loads(sessions_json.read_text(encoding="utf-8"))
+        assert data[entry.session_key]["last_prompt_tokens"] == 1234
+        assert _routing_row(store, entry.session_key)["last_prompt_tokens"] == 1234
+        store._db.close()
+
+
+class TestPeerRecordConsistency:
+    def test_update_session_records_peer_fields_snapshotted_under_lock(
+        self, tmp_path, monkeypatch
+    ):
+        """Peer fields must come from one lock-held snapshot, not late reads.
+
+        The peer record runs outside ``_lock``; a concurrent reset that
+        rewrites the entry in that window must not produce a torn
+        old/new field mix in the recorded row.
+        """
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+        original_id = entry.session_id
+
+        recorded = []
+        monkeypatch.setattr(
+            store,
+            "_record_gateway_session_peer",
+            lambda sid, key, origin, display_name=None: recorded.append(
+                (sid, key, display_name)
+            ),
+        )
+        orig_save_entry = store._save_entry
+
+        def swap_then_save(key):
+            # Simulate a concurrent reset landing after update_session
+            # released _lock but before the peer record runs.
+            with store._lock:
+                store._entries[key].session_id = "reset-rewrote-me"
+            orig_save_entry(key)
+
+        monkeypatch.setattr(store, "_save_entry", swap_then_save)
+        store.update_session(entry.session_key, last_prompt_tokens=5)
+
+        assert recorded == [
+            (original_id, entry.session_key, entry.display_name)
+        ]
+        store._db.close()
+
+
+class TestGenerationOrdering:
+    def test_upsert_skipped_when_newer_full_snapshot_persisted(
+        self, tmp_path, monkeypatch
+    ):
+        """A full snapshot taken after our serialize point must win.
+
+        Its copy of the key is same-or-newer, so writing ours would
+        regress it. Simulated by advancing _persisted_routing_generation
+        past the generation captured at serialize time.
+        """
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        calls = []
+        monkeypatch.setattr(
+            store._db,
+            "save_gateway_routing_entry",
+            lambda *a, **k: calls.append((a, k)),
+        )
+        store._persisted_routing_generation = store._routing_generation + 1
+
+        store._save_entry(entry.session_key)
+
+        assert calls == []
+        store._db.close()
+
+    def test_restart_rebind_after_skipped_idempotent_write(
+        self, tmp_path, monkeypatch
+    ):
+        """A skipped fast-path write never orphans the session on restart.
+
+        The skip only fires when a newer FULL snapshot — which contains
+        this key — already persisted, so state.db can always rebind.
+        """
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        calls = []
+        monkeypatch.setattr(
+            store._db,
+            "save_gateway_routing_entry",
+            lambda *a, **k: calls.append(a),
+        )
+        store._persisted_routing_generation = store._routing_generation + 1
+        store._save_entry(entry.session_key)
+        assert calls == []  # the idempotent write was skipped
+        store._db.close()
+
+        restarted = _make_store(tmp_path, monkeypatch)
+        rebound = restarted.get_or_create_session(_source())
+        assert rebound.session_id == entry.session_id
+        restarted._db.close()
+
+    def test_upsert_proceeds_at_current_generation(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        calls = []
+        monkeypatch.setattr(
+            store._db,
+            "save_gateway_routing_entry",
+            lambda key, entry_json, **k: calls.append((key, entry_json, k)),
+        )
+
+        store._save_entry(entry.session_key)
+
+        assert len(calls) == 1
+        key, entry_json, kwargs = calls[0]
+        assert key == entry.session_key
+        assert json.loads(entry_json)["session_id"] == entry.session_id
+        assert kwargs["scope"] == store._routing_scope()
+        store._db.close()
+
+    def test_missing_key_is_a_noop(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch)
+        store._ensure_loaded()
+
+        calls = []
+        monkeypatch.setattr(
+            store._db,
+            "save_gateway_routing_entry",
+            lambda *a, **k: calls.append(a),
+        )
+
+        store._save_entry("agent:main:local:nope")
+
+        assert calls == []
+        store._db.close()
+
+
+class _GatedSaveLock:
+    """``_save_lock`` wrapper that parks one thread at lock entry.
+
+    The parked thread has already serialized its entry (and taken its
+    revision) under ``_lock``, so this deterministically reproduces a
+    delayed write: the writer sits between its serialize point and the
+    durable-write section while other writers run to completion.
+    """
+
+    def __init__(self, inner: threading.Lock) -> None:
+        self._inner = inner
+        self.gated_thread: threading.Thread | None = None
+        self.reached = threading.Event()
+        self.release = threading.Event()
+
+    def __enter__(self):
+        if threading.current_thread() is self.gated_thread:
+            self.reached.set()
+            assert self.release.wait(timeout=5), "gated writer never released"
+        return self._inner.__enter__()
+
+    def __exit__(self, *exc):
+        return self._inner.__exit__(*exc)
+
+
+class TestDelayedWriteOrdering:
+    def test_reverse_completion_fast_saves_keep_newer_entry(
+        self, tmp_path, monkeypatch
+    ):
+        """Two same-key fast saves completing in reverse order.
+
+        The older save serializes first but its UPSERT is delayed past
+        the newer save's. Its revision is below the newer one recorded
+        in ``_fast_persisted_entries``, so it must skip — the newer
+        entry_json stays in state.db.
+        """
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        gate = _GatedSaveLock(store._save_lock)
+        store._save_lock = gate
+        older = threading.Thread(
+            target=store.update_session,
+            args=(entry.session_key,),
+            kwargs={"last_prompt_tokens": 1},
+        )
+        gate.gated_thread = older
+        older.start()
+        # The older save has serialized last_prompt_tokens=1 and parked
+        # before its UPSERT; the newer save now runs to completion.
+        assert gate.reached.wait(timeout=5)
+        store.update_session(entry.session_key, last_prompt_tokens=2)
+
+        gate.release.set()
+        older.join(timeout=5)
+        assert not older.is_alive()
+
+        assert _routing_row(store, entry.session_key)["last_prompt_tokens"] == 2
+        store._db.close()
+
+    def test_delayed_full_rewrite_folds_in_newer_fast_save(
+        self, tmp_path, monkeypatch
+    ):
+        """A full rewrite landing after a later-serialized fast save.
+
+        The rewrite's snapshot predates the fast save, so replaying it
+        verbatim would regress the key. ``_persist_routing_data`` must
+        fold the newer fast record into the rewrite — in state.db and in
+        the sessions.json mirror.
+        """
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        with store._lock:
+            data, generation = store._snapshot_routing_locked()
+        store.update_session(entry.session_key, last_prompt_tokens=7)
+
+        # The delayed full rewrite lands last.
+        store._persist_routing_data(data, generation)
+
+        assert _routing_row(store, entry.session_key)["last_prompt_tokens"] == 7
+        sessions_json = tmp_path / "sessions" / "sessions.json"
+        mirror = json.loads(sessions_json.read_text(encoding="utf-8"))
+        assert mirror[entry.session_key]["last_prompt_tokens"] == 7
+        store._db.close()
+
+    def test_delayed_fast_save_skips_after_newer_full_rewrite(
+        self, tmp_path, monkeypatch
+    ):
+        """A fast save delayed past a full rewrite serialized after it.
+
+        The rewrite's snapshot contains a newer copy of the key, so the
+        parked UPSERT must skip instead of regressing it.
+        """
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+
+        upserts = []
+        real_saver = store._db.save_gateway_routing_entry
+
+        def counting_saver(session_key, entry_json, **kwargs):
+            upserts.append(session_key)
+            real_saver(session_key, entry_json, **kwargs)
+
+        monkeypatch.setattr(
+            store._db, "save_gateway_routing_entry", counting_saver
+        )
+        gate = _GatedSaveLock(store._save_lock)
+        store._save_lock = gate
+        older = threading.Thread(
+            target=store.update_session,
+            args=(entry.session_key,),
+            kwargs={"last_prompt_tokens": 1},
+        )
+        gate.gated_thread = older
+        older.start()
+        assert gate.reached.wait(timeout=5)
+
+        # A full rewrite serialized after the parked save persists first.
+        with store._lock:
+            store._entries[entry.session_key].last_prompt_tokens = 2
+        store._save_entries()
+
+        gate.release.set()
+        older.join(timeout=5)
+        assert not older.is_alive()
+
+        assert upserts == []  # the delayed UPSERT was skipped
+        assert _routing_row(store, entry.session_key)["last_prompt_tokens"] == 2
+        store._db.close()


### PR DESCRIPTION
## Problem

On a production deployment with ~1,100 gateway routing keys, per-turn gateway persistence (session resolve + post-turn save) measured ~175ms p50. Profiling attributed ~50ms of that to the routing-index save: every `SessionEntry` re-serialized, a full `DELETE`+`INSERT` of every `gateway_routing` row in state.db, and a multi-MB `sessions.json` dump+fsync — and the steady-state turn pays it **twice** (once in `get_or_create_session`'s healthy-path `updated_at` bump, once in `update_session`), even though both writes only change `updated_at`/`last_prompt_tokens` on a single entry.

## Change

Add `SessionStore._save_entry(session_key)`: persist one routing entry via the existing `HermesDB.save_gateway_routing_entry` UPSERT instead of rewriting the whole index. Only the two metadata-only call sites use it:

- `get_or_create_session`'s healthy path (existing entry, no reset/recover/heal — just the `updated_at` bump)
- `update_session` (`updated_at` / `last_prompt_tokens`)

Structural transitions — create, recover, reset, session switch, prune, and compression-tip heals (anything that changes the key → session_id mapping) — keep the full-rewrite path, which also refreshes the legacy `sessions.json` mirror. Between structural saves the mirror can lag in metadata only; state.db is the primary durable store for routing, so restart rebinding is unaffected.

`update_session` also now runs its SQLite write and peer-record update outside `_lock`, so the commit never blocks concurrent routing lookups.

## Correctness notes

- **Generation guard vs concurrent full rewrites**: the entry is serialized under `_lock` together with the current routing generation. Under `_save_lock`, the UPSERT is skipped when a full snapshot taken *after* our serialize point has already persisted — that snapshot necessarily contains a same-or-newer copy of the key, so writing ours would regress it. A full snapshot *older* than our serialize point that lands after us can only regress that key's metadata by one racing turn (the next turn rewrites it), never the session_id: session_id changes always carry a newer generation and win via the existing guard in `_persist_routing_data`.
- **Torn peer rows**: `update_session` snapshots `session_id`/`origin`/`display_name` while still holding `_lock`, so a concurrent reset that rewrites the entry between lock release and the peer record cannot record a mix of old and new fields.
- **Heals force the full path**: `_heal_compression_tip_locked`'s return value now gates the fast path — a heal rewrites `entry.session_id` and must reach the `sessions.json` mirror too.
- **Fallbacks**: no DB, or a failed UPSERT, falls back to the full rewrite, so DB-less installs keep `sessions.json` — their primary store — durable every turn.

## Tests

New `tests/gateway/test_routing_save_fast_path.py` (13 tests): changed values always land in state.db; restart rebinding works when the `sessions.json` mirror lagged fast-path writes (or was deleted); compression heals and `force_new` transitions still rewrite the mirror; no-DB and failed-UPSERT fallbacks; peer fields snapshotted under `_lock`; generation-guard skip/proceed ordering, including restart rebinding after a skipped idempotent write.

`python -m pytest tests/gateway`: 9,124 tests, no regressions vs a clean checkout of `main` in the same environment (the same set of environment-dependent failures — Telegram/PTB and Feishu SDK version drift, path-completion fixtures — fails identically before and after this change).

## Measured impact

Production deployment of this change at ~1,100 routing keys: metadata-only routing saves dropped from ~50ms (full index rewrite + `sessions.json` dump+fsync, twice per turn) to <1ms per single-row UPSERT. Structural transitions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
