### PR TITLE
fix(bedrock): evict cached client on mid-stream stale-connection failure

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2001,6 +2001,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     pass
 
         def _bedrock_call():
+            _region_holder = {"region": "us-east-1"}
             try:
                 from agent.bedrock_adapter import (
                     _get_bedrock_runtime_client,
@@ -2011,6 +2012,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     stream_converse_with_callbacks,
                 )
                 region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+                _region_holder["region"] = region
                 api_kwargs.pop("__bedrock_converse__", None)
                 client = _get_bedrock_runtime_client(region)
                 try:
@@ -2066,6 +2068,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     on_interrupt_check=lambda: agent._interrupt_requested,
                 )
             except Exception as e:
+                # A stale/dead pooled connection can survive the initial
+                # converse_stream() call and only fail while the stream is
+                # being consumed — surfacing as a bare AssertionError raised
+                # from inside urllib3/botocore (empty str(exc)). The inner
+                # except above evicts the cached client on stale-connection
+                # errors, but failures during stream consumption land here
+                # instead, where the client was never evicted — so all outer
+                # retries reused the same wedged pool and reproduced the
+                # AssertionError forever. Mirror the inner eviction so the
+                # outer retry loop rebuilds a fresh client/pool. Import and
+                # region are re-resolved locally: this except also covers a
+                # failure before the outer try's import/region binding, so we
+                # cannot assume those names are bound here.
+                try:
+                    from agent.bedrock_adapter import (
+                        invalidate_runtime_client as _invalidate,
+                        is_stale_connection_error as _is_stale,
+                    )
+                    if _is_stale(e):
+                        _invalidate(_region_holder["region"])
+                except Exception:
+                    pass
                 result["error"] = e
 
         t = threading.Thread(target=_bedrock_call, daemon=True)

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1541,6 +1541,79 @@ class TestCallConverseInvalidatesOnStaleError:
         assert _bedrock_runtime_client_cache.get("us-east-1") is live_client
 
 
+class TestStreamConsumptionStaleEviction:
+    """Regression for the mid-stream stale-connection bug: a dead pooled
+    connection can survive the initial converse_stream() call and only fail
+    while the *stream is being consumed*, surfacing as a bare AssertionError
+    raised from inside urllib3/botocore (empty str(exc)). The true-streaming
+    path in chat_completion_helpers caught that in a bare ``except`` and stored
+    the error WITHOUT evicting the cached client, so every outer retry reused
+    the same wedged pool and reproduced the AssertionError forever. The fix
+    mirrors the inner eviction on the consumption-failure branch.
+
+    This test pins the two invariants the fix depends on:
+      1. a bare AssertionError raised from a urllib3 frame is classified as a
+         stale-connection error, and
+      2. evicting on that classification removes the region's cached client so
+         the next attempt rebuilds a fresh pool.
+    """
+
+    def _raise_bare_assertion_from_urllib3(self):
+        # Build an AssertionError whose traceback top frame reports a
+        # urllib3.* module name — the real failure has an empty message and a
+        # urllib3-internal frame (connectionpool / response reader).
+        try:
+            exec(
+                compile("raise AssertionError()", "<urllib3.connectionpool>", "exec"),
+                {"__name__": "urllib3.connectionpool"},
+            )
+        except AssertionError as exc:  # noqa: PERF203
+            return exc
+        raise RuntimeError("expected AssertionError")
+
+    def test_bare_urllib3_assertion_is_stale(self):
+        from agent.bedrock_adapter import is_stale_connection_error
+
+        exc = self._raise_bare_assertion_from_urllib3()
+        assert str(exc) == "", "the real mid-stream failure has an empty message"
+        assert is_stale_connection_error(exc) is True
+
+    def test_application_assertion_is_not_stale(self):
+        # An AssertionError from application code (no urllib3/botocore/boto3
+        # frame) must NOT be treated as a stale connection — otherwise a real
+        # invariant bug would be silently retried.
+        from agent.bedrock_adapter import is_stale_connection_error
+
+        try:
+            assert False, "app-level invariant"
+        except AssertionError as exc:
+            assert is_stale_connection_error(exc) is False
+
+    def test_consumption_stale_error_evicts_client(self):
+        """Simulate the patched consumption-failure branch: on a stale error we
+        must invalidate the region's cached client."""
+        from agent.bedrock_adapter import (
+            _bedrock_runtime_client_cache,
+            invalidate_runtime_client,
+            is_stale_connection_error,
+            reset_client_cache,
+        )
+
+        reset_client_cache()
+        wedged_client = MagicMock()
+        _bedrock_runtime_client_cache["us-west-2"] = wedged_client
+
+        exc = self._raise_bare_assertion_from_urllib3()
+        # This mirrors the fixed except-branch logic in chat_completion_helpers.
+        if is_stale_connection_error(exc):
+            invalidate_runtime_client("us-west-2")
+
+        assert "us-west-2" not in _bedrock_runtime_client_cache, (
+            "stale mid-stream error must evict the cached client so the outer "
+            "retry rebuilds a fresh connection pool"
+        )
+
+
 class TestStreamingAccessDeniedDetection:
     """is_streaming_access_denied_error() recognizes IAM denials of
     bedrock:InvokeModelWithResponseStream (InvokeModel-only policies)."""


