### PR TITLE
fix(browser): add timeout to post-kill proc.wait() in browser tool

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1114,7 +1114,7 @@ def _run_chrome_fallback_command(
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
-            proc.wait()
+            proc.wait(timeout=10)
             return {"success": False, "error": f"Chrome fallback '{cmd}' timed out"}
         try:
             with open(stdout_path, "r", encoding="utf-8") as f:
@@ -2457,7 +2457,7 @@ def _run_browser_command(
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
-            proc.wait()
+            proc.wait(timeout=10)
             stdout, stderr = _read_command_output_files(stdout_path, stderr_path)
             _unlink_command_output_files(stdout_path, stderr_path)
             if stderr and stderr.strip():


### PR DESCRIPTION
## Summary

Add a 10-second timeout to both `proc.wait()` calls that follow `proc.kill()` in the browser tool's Chrome launch fallback and launch paths.

## Problem

When `proc.wait(timeout=...)` expires and `proc.kill()` is called, the subsequent bare `proc.wait()` has no timeout. On macOS/Windows (and occasionally Linux), `kill()` doesn't guarantee immediate process termination — zombie reaper races, signal-delivery delays, or a wedged child process can cause `proc.wait()` to block indefinitely, freezing the entire agent turn.

## Fix

Changed both bare `proc.wait()` → `proc.wait(timeout=10)` in `tools/browser_tool.py` (lines 1117, 2460).

## Testing
- Syntax check passed (py_compile)
- Behavior verified: both post-kill waits now bounded at 10s
