### PR TITLE
feat(skills): inventory and audit effective skill roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ website/static/api/automation-blueprints-index.json
 models-dev-upstream/
 
 # Local editor / agent tooling (machine-specific; keep in global config, not the repo)
+.hardening-task.txt
 .codex/
 .cursor/
 .gemini/

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12776,7 +12776,9 @@ def cmd_skills(args):
     else:
         from hermes_cli.skills_hub import skills_command
 
-        skills_command(args)
+        code = skills_command(args)
+        if code:
+            sys.exit(int(code))
 
 
 def cmd_pairing(args):

--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -532,7 +532,7 @@ def cmd_security_audit(args: argparse.Namespace) -> int:
     skip_plugins = bool(getattr(args, "skip_plugins", False))
     skip_mcp = bool(getattr(args, "skip_mcp", False))
     output_json = bool(getattr(args, "json", False))
-    fail_on = (getattr(args, "fail_on", None) or "critical").upper()
+    fail_on = (getattr(args, "fail_on", None) or "high").upper()
     if fail_on not in SEVERITY_ORDER:
         print(
             f"unknown --fail-on value: {fail_on.lower()} "

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1063,8 +1063,22 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 
 
+def do_inventory(as_json: bool = False,
+                 console: Optional[Console] = None) -> dict:
+    """Report the active profile's skill inventory."""
+    from hermes_cli.skills_inventory import (
+        collect_skill_inventory,
+        print_skill_inventory,
+    )
+
+    c = console or _console
+    report = collect_skill_inventory()
+    print_skill_inventory(report, console=c, as_json=as_json)
+    return report
+
+
 def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
-             deep: bool = False) -> None:
+             deep: bool = False, all_active: bool = False) -> int:
     """Re-run security scan on installed hub skills.
 
     When ``deep=True``, also runs an opt-in AST-level diagnostic on Python
@@ -1075,19 +1089,63 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
     from tools.skills_guard import scan_skill, format_scan_report
 
     c = console or _console
+
+    if all_active:
+        from hermes_cli.skills_inventory import collect_skill_inventory
+
+        report = collect_skill_inventory()
+        active_entries = [e for e in report["entries"] if e["active"]]
+        if name:
+            active_entries = [e for e in active_entries if e["name"] == name]
+            if not active_entries:
+                c.print(f"[bold red]Error:[/] '{name}' is not an active skill.\n")
+                return 1
+
+        skipped = report["counts"]["total"] - len(active_entries)
+        c.print(f"\n[bold]Auditing {len(active_entries)} active skill(s)...[/]\n")
+
+        if deep:
+            from tools.skills_ast_audit import ast_scan_path, format_ast_report
+
+        scanned = 0
+        errors = 0
+        for entry in active_entries:
+            skill_path = Path(entry["path"])
+            if not skill_path.exists():
+                errors += 1
+                c.print(f"[bold red]Error:[/] {entry['name']} — path missing: {skill_path}")
+                continue
+            c.print(f"[dim]{entry['name']}: {skill_path}[/]")
+            if entry.get("symlinked"):
+                c.print(f"[dim]  real path: {entry['real_path']}[/]")
+            try:
+                result = scan_skill(skill_path, source=entry.get("source", "active"))
+            except Exception as exc:
+                errors += 1
+                c.print(f"[bold red]Error:[/] {entry['name']} — scan failed: {exc}")
+                continue
+            scanned += 1
+            c.print(format_scan_report(result))
+            if deep:
+                c.print(format_ast_report(ast_scan_path(skill_path), skill_name=entry["name"]))
+            c.print()
+
+        c.print(f"[dim]Summary: scanned={scanned} skipped={skipped} errors={errors}[/]\n")
+        return 1 if errors else 0
+
     lock = HubLockFile()
     installed = lock.list_installed()
 
     if not installed:
         c.print("[dim]No hub-installed skills to audit.[/]\n")
-        return
+        return 0
 
     targets = installed
     if name:
         targets = [e for e in installed if e["name"] == name]
         if not targets:
             c.print(f"[bold red]Error:[/] '{name}' is not a hub-installed skill.\n")
-            return
+            return 0
 
     c.print(f"\n[bold]Auditing {len(targets)} skill(s)...[/]\n")
 
@@ -1107,6 +1165,7 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
             c.print(format_ast_report(ast_scan_path(skill_path), skill_name=entry["name"]))
 
         c.print()
+    return 0
 
 
 def do_uninstall(name: str, console: Optional[Console] = None,
@@ -1723,9 +1782,13 @@ def skills_command(args) -> None:
         do_check(name=getattr(args, "name", None))
     elif action == "update":
         do_update(name=getattr(args, "name", None))
+    elif action == "inventory":
+        do_inventory(as_json=getattr(args, "json", False))
+        return 0
     elif action == "audit":
-        do_audit(name=getattr(args, "name", None),
-                 deep=getattr(args, "deep", False))
+        return do_audit(name=getattr(args, "name", None),
+                        deep=getattr(args, "deep", False),
+                        all_active=getattr(args, "all_active", False))
     elif action == "uninstall":
         do_uninstall(args.name)
     elif action == "reset":
@@ -1765,8 +1828,9 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|inventory|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -1901,6 +1965,9 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
                 source_filter = args[idx + 1]
         do_list(source_filter=source_filter, enabled_only=enabled_only, console=c)
 
+    elif action == "inventory":
+        do_inventory(as_json="--json" in args, console=c)
+
     elif action == "check":
         name = args[0] if args else None
         do_check(name=name, console=c)
@@ -1912,7 +1979,8 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     elif action == "audit":
         name = args[0] if args and not args[0].startswith("--") else None
         deep = "--deep" in args
-        do_audit(name=name, console=c, deep=deep)
+        all_active = "--all-active" in args
+        do_audit(name=name, console=c, deep=deep, all_active=all_active)
 
     elif action == "uninstall":
         if not args:
@@ -1999,9 +2067,10 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
         "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only]\n"
         "       List installed skills; --enabled-only filters to the active profile's live set\n"
+        "  [cyan]inventory[/] [--json]          Report active, disabled, archived, external, and duplicate skills\n"
         "  [cyan]check[/] [name]                Check hub skills for upstream updates\n"
         "  [cyan]update[/] [name]               Update hub skills with upstream changes\n"
-        "  [cyan]audit[/] [name]                Re-scan hub skills for security\n"
+        "  [cyan]audit[/] [name] [--all-active] Re-scan hub or active skills for security\n"
         "  [cyan]uninstall[/] <name>            Remove a hub-installed skill\n"
         "  [cyan]list-modified[/]               List bundled skills you've edited (kept by update)\n"
         "  [cyan]diff[/] <name>                 Diff your copy of a bundled skill vs the stock version\n"

--- a/hermes_cli/skills_inventory.py
+++ b/hermes_cli/skills_inventory.py
@@ -1,0 +1,309 @@
+"""Skill inventory and active-skill audit helpers for ``hermes skills``."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+
+@dataclass
+class SkillInventoryEntry:
+    name: str
+    category: str
+    path: Path
+    real_path: Path
+    root: Path
+    source: str
+    active: bool
+    disabled: bool = False
+    archived: bool = False
+    quarantined: bool = False
+    external: bool = False
+    symlinked: bool = False
+    shadowed: bool = False
+    duplicate: bool = False
+    skipped_reason: str = ""
+    error: str = ""
+
+
+def _safe_resolve(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def _path_contains_symlink(path: Path, root: Path) -> bool:
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        rel_parts = path.parts
+    current = root
+    if root.is_symlink():
+        return True
+    for part in rel_parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False
+
+
+def _skill_category(root: Path, skill_dir: Path) -> str:
+    try:
+        rel = skill_dir.relative_to(root)
+    except ValueError:
+        return ""
+    if len(rel.parts) > 1:
+        return rel.parts[0]
+    return ""
+
+
+def _entry_to_dict(entry: SkillInventoryEntry) -> dict[str, Any]:
+    return {
+        "name": entry.name,
+        "category": entry.category,
+        "path": str(entry.path),
+        "real_path": str(entry.real_path),
+        "root": str(entry.root),
+        "source": entry.source,
+        "active": entry.active,
+        "disabled": entry.disabled,
+        "archived": entry.archived,
+        "quarantined": entry.quarantined,
+        "external": entry.external,
+        "symlinked": entry.symlinked,
+        "shadowed": entry.shadowed,
+        "duplicate": entry.duplicate,
+        "skipped_reason": entry.skipped_reason,
+        "error": entry.error,
+    }
+
+
+def _iter_status_skill_files(status_root: Path):
+    if not status_root.is_dir():
+        return
+    for skill_md in sorted(status_root.rglob("SKILL.md")):
+        yield skill_md
+
+
+def _read_skill_entry(
+    *,
+    skill_md: Path,
+    root: Path,
+    source: str,
+    disabled_names: set[str],
+    archived: bool = False,
+    quarantined: bool = False,
+    external: bool = False,
+) -> SkillInventoryEntry:
+    from agent.skill_utils import (
+        parse_frontmatter,
+        skill_matches_environment,
+        skill_matches_platform,
+    )
+
+    skill_dir = skill_md.parent
+    real_path = _safe_resolve(skill_dir)
+    symlinked = _path_contains_symlink(skill_dir, root)
+    if symlinked:
+        try:
+            external = external or not real_path.is_relative_to(_safe_resolve(root))
+        except (OSError, RuntimeError):
+            external = True
+
+    try:
+        raw = skill_md.read_text(encoding="utf-8")
+        frontmatter, _body = parse_frontmatter(raw)
+        name = str(frontmatter.get("name") or skill_dir.name)
+    except Exception as exc:
+        return SkillInventoryEntry(
+            name=skill_dir.name,
+            category=_skill_category(root, skill_dir),
+            path=skill_dir,
+            real_path=real_path,
+            root=root,
+            source=source,
+            active=False,
+            archived=archived,
+            quarantined=quarantined,
+            external=external,
+            symlinked=symlinked,
+            skipped_reason="error",
+            error=str(exc),
+        )
+
+    disabled = name in disabled_names
+    skipped_reason = ""
+    active = not archived and not quarantined and not disabled
+    if disabled:
+        skipped_reason = "disabled"
+    elif archived:
+        skipped_reason = "archived"
+    elif quarantined:
+        skipped_reason = "quarantined"
+    elif not skill_matches_platform(frontmatter):
+        active = False
+        skipped_reason = "platform"
+    elif not skill_matches_environment(frontmatter):
+        active = False
+        skipped_reason = "environment"
+
+    return SkillInventoryEntry(
+        name=name,
+        category=_skill_category(root, skill_dir),
+        path=skill_dir,
+        real_path=real_path,
+        root=root,
+        source=source,
+        active=active,
+        disabled=disabled,
+        archived=archived,
+        quarantined=quarantined,
+        external=external,
+        symlinked=symlinked,
+        skipped_reason=skipped_reason,
+    )
+
+
+def collect_skill_inventory() -> dict[str, Any]:
+    """Return resolver-backed skill inventory for the active profile."""
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        get_disabled_skill_names,
+        get_external_skills_dirs,
+        iter_skill_index_files,
+    )
+    from hermes_constants import get_skills_dir
+
+    disabled_names = get_disabled_skill_names()
+    external_roots = {_safe_resolve(p) for p in get_external_skills_dirs()}
+    local_root = get_skills_dir()
+    entries: list[SkillInventoryEntry] = []
+
+    for root in get_all_skills_dirs():
+        if not root.is_dir():
+            continue
+        resolved_root = _safe_resolve(root)
+        is_external_root = resolved_root in external_roots
+        source = "external" if is_external_root else "local"
+        for skill_md in iter_skill_index_files(root, "SKILL.md"):
+            entries.append(
+                _read_skill_entry(
+                    skill_md=skill_md,
+                    root=root,
+                    source=source,
+                    disabled_names=disabled_names,
+                    external=is_external_root,
+                )
+            )
+
+    for skill_md in _iter_status_skill_files(local_root / ".archive"):
+        entries.append(
+            _read_skill_entry(
+                skill_md=skill_md,
+                root=local_root / ".archive",
+                source="archive",
+                disabled_names=disabled_names,
+                archived=True,
+            )
+        )
+
+    for skill_md in _iter_status_skill_files(local_root / ".hub" / "quarantine"):
+        entries.append(
+            _read_skill_entry(
+                skill_md=skill_md,
+                root=local_root / ".hub" / "quarantine",
+                source="quarantine",
+                disabled_names=disabled_names,
+                quarantined=True,
+            )
+        )
+
+    by_name: dict[str, list[SkillInventoryEntry]] = {}
+    for entry in entries:
+        by_name.setdefault(entry.name, []).append(entry)
+    for group in by_name.values():
+        if len(group) <= 1:
+            continue
+        for entry in group:
+            entry.duplicate = True
+        winner_seen = False
+        for entry in group:
+            if entry.active and not winner_seen:
+                winner_seen = True
+                continue
+            if entry.active:
+                entry.active = False
+                entry.shadowed = True
+                entry.skipped_reason = "shadowed"
+            elif not entry.archived and not entry.quarantined:
+                entry.shadowed = True
+                if not entry.skipped_reason:
+                    entry.skipped_reason = "shadowed"
+
+    counts = {
+        "total": len(entries),
+        "active": sum(1 for e in entries if e.active),
+        "disabled": sum(1 for e in entries if e.disabled),
+        "archived": sum(1 for e in entries if e.archived),
+        "quarantined": sum(1 for e in entries if e.quarantined),
+        "external": sum(1 for e in entries if e.external),
+        "symlinked": sum(1 for e in entries if e.symlinked),
+        "shadowed": sum(1 for e in entries if e.shadowed),
+        "duplicate": sum(1 for e in entries if e.duplicate),
+        "errors": sum(1 for e in entries if e.error),
+    }
+
+    return {
+        "counts": counts,
+        "entries": [_entry_to_dict(e) for e in entries],
+    }
+
+
+def print_skill_inventory(
+    report: dict[str, Any],
+    *,
+    console: Console,
+    as_json: bool = False,
+) -> None:
+    if as_json:
+        # Rich wraps long strings to terminal width, which inserts literal
+        # newlines inside JSON strings and corrupts machine-readable output.
+        print(json.dumps(report, indent=2, sort_keys=True), file=console.file)
+        return
+
+    counts = report["counts"]
+    table = Table(title="Skills Inventory")
+    table.add_column("Name", style="bold cyan")
+    table.add_column("Status", style="dim")
+    table.add_column("Source", style="dim")
+    table.add_column("Path", style="dim")
+    table.add_column("Real Path", style="dim")
+
+    for entry in sorted(report["entries"], key=lambda e: (e["name"], e["path"])):
+        if entry["active"]:
+            status = "active"
+        else:
+            status = entry["skipped_reason"] or "inactive"
+        table.add_row(
+            entry["name"],
+            status,
+            entry["source"],
+            entry["path"],
+            entry["real_path"],
+        )
+
+    console.print(table)
+    console.print(
+        "[dim]"
+        f"{counts['active']} active, {counts['disabled']} disabled, "
+        f"{counts['archived']} archived, {counts['quarantined']} quarantined, "
+        f"{counts['external']} external, {counts['symlinked']} symlinked, "
+        f"{counts['shadowed']} shadowed, {counts['duplicate']} duplicate"
+        "[/]\n"
+    )

