### PR TITLE
fix(cli): propagate subcommand exit codes

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14778,10 +14778,10 @@ def main():
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
+        return args.func(args)
     else:
         parser.print_help()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_main_exit_codes.py
+++ b/tests/hermes_cli/test_main_exit_codes.py
@@ -1,0 +1,12 @@
+"""Regression tests for top-level Hermes CLI exit-code propagation."""
+
+import sys
+
+from hermes_cli import main as cli
+
+
+def test_main_returns_subcommand_exit_code(monkeypatch):
+    monkeypatch.setattr(cli, "cmd_kanban", lambda _args: 7)
+    monkeypatch.setattr(sys, "argv", ["hermes", "kanban", "list"])
+
+    assert cli.main() == 7


### PR DESCRIPTION
## Summary
- Preserves nonzero return codes from dispatched CLI subcommands instead of always returning success from the top-level wrapper.
- Keeps successful subcommands returning 0 while allowing failures to propagate to shells, scripts, and CI.
- Adds a focused regression test around `hermes_cli.main.main()` dispatch behavior.

## Receipts
- Exit-code regression: `python -m pytest tests/hermes_cli/test_main_exit_codes.py -q -o 'addopts='` → 1 passed.
- Clean upstream base: branch created from `origin/main` at `226e8de82` in a fresh clone.
