### PR TITLE
fix(holographic): keep hyphenated identifiers searchable (split on -/_)

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -603,16 +603,22 @@ class FactRetriever:
         _FTS_SPECIAL = '"()*^:-+'
         tokens: list[str] = []
         for raw in query.lower().split():
-            cleaned = raw.strip(".,;:!?\"'()[]{}#@<>") .translate(
-                str.maketrans("", "", _FTS_SPECIAL)
-            )
-            if len(cleaned) < 2:
-                continue
-            if cleaned in cls._FTS_STOPWORDS:
-                continue
-            # FTS5 phrase-literal each token to ensure no special chars
-            # sneak through as operators.
-            tokens.append(f'"{cleaned}"')
+            # Split on hyphen/underscore FIRST so hyphenated identifiers
+            # ("vibe-trading", "cincin-coord", "fastembed_bge-small") expand
+            # into OR-joined sub-tokens. FTS5's default tokenizer also splits
+            # on those separators, so gluing them (the old behavior) produced a
+            # token that never exists in the index and silently returned 0 hits.
+            word = raw.strip(".,;:!?\"'()[]{}#@<>")
+            for part in word.split("-"):
+                for sub in part.split("_"):
+                    cleaned = sub.translate(str.maketrans("", "", _FTS_SPECIAL))
+                    if len(cleaned) < 2:
+                        continue
+                    if cleaned in cls._FTS_STOPWORDS:
+                        continue
+                    # FTS5 phrase-literal each token to ensure no special chars
+                    # sneak through as operators.
+                    tokens.append(f'"{cleaned}"')
         if not tokens:
             # Fallback: raw query (likely returns 0, but never crashes)
             return query


### PR DESCRIPTION
fix(holographic): hyphenated-identifier search returned 0 results

_Sanitize FTS query glued hyphenated tokens (vibe-trading -> vibetrading)
but FTS5's default tokenizer splits stored text on the same separators, so
the glued token never existed in the index and search returned 0 hits for
any hyphenated identifier (MCP server names, package names, domains).

Split each token on '-' and '_' before sanitizing so identifiers expand
into OR-joined sub-tokens (vibe-trading -> "vibe" OR "trading"). Phrase
quoting preserved; non-hyphenated queries unaffected.

Re-submission of closed PR #64209. Upstream `main` still uses plain `query.lower().split()` which glues `vibe-trading` into `vibetrading`; FTS5 tokenizes on `-`/`_` so the glued form never matches. This splits tokens on `-`/`_` into OR-joined sub-tokens.