### PR TITLE
fix(chat): repaint after WebGL context loss so DOM fallback appears

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -755,7 +755,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (useWebgl) {
       try {
         const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
+        // On WebGL context loss (GPU-process crash, tab throttled after long
+        // background, mobile browser suspend/resume, driver reset, aggressive
+        // hardware-acceleration blocklists on some mobile Chrome builds) the
+        // WebglAddon is left in a defunct state. Merely disposing it removes
+        // the WebGL renderer but xterm's DOM fallback only re-paints on the
+        // next dirty region — so the terminal freezes on the last GL frame
+        // until the user types or resizes. Reported in the wild as "chat pane
+        // shows only the Hermes banner and nothing else on mobile Chrome
+        // while Firefox on the same device is fine". Force a full repaint so
+        // the DOM renderer picks up immediately.
+        webgl.onContextLoss(() => {
+          webgl.dispose();
+          try {
+            term.refresh(0, term.rows - 1);
+          } catch {
+            /* term already disposed — nothing to repaint */
+          }
+        });
         term.loadAddon(webgl);
       } catch (err) {
         console.warn(


### PR DESCRIPTION
## Summary

Fixes a bug where the dashboard Chat tab renders only the Hermes banner and appears frozen on mobile Chrome (Firefox on the same device is fine). Root cause is xterm's WebGL renderer losing its GL context; `WebglAddon.onContextLoss` disposed the addon but never repainted, so xterm's DOM fallback stayed empty until the user typed or resized.

## Reproduction

- Open the dashboard from a mobile Chrome build with an aggressive hardware-acceleration blocklist (also reproducible on desktop Chrome via `chrome://gpu` → "Disable Accelerated Canvas 2D" or by triggering context loss with a devtools extension).
- Navigate to `/chat?resume=<any-existing-session>`.
- Observed: only the boot banner + tool/skill list; the resumed history and any new output never appear. WebSocket is fine — a resize (rotate device / drag DevTools) makes everything appear at once.
- Expected: the terminal keeps painting after the GL context is lost, just via the DOM renderer.

## Fix

In `web/src/pages/ChatPage.tsx`, after `webgl.dispose()` in the context-loss handler, force a full `term.refresh(0, term.rows - 1)` so the DOM fallback repaints the current buffer immediately instead of waiting for the next dirty region.

- No new dependencies (matches the "extend existing code" rung on the Footprint Ladder from AGENTS.md).
- The stable `@xterm/addon-canvas` releases still declare `peerDependency: @xterm/xterm ^5.0.0` (we're on `^6.0.0`), so introducing an explicit Canvas addon would drag in a peer-dep warning for a code path that already has a working DOM fallback in xterm 6.
- `try/catch` around `term.refresh` because context loss can race with tab-close teardown.

## Verification

From the repo root (using the workspace's root `node_modules`):

```
cd web && ../node_modules/.bin/tsc -p . --noEmit             # 0 errors
cd web && ../node_modules/.bin/eslint src/pages/ChatPage.tsx  # 0 errors (only the pre-existing 1185:6 exhaustive-deps warning, untouched)
```

Manual: reproduced the black-pane symptom on mobile Chrome against a dashboard running the unpatched build, confirmed the terminal now repaints post-context-loss with the patched build.

## Rubric fit (per `AGENTS.md`)

- Fixes a real reported symptom ("chat pane blank on mobile Chrome; Firefox works").
- Smallest possible footprint at the "extend existing code" rung — no schema, no config, no toolset changes.
- No cache-invalidation, no system-prompt mutation, no toolset changes.
- No change-detector tests added.
