### PR TITLE
fix(tests): isolate systemd checks across platforms

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1536,6 +1536,11 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        # Bypass user-scope preflight — this test exercises the restart flow,
+        # not D-Bus availability. Fails on macOS/WSL/Docker where linger is
+        # disabled and the user systemd socket is absent. (See sibling tests
+        # in TestSystemdServiceRefresh for the same pattern.)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
@@ -1581,6 +1586,9 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        # Bypass user-scope preflight (D-Bus availability — not the focus of
+        # this test; fails on macOS/WSL/Docker without linger).
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -1640,6 +1648,9 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        # Bypass user-scope preflight (D-Bus availability — not the focus of
+        # this test; fails on macOS/WSL/Docker without linger).
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
         monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
@@ -1670,6 +1681,9 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        # Bypass user-scope preflight (D-Bus availability — not the focus of
+        # this test; fails on macOS/WSL/Docker without linger).
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
 
 import pytest
 
@@ -204,51 +205,42 @@ def test_subprocess_killall_hermes_blocked():
 # ──────────────────── pass-through cases (must NOT raise) ──────
 
 
+def _systemctl_pass_through(cmd):
+    """Exercise the real guard without requiring a ``systemctl`` binary.
+
+    The Python child ignores the trailing arguments, while the guard still
+    inspects their complete command string. This verifies the allowlist rather
+    than replacing the guarded ``subprocess.run`` wrapper with a mock.
+    """
+    probe = [sys.executable, "-c", "pass", "--", *cmd]
+    result = subprocess.run(probe, capture_output=True, text=True, check=False)
+    assert result.returncode == 0
+
+
 def test_systemctl_status_passes_through():
     """Read-only systemctl probes (status/show/list-units) are fine."""
-    # Run with check=False so we don't fail on the gateway's exit code.
-    r = subprocess.run(
-        ["systemctl", "--user", "status", "hermes-gateway", "--no-pager"],
-        capture_output=True,
-        text=True,
-        check=False,
+    _systemctl_pass_through(
+        ["systemctl", "--user", "status", "hermes-gateway", "--no-pager"]
     )
-    assert r is not None  # Did not raise — the guard let it through.
 
 
 def test_systemctl_show_passes_through():
-    r = subprocess.run(
-        ["systemctl", "--user", "show", "hermes-gateway", "--no-pager"],
-        capture_output=True,
-        text=True,
-        check=False,
+    _systemctl_pass_through(
+        ["systemctl", "--user", "show", "hermes-gateway", "--no-pager"]
     )
-    assert r is not None
 
 
 def test_systemctl_list_units_passes_through():
-    r = subprocess.run(
-        ["systemctl", "--user", "list-units", "fake-not-real-unit*", "--no-pager"],
-        capture_output=True,
-        text=True,
-        check=False,
+    _systemctl_pass_through(
+        ["systemctl", "--user", "list-units", "fake-not-real-unit*", "--no-pager"]
     )
-    assert r is not None
 
 
 def test_systemctl_unrelated_unit_passes_through():
-    """systemctl restart of a non-hermes unit is allowed (we only protect hermes)."""
-    # Use --dry-run so we don't actually try to restart anything; just
-    # verify the guard doesn't block the call. systemctl supports
-    # --dry-run via the privileged API; on user scope it usually fails
-    # quickly without side effects.
-    r = subprocess.run(
-        ["systemctl", "--user", "show", "fake-not-real-unit"],
-        capture_output=True,
-        text=True,
-        check=False,
+    """Read-only probes of unrelated units are also allowed."""
+    _systemctl_pass_through(
+        ["systemctl", "--user", "show", "fake-not-real-unit"]
     )
-    assert r is not None
 
 
 def test_kill_own_subtree_passes_through():


### PR DESCRIPTION
## Summary

- isolate user-systemd restart tests from the host's real D-Bus/session state
- exercise live-system-guard allowlist behavior without requiring a `systemctl` binary
- keep production code unchanged and preserve guard coverage on macOS, Windows, WSL, containers, and Linux

## Why

These unit tests currently fail on non-systemd hosts because they reach real platform facilities after all behavior-relevant collaborators have already been mocked. The live-system-guard self-tests also execute `systemctl` merely to prove the guard allowed the command, causing `FileNotFoundError` on macOS.

The revised self-test runs a harmless Python child whose trailing arguments contain the exact `systemctl` command string. The real guard wrapper still inspects and allows that command, so the test does not bypass the boundary it claims to cover.

## Verification

Baseline on current `origin/main` (`226e8de82`):

- 8 failures across the two changed files on macOS

This branch:

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/test_live_system_guard_self_test.py`
- 222 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed

## Scope

Test-only; no production behavior changes.

The separate existing PR #10861 already addresses the two WSL test failures, so this PR intentionally does not duplicate that file.
