### PR TITLE
fix(dashboard-auth): retry OIDC refresh without scope when the IDP rejects it

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -291,13 +291,43 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         # rejects the rotation with invalid_client.
         extra_data, extra_headers = self._token_endpoint_auth(disco)
         data.update(extra_data)
-        return self._exchange(
-            disco["token_endpoint"],
-            data,
-            bad_request_exc=RefreshExpiredError,
-            previous_refresh_token=refresh_token,
-            extra_headers=extra_headers,
-        )
+        try:
+            return self._exchange(
+                disco["token_endpoint"],
+                data,
+                bad_request_exc=RefreshExpiredError,
+                previous_refresh_token=refresh_token,
+                extra_headers=extra_headers,
+            )
+        except RefreshExpiredError:
+            # Providers disagree about `scope` on a refresh grant, in opposite
+            # directions: some narrow the granted scope when it is omitted
+            # (hence sending it above), while others -- WSO2 IS among them --
+            # reject a refresh that repeats the scope string at all. RFC 6749
+            # §6 makes the parameter optional, so both are defensible readings.
+            #
+            # Sending it unconditionally strands the second group: their
+            # rejection surfaces as an expired refresh token and forces a full
+            # interactive re-login on every access-token expiry. Omitting it
+            # unconditionally would strand the first group instead.
+            #
+            # So: keep sending it by default, and retry once without it when
+            # the grant is refused. The retry costs one request on a path that
+            # otherwise ends in interactive login, and it cannot turn a working
+            # refresh into a broken one -- we only get here after a failure. A
+            # genuinely expired refresh token simply fails twice and raises as
+            # before.
+            # Build a fresh payload rather than mutating the one already handed
+            # to the first request: nothing should be able to observe the first
+            # attempt's body changing after the fact.
+            retry_data = {k: v for k, v in data.items() if k != "scope"}
+            return self._exchange(
+                disco["token_endpoint"],
+                retry_data,
+                bad_request_exc=RefreshExpiredError,
+                previous_refresh_token=refresh_token,
+                extra_headers=extra_headers,
+            )
 
     def verify_session(self, *, access_token: str) -> Optional[Session]:
         # The session cookie stores the ID token in the access-token slot (see

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -582,6 +582,148 @@ class TestRefreshAndRevoke:
     def provider(self, rsa_keypair):
         return _make_provider(rsa_keypair)
 
