### PR TITLE
fix(tui-gateway): negotiate and isolate profile sessions

### DIFF
--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -197,6 +197,7 @@ export interface MessagingPlatformTestResponse {
 }
 
 export interface GatewayReadyPayload {
+  capabilities?: Record<string, boolean>
   skin?: unknown
 }
 
@@ -312,6 +313,7 @@ export interface SessionCreateResponse {
   info?: SessionRuntimeInfo
   message_count?: number
   messages?: SessionMessage[]
+  profile?: string
   session_id: string
   stored_session_id?: string
 }
@@ -389,6 +391,7 @@ export interface SessionResumeResponse {
   info?: SessionRuntimeInfo
   message_count: number
   messages: SessionMessage[]
+  profile?: string
   resumed: string
   session_id: string
 }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7156,7 +7156,8 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", _opener)
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with patch(
-            "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=True
+            "hermes_cli.browser_connect.launch_chrome_debug",
+            return_value=ChromeDebugLaunch(launched=True),
         ):
             resp = server.handle_request(
                 {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
@@ -9117,17 +9118,75 @@ def test_session_resume_echoes_effective_profile(monkeypatch):
 
 
 def test_gateway_ready_advertises_session_profile_capability():
-    """Both gateway.ready emitters advertise the session_profiles capability.
-
-    Clients (the browser extension's remote dashboard mode) refuse to send a
-    profile-scoped session.create/session.resume unless this flag arrives on
-    gateway.ready, so a legacy gateway never receives a scoped RPC it would
-    silently resolve to the launch profile.
-    """
-    import inspect
-
-    from tui_gateway import entry, ws
-
+    """The optional profile-session contract has one canonical capability."""
     assert server.GATEWAY_CAPABILITIES["session_profiles"] is True
-    assert "GATEWAY_CAPABILITIES" in inspect.getsource(ws)
-    assert "GATEWAY_CAPABILITIES" in inspect.getsource(entry)
+
+
+def test_session_resume_does_not_reuse_same_key_from_another_profile(
+    monkeypatch, tmp_path
+):
+    """Durable ids are profile-local and cannot identify a live session alone."""
+    import hermes_state
+    from hermes_cli import profiles as profiles_mod
+
+    target = "same-durable-id"
+    profile_home = tmp_path / "profiles" / "research"
+    profile_home.mkdir(parents=True)
+
+    class FakeDB:
+        def __init__(self, db_path=None):
+            assert db_path == profile_home / "state.db"
+
+        def get_session(self, session_id):
+            assert session_id == target
+            return {"id": target, "cwd": str(tmp_path)}
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+        def reopen_session(self, session_id):
+            assert session_id == target
+
+        def get_messages_as_conversation(self, session_id, include_ancestors=False):
+            assert session_id == target
+            return [{"role": "user", "content": "research profile history"}]
+
+    launch_sid = "launch-live-id"
+    launch_session = server._deferred_session_record(
+        target,
+        cols=80,
+        cwd=str(tmp_path),
+        history=[{"role": "user", "content": "launch profile history"}],
+        lease=None,
+        profile_home=None,
+    )
+    server._sessions[launch_sid] = launch_session
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda _name: profile_home)
+    monkeypatch.setattr(hermes_state, "SessionDB", FakeDB)
+    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": target, "profile": "research"},
+            }
+        )
+        result = resp["result"]
+        scoped_sid = result["session_id"]
+
+        assert scoped_sid != launch_sid
+        assert result["profile"] == "research"
+        assert result["messages"] == [
+            {"role": "user", "text": "research profile history"}
+        ]
+        assert server._sessions[scoped_sid]["profile_home"] == str(profile_home)
+        assert server._sessions[launch_sid] is launch_session
+    finally:
+        for sid, session in list(server._sessions.items()):
+            if session is launch_session or session.get("session_key") == target:
+                server._sessions.pop(sid, None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9114,3 +9114,20 @@ def test_session_resume_echoes_effective_profile(monkeypatch):
         assert sid and sid != "tip"
     finally:
         server._sessions.pop(sid, None)
+
+
+def test_gateway_ready_advertises_session_profile_capability():
+    """Both gateway.ready emitters advertise the session_profiles capability.
+
+    Clients (the browser extension's remote dashboard mode) refuse to send a
+    profile-scoped session.create/session.resume unless this flag arrives on
+    gateway.ready, so a legacy gateway never receives a scoped RPC it would
+    silently resolve to the launch profile.
+    """
+    import inspect
+
+    from tui_gateway import entry, ws
+
+    assert server.GATEWAY_CAPABILITIES["session_profiles"] is True
+    assert "GATEWAY_CAPABILITIES" in inspect.getsource(ws)
+    assert "GATEWAY_CAPABILITIES" in inspect.getsource(entry)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9028,6 +9028,31 @@ def test_session_create_rejects_unresolved_explicit_profile(monkeypatch):
     assert set(server._sessions) == before
 
 
+def test_session_create_rejects_invalid_profile_before_path_resolution(monkeypatch):
+    """Path-like profile input cannot escape the profile namespace."""
+    from hermes_cli import profiles as profiles_mod
+
+    resolved = []
+    monkeypatch.setattr(
+        profiles_mod,
+        "get_profile_dir",
+        lambda name: resolved.append(name) or Path("/tmp/outside-profile-root"),
+    )
+    before = set(server._sessions)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.create",
+            "params": {"cols": 80, "profile": "../../outside-profile-root"},
+        }
+    )
+
+    assert resp["error"]["code"] == 4041
+    assert set(server._sessions) == before
+    assert resolved == []
+
+
 def test_session_create_echoes_effective_profile(monkeypatch, tmp_path):
     """session.create returns the authoritative effective profile scope.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9001,3 +9001,116 @@ def test_get_usage_clamps_post_compression_sentinel():
     usage = server._get_usage(agent)
     assert "context_used" not in usage
     assert "context_percent" not in usage
+
+
+def test_session_create_rejects_unresolved_explicit_profile(monkeypatch):
+    """The discovery-to-create race must fail closed.
+
+    A profile deleted or renamed after the client discovered it used to resolve
+    to ``None`` and silently scope the new session to the launch profile while
+    the client believed it was profile-scoped. An explicit profile that does
+    not resolve is now rejected before any session state is claimed.
+    """
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    before = set(server._sessions)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.create",
+            "params": {"cols": 80, "profile": "ghost-profile-that-does-not-exist"},
+        }
+    )
+
+    assert resp["error"]["code"] == 4041
+    assert resp["error"]["message"] == "profile not found: ghost-profile-that-does-not-exist"
+    assert set(server._sessions) == before
+
+
+def test_session_create_echoes_effective_profile(monkeypatch, tmp_path):
+    """session.create returns the authoritative effective profile scope.
+
+    Clients that request an explicit profile compare this echo against their
+    request before trusting the session ("" = launch profile).
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    profile_home = tmp_path / "profiles" / "research"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda name: profile_home)
+
+    scoped = server.handle_request(
+        {"id": "1", "method": "session.create", "params": {"cols": 80, "profile": "research"}}
+    )
+    scoped_sid = scoped["result"]["session_id"]
+    try:
+        assert scoped["result"]["profile"] == "research"
+        assert server._sessions[scoped_sid]["profile_home"] == str(profile_home)
+    finally:
+        server._sessions.pop(scoped_sid, None)
+
+    launch = server.handle_request(
+        {"id": "2", "method": "session.create", "params": {"cols": 80}}
+    )
+    launch_sid = launch["result"]["session_id"]
+    try:
+        assert launch["result"]["profile"] == ""
+        assert server._sessions[launch_sid]["profile_home"] is None
+    finally:
+        server._sessions.pop(launch_sid, None)
+
+
+def test_session_resume_rejects_unresolved_explicit_profile(monkeypatch):
+    """Resume rejects a stale explicit profile before touching any database."""
+    touched = []
+
+    class FakeDB:
+        def get_session(self, target):
+            touched.append(target)
+            return {"id": target}
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.resume",
+            "params": {"session_id": "any", "profile": "ghost-profile-that-does-not-exist"},
+        }
+    )
+
+    assert resp["error"]["code"] == 4041
+    assert resp["error"]["message"] == "profile not found: ghost-profile-that-does-not-exist"
+    assert touched == []
+
+
+def test_session_resume_echoes_effective_profile(monkeypatch):
+    """Successful resumes echo the validated effective profile scope."""
+
+    class FakeDB:
+        def get_session(self, target):
+            return {"id": target}
+
+        def reopen_session(self, target):
+            pass
+
+        def get_messages_as_conversation(self, target, include_ancestors=False):
+            return [{"role": "user", "content": "hello"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.resume", "params": {"session_id": "tip"}}
+    )
+    sid = resp["result"]["session_id"]
+    try:
+        assert resp["result"]["profile"] == ""
+        assert resp["result"]["resumed"] == "tip"
+        assert resp["result"]["session_key"] == "tip"
+        assert sid and sid != "tip"
+    finally:
+        server._sessions.pop(sid, None)

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import threading
 import time
 
@@ -40,6 +41,34 @@ def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
         server._sessions.clear()
 
     assert calls == [{"logger": ws_mod._log, "thread_name": "tui-ws-mcp-discovery"}]
+
+
+def test_ws_gateway_ready_advertises_session_profile_capability(monkeypatch):
+    """Remote clients receive the capability before sending scoped RPCs."""
+    sent = []
+    monkeypatch.setattr(
+        mcp_startup,
+        "start_background_mcp_discovery",
+        lambda **_kwargs: None,
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    assert sent[0]["params"]["type"] == "gateway.ready"
+    assert sent[0]["params"]["payload"]["capabilities"]["session_profiles"] is True
 
 
 def _run_disconnect(monkeypatch, seed):

--- a/tests/tui_gateway/test_entry_ready.py
+++ b/tests/tui_gateway/test_entry_ready.py
@@ -1,0 +1,22 @@
+"""Behavior tests for the stdio gateway.ready contract."""
+
+import io
+
+from hermes_cli import config as config_mod
+from tui_gateway import entry
+
+
+def test_stdio_gateway_ready_advertises_session_profile_capability(monkeypatch):
+    """The stdio transport advertises the same optional RPC capability as WS."""
+    sent = []
+    monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: {})
+    monkeypatch.setattr(entry, "resolve_skin", lambda: {"name": "test"})
+    monkeypatch.setattr(entry, "write_json", lambda frame: sent.append(frame) or True)
+    monkeypatch.setattr(entry, "_log_exit", lambda _reason: None)
+    monkeypatch.setattr(entry.sys, "stdin", io.StringIO(""))
+
+    entry.main()
+
+    assert sent[0]["params"]["type"] == "gateway.ready"
+    assert sent[0]["params"]["payload"]["capabilities"]["session_profiles"] is True

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -17,7 +17,13 @@ import time
 import traceback
 
 from tui_gateway import server
-from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
+from tui_gateway.server import (
+    _CRASH_LOG,
+    GATEWAY_CAPABILITIES,
+    dispatch,
+    resolve_skin,
+    write_json,
+)
 from tui_gateway.transport import TeeTransport
 
 logger = logging.getLogger(__name__)
@@ -349,7 +355,13 @@ def main():
     if not write_json({
         "jsonrpc": "2.0",
         "method": "event",
-        "params": {"type": "gateway.ready", "payload": {"skin": resolve_skin()}},
+        "params": {
+            "type": "gateway.ready",
+            "payload": {
+                "skin": resolve_skin(),
+                "capabilities": dict(GATEWAY_CAPABILITIES),
+            },
+        },
     }):
         _log_exit("startup write failed (broken stdout pipe before first event)")
         sys.exit(0)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1029,14 +1029,19 @@ def _resolve_profile_scope(profile: str | None) -> tuple[Path | None, bool]:
     name = (profile or "").strip()
     if not name:
         return None, True
+    try:
+        from hermes_cli import profiles as profiles_mod
+
+        name = profiles_mod.normalize_profile_name(name)
+        profiles_mod.validate_profile_name(name)
+    except (ImportError, TypeError, ValueError):
+        return None, False
     home = _profile_home(name)
     if home is not None:
         return home, True
     # ``home`` is None both when the name IS the launch profile and when it
     # does not resolve; only the former is a valid explicit request.
     try:
-        from hermes_cli import profiles as profiles_mod
-
         is_launch = Path(profiles_mod.get_profile_dir(name)).resolve() == Path(_hermes_home).resolve()
     except Exception:
         return None, False
@@ -5229,6 +5234,15 @@ def _inflight_snapshot(session: dict) -> dict | None:
 
 @method("session.create")
 def _(rid, params: dict) -> dict:
+    # ``profile`` (app-global remote mode): a new chat started under a non-launch
+    # profile must build its agent + persist against THAT profile's home/state.db,
+    # not the dashboard's launch profile. Validate it before any profile-derived
+    # cwd lookup, session allocation, or database access.
+    profile = (params.get("profile") or "").strip() or None
+    profile_home, profile_resolved = _resolve_profile_scope(profile)
+    if profile and not profile_resolved:
+        return _err(rid, 4041, f"profile not found: {profile}")
+
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
     cols = int(params.get("cols", 80))
@@ -5250,18 +5264,6 @@ def _(rid, params: dict) -> dict:
     resolved_cwd = _completion_cwd(params)
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
     _enable_gateway_prompts()
-
-    # ``profile`` (app-global remote mode): a new chat started under a non-launch
-    # profile must build its agent + persist against THAT profile's home/state.db,
-    # not the dashboard's launch profile. Stored on the session so _start_agent_build
-    # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
-    # An explicit profile that does not resolve is REJECTED rather than being
-    # silently scoped to the launch profile: the name may have been deleted or
-    # renamed between the client's discovery and this request.
-    profile = (params.get("profile") or "").strip() or None
-    profile_home, profile_resolved = _resolve_profile_scope(profile)
-    if profile and not profile_resolved:
-        return _err(rid, 4041, f"profile not found: {profile}")
 
     # The desktop composer owns its model/effort/fast as plain UI state and ships
     # it on every session.create. Honor each as a PER-SESSION override (built into

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1017,6 +1017,32 @@ def _profile_home(profile: str | None) -> Path | None:
     return home if (home / "state.db").exists() or home.exists() else None
 
 
+def _resolve_profile_scope(profile: str | None) -> tuple[Path | None, bool]:
+    """Resolve an explicitly requested profile to ``(home_override, resolved)``.
+
+    ``home_override`` is None both for the launch profile and for a name that
+    does not resolve on this host; ``resolved`` distinguishes them so session
+    RPCs can REJECT an unresolved explicit profile instead of silently scoping
+    the session to the launch profile (clients that verify profile scope, such
+    as the browser extension, rely on that rejection).
+    """
+    name = (profile or "").strip()
+    if not name:
+        return None, True
+    home = _profile_home(name)
+    if home is not None:
+        return home, True
+    # ``home`` is None both when the name IS the launch profile and when it
+    # does not resolve; only the former is a valid explicit request.
+    try:
+        from hermes_cli import profiles as profiles_mod
+
+        is_launch = Path(profiles_mod.get_profile_dir(name)).resolve() == Path(_hermes_home).resolve()
+    except Exception:
+        return None, False
+    return None, is_launch
+
+
 def _profile_scoped(handler):
     """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
 
@@ -5220,8 +5246,13 @@ def _(rid, params: dict) -> dict:
     # profile must build its agent + persist against THAT profile's home/state.db,
     # not the dashboard's launch profile. Stored on the session so _start_agent_build
     # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
+    # An explicit profile that does not resolve is REJECTED rather than being
+    # silently scoped to the launch profile: the name may have been deleted or
+    # renamed between the client's discovery and this request.
     profile = (params.get("profile") or "").strip() or None
-    profile_home = _profile_home(profile)
+    profile_home, profile_resolved = _resolve_profile_scope(profile)
+    if profile and not profile_resolved:
+        return _err(rid, 4041, f"profile not found: {profile}")
 
     # The desktop composer owns its model/effort/fast as plain UI state and ships
     # it on every session.create. Honor each as a PER-SESSION override (built into
@@ -5309,6 +5340,10 @@ def _(rid, params: dict) -> dict:
         {
             "session_id": sid,
             "stored_session_id": key,
+            # Authoritative effective scope for this session ("" = launch
+            # profile). Clients that requested an explicit profile compare
+            # this echo against their request before trusting the session.
+            "profile": profile or "",
             "message_count": len(history),
             "messages": _history_to_messages(history),
             "info": {
@@ -5576,6 +5611,22 @@ def _schedule_agent_build(sid: str, delay: float = 0.05) -> None:
 
 @method("session.resume")
 def _(rid, params: dict) -> dict:
+    # ``profile`` (app-global remote mode): resume a session that lives in another
+    # local profile's state.db. None/own profile → the launch profile (unchanged).
+    # An explicit profile that does not resolve is REJECTED (see session.create),
+    # and the validated effective scope is echoed on every success payload so
+    # clients can verify the session landed where they asked.
+    profile = (params.get("profile") or "").strip() or None
+    profile_home, profile_resolved = _resolve_profile_scope(profile)
+    if profile and not profile_resolved:
+        return _err(rid, 4041, f"profile not found: {profile}")
+    response = _session_resume(rid, params, profile_home)
+    if isinstance(response, dict) and isinstance(response.get("result"), dict):
+        response["result"]["profile"] = profile or ""
+    return response
+
+
+def _session_resume(rid, params: dict, profile_home: Path | None) -> dict:
     target = params.get("session_id", "")
     if not target:
         return _err(rid, 4006, "session_id required")
@@ -5583,10 +5634,6 @@ def _(rid, params: dict) -> dict:
         cols = int(params.get("cols", 80))
     except (TypeError, ValueError):
         cols = 80
-    # ``profile`` (app-global remote mode): resume a session that lives in another
-    # local profile's state.db. None/own profile → the launch profile (unchanged).
-    profile = (params.get("profile") or "").strip() or None
-    profile_home = _profile_home(profile)
 
     # In a profile scope, the agent OWNS a long-lived db handle bound to that
     # profile (do NOT auto-close it here). Otherwise reuse the shared launch db.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5593,7 +5593,10 @@ def _claim_or_reuse_live(
     resume lock, or — if a concurrent resume already won — release ``lease`` and
     return the winner for the caller to reuse."""
     with _session_resume_lock:
-        live = _find_live_session_by_key(session_key)
+        live = _find_live_session_by_key(
+            session_key,
+            profile_home=record.get("profile_home"),
+        )
         if live is not None:
             if lease is not None:
                 lease.release()
@@ -5719,7 +5722,7 @@ def _session_resume(rid, params: dict, profile_home: Path | None) -> dict:
 
     # Fast path: if the session is already live, reuse it under the lock.
     with _session_resume_lock:
-        live = _find_live_session_by_key(target)
+        live = _find_live_session_by_key(target, profile_home=profile_home)
         if live is not None:
             return _ok(rid, _reuse_live_payload(*live))
 
@@ -5927,7 +5930,7 @@ def _session_resume(rid, params: dict, profile_home: Path | None) -> dict:
     # live session while we were building. Re-check under the lock; if it won,
     # discard our just-built agent and reuse theirs (no worker/poller wired yet).
     with _session_resume_lock:
-        live = _find_live_session_by_key(target)
+        live = _find_live_session_by_key(target, profile_home=profile_home)
         if live is not None:
             try:
                 if hasattr(agent, "close"):
@@ -6100,9 +6103,36 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     )
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
+_ANY_PROFILE_HOME = object()
+
+
+def _profile_home_identity(profile_home: object) -> str | None:
+    """Return a stable comparison key for a live session's profile scope."""
+    if profile_home is None:
+        return None
+    return os.path.normcase(
+        os.path.abspath(os.path.expanduser(os.fspath(profile_home)))
+    )
+
+
+def _find_live_session_by_key(
+    session_key: str,
+    *,
+    profile_home: object = _ANY_PROFILE_HOME,
+) -> tuple[str, dict] | None:
+    requested_profile_home = (
+        _profile_home_identity(profile_home)
+        if profile_home is not _ANY_PROFILE_HOME
+        else _ANY_PROFILE_HOME
+    )
     for sid, session in list(_sessions.items()):
         if session.get("_finalized"):