--- a/hermes_cli/subcommands/security.py
+++ b/hermes_cli/subcommands/security.py
@@ -39,9 +39,9 @@ def build_security_parser(subparsers, *, cmd_security: Callable) -> None:
     )
     audit_parser.add_argument(
         "--fail-on",
-        default="critical",
+        default="high",
         choices=["low", "moderate", "high", "critical"],
-        help="Exit non-zero when any finding meets this severity (default: critical)",
+        help="Exit non-zero when any finding meets this severity (default: high)",
     )
     audit_parser.add_argument(
         "--skip-venv",

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -151,6 +151,20 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         action="store_true",
         help="Run AST-level analysis on Python files (opt-in diagnostic)",
     )
+    skills_audit.add_argument(
+        "--all-active",
+        action="store_true",
+        help="Audit every effectively active skill, including external roots and symlinks",
+    )
+
+    skills_inventory = skills_subparsers.add_parser(
+        "inventory", help="Report active, inactive, external, and duplicate skills"
+    )
+    skills_inventory.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of a table",
+    )
 
     skills_uninstall = skills_subparsers.add_parser(
         "uninstall", help="Remove a hub-installed skill"

--- a/tests/hermes_cli/test_security_audit.py
+++ b/tests/hermes_cli/test_security_audit.py
@@ -10,11 +10,28 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 
 from hermes_cli import security_audit as sa
+from hermes_cli.subcommands.security import build_security_parser
 
 
 # ─── Parsers ──────────────────────────────────────────────────────────────────
+
+
+def test_security_audit_parser_defaults_fail_on_high(capsys):
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_security_parser(subparsers, cmd_security=lambda _args: None)
+
+    args = parser.parse_args(["security", "audit"])
+
+    assert args.fail_on == "high"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["security", "audit", "--help"])
+    assert "default: high" in capsys.readouterr().out
 
 
 class TestRequirementsParser:
