### PR TITLE
fix(doctor): recognize configured MoA orchestration

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -751,7 +751,9 @@ def run_doctor(args):
                     PROVIDER_REGISTRY,
                     resolve_provider as _resolve_auth_provider,
                 )
-                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto"}
+                known_providers = set(PROVIDER_REGISTRY.keys()) | {
+                    "openrouter", "custom", "auto", "moa"
+                }
             except Exception:
                 _resolve_auth_provider = None
                 pass
@@ -815,7 +817,7 @@ def run_doctor(args):
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
 
-            if provider and provider != "auto":
+            if provider and provider not in {"auto", "moa"}:
                 if catalog_provider is None or (
                     known_providers
                     and not (provider_ids_to_accept & valid_provider_ids)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -517,6 +517,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("kilocode", "anthropic/claude-sonnet-4.6"),
         ("kimi-coding", "kimi-k2"),
         ("nvidia", "qwen/qwen3.5-122b-a10b"),
+        ("moa", "MOA7"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(


### PR DESCRIPTION
## Summary

- recognize the configured `moa` orchestration provider in `hermes doctor`
- avoid treating `moa` as a credential-bearing catalog provider
- add `moa` to the existing provider-ID acceptance coverage

## Why

`moa` is an orchestration layer, not a standalone model API provider. A valid MoA configuration should not produce an unknown-provider or missing-credentials warning.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py`
- 67 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
