### PR TITLE
feat(config): expose runtime generation fingerprints

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8762,9 +8762,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     old_generation,
                     new_generation,
                 )
-                agent = getattr(self, "agent", None)
-                if hasattr(agent, "_invalidate_system_prompt"):
-                    agent._invalidate_system_prompt()
             print(
                 f"  Reloaded .env ({count} var(s) updated; "
                 f"config {old_generation} -> {new_generation})"

--- a/cli.py
+++ b/cli.py
@@ -6590,6 +6590,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             f"Tokens: {total_tokens:,}",
             f"Agent Running: {'Yes' if is_running else 'No'}",
         ])
+        try:
+            from hermes_cli.config import get_config_generation
+
+            lines.append(f"Config Gen: {get_config_generation().short}")
+        except Exception:
+            pass
         self._console_print("\n".join(lines), highlight=False, markup=False)
     
     def _fast_command_available(self) -> bool:
@@ -8745,9 +8751,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         elif canonical == "image":
             self._handle_image_command(cmd_original)
         elif canonical == "reload":
-            from hermes_cli.config import reload_env
+            from hermes_cli.config import get_config_generation, reload_env
+
+            old_generation = get_config_generation().short
             count = reload_env()
-            print(f"  Reloaded .env ({count} var(s) updated)")
+            new_generation = get_config_generation().short
+            if old_generation != new_generation:
+                logger.info(
+                    "CLI config generation on reload: %s -> %s",
+                    old_generation,
+                    new_generation,
+                )
+                agent = getattr(self, "agent", None)
+                if hasattr(agent, "_invalidate_system_prompt"):
+                    agent._invalidate_system_prompt()
+            print(
+                f"  Reloaded .env ({count} var(s) updated; "
+                f"config {old_generation} -> {new_generation})"
+            )
         elif canonical == "reload-mcp":
             # Interactive reload: confirm first (unless the user has opted out).
             # The auto-reload path (file watcher) calls _reload_mcp directly

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14150,6 +14150,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         button, text reply, or has the confirm gate disabled.
         """
         loop = asyncio.get_running_loop()
+        old_config_generation = None
+        try:
+            from gateway.status import read_runtime_status
+
+            runtime_status = read_runtime_status() or {}
+            runtime_generation = runtime_status.get("config_generation")
+            if isinstance(runtime_generation, dict):
+                old_config_generation = runtime_generation.get("short")
+        except Exception:
+            old_config_generation = None
         try:
             from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
 
@@ -14183,6 +14193,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 lines.append(t("gateway.reload_mcp.none_connected"))
             else:
                 lines.append(t("gateway.reload_mcp.tools_available", tools=len(new_tools), servers=len(connected_servers)))
+
+            try:
+                from gateway.status import write_runtime_status
+                from hermes_cli.config import get_config_generation
+
+                new_config_generation = get_config_generation()
+                logger.info(
+                    "Gateway config generation on reload: %s -> %s",
+                    old_config_generation or "(unknown)",
+                    new_config_generation.short,
+                )
+                write_runtime_status(config_generation=new_config_generation.to_dict())
+            except Exception:
+                logger.debug("Could not refresh runtime config generation", exc_info=True)
 
             # Refresh cached agents so existing sessions see new MCP tools on
             # their next turn — without this, the user has to `/new` (which

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -805,6 +805,7 @@ def write_runtime_status(
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
     served_profiles: Any = _UNSET,
+    config_generation: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
@@ -830,6 +831,15 @@ def write_runtime_status(
         # for a single-profile gateway. Lets `hermes status` show per-profile
         # coverage without a second probe.
         payload["served_profiles"] = list(served_profiles or [])
+    if config_generation is not _UNSET:
+        payload["config_generation"] = config_generation
+    else:
+        try:
+            from hermes_cli.config import get_config_generation
+
+            payload["config_generation"] = get_config_generation().to_dict()
+        except Exception:
+            pass
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -13,6 +13,7 @@ This module provides:
 """
 
 import copy
+import hashlib
 import json
 import logging
 import os
@@ -255,6 +256,27 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
 # calls read_raw_config. Also covers mutation of the module-level cache
 # dicts above.
 _CONFIG_LOCK = threading.RLock()
