### PR TITLE
fix(kanban): scope worker guidance to task sessions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1207,15 +1207,18 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
-    # Kanban worker/orchestrator lifecycle guidance is session-static:
-    # the dispatcher decides at spawn time whether this process is a kanban
-    # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).
-    # Resolving the ~835-token block once here avoids re-running the
-    # membership test + reference on every system-prompt rebuild
-    # (init + each context compression).
+    # Kanban worker lifecycle guidance is session-static, so resolve it once
+    # here rather than on every system-prompt rebuild. Both gates matter:
+    # HERMES_KANBAN_TASK marks a dispatcher-spawned single-task worker (tool
+    # presence alone is not a worker signal — the kanban toolset can be
+    # enabled outside a worker run), and kanban_show must actually be loaded
+    # (#60119) so the guidance never references tools the session can't call.
     from agent.prompt_builder import KANBAN_GUIDANCE
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        KANBAN_GUIDANCE
+        if os.environ.get("HERMES_KANBAN_TASK")
+        and "kanban_show" in agent.valid_tool_names
+        else ""
     )
 
     # Check tool requirements

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -224,14 +224,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
-    # Kanban worker/orchestrator lifecycle — only present when the
-    # dispatcher spawned this process (kanban_show check_fn gates on
-    # HERMES_KANBAN_TASK env var). Normal chat sessions never see
-    # this block. Resolved once at __init__ (see _kanban_worker_guidance).
+    # Kanban worker lifecycle — only present when the dispatcher spawned this
+    # process for one task (HERMES_KANBAN_TASK env var) and the kanban tools
+    # are loaded. Resolved once at __init__ (see _kanban_worker_guidance).
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+    elif (
+        _kanban_guidance is None
+        and os.environ.get("HERMES_KANBAN_TASK")
+        and "kanban_show" in agent.valid_tool_names
+    ):
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1419,9 +1419,94 @@ def test_kanban_guidance_not_in_normal_prompt(monkeypatch, tmp_path):
         skip_context_files=True,
         skip_memory=True,
     )
+    from agent.prompt_builder import KANBAN_GUIDANCE
+
     prompt = a._build_system_prompt()
-    assert "You are a Kanban worker" not in prompt
+    assert KANBAN_GUIDANCE not in prompt
     assert "kanban_show()" not in prompt
+
+
+def test_kanban_guidance_not_in_orchestrator_prompt(monkeypatch, tmp_path):
+    """An orchestrator profile can expose kanban tools without receiving
+    worker-only lifecycle guidance.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    from run_agent import AIAgent
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    valid_tool_names = getattr(a, "valid_tool_names")
+    assert "kanban_show" in valid_tool_names
+    assert "kanban_list" in valid_tool_names
+
+    from agent.prompt_builder import KANBAN_GUIDANCE
+
+    prompt = a._build_system_prompt()
+    assert KANBAN_GUIDANCE not in prompt
+    assert "kanban_show()" not in prompt
+
+
+def test_kanban_guidance_bypass_path_respects_env_and_tool_gate(monkeypatch, tmp_path):
+    """The system_prompt.py fallback for code paths that bypass agent_init
+    (no ``_kanban_worker_guidance`` attribute set) must:
+    1. Not crash (regression: the fallback references ``os.environ``).
+    2. Only inject guidance when both the env var AND the tool are present
+       (regression: guidance must not reference an unloaded tool — #60119
+       shows HERMES_KANBAN_TASK can be set while kanban_show is still
+       absent from valid_tool_names).
+
+    A real AIAgent always goes through agent_init, which always sets
+    ``_kanban_worker_guidance`` — so the bypass path is simulated by
+    deleting that attribute after construction, same effect as a code path
+    that never calls agent_init's resolution step.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    from run_agent import AIAgent
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert "kanban_show" in a.valid_tool_names
+    del a._kanban_worker_guidance
+
+    from agent.prompt_builder import KANBAN_GUIDANCE
+
+    prompt = a._build_system_prompt()
+    assert KANBAN_GUIDANCE in prompt
+
+    a.valid_tool_names = [n for n in a.valid_tool_names if n != "kanban_show"]
+    prompt_no_tool = a._build_system_prompt()
+    assert KANBAN_GUIDANCE not in prompt_no_tool
 
 
 def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
