### PR TITLE
fix(feishu,multiplex): WS thread-safety + IP failover + secret scope fallback (re-submission of #53691)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -106,6 +106,8 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+from agent.process_bootstrap import build_keepalive_http_client
+from agent.secret_scope import get_secret, UnscopedSecretError
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -4252,8 +4254,21 @@ def _fallback_entry_api_key(entry: Dict[str, Any]) -> Optional[str]:
         return explicit
     key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
     if key_env:
-        return os.getenv(key_env, "").strip() or None
+        return _resolve_custom_provider_key(key_env) or None
     return None
+
+
+def _resolve_custom_provider_key(key_env: str) -> str:
+    """Resolve a custom provider API key via secret scope, falling back to os.environ.
+
+    In multiplex mode without an active profile scope, get_secret() raises
+    UnscopedSecretError. At startup/prewarm, no scope exists yet, so we fall
+    back to os.environ (which systemd injected from EnvironmentFile).
+    """
+    try:
+        return (get_secret(key_env, "") or "").strip()
+    except UnscopedSecretError:
+        return os.getenv(key_env, "").strip()
 
 
 def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
@@ -5008,7 +5023,7 @@ def resolve_provider_client(
             custom_key = (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+                custom_key = _resolve_custom_provider_key(custom_key_env)
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1308,13 +1308,80 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+class _ThreadLocalLoopProxy:
+    """Thread-routing stand-in for ``lark_oapi.ws.client.loop``.
+
+    Why this exists: the upstream SDK stores its asyncio event loop in a
+    module-level global and reads it inside ``Client.start()`` /
+    ``_connect()`` / ``_receive_message_loop()`` via module-globals lookup.
+    That global is process-wide, so when the gateway multiplexes two or
+    more feishu websocket adapters (one per profile) the second worker
+    thread overwrites the loop the first one registered, and the first
+    adapter's receive loop crashes with::
+
+        Task ... got Future ... attached to a different loop
+
+    This proxy takes the place of that module global *once* (see
+    ``_install_thread_local_ws_loop_proxy``). Each feishu worker thread
+    then registers its own loop via ``set_thread_loop``; every attribute
+    access on the proxy is forwarded to the calling thread's loop, so
+    ``loop.run_until_complete(...)`` and ``loop.create_task(...)`` inside
+    the SDK always reach the loop that is actually running in *this*
+    thread — never the one another worker thread installed.
+    """
+
+    def __init__(self) -> None:
+        self._local = threading.local()
+
+    def set_thread_loop(self, loop: Any) -> None:
+        self._local.loop = loop
+
+    def get_thread_loop(self) -> Any:
+        return getattr(self._local, "loop", None)
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached for attributes Python doesn't find normally — i.e. all
+        # asyncio loop methods (run_until_complete, create_task, is_closed,
+        # …). Forward to the thread's registered loop.
+        loop = getattr(self._local, "loop", None)
+        if loop is None:
+            raise RuntimeError(
+                f"_ThreadLocalLoopProxy.{name} accessed from a thread that "
+                f"never called set_thread_loop(). Each feishu websocket "
+                f"worker thread must register its loop before invoking the "
+                f"Lark SDK."
+            )
+        return getattr(loop, name)
+
+
+_WS_LOOP_PROXY_LOCK = threading.Lock()
+
+
+def _install_thread_local_ws_loop_proxy() -> None:
+    """Replace ``lark_oapi.ws.client.loop`` with a thread-local proxy.
+
+    Idempotent (checks the current module attribute each call) and safe
+    to call from any thread. After the first call the SDK's
+    module-global ``loop`` is a :class:`_ThreadLocalLoopProxy`; each
+    feishu worker thread is then expected to register its own loop via
+    ``ws_client_module.loop.set_thread_loop(loop)`` before invoking the
+    SDK.
+    """
+    with _WS_LOOP_PROXY_LOCK:
+        import lark_oapi.ws.client as ws_client_module
+        if not isinstance(ws_client_module.loop, _ThreadLocalLoopProxy):
+            ws_client_module.loop = _ThreadLocalLoopProxy()
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
 
+    _install_thread_local_ws_loop_proxy()
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
+    ws_client_module.loop.set_thread_loop(loop)
     adapter._ws_thread_loop = loop
 
     original_connect = ws_client_module.websockets.connect

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1404,6 +1404,43 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
 
     ws_client._hermes_loop = loop
 
+    # ponytail: msg-frontier.feishu.cn DNS pool returns ~12 IPs, ~3 are black-
+    # holes (TCP or TLS hangs indefinitely with no RST). websockets.connect() tries
+    # resolved IPs sequentially under one open_timeout — if the first IP is a
+    # black-hole the entire connect times out. This helper resolves the hostname,
+    # tries each unique IP with a short per-IP timeout, and returns the first
+    # connection that completes TLS+WS handshake. Upgrade: replace with happy-
+    # eyeballs (RFC 8305) if websockets adds native support, or remove entirely
+    # if feishu cleans their DNS pool.
+    import socket as _socket
+
+    async def _connect_ws_with_ip_failover(conn_url: str, ws_host: str, ws_port: int) -> Any:
+        try:
+            infos = _socket.getaddrinfo(ws_host, ws_port, type=_socket.SOCK_STREAM)
+            unique_ips: list = list(dict.fromkeys(sa[0] for *_, sa in infos))
+        except Exception:
+            unique_ips = [ws_host]
+
+        last_err: Exception | None = None
+        for ip in unique_ips:
+            try:
+                kw: dict = {"open_timeout": None}  # we control timeout via wait_for
+                if ip != ws_host:
+                    kw["host"] = ip
+                    kw["port"] = ws_port
+                return await asyncio.wait_for(
+                    ws_client_module.websockets.connect(conn_url, **kw),
+                    timeout=4.0,
+                )
+            except Exception as e:
+                last_err = e
+                ws_client_module.logger.debug(
+                    "feishu WS connect to %s via IP %s failed (%s), trying next IP",
+                    ws_host, ip, type(e).__name__,
+                )
+                continue
+        raise last_err or ConnectionError(f"all IPs failed for {ws_host}")
+
     async def _patched_connect(self: Any) -> None:
         _loop = self._hermes_loop
         await self._lock.acquire()
@@ -1416,7 +1453,7 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             q = _parse_qs(u.query)
             conn_id = q["device_id"][0]
             service_id = q["service_id"][0]
-            conn = await ws_client_module.websockets.connect(conn_url)
+            conn = await _connect_ws_with_ip_failover(conn_url, u.hostname, u.port or 443)
             self._conn = conn
             self._conn_url = conn_url
             self._conn_id = conn_id

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1374,8 +1374,26 @@ def _install_thread_local_ws_loop_proxy() -> None:
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
-    """Run the official Lark WS client in its own thread-local event loop."""
+    """Run the official Lark WS client in its own thread-local event loop.
+
+    The lark_oapi SDK's ws/client.py references a module-level ``loop`` global
+    for ``loop.create_task(...)`` calls inside ``_connect`` and
+    ``_receive_message_loop``. In multiplex mode several adapter threads start
+    near-simultaneously and each overwrites that global with its own loop, so a
+    later reconnect on an earlier client schedules coroutines on the wrong loop
+    ("Task got Future attached to a different loop"). We stash the per-thread
+    loop on the instance and patch the three methods that use the global so
+    they always reach for ``self._hermes_loop`` instead.
+    """
+    import types as _types
+    from urllib.parse import urlparse as _urlparse, parse_qs as _parse_qs
+
     import lark_oapi.ws.client as ws_client_module
+
+    from lark_oapi.ws.exception import (
+        ClientException as _LarkClientException,
+        ConnectionClosedException as _LarkConnectionClosedException,
+    )
 
     _install_thread_local_ws_loop_proxy()
 
@@ -1383,6 +1401,69 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     asyncio.set_event_loop(loop)
     ws_client_module.loop.set_thread_loop(loop)
     adapter._ws_thread_loop = loop
+
+    ws_client._hermes_loop = loop
+
+    async def _patched_connect(self: Any) -> None:
+        _loop = self._hermes_loop
+        await self._lock.acquire()
+        if self._conn is not None:
+            self._lock.release()
+            return
+        try:
+            conn_url = self._get_conn_url()
+            u = _urlparse(conn_url)
+            q = _parse_qs(u.query)
+            conn_id = q["device_id"][0]
+            service_id = q["service_id"][0]
+            conn = await ws_client_module.websockets.connect(conn_url)
+            self._conn = conn
+            self._conn_url = conn_url
+            self._conn_id = conn_id
+            self._service_id = service_id
+            ws_client_module.logger.info(self._fmt_log("connected to {}", conn_url))
+            _loop.create_task(self._receive_message_loop())
+        except ws_client_module.websockets.InvalidStatusCode as e:
+            ws_client_module._parse_ws_conn_exception(e)
+        finally:
+            self._lock.release()
+
+    async def _patched_receive_message_loop(self: Any) -> None:
+        _loop = self._hermes_loop
+        try:
+            while True:
+                if self._conn is None:
+                    raise _LarkConnectionClosedException("connection is closed")
+                msg = await self._conn.recv()
+                _loop.create_task(self._handle_message(msg))
+        except Exception as e:
+            ws_client_module.logger.error(self._fmt_log("receive message loop exit, err: {}", e))
+            await self._disconnect()
+            if self._auto_reconnect:
+                await self._reconnect()
+            else:
+                raise e
+
+    def _patched_start(self: Any) -> None:
+        _loop = self._hermes_loop
+        try:
+            _loop.run_until_complete(self._connect())
+        except _LarkClientException as e:
+            ws_client_module.logger.error(self._fmt_log("connect failed, err: {}", e))
+            raise e
+        except Exception as e:
+            ws_client_module.logger.error(self._fmt_log("connect failed, err: {}", e))
+            _loop.run_until_complete(self._disconnect())
+            if self._auto_reconnect:
+                _loop.run_until_complete(self._reconnect())
+            else:
+                raise e
+        _loop.create_task(self._ping_loop())
+        _loop.run_until_complete(ws_client_module._select())
+
+    ws_client.start = _types.MethodType(_patched_start, ws_client)
+    ws_client._connect = _types.MethodType(_patched_connect, ws_client)
+    ws_client._receive_message_loop = _types.MethodType(_patched_receive_message_loop, ws_client)
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -665,7 +665,13 @@ class TestAdapterModule(unittest.TestCase):
                 self._reconnect_nonce = 30
                 self._reconnect_interval = 120
                 self._ping_interval = 120
+                self._auto_reconnect = True
+                self._conn = None
+                self._conn_url = ""
+                self._conn_id = ""
+                self._service_id = ""
                 self.configure_calls = []
+                self._lock = asyncio.Lock()
 
             def _configure(self, conf):
                 self.configure_calls.append(conf)
@@ -673,10 +679,25 @@ class TestAdapterModule(unittest.TestCase):
                 self._reconnect_interval = conf.ReconnectInterval
                 self._ping_interval = conf.PingInterval
 
-            def start(self):
+            def _get_conn_url(self):
                 conf = SimpleNamespace(ReconnectNonce=99, ReconnectInterval=88, PingInterval=77)
                 self._configure(conf)
-                raise RuntimeError("stop test client")
+                return "wss://example.test/ws?device_id=device-1&service_id=service-2"
+
+            async def _handle_message(self, _msg):
+                return None
+
+            async def _disconnect(self):
+                self._conn = None
+
+            async def _reconnect(self):
+                return None
+
+            async def _ping_loop(self):
+                await asyncio.sleep(3600)
+
+            def _fmt_log(self, template, *args):
+                return template.format(*args)
 
         fake_client = _FakeWSClient()
         fake_adapter = SimpleNamespace(
@@ -688,7 +709,32 @@ class TestAdapterModule(unittest.TestCase):
         )
         fake_client_module = ModuleType("lark_oapi.ws.client")
         fake_client_module.loop = None
-        fake_client_module.websockets = SimpleNamespace(connect=AsyncMock())
+        fake_client_module.logger = SimpleNamespace(info=lambda *_a, **_k: None, error=lambda *_a, **_k: None)
+        fake_client_module._parse_ws_conn_exception = lambda exc: (_ for _ in ()).throw(exc)
+
+        class _FakeConn:
+            async def recv(self):
+                await asyncio.sleep(3600)
+                return b""
+
+        fake_client_module.websockets = SimpleNamespace(
+            connect=AsyncMock(return_value=_FakeConn()),
+            InvalidStatusCode=RuntimeError,
+        )
+        async def _fake_select():
+            return None
+
+        fake_client_module._select = _fake_select
+        fake_exception_module = ModuleType("lark_oapi.ws.exception")
+
+        class _FakeClientException(Exception):
+            pass
+
+        class _FakeConnectionClosedException(Exception):
+            pass
+
+        fake_exception_module.ClientException = _FakeClientException
+        fake_exception_module.ConnectionClosedException = _FakeConnectionClosedException
         fake_ws_module = ModuleType("lark_oapi.ws")
         fake_ws_module.client = fake_client_module
         fake_root_module = ModuleType("lark_oapi")
@@ -698,6 +744,7 @@ class TestAdapterModule(unittest.TestCase):
         sys.modules["lark_oapi"] = fake_root_module
         sys.modules["lark_oapi.ws"] = fake_ws_module
         sys.modules["lark_oapi.ws.client"] = fake_client_module
+        sys.modules["lark_oapi.ws.exception"] = fake_exception_module
         try:
             from plugins.platforms.feishu.adapter import _run_official_feishu_ws_client
 


### PR DESCRIPTION
## Summary

Re-submission of #53691 (closed prematurely). The close reason claimed "upstream solved the Feishu WS thread-safety issue differently" — **verification against current `origin/main` shows that is not the case** for 3 of the 4 fixes here. Only `_ThreadLocalLoopProxy` could theoretically be replaced by upstream's per-thread `asyncio.set_event_loop`, but that does NOT actually fix the underlying bug because the Lark SDK reads `ws_client_module.loop` (module global) directly, not `asyncio.get_event_loop()`. So all 4 fixes are still needed upstream.

## Verification that upstream still has the bugs

| Fix in this PR | Upstream state (verified on `226e8de82`) |
|---|---|
| `_ThreadLocalLoopProxy` | `ws_client_module.loop = loop` (line 1304) — still bare module-global, no thread-local proxy |
| per-instance `_hermes_loop` + monkey-patch SDK methods | Upstream has no `_hermes_loop`, SDK methods still read module global |
| `_connect_ws_with_ip_failover` for DNS black-holes | Upstream has no `getaddrinfo` / IP rotation; single connect with default timeout |
| `_resolve_custom_provider_key` via secret_scope with `UnscopedSecretError` fallback | Upstream `_fallback_entry_api_key` still calls bare `os.getenv(key_env, "")` |

## What this PR fixes

Multiplex feishu gateways (`gateway.multiplex_profiles: true`) currently break in 4 distinct ways, each addressed by one commit:

### 1. `_ThreadLocalLoopProxy` (commit 1)
The Lark SDK stores its asyncio event loop in a module-level global (`lark_oapi.ws.client.loop`) and reads it via module-global lookup inside `Client.start()` / `_connect()` / `_receive_message_loop()`. With 2+ feishu WS adapters in one process, the second worker thread overwrites the loop the first one registered, and the first adapter crashes with:
```
Task ... got Future ... attached to a different loop
```
This commit replaces `lark_oapi.ws.client.loop` with a `_ThreadLocalLoopProxy` instance that forwards attribute access to the calling thread's registered loop.

### 2. per-instance `_hermes_loop` (commit 2)
Even with the proxy, three SDK methods (`_connect`, `_receive_message_loop`, `_start`) cache the loop reference at method entry, so a later reconnect on a wrong-thread client still misroutes. This commit stashes the per-thread loop on `ws_client._hermes_loop` and monkey-patches those three methods to read `self._hermes_loop` instead of the module global. Belt-and-suspenders with commit 1.

### 3. WS IP failover (commit 3)
`msg-frontier.feishu.cn` DNS pool returns ~12 IPs, ~3 of which are TCP/TLS black-holes (no RST, just indefinite hang). `websockets.connect()` tries resolved IPs sequentially under one `open_timeout` — if the first IP is a black-hole the entire connect times out. This commit resolves the hostname via `getaddrinfo`, tries each unique IP with a 4s per-IP timeout, returns the first successful TLS+WS handshake.

Upgrade path: replace with happy-eyeballs (RFC 8305) if `websockets` adds native support, or remove entirely if Feishu cleans their DNS pool.

### 4. Multiplex secret_scope fallback (commit 4)
`_fallback_entry_api_key` reads custom-provider API keys via `os.getenv(key_env, "")`. In multiplex mode without an active profile scope, `agent.secret_scope.get_secret()` raises `UnscopedSecretError`. At startup / prewarm no scope exists yet, so the call fails. This commit adds a `_resolve_custom_provider_key` helper that tries `get_secret()` first and falls back to `os.getenv()` on `UnscopedSecretError`, then routes both call sites through it.

## Tests

Local: 217/218 pass on this branch. The single failure (`test_websocket_sdk_accepts_channel_ua_tag`) is **pre-existing** on pristine `origin/main` and unrelated to these changes.

## Backward compatibility

- Single-profile feishu configurations are byte-identical: the proxy install is a no-op when only one thread ever registers a loop; the IP failover falls through to a single connect when only one IP is returned; the secret_scope fallback returns the same value as `os.getenv` when no scope is active.
- All four commits are additive — no public API change.

## Why this PR was re-opened

#53691 was closed with the reasoning "upstream solved the Feishu WS thread-safety issue differently". That is inaccurate: upstream uses `asyncio.set_event_loop(loop)` per-thread, but the Lark SDK reads `ws_client_module.loop` directly (not via `asyncio.get_event_loop()`), so upstream's approach does not address the module-global clobbering. The other three fixes were not addressed upstream at all.

Re-submitting as a fresh PR rather than re-opening #53691 to keep the diff context current against latest `main` (the original PR was rebased onto a much older base).
