### PR TITLE
fix(google_chat): clear stale _last_inbound_thread on top-level group messages

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1621,6 +1621,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
             # Groups always reply in-thread.
             if thread_name and space_name:
                 self._last_inbound_thread[space_name] = thread_name
+            elif space_name:
+                self._last_inbound_thread.pop(space_name, None)
 
         source = self.build_source(
             chat_id=space_name,

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -855,6 +855,24 @@ class TestBuildMessageEvent:
         assert event.source.thread_id == "spaces/G/threads/T1"
 
     @pytest.mark.asyncio
+    async def test_group_top_level_message_clears_stale_thread_cache(self, adapter):
+        """A top-level group message (no thread_name) must clear any stale
+        _last_inbound_thread entry so the thinking indicator doesn't land
+        in a wrong thread from a previous side-thread interaction."""
+        # Pre-populate a stale thread cache for the SAME space as the message.
+        adapter._last_inbound_thread["spaces/S"] = "spaces/S/threads/STALE"
+        # Build a group-space message with NO thread name.
+        env = _make_chat_envelope(text="hello")
+        env["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
+        env["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+        msg = env["chat"]["messagePayload"]["message"]
+        msg["thread"] = {"name": None}  # Explicitly no thread.
+        event = await adapter._build_message_event(msg, env)
+        assert event.source.chat_type == "group"
+        # Stale thread cache must be cleared for this space.
+        assert "spaces/S" not in adapter._last_inbound_thread
+
+    @pytest.mark.asyncio
     async def test_slash_command_yields_command_type(self, adapter):
         env = _make_chat_envelope(
             text="foo bar",


### PR DESCRIPTION
When a user sends a top-level message (not in a thread) in a Google Chat
group space, _last_inbound_thread[space_name] was never cleared. The
thinking indicator and bot response fell back to a stale cached thread
name from a previous side-thread interaction, causing them to appear in
the wrong thread.

This mirrors the existing DM branch (lines 1617-1618) which already pops
the cache entry when thread_name is None.

Adds a test verifying the group-space path clears the stale cache.

## What does this PR do?

Adds the missing `elif space_name:` branch to the group-space thread
routing in `_build_message_event()`. When a top-level (non-threaded)
message arrives in a group space, the stale `_last_inbound_thread[space]`
entry is now cleared, preventing the thinking indicator and response from
being sent into a previously active thread.

## Related Issue

Newly discovered bug — no issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/google_chat/adapter.py` — 2 lines added to the
  `else:` (group) branch: `elif space_name: self._last_inbound_thread.pop(space_name, None)`
- `tests/gateway/test_google_chat.py` — added
  `test_group_top_level_message_clears_stale_thread_cache`

## How to Test

1. Unit test: `pytest tests/gateway/test_google_chat.py -k "test_group_top_level_message_clears_stale_thread_cache" -v`
2. Existing thread tests still pass: `pytest tests/gateway/test_google_chat.py -k "thread" -v`
3. E2E (live Google Chat group):
   - Send a message in a thread → bot replies in that thread ✓
   - Send a top-level message (outside thread) → bot replies at top-level ✓
   - Switch from thread → top-level → response stays top-level ✓

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/gateway/test_google_chat.py -k "thread" -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu 24.04)

### Documentation & Housekeeping

- [x] N/A — no doc/config changes needed
- [x] N/A — no config keys added
- [x] N/A — no architecture change
- [x] N/A — Google Chat only, no cross-platform impact
- [x] N/A — no tool behavior change
