### PR TITLE
feat(context): report exact truncation ranges

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1776,6 +1776,57 @@ def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -
 # Context files (SOUL.md, AGENTS.md, .cursorrules)
 # =========================================================================
 
+def _char_to_line(content: str, char_pos: int) -> int:
+    """Return the 1-based line number containing ``char_pos`` in ``content``.
+
+    ``char_pos`` is clamped to ``[0, len(content)]``.  Line counting follows
+    Python's ``str.splitlines`` semantics so trailing newlines don't inflate
+    the count.
+    """
+    pos = max(0, min(char_pos, len(content)))
+    # Count newlines before pos; +1 for 1-based line numbering.
+    return content.count("\n", 0, pos) + 1
+
+
+def _format_truncation_warning(
+    filename: str,
+    total_chars: int,
+    max_chars: int,
+    head_chars: int,
+    tail_chars: int,
+    omitted_start: int,
+    omitted_end: int,
+    content: str,
+) -> str:
+    """Build a detailed truncation warning message with exact omitted ranges.
+
+    Reports the exact character range omitted (``chars A–B of N``) and, when
+    practical, the line range (``lines X–Y``) so operators can locate the
+    missing material without guessing.
+    """
+    omitted_chars = omitted_end - omitted_start
+    line_start = _char_to_line(content, omitted_start)
+    line_end = (
+        _char_to_line(content, omitted_end - 1)
+        if omitted_end > omitted_start
+        else line_start
+    )
+    line_range = (
+        f", lines {line_start}–{line_end}"
+        if line_end > line_start
+        else f", line {line_start}"
+    )
+    return (
+        f"⚠️  Context file {filename} TRUNCATED: "
+        f"{total_chars} chars exceeds limit of {max_chars} "
+        f"(omitted chars {omitted_start}–{omitted_end} of {total_chars}, "
+        f"~{omitted_chars} chars{line_range}; "
+        f"kept {head_chars} head + {tail_chars} tail) — "
+        f"trim the file, pin a larger context_file_max_chars, or use a "
+        f"larger-context model!"
+    )
+
+
 def _truncate_content(
     content: str,
     filename: str,
@@ -1789,24 +1840,29 @@ def _truncate_content(
     concrete path the agent should ``read_file`` to recover the full content
     (defaults to ``filename`` when not supplied). ``context_length`` lets the
     cap scale to the model's window when no explicit config override is set.
+
+    The truncation warning reports the exact omitted character range and the
+    line range so operators can pinpoint the missing material, not just the
+    total / limit.
     """
     if max_chars is None:
         max_chars = _get_context_file_max_chars(context_length)
     if len(content) <= max_chars:
         return content
     target = read_path or filename
-    msg = (
-        f"⚠️  Context file {filename} TRUNCATED: "
-        f"{len(content)} chars exceeds limit of {max_chars} — "
-        f"trim the file, pin a larger context_file_max_chars, or use a "
-        f"larger-context model!"
-    )
-    logger.warning(msg)
-    _record_truncation_warning(msg)
     head_chars = int(max_chars * CONTEXT_TRUNCATE_HEAD_RATIO)
     tail_chars = int(max_chars * CONTEXT_TRUNCATE_TAIL_RATIO)
     head = content[:head_chars]
     tail = content[-tail_chars:]
+    # Exact omitted range: characters head_chars .. (len(content) - tail_chars)
+    omitted_start = head_chars
+    omitted_end = len(content) - tail_chars
+    msg = _format_truncation_warning(
+        filename, len(content), max_chars, head_chars, tail_chars,
+        omitted_start, omitted_end, content,
+    )
+    logger.warning(msg)
+    _record_truncation_warning(msg)
     marker = (
         f"\n\n[...truncated {filename}: kept {head_chars}+{tail_chars} of "
         f"{len(content)} chars. The middle is omitted — if you need the full "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -224,6 +224,79 @@ class TestTruncateContent:
         assert "parent.md" in parent_warnings[0]
 
 
+class TestDetailedTruncationWarnings:
+    """Truncation warnings report exact omitted char and line ranges."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_truncation_state(self, monkeypatch):
+        drain_truncation_warnings()
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    def test_warning_reports_exact_char_range(self):
+        """The warning includes the exact omitted character range, not just total/limit."""
+        max_chars = 200
+        content = "A" * max_chars + "B" * 300  # 500 chars total
+        _truncate_content(content, "range.md", max_chars=max_chars)
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        w = warnings[0]
+        # Must contain the word 'omitted' (the key signal that ranges are reported).
+        assert "omitted" in w.lower()
+        # Must contain the exact start char (head_chars = 200 * 0.7 = 140).
+        assert "140" in w
+        # Must contain the exact end char (500 - 200 * 0.2 = 460).
+        assert "460" in w
+
+    def test_warning_reports_line_range_single_line(self):
+        """When content is a single line, warning reports 'line N' not 'lines'."""
+        content = "x" * 500  # one long line, no newlines
+        _truncate_content(content, "single.md", max_chars=200)
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        # Single line → "line 1" not "lines 1–N"
+        assert "line 1" in warnings[0]
+        assert "lines " not in warnings[0]
+
+    def test_warning_reports_line_range_multiline(self):
+        """When content spans multiple lines, warning reports 'lines X–Y'."""
+        # 10 lines of ~60 chars each = 600 chars (with newlines)
+        lines = [f"line {i}: " + "x" * 50 for i in range(10)]
+        content = "\n".join(lines)
+        _truncate_content(content, "multi.md", max_chars=200)
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        # Must contain "lines " (plural) with a range
+        assert "lines " in warnings[0]
+
+    def test_warning_includes_head_and_tail_counts(self):
+        """Warning reports kept head + tail counts for quick verification."""
+        content = "x" * 500
+        _truncate_content(content, "counts.md", max_chars=200)
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        # head = 140, tail = 40 (200 * 0.7 and 200 * 0.2)
+        assert "140 head" in warnings[0]
+        assert "40 tail" in warnings[0]
+
+    def test_warning_omitted_chars_sum_matches_total(self):
+        """The omitted range size + kept size should be consistent with total."""
+        max_chars = 200
+        total = 500
+        content = "x" * total
+        _truncate_content(content, "consistency.md", max_chars=max_chars)
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        w = warnings[0]
+        # head_chars = 140, tail_chars = 40
+        # omitted = 500 - 140 - 40 = 320
+        assert "~320 chars" in w
+
+
 class TestDynamicContextFileCap:
     """B — cap scales with the model's context window when not pinned.
     C — truncation marker points the agent at the full file to read_file."""
@@ -1644,5 +1717,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-


### PR DESCRIPTION
## Summary

- report exact omitted character ranges when context files are truncated
- include the corresponding one-based line range when available
- report retained head/tail sizes and the omitted size consistently
- preserve the existing bounded head/tail truncation and full-file recovery path

## Why

The previous warning only said that a file exceeded its limit. Operators could not determine which section was missing or whether the omitted content contained the rule they expected the agent to see. Exact ranges make bounded context behavior observable without increasing prompt size.

## Verification

- `/Users/mudrii/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_prompt_builder.py`
- 165 passed, 1 skipped
- `ruff check` passed
- `git diff --check` passed
