### PR TITLE
fix: WeCom image support - SSRF whitelist and MIME type detection

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -789,7 +789,15 @@ class WeComAdapter(BasePlatformAdapter):
         if kind == "image":
             ext = self._guess_extension(url, content_type, fallback=self._detect_image_ext(raw))
             try:
-                return cache_image_from_bytes(raw, ext), content_type or self._mime_for_ext(ext, fallback="image/jpeg")
+                # Use detected extension to determine correct MIME type
+                # when CDN returns generic content-type (e.g. application/octet-stream)
+                resolved_content_type = content_type
+                if not content_type or content_type in ("application/octet-stream", "text/plain"):
+                    resolved_content_type = self._mime_for_ext(ext, fallback="image/jpeg")
+                    # If extension also resolves to generic type, use fallback
+                    if resolved_content_type in ("application/octet-stream", "text/plain"):
+                        resolved_content_type = "image/jpeg"
+                return cache_image_from_bytes(raw, ext), resolved_content_type
             except ValueError as exc:
                 logger.warning("[%s] Rejected non-image bytes from %s: %s", self.name, url, exc)
                 return None
@@ -820,9 +828,15 @@ class WeComAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _guess_extension(url: str, content_type: str, fallback: str) -> str:
-        ext = mimetypes.guess_extension(content_type) if content_type else None
-        if ext:
-            return ext
+        # Skip mimetypes.guess_extension for generic content-types that
+        # would return .bin (e.g. application/octet-stream from CDN).
+        # Fall through to URL path extension or magic-byte fallback.
+        if content_type and content_type not in (
+            "application/octet-stream", "text/plain",
+        ):
+            ext = mimetypes.guess_extension(content_type)
+            if ext:
+                return ext
         path_ext = Path(urlparse(url).path).suffix
         if path_ext:
             return path_ext

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -181,6 +181,12 @@ _ALWAYS_BLOCKED_NETWORKS = (
 # to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    # WeCom (企业微信) AI Bot image CDN — resolves to 198.18.0.0/15 behind
+    # local proxy/benchmark infrastructure.  Must be allowed for inbound
+    # image downloads in the WeCom platform adapter.
+    # Uses wildcard to match all Tencent Cloud COS CDN subdomains
+    # (e.g. ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com)
+    "*.myqcloud.com",
 })
 
 # 100.64.0.0/10 (CGNAT / Shared Address Space, RFC 6598) is NOT covered by
@@ -377,8 +383,21 @@ def is_always_blocked_url(url: str) -> bool:
 
 
 def _allows_private_ip_resolution(hostname: str, scheme: str) -> bool:
-    """Return True when a trusted HTTPS hostname may bypass IP-class blocking."""
-    return scheme == "https" and hostname in _TRUSTED_PRIVATE_IP_HOSTS
+    """Return True when a trusted HTTPS hostname may bypass IP-class blocking.
+
+    Supports both exact matches and wildcard suffixes (e.g. ``*.myqcloud.com``)
+    so that CDN subdomains like ``ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com``
+    are matched by a single ``*.myqcloud.com`` entry.
+    """
+    if scheme != "https":
+        return False
+    if hostname in _TRUSTED_PRIVATE_IP_HOSTS:
+        return True
+    # Wildcard suffix matching: ``*.example.com`` matches ``foo.example.com``
+    for trusted in _TRUSTED_PRIVATE_IP_HOSTS:
+        if trusted.startswith("*.") and hostname.endswith(trusted[1:]):
+            return True
+    return False
 
 
 def is_safe_url(url: str) -> bool:


### PR DESCRIPTION
## Summary

Fixes WeCom AI Bot image reception and native vision routing in Hermes Agent.

## Changes

### 1. SSRF Protection Whitelist (`tools/url_safety.py`)
- Added `*.myqcloud.com` to `_TRUSTED_PRIVATE_IP_HOSTS` for WeCom CDN
- WeCom images use Tencent Cloud COS CDN which resolves to `198.18.0.0/15` (benchmark range)
- Added wildcard matching support in `_allows_private_ip_resolution()`

### 2. MIME Type Detection (`plugins/platforms/wecom/adapter.py`)
- Fixed `_guess_extension()` to skip `application/octet-stream` and `text/plain` (which return `.bin`)
- Fixed `_cache_media()` to use magic-byte detected MIME type when CDN returns generic content-type
- Images now correctly identified as `image/png` instead of `application/octet-stream`

## Problem

When users send images to WeCom AI Bot:
1. Images were blocked by SSRF protection (CDN resolves to private IP range)
2. Images saved with `.bin` extension instead of `.png`
3. MIME type returned as `application/octet-stream` instead of `image/png`
4. Images classified as DOCUMENT type instead of PHOTO
5. Vision content not injected into model context

## Solution

1. Whitelist WeCom CDN domain in SSRF protection
2. Use magic bytes for extension detection when CDN returns generic content-type
3. Resolve correct MIME type from detected extension
4. Images now correctly routed as native vision input

## Testing

- Verified WeCom CDN URL (`ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com`) now allowed
- Verified images saved with correct `.png` extension
- Verified MIME type correctly returns `image/png`
- Verified images attached inline to model (native vision mode)
- All existing tests pass