### PR TITLE
fix(security): harden backups and write staging

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import time
 import zipfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -24,6 +25,35 @@ from typing import Any, Dict, List, Optional
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _secure_zip_writer(out_path: Path):
+    """Atomically create an owner-only zip, independent of process umask."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{out_path.name}.", suffix=".tmp", dir=str(out_path.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        else:  # Windows has no os.fchmod; mkstemp is exclusive, then tighten by path.
+            os.chmod(tmp_path, 0o600)
+        with os.fdopen(fd, "w+b") as raw:
+            with zipfile.ZipFile(raw, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+                yield zf
+            raw.flush()
+            os.fsync(raw.fileno())
+        os.replace(tmp_path, out_path)
+        os.chmod(out_path, 0o600)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -381,7 +411,7 @@ def run_backup(args) -> None:
     errors = []
     t0 = time.monotonic()
 
-    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+    with _secure_zip_writer(out_path) as zf:
         for i, (abs_path, rel_path) in enumerate(files_to_add, 1):
             try:
                 # Safe copy for SQLite databases (handles WAL mode)
@@ -1178,7 +1208,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
         return None
 
     try:
-        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        with _secure_zip_writer(out_path) as zf:
             for abs_path, rel_path in files_to_add:
                 try:
                     if abs_path.suffix == ".db":
@@ -1283,7 +1313,8 @@ def create_pre_update_backup(
 
     backup_dir = _pre_update_backup_dir(hermes_root)
     try:
-        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(backup_dir, 0o700)
     except OSError as exc:
         logger.warning("Could not create pre-update backup dir %s: %s", backup_dir, exc)
         return None
@@ -1360,7 +1391,8 @@ def create_pre_migration_backup(
     # update-backup listing pick up pre-migration archives too.
     backup_dir = _pre_update_backup_dir(hermes_root)
     try:
-        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(backup_dir, 0o700)
     except OSError as exc:
         logger.warning("Could not create pre-migration backup dir %s: %s", backup_dir, exc)
         return None

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -3,6 +3,8 @@
 import json
 import os
 import sqlite3
+import stat
+import sys
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -191,6 +193,18 @@ class TestShouldExclude:
 # ---------------------------------------------------------------------------
 
 class TestBackup:
+    def test_secure_writer_without_fchmod_remains_portable(self, tmp_path, monkeypatch):
+        """Windows lacks os.fchmod; backup creation must still succeed."""
+        from hermes_cli.backup import _secure_zip_writer
+
+        monkeypatch.delattr(os, "fchmod", raising=False)
+        out_zip = tmp_path / "portable.zip"
+        with _secure_zip_writer(out_zip) as zf:
+            zf.writestr("probe.txt", "ok")
+
+        with zipfile.ZipFile(out_zip) as zf:
+            assert zf.read("probe.txt") == b"ok"
+
     def test_creates_zip(self, tmp_path, monkeypatch):
         """Backup creates a valid zip containing expected files."""
         hermes_home = tmp_path / ".hermes"
@@ -224,6 +238,9 @@ class TestBackup:
             assert "logs/agent.log" in names
             # Skins
             assert "skins/cyber.yaml" in names
+
+        if not sys.platform.startswith("win"):
+            assert stat.S_IMODE(out_zip.stat().st_mode) == 0o600
 
     def test_db_snapshots_staged_beside_output_zip(self, tmp_path, monkeypatch):
         """SQLite staging temp files must be created on the output zip's
@@ -1883,6 +1900,9 @@ class TestPreUpdateBackup:
         assert out.parent == hermes_home / "backups"
         assert out.name.startswith("pre-update-")
         assert out.suffix == ".zip"
