### PR TITLE
feat(plugins): add goal judge hook

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -33,11 +33,80 @@ import json
 import logging
 import re
 import time
-from dataclasses import dataclass, field, asdict
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+def _plugin_goal_judge(**kwargs: Any) -> Optional[Tuple[str, str, bool, Optional[Dict[str, Any]]]]:
+    """Return the first valid plugin goal verdict, or ``None`` for fallback.
+
+    Plugins may replace only the judge verdict. Goal state transitions, turn
+    budgets, wait barriers, persistence, and continuation prompts stay owned
+    by :class:`GoalManager`.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        results = invoke_hook("goal_judge", **kwargs)
+    except Exception as exc:
+        logger.warning("Goal judge hook dispatch failed: %s", exc)
+        return None
+
+    try:
+        iterator = iter(results)
+    except Exception as exc:
+        logger.warning("Goal judge hook results were not iterable: %s", exc)
+        return None
+
+    while True:
+        try:
+            result = next(iterator)
+        except StopIteration:
+            break
+        except Exception as exc:
+            logger.warning("Goal judge hook result iteration failed: %s", exc)
+            return None
+        try:
+            if not isinstance(result, dict):
+                continue
+            verdict_value = result.get("verdict")
+            reason_value = result.get("reason", "")
+            if not isinstance(verdict_value, str) or not isinstance(reason_value, str):
+                continue
+            verdict = verdict_value.strip().lower()
+            reason = reason_value.strip()
+            if verdict in {"done", "continue"}:
+                return verdict, reason, False, None
+            if verdict != "wait":
+                continue
+
+            targets = []
+            session_id = result.get("wait_on_session")
+            pid = result.get("wait_on_pid")
+            seconds = result.get("wait_for_seconds")
+            if isinstance(session_id, str) and session_id.strip():
+                targets.append({"session_id": session_id.strip()})
+            if (
+                isinstance(pid, int)
+                and not isinstance(pid, bool)
+                and 0 < pid <= MAX_PLUGIN_WAIT_INTEGER
+            ):
+                targets.append({"pid": pid})
+            if (
+                isinstance(seconds, int)
+                and not isinstance(seconds, bool)
+                and 0 < seconds <= MAX_PLUGIN_WAIT_INTEGER
+            ):
+                targets.append({"seconds": seconds})
+            if len(targets) == 1:
+                return "wait", reason, False, targets[0]
+        except Exception as exc:
+            logger.warning("Invalid goal judge hook result skipped: %s", exc)
+    return None
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -46,6 +115,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_TURNS = 20
 DEFAULT_JUDGE_TIMEOUT = 30.0
+# Plugin wait directives cross a trust boundary. Keep numeric targets within
+# the portable signed 32-bit range used by process IDs and time APIs so a
+# malformed plugin cannot trigger overflow while the core applies the wait.
+MAX_PLUGIN_WAIT_INTEGER = 2_147_483_647
 # Judge output budget. The freeform judge returns a one-line JSON verdict, but
 # reasoning models (deepseek-v4, qwq, etc.) burn tokens on hidden reasoning
 # before emitting the visible JSON — and the first /goal turn's prompt is
@@ -1441,13 +1514,31 @@ class GoalManager:
         state.turns_used += 1
         state.last_turn_at = time.time()
 
-        verdict, reason, parse_failed, wait_directive = judge_goal(
-            state.goal,
-            last_response,
-            subgoals=state.subgoals or None,
-            background_processes=background_processes,
-            contract=state.contract if state.has_contract() else None,
+        contract = state.contract if state.has_contract() else None
+        contract_snapshot = contract.to_dict() if contract is not None else None
+        plugin_verdict = _plugin_goal_judge(
+            session_id=self.session_id,
+            goal=state.goal,
+            last_response=last_response,
+            user_initiated=user_initiated,
+            background_processes=deepcopy(background_processes),
+            subgoals=list(state.subgoals),
+            contract=contract_snapshot,
         )
+        plugin_handled = plugin_verdict is not None
+        if plugin_handled:
+            verdict, reason, parse_failed, wait_directive = plugin_verdict
+        else:
+            verdict, reason, parse_failed, wait_directive = judge_goal(
+                state.goal,
+                last_response,
+                subgoals=state.subgoals or None,
+                background_processes=background_processes,
+                contract=contract,
+            )
+        if plugin_handled and verdict == "wait" and state.turns_used >= state.max_turns:
+            verdict = "continue"
+            wait_directive = None
         state.last_verdict = verdict
         state.last_reason = reason
 
@@ -1459,12 +1550,8 @@ class GoalManager:
         else:
             state.consecutive_parse_failures = 0
 
-        # WAIT verdict: the judge decided the agent is blocked on async work
-        # and re-poking now would be busy-work. Set the barrier and park —
-        # the turn we just counted stands (the judge call happened), but no
-        # continuation fires. The loop resumes automatically when the pid
-        # exits or the deadline passes (next evaluate_after_turn falls through
-        # the is_waiting() short-circuit once the barrier clears).
+        # Preserve the built-in judge's established wait ordering. Plugin
+        # waits that would exceed the budget were normalized to continue above.
         if verdict == "wait" and wait_directive:
             if wait_directive.get("session_id"):
                 self.wait_on_session(str(wait_directive["session_id"]), reason=reason)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -154,6 +154,16 @@ VALID_HOOKS: Set[str] = {
     # verification-stop nudge; this hook is for user/plugin policy and is
     # bounded by agent.max_verify_nudges.
     "pre_verify",
+    # Goal verdict provider. Fired after an active goal turn and before the
+    # built-in auxiliary-model judge. A plugin may return a verdict mapping:
+    #   {"verdict": "done" | "continue", "reason": "..."}
+    # or a bounded wait verdict with exactly one target:
+    #   {"verdict": "wait", "reason": "...", "wait_on_pid": 123}
+    #   {"verdict": "wait", "reason": "...", "wait_on_session": "id"}
+    #   {"verdict": "wait", "reason": "...", "wait_for_seconds": 30}
+    # Invalid/None results are ignored and the built-in judge remains the
+    # fallback. Hermes core still owns state, budgets, waiting, and prompts.
+    "goal_judge",
     "pre_api_request",
     "post_api_request",
     "api_request_error",

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -371,6 +371,377 @@ class TestGoalManager:
         assert d2["verdict"] == "inactive"
         assert d2["should_continue"] is False
 
+    def test_goal_judge_hook_can_supply_verdict(self, hermes_home):
+        """A valid plugin verdict replaces the built-in judge result."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="plugin-judge-handled")
+        mgr.set("ship it")
+        hook_result = {"verdict": "done", "reason": "external verifier passed"}
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=[hook_result]) as hook,
+            patch.object(goals, "judge_goal") as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("feature shipped")
+
+        hook.assert_called_once()
+        assert hook.call_args.args == ("goal_judge",)
+        assert hook.call_args.kwargs["session_id"] == "plugin-judge-handled"
+        assert hook.call_args.kwargs["goal"] == "ship it"
+        assert hook.call_args.kwargs["last_response"] == "feature shipped"
+        builtin_judge.assert_not_called()
+        assert decision["verdict"] == "done"
+        assert decision["should_continue"] is False
+        assert mgr.state.status == "done"
+        assert mgr.state.turns_used == 1
+
+    def test_goal_judge_hook_real_plugin_registration(self, hermes_home, monkeypatch):
+        """A callback registered through PluginContext reaches GoalManager."""
+        from hermes_cli import goals, plugins
+        from hermes_cli.goals import GoalContract, GoalManager
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+        manager = PluginManager()
+        context = PluginContext(PluginManifest(name="external-verifier"), manager)
+        calls = []
+
+        def verify(**kwargs):
+            calls.append(kwargs)
+            kwargs["contract"]["verification"] = "plugin tried to mutate state"
+            return {"verdict": "done", "reason": "registered verifier passed"}
+
+        context.register_hook("goal_judge", verify)
+        monkeypatch.setattr(plugins, "_plugin_manager", manager)
+
+        mgr = GoalManager(session_id="plugin-judge-real-registration")
+        mgr.set("ship it", contract=GoalContract(verification="original check"))
+        with patch.object(goals, "judge_goal") as builtin_judge:
+            decision = mgr.evaluate_after_turn("feature shipped")
+
+        builtin_judge.assert_not_called()
+        assert len(calls) == 1
+        assert calls[0]["session_id"] == "plugin-judge-real-registration"
+        assert calls[0]["goal"] == "ship it"
+        assert calls[0]["contract"]["verification"] == "plugin tried to mutate state"
+        assert decision["verdict"] == "done"
+        state = mgr.state
+        assert state is not None
+        assert state.status == "done"
+        assert state.contract.verification == "original check"
+
+    @pytest.mark.parametrize(
+        "hook_results",
+        [
+            [],
+            [None],
+            [{"verdict": "maybe", "reason": "unclear"}],
+            [{"verdict": "wait", "reason": "bad target", "wait_on_session": ["not", "an", "id"]}],
+        ],
+    )
+    def test_goal_judge_hook_falls_back_to_builtin(self, hermes_home, hook_results):
+        """No usable plugin verdict preserves the existing built-in judge path."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="plugin-judge-fallback")
+        mgr.set("ship it")
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=hook_results),
+            patch.object(
+                goals,
+                "judge_goal",
+                return_value=("continue", "builtin result", False, None),
+            ) as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("still working")
+
+        builtin_judge.assert_called_once()
+        assert decision["verdict"] == "continue"
+        assert decision["reason"] == "builtin result"
+
+    def test_goal_judge_hook_background_snapshot_preserves_fallback(self, hermes_home):
+        """An observing plugin cannot mutate the built-in judge's process input."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        background_processes = [{"session_id": "build-1", "status": "running"}]
+
+        def observe_then_fall_back(_hook_name, **kwargs):
+            kwargs["background_processes"][0]["status"] = "exited"
+            return [None]
+
+        mgr = GoalManager(session_id="plugin-judge-background-snapshot")
+        mgr.set("ship it")
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=observe_then_fall_back),
+            patch.object(
+                goals,
+                "judge_goal",
+                return_value=("continue", "builtin result", False, None),
+            ) as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn(
+                "still working", background_processes=background_processes
+            )
+
+        builtin_judge.assert_called_once()
+        assert builtin_judge.call_args.kwargs["background_processes"] == [
+            {"session_id": "build-1", "status": "running"}
+        ]
+        assert background_processes[0]["status"] == "running"
+        assert decision["verdict"] == "continue"
+
+    @pytest.mark.parametrize(
+        ("hook_results", "expected"),
+        [
+            (
+                [{"verdict": "wait", "reason": "build", "wait_on_pid": 4242}],
+                ("wait", "build", False, {"pid": 4242}),
+            ),
+            (
+                [{"verdict": "wait", "reason": "backoff", "wait_for_seconds": 30}],
+                ("wait", "backoff", False, {"seconds": 30}),
+            ),
+            (
+                [
+                    {
+                        "verdict": "wait",
+                        "reason": "ambiguous",
+                        "wait_on_pid": 4242,
+                        "wait_for_seconds": 30,
+                    },
+                    {"verdict": "continue", "reason": "second valid result"},
+                ],
+                ("continue", "second valid result", False, None),
+            ),
+            (
+                [
+                    {
+                        "verdict": "wait",
+                        "reason": "unbounded delay",
+                        "wait_for_seconds": 10**10000,
+                    },
+                    {"verdict": "continue", "reason": "bounded fallback"},
+                ],
+                ("continue", "bounded fallback", False, None),
+            ),
+            (
+                [
+                    {
+                        "verdict": "wait",
+                        "reason": "unbounded pid",
+                        "wait_on_pid": 10**10000,
+                    },
+                    {"verdict": "continue", "reason": "bounded fallback"},
+                ],
+                ("continue", "bounded fallback", False, None),
+            ),
+        ],
+    )
+    def test_goal_judge_hook_wait_contract_and_first_valid_result(
+        self, hermes_home, hook_results, expected
+    ):
+        """All wait forms are bounded and invalid results do not block later ones."""
+        from hermes_cli.goals import _plugin_goal_judge
+
+        with patch("hermes_cli.plugins.invoke_hook", return_value=hook_results):
+            result = _plugin_goal_judge(session_id="contract-test")
+
+        assert result == expected
+
+    def test_goal_judge_hook_malformed_result_falls_back(self, hermes_home):
+        """A plugin result that raises during parsing cannot break the Goal loop."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        class BadString:
+            def __str__(self):
+                raise RuntimeError("malformed plugin value")
+
+        mgr = GoalManager(session_id="plugin-judge-malformed")
+        mgr.set("ship it")
+
+        with (
+            patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"verdict": BadString(), "reason": "bad"}],
+            ),
+            patch.object(
+                goals,
+                "judge_goal",
+                return_value=("continue", "builtin result", False, None),
+            ) as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("still working")
+
+        builtin_judge.assert_called_once()
+        assert decision["verdict"] == "continue"
+        assert decision["reason"] == "builtin result"
+
+    def test_goal_judge_hook_mapping_error_falls_back(self, hermes_home):
+        """A dict subclass that raises during access cannot break the Goal loop."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        class BadMapping(dict):
+            def get(self, key, default=None):
+                raise RuntimeError("malformed plugin mapping")
+
+        mgr = GoalManager(session_id="plugin-judge-bad-mapping")
+        mgr.set("ship it")
+
+        with (
+            patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[BadMapping(), {"verdict": "done", "reason": "second verifier"}],
+            ),
+            patch.object(goals, "judge_goal") as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("still working")
+
+        builtin_judge.assert_not_called()
+        assert decision["verdict"] == "done"
+        assert decision["reason"] == "second verifier"
+
+    def test_goal_judge_hook_result_iteration_error_falls_back(self, hermes_home):
+        """A dispatcher iterable that raises cannot break the Goal loop."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        class BadResults:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise RuntimeError("broken dispatcher iterable")
+
+        mgr = GoalManager(session_id="plugin-judge-iteration-error")
+        mgr.set("ship it")
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=BadResults()),
+            patch.object(
+                goals,
+                "judge_goal",
+                return_value=("continue", "builtin result", False, None),
+            ) as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("still working")
+
+        builtin_judge.assert_called_once()
+        assert decision["verdict"] == "continue"
+        assert decision["reason"] == "builtin result"
+
+    def test_goal_judge_hook_cannot_bypass_turn_budget(self, hermes_home):
+        """Core still owns budget enforcement after accepting a plugin verdict."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="plugin-judge-budget", default_max_turns=1)
+        mgr.set("hard goal")
+
+        with (
+            patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"verdict": "continue", "reason": "more work"}],
+            ),
+            patch.object(goals, "judge_goal") as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("step one")
+
+        builtin_judge.assert_not_called()
+        assert decision["should_continue"] is False
+        assert mgr.state.status == "paused"
+        assert mgr.state.turns_used == 1
+        assert "budget" in (mgr.state.paused_reason or "").lower()
+
+    def test_goal_judge_hook_wait_cannot_bypass_turn_budget(self, hermes_home):
+        """Core enforces the turn budget before accepting a plugin wait."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="plugin-judge-wait-budget", default_max_turns=1)
+        mgr.set("watch CI")
+        hook_result = {
+            "verdict": "wait",
+            "reason": "CI still running",
+            "wait_for_seconds": 30,
+        }
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=[hook_result]),
+            patch.object(goals, "judge_goal") as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("CI has started")
+
+        builtin_judge.assert_not_called()
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is False
+        state = mgr.state
+        assert state is not None
+        assert state.status == "paused"
+        assert state.last_verdict == "continue"
+        assert state.waiting_until == 0.0
+        assert state.turns_used == 1
+        assert "budget" in (state.paused_reason or "").lower()
+
+    def test_builtin_goal_judge_wait_keeps_existing_budget_order(self, hermes_home):
+        """The new plugin bound does not change built-in judge wait behavior."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="builtin-judge-wait-budget", default_max_turns=1)
+        mgr.set("watch CI")
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(
+                goals,
+                "judge_goal",
+                return_value=("wait", "CI still running", False, {"seconds": 30}),
+            ),
+        ):
+            decision = mgr.evaluate_after_turn("CI has started")
+
+        assert decision["verdict"] == "wait"
+        state = mgr.state
+        assert state is not None
+        assert state.status == "active"
+        assert state.waiting_until > 0.0
+        assert state.turns_used == 1
+
+    def test_goal_judge_hook_wait_uses_core_barrier(self, hermes_home):
+        """A plugin wait verdict is persisted through the core wait API."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="plugin-judge-wait")
+        mgr.set("watch CI")
+        hook_result = {
+            "verdict": "wait",
+            "reason": "CI still running",
+            "wait_on_session": "process-session-1",
+        }
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", return_value=[hook_result]),
+            patch.object(goals, "judge_goal") as builtin_judge,
+        ):
+            decision = mgr.evaluate_after_turn("CI has started")
+
+        builtin_judge.assert_not_called()
+        assert decision["verdict"] == "wait"
+        assert decision["should_continue"] is False
+        state = mgr.state
+        assert state is not None
+        assert state.waiting_on_session == "process-session-1"
+        assert state.waiting_reason == "CI still running"
+        assert state.turns_used == 1
+
     def test_continuation_prompt_shape(self, hermes_home):
         """The continuation prompt must include the goal text verbatim —
         and must be safe to inject as a user-role message (prompt-cache

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -631,6 +631,7 @@ class TestPluginHooks:
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
         assert "transform_llm_output" in VALID_HOOKS
+        assert "goal_judge" in VALID_HOOKS
 
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -371,7 +371,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Some hooks have explicitly documented behavior-changing return contracts — for example, [`pre_tool_call`](#pre_tool_call) can **block** a tool, [`pre_llm_call`](#pre_llm_call) can **inject context**, and [`goal_judge`](#goal_judge) can supply a Goal verdict. Hooks without a documented return contract are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -383,6 +383,7 @@ def register(ctx):
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`pre_verify`](#pre_verify) | Once per turn when the agent edited code, before it verifies/finishes | `{"action": "continue", "message": str}` to keep going |
+| [`goal_judge`](#goal_judge) | After an active Goal turn, before the built-in auxiliary-model judge | A bounded Goal verdict mapping, or `None` to use the built-in judge |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
 | [`on_session_end`](#on_session_end) | Session ends | ignored |
 | [`on_session_finalize`](#on_session_finalize) | CLI/gateway tears down an active session (flush, save, stats) | ignored |
@@ -715,6 +716,46 @@ def register(ctx):
 ```
 
 For standing guidance that should shape the built-in missing-evidence nudge, use `agent.verify_guidance`. For broader coding posture rules that don't need to *gate* verification, prefer `agent.coding_instructions` in `config.yaml` — it rides the coding brief and costs no extra turn.
+
+---
+
+### `goal_judge`
+
+Fires after a turn for an active `/goal`, after Hermes has enforced any existing wait barrier and counted the completed turn, but before the built-in auxiliary-model judge runs. It lets a plugin provide an external verification verdict without replacing the Goal state machine.
+
+**Callback signature:**
+
+```python
+def my_callback(session_id: str, goal: str, last_response: str,
+                user_initiated: bool, background_processes: list | None,
+                subgoals: list, contract: dict | None, **kwargs):
+```
+
+Return `None` when the plugin does not handle this Goal. To supply a verdict, return one of these mappings:
+
+```python
+{"verdict": "done", "reason": "external checks passed"}
+{"verdict": "continue", "reason": "deployment is not healthy yet"}
+{"verdict": "wait", "reason": "CI is still running", "wait_on_session": "proc-123"}
+{"verdict": "wait", "reason": "build is still running", "wait_on_pid": 4242}
+{"verdict": "wait", "reason": "rate limited", "wait_for_seconds": 30}
+```
+
+For `wait`, provide exactly one positive target. Numeric PID/seconds targets must be integers no greater than `2147483647`; booleans, non-positive values, and larger integers are invalid. Invalid values are ignored. The first valid plugin result wins; if no plugin returns one, Hermes calls its built-in Goal judge.
+
+The hook supplies **only the verdict**. `subgoals`, `contract`, and `background_processes` are snapshots; mutating them does not alter the Goal or the built-in judge fallback input. Hermes core still owns turn-budget enforcement, wait barriers, Goal state transitions, persistence, and continuation prompts. A plugin cannot bypass those controls by returning extra fields. Hook exceptions are logged and skipped, so the built-in judge remains the safe fallback.
+
+```python
+def verify_goal(goal, last_response, **kwargs):
+    if goal != "Deploy the service":
+        return None
+    if "health check: passed" in last_response.lower():
+        return {"verdict": "done", "reason": "health check passed"}
+    return {"verdict": "continue", "reason": "health check evidence missing"}
+
+def register(ctx):
+    ctx.register_hook("goal_judge", verify_goal)
+```
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds a generic `goal_judge` plugin hook so standalone plugins can supply an external verification verdict for an active `/goal` before Hermes falls back to the built-in auxiliary-model judge.

The hook is intentionally bounded: plugins may return only `done`, `continue`, or a `wait` verdict with exactly one validated wait target. `GoalManager` continues to own turn accounting, budget enforcement, wait barriers, state transitions, persistence, and continuation prompts.

Invalid, missing, or malformed results are skipped. A later valid plugin may still handle the Goal; otherwise Hermes falls back to the built-in judge. Hook dispatch errors also fall back safely.

## Related Issue

N/A. This is a generic plugin-surface addition for a standalone plugin consumer.

Related but non-duplicative work:

- #26991 adds a post-judge continuation veto; it cannot supply or replace the Goal judge verdict.
- #27790 adds observer hooks for state transitions; it does not provide pre-judge verification.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Tests

## Changes Made

- Add `goal_judge` to the supported plugin hooks.
- Dispatch the hook before the built-in Goal judge.
- Strictly validate plugin verdicts and bounded wait targets.
- Use the first valid plugin result.
- Preserve core-owned Goal state transitions and safety controls.
- Pass snapshots of mutable Goal context to prevent callbacks from mutating persisted state.
- Document the callback contract, fallback behavior, and ownership boundary.
- Add regression tests for malformed results, exception fallback, snapshot isolation, turn budgets, persistence, and wait barriers.

## How to Test

```bash
pytest tests/hermes_cli/test_goals.py tests/hermes_cli/test_plugins.py -q