### PR TITLE
fix(feishu): strip residual markdown markers in table text fallback

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4530,7 +4530,10 @@ class FeishuAdapter(BasePlatformAdapter):
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
+            # Strip residual markdown markers (**, `, ~~, etc.) when forcing
+            # table content to plain text. Previously the raw content was
+            # emitted verbatim, leaving literal ** / ` visible on the client.
+            text_payload = {"text": _strip_markdown_to_plain_text(content)}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)

--- a/tests/plugins/platforms/feishu/test_table_strip_markdown.py
+++ b/tests/plugins/platforms/feishu/test_table_strip_markdown.py
@@ -1,0 +1,84 @@
+"""Tests for Feishu adapter markdown handling in _build_outbound_payload.
+
+Verifies that:
+- Markdown table content falls back to text type (Feishu post doesn't render tables)
+- When forced to text, residual markdown markers (** / ` / ~~) are stripped
+  instead of being emitted verbatim
+- Non-table content keeps its existing post / text branch behaviour
+
+See issue: markdown tables in Feishu text fallback leak literal ** / ` markers
+"""
+
+import json
+
+import pytest
+
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+class _StubAdapter(FeishuAdapter):
+    """Bypass BasePlatformAdapter.__init__ — we only test the pure helper."""
+
+    def __init__(self):
+        # skip super().__init__ — only call the bound method
+        pass
+
+
+@pytest.fixture
+def adapter():
+    return _StubAdapter()
+
+
+def test_table_with_bold_strips_double_star(adapter):
+    content = "| **指标** | **值** |\n| --- | --- |\n| users | 100 |"
+    msg_type, payload = adapter._build_outbound_payload(content)
+    assert msg_type == "text", "Table content must force text type"
+    decoded = json.loads(payload)
+    assert "**" not in decoded["text"], "** must be stripped in text fallback"
+    assert decoded["text"].startswith("|")
+
+
+def test_table_with_inline_code_strips_backticks(adapter):
+    content = "| name | snippet |\n| --- | --- |\n| foo | `bar` |"
+    msg_type, payload = adapter._build_outbound_payload(content)
+    assert msg_type == "text"
+    decoded = json.loads(payload)
+    assert "`" not in decoded["text"], "backticks must be stripped"
+
+
+def test_table_with_strikethrough_strips_tildes(adapter):
+    content = "| status |\n| --- |\n| ~~done~~ |"
+    msg_type, payload = adapter._build_outbound_payload(content)
+    decoded = json.loads(payload)
+    assert "~~" not in decoded["text"], "~~ must be stripped"
+    assert "done" in decoded["text"]
+
+
+def test_table_rows_preserved_after_strip(adapter):
+    """Behavior contract: stripping markdown must not destroy table structure."""
+    content = "| a | b |\n| --- | --- |\n| 1 | 2 |"
+    _, payload = adapter._build_outbound_payload(content)
+    decoded = json.loads(payload)
+    # row count preserved (no row collapsing)
+    assert decoded["text"].count("\n") == 2
+    # column count preserved per row (each row has 2 separators)
+    for line in decoded["text"].split("\n"):
+        assert line.count("|") >= 2
+
+
+def test_plain_text_no_markdown_stays_text(adapter):
+    """No markdown hint → text type, content unchanged."""
+    content = "正常文本没有 markdown"
+    msg_type, payload = adapter._build_outbound_payload(content)
+    assert msg_type == "text"
+    assert json.loads(payload)["text"] == content
+
+
+def test_post_branch_unaffected_by_table_fix(adapter):
+    """Non-table content with markdown hint still goes through post branch."""
+    content = "这是 **加粗** 测试"
+    msg_type, payload = adapter._build_outbound_payload(content)
+    assert msg_type == "post", "non-table markdown must keep post branch"
+    # post branch payload uses zh_cn.content shape
+    decoded = json.loads(payload)
+    assert "zh_cn" in decoded


### PR DESCRIPTION
## Bug

When Feishu adapter's `_build_outbound_payload()` forces table content to `msg_type='text'` (because Feishu post `md` elements don't render GFM tables, the message would otherwise appear blank on the client), the **raw content is emitted verbatim**. Markdown markers like `**` (bold), `` ` `` (inline code), and `~~` (strikethrough) appear as literal characters on the recipient's client, e.g. `**指标**` shows up instead of `指标`.

## Fix

Mirror the non-table post-fallback path by running table content through `_strip_markdown_to_plain_text()` before serializing. This matches the behavior already applied to post-rejection and update-rejection fallbacks (see `_strip_markdown_to_plain_text` callers at the table-fallback sites in `adapter.py`).

## Tests

Added `tests/plugins/platforms/feishu/test_table_strip_markdown.py` with 5 cases:

- table+bold strips `**`
- table+inline-code strips backticks
- table+strikethrough strips `~~`
- plain text unchanged
- non-table markdown still routes to `post` branch

All 5 cases pass against the modified `_build_outbound_payload`.

## Fixes

References #9549.

## Diff

```
diff --git a/plugins/platforms/feishu/adapter.py b/plugins/platforms/feishu/adapter.py
@@ -4530,7 +4530,10 @@ class FeishuAdapter(BasePlatformAdapter):
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
+            # Strip residual markdown markers (**, `, ~~, etc.) when forcing
+            # table content to plain text. Previously the raw content was
+            # emitted verbatim, leaving literal ** / ` visible on the client.
+            text_payload = {"text": _strip_markdown_to_plain_text(content)}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
```