@@ -205,7 +222,7 @@ class TestExitCodes:
             "skip_plugins": True,
             "skip_mcp": True,
             "json": False,
-            "fail_on": "critical",
+            "fail_on": "high",
         }
         defaults.update(kwargs)
         return argparse.Namespace(**defaults)
@@ -256,6 +273,27 @@ class TestExitCodes:
             self._build_args(skip_venv=False, fail_on="critical")
         )
         assert code == 0
+
+    def test_default_threshold_fails_on_high(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(sa, "get_hermes_home", lambda: str(tmp_path))
+        fake_comp = sa.Component(
+            name="pkg", version="1.0", ecosystem="PyPI", source="venv"
+        )
+        monkeypatch.setattr(sa, "_discover_venv", lambda: [fake_comp])
+        monkeypatch.setattr(
+            sa, "_osv_query_batch", lambda comps: {fake_comp: ["X-1"]}
+        )
+        monkeypatch.setattr(
+            sa,
+            "_osv_fetch_details",
+            lambda ids: {"X-1": sa.Vulnerability(osv_id="X-1", severity="HIGH")},
+        )
+
+        code = sa.cmd_security_audit(
+            self._build_args(skip_venv=False, fail_on=None)
+        )
+
+        assert code == 1
 
     def test_unknown_fail_on_value_exits_two(self, tmp_path: Path, monkeypatch, capsys):
         monkeypatch.setattr(sa, "get_hermes_home", lambda: str(tmp_path))

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,3 +1,4 @@
+import json
 from io import StringIO
 from unittest.mock import patch
 
@@ -5,7 +6,15 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    do_audit,
+    do_check,
+    do_install,
+    do_inventory,
+    do_list,
+    do_update,
+    handle_skills_slash,
+)
 
 
 class _DummyLockFile:
