### PR TITLE
feat(delegation): add explicit read-only capability

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3022,7 +3022,7 @@ def _blank_slate_minimal_toolsets(config: dict):
     config.setdefault("platform_toolsets", {})["cli"] = sorted(keep)
 
     try:
-        from toolsets import TOOLSETS
+        from toolsets import TOOLSETS, resolve_toolset
         from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS, _get_plugin_toolset_keys
 
         all_keys = set()
@@ -3043,7 +3043,18 @@ def _blank_slate_minimal_toolsets(config: dict):
                 # minimal Blank Slate surface (#57315).
             all_keys.add(k)
 
-        disabled = sorted(all_keys - keep)
+        # disabled_toolsets is applied at tool granularity.  Do not disable an
+        # alias/leaf that shares tools with the retained minimal surface (for
+        # example ``file_read`` shares read_file/search_files with ``file``),
+        # or model_tools would subtract those retained tools again.
+        kept_tools = set()
+        for key in keep:
+            kept_tools.update(resolve_toolset(key))
+        disabled = sorted(
+            key
+            for key in all_keys - keep
+            if not (set(resolve_toolset(key)) & kept_tools)
+        )
         if disabled:
             config.setdefault("agent", {})["disabled_toolsets"] = disabled
     except Exception as exc:

--- a/model_tools.py
+++ b/model_tools.py
@@ -1143,6 +1143,32 @@ def handle_function_call(
                 disabled_toolsets=disabled_toolsets,
             )
 
+    if enabled_toolsets is not None:
+        try:
+            current_defs = get_tool_definitions(
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            ) or []
+            available_tool_names = {
+                tool["function"]["name"]
+                for tool in current_defs
+                if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+            }
+        except Exception:
+            available_tool_names = set()
+        if function_name not in available_tool_names:
+            return json.dumps(
+                {
+                    "error": (
+                        f"'{function_name}' is not available in this session. "
+                        "Use the tools registered for this session."
+                    )
+                },
+                ensure_ascii=False,
+            )
+
     _tool_original_args = dict(function_args)
     if not skip_tool_request_middleware:
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5721,6 +5721,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            capability=function_args.get("capability"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -65,6 +65,93 @@ class TestToolsetIntersection:
         assert scoped == []
 
 
+class TestReadOnlyDelegation:
+    def test_build_child_agent_read_only_strips_side_effect_toolsets(self, monkeypatch):
+        import sys
+        import types
+        import tools.delegate_tool as dt
+
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.session_id = "child-session"
+                self.enabled_toolsets = kwargs.get("enabled_toolsets")
+
+        fake_mod = types.ModuleType("run_agent")
+        fake_mod.AIAgent = FakeAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+        monkeypatch.setattr(dt, "_load_config", lambda: {})
+        monkeypatch.setattr(dt, "_build_child_progress_callback", lambda *a, **k: None)
+
+        parent = SimpleNamespace(
+            enabled_toolsets=[
+                "terminal",
+                "file",
+                "web",
+                "browser",
+                "skills",
+                "memory",
+                "delegation",
+                "cronjob",
+                "code_execution",
+                "computer_use",
+            ],
+            model="parent-model",
+            provider="test",
+            base_url="http://test.local",
+            api_key="key",
+            _delegate_depth=0,
+            session_id="parent-session",
+        )
+
+        child = dt._build_child_agent(
+            task_index=0,
+            goal="read the repo",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=1,
+            task_count=1,
+            parent_agent=parent,
+            capability="read_only",
+        )
+
+        assert set(child.enabled_toolsets) == {
+            "browser_read",
+            "file_read",
+            "skills_read",
+            "web",
+        }
+        assert captured["enabled_toolsets"] == child.enabled_toolsets
+        assert "terminal" not in child.enabled_toolsets
+        assert "file" not in child.enabled_toolsets
+        assert "skills" not in child.enabled_toolsets
+        assert "memory" not in child.enabled_toolsets
+        assert "delegation" not in child.enabled_toolsets
+        assert "cronjob" not in child.enabled_toolsets
+        assert "code_execution" not in child.enabled_toolsets
+        assert "computer_use" not in child.enabled_toolsets
+
+    def test_dispatch_rejects_tool_not_available_in_enabled_toolsets(self, tmp_path):
+        import json
+        from model_tools import handle_function_call
+
+        target = tmp_path / "should-not-exist.txt"
+        raw = handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "nope"},
+            task_id="read-only-adversarial",
+            enabled_toolsets=["file_read"],
+            skip_pre_tool_call_hook=True,
+        )
+
+        result = json.loads(raw)
+        assert "not available in this session" in result["error"]
+        assert not target.exists()
+
+
 class TestEmitParentConsole:
     """Progress lines (e.g. ``✓ [N/M] …``) must route through the parent's
     configured ``_safe_print`` in headless stdio hosts (ACP, gateway) so

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -53,6 +53,20 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
     ]
 )
 
+_READ_ONLY_TOOLSET_MAP = {
+    "file": "file_read",
+    "file_read": "file_read",
+    "web": "web",
+    "search": "search",
+    "x_search": "x_search",
+    "browser": "browser_read",
+    "browser_read": "browser_read",
+    "skills": "skills_read",
+    "skills_read": "skills_read",
+    "session_search": "session_search",
+    "vision": "vision",
+}
+
 
 # ---------------------------------------------------------------------------
 # Subagent approval callbacks
@@ -349,6 +363,16 @@ def _normalize_role(r: Optional[str]) -> str:
         return r_norm
     logger.warning("Unknown delegate_task role=%r, coercing to 'leaf'", r)
     return "leaf"
+
+
+def _normalize_capability(value: Optional[str]) -> str:
+    if value is None or not str(value).strip():
+        return "standard"
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized in {"read_only", "standard"}:
+        return normalized
+    logger.warning("Unknown delegate_task capability=%r, coercing to 'standard'", value)
+    return "standard"
 
 
 def _get_max_concurrent_children() -> int:
@@ -783,6 +807,16 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _apply_read_only_toolset_policy(toolsets: List[str]) -> List[str]:
+    """Map inherited toolsets to the read/search-only subset for a child."""
+    scoped: List[str] = []
+    for toolset in toolsets:
+        read_only_toolset = _READ_ONLY_TOOLSET_MAP.get(toolset)
+        if read_only_toolset and read_only_toolset not in scoped:
+            scoped.append(read_only_toolset)
+    return scoped
+
+
 def _emit_parent_console(parent_agent, line: str) -> None:
     """Emit a human-readable progress line to the parent's console.
 
