### PR TITLE
fix(environments): exclude runtime-scoped cron delivery vars from terminal snapshot

### DIFF
--- a/tests/tools/test_local_env_cron_snapshot_leak.py
+++ b/tests/tools/test_local_env_cron_snapshot_leak.py
@@ -1,0 +1,102 @@
+"""Regression test for issue #64199: terminal snapshot leaks cron delivery context.
+
+A local terminal environment snapshot can retain ``HERMES_CRON_AUTO_DELIVER_*``
+values from one cron run and override the correct task-local values in a later,
+unrelated cron run. The shell snapshot (``export -p``) is sourced *after* the
+authoritative task-local ContextVars are bridged into the child env, so a stale
+snapshot copy wins and a nested ``hermes send`` gets the wrong dedupe target.
+
+Fix (tools/environments/base.py): runtime-scoped Hermes routing vars
+(``HERMES_CRON_AUTO_DELIVER_*``) are excluded from the persisted snapshot and
+unset from the child shell after the snapshot is sourced, so the per-call
+ContextVar values (re-injected via ``_inject_session_context_env``) remain
+authoritative.
+"""
+
+import json
+import os
+
+import pytest
+
+from gateway.session_context import _UNSET, _VAR_MAP
+from tools.environments.local import LocalEnvironment
+
+_CRON_VARS = (
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+    "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cron_context():
+    """Snapshot and restore the three cron ContextVars around each test."""
+    saved = {name: _VAR_MAP[name].get() for name in _CRON_VARS}
+    for name in _CRON_VARS:
+        _VAR_MAP[name].set(_UNSET)
+    try:
+        yield
+    finally:
+        for name in _CRON_VARS:
+            _VAR_MAP[name].set(saved[name])
+
+
+def _set_context(platform, chat_id, thread_id):
+    _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(platform)
+    _VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"].set(chat_id)
+    _VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"].set(thread_id)
+
+
+def _read_cron_env(env: LocalEnvironment) -> dict:
+    """Run a command that dumps the cron delivery vars from the child env."""
+    code = (
+        "import json, os; "
+        "print(json.dumps({k: os.environ.get(k) for k in "
+        + repr(list(_CRON_VARS))
+        + "}, sort_keys=True))"
+    )
+    result = env.execute(f"python3 -c {code!r}", timeout=30)
+    return json.loads(result["output"].strip().splitlines()[-1])
+
+
+def test_snapshot_does_not_leak_cron_context_between_jobs():
+    """Reusing one LocalEnvironment across two cron contexts must see the 2nd.
+
+    Mirrors the issue's reproduction: job A sets Telegram delivery, the
+    snapshot captures it, then job B switches to ntfy and must see ntfy — not
+    the stale Telegram values.
+    """
+    env = LocalEnvironment(cwd="/tmp", timeout=30)
+    try:
+        # Cron job A: auto-deliver to Telegram.
+        _set_context("telegram", "-100111", "")
+        _read_cron_env(env)  # forces the snapshot to capture context A
+
+        # Unrelated cron job B: auto-deliver to ntfy.
+        _set_context("ntfy", "alerts", "")
+
+        observed = _read_cron_env(env)
+        assert observed == {
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM": "ntfy",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "alerts",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID": "",
+        }, f"stale snapshot leaked: {observed}"
+    finally:
+        env.cleanup()
+
+
+def test_snapshot_redump_excludes_cron_vars():
+    """The persisted snapshot file must not contain HERMES_CRON_AUTO_DELIVER_*."""
+    _set_context("telegram", "-100111", "9")
+
+    env = LocalEnvironment(cwd="/tmp", timeout=30)
+    try:
+        _read_cron_env(env)  # populate + redump the snapshot
+        with open(env._snapshot_path, "r", encoding="utf-8", errors="replace") as fh:
+            snapshot = fh.read()
+        for var in _CRON_VARS:
+            assert f'HERMES_CRON_AUTO_DELIVER' not in snapshot or \
+                f'"{var}"' not in snapshot, \
+                f"{var} leaked into the persisted snapshot"
+    finally:
+        env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -26,7 +26,15 @@ from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
 
-# Opt-in debug tracing for the interrupt/activity/poll machinery.  Set
+# Runtime-scoped Hermes routing/session variables that must NOT be persisted in
+# the login-shell snapshot (issue #64199). These are task-local ContextVars
+# (gateway/session_context.py) that are authoritative per cron run. If they leak
+# into the snapshot they override the correct per-call values on the next
+# terminal call, causing cross-job delivery interference. They are re-injected
+# for every terminal call via LocalEnvironment._inject_session_context_env, so
+# dropping them from the snapshot is lossless.
+_RUNTIME_SCOPED_ENV_PREFIXES = ("HERMES_CRON_AUTO_DELIVER_",)
+
 # HERMES_DEBUG_INTERRUPT=1 to log loop entry/exit, periodic heartbeats, and
 # every is_interrupted() state change from _wait_for_process.  Off by default
 # to avoid flooding production gateway logs.
@@ -399,7 +407,7 @@ class BaseEnvironment(ABC):
         _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
         bootstrap = (
             f"umask 077\n"
-            f"export -p > {_snap_tmp}\n"
+            f"export -p | grep -vE '^(export |declare -x )({'|'.join(_RUNTIME_SCOPED_ENV_PREFIXES)})' > {_snap_tmp}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
             # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
@@ -527,6 +535,17 @@ class BaseEnvironment(ABC):
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
+            # Drop runtime-scoped Hermes routing vars that may have leaked into
+            # the snapshot (issue #64199). They are re-injected per-call by
+            # LocalEnvironment._inject_session_context_env from the authoritative
+            # task-local ContextVars, so unsetting here lets those values win
+            # instead of the stale snapshot copy.
+            _unset_expr = " ".join(
+                f'"{p}"*' for p in _RUNTIME_SCOPED_ENV_PREFIXES
+            )
+            parts.append(
+                f'for __h_var in ${{!{_unset_expr}}}; do unset "$__h_var"; done 2>/dev/null || true'
+            )
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
@@ -546,8 +565,14 @@ class BaseEnvironment(ABC):
         # replaces a good snapshot; drop the temp on failure so it isn't
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
         if self._snapshot_ready:
+            # Exclude runtime-scoped Hermes routing vars (issue #64199) so a
+            # stale snapshot can never re-persist another cron job's delivery
+            # target. They are re-injected per call from the task-local
+            # ContextVars, so filtering them here is lossless.
+            _routing_grep = "|".join(_RUNTIME_SCOPED_ENV_PREFIXES)
             parts.append(
-                f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
+                f"{{ export -p | grep -vE '^(export |declare -x )({_routing_grep})' "
+                f"> {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
                 f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
             )
 


### PR DESCRIPTION
## Bug (issue #64199)

A local terminal environment snapshot can retain `HERMES_CRON_AUTO_DELIVER_*` values from one cron run and override the correct task-local values in a later, unrelated cron run. This causes cross-job delivery interference: a later cron job that invokes `hermes send --to telegram` through `terminal` receives job A's stale Telegram auto-delivery values, so `send_message_tool` incorrectly skips the message as a duplicate.

Root cause: `HERMES_CRON_AUTO_DELIVER_*` are task-local ContextVars (gateway/session_context.py) re-injected per terminal call via `_inject_session_context_env`. But `BaseEnvironment._wrap_command` sources the login-shell snapshot (`export -p`) **after** that bridge, and then re-dumps the snapshot — so a stale snapshot copy overrides the authoritative per-call values on the next call.

## Fix (tools/environments/base.py)
- Exclude `HERMES_CRON_AUTO_DELIVER_*` from the persisted snapshot, in both the `init_session` bootstrap capture and the per-call re-dump (`export -p | grep -vE ...`).
- Unset them from the child shell after sourcing the snapshot, so the per-call ContextVar values remain authoritative.

The vars are re-injected for every terminal call from the authoritative ContextVars, so dropping them from the snapshot is lossless.

## Verification
- New regression test `tests/tools/test_local_env_cron_snapshot_leak.py`: reusing one `LocalEnvironment` across two cron contexts must observe the second. **Fails on `main`, passes with the fix.**
- Existing `tests/tools/test_local_env_session_leak.py` (12 tests) unaffected.

Co-Authored-By: Hermes Agent <noreply@nousresearch.com>