### PR TITLE
fix(security): enforce runtime tool scope before middleware

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -263,6 +263,21 @@ def _tool_search_scoped_names(agent) -> frozenset:
     return names
 
 
+def _session_tool_scope_block(agent, function_name: str) -> Optional[str]:
+    """Reject direct calls that are absent from this session's tool schema.
+
+    Some agent-runtime tools bypass ``model_tools.handle_function_call`` and
+    therefore need the same authoritative scope check at this dispatch layer.
+    Older test doubles without ``valid_tool_names`` retain legacy behavior.
+    """
+    if not hasattr(agent, "valid_tool_names"):
+        return None
+    valid_tool_names = getattr(agent, "valid_tool_names", None)
+    if valid_tool_names is None or function_name in valid_tool_names:
+        return None
+    return f"'{function_name}' is not available in this session."
+
+
 def _apply_tool_request_middleware_for_agent(
     agent,
     *,
@@ -396,10 +411,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # scope check), so we enforce session toolset scope HERE. A tool
         # the session was not granted is rejected before any checkpoint,
         # hook, or dispatch fires.
-        _ts_scope_block = None
+        _ts_scope_block = _session_tool_scope_block(agent, function_name)
         try:
             from tools import tool_search as _ts
-            if function_name == _ts.TOOL_CALL_NAME:
+            if _ts_scope_block is None and function_name == _ts.TOOL_CALL_NAME:
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):
@@ -415,13 +430,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         except Exception:
             pass
 
-        function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
-            agent,
-            function_name=function_name,
-            function_args=function_args,
-            effective_task_id=effective_task_id,
-            tool_call_id=getattr(tool_call, "id", "") or "",
-        )
+        middleware_trace = []
+        if _ts_scope_block is None:
+            function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+            )
 
         # ── Block evaluation (BEFORE checkpoint preflight) ───────────
         # We must know whether the tool will execute before touching
@@ -1070,10 +1087,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Tool Search unwrap — see execute_tool_calls_concurrent for full
         # rationale, including the scope gate (the unwrap dispatches the
         # underlying tool directly, so session toolset scope is enforced here).
-        _ts_scope_block: Optional[str] = None
+        _ts_scope_block: Optional[str] = _session_tool_scope_block(
+            agent, function_name
+        )
         try:
             from tools import tool_search as _ts
-            if function_name == _ts.TOOL_CALL_NAME:
+            if _ts_scope_block is None and function_name == _ts.TOOL_CALL_NAME:
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):
@@ -1087,13 +1106,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         except Exception:
             pass
 
-        function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
-            agent,
-            function_name=function_name,
-            function_args=function_args,
-            effective_task_id=effective_task_id,
-            tool_call_id=getattr(tool_call, "id", "") or "",
-        )
+        middleware_trace = []
+        if _ts_scope_block is None:
+            function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+            )
 
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2248,6 +2248,7 @@ class TestExecuteToolCalls:
         assert "search result" in messages[0]["content"]
 
     def test_sequential_memory_remove_notifies_provider_with_tool_result(self, agent):