### PR DESCRIPTION
## Summary

Evict the cached Bedrock runtime client when a stale/dead pooled connection fails **during stream consumption** on the true-streaming Converse path, so the outer retry loop can rebuild a fresh connection pool instead of hammering the wedged one forever.

## The bug

A pooled HTTPS connection can die under us (NAT/idle cull, VPN flap, server-side RST) and survive the initial `converse_stream()` call, only failing while the stream is being **consumed**. urllib3 trips an internal invariant on the corrupted pool state, which bubbles up as a **bare `AssertionError` with an empty `str(exc)`** — exactly the signature already documented in `bedrock_adapter.is_stale_connection_error`.

In `agent/chat_completion_helpers.py`, `interruptible_streaming_api_call`'s Bedrock worker (`_bedrock_call`) already handles this correctly for the *initial* `converse_stream()` call — the inner `except` calls `invalidate_runtime_client(region)` on a stale-connection error. But failures that occur **later, while consuming the stream** via `stream_converse_with_callbacks(...)`, were caught by a bare:

```python
except Exception as e:
    result["error"] = e
```

with no stale-connection check and no eviction. Because the wedged client stayed cached, every one of the outer loop's retries reused the same dead pool and reproduced the `AssertionError` — the call failed all 3 attempts in milliseconds, across every Bedrock model, until the process was restarted.

### Observed symptom

```
INFO  agent.chat_completion_helpers: Streaming failed before delivery:
WARNING agent.conversation_loop: API call failed (attempt 1/3) error_type=AssertionError ... provider=bedrock model=us.anthropic.claude-opus-4-8 summary=
WARNING agent.conversation_loop: API call failed (attempt 2/3) error_type=AssertionError ...
WARNING agent.conversation_loop: API call failed (attempt 3/3) error_type=AssertionError ...
ERROR   agent.conversation_loop: API call failed after 3 retries.
```

Empty `error_type=AssertionError` (no message), fails instantly on every retry, and a non-Bedrock provider call in the *same* session succeeds — confirming a wedged client rather than a bad request or a provider outage. Replaying the exact saved request body against the same model/region from a fresh client succeeds, further confirming the payload is healthy and the fault is dead-pool state.

## The fix

Mirror the inner eviction on the stream-consumption `except` branch. The branch re-imports the helpers and reads the region from a small holder (rather than assuming the outer `try`'s local names are bound — this `except` also covers a failure before those bindings), classifies the error with the existing `is_stale_connection_error`, and evicts the region's client so the next retry rebuilds the pool. Non-stale errors are untouched and still surface unchanged.

## Scope / blast radius

- Only the Bedrock true-streaming consumption-failure branch changes.
- Non-stale errors keep their exact current behavior (stored + surfaced, no eviction).
- Eviction is idempotent and wrapped so it can never mask the original error.

## Tests

Adds `TestStreamConsumptionStaleEviction` to `tests/agent/test_bedrock_adapter.py`:

- `test_bare_urllib3_assertion_is_stale` — a bare `AssertionError` raised from a `urllib3.*` frame (empty message) is classified stale.
- `test_application_assertion_is_not_stale` — an app-level `AssertionError` (no library frame) is **not** classified stale, so genuine invariant bugs aren't silently retried.
- `test_consumption_stale_error_evicts_client` — the fixed branch logic evicts the region's cached client on a stale mid-stream error.

Full suite: `135 passed` in `tests/agent/test_bedrock_adapter.py`.
