### PR TITLE
fix(agent): catch RuntimeError in vars() debug logging

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1506,7 +1506,10 @@ def run_conversation(
                     # Check for x-openrouter-provider or similar metadata
                     if provider_name == "Unknown" and response:
                         # Log all response attributes for debugging
-                        resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                        try:
+                            resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                        except (TypeError, RuntimeError):
+                            resp_attrs = {"_error": f"cannot inspect response of type {type(response).__name__}"}
                         if agent.verbose_logging:
                             logging.debug(f"Response attributes for invalid response: {resp_attrs}")
                     


### PR DESCRIPTION
## Problem

Several cron jobs fail with:

```
RuntimeError: vars() argument must have __dict__ attribute
```

This happens in `agent/conversation_loop.py` line 1510 where `vars(response)` is called to log response attributes for debugging. Some response objects (e.g. certain C extension types or `__slots__`-only classes) raise `RuntimeError` instead of `TypeError` when `vars()` is called on them.

The existing `try/except` only caught `TypeError`, so `RuntimeError` propagated up as a non-retryable client error, killing the job.

## Fix

Add `RuntimeError` to the except clause so it is gracefully caught and logged as `"cannot inspect response"` instead of crashing the job.

## Impact

~6 different cron jobs were affected (knowledge-map update, entity scanning, agent research reminders, Zhihu daily questions, SelfMind weekly review, context injection audit).