### PR TITLE
fix(cron): preserve resolved fallback credential pool

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3063,9 +3063,9 @@ def run_job(
             )
 
         fallback_model = get_fallback_chain(_cfg) or None
-        credential_pool = None
+        credential_pool = runtime.get("credential_pool")
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
-        if runtime_provider:
+        if credential_pool is None and runtime_provider:
             try:
                 from agent.credential_pool import load_pool
                 pool = load_pool(runtime_provider)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2032,6 +2032,51 @@ class TestRunJobConfigEnvVarExpansion:
         models = [e.get("model") for e in fb if isinstance(e, dict)]
         assert models == ["gpt-4o-mini", "claude-sonnet-4-6"]
 
+    def test_fallback_runtime_preserves_resolved_credential_pool(self, tmp_path, monkeypatch):
+        """Cron must not discard a custom fallback runtime's resolved credential pool."""
+        from hermes_cli.auth import AuthError
+
+        (tmp_path / "config.yaml").write_text(
+            "fallback_providers:\n"
+            "  - provider: custom\n"
+            "    base_url: https://fallback.example/v1\n"
+            "    model: fallback-model\n"
+        )
+
+        job = {"id": "custom-fb-pool", "name": "custom fallback", "prompt": "hi"}
+        fake_db = MagicMock()
+        fallback_pool = MagicMock()
+        fallback_runtime = {
+            "api_key": "fallback-key",
+            "base_url": "https://fallback.example/v1",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "credential_pool": fallback_pool,
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=[
+                     AuthError("primary unavailable", provider="openrouter"),
+                     fallback_runtime,
+                 ],
+             ), \
+             patch("agent.credential_pool.load_pool") as load_pool, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        load_pool.assert_not_called()
+        assert mock_agent_cls.call_args.kwargs["credential_pool"] is fallback_pool
+
     def test_unexpanded_ref_passthrough_when_var_unset(self, tmp_path, monkeypatch):
         """When the env var is not set, the literal ${VAR} is kept verbatim (not crashed)."""
         (tmp_path / "config.yaml").write_text("model: ${_HERMES_TEST_CRON_UNSET_VAR}\n")

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -949,7 +949,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models(
@@ -965,7 +965,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models("provider-key", "https://api.example.com/v1")


### PR DESCRIPTION
## Summary

Preserve the credential pool returned by `resolve_runtime_provider()` when cron falls back to a custom provider.

## Problem

Cron resolves runtime credentials before constructing `AIAgent`. For custom providers, `resolve_runtime_provider()` can return a provider-specific credential pool, keyed by the named custom provider (`custom:<name>`). However, `cron/scheduler.py` discarded `runtime["credential_pool"]` and tried to reload a pool from `runtime["provider"]`.

For custom fallback runtimes, `runtime["provider"]` is commonly `"custom"`, not the named pool key. That means cron can lose the resolved fallback credential pool immediately before creating the agent.

This is the cron sibling of the custom fallback credential-pool issue fixed in the agent fallback path.

## Changes

- Reuse `runtime["credential_pool"]` when the runtime resolver already returned one.
- Keep the existing `load_pool(runtime_provider)` fallback only when the runtime did not provide a pool.
- Add a cron regression where primary auth fails, fallback resolves to a custom runtime with a credential pool, and `AIAgent` receives that exact pool.

## Tests

```text
python -m pytest -p no:cacheprovider tests/cron/test_scheduler.py -k "fallback_runtime_preserves_resolved_credential_pool or fallback_chain_merges_providers_and_legacy_model" -q --timeout-method=thread
2 passed, 215 deselected

python -m ruff check --no-cache cron/scheduler.py tests/cron/test_scheduler.py
All checks passed