### PR TITLE
fix(webhook): require explicit public bind consent

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -30,7 +30,7 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_HOST = "0.0.0.0"
+DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8646
 DEFAULT_WEBHOOK_PATH = "/msgraph/webhook"
 DEFAULT_MAX_SEEN_RECEIPTS = 5000

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -77,7 +77,7 @@ _BUILTIN_DELIVER_PLATFORMS = {
     "qqbot", "yuanbao",
 }
 
-DEFAULT_HOST = "0.0.0.0"
+DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
@@ -106,6 +106,15 @@ def _is_loopback_host(host: str) -> bool:
     return host.strip().lower() in _LOOPBACK_HOSTS
 
 
+def _explicit_bool(value: Any) -> bool:
+    """Accept only explicit boolean consent, never generic object truthiness."""
+    if value is True:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return False
+
+
 def check_webhook_requirements() -> bool:
     """Check if webhook adapter dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -118,6 +127,9 @@ class WebhookAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.WEBHOOK)
         self._host: str = config.extra.get("host", DEFAULT_HOST)
         self._port: int = int(config.extra.get("port", DEFAULT_PORT))
+        self._allow_public_bind: bool = _explicit_bool(
+            config.extra.get("allow_public_bind", False)
+        )
         self._global_secret: str = config.extra.get("secret", "")
         self._static_routes: Dict[str, dict] = config.extra.get("routes", {})
         self._dynamic_routes: Dict[str, dict] = {}
@@ -209,6 +221,13 @@ class WebhookAdapter(BasePlatformAdapter):
                         f"deliver is '{deliver}'. Direct delivery requires a "
                         f"real target (telegram, discord, slack, github_comment, etc.)."
                     )
+
+        if not _is_loopback_host(self._host) and not self._allow_public_bind:
+            raise ValueError(
+                f"[webhook] Refusing non-loopback bind '{self._host}' without "
+                "explicit allow_public_bind=true. Public webhook ingress must "
+                "use authenticated routes and explicit operator consent."
+            )
 
         # client_max_size makes aiohttp enforce the cap on every read path,
         # including Transfer-Encoding: chunked bodies that carry no

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -33,7 +33,7 @@ Optional / Phase-3+:
 - WHATSAPP_CLOUD_APP_SECRET       (HMAC key for X-Hub-Signature-256)
 - WHATSAPP_CLOUD_WABA_ID          (analytics / future use)
 - WHATSAPP_CLOUD_VERIFY_TOKEN     (hub.verify_token shared secret)
-- WHATSAPP_CLOUD_WEBHOOK_HOST     (default 0.0.0.0)
+- WHATSAPP_CLOUD_WEBHOOK_HOST     (default 127.0.0.1; set explicitly for public ingress)
 - WHATSAPP_CLOUD_WEBHOOK_PORT     (default 8090)
 - WHATSAPP_CLOUD_WEBHOOK_PATH     (default /whatsapp/webhook)
 - WHATSAPP_CLOUD_API_VERSION      (default v20.0)
@@ -86,7 +86,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_API_VERSION = "v20.0"
-DEFAULT_WEBHOOK_HOST = "0.0.0.0"
+DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
 GRAPH_API_BASE = "https://graph.facebook.com"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1933,8 +1933,10 @@ def _setup_webhooks():
     print_success("Webhooks enabled! Next steps:")
     from hermes_constants import display_hermes_home as _dhh
     print_info(f"   1. Define webhook routes in {_dhh()}/config.yaml")
-    print_info("   2. Point your service (GitHub, GitLab, etc.) at:")
-    print_info("      http://your-server:8644/webhooks/<route-name>")
+    print_info("   2. Test the loopback-only default at:")
+    print_info("      http://127.0.0.1:8644/webhooks/<route-name>")
+    print_warning("   Direct public ingress is opt-in: set extra.host to 0.0.0.0")
+    print_warning("   and extra.allow_public_bind to true in config.yaml.")
     print()
     print_info("   Route configuration guide:")
     print_info("   https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/#configuring-routes")

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -96,7 +96,7 @@ def _is_webhook_enabled() -> bool:
 
 def _get_webhook_base_url() -> str:
     wh = _get_webhook_config().get("extra", {})
-    host = wh.get("host", "0.0.0.0")
+    host = wh.get("host", "127.0.0.1")
     port = wh.get("port", 8644)
     display_host = "localhost" if host == "0.0.0.0" else host
     return f"http://{display_host}:{port}"
@@ -115,9 +115,13 @@ def _setup_hint() -> str:
        webhook:
          enabled: true
          extra:
-           host: "0.0.0.0"
+           host: "127.0.0.1"
            port: 8644
            secret: "your-global-hmac-secret"
+
+     For intentional direct public ingress, also set:
+           host: "0.0.0.0"
+           allow_public_bind: true
 
   3. Or set environment variables in {_dhh}/.env:
      WEBHOOK_ENABLED=true

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -9,6 +9,12 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_o
 from gateway.platforms.msgraph_webhook import AIOHTTP_AVAILABLE, MSGraphWebhookAdapter
 
 
+def test_default_host_is_loopback():
+    from gateway.platforms.msgraph_webhook import DEFAULT_HOST
+
+    assert DEFAULT_HOST == "127.0.0.1"
+
+
 def _make_adapter(**extra_overrides) -> MSGraphWebhookAdapter:
     extra = {
         "host": "127.0.0.1",

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -46,6 +46,7 @@ def _make_config(
     rate_limit=30,
     max_body_bytes=1_048_576,
     host="0.0.0.0",
+    allow_public_bind=False,
     port=0,  # let OS pick a free port in tests
 ):
     """Build a PlatformConfig suitable for WebhookAdapter."""
@@ -55,6 +56,7 @@ def _make_config(
         "routes": routes or {},
         "rate_limit": rate_limit,
         "max_body_bytes": max_body_bytes,
+        "allow_public_bind": allow_public_bind,
     }
     if secret:
         extra["secret"] = secret
@@ -65,6 +67,11 @@ def _make_adapter(routes=None, **kwargs):
     """Create a WebhookAdapter with sensible defaults for testing."""
     config = _make_config(routes=routes, **kwargs)
     return WebhookAdapter(config)
+
+
+def test_default_bind_is_loopback_only():
+    adapter = WebhookAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter._host == "127.0.0.1"
 
 
 def _create_app(adapter: WebhookAdapter) -> web.Application:
@@ -1515,10 +1522,31 @@ class TestInsecureNoAuthSafetyRail:
         assert _is_loopback_host(host) is False
 
     @pytest.mark.asyncio
-    async def test_connect_allows_real_secret_on_public_bind(self):
-        """A real HMAC secret bound to 0.0.0.0 is the normal production case."""
+    async def test_connect_rejects_real_secret_without_public_bind_consent(self):
         routes = {"r1": {"secret": "real-secret-abc123", "prompt": "x"}}
         adapter = _make_adapter(routes=routes, host="0.0.0.0", port=0)
+        with pytest.raises(ValueError, match="allow_public_bind=true"):
+            await adapter.connect()
+
+    @pytest.mark.parametrize(
+        "configured_value",
+        [False, "false", "False", "0", "no", "off", "", None, "unexpected"],
+    )
+    def test_public_bind_consent_rejects_false_like_values(self, configured_value):
+        adapter = _make_adapter(allow_public_bind=configured_value)
+        assert adapter._allow_public_bind is False
+
+    @pytest.mark.parametrize("configured_value", [True, "true", "1", "yes", "on"])
+    def test_public_bind_consent_accepts_explicit_truthy_values(self, configured_value):
+        adapter = _make_adapter(allow_public_bind=configured_value)
+        assert adapter._allow_public_bind is True
+
+    @pytest.mark.asyncio
+    async def test_connect_allows_real_secret_with_public_bind_consent(self):
+        routes = {"r1": {"secret": "real-secret-abc123", "prompt": "x"}}
+        adapter = _make_adapter(
+            routes=routes, host="0.0.0.0", port=0, allow_public_bind=True
+        )
         try:
             with patch.object(adapter, "_reload_dynamic_routes"):
                 result = await adapter.connect()

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -21,6 +21,12 @@ import pytest
 from gateway.config import Platform
 
 
+def test_default_webhook_host_is_loopback():
+    from gateway.platforms.whatsapp_cloud import DEFAULT_WEBHOOK_HOST
+
+    assert DEFAULT_WEBHOOK_HOST == "127.0.0.1"
+
+
 @pytest.fixture(autouse=True)
 def _whatsapp_open_optin(monkeypatch):
     """Opt into WhatsApp allow-all for the file's dispatch-mechanics tests.

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -7,11 +7,18 @@ import stat
 from argparse import Namespace
 
 from hermes_cli.webhook import (
-    webhook_command,
     _load_subscriptions,
     _save_subscriptions,
+    _setup_hint,
     _subscriptions_path,
+    webhook_command,
 )
+
+
+def test_setup_hint_defaults_to_loopback_and_documents_public_consent():
+    hint = _setup_hint()
+    assert 'host: "127.0.0.1"' in hint
+    assert "allow_public_bind: true" in hint
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- default built-in webhook listeners to loopback instead of all interfaces
- require explicit boolean `allow_public_bind` consent before the generic webhook adapter binds a non-loopback host
- update CLI/setup guidance to show the safe default and explicit public-ingress opt-in

## Security rationale

Enabling a webhook platform should not silently expose an unauthenticated or misconfigured listener on every network interface. Public ingress remains supported, but it now requires an operator to choose both a public host and explicit consent.

## Verification

- `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py tests/gateway/test_msgraph_webhook.py tests/gateway/test_whatsapp_cloud.py tests/hermes_cli/test_webhook_cli.py tests/hermes_cli/test_setup.py`
- 282 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
