### PR TITLE
fix(lsp): hide Windows language-server consoles

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -62,6 +62,7 @@ from agent.lsp.protocol import (
     make_response,
     read_message,
 )
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 logger = logging.getLogger("agent.lsp.client")
 
@@ -263,13 +264,16 @@ class LSPClient:
             cmd = self._win_wrap_cmd(cmd)
 
         try:
-            # start_new_session=True detaches the LSP server into its own
-            # process group / session. Without this, the LSP server inherits
-            # the gateway's pgid (= TUI parent PID). When mcp_tool's
-            # _kill_orphaned_mcp_children races with LSP spawn and sweeps the
-            # gateway's child set, it captures the LSP PID, records the
-            # inherited pgid, and killpg() then kills the TUI parent itself.
-            # See tui_gateway_crash.log "killpg → SIGTERM received" stacks.
+            # POSIX needs a separate session so an orphan-child sweep cannot
+            # kill the TUI's process group. Windows ignores
+            # start_new_session, so use CREATE_NO_WINDOW there instead: LSP
+            # servers are stdio-only background children and must not open a
+            # transient console, while their pipes and lifecycle stay intact.
+            session_kwargs: Dict[str, Any] = (
+                {"creationflags": windows_hide_flags()}
+                if sys.platform == "win32"
+                else {"start_new_session": True}
+            )
             self._proc = await asyncio.create_subprocess_exec(
                 cmd[0],
                 *cmd[1:],
@@ -278,7 +282,7 @@ class LSPClient:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
                 cwd=self._cwd,
-                start_new_session=True,
+                **session_kwargs,
             )
         except FileNotFoundError as e:
             raise LSPProtocolError(

--- a/tests/agent/lsp/test_windows_no_window.py
+++ b/tests/agent/lsp/test_windows_no_window.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agent.lsp import client as client_module
+from agent.lsp.client import LSPClient
+from hermes_cli import _subprocess_compat
+
+
+_CREATE_NO_WINDOW = 0x08000000
+
+
+class _EOFStream:
+    async def readline(self) -> bytes:
+        return b""
+
+    async def readuntil(self, _separator: bytes) -> bytes:
+        raise asyncio.IncompleteReadError(partial=b"", expected=None)
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.returncode = None
+        self.stdout = _EOFStream()
+        self.stderr = _EOFStream()
+
+
+@pytest.mark.asyncio
+async def test_lsp_spawn_hides_background_console_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_argv: tuple[str, ...] = ()
+    captured_kwargs: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*argv: str, **kwargs: object) -> _FakeProcess:
+        nonlocal captured_argv, captured_kwargs
+        captured_argv = argv
+        captured_kwargs = kwargs
+        return _FakeProcess()
+
+    monkeypatch.setattr(client_module.sys, "platform", "win32")
+    monkeypatch.setattr(_subprocess_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(
+        client_module.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=["typescript-language-server.cmd", "--stdio"],
+    )
+
+    await client._spawn()
+    await asyncio.sleep(0)
+
+    assert captured_argv[:3] == ("cmd.exe", "/c", "typescript-language-server.cmd")
+    assert captured_kwargs.get("creationflags") == _CREATE_NO_WINDOW
+    assert "start_new_session" not in captured_kwargs
+
+
+@pytest.mark.asyncio
+async def test_lsp_spawn_keeps_separate_session_on_posix(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*_argv: str, **kwargs: object) -> _FakeProcess:
+        nonlocal captured_kwargs
+        captured_kwargs = kwargs
+        return _FakeProcess()
+
+    monkeypatch.setattr(client_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        client_module.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    client = LSPClient(
+        server_id="typescript",
+        workspace_root=str(tmp_path),
+        command=["typescript-language-server", "--stdio"],
+    )
+
+    await client._spawn()
+    await asyncio.sleep(0)
+
+    assert captured_kwargs.get("start_new_session") is True
+    assert "creationflags" not in captured_kwargs


### PR DESCRIPTION
## Summary
- use `CREATE_NO_WINDOW` for Windows LSP subprocesses while retaining stdio pipes and normal termination
- preserve the existing separate-session behavior on POSIX
- cover both platform contracts with focused regression tests

## Root cause
Windows ignores `start_new_session=True`. Headless LSP launches that route npm `.cmd` shims through `cmd.exe` could therefore open transient Windows Terminal windows. A bounded top-level-window probe reproduced a new `CASCADIA_HOSTING_WINDOW_CLASS` window on the existing code and no new window with this change.

## Verification
- `pytest tests/agent/lsp/test_windows_no_window.py -q` — 2 passed
- `pytest tests/agent/lsp tests/test_windows_subprocess_no_window_flags.py -q -k 'not normalize_path_expands_tilde'` — 175 passed, 1 deselected
- `python scripts/check-windows-footguns.py --all` — 760 files scanned, no findings
- `uvx ruff check agent/lsp/client.py tests/agent/lsp/test_windows_no_window.py` — passed
- `git diff --check` — passed

The one deselected test is the existing Windows `HOME`/`expanduser` expectation in `test_normalize_path_expands_tilde`; it is unrelated to this change.
