### PR TITLE
fix(cron): require trusted agent workdirs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -894,7 +894,70 @@ def save_jobs(jobs: List[Dict[str, Any]]):
         _save_jobs_unlocked(jobs)
 
 
-def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
+def _load_cron_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        return cron_cfg if isinstance(cron_cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _as_trusted_workdir_paths(cron_cfg: Dict[str, Any]) -> List[Path]:
+    raw = cron_cfg.get("trusted_workdirs", [])
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+
+    trusted: List[Path] = []
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            continue
+        path = Path(item.strip()).expanduser()
+        if not path.is_absolute():
+            continue
+        try:
+            trusted.append(path.resolve())
+        except Exception:
+            continue
+    return trusted
+
+
+def is_trusted_cron_workdir(workdir: str, cron_cfg: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True when *workdir* is explicitly trusted for cron context files."""
+    try:
+        resolved = Path(workdir).expanduser().resolve()
+    except Exception:
+        return False
+    for trusted in _as_trusted_workdir_paths(cron_cfg if cron_cfg is not None else _load_cron_config()):
+        try:
+            if resolved == trusted or resolved.is_relative_to(trusted):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def validate_trusted_cron_workdir(
+    workdir: str,
+    cron_cfg: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Raise a clear error if an agent cron job workdir is not trusted."""
+    if is_trusted_cron_workdir(workdir, cron_cfg):
+        return
+    raise ValueError(
+        f"Cron workdir {workdir!r} is not trusted for unattended "
+        "context-file ingestion. Add the directory, or one of its parents, "
+        "to cron.trusted_workdirs in config.yaml before scheduling an agent "
+        "job with workdir. Jobs without workdir are unchanged; no_agent script "
+        "jobs may still use workdir as a process cwd without this trust entry."
+    )
+
+
+def _normalize_workdir(workdir: Optional[str], *, require_trusted: bool = False) -> Optional[str]:
     """Normalize and validate a cron job workdir.
 
     Rules:
@@ -924,7 +987,10 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
         raise ValueError(f"Cron workdir does not exist: {resolved}")
     if not resolved.is_dir():
         raise ValueError(f"Cron workdir is not a directory: {resolved}")
-    return str(resolved)
+    normalized = str(resolved)
+    if require_trusted:
+        validate_trusted_cron_workdir(normalized)
+    return normalized
 
 
 def _resolve_default_model_snapshot() -> Optional[str]:
@@ -1121,8 +1187,11 @@ def create_job(
     normalized_script = normalized_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
-    normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_workdir = _normalize_workdir(
+        workdir,
+        require_trusted=not normalized_no_agent,
+    )
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
 
     # no_agent jobs are meaningless without a script — the script IS the job.
@@ -1307,10 +1376,20 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 if _wd in {None, "", False}:
                     updates["workdir"] = None
                 else:
-                    updates["workdir"] = _normalize_workdir(_wd)
+                    updates["workdir"] = _normalize_workdir(
+                        _wd,
+                        require_trusted=not bool(
+                            updates.get("no_agent", job.get("no_agent"))
+                        ),
+                    )
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
+            became_agent_job = bool(job.get("no_agent")) and not bool(
+                updated.get("no_agent")
+            )
+            if updated.get("workdir") and became_agent_job:
+                validate_trusted_cron_workdir(updated["workdir"])
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -238,7 +238,15 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_run,
+    claim_dispatch,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_run,
+    save_job_output,
+    validate_trusted_cron_workdir,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -3100,6 +3108,9 @@ def run_job(
                 "Job '%s': MCP initialization failed (non-fatal): %s",
                 job_id, _mcp_exc,
             )
+
+        if _job_workdir:
+            validate_trusted_cron_workdir(_job_workdir, _cfg.get("cron", {}))
 
         agent = AIAgent(
             model=model,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2675,6 +2675,10 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
+        # Agent jobs ingest project context from workdir unattended, so trust
+        # absolute parent directories explicitly. Script-only jobs only use
+        # workdir as cwd and do not require this trust boundary.
+        "trusted_workdirs": [],
         # Make cron deliveries CONTINUABLE: a user can reply to a cron brief
         # and the agent has it in context (no "what is Task #2?" amnesia).
         # Default False preserves the historical isolation guarantee (cron

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -23,6 +23,10 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
     monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
     monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"cron": {"trusted_workdirs": [str(tmp_path)]}},
+    )
     return tmp_path
 
 
@@ -69,6 +73,29 @@ class TestNormalizeWorkdir:
         with pytest.raises(ValueError, match="not a directory"):
             _normalize_workdir(str(f))
 
+    def test_untrusted_agent_workdir_rejected(self, tmp_path, monkeypatch):
+        from cron.jobs import _normalize_workdir
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"cron": {"trusted_workdirs": []}},
+        )
+
+        with pytest.raises(ValueError, match="cron.trusted_workdirs"):
+            _normalize_workdir(str(tmp_path), require_trusted=True)
+
+    def test_trusted_agent_workdir_allowed(self, tmp_path, monkeypatch):
+        from cron.jobs import _normalize_workdir
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"cron": {"trusted_workdirs": [str(tmp_path)]}},
+        )
+
+        assert _normalize_workdir(str(tmp_path), require_trusted=True) == str(
+            tmp_path.resolve()
+        )
+
 
 # ---------------------------------------------------------------------------
 # jobs.create_job and update_job
@@ -102,6 +129,40 @@ class TestCreateJobWorkdir:
                 workdir="not/absolute",
             )
 
+    def test_create_rejects_untrusted_agent_workdir(self, tmp_cron_dir, monkeypatch):
+        from cron.jobs import create_job
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"cron": {"trusted_workdirs": []}},
+        )
+
+        with pytest.raises(ValueError, match="unattended context-file ingestion"):
+            create_job(
+                prompt="hello",
+                schedule="every 1h",
+                workdir=str(tmp_cron_dir),
+            )
+
+    def test_no_agent_workdir_does_not_require_context_trust(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        from cron.jobs import create_job, get_job
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"cron": {"trusted_workdirs": []}},
+        )
+
+        job = create_job(
+            prompt=None,
+            schedule="every 1h",
+            script="noop.py",
+            no_agent=True,
+            workdir=str(tmp_cron_dir),
+        )
+        assert get_job(job["id"])["workdir"] == str(tmp_cron_dir.resolve())
+
 
 class TestUpdateJobWorkdir:
     def test_set_workdir_via_update(self, tmp_cron_dir):
@@ -131,6 +192,65 @@ class TestUpdateJobWorkdir:
         job = create_job(prompt="x", schedule="every 1h")
         with pytest.raises(ValueError):
             update_job(job["id"], {"workdir": "nope/relative"})
+
+    def test_update_to_no_agent_allows_untrusted_workdir(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        from cron.jobs import create_job, get_job, update_job
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"cron": {"trusted_workdirs": []}},
+        )
+        job = create_job(prompt="x", schedule="every 1h")
+
+        update_job(
+            job["id"],
+            {"no_agent": True, "script": "noop.py", "workdir": str(tmp_cron_dir)},
+        )
+
+        stored = get_job(job["id"])
+        assert stored["no_agent"] is True
+        assert stored["workdir"] == str(tmp_cron_dir.resolve())
+
+    def test_pause_legacy_untrusted_agent_workdir_is_allowed(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        from cron.jobs import create_job, get_job, pause_job
+
+        job = create_job(
+            prompt="x", schedule="every 1h", workdir=str(tmp_cron_dir)
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"cron": {"trusted_workdirs": []}},
+        )
+
+        pause_job(job["id"])
+
+        stored = get_job(job["id"])
+        assert stored["enabled"] is False
+        assert stored["state"] == "paused"
+
+    def test_update_from_no_agent_to_agent_revalidates_existing_workdir(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        from cron.jobs import create_job, update_job
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"cron": {"trusted_workdirs": []}},
+        )
+        job = create_job(
+            prompt=None,
+            schedule="every 1h",
+            script="noop.py",
+            no_agent=True,
+            workdir=str(tmp_cron_dir),
+        )
+
+        with pytest.raises(ValueError, match="not trusted"):
+            update_job(job["id"], {"no_agent": False, "prompt": "x"})
 
 
 # ---------------------------------------------------------------------------
@@ -318,6 +438,56 @@ class TestRunJobTerminalCwd:
         import dotenv
         monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_kw: True)
 
+    def test_untrusted_workdir_job_fails_before_agent_init(self, tmp_path, monkeypatch):
+        import sys
+        import cron.scheduler as sched
+
+        observed = {"agent_init": False}
+
+        class FakeAgent:
+            def __init__(self, **_kwargs):
+                observed["agent_init"] = True
+
+        fake_mod = type(sys)("run_agent")
+        fake_mod.AIAgent = FakeAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+        monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+        monkeypatch.setattr(
+            sched,
+            "load_config",
+            lambda: {"cron": {"trusted_workdirs": []}, "model": "test-model"},
+        )
+
+        from hermes_cli import runtime_provider as _rtp
+
+        monkeypatch.setattr(
+            _rtp,
+            "resolve_runtime_provider",
+            lambda **_kw: {
+                "provider": "test",
+                "api_key": "k",
+                "base_url": "http://test.local",
+                "api_mode": "chat_completions",
+            },
+        )
+
+        success, _output, response, error = sched.run_job(
+            {
+                "id": "abc",
+                "name": "wd-job",
+                "workdir": str(tmp_path),
+                "schedule_display": "manual",
+            }
+        )
+
+        assert success is False
+        assert observed["agent_init"] is False
+        assert "cron.trusted_workdirs" in (error or response)
+
     def test_workdir_sets_and_restores_terminal_cwd(
         self, tmp_path, monkeypatch
     ):
@@ -331,6 +501,9 @@ class TestRunJobTerminalCwd:
 
         observed: dict = {}
         self._install_stubs(monkeypatch, observed)
+        monkeypatch.setattr(
+            sched, "validate_trusted_cron_workdir", lambda *_args, **_kwargs: None
+        )
 
         job = {
             "id": "abc",


### PR DESCRIPTION
## Summary

- require agent cron workdirs to fall under an explicitly configured `cron.trusted_workdirs` parent
- resolve paths before comparison so symlink escapes do not bypass the boundary
- revalidate when converting script-only jobs into agent jobs and again immediately before agent initialization
- preserve script-only `no_agent` jobs, which use workdir only as process cwd
- allow administrative updates to legacy jobs without unexpectedly revalidating an unchanged workdir

## Security rationale

Agent cron jobs ingest `AGENTS.md`, `CLAUDE.md`, and `.cursorrules` from their workdir while unattended. A writable or untrusted workdir therefore becomes an instruction-injection boundary. Trust must be explicit before scheduling or executing an agent job there.

## Verification

- `scripts/run_tests.sh tests/cron/test_cron_workdir.py tests/cron/test_scheduler.py tests/hermes_cli/test_config.py`
- 396 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