@@ -220,6 +229,108 @@ def test_do_list_platform_env_is_ignored(three_source_env, monkeypatch):
     _capture()
 
     assert seen["platform"] is None
+
+
+def _write_skill(root, rel, name, *, extra=""):
+    skill_dir = root / rel
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+    if extra:
+        script = skill_dir / extra
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+        script.chmod(0o644)
+    return skill_dir
+
+
+def test_inventory_reports_active_external_symlink_shadowed_and_inactive_paths(
+    tmp_path,
+    monkeypatch,
+):
+    from agent import skill_utils
+
+    home = tmp_path / "home"
+    local_root = home / "skills"
+    external_root = tmp_path / "external-skills"
+    local_root.mkdir(parents=True)
+    external_root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [external_root])
+    skill_utils._external_dirs_cache_clear()
+
+    _write_skill(local_root, "productivity/alpha", "alpha")
+    _write_skill(local_root, "disabled", "disabled-skill")
+    _write_skill(local_root, ".archive/old-alpha", "old-alpha")
+    _write_skill(local_root, ".hub/quarantine/bad", "bad-skill")
+    external_duplicate = _write_skill(external_root, "alpha-copy", "alpha")
+    external_unique = _write_skill(external_root, "beta", "beta")
+    symlink_path = local_root / "linked-beta"
+    symlink_path.symlink_to(external_unique, target_is_directory=True)
+
+    monkeypatch.setattr(
+        skill_utils,
+        "get_disabled_skill_names",
+        lambda platform=None: {"disabled-skill"},
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=40)
+    report = do_inventory(as_json=True, console=console)
+    rendered = json.loads(sink.getvalue())
+    paths = {entry["path"] for entry in report["entries"]}
+
+    assert report["counts"]["active"] == 2
+    assert report["counts"]["disabled"] == 1
+    assert report["counts"]["archived"] == 1
+    assert report["counts"]["quarantined"] == 1
+    assert report["counts"]["external"] >= 2
+    assert report["counts"]["symlinked"] == 1
+    assert report["counts"]["shadowed"] >= 2
+    assert str(external_duplicate) in paths
+    assert str(symlink_path) in paths
+    linked = next(entry for entry in report["entries"] if entry["path"] == str(symlink_path))
+    assert linked["external"] is True
+    assert str(external_duplicate) in sink.getvalue()
+    assert str(symlink_path) in sink.getvalue()
+    assert rendered == report
+
+
+def test_all_active_audit_scans_external_root_and_reports_symlink_duplicate(
+    tmp_path,
+    monkeypatch,
+):
+    from agent import skill_utils
+
+    home = tmp_path / "home"
+    local_root = home / "skills"
+    external_root = tmp_path / "external-skills"
+    local_root.mkdir(parents=True)
+    external_root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [external_root])
+    monkeypatch.setattr(skill_utils, "get_disabled_skill_names", lambda platform=None: set())
+    skill_utils._external_dirs_cache_clear()
+
+    _write_skill(local_root, "alpha", "alpha")
+    external_skill = _write_skill(external_root, "beta", "beta")
+    symlink_path = local_root / "linked-beta"
+    symlink_path.symlink_to(external_skill, target_is_directory=True)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=240)
+    code = do_audit(all_active=True, console=console)
+    output = sink.getvalue()
+
+    assert code == 0
+    assert "Auditing 2 active skill(s)" in output
+    assert "alpha:" in output
+    assert "beta:" in output
+    assert str(symlink_path) in output
+    assert "scanned=2" in output
+    assert "errors=0" in output
 
 
 def test_do_check_reports_available_updates(monkeypatch):
