### PR TITLE
fix(security): keep model caches owner-only

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -168,6 +168,7 @@ def _save_model_metadata_disk_cache(data: Dict[str, Dict[str, Any]]) -> None:
             data,
             indent=0,
             separators=(",", ":"),
+            mode=0o600,
         )
     except Exception as e:
         logger.debug("Failed to save OpenRouter model metadata disk cache: %s", e)

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -53,7 +53,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_cli import __version__ as _HERMES_VERSION
-from utils import atomic_replace
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -219,12 +219,7 @@ def _read_disk_cache() -> tuple[dict[str, Any] | None, float]:
 def _write_disk_cache(data: dict[str, Any]) -> None:
     path = _cache_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, indent=2)
-            fh.write("\n")
-        atomic_replace(tmp, path)
+        atomic_json_write(path, data, indent=2, mode=0o600)
     except OSError as exc:
         logger.info("model catalog cache write failed: %s", exc)
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -10,6 +10,8 @@ Coverage levels:
   Persistent cache       — save/load, corruption, update, provider isolation
 """
 
+import os
+import stat
 import time
 
 import pytest
@@ -1213,6 +1215,8 @@ class TestFetchModelMetadata:
             fetch_model_metadata(force_refresh=True)
 
         assert cache_path.exists()
+        if os.name != "nt":
+            assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
         assert "live/model" in cache_path.read_text(encoding="utf-8")
 
     def test_network_failure_falls_back_to_stale_disk_cache(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -108,6 +109,8 @@ class TestFetchSuccess:
 
         cache_file = model_catalog._cache_path()
         assert cache_file.exists()
+        if os.name != "nt":
+            assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600
         with open(cache_file) as fh:
             assert json.load(fh) == manifest
 


### PR DESCRIPTION
## Summary

- create OpenRouter metadata and model-catalog caches with owner-only `0600` permissions
- route model-catalog writes through the shared atomic JSON writer
- verify permissions on POSIX while retaining the existing content assertions on Windows

## Why

These caches contain locally selected/provider-derived model metadata and previously inherited the process umask. Explicit owner-only modes align them with Hermes' other private state files.

## Verification

- `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/hermes_cli/test_model_catalog.py`
- 150 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
