### PR TITLE
fix(cli): respect the .hub path boundary

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1043,7 +1043,7 @@ def discord_skill_commands_by_category(
             sp = _P(skill_path).resolve()
             # Hub skills are loaded via the skill hub, not surfaced as
             # slash commands.
-            if str(sp).startswith(str(_hub_dir)):
+            if sp.is_relative_to(_hub_dir):
                 continue
             # Accept skill if it lives under any scan root; record the
             # matching root so we can derive the category correctly.

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1914,18 +1914,29 @@ class TestDiscordSkillCommandsByCategory:
         assert uncategorized[0][0] == "dogfood"
 
     def test_hub_skills_excluded(self, tmp_path, monkeypatch):
-        """Skills under .hub should be excluded."""
+        """Skills under .hub, but not sibling directories, should be excluded."""
         from unittest.mock import patch
 
         fake_skills_dir = str(tmp_path / "skills")
         (tmp_path / "skills" / ".hub" / "some-skill").mkdir(parents=True, exist_ok=True)
         (tmp_path / "skills" / ".hub" / "some-skill" / "SKILL.md").write_text("")
+        (tmp_path / "skills" / ".hub-backup" / "other-skill").mkdir(
+            parents=True, exist_ok=True
+        )
+        (tmp_path / "skills" / ".hub-backup" / "other-skill" / "SKILL.md").write_text(
+            ""
+        )
 
         fake_cmds = {
             "/some-skill": {
                 "name": "some-skill",
                 "description": "Hub skill",
                 "skill_md_path": f"{fake_skills_dir}/.hub/some-skill/SKILL.md",
+            },
+            "/other-skill": {
+                "name": "other-skill",
+                "description": "Sibling skill",
+                "skill_md_path": f"{fake_skills_dir}/.hub-backup/other-skill/SKILL.md",
             },
         }
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1937,7 +1948,9 @@ class TestDiscordSkillCommandsByCategory:
                 reserved_names=set(),
             )
 
-        assert categories == {}
+        assert categories == {
+            ".hub-backup": [("other-skill", "Sibling skill", "/other-skill")]
+        }
         assert uncategorized == []
 
     def test_deep_nested_skills_use_top_category(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Skill-command discovery currently excludes paths with a string-prefix check. That makes a valid sibling such as `.hub-backup/other-skill` look like a descendant of `.hub` and silently omits it.

This replaces the string-prefix comparison with `Path.is_relative_to()` after the existing path resolution, so only `.hub` itself and its real descendants are excluded.

## Related Issue

No matching issue or PR was found in the duplicate search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/commands.py`: use path-component ancestry for the hub exclusion.
- `tests/hermes_cli/test_commands.py`: verify `.hub` stays excluded while `.hub-backup` remains discoverable.

## How to Test

1. Run the commands test file through the required `scripts/run_tests.sh` wrapper.
2. Confirm `test_hub_skills_excluded` includes the sibling skill and excludes the actual hub skill.
3. Run targeted Ruff lint.

Observed validation:

- Test-first regression: failed before the source change, passed afterward
- Required wrapper, commands test file: **173 passed**
- Targeted Ruff lint: **passed**
- `git diff --check`: **passed**

The full approximately 17k-test suite, provider integrations, gateways, and npm workspaces were not run.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and issues for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added a regression test
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A
- [x] Contributor/architecture documentation update is N/A
- [x] Cross-platform impact was considered; `Path.is_relative_to()` is supported by Python 3.11+
- [x] Tool description/schema update is N/A

## Screenshots / Logs

Not applicable.