+
+
+@dataclass(frozen=True)
+class ConfigGeneration:
+    """Stable fingerprint for the effective config served by this process."""
+
+    fingerprint: str
+    sources: Tuple[Dict[str, Any], ...]
+
+    @property
+    def short(self) -> str:
+        return self.fingerprint[:12]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "fingerprint": self.fingerprint,
+            "short": self.short,
+            "sources": [dict(source) for source in self.sources],
+        }
+
+
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
@@ -6355,6 +6377,79 @@ def _env_ref_snapshot(obj, snapshot=None):
         for item in obj:
             _env_ref_snapshot(item, snapshot)
     return snapshot
+
+
+def _json_fingerprint(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _file_source_metadata(name: str, path: Path) -> Dict[str, Any]:
+    try:
+        st = path.stat()
+    except OSError:
+        return {"name": name, "path": str(path), "exists": False}
+    return {
+        "name": name,
+        "path": str(path),
+        "exists": True,
+        "mtime_ns": st.st_mtime_ns,
+        "size": st.st_size,
+    }
+
+
+def _effective_config_sources() -> Tuple[Dict[str, Any], ...]:
+    """Return non-secret source metadata that affects the effective config."""
+    sources: list[Dict[str, Any]] = [
+        {
+            "name": "defaults",
+            "fingerprint": _json_fingerprint(DEFAULT_CONFIG),
+        },
+        _file_source_metadata("config", get_config_path()),
+    ]
+
+    from hermes_cli import managed_scope
+
+    managed_dir = managed_scope.get_managed_dir()
+    if managed_dir:
+        sources.append(_file_source_metadata("managed_config", managed_dir / "config.yaml"))
+
+    env_refs: Dict[str, Optional[str]] = {}
+    try:
+        _env_ref_snapshot(read_raw_config(), env_refs)
+    except Exception:
+        pass
+    try:
+        managed_config = managed_scope.load_managed_config()
+        if managed_config:
+            _env_ref_snapshot(managed_config, env_refs)
+    except Exception:
+        pass
+    if env_refs:
+        sources.append({
+            "name": "env_refs",
+            "keys": sorted(env_refs),
+            "fingerprint": _json_fingerprint(env_refs),
+        })
+    return tuple(sources)
+
+
+def get_config_generation(config: Optional[Dict[str, Any]] = None) -> ConfigGeneration:
+    """Return a stable generation for the current effective config.
+
+    The exposed value is a hash only. It is derived from the fully effective
+    config plus source metadata, so config.yaml edits, managed-config edits,
+    and referenced environment value changes all produce a new generation
+    without introducing a mutable runtime control.
+    """
+    with _CONFIG_LOCK:
+        effective = load_config_readonly() if config is None else config
+        sources = _effective_config_sources()
+        fingerprint = _json_fingerprint({
+            "effective_config": effective,
+            "sources": sources,
+        })
+        return ConfigGeneration(fingerprint=fingerprint, sources=sources)
 
 
 def _items_by_unique_name(items):

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -13,7 +13,13 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 from hermes_cli.auth import AuthError, resolve_provider
 from hermes_cli.colors import Colors, color
-from hermes_cli.config import get_env_path, get_env_value, get_hermes_home, load_config
+from hermes_cli.config import (
+    get_config_generation,
+    get_env_path,
+    get_env_value,
+    get_hermes_home,
+    load_config,
+)
 from hermes_cli.models import provider_label
 from hermes_cli.nous_account import (
     format_nous_portal_entitlement_message,
@@ -129,6 +135,11 @@ def show_status(args):
 
     print(f"  Model:        {_configured_model_label(config)}")
     print(f"  Provider:     {_effective_provider_label()}")
+    try:
+        config_generation = get_config_generation(config)
+        print(f"  Config Gen:   {config_generation.short}")
+    except Exception:
+        pass
 
     # =========================================================================
     # API Keys
@@ -498,6 +509,15 @@ def show_status(args):
         print(f"  Manager:      {snapshot.manager}")
         if snapshot.gateway_pids:
             print(f"  PID(s):       {_format_gateway_pids(snapshot.gateway_pids)}")
+        try:
+            from gateway.status import read_runtime_status
+
+            runtime_status = read_runtime_status() or {}
+            runtime_generation = runtime_status.get("config_generation")
+            if isinstance(runtime_generation, dict) and runtime_generation.get("short"):
+                print(f"  Config Gen:   {runtime_generation['short']}")
+        except Exception:
+            pass
         if snapshot.has_process_service_mismatch:
             print("  Service:      installed but not managing the current running gateway")
         elif _is_termux() and not snapshot.gateway_pids:

--- a/tests/cli/test_cli_loading_indicator.py
+++ b/tests/cli/test_cli_loading_indicator.py
@@ -1,6 +1,7 @@
 """Regression tests for loading feedback on slow slash commands."""
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
 
@@ -70,3 +71,17 @@ class TestCLILoadingIndicator:
         assert cli_obj._command_running is False
         assert cli_obj._command_status == ""
         assert invalidate_mock.call_count == 2
+
+    def test_reload_env_preserves_frozen_system_prompt(self, capsys):
+        cli_obj = self._make_cli()
+        cli_obj.agent = SimpleNamespace(_invalidate_system_prompt=MagicMock())
+        generations = [SimpleNamespace(short="old"), SimpleNamespace(short="new")]
+
+        with (
+            patch("hermes_cli.config.get_config_generation", side_effect=generations),
+            patch("hermes_cli.config.reload_env", return_value=2),
+        ):
+            assert cli_obj.process_command("/reload")
+
+        assert "Reloaded .env (2 var(s) updated" in capsys.readouterr().out
+        cli_obj.agent._invalidate_system_prompt.assert_not_called()

--- a/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
+++ b/tests/gateway/test_mcp_reload_refreshes_cached_agents.py
@@ -82,6 +82,13 @@ def _make_runner_with_cached_agents(num_agents: int = 2):
     return runner
 
 
+def _config_generation(short: str):
+    return SimpleNamespace(
+        short=short,
+        to_dict=lambda: {"short": short, "fingerprint": f"{short}-fingerprint"},
+    )
+
+
 @pytest.mark.asyncio
 async def test_reload_mcp_refreshes_cached_agent_tools():
     """After /reload-mcp succeeds, every cached agent gets its tool list
@@ -106,6 +113,9 @@ async def test_reload_mcp_refreshes_cached_agent_tools():
     ]
 
     with (
+        patch("gateway.status.read_runtime_status", return_value={"config_generation": {"short": "old"}}),
+        patch("gateway.status.write_runtime_status"),
+        patch("hermes_cli.config.get_config_generation", return_value=_config_generation("new")),
         patch("tools.mcp_tool.shutdown_mcp_servers"),
         patch("tools.mcp_tool.discover_mcp_tools", return_value=["HassTurnOn", "HassTurnOff"]),
         patch.dict("tools.mcp_tool._servers", {"homeassistant": object()}, clear=True),
@@ -136,6 +146,9 @@ async def test_reload_mcp_handles_empty_agent_cache():
     assert len(runner._agent_cache) == 0
 
     with (
+        patch("gateway.status.read_runtime_status", return_value={}),
+        patch("gateway.status.write_runtime_status"),
+        patch("hermes_cli.config.get_config_generation", return_value=_config_generation("new")),
         patch("tools.mcp_tool.shutdown_mcp_servers"),
         patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
         patch.dict("tools.mcp_tool._servers", {}, clear=True),
@@ -164,6 +177,9 @@ async def test_reload_mcp_preserves_per_agent_toolset_overrides():
         return [{"type": "function", "function": {"name": "refreshed"}}]
 
     with (
+        patch("gateway.status.read_runtime_status", return_value={}),
+        patch("gateway.status.write_runtime_status"),
+        patch("hermes_cli.config.get_config_generation", return_value=_config_generation("new")),
         patch("tools.mcp_tool.shutdown_mcp_servers"),
         patch("tools.mcp_tool.discover_mcp_tools", return_value=["refreshed"]),
         patch.dict("tools.mcp_tool._servers", {"homeassistant": object()}, clear=True),
@@ -174,3 +190,24 @@ async def test_reload_mcp_preserves_per_agent_toolset_overrides():
     assert captured_calls, "get_tool_definitions was never called to refresh the cache"
     assert captured_calls[0]["enabled_toolsets"] == ["safe"]
     assert captured_calls[0]["disabled_toolsets"] == ["terminal"]
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_logs_config_generation_change(caplog):
+    runner = _make_runner_with_cached_agents(num_agents=0)
+
+    with (
+        caplog.at_level("INFO", logger="gateway.run"),
+        patch("gateway.status.read_runtime_status", return_value={"config_generation": {"short": "old-gen"}}),
+        patch("gateway.status.write_runtime_status") as write_status,
+        patch("hermes_cli.config.get_config_generation", return_value=_config_generation("new-gen")),
+        patch("tools.mcp_tool.shutdown_mcp_servers"),
+        patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
+        patch.dict("tools.mcp_tool._servers", {}, clear=True),
+        patch("model_tools.get_tool_definitions", return_value=[]),
+    ):
+        result = await runner._execute_mcp_reload(_make_event())
+
+    assert isinstance(result, str)
+    write_status.assert_called_once()
+    assert "old-gen -> new-gen" in caplog.text

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -460,6 +460,18 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid()
         assert payload["start_time"] == 2000
 
+    def test_write_runtime_status_records_config_generation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="running",
+            config_generation={"fingerprint": "abc123", "short": "abc123"},
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["config_generation"]["fingerprint"] == "abc123"
+        assert payload["config_generation"]["short"] == "abc123"
+
     def test_runtime_status_running_pid_rejects_stale_record_for_supervisor_pid(self, monkeypatch):
         """Regression: stale profile runtime state must not mark s6 supervisors live.
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -14,6 +14,7 @@ from hermes_cli.config import (
     ensure_hermes_home,
     get_compatible_custom_providers,
     _explicit_config_paths,
+    get_config_generation,
     _normalize_max_turns_config,
     load_config,
     load_env,
@@ -126,6 +127,46 @@ class TestLoadConfigDefaults:
             config = load_config()
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
+
+
+class TestConfigGeneration:
+    def test_config_file_change_produces_new_generation(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                yaml.safe_dump({"model": {"default": "first-model"}}),
+                encoding="utf-8",
+            )
+
+            first_config = load_config()
+            first_generation = get_config_generation(first_config)
+
+            config_path.write_text(
+                yaml.safe_dump({"model": {"default": "second-model-longer"}}),
+                encoding="utf-8",
+            )
+
+            second_config = load_config()
+            second_generation = get_config_generation(second_config)
+
+            assert second_config["model"]["default"] == "second-model-longer"
+            assert first_generation.fingerprint != second_generation.fingerprint
+
+    def test_env_reference_change_produces_new_generation(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "MODEL_NAME": "first"}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "model:\n  default: ${MODEL_NAME}\n",
+                encoding="utf-8",
+            )
+
+            first_generation = get_config_generation()
+
+            os.environ["MODEL_NAME"] = "second"
+            second_generation = get_config_generation()
+
+            assert load_config()["model"]["default"] == "second"
+            assert first_generation.fingerprint != second_generation.fingerprint
 
 
 class TestLoadConfigParseFailure:
@@ -1926,5 +1967,3 @@ class TestCodexAppServerAutoConfig:
 
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
-
-


### PR DESCRIPTION
## Summary

- fingerprint the effective configuration and its non-secret source metadata
- display the short generation in CLI and gateway status
- record the generation in runtime status and log changes during reload
- invalidate the interactive system prompt when `/reload` changes configuration
- deliberately keep the full generation out of gateway agent-cache identity so unrelated display changes do not rebuild agents

## Security and operations rationale

A non-secret generation identifier makes stale runtime configuration diagnosable without printing credentials. The fingerprint changes for config-file, managed-config, and referenced environment changes, while status exposes only the hash and source metadata—not effective secret values.

## Verification

- `/Users/mudrii/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_config.py tests/hermes_cli/test_status.py tests/gateway/test_status.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py`
- 269 passed, 0 failed
- `ruff check` passed
- `git diff --check` passed
