### PR TITLE
fix(holographic): hyphenated-identifier search returned 0 results

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -603,16 +603,22 @@ class FactRetriever:
         _FTS_SPECIAL = '"()*^:-+'
         tokens: list[str] = []
         for raw in query.lower().split():
-            cleaned = raw.strip(".,;:!?\"'()[]{}#@<>") .translate(
-                str.maketrans("", "", _FTS_SPECIAL)
-            )
-            if len(cleaned) < 2:
-                continue
-            if cleaned in cls._FTS_STOPWORDS:
-                continue
-            # FTS5 phrase-literal each token to ensure no special chars
-            # sneak through as operators.
-            tokens.append(f'"{cleaned}"')
+            # Split on hyphen/underscore FIRST so hyphenated identifiers
+            # ("vibe-trading", "cincin-coord", "fastembed_bge-small") expand
+            # into OR-joined sub-tokens. FTS5's default tokenizer also splits
+            # on those separators, so gluing them (the old behavior) produced a
+            # token that never exists in the index and silently returned 0 hits.
+            word = raw.strip(".,;:!?\"'()[]{}#@<>")
+            for part in word.split("-"):
+                for sub in part.split("_"):
+                    cleaned = sub.translate(str.maketrans("", "", _FTS_SPECIAL))
+                    if len(cleaned) < 2:
+                        continue
+                    if cleaned in cls._FTS_STOPWORDS:
+                        continue
+                    # FTS5 phrase-literal each token to ensure no special chars
+                    # sneak through as operators.
+                    tokens.append(f'"{cleaned}"')
         if not tokens:
             # Fallback: raw query (likely returns 0, but never crashes)
             return query


### PR DESCRIPTION
## Bug
The holographic memory provider's `FactRetriever._sanitize_fts_query` stripped hyphens/underscores from query tokens and glued the remainder (e.g. `vibe-trading` -> `vibetrading`). FTS5's default tokenizer, however, splits the stored text on those same separators (`vibe` + `trading`). The glued token never exists in the index, so searching memory for any hyphenated identifier — MCP server names, package names, domains — silently returned **0 results**.

## Fix
Split each query token on `-` and `_` *before* sanitizing, expanding hyphenated/underscore identifiers into OR-joined sub-tokens:
- `vibe-trading` -> `"vibe" OR "trading"`
- `fastembed_bge-small` -> `"fastembed" OR "bge" OR "small"`

Phrase-literal quoting is retained, so no FTS5 special characters leak as operators. Non-hyphenated queries are unaffected.

## Verification
Stored fact: "Vibe-Trading MCP server runs on roci port 8900..."
- Before: `search("Vibe-Trading")` -> 0 hits
- After:  `search("Vibe-Trading")` -> 1 hit (correct fact returned)