@@ -1064,6 +1098,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    capability: str = "standard",
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1087,6 +1122,7 @@ def _build_child_agent(
     max_spawn = _get_max_spawn_depth()
     orchestrator_ok = _get_orchestrator_enabled() and child_depth < max_spawn
     effective_role = role if (role == "orchestrator" and orchestrator_ok) else "leaf"
+    effective_capability = _normalize_capability(capability)
 
     # ── Subagent identity (stable across events, 0-indexed for TUI) ─────
     # subagent_id is generated here so the progress callback, the
@@ -1136,11 +1172,18 @@ def _build_child_agent(
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
+    if effective_capability == "read_only":
+        child_toolsets = _apply_read_only_toolset_policy(child_toolsets)
+
     # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
     # removed.  The re-add is unconditional on parent-toolset membership because
     # orchestrator capability is granted by role, not inherited — see the
     # test_intersection_preserves_delegation_bound test for the design rationale.
-    if effective_role == "orchestrator" and "delegation" not in child_toolsets:
+    if (
+        effective_capability != "read_only"
+        and effective_role == "orchestrator"
+        and "delegation" not in child_toolsets
+    ):
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
@@ -1366,6 +1409,7 @@ def _build_child_agent(
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
+    child._delegate_capability = effective_capability
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
@@ -2372,6 +2416,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    capability: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2403,6 +2448,7 @@ def delegate_task(
 
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
+    top_capability = _normalize_capability(capability)
 
     # Background (async) delegation now applies to BOTH single tasks and
     # batches. A batch simply becomes N independent async dispatches: each
@@ -2473,7 +2519,14 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
+        task_list = [
+            {
+                "goal": goal,
+                "context": context,
+                "role": top_role,
+                "capability": top_capability,
+            }
+        ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2512,6 +2565,9 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            effective_capability = _normalize_capability(
+                t.get("capability") or top_capability
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2532,6 +2588,7 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                capability=effective_capability,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -3422,6 +3479,11 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "capability": {
+                            "type": "string",
+                            "enum": ["read_only", "standard"],
+                            "description": "Per-task capability profile. read_only exposes only read/search tools.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3434,6 +3496,15 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "capability": {
+                "type": "string",
+                "enum": ["read_only", "standard"],
+                "description": (
+                    "Capability profile for child runtime tools. read_only "
+                    "exposes only read/search toolsets; standard preserves the "
+                    "normal delegated toolset scope."
+                ),
             },
             "background": {
                 "type": "boolean",
@@ -3505,6 +3576,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        capability=args.get("capability"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
     ),

--- a/toolsets.py
+++ b/toolsets.py
@@ -180,6 +180,12 @@ TOOLSETS = {
         ],
         "includes": []
     },
+
+    "browser_read": {
+        "description": "Read-only browser inspection tools",
+        "tools": ["browser_snapshot", "browser_get_images"],
+        "includes": [],
+    },
     
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",
@@ -192,6 +198,18 @@ TOOLSETS = {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
         "tools": ["read_file", "write_file", "patch", "search_files"],
         "includes": []
+    },
+
+    "file_read": {
+        "description": "Read-only file tools: read files and search paths/content",
+        "tools": ["read_file", "search_files"],
+        "includes": [],
+    },
+
+    "skills_read": {
+        "description": "Read-only skill inspection tools",
+        "tools": ["skills_list", "skill_view"],
+        "includes": [],
     },
     
     "tts": {


### PR DESCRIPTION
## Summary

- add an explicit per-task/top-level `capability: read_only` delegation option
- map inherited write-capable umbrella toolsets to concrete read-only toolsets
- prevent orchestrator/delegation, terminal, file writes, memory writes, cron, code execution, and computer control from leaking into read-only children
- enforce each child's resolved tool surface again at dispatch time

## Security rationale

Toolset inheritance alone is not a read-only boundary: umbrella toolsets such as `file`, `browser`, and `skills` contain mutating operations. This capability converts them to `file_read`, `browser_read`, and `skills_read` and rejects direct calls outside the resulting session schema.

## Verification

- `scripts/run_tests.sh tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_composite_toolsets.py tests/test_toolsets.py tests/test_toolset_distributions.py tests/test_model_tools.py tests/run_agent/test_run_agent.py`
- 517 passed, 0 failed
- `ruff check` passed (one pre-existing malformed-noqa warning in `run_agent.py`)
- `git diff --check` passed

## Related work

#4929 adds configurable delegation profiles and broader memory/backend policy. This PR is narrower: it provides an explicit, per-call read-only security boundary and concrete read-only toolsets. The implementations may be complementary or the capability can be absorbed into the profile architecture during review.

#63897 adds a heuristic goal/capability precheck; it does not restrict the child's actual tool surface.
