### PR TITLE
fix(tests): make paths and modes portable on macOS

### DIFF
--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -335,16 +335,22 @@ class TestRunBackgroundTask:
         )
 
         try:
+            # Canonicalize the expected paths the same way the runtime
+            # does: on macOS, ``tempfile.mkdtemp`` under ``/tmp`` resolves
+            # through ``/private/tmp``. Comparing the raw ``/tmp/...``
+            # strings would falsely fail there even though the call was
+            # wired correctly.
+            _canon = _os.path.realpath
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert _canon(mock_adapter.send_voice.call_args.kwargs["audio_path"]) == _canon(_ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert _canon(mock_adapter.send_video.call_args.kwargs["video_path"]) == _canon(_mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert _canon(mock_adapter.send_image_file.call_args.kwargs["image_path"]) == _canon(_png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert _canon(mock_adapter.send_document.call_args.kwargs["file_path"]) == _canon(_pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -450,8 +450,11 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
+    # macOS may clear setgid when the directory's group is not in the
+    # caller's groups; sticky and ordinary permissions remain contractual.
+    event_mode = stat.S_IMODE(event.stat().st_mode)
+    assert event_mode & ~stat.S_ISGID == 0o1730, (
+        f"event/ mode = {oct(event_mode)}, want 01730 plus optional setgid"
     )
 
     # supervise/ dir.
@@ -462,7 +465,8 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    supervise_event_mode = stat.S_IMODE(supervise_event.stat().st_mode)
+    assert supervise_event_mode & ~stat.S_ISGID == 0o1730
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -497,7 +501,8 @@ def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     log_control = log_supervise / "control"
 
     assert log_event.is_dir()
-    assert stat.S_IMODE(log_event.stat().st_mode) == 0o3730
+    log_event_mode = stat.S_IMODE(log_event.stat().st_mode)
+    assert log_event_mode & ~stat.S_ISGID == 0o1730
     assert log_supervise.is_dir()
     assert log_supervise_event.is_dir()
     assert log_control.exists() and stat.S_ISFIFO(log_control.stat().st_mode)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -120,13 +120,14 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
-        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
-            for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
-                    False,
-                    None,
-                    None,
-                )
+        temp_root = os.path.realpath(tempfile.gettempdir())
+        for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
+            path = os.path.join(temp_root, f"{prefix}example.py")
+            assert detect_dangerous_command(f"rm -f {path}") == (
+                False,
+                None,
+                None,
+            )
 
     def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
         real_temp = tmp_path / "real-temp"

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -75,9 +76,16 @@ class TestWriteFileHandler:
         mock_get.return_value = mock_ops
 
         from tools.file_tools import write_file_tool
+        # Canonicalize both sides — realpath("/tmp/...") is "/private/tmp/..."
+        # on macOS. The portable contract is "the same file path was written";
+        # the platform's symlink resolution is a kernel detail we don't want
+        # to bake into the assertion.
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        _real = os.path.realpath
+        mock_ops.write_file.assert_called_once_with(
+            _real("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -182,7 +190,13 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        # Canonicalize the path arg so macOS /tmp → /private/tmp symlink
+        # resolution doesn't make the assertion brittle. The portable
+        # contract is "the same file was patched"; the platform's symlink
+        # layer is a kernel detail we don't want to bake in.
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "foo", "bar", False
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -193,9 +207,13 @@ class TestPatchHandler:
         mock_get.return_value = mock_ops
 
         from tools.file_tools import patch_tool
+        # See TestWriteFileHandler.test_writes_content for the macOS
+        # /tmp → /private/tmp canonicalization rationale.
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "x", "y", True
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):


### PR DESCRIPTION
## Summary

- compare temporary paths using their canonical filesystem identity on macOS
- derive approval cleanup paths from the platform's canonical temporary directory
- preserve sticky and ordinary event-directory permission checks while tolerating macOS clearing setgid for a group the caller does not belong to
- keep production code unchanged

## Baseline

Current `origin/main` (`226e8de82`) on macOS:

- 7 failures across the four changed test files
- `/tmp/...` expectations disagreed with runtime `/private/tmp/...` paths
- event directories requested as `03730` were observed as `01730` because macOS cleared setgid

## Verification

- `scripts/run_tests.sh tests/gateway/test_background_command.py tests/tools/test_file_tools.py tests/tools/test_approval.py tests/hermes_cli/test_service_manager.py`
- 452 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed

## Scope

Test-only portability fix. Linux still resolves `/tmp` to itself, and the permission assertions continue to require sticky plus the complete ordinary permission mask.