@@ -1447,9 +1532,11 @@ def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
         skip_context_files=True,
         skip_memory=True,
     )
+    from agent.prompt_builder import KANBAN_GUIDANCE
+
     prompt = a._build_system_prompt()
-    # Header phrase (identity-free — SOUL.md owns identity, layer 3 is protocol)
-    assert "Kanban task execution protocol" in prompt
+    # Full block present verbatim (identity-free — SOUL.md owns identity)
+    assert KANBAN_GUIDANCE in prompt
     # Lifecycle signals
     assert "kanban_show()" in prompt
     assert "kanban_complete" in prompt


### PR DESCRIPTION
## What does this PR do?

Scopes Kanban worker lifecycle guidance (`KANBAN_GUIDANCE`) to sessions the dispatcher actually spawned for a single task, instead of inferring worker status from `kanban_show` tool presence.

`agent_init.py`/`system_prompt.py` decided whether to inject the ~835-token worker-only lifecycle block by checking `"kanban_show" in agent.valid_tool_names`. That conflates two different things: "does this session have the kanban toolset" and "is this session a dispatcher-spawned single-task worker." Orchestrator profiles that explicitly enable the `kanban` toolset (to browse or manage the board outside of a dispatched worker run) get `kanban_show` without being a worker — under the old logic they'd incorrectly receive worker-only lifecycle instructions (block/complete-a-single-task framing) that don't apply to their actual role.

The dispatcher already sets `HERMES_KANBAN_TASK` when spawning a worker for one task — that's the correct, unambiguous signal, and it's the same signal `tools/kanban_tools.py::_check_kanban_mode` already keys off. This is the more targeted fix: switch the prompt-injection gate to match the existing mode-detection gate, rather than introducing a new signal.

## Related Issue

No existing issue matched this specific symptom (searched both open and closed issues/PRs for `kanban_show`, `worker guidance`, `orchestrator kanban` first). Adjacent but distinct: #60119 (toolset assembly never delivers `kanban_*` for platform `cli` — different code path, `hermes_cli/tools_config.py`) and #61222 (`KANBAN_GUIDANCE` wording clarification — doesn't touch the tool-presence-vs-env-var gating this PR fixes). Happy to file a tracking issue first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: `_kanban_worker_guidance` now requires `HERMES_KANBAN_TASK` to be set *and* `kanban_show` to be loaded, instead of tool presence alone — the tool check stays because #60119 shows platform tool assembly can drop the `kanban` toolset even when the env var is set, and the guidance must never reference tools the session can't call
- `agent/system_prompt.py`: the bypass-path fallback (for code paths that skip `agent_init`) applies the same `HERMES_KANBAN_TASK` + `kanban_show` check
- `tests/tools/test_kanban_tools.py`: added regression coverage proving an orchestrator session with the `kanban` toolset enabled but no `HERMES_KANBAN_TASK` does not receive worker lifecycle guidance, and that the bypass-path fallback respects both the env var and tool gates

## How to Test

1. Orchestrator profile with the `kanban` toolset explicitly enabled, no dispatcher task: `hermes -p <orchestrator-profile> chat -q "call kanban_show for task t_x"` — system prompt should **not** contain the worker-only lifecycle block.
2. Dispatcher-spawned worker: `HERMES_KANBAN_TASK=t_x hermes -p <profile> chat -q "call kanban_show"` — system prompt **should** contain worker lifecycle guidance, unchanged from current behavior.
3. `pytest tests/tools/test_kanban_tools.py -q` — new cases assert both of the above directly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu, dev container)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A — no user-facing docs describe this internal gating logic)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys changed)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A — no architecture/workflow change)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — no tool schema changed, only when the guidance text is injected)*

## Screenshots / Logs

Full test suite (`scripts/run_tests.sh`, this repo's CI-parity runner) against current `upstream/main` (`c7e09f257`): all tests passed, 0 failures.