### PR TITLE
fix(terminal): use portable unique snapshot staging paths

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -114,34 +114,30 @@ class TestAtomicSnapshotWrite:
         assert f"export -p > {snap} " not in wrapped
         assert f"export -p > '{snap}'" not in wrapped
 
-    def test_temp_path_uses_bashpid_not_dollardollar(self):
-        """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
-        ``$$``.  In ``&``-launched concurrent subshells ``$$`` stays the parent
-        shell's PID, so two writers would pick the same temp name, clobber each
-        other mid-write, and mv would publish a torn file — the corruption is
-        only narrowed, not closed.  This is the bug shared by every prior PR in
-        the #38249 cluster."""
+    def test_temp_path_uses_python_uuid(self, monkeypatch):
+        """Temp names must not depend on $BASHPID, absent from macOS Bash 3.2."""
+        monkeypatch.setattr(
+            "tools.environments.base.uuid.uuid4",
+            lambda: MagicMock(hex="writer123"),
+        )
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "$BASHPID" in wrapped
-        # The bare $$ temp form must be gone.
+        assert ".tmp.writer123" in wrapped
+        assert "$BASHPID" not in wrapped
         assert ".tmp.$$" not in wrapped
 
-    def test_temp_path_static_part_is_quoted_bashpid_outside(self):
-        """The static path portion must be shlex-quoted (Windows/Git-Bash
-        ``C:/Users/...`` or spaces) while ``$BASHPID`` stays OUTSIDE the quotes
-        so it still expands."""
+    def test_temp_path_is_fully_quoted(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.environments.base.uuid.uuid4",
+            lambda: MagicMock(hex="writer123"),
+        )
         env = _TestableEnv()
         env._snapshot_ready = True
         env._snapshot_path = "/tmp/has space/hermes-snap-x.sh"
         wrapped = env._wrap_command("echo hi", "/tmp")
-        # The static path (with its space) is shlex-quoted as a single word, with
-        # $BASHPID appended OUTSIDE the quotes so it still expands at runtime.
-        assert "'/tmp/has space/hermes-snap-x.sh.tmp.'$BASHPID" in wrapped
-        # The space must never appear bare/unquoted in the temp token (that would
-        # word-split into two args and break the redirect/mv).
-        assert " space/hermes-snap-x.sh.tmp.$BASHPID" not in wrapped
+        assert "'/tmp/has space/hermes-snap-x.sh.tmp.writer123'" in wrapped
+        assert "export -p > /tmp/has space" not in wrapped
 
     def test_wrap_command_mv_chained_on_export_success(self):
         """A failed/partial ``export -p`` must NOT mv a torn temp over a good
@@ -153,10 +149,12 @@ class TestAtomicSnapshotWrite:
         assert "export -p > " in wrapped and "&& mv -f " in wrapped
         assert "rm -f " in wrapped  # temp cleanup on failure
 
-    def test_init_session_bootstrap_also_atomic_and_bashpid(self):
-        """The init_session bootstrap (first snapshot write) is the same shared
-        file a concurrent command could source — it must be atomic and use
-        ``$BASHPID`` too."""
+    def test_init_session_bootstrap_also_atomic_and_unique(self, monkeypatch):
+        """The initial shared snapshot must use the same atomic UUID staging."""
+        monkeypatch.setattr(
+            "tools.environments.base.uuid.uuid4",
+            lambda: MagicMock(hex="bootstrap123"),
+        )
         env = _TestableEnv()
         captured = {}
 
@@ -170,8 +168,8 @@ class TestAtomicSnapshotWrite:
         except Exception:
             pass
         boot = captured.get("cmd", "")
-        assert ".tmp." in boot and "mv -f " in boot, boot
-        assert "$BASHPID" in boot
+        assert ".tmp.bootstrap123" in boot and "mv -f " in boot, boot
+        assert "$BASHPID" not in boot
         assert ".tmp.$$" not in boot
 
     def test_snapshot_writes_use_private_umask_after_user_command(self):
@@ -209,8 +207,8 @@ class TestAtomicSnapshotConcurrencyBehavioral:
     the emitted script's guarantee holds under real concurrency: N concurrent
     writers + readers, and the snapshot is ALWAYS a complete, parseable env
     dump — never truncated mid-line with a ``declare -x`` / ``export`` fragment
-    that would corrupt PATH.  Crucially it uses ``$BASHPID`` (per-subshell
-    unique), which is what closes the race; ``$$`` would still tear here.
+    that would corrupt PATH. Each simulated command gets the same kind of
+    Python-generated unique token used by ``_wrap_command``.
     """
 
     def _run(self, script):
@@ -225,15 +223,15 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         import shlex
         snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
