### PR TITLE
fix(auth): preserve custom fallback credential pools

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1521,10 +1521,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # entries with different routing) the pool is preserved.  When the
         # providers differ, load the fallback provider's own pool if one exists
         # so provider-specific rotation continues to work after the switch.
+        fallback_pool_provider = fb_provider
+        if fb_provider == "custom":
+            try:
+                from agent.credential_pool import get_custom_provider_pool_key
+
+                fallback_pool_provider = (
+                    get_custom_provider_pool_key(fb_base_url, provider_name=str(fb.get("provider") or ""))
+                    or fb_provider
+                )
+            except Exception:
+                fallback_pool_provider = fb_provider
         _existing_pool = getattr(agent, "_credential_pool", None)
         if _existing_pool is not None:
             _pool_provider = (getattr(_existing_pool, "provider", "") or "").strip().lower()
-            if _pool_provider and _pool_provider != fb_provider:
+            if _pool_provider and _pool_provider != fallback_pool_provider:
                 logger.info(
                     "Fallback to %s/%s: clearing primary credential pool "
                     "(pool_provider=%s) to prevent cross-provider contamination",
@@ -1535,7 +1546,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             try:
                 from agent.credential_pool import load_pool
 
-                fallback_pool = load_pool(fb_provider)
+                fallback_pool = load_pool(fallback_pool_provider)
                 if fallback_pool and fallback_pool.has_credentials():
                     agent._credential_pool = fallback_pool
                     logger.info(

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -949,7 +949,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models(
@@ -965,7 +965,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models("provider-key", "https://api.example.com/v1")

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -182,6 +182,42 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
+    def test_custom_fallback_loads_named_custom_credential_pool(self):
+        """Custom fallback endpoints must attach the matching custom:<name> pool."""
+        fbs = [
+            {
+                "provider": "custom",
+                "model": "fallback-model",
+                "base_url": "https://fallback.example/v1",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent._credential_pool = None
+        fallback_pool = MagicMock()
+        fallback_pool.has_credentials.return_value = True
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://fallback.example/v1",
+                        api_key="fallback-key",
+                    ),
+                    "fallback-model",
+                ),
+            ),
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                return_value="custom:fallback",
+            ),
+            patch("agent.credential_pool.load_pool", return_value=fallback_pool) as load_pool,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        load_pool.assert_called_once_with("custom:fallback")
+        assert agent._credential_pool is fallback_pool
+
     def test_anthropic_host_custom_provider_uses_anthropic_messages(self):
         """A custom provider on the native api.anthropic.com host (no
         "/anthropic" path suffix, name != "anthropic") must resolve to the


### PR DESCRIPTION
## Summary

Custom fallback providers were loading the generic `custom` credential pool instead of the named `custom:<name>` pool that actually owns their credentials.

When `_try_activate_fallback()` switches to a fallback with `provider: custom`, the live runtime provider remains `custom`, but credential pools for configured custom endpoints are keyed by endpoint identity, for example `custom:fallback`. Current main calls `load_pool("custom")`, so the fallback can run with its initial resolved key but loses credential rotation/failover for later 401/429 recovery.

This is the fallback-activation sibling of the provider/pool identity class fixed in the constructor and restore paths.

## Changes

- Resolve the fallback custom endpoint's pool key from `fb_base_url`.
- Use that resolved `custom:<name>` key when comparing an existing pool against the fallback target.
- Use the same key when loading the fallback credential pool.
- Preserve existing behavior for non-custom fallback providers.

## Reproduction

The new regression fails on current main because `load_pool()` is called with `custom`:

```text
Expected: load_pool('custom:fallback')
Actual:   load_pool('custom')