@@ -780,4 +891,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/hermes_cli/test_skills_subparser.py
+++ b/tests/hermes_cli/test_skills_subparser.py
@@ -3,6 +3,23 @@
 import argparse
 
 
+def test_skills_parser_accepts_inventory_and_all_active_audit():
+    from hermes_cli.subcommands.skills import build_skills_parser
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_skills_parser(subparsers, cmd_skills=lambda _args: None)
+
+    audit_args = parser.parse_args(["skills", "audit", "--all-active", "--deep"])
+    assert audit_args.skills_action == "audit"
+    assert audit_args.all_active is True
+    assert audit_args.deep is True
+
+    inventory_args = parser.parse_args(["skills", "inventory", "--json"])
+    assert inventory_args.skills_action == "inventory"
+    assert inventory_args.json is True
+
+
 def test_no_duplicate_skills_subparser():
     """Ensure 'skills' subparser is only registered once to avoid Python 3.11+ crash.
 


### PR DESCRIPTION
## Summary

- add `hermes skills inventory` with table and machine-readable JSON output
- classify active, disabled, archived, quarantined, external, symlinked, and shadowed skills
- extend `hermes skills audit --all-active` across effective external roots while deduplicating symlink targets
- propagate meaningful CLI exit codes and raise the default security-audit failure threshold to high

## Why

Auditing only the stock profile directory misses effectively active skills supplied through external roots and symlinks. Operators need one deterministic inventory of the actual skill surface and an audit mode that scans each active target exactly once.

## Verification

- `/Users/mudrii/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_security_audit.py tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_skills_subparser.py`
- 60 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
