### PR TITLE
fix(kanban): reject unsafe assignees before dispatch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2376,12 +2376,14 @@ def _claimer_id() -> str:
 # ---------------------------------------------------------------------------
 
 def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
-    """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
+    """Return a normalized, filesystem-safe Kanban assignee."""
     if assignee is None:
         return None
-    from hermes_cli.profiles import normalize_profile_name
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
 
-    return normalize_profile_name(assignee)
+    normalized = normalize_profile_name(assignee)
+    validate_profile_name(normalized)
+    return normalized
 
 
 def create_task(

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -377,6 +377,10 @@ def profile_exists(name: str) -> bool:
     canon = normalize_profile_name(name)
     if canon == "default":
         return True
+    try:
+        validate_profile_name(canon)
+    except ValueError:
+        return False
     return get_profile_dir(canon).is_dir()
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -222,6 +222,22 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+@pytest.mark.parametrize(
+    "assignee",
+    [
+        "<profile> | priority: <1|2|3> | body: <instructions>",
+        "builder|priority:1",
+        "a" * 65,
+    ],
+)
+def test_create_task_rejects_non_filesystem_safe_assignee(kanban_home, assignee):
+    with kb.connect() as conn, pytest.raises(ValueError, match="Invalid profile name"):
+        kb.create_task(conn, title="must not poison dispatcher", assignee=assignee)
+
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn) == []
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -89,6 +89,14 @@ class TestNormalizeProfileName:
             normalize_profile_name("   ")
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["<profile> | priority: <1|2|3>", "builder|priority:1", "a" * 65],
+)
+def test_profile_exists_rejects_unsafe_name_without_filesystem_probe(profile_env, name):
+    assert profiles.profile_exists(name) is False
+
+
 class TestValidateProfileName:
     """Tests for validate_profile_name()."""
 


### PR DESCRIPTION
## Summary
- Rejects unsafe/non-filesystem-safe Kanban assignee values before dispatch paths can probe profile directories.
- Reuses the profile-name validator in profile existence checks so shell fragments and overlong names fail closed.
- Adds regression coverage for unsafe assignees at task creation and profile lookup boundaries.

## Receipts
- Targeted unsafe-assignee tests: `python -m pytest tests/hermes_cli/test_kanban_db.py::test_create_task_rejects_non_filesystem_safe_assignee tests/hermes_cli/test_profiles.py::test_profile_exists_rejects_unsafe_name_without_filesystem_probe -q -o 'addopts='` → 6 passed.
- Clean upstream base: branch created from `origin/main` at `226e8de82` in a fresh clone.