+        agent.valid_tool_names.add("memory")
         old_text = "stale preference entry"
         tc = _mock_tool_call(
             name="memory",
@@ -2887,6 +2888,7 @@ class TestConcurrentToolExecution:
         assert completes == [("c1", "web_search", {"query": "hello"}, '{"success": true}')]
 
     def test_sequential_browser_type_callbacks_redact_api_key(self, agent):
+        agent.valid_tool_names.add("browser_type")
         secret = "sk-proj-ABCD1234567890EFGH"
         tool_call = _mock_tool_call(
             name="browser_type",
@@ -2932,6 +2934,7 @@ class TestConcurrentToolExecution:
         assert {entry[3] for entry in completes} == {'{"id":1}', '{"id":2}'}
 
     def test_concurrent_browser_type_callbacks_redact_api_key(self, agent):
+        agent.valid_tool_names.add("browser_type")
         secret = "sk-proj-ABCD1234567890EFGH"
         tc = _mock_tool_call(
             name="browser_type",
@@ -3012,6 +3015,7 @@ class TestConcurrentToolExecution:
 
     def test_sequential_blocked_tool_skips_checkpoints_and_callbacks(self, agent, monkeypatch):
         """Sequential path: blocked tool should not trigger checkpoints or start callbacks."""
+        agent.valid_tool_names.add("write_file")
         tool_call = _mock_tool_call(name="write_file",
                                     arguments='{"path":"test.txt","content":"hello"}',
                                     call_id="c1")
@@ -3041,6 +3045,7 @@ class TestConcurrentToolExecution:
 
     def test_sequential_blocked_tool_emits_terminal_post_tool_hook(self, agent, monkeypatch):
         """Blocked pre_tool_call decisions still terminate observer tool spans."""
+        agent.valid_tool_names.add("write_file")
         tool_call = _mock_tool_call(name="write_file",
                                     arguments='{"path":"test.txt","content":"hello"}',
                                     call_id="c1")
@@ -3070,6 +3075,7 @@ class TestConcurrentToolExecution:
 
     def test_sequential_agent_level_tool_emits_terminal_post_tool_hook(self, agent, monkeypatch):
         """Sequential built-in tool paths should also close observer tool spans."""
+        agent.valid_tool_names.add("todo")
         tool_call = _mock_tool_call(name="todo", arguments='{"todos":[]}', call_id="todo-1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
         messages = []
@@ -3097,6 +3103,7 @@ class TestConcurrentToolExecution:
 
     def test_sequential_agent_level_tool_execution_middleware_wraps_inline_dispatch(self, agent, monkeypatch):
         """Sequential built-in tool paths should expose the adaptive execution boundary."""
+        agent.valid_tool_names.add("todo")
         tool_call = _mock_tool_call(name="todo", arguments='{"todos":[]}', call_id="todo-1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
         messages = []
@@ -3143,6 +3150,7 @@ class TestConcurrentToolExecution:
         assert post_call[1]["middleware_trace"] == [{"source": "request-test"}]
 
     def test_concurrent_agent_level_tool_preserves_request_middleware_trace(self, agent, monkeypatch):
+        agent.valid_tool_names.add("todo")
         tool_call = _mock_tool_call(name="todo", arguments='{"todos":[]}', call_id="todo-1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
         messages = []
@@ -3354,6 +3362,7 @@ class TestConcurrentToolExecution:
     def test_concurrent_blocked_write_does_not_steal_slot_from_allowed_write(self, agent, monkeypatch):
         """When write_file is blocked, its dedup slot must not be consumed,
         so a subsequent allowed write_file for the same path still checkpoints."""
+        agent.valid_tool_names.add("write_file")
         tc1 = _mock_tool_call(name="write_file",
                               arguments='{"path":"dup.txt","content":"blocked"}',
                               call_id="c1")

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -238,6 +238,40 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
 
 
+def test_sequential_rejects_out_of_schema_agent_runtime_tool():
+    agent = _make_agent("web_search")
+    tc = _mock_tool_call("memory", json.dumps({"target": "memory"}), "c-scope")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch("tools.memory_tool.memory_tool", return_value="SHOULD_NOT_RUN") as memory_tool,
+        patch("agent.tool_executor._apply_tool_request_middleware_for_agent") as middleware,
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    memory_tool.assert_not_called()
+    middleware.assert_not_called()
+    assert "not available in this session" in messages[0]["content"]
+
+
+def test_concurrent_rejects_out_of_schema_agent_runtime_tool():
+    agent = _make_agent("web_search")
+    tc = _mock_tool_call("todo", json.dumps({"todos": []}), "c-scope")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch.object(agent, "_invoke_tool", return_value="SHOULD_NOT_RUN") as invoke,
+        patch("agent.tool_executor._apply_tool_request_middleware_for_agent") as middleware,
+    ):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    invoke.assert_not_called()
+    middleware.assert_not_called()
+    assert "not available in this session" in messages[0]["content"]
+
+
 def test_default_run_conversation_warns_without_guardrail_halt():
     agent = _make_agent("web_search", max_iterations=10)
     same_args = {"query": "same"}


### PR DESCRIPTION
## Summary

- enforce the session's advertised tool schema for direct agent-runtime tools as well as Tool Search calls
- reject out-of-scope tools before request middleware, checkpoints, hooks, or dispatch
- cover sequential and concurrent execution paths

## Security rationale

Several agent-runtime tools bypass the common `model_tools.handle_function_call` path. Without an equivalent check in the executor, a model could call a tool absent from the current session schema. Request middleware must not run for an already-rejected call because middleware itself may have side effects.

## Verification

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/run_agent/test_tool_call_guardrail_runtime.py`
- 433 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