-        _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
-        # One writer iteration = the exact atomic sequence _wrap_command emits.
-        writer = (
-            "for i in $(seq 1 80); do "
-            "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
-            "done"
-        )
+        def writer(token):
+            snap_tmp = _q(f"{snap}.tmp.{token}")
+            return (
+                "for i in $(seq 1 80); do "
+                "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
+                f"{{ export -p > {snap_tmp} && mv -f {snap_tmp} {_q(snap)}; }} "
+                f"2>/dev/null || rm -f {snap_tmp} 2>/dev/null || true; "
+                "done"
+            )
         # Reader: repeatedly source the snapshot and check PATH never absorbs
         # an `export `/`declare -x` fragment (the corruption signature).
         reader = (
@@ -245,7 +243,7 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         )
         self._run(f"export -p > {_q(snap)}")  # seed a valid snapshot
         # 4 concurrent writers + 4 readers, repeated.
-        w = " & ".join([writer] * 4)
+        w = " & ".join(writer(f"writer-{i}") for i in range(4))
         r = " & ".join([reader] * 4)
         procs = [self._run(f"{w} & {r} & wait") for _ in range(3)]
         corrupt = any("CORRUPT" in p.stdout for p in procs)
@@ -266,7 +264,7 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         self._run(f"echo 'export GOOD=1' > {_q(snap)}")  # seed good snapshot
         # Redirect export into an unwritable dir so the export side fails; mv
         # must then NOT run (&&) and not clobber snap.
-        bad_tmp = _q("/nonexistent-dir/snap.tmp.") + "$BASHPID"
+        bad_tmp = _q("/nonexistent-dir/snap.tmp.failed")
         script = (
             f"{{ export -p > {bad_tmp} && mv -f {bad_tmp} {_q(snap)}; }} "
             f"2>/dev/null || rm -f {bad_tmp} 2>/dev/null || true"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -387,16 +387,11 @@ class BaseEnvironment(ABC):
         # source() either sees the old complete snapshot or the new complete
         # one — never a partial/truncated file.
         #
-        # The temp name MUST be unique per concurrent writer.  ``$$`` is the
-        # bash PID, but in ``&``-launched subshells (how concurrent terminal
-        # calls run) ``$$`` stays the *parent* shell's PID — so two concurrent
-        # writers would pick the SAME temp name, clobber each other's temp
-        # mid-write, and mv would then publish a torn file (the corruption is
-        # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Each wrapper is built in Python before its shell is spawned, so a
+        # UUID is portable and unique even on macOS' Bash 3.2 (which has no
+        # $BASHPID). Quoting the complete path also handles spaces and MSYS
+        # path rewriting without leaving a shell expansion outside the quote.
+        _snap_tmp = self._snapshot_temp_path()
         bootstrap = (
             f"umask 077\n"
             f"export -p > {_snap_tmp}\n"
@@ -497,6 +492,11 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
+    def _snapshot_temp_path(self) -> str:
+        """Return a shell-safe, per-writer snapshot staging path."""
+        path = f"{self._snapshot_path}.tmp.{uuid.uuid4().hex}"
+        return self._quote_shell_path(path)
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -507,13 +507,10 @@ class BaseEnvironment(ABC):
         _quoted_snap = self._quote_shell_path(self._snapshot_path)
         _quoted_cwd_file = self._quote_shell_path(self._cwd_file)
         # Use atomic file replacement for env snapshot updates (issue #38249).
-        # Assemble into a per-writer-unique temp file, then mv to atomically
-        # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shell-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Assemble into a per-writer UUID temp file, then atomically replace
+        # the snapshot. The UUID is generated in Python, so uniqueness does not
+        # depend on shell features unavailable in macOS' Bash 3.2.
+        _snap_tmp = self._snapshot_temp_path()
 
         parts = []
 


### PR DESCRIPTION
## Summary

- generate snapshot staging names with a Python UUID instead of shell `$BASHPID`
- quote the complete staging path, including the unique token
- keep atomic same-filesystem replacement and failed-export cleanup unchanged
- update the real concurrency regression to run four writers with distinct per-command tokens

## Why

`$BASHPID` is unavailable in the Bash 3.2 shipped by macOS, where it expands to an empty string. Concurrent terminal calls then reuse the same `.tmp.` path and can publish a torn environment snapshot. Python already generates each command wrapper independently and already imports `uuid`, so generating the writer token there is portable across macOS, Linux, Windows/Git-Bash, and remote backends.

## Verification

Repeated three consecutive times:

`/Users/mudrii/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/tools/test_base_environment.py`

Each run: 30 passed, 0 failed.

Also:

- `ruff check tools/environments/base.py tests/tools/test_base_environment.py`
- `git diff --check`