+    def test_refresh_happy_path_rotates(self, provider, rsa_keypair):
+        id_token = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(
+            200,
+            {
+                "id_token": id_token,
+                "token_type": "Bearer",
+                "refresh_token": "rt_rotated",
+            },
+        )
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ) as mock_post:
+            session = provider.refresh_session(refresh_token="rt_old")
+        assert isinstance(session, Session)
+        assert session.access_token == id_token
+        assert session.refresh_token == "rt_rotated"
+        assert session.provider == "self-hosted"
+        _, kwargs = mock_post.call_args
+        assert kwargs["data"]["grant_type"] == "refresh_token"
+        assert kwargs["data"]["refresh_token"] == "rt_old"
+        assert kwargs["data"]["client_id"] == _CLIENT_ID
+        # A provider that accepts the scoped refresh must only be asked once,
+        # and must still be sent the scope (some IDPs narrow it otherwise).
+        assert kwargs["data"]["scope"] == provider._scopes
+        assert mock_post.call_count == 1
+
+    def test_refresh_retries_without_scope_when_idp_rejects_it(
+        self, provider, rsa_keypair
+    ):
+        # WSO2 IS (and others) issue a valid refresh token but reject a refresh
+        # grant that repeats the scope string. That 400 used to surface as an
+        # expired refresh token, forcing a full interactive re-login on every
+        # access-token expiry. Retry once without scope instead.
+        id_token = _mint_id_token(rsa_keypair)
+        rejected = _mock_post(400, {"error": "invalid_scope"})
+        accepted = _mock_post(
+            200,
+            {
+                "id_token": id_token,
+                "token_type": "Bearer",
+                "refresh_token": "rt_rotated",
+            },
+        )
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post",
+            side_effect=[rejected, accepted],
+        ) as mock_post:
+            session = provider.refresh_session(refresh_token="rt_old")
+
+        assert isinstance(session, Session)
+        assert session.access_token == id_token
+        assert session.refresh_token == "rt_rotated"
+        assert mock_post.call_count == 2
+
+        first_kwargs = mock_post.call_args_list[0].kwargs
+        second_kwargs = mock_post.call_args_list[1].kwargs
+        # First attempt keeps upstream behaviour; the retry drops only `scope`.
+        assert first_kwargs["data"]["scope"] == provider._scopes
+        assert "scope" not in second_kwargs["data"]
+        assert second_kwargs["data"]["grant_type"] == "refresh_token"
+        assert second_kwargs["data"]["refresh_token"] == "rt_old"
+        assert second_kwargs["data"]["client_id"] == _CLIENT_ID
+
+    def test_refresh_raises_when_both_attempts_rejected(self, provider):
+        # A genuinely expired refresh token fails with and without scope; the
+        # fallback must not mask that as anything other than expiry.
+        rejected = _mock_post(400, {"error": "invalid_grant"})
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post",
+            side_effect=[rejected, rejected],
+        ) as mock_post:
+            with pytest.raises(RefreshExpiredError):
+                provider.refresh_session(refresh_token="rt_old")
+
+        assert mock_post.call_count == 2
+
+    def test_refresh_keeps_previous_rt_when_idp_omits(self, provider, rsa_keypair):
+        # Some IDPs don't rotate; keep the caller's existing RT alive.
+        id_token = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(200, {"id_token": id_token, "token_type": "Bearer"})
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            session = provider.refresh_session(refresh_token="rt_kept")
+        assert session.refresh_token == "rt_kept"
+
+    def test_refresh_400_raises_refresh_expired(self, provider):
+        mock_resp = _mock_post(400, {"error": "invalid_grant"})
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            with pytest.raises(RefreshExpiredError, match="invalid_grant"):
+                provider.refresh_session(refresh_token="rt_dead")
+
+    def test_refresh_empty_token_no_network(self, provider):
+        with patch("plugins.dashboard_auth.self_hosted.httpx.post") as mock_post:
+            with pytest.raises(RefreshExpiredError):
+                provider.refresh_session(refresh_token="")
+        mock_post.assert_not_called()
+
+    def test_refresh_network_error_raises_provider_error(self, provider):
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post",
+            side_effect=httpx.RequestError("boom"),
+        ):
+            with pytest.raises(ProviderError, match="unreachable"):
+                provider.refresh_session(refresh_token="rt_x")
+
+    def test_revoke_posts_to_revocation_endpoint(self, provider):
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post"
+        ) as mock_post:
+            provider.revoke_session(refresh_token="rt_x")
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == f"{_ISSUER}/revoke"
+        assert kwargs["data"]["token"] == "rt_x"
+
+    def test_revoke_empty_token_noop(self, provider):
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post"
+        ) as mock_post:
+            assert provider.revoke_session(refresh_token="") is None
+        mock_post.assert_not_called()
+
+    def test_revoke_swallows_errors(self, provider):
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post",
+            side_effect=httpx.RequestError("down"),
+        ):
+            # Must not raise.
+            assert provider.revoke_session(refresh_token="rt_x") is None
+
+    def test_revoke_noop_when_no_revocation_endpoint(self, provider):
+        provider._discovery["revocation_endpoint"] = ""
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post"
+        ) as mock_post:
+            assert provider.revoke_session(refresh_token="rt_x") is None
+        mock_post.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Plugin entry point: env + config.yaml precedence


### PR DESCRIPTION
## What does this PR do?