+        if not sys.platform.startswith("win"):
+            assert stat.S_IMODE(out.parent.stat().st_mode) == 0o700
+            assert stat.S_IMODE(out.stat().st_mode) == 0o600
 
     def test_backup_contents_match_full_backup(self, hermes_home):
         """Pre-update backup should include the same user data that

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -9,6 +9,8 @@ subcommand dispatch.
 
 import json
 import os
+import stat
+import sys
 import tempfile
 import shutil
 
@@ -235,6 +237,42 @@ def test_pending_store_roundtrip(hermes_home):
     assert wa.discard_pending("memory", rec["id"]) is True
     assert wa.pending_count("memory") == 0
     assert wa.get_pending("memory", rec["id"]) is None
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+def test_pending_store_uses_owner_only_permissions(hermes_home):
+    from pathlib import Path
+    from tools import write_approval as wa
+
+    rec = wa.stage_write(
+        "skills", {"action": "create", "name": "private"},
+        summary="private proposal", origin="background_review",
+    )
+    root = Path(hermes_home) / "pending"
+    record = root / "skills" / f"{rec['id']}.json"
+
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(record.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(record.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+def test_pending_store_preserves_group_shared_home(hermes_home):
+    from pathlib import Path
+    from tools import write_approval as wa
+
+    home = Path(hermes_home)
+    home.chmod(0o770)
+    rec = wa.stage_write(
+        "skills", {"action": "create", "name": "shared"},
+        summary="shared proposal", origin="background_review",
+    )
+    root = home / "pending"
+    record = root / "skills" / f"{rec['id']}.json"
+
+    assert stat.S_IMODE(root.stat().st_mode) & 0o070 == 0o070
+    assert stat.S_IMODE(record.parent.stat().st_mode) & 0o070 == 0o070
+    assert stat.S_IMODE(record.stat().st_mode) == 0o660
 
 
 # ---------------------------------------------------------------------------

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -111,6 +111,17 @@ def _pending_dir(subsystem: str) -> Path:
     return get_hermes_home() / "pending" / subsystem
 
 
+def _pending_store_modes() -> tuple[int, int]:
+    """Preserve an explicitly group-writable HERMES_HOME sharing contract."""
+    if os.name != "nt":
+        try:
+            if get_hermes_home().stat().st_mode & 0o020:
+                return 0o2770, 0o660
+        except OSError:
+            pass
+    return 0o700, 0o600
+
+
 def stage_write(subsystem: str, payload: Dict[str, Any],
                 *, summary: str, origin: str) -> Dict[str, Any]:
     """Persist a pending write and return a short record describing it.
@@ -141,11 +152,27 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
     }
     try:
         d = _pending_dir(subsystem)
-        d.mkdir(parents=True, exist_ok=True)
+        dir_mode, file_mode = _pending_store_modes()
+        d.mkdir(parents=True, exist_ok=True, mode=dir_mode)
+        # Pending records can contain prompts, source code, and memory entries.
+        # Keep stock installs owner-only, while preserving an explicit
+        # group-writable HERMES_HOME used by managed CLI/gateway deployments.
+        os.chmod(d.parent, dir_mode)
+        os.chmod(d, dir_mode)
         path = d / f"{pid}.json"
         tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        data = json.dumps(record, ensure_ascii=False, indent=2)
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, file_mode)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+            os.chmod(path, file_mode)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
     return record


### PR DESCRIPTION
## Summary

- write backup archives through an owner-only atomic temporary file, flush them, then replace the destination
- keep pre-update and pre-migration backup directories owner-only
- create pending approval records atomically with explicit permissions independent of umask
- retain an explicitly group-writable `HERMES_HOME` contract for managed shared deployments

## Security rationale

Backup archives and pending approval records can contain configuration, prompts, source code, memory entries, and other private state. Inheriting a permissive process umask can expose that state to other local users.

Stock installations remain `0700`/`0600`. A deliberately group-writable Hermes home remains `02770`/`0660` rather than being silently broken.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/tools/test_write_approval.py`
- 182 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed

## Scope

This PR excludes dependency-floor changes already covered by #63099 and excludes webhook binding changes that belong in a separate PR.
