### PR TITLE
fix(gateway): make shutdown diagnostics cross-platform

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -226,15 +226,30 @@ def spawn_async_diagnostic(
     if sys.platform == "win32":
         return None
 
+    # Cross-platform self-timeout watchdog.  GNU ``timeout`` is not on
+    # macOS or stock Windows-bash, so we bake the timeout into the script:
+    # a background subshell sleeps for ``timeout_seconds`` and then sends
+    # SIGKILL to the parent (``$$`` resolves to the parent shell even
+    # from inside a backgrounded subshell under POSIX).  The foreground
+    # trap cancels the watchdog on a clean exit so a fast ``ps`` run
+    # doesn't pay the sleep.  Net contract is the same as
+    # ``timeout $N bash -c "$script"`` — the subprocess self-terminates
+    # within ``timeout_seconds`` even if ``ps`` wedges.
+    watchdog = (
+        f"( sleep {timeout_seconds:.0f} && kill -KILL $$ ) >/dev/null 2>&1 & "
+        "WD=$!; "
+        "trap 'kill -KILL $WD 2>/dev/null || true' EXIT; "
+    )
+
     script = (
-        f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
+        watchdog + f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
         "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
         "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+        "ps auxf 2>/dev/null | head -60; "
         "echo '--- pstree of self ---'; "
         f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
+        "echo '--- loadavg ---'; "
+        "cat /proc/loadavg 2>/dev/null || sysctl -n vm.loadavg 2>/dev/null || true; "
         "echo '--- recent dmesg (oom/killed) ---'; "
         "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
         "echo '=== end ==='"
@@ -255,7 +270,7 @@ def spawn_async_diagnostic(
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            ["bash", "-c", script],
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -79,11 +79,17 @@ def _synthetic_worker_script() -> str:
 
 
 def _is_alive_like_dispatcher(pid: int) -> bool:
-    """Mirrors hermes_cli/kanban_db.py:_pid_alive on Linux.
+    """Mirrors hermes_cli/kanban_db.py:_pid_alive on POSIX.
 
-    A zombie is treated as dead — the dispatcher's _pid_alive checks
-    /proc/<pid>/status for State: Z. We replicate that here so a clean
-    os._exit followed by zombie-state is correctly counted as dead.
+    A zombie is treated as dead.  Production uses ``/proc/<pid>/status``
+    on Linux and ``ps -o stat=`` on macOS — we replicate both here so
+    the test correctly counts a clean ``os._exit`` followed by
+    zombie-state as dead on either platform.
+
+    On Windows this path is unreachable (the calling test is gated by
+    ``@pytest.mark.skipif(sys.platform == "win32")``), but we still
+    fall back to ``os.kill(pid, 0)`` for any other POSIX the helper
+    might be exercised on.
     """
     if pid <= 0:
         return False
@@ -102,6 +108,26 @@ def _is_alive_like_dispatcher(pid: int) -> bool:
                             return False
                         break
         except (FileNotFoundError, PermissionError, OSError):
+            pass
+    elif sys.platform == "darwin":
+        # BSD ``ps`` stat field: ``Z`` (or any leading ``Z`` like ``ZN``)
+        # indicates a zombie.  Cheap subprocess with a tight timeout so a
+        # wedged ps can't stall the polling loop.
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                timeout=1.0,
+                check=False,
+            )
+            if result.returncode != 0:
+                # ps could not find the PID — already reaped.
+                return False
+            if "Z" in (result.stdout or "").strip():
+                return False
+        except (OSError, subprocess.TimeoutExpired):
+            # Secondary probe failed; fall through to the kill(0) answer.
             pass
     return True
 


### PR DESCRIPTION
## Summary

- replace the GNU-only `timeout` dependency in shutdown diagnostics with a self-contained shell watchdog
- avoid GNU-specific `ps --sort` and add a macOS load-average fallback
- make the signal-handler worker test recognize macOS zombie processes via BSD `ps`

## Why

Stock macOS does not provide GNU `timeout`, `/proc/loadavg`, or GNU `ps --sort`. The diagnostic subprocess therefore failed before collecting anything, while zombie workers could be misclassified as alive by the test helper.

## Verification

- `scripts/run_tests.sh tests/gateway/test_shutdown_forensics.py tests/hermes_cli/test_signal_handler_kanban_worker.py`
- 33 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