Some OIDC providers — WSO2 IS among them — issue a valid refresh token but reject a
refresh grant that repeats the configured `scope` string. Hermes mapped that rejection to
an expired refresh token, so users were forced through a full interactive login every time
the access token expired.

Root cause: `SelfHostedProvider.refresh_session()` always sends `"scope": self._scopes` on
the refresh grant. When the IDP rejects it, `_exchange()` raises the 400 as
`RefreshExpiredError` — indistinguishable from a genuinely dead refresh token — so the
middleware re-prompts for login.

This keeps sending `scope` and **retries once without it** when the grant is refused.

### Why not just drop `scope`?

That was this PR's previous revision, and it trades one broken set of providers for
another. The parameter is sent deliberately — the comment on it reads *"Re-request the same
scopes so the rotated ID token keeps the identity claims (some IDPs narrow scope on refresh
otherwise)."* Providers disagree in **opposite** directions:

| Provider behaviour | `scope` sent | `scope` omitted |
|---|---|---|
| narrows scope when omitted | works | rotated ID token loses identity claims |
| rejects a repeated scope (WSO2 IS) | refresh fails → interactive login | works |

RFC 6749 §6 makes the parameter optional, so both readings are legitimate and no
unconditional choice is correct for everyone. The retry satisfies both.

## Related Issue

Fixes #74988

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/dashboard_auth/self_hosted/__init__.py`: `refresh_session()` keeps `"scope"` on
  the first attempt; on `RefreshExpiredError` it retries once with a payload that omits
  only `scope`. The retry builds a **fresh dict** rather than mutating the one already
  handed to the first request, so the first attempt's body cannot be observed changing
  after the fact.
- `tests/plugins/dashboard_auth/test_self_hosted_provider.py`: happy path now asserts
  `scope` **is** sent and that an accepting provider is called exactly once; new test
  drives reject-then-accept and asserts the two payloads differ *only* by `scope`; new test
  asserts a double rejection still surfaces as `RefreshExpiredError`.

## How to Test

```bash
pytest tests/plugins/dashboard_auth/test_self_hosted_provider.py -q   # 85/85 pass
```

The behaviour is pinned by three cases in `TestRefreshAndRevoke`:

1. `test_refresh_happy_path_rotates` — an accepting provider is called **once** and still
   receives `scope` (guards against silently dropping the parameter).
2. `test_refresh_retries_without_scope_when_idp_rejects_it` — a 400 on the first attempt is
   followed by a second request identical **except** for the omitted `scope`, which
   succeeds and rotates the session.
3. `test_refresh_raises_when_both_attempts_rejected` — a genuinely dead refresh token still
   ends in `RefreshExpiredError`, so this cannot mask real expiry.

Against a live IDP: configure the self-hosted OIDC provider against WSO2 IS, sign in to the
dashboard, and wait for the access token to expire. Before this change the session drops to
an interactive login; after it, the refresh rotates silently.

| Scenario | Before | After |
|---|---|---|
| provider accepts scoped refresh | 1 request, succeeds | 1 request, succeeds (unchanged) |
| provider rejects repeated scope | `RefreshExpiredError` → interactive login | 2nd request without `scope` succeeds |
| refresh token genuinely expired | `RefreshExpiredError` | `RefreshExpiredError` (after 2 attempts) |

The extra request only ever occurs on a path that otherwise ends in a full interactive
re-login, and it cannot convert a working refresh into a broken one because it runs only
after a failure.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (client) against WSO2 IS 7.3 on Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config or behaviour change for valid setups)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture change)
- [x] I've considered cross-platform impact — N/A (pure HTTP payload logic)
- [x] I've updated tool descriptions/schemas — N/A

## Notes

- Rebased onto current `main`; `main` still sends `scope` on the refresh grant, so the fix
  still applies.
- **Duplicate check**: searched open and merged PRs for OIDC/refresh-scope work — no other
  PR touches the refresh grant payload. #63057 (24h session TTL fallback + transparent
  auth) is adjacent but concerns session lifetime rather than grant shape.