### PR TITLE
fix(plugins): hook delivery parity foundation (#64178)

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -293,6 +293,22 @@ def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
     return _parse_hooks_block(cfg.get("hooks"))
 
 
+def re_register_config_hooks() -> None:
+    """Re-register shell hooks from config after a plugin force-reload.
+
+    ``PluginManager.discover_and_load(force=True)`` clears the plugin manager's
+    ``_hooks`` dict, which silently drops shell hooks that were registered from
+    ``config.yaml`` at startup.  Clear the idempotence set and re-run
+    ``register_from_config()`` so hooks are wired again (#60036 / PR #60267;
+    tracking #64178).
+    """
+    with _registered_lock:
+        _registered.clear()
+    from hermes_cli.config import load_config
+
+    register_from_config(load_config())
+
+
 def reset_for_tests() -> None:
     """Clear the idempotence set.  Test-only helper."""
     with _registered_lock:

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -181,6 +181,11 @@ class PlatformRegistry:
         # actually asks for that platform (gateway start, cron delivery,
         # `hermes setup`/`gateway status`, send_message).
         self._deferred: dict[str, Callable[[], None]] = {}
+        # Displaced entries preserved on override so unregister() can restore
+        # the prior adapter (e.g. a built-in shadowed by a plugin that is later
+        # disabled) instead of leaving the name unbound (teknium1 review on
+        # #64188). LIFO stack per name for chained overrides.
+        self._displaced: dict[str, list[PlatformEntry]] = {}
 
     # -- deferred loading ----------------------------------------------------
 
@@ -244,13 +249,32 @@ class PlatformRegistry:
                 prev.source,
                 entry.source,
             )
+            # Preserve the displaced adapter so unregister() can restore it.
+            self._displaced.setdefault(entry.name, []).append(prev)
         self._entries[entry.name] = entry
         logger.debug("Registered platform adapter: %s (%s)", entry.name, entry.source)
 
     def unregister(self, name: str) -> bool:
-        """Remove a platform entry.  Returns True if it existed."""
+        """Remove a platform entry.  Returns True if it existed.
+
+        If the entry had displaced a prior adapter via override, the most
+        recently displaced entry is restored rather than leaving the name
+        unbound (teknium1 review on #64188).
+        """
         self._deferred.pop(name, None)