+            continue
+        if (
+            requested_profile_home is not _ANY_PROFILE_HOME
+            and _profile_home_identity(session.get("profile_home"))
+            != requested_profile_home
+        ):
             continue
         if _session_lookup_key(session, fallback=sid) == session_key:
             return sid, session

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3370,6 +3370,15 @@ def _current_profile_name() -> str:
 # v3: adds approvals.mode config RPCs and session.info reconciliation.
 DESKTOP_BACKEND_CONTRACT = 3
 
+# Capabilities advertised on the gateway.ready event (both the WS accept and
+# the stdio startup emit them). Clients gate optional request surfaces on
+# these flags BEFORE sending the RPC: the browser extension refuses to send a
+# profile-scoped session.create/session.resume unless ``session_profiles`` is
+# advertised, because a gateway without this build would silently create the
+# session in the launch scope. Legacy gateways advertise nothing, which
+# clients must treat as "unsupported".
+GATEWAY_CAPABILITIES = {"session_profiles": True}
+
 
 def _session_info(agent, session: dict | None = None) -> dict:
     if session is None:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -322,7 +322,10 @@ async def handle_ws(ws: Any) -> None:
                 "method": "event",
                 "params": {
                     "type": "gateway.ready",
-                    "payload": {"skin": server.resolve_skin()},
+                    "payload": {
+                        "skin": server.resolve_skin(),
+                        "capabilities": dict(server.GATEWAY_CAPABILITIES),
+                    },
                 },
             }
         )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -224,6 +224,7 @@ export interface SetupStatusResponse {
 
 export interface SessionCreateResponse {
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
+  profile?: string
   session_id: string
 }
 
@@ -232,6 +233,7 @@ export interface SessionResumeResponse {
   info?: SessionInfo
   message_count?: number
   messages: GatewayTranscriptMessage[]
+  profile?: string
   resumed?: string
   running?: boolean
   session_id: string
@@ -614,7 +616,11 @@ export interface SpawnTreeLoadResponse {
 }
 
 export type GatewayEvent =
-  | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
+  | {
+      payload?: { capabilities?: Record<string, boolean>; skin?: GatewaySkin }
+      session_id?: string
+      type: 'gateway.ready'
+    }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }


### PR DESCRIPTION
## What does this PR do?

Defines a safe, optional backend contract for clients that create or resume sessions in an explicit Hermes profile.

Without this contract, an app-global remote client cannot distinguish a legacy gateway from a profile-aware gateway. If a requested profile was deleted or renamed, the gateway could silently fall back to its launch profile. Durable session IDs are also local to each profile database, so a live session from another profile could be reused when IDs collide.

This PR:

- advertises `capabilities.session_profiles: true` on both `gateway.ready` transports;
- validates profile identifiers and rejects malformed or unresolved explicit profiles before path lookup, session creation, or resume;
- echoes the effective profile in successful `session.create` and `session.resume` results;
- scopes live-session reuse by both durable session ID and profile home;
- adds the additive response/capability fields to the desktop and TUI TypeScript contracts.

This is complementary to #62509. That PR broadens profile-aware database routing across the other `session.*` methods; this PR defines capability negotiation and scope verification for create/resume, including the live-session collision guard.

## Related Issue

No dedicated issue. Related profile-routing work: #62503 / #62509.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/server.py`: validate explicit profile identifiers before path resolution, reject missing profiles, echo effective scope, and isolate live-session reuse by profile.
- `tui_gateway/entry.py`, `tui_gateway/ws.py`: advertise the optional `session_profiles` capability.
- `apps/desktop/src/types/hermes.ts`, `ui-tui/src/gatewayTypes.ts`: model the additive protocol fields.
- Gateway tests cover unresolved profiles, authoritative echoes, both ready-event transports, and same-ID cross-profile resume.
- Correct an obsolete browser-launch test mock so the test cannot invoke the real local browser launcher.

## How to Test

1. Run `.venv/bin/python -m pytest tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py tests/tui_gateway/test_entry_ready.py tests/tui_gateway/test_protocol.py -q`.
2. Run `.venv/bin/python -m ruff check tui_gateway/server.py tui_gateway/entry.py tui_gateway/ws.py tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py tests/tui_gateway/test_entry_ready.py`.
3. Run `npm run typecheck --workspace apps/desktop` and `npm run typecheck --workspace ui-tui`.

Verified locally: 418 targeted tests passed; Ruff passed; both TypeScript typechecks passed. A fresh read-only `claude-fable-5[1m]` architecture review returned PASS with no blocking findings; its strongest hardening suggestion, rejecting path-like profile identifiers before resolution, is included in the current head. A broader 680-test gateway run had one order-dependent failure in `test_prompt_submit_rejected_while_child_run_active`; the exact failure passes in isolation and reproduces unchanged on `origin/main` under the same ordering.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and documented the related #62509 above
- [x] My PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation update: N/A; this is an additive gateway protocol contract covered by types and docstrings
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no contributor workflow changed
- [x] Cross-platform impact considered; profile identities use normalized absolute paths
- [x] Tool descriptions/schemas: N/A; no Hermes tool behavior changed

## Screenshots / Logs

Not applicable; this is a backend protocol change with automated transport and behavior coverage.
