### PR TITLE
fix(cron): keep approval context task-local

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2740,11 +2740,6 @@ def run_job(
 
     agent = None
 
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
-
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
     from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
@@ -2774,6 +2769,7 @@ def run_job(
         platform="",
         chat_id="",
         chat_name="",
+        cron_session=True,
     )
     _cron_delivery_vars = (
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -92,6 +92,10 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+# True only while a scheduled job is running. This must be task-local: the cron
+# scheduler also runs inside the long-lived messaging gateway, where a
+# process-global marker would misclassify later interactive turns as cron.
+_CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
 
 # Whether the current session's delivery channel can route an ASYNC completion
 # back to the agent AFTER the current turn ends (i.e. wake a fresh turn).
@@ -133,6 +137,7 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_CRON_SESSION": _CRON_SESSION,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
@@ -169,6 +174,7 @@ def set_session_vars(
     cwd: str = "",
     async_delivery: bool = True,
     ui_session_id: str = "",
+    cron_session: bool = False,
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -203,6 +209,7 @@ def set_session_vars(
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
+        _CRON_SESSION.set("1" if cron_session else ""),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
     ]
     try:
@@ -238,6 +245,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _CRON_SESSION,
     ):
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -958,13 +958,26 @@ class TestDeliverResultErrorReturns:
 
 
 class TestRunJobSessionPersistence:
-    def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
+    def test_run_job_passes_session_db_and_cron_platform(self, tmp_path, monkeypatch):
+        from gateway.session_context import get_session_env
+
         job = {
             "id": "test-job",
             "name": "test",
             "prompt": "hello",
         }
         fake_db = MagicMock()
+        cron_contexts = []
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+        def run_conversation(*_args, **_kwargs):
+            cron_contexts.append(
+                (
+                    get_session_env("HERMES_CRON_SESSION"),
+                    os.environ.get("HERMES_CRON_SESSION"),
+                )
+            )
+            return {"final_response": "ok"}
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
@@ -982,11 +995,14 @@ class TestRunJobSessionPersistence:
              ), \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent.run_conversation.side_effect = run_conversation
             mock_agent_cls.return_value = mock_agent
 
             success, output, final_response, error = run_job(job)
 
+        assert cron_contexts == [("1", None)]
+        assert "HERMES_CRON_SESSION" not in os.environ
+        assert get_session_env("HERMES_CRON_SESSION") == ""
         assert success is True
         assert error is None
         assert final_response == "ok"

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -84,6 +84,20 @@ def test_session_source_uses_contextvars(monkeypatch):
     assert get_session_env("HERMES_SESSION_SOURCE") == ""
 
 
+def test_cron_marker_is_task_local_and_suppresses_stale_process_state(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    interactive_tokens = set_session_vars(platform="telegram")
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+    clear_session_vars(interactive_tokens)
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+
+    cron_tokens = set_session_vars(cron_session=True)
+    assert get_session_env("HERMES_CRON_SESSION") == "1"
+    clear_session_vars(cron_tokens)
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+
+
 def test_clear_session_env_restores_previous_state(monkeypatch):
     """_clear_session_env should restore contextvars to their pre-handler values."""
     runner = object.__new__(GatewayRunner)

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -359,6 +359,19 @@ class TestCronModeInteractions:
         result = check_dangerous_command("rm -rf /tmp/stuff", "local")
         assert result["approved"]
 
+    def test_interactive_context_ignores_stale_process_cron_marker(self, monkeypatch):
+        """A completed cron job must not turn a later gateway turn into cron."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        from tools.approval import _is_cron_approval_context
+
+        tokens = set_session_vars(platform="telegram")
+        try:
+            assert not _is_cron_approval_context()
+        finally:
+            clear_session_vars(tokens)
+
 
 class TestCronWithGatewayOrigin:
     """Cron jobs originating from a gateway platform must NOT be treated as gateway.
@@ -380,7 +393,9 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="123")
+        tokens = set_session_vars(
+            platform="telegram", chat_id="123", cron_session=True
+        )
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
@@ -402,7 +417,9 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="discord", chat_id="456")
+        tokens = set_session_vars(
+            platform="discord", chat_id="456", cron_session=True
+        )
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
@@ -422,7 +439,9 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="789")
+        tokens = set_session_vars(
+            platform="telegram", chat_id="789", cron_session=True
+        )
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -103,8 +103,7 @@ class TestRequestToolApproval:
     def test_cron_deny_mode_blocks(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "env_var_enabled",
-                            lambda v: v == "HERMES_CRON_SESSION")
+        monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: True)
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is False
@@ -113,8 +112,7 @@ class TestRequestToolApproval:
     def test_cron_approve_mode_allows(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "env_var_enabled",
-                            lambda v: v == "HERMES_CRON_SESSION")
+        monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: True)
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "approve")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -224,6 +224,16 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_approval_context() -> bool:
+    """True only for the task-local scheduled-job execution context."""
+    try:
+        from gateway.session_context import get_session_env
+
+        return is_truthy_value(get_session_env("HERMES_CRON_SESSION", ""))
+    except Exception:
+        return env_var_enabled("HERMES_CRON_SESSION")
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -238,7 +248,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2170,7 +2180,7 @@ def _run_approval_gate(
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -2697,7 +2707,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -3118,7 +3128,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,


### PR DESCRIPTION
## Summary

- make `HERMES_CRON_SESSION` task-local via the existing gateway `ContextVar` session state
- stop `run_job()` from permanently mutating the gateway process environment
- make all approval gates resolve cron status through the context-local marker

## Bug

The cron scheduler runs inside the long-lived messaging gateway, but `run_job()` sets:

```python
os.environ["HERMES_CRON_SESSION"] = "1"
```

and never clears it. After the first scheduled job, later interactive Telegram turns are classified as cron. In a live DM, `execute_code` consequently returned:

```text
BLOCKED: ... Cron jobs run without a user present to approve it.
```

instead of routing through the interactive approval flow.

## Verification

```text
scripts/run_tests.sh \
  tests/gateway/test_session_env.py \
  tests/tools/test_cron_approval_mode.py \
  tests/tools/test_execute_code_approval_cluster.py \
  tests/tools/test_request_tool_approval.py \
  tests/cron/test_scheduler.py -q

301 passed
```

The scheduler test also asserts that cron context is visible during the agent turn while `os.environ` remains untouched, and that cleanup removes the task-local marker.