-        return self._entries.pop(name, None) is not None
+        existed = self._entries.pop(name, None) is not None
+        stack = self._displaced.get(name)
+        if stack:
+            restored = stack.pop()
+            if not stack:
+                self._displaced.pop(name, None)
+            self._entries[name] = restored
+            logger.info(
+                "Platform '%s': restored displaced adapter (%s) after removal",
+                name,
+                restored.source,
+            )
+        return existed
 
     def get(self, name: str) -> Optional[PlatformEntry]:
         """Look up a platform entry by name."""

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -175,12 +175,18 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
     it through.
     """
     try:
+        # invoke_hook lazy-discovers plugins (#64178 / #59775) — explicit
+        # discover keeps behavior obvious if that guarantee changes.
+        # invoke_hook routes through lifecycle so first-party observers fire
+        # alongside compatibility plugin hooks.
         from hermes_cli.lifecycle import invoke_hook
+        from hermes_cli.plugins import discover_plugins
         from hermes_cli.profiles import get_active_profile_name
         try:
             profile_name = get_active_profile_name()
         except Exception:
             profile_name = "default"
+        discover_plugins()
         invoke_hook(event, task_id=task_id, profile_name=profile_name, **fields)
     except Exception as exc:  # pragma: no cover - defensive
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1309,6 +1309,9 @@ class PluginManager:
             self._discovered = True
             return
         if force:
+            # Unload from global registries BEFORE clearing manager bookkeeping,
+            # so force-reload does not leave stale tools/platforms (#60050).
+            self._unload_global_plugin_registrations()
             self._plugins.clear()
             self._hooks.clear()
             self._middleware.clear()
@@ -1329,9 +1332,66 @@ class PluginManager:
         self._discovered = True
         try:
             self._discover_and_load_inner()
+            if force:
+                # Shell hooks live in manager._hooks but are not plugin-owned;
+                # re-register them after the clear+rescan (#60036 / PR #60267).
+                self._re_register_shell_hooks_after_force()
         except BaseException:
             self._discovered = False
             raise
+
+    def _unload_global_plugin_registrations(self) -> None:
+        """Remove plugin tools/platforms from process-global registries.
+
+        ``discover_and_load(force=True)`` historically only cleared PluginManager
+        internal maps. Tools and platforms registered into the process-global
+        ``tools.registry`` / ``platform_registry`` survived, so disabled plugins
+        left zombie entries (#60050, tracking #64178).
+        """
+        tool_names = list(self._plugin_tool_names)
+        platform_names = list(self._plugin_platform_names)
+        if tool_names:
+            try:
+                from tools.registry import registry as tool_registry
+
+                for name in tool_names:
+                    try:
+                        tool_registry.deregister(name)
+                    except Exception as exc:
+                        logger.debug(
+                            "force-reload: tool deregister %s failed: %s",
+                            name,
+                            exc,
+                        )
+            except Exception as exc:
+                logger.debug("force-reload: tools.registry unavailable: %s", exc)
+        if platform_names:
+            try:
+                from gateway.platform_registry import platform_registry
+
+                for name in platform_names:
+                    try:
+                        platform_registry.unregister(name)
+                    except Exception as exc:
+                        logger.debug(
+                            "force-reload: platform unregister %s failed: %s",
+                            name,
+                            exc,
+                        )
+            except Exception as exc:
+                logger.debug(
+                    "force-reload: platform_registry unavailable: %s", exc
+                )
+
+    def _re_register_shell_hooks_after_force(self) -> None:
+        """Restore config.yaml shell hooks wiped by force-clear of ``_hooks`."""
+        try:
+            from agent.shell_hooks import re_register_config_hooks
+
+            re_register_config_hooks()
+        except Exception as exc:
+            # Import cycle / missing module must not abort force reload.
+            logger.debug("force-reload shell-hook re-register skipped: %s", exc)
 
     def _discover_and_load_inner(self) -> None:
         """The actual discovery sweep — see :meth:`discover_and_load`."""
@@ -2046,13 +2106,20 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+_plugin_manager_lock = threading.Lock()
 
 
 def get_plugin_manager() -> PluginManager:
-    """Return (and lazily create) the global PluginManager singleton."""
+    """Return (and lazily create) the global PluginManager singleton.
+
+    Creation is double-checked under a lock so concurrent first access cannot
+    orphan a second manager (#24714 / tracking #64178).
+    """
     global _plugin_manager
     if _plugin_manager is None:
-        _plugin_manager = PluginManager()
+        with _plugin_manager_lock:
+            if _plugin_manager is None:
+                _plugin_manager = PluginManager()
     return _plugin_manager
 
 
@@ -2068,17 +2135,32 @@ def discover_plugins(force: bool = False) -> None:
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     """Invoke a lifecycle hook on loaded plugins.
 
+    Ensures plugins are discovered on first invocation so callers in processes
+    that never explicitly call ``discover_plugins()`` (e.g. the gateway, which
+    uses its own ``HookRegistry`` for platform events) still fire callbacks
+    registered by user plugins (tracking #64178; salvage direction of #59775).
+
     Returns a list of non-``None`` return values from plugin callbacks.
     """
-    return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+    pm = get_plugin_manager()
+    # getattr so test mocks that replace get_plugin_manager() with a
+    # SimpleNamespace don't break.
+    if not getattr(pm, "_discovered", True):
+        pm.discover_and_load()
+    return pm.invoke_hook(hook_name, **kwargs)
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
     """Invoke registered middleware callbacks.
 
+    Lazy-discovers plugins on first use — same guarantee as :func:`invoke_hook`.
+
     Returns a list of non-``None`` return values from middleware callbacks.
     """
-    return get_plugin_manager().invoke_middleware(kind, **kwargs)
+    pm = get_plugin_manager()
+    if not getattr(pm, "_discovered", True):
+        pm.discover_and_load()
+    return pm.invoke_middleware(kind, **kwargs)
 
 
 def has_middleware(kind: str) -> bool:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1277,6 +1277,20 @@ class PluginManager:
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
         self._discovered: bool = False
+        # Serializes initial discovery so a concurrent first caller cannot
+        # observe ``_discovered = True`` (set up front as a same-thread
+        # re-entrancy guard) and start invoking hooks before
+        # ``_discover_and_load_inner()`` has finished registering callbacks
+        # (teknium1 review on #64188). Re-entrant (RLock) so a plugin's
+        # register() transitively triggering discovery on the SAME thread
+        # still works.
+        self._discovery_lock = threading.RLock()
+        # Thread id currently running a discovery sweep. Used as a same-thread
+        # re-entrancy guard: a plugin's register() can transitively call
+        # discover_plugins() on the SAME thread, and we must let that fall
+        # through (returning immediately) rather than recursing or deadlocking,
+        # WITHOUT prematurely publishing _discovered=True to other threads.
+        self._discovering_thread: Optional[int] = None
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
         self._plugin_skills: Dict[str, Dict[str, Any]] = {}
@@ -1304,10 +1318,35 @@ class PluginManager:
         """
         if self._discovered and not force:
             return
+        # Same-thread re-entrancy: a plugin's register() called during the
+        # sweep may transitively trigger discovery again on this thread. Let
+        # it fall through immediately — the in-progress sweep owns completion.
+        if self._discovering_thread == threading.get_ident():
+            return
+        with self._discovery_lock:
+            # Re-check after acquiring: a concurrent first caller may have
+            # completed discovery while we waited on the lock. Because
+            # _discovered is only published AFTER the sweep fully finishes,
+            # a racing caller either does real work here or observes a fully
+            # built manager — never a half-built one.
+            if self._discovered and not force:
+                return
+            self._discovering_thread = threading.get_ident()
+            try:
+                self._discover_and_load_locked(force=force)
+            finally:
+                self._discovering_thread = None
+
+    def _discover_and_load_locked(self, force: bool = False) -> None:
         if env_var_enabled("HERMES_SAFE_MODE"):
             logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
             self._discovered = True
             return
+        # NOTE: _discovered is published only after the sweep below completes
+        # (not up front). Same-thread re-entrancy is handled by
+        # _discovering_thread in discover_and_load, so we no longer need the
+        # early _discovered=True re-entrancy guard that used to expose a
+        # half-built manager to concurrent first callers.
         if force:
             # Unload from global registries BEFORE clearing manager bookkeeping,
             # so force-reload does not leave stale tools/platforms (#60050).
@@ -1323,13 +1362,11 @@ class PluginManager:
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
             self._context_engine = None
-        # Set the flag up front as a re-entrancy guard (a plugin's register()
-        # can transitively trigger discovery again), but reset it if the sweep
-        # raises so a failed scan is NOT cached as "discovered with an empty
-        # registry" — callers swallow the exception and would otherwise be
-        # permanently stranded on the early-return above (the "No web provider
-        # configured" class of failures).
-        self._discovered = True
+        # Publish _discovered only after the sweep succeeds. A failed scan must
+        # NOT be cached as "discovered with an empty registry" — callers swallow
+        # the exception and would otherwise be permanently stranded on the
+        # early-return above (the "No web provider configured" class of
+        # failures).
         try:
             self._discover_and_load_inner()
             if force:
@@ -1339,6 +1376,7 @@ class PluginManager:
         except BaseException:
             self._discovered = False
             raise
+        self._discovered = True
 
     def _unload_global_plugin_registrations(self) -> None:
         """Remove plugin tools/platforms from process-global registries.

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -943,6 +943,121 @@ class TestLazyDiscoverAndSingleton:
         plat_reg.unregister.assert_called_with("zombie_platform")
 
 
+class TestRegistryOverrideRestore:
+    """Displaced entries are restored on removal (teknium1 review on #64188).
+
+    Uses the REAL registries rather than mocks so the actual replace/restore
+    lifecycle is exercised.
+    """
+
+    def _schema(self, name):
+        return {"name": name, "description": f"{name} desc", "parameters": {}}
+
+    def test_tool_override_then_deregister_restores_builtin(self):
+        from tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+
+        def builtin_handler():  # pragma: no cover - identity marker only
+            return "builtin"
+
+        def plugin_handler():  # pragma: no cover - identity marker only
+            return "plugin"
+
+        reg.register(
+            name="shared_tool", toolset="builtins",
+            schema=self._schema("shared_tool"), handler=builtin_handler,
+            check_fn=None,
+        )
+        # Non-plugin caller override is permitted without opt-in.
+        reg.register(
+            name="shared_tool", toolset="plugin_ts",
+            schema=self._schema("shared_tool"), handler=plugin_handler,
+            check_fn=None, override=True,
+        )
+        assert reg.get_entry("shared_tool").toolset == "plugin_ts"
+
+        # Removing the overriding entry restores the original built-in.
+        reg.deregister("shared_tool")
+        restored = reg.get_entry("shared_tool")
+        assert restored is not None
+        assert restored.toolset == "builtins"
+        assert restored.handler is builtin_handler
+
+    def test_tool_no_displacement_deregisters_clean(self):
+        from tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        reg.register(
+            name="solo_tool", toolset="builtins",
+            schema=self._schema("solo_tool"), handler=lambda: None,
+            check_fn=None,
+        )
+        reg.deregister("solo_tool")
+        assert reg.get_entry("solo_tool") is None
+
+    def test_platform_override_then_unregister_restores(self):
+        from gateway.platform_registry import PlatformRegistry, PlatformEntry
+
+        reg = PlatformRegistry()
+        builtin = PlatformEntry(
+            name="chat", label="Chat",
+            adapter_factory=lambda cfg: None, check_fn=lambda: True,
+            source="builtin",
+        )
+        plugin = PlatformEntry(
+            name="chat", label="Chat",
+            adapter_factory=lambda cfg: None, check_fn=lambda: True,
+            source="plugin",
+        )
+        reg.register(builtin)
+        reg.register(plugin)
+        assert reg.get("chat").source == "plugin"
+
+        reg.unregister("chat")
+        restored = reg.get("chat")
+        assert restored is not None
+        assert restored.source == "builtin"
+
+
+class TestDiscoveryConcurrency:
+    """Initial discovery is serialized so concurrent first callers never see a
+    half-built manager (teknium1 review on #64188)."""
+
+    def test_concurrent_first_discovery_completes_before_invoke(self, monkeypatch):
+        import threading
+        import concurrent.futures
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        observed_incomplete = []
+
+        def slow_inner(self_inner):
+            # Simulate the window between _discovered=True and callback
+            # registration; a racing caller must NOT proceed past the lock.
+            import time
+            time.sleep(0.05)
+            self_inner._hooks.setdefault("on_x", []).append(lambda **k: "ok")
+
+        monkeypatch.setattr(PluginManager, "_discover_and_load_inner", slow_inner)
+        monkeypatch.setattr(
+            PluginManager, "_re_register_shell_hooks_after_force",
+            lambda s: None,
+        )
+
+        def worker():
+            mgr.discover_and_load()
+            # By the time discover_and_load returns, hooks must be registered.
+            if not mgr._hooks.get("on_x"):
+                observed_incomplete.append(True)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+            list(ex.map(lambda _: worker(), range(8)))
+
+        assert not observed_incomplete
+        assert mgr._hooks.get("on_x")
+
+
 class TestPreToolCallBlocking:
     """Tests for the pre_tool_call block directive helper."""
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -841,6 +841,108 @@ class TestPluginHooks:
 
         assert any("on_banana" in record.message for record in caplog.records)
 
+
+
+
+class TestLazyDiscoverAndSingleton:
+    """Hook delivery guarantees for #64178 (lazy discover + singleton lock)."""
+
+    def test_module_level_invoke_hook_lazily_discovers_plugins(self, tmp_path, monkeypatch):
+        """invoke_hook discovers when manager has not been loaded yet."""
+        called = []
+
+        def _cb(**kw):
+            called.append(kw)
+            return "ok"
+
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "lazy_discover",
+            register_body='ctx.register_hook("kanban_task_claimed", lambda **kw: None)',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        import hermes_cli.plugins as _plugins_mod
+
+        monkeypatch.setattr(_plugins_mod, "_plugin_manager", None)
+
+        pm = _plugins_mod.get_plugin_manager()
+        pm._hooks["test_hook"] = [_cb]
+
+        results = _plugins_mod.invoke_hook("test_hook", task_id="t1")
+
+        assert len(called) == 1
+        assert results == ["ok"]
+        assert pm.has_hook("kanban_task_claimed")
+
+    def test_module_level_invoke_middleware_lazily_discovers(self, tmp_path, monkeypatch):
+        import hermes_cli.plugins as _plugins_mod
+
+        monkeypatch.setattr(_plugins_mod, "_plugin_manager", None)
+
+        called = []
+
+        def _mw(**kw):
+            called.append(kw)
+            return "mw-ok"
+
+        pm = _plugins_mod.get_plugin_manager()
+        pm._middleware["test_mw"] = [_mw]
+
+        results = _plugins_mod.invoke_middleware("test_mw")
+
+        assert len(called) == 1
+        assert results == ["mw-ok"]
+
+    def test_get_plugin_manager_thread_safe_singleton(self, monkeypatch):
+        import hermes_cli.plugins as _plugins_mod
+        import concurrent.futures
+
+        monkeypatch.setattr(_plugins_mod, "_plugin_manager", None)
+        ids = []
+
+        def _get():
+            ids.append(id(_plugins_mod.get_plugin_manager()))
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
+            list(ex.map(lambda _: _get(), range(64)))
+        assert len(set(ids)) == 1
+
+    def test_force_reload_deregisters_tools_from_global_registry(self, monkeypatch):
+        """force=True removes plugin tools via tools.registry.deregister (#60050)."""
+        from unittest.mock import MagicMock
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr._plugin_tool_names.add("zombie_tool")
+        mgr._plugin_platform_names.add("zombie_platform")
+        mgr._discovered = True
+
+        tool_reg = MagicMock()
+        plat_reg = MagicMock()
+
+        import tools.registry as tool_mod
+        import gateway.platform_registry as plat_mod
+
+        monkeypatch.setattr(tool_mod, "registry", tool_reg, raising=False)
+        # package may expose registry differently; patch where unload imports
+        monkeypatch.setattr(
+            "tools.registry.registry", tool_reg, raising=False
+        )
+        monkeypatch.setattr(
+            "gateway.platform_registry.platform_registry", plat_reg, raising=False
+        )
+        monkeypatch.setattr(PluginManager, "_discover_and_load_inner", lambda self_inner: None)
+        monkeypatch.setattr(
+            PluginManager, "_re_register_shell_hooks_after_force", lambda self_inner: None
+        )
+
+        mgr.discover_and_load(force=True)
+        tool_reg.deregister.assert_called_with("zombie_tool")
+        plat_reg.unregister.assert_called_with("zombie_platform")
+
+
 class TestPreToolCallBlocking:
     """Tests for the pre_tool_call block directive helper."""
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -225,6 +225,12 @@ class ToolRegistry:
         # code that defined the handler, independent of WHEN the register() call
         # happens (sync during load, or a delayed/threaded callback afterwards).
         self._plugin_override_policy: Dict[str, bool] = {}
+        # When an override=True register() displaces an existing entry, stash
+        # the displaced ToolEntry here keyed by name so a later deregister()
+        # (e.g. plugin disabled / force-reload teardown) can restore the
+        # original instead of leaving the slot empty (teknium1 review on
+        # #64188 / #60050). LIFO stack per name handles chained overrides.
+        self._displaced_tools: Dict[str, List["ToolEntry"]] = {}
         self._toolset_checks: Dict[str, Callable] = {}
         self._toolset_aliases: Dict[str, str] = {}
         # MCP dynamic refresh can mutate the registry while other threads are
@@ -411,6 +417,10 @@ class ToolRegistry:
                         "(override=True opt-in)",
                         name, toolset, existing.toolset,
                     )
+                    # Preserve the displaced entry so removing the overriding
+                    # tool later restores the original (e.g. a built-in tool
+                    # shadowed by a plugin that is subsequently disabled).
+                    self._displaced_tools.setdefault(name, []).append(existing)
                 else:
                     # Reject every cross-toolset shadow, including MCP-to-MCP
                     # collisions. Legitimate MCP reconnect/refresh re-registers
@@ -498,6 +508,26 @@ class ToolRegistry:
                         f"opt-in (allow_tool_override)."
                     )
             del self._tools[name]
+            # If this entry had displaced a prior one (override=True), restore
+            # the most-recently displaced entry instead of leaving the slot
+            # empty (teknium1 review on #64188). Restoration is a direct map
+            # write — it re-instates the original built-in/tool that was there
+            # before the override, and does not re-run override policy checks.
+            stack = self._displaced_tools.get(name)
+            if stack:
+                restored = stack.pop()
+                if not stack:
+                    self._displaced_tools.pop(name, None)
+                self._tools[name] = restored
+                if restored.check_fn and restored.toolset not in self._toolset_checks:
+                    self._toolset_checks[restored.toolset] = restored.check_fn
+                self._generation += 1
+                logger.info(
+                    "Tool '%s': restored displaced toolset '%s' after removal "
+                    "of overriding entry",
+                    name, restored.toolset,
+                )
+                return
             # Drop the toolset check and aliases if this was the last tool in
             # that toolset.
             toolset_still_exists = any(


### PR DESCRIPTION
## Summary

Phase-0 reliability foundation for **#64178** (part of Teknium’s plugin interface expansion tracking **#64182**).

Makes hook/middleware delivery reliable without expanding the plugin *API surface*:

1. **Lazy discovery** in module-level `invoke_hook` / `invoke_middleware` so processes that never call `discover_plugins()` (notably gateway / kanban path) still load user plugins and fire hooks.
2. Explicit `discover_plugins()` in kanban lifecycle fire path (belt + suspenders).
3. **Thread-safe** `get_plugin_manager()` creation (double-checked lock) for #24714-class races.
4. **Symmetric force-reload (partial)**: before clearing manager maps, unload plugin tools/platforms from process-global `tools.registry` / `platform_registry` (#60050).
5. **Shell hooks survive force-reload**: re-register config.yaml shell hooks after force clear of `_hooks` (#60036).

### Credit / salvage
- Lazy-discover + test direction: **#59775** (@magicbluesmoke)
- `re_register_config_hooks` shape: **#60267** (@webtecnica)

Those original PRs remain open. This consolidates the #64178 acceptance core on current `main` with registry teardown added. Maintainers may close or narrow the precursor PRs after merge.

## Not in this PR (follow-ups)
- Full multi-surface spawn matrix (slash_worker / TUI / cron / kanban subprocess) as hard e2e fixtures — can stack next.
- Idempotent hook registration / logical_id dedupe (#49828) — intentional leave-alone to keep this PR small.
- Manifest v2 / versioning (#64179, #64165) — separate waves.

## Test plan
- [x] `pytest tests/hermes_cli/test_plugins.py` (120 passed locally)
- [x] New: lazy discover hook/middleware, singleton race, force-reload global deregister
- [ ] CI on this PR

Closes nothing by itself until CI + maintainer review; targets **#64178**.