### PR TITLE
fix(telegram): don't resend post-write NetworkError to avoid duplicate messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2230,6 +2230,29 @@ class SendResult:
     # ``None`` (unset / not classified).  Producers should set this via
     # :func:`classify_send_error`.
     error_kind: Optional[str] = None
+    # True when the send failed *after* the request body may already have
+    # reached the platform, so the message might have been delivered even
+    # though the call raised (post-write connection reset / RemoteProtocolError
+    # / ReadError, or a generic read timeout).  Re-sending such a payload
+    # duplicates the message in the user's chat (#64238).
+    #
+    # This is deliberately a separate flag rather than a ``retryable=False``
+    # or an ``error_kind`` member:
+    #
+    # * ``retryable=False`` is NOT sufficient — :meth:`_send_with_retry` ORs it
+    #   with :meth:`_is_retryable_error`, whose ``_RETRYABLE_ERROR_PATTERNS``
+    #   include ``"network"`` and ``"connectionreset"``, so an adapter cannot
+    #   veto a re-send through that field alone.
+    # * ``error_kind`` answers *why* the send failed and is derived from the
+    #   error text by :func:`classify_send_error`; whether the bytes were
+    #   already on the wire is an orthogonal delivery-safety property that no
+    #   substring classifier can determine (only the adapter knows which
+    #   exception type it caught and at which phase).
+    #
+    # Contract for consumers: a result with ``ambiguous_delivery=True`` must
+    # never be re-sent — not by the retry loop and not by the plain-text
+    # fallback.  Return it to the caller as-is.
+    ambiguous_delivery: bool = False
 
 
 # Machine-readable send-failure categories.  Kept platform-neutral so every
@@ -5033,6 +5056,20 @@ class BasePlatformAdapter(ABC):
             return result
 
         error_str = result.error or ""
+
+        # Ambiguous delivery: the adapter knows the payload may already have
+        # reached the platform, so ANY re-send (retry loop or plain-text
+        # fallback) risks duplicating the message.  This must be checked before
+        # ``is_network`` — ``retryable=False`` alone cannot veto a re-send,
+        # because ``_is_retryable_error`` matches "network"/"connectionreset"
+        # in the error text and ORs the adapter's answer away (#64238).
+        if result.ambiguous_delivery:
+            logger.warning(
+                "[%s] Send failed with ambiguous delivery — not re-sending: %s",
+                self.name, error_str,
+            )
+            return result
+
         is_network = result.retryable or self._is_retryable_error(error_str)
 
         # Timeout errors are not safe to retry (message may have been
@@ -5068,6 +5105,15 @@ class BasePlatformAdapter(ABC):
                 error_str = result.error or ""
                 if result.retry_after is not None:
                     server_retry_after = result.retry_after
+                if result.ambiguous_delivery:
+                    # A retry itself came back ambiguous: return immediately
+                    # rather than breaking, because the break path falls
+                    # through to the plain-text fallback, which re-sends.
+                    logger.warning(
+                        "[%s] Retry %d failed with ambiguous delivery — not re-sending: %s",
+                        self.name, attempt, error_str,
+                    )
+                    return result
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2379,6 +2379,15 @@ class PhotonAdapter(BasePlatformAdapter):
             return result
 
         error_str = result.error or ""
+        # Mirror the base class: an ambiguous-delivery failure may already have
+        # reached the platform, so neither the retry loop nor the plain-text
+        # fallback below may re-send it (#64238).
+        if result.ambiguous_delivery:
+            logger.warning(
+                "[photon] Send failed with ambiguous delivery - not re-sending: %s",
+                error_str,
+            )
+            return result
         is_network = result.retryable or self._is_retryable_error(error_str)
         if not is_network and self._is_timeout_error(error_str):
             return result
@@ -2400,6 +2409,15 @@ class PhotonAdapter(BasePlatformAdapter):
                 if result.success:
                     return result
                 error_str = result.error or ""
+                if result.ambiguous_delivery:
+                    # Return instead of break: the break path falls through to
+                    # the plain-text retry below, which would re-send.
+                    logger.warning(
+                        "[photon] Retry %d failed with ambiguous delivery - "
+                        "not re-sending: %s",
+                        attempt, error_str,
+                    )
+                    return result
                 if self._is_permanent_sidecar_failure(result):
                     # A retry surfaced a permanent class — don't fall through
                     # to the plain-text resend either.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1424,6 +1424,54 @@ class TelegramAdapter(BasePlatformAdapter):
         return False
 
     @staticmethod
+    def _looks_like_connect_error(error: Exception) -> bool:
+        """Return True when a NetworkError wraps a pre-write connection failure.
+
+        Mirrors :meth:`_looks_like_connect_timeout` for the non-timeout
+        ``NetworkError`` case. A ``NetworkError`` raised *after* the request
+        body was written (connection reset, ``RemoteProtocolError``,
+        ``ReadError``) may mean the request reached Telegram and must not be
+        re-sent -- exactly like a plain ``TimedOut``. A connection
+        *establishment* failure -- ``httpx.ConnectError``, connection refused,
+        or DNS resolution error -- happens before any bytes leave the process,
+        so re-sending is safe and prevents a silent drop. We match the wrapped
+        ``httpx.ConnectError`` class as well as the message string so the check
+        survives wrapper/wording changes, and deliberately do NOT match
+        connection-reset / broken-pipe / protocol errors, which are ambiguous
+        post-write failures.
+        """
+        seen: set[int] = set()
+        stack: list[BaseException] = [error]
+        while stack:
+            cur = stack.pop()
+            ident = id(cur)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            name = cur.__class__.__name__.lower()
+            text = str(cur).lower()
+            if "connecterror" in name:
+                return True
+            if (
+                "connect error" in text
+                or "connection refused" in text
+                or "[errno 111]" in text
+                or "getaddrinfo" in text
+                or "name or service not known" in text
+                or "temporary failure in name resolution" in text
+                or "nodename nor servname" in text
+                or "no address associated with hostname" in text
+            ):
+                return True
+            cause = getattr(cur, "__cause__", None)
+            context = getattr(cur, "__context__", None)
+            if cause is not None:
+                stack.append(cause)
+            if context is not None:
+                stack.append(context)
+        return False
+
+    @staticmethod
     def _looks_like_pool_timeout(error: Exception) -> bool:
         """Return True when a Telegram TimedOut wraps an httpx pool timeout.
 
@@ -4547,20 +4595,22 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                             # Other BadRequest errors are permanent — don't retry
                             raise
-                        # TimedOut is also a subclass of NetworkError. A
-                        # generic timeout may have reached Telegram, so don't
-                        # retry; a wrapped ConnectTimeout means no connection
-                        # was established, so retrying is safe. A pool timeout
-                        # (httpx pool exhausted) is explicitly "not sent to
-                        # Telegram" -- retrying through the loop is safe and
-                        # prevents silent drops when the pool frees up.
+                        # TimedOut is a subclass of NetworkError. A generic
+                        # NetworkError (connection reset / RemoteProtocolError /
+                        # ReadError) or a generic TimedOut raised *after* the
+                        # request body was written may have already reached
+                        # Telegram, so re-sending would duplicate the message
+                        # (#64238). Only re-send when the failure demonstrably
+                        # happened before the request left the process: a
+                        # connect-phase failure (ConnectTimeout / ConnectError /
+                        # DNS / connection refused) or an httpx pool timeout,
+                        # which PTB reports as explicitly "not sent to Telegram".
                         is_pool_timeout = self._looks_like_pool_timeout(send_err)
-                        if (
-                            _TimedOut
-                            and isinstance(send_err, _TimedOut)
-                            and not self._looks_like_connect_timeout(send_err)
-                            and not is_pool_timeout
-                        ):
+                        is_connect_phase = (
+                            self._looks_like_connect_timeout(send_err)
+                            or self._looks_like_connect_error(send_err)
+                        )
+                        if not is_pool_timeout and not is_connect_phase:
                             raise
                         if is_pool_timeout:
                             await self._drain_general_connections_after_pool_timeout()
@@ -4638,10 +4688,29 @@ class TelegramAdapter(BasePlatformAdapter):
             is_timeout = (_to and isinstance(e, _to)) or "timed out" in err_str
             is_connect_timeout = self._looks_like_connect_timeout(e)
             is_pool_timeout = self._looks_like_pool_timeout(e)
+            # A non-timeout NetworkError raised *after* the request body was
+            # written (connection reset / RemoteProtocolError / ReadError) is
+            # exactly as ambiguous as a generic TimedOut: the message may have
+            # already reached Telegram. Marking it retryable here would let the
+            # gateway's _send_with_retry() re-send it and duplicate the message
+            # (#64238), so treat it as non-retryable unless it demonstrably
+            # never left the process (connect-phase or pool timeout).
+            is_post_write_network_error = (
+                self._looks_like_network_error(e)
+                and not is_timeout
+                and not is_connect_timeout
+                and not is_pool_timeout
+                and not self._looks_like_connect_error(e)
+            )
+            retryable = (
+                False
+                if is_post_write_network_error
+                else (is_connect_timeout or is_pool_timeout or not is_timeout)
+            )
             return SendResult(
                 success=False,
                 error=safe_error,
-                retryable=(is_connect_timeout or is_pool_timeout or not is_timeout),
+                retryable=retryable,
                 error_kind=error_kind,
             )
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1882,6 +1882,23 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None
             is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
             is_connect_timeout = self._looks_like_connect_timeout(exc)
+            # Same post-write ambiguity as the legacy send() path (#64238): a
+            # non-timeout NetworkError raised after the request body was written
+            # may already have reached Telegram, so the base retry layer must
+            # not re-send it. Only a demonstrably pre-write failure
+            # (connect-phase or an httpx pool timeout, which PTB reports as
+            # explicitly "not sent to Telegram") is safe to re-send.
+            is_pool_timeout = self._looks_like_pool_timeout(exc)
+            never_left_process = (
+                is_connect_timeout
+                or is_pool_timeout
+                or self._looks_like_connect_error(exc)
+            )
+            is_post_write_network_error = (
+                self._looks_like_network_error(exc)
+                and not is_timeout
+                and not never_left_process
+            )
             # Extract server-requested retry_after for flood control so the
             # base retry layer honors Telegram's backoff instead of its own
             # short exponential schedule.
@@ -1899,8 +1916,16 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(
                 success=False,
                 error=safe_error,
-                retryable=(is_connect_timeout or not is_timeout),
+                retryable=(
+                    False
+                    if is_post_write_network_error
+                    else (is_connect_timeout or is_pool_timeout or not is_timeout)
+                ),
                 retry_after=_retry_after,
+                ambiguous_delivery=(
+                    not never_left_process
+                    and (is_timeout or is_post_write_network_error)
+                ),
             )
 
         message_id = None
@@ -4695,12 +4720,15 @@ class TelegramAdapter(BasePlatformAdapter):
             # gateway's _send_with_retry() re-send it and duplicate the message
             # (#64238), so treat it as non-retryable unless it demonstrably
             # never left the process (connect-phase or pool timeout).
+            never_left_process = (
+                is_connect_timeout
+                or is_pool_timeout
+                or self._looks_like_connect_error(e)
+            )
             is_post_write_network_error = (
                 self._looks_like_network_error(e)
                 and not is_timeout
-                and not is_connect_timeout
-                and not is_pool_timeout
-                and not self._looks_like_connect_error(e)
+                and not never_left_process
             )
             retryable = (
                 False
@@ -4712,6 +4740,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 error=safe_error,
                 retryable=retryable,
                 error_kind=error_kind,
+                # `retryable=False` alone does NOT stop the gateway retry:
+                # BasePlatformAdapter._send_with_retry() ORs it with
+                # _is_retryable_error(), whose patterns include "network" and
+                # "connectionreset". Set the explicit ambiguous-delivery signal
+                # the base layer honors unconditionally, for both the post-write
+                # NetworkError and the generic read timeout.
+                ambiguous_delivery=(
+                    not never_left_process
+                    and (is_timeout or is_post_write_network_error)
+                ),
             )
 
     async def send_or_update_status(

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -169,6 +169,119 @@ class TestSendWithRetryFallback:
 
 
 # ---------------------------------------------------------------------------
+# _send_with_retry — ambiguous delivery (#64238)
+# ---------------------------------------------------------------------------
+
+class TestSendWithRetryAmbiguousDelivery:
+    """``SendResult.ambiguous_delivery`` must veto every re-send.
+
+    ``retryable=False`` alone is NOT enough: ``_send_with_retry`` computes
+    ``is_network = result.retryable or self._is_retryable_error(error_str)``
+    and ``_RETRYABLE_ERROR_PATTERNS`` contains both ``"network"`` and
+    ``"connectionreset"``, so an adapter that knows the payload may already be
+    on the wire cannot veto the re-send through ``retryable`` at all — the OR
+    discards its answer.  ``ambiguous_delivery`` is the explicit signal the
+    base layer honors unconditionally.
+    """
+
+    AMBIGUOUS_ERROR = "NetworkError: connection reset by peer"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_delivery_sends_exactly_once(self):
+        """The whole point: one send() call, no retries, no fallback, no notice."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(
+                success=False,
+                error=self.AMBIGUOUS_ERROR,
+                ambiguous_delivery=True,
+            ),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert not result.success
+        assert len(adapter._send_calls) == 1
+        mock_sleep.assert_not_called()
+        # The failure is surfaced verbatim — not replaced by a fallback result.
+        assert result.error == self.AMBIGUOUS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_retryable_false_alone_does_not_stop_the_resend(self):
+        """Control case pinning WHY the new flag is needed.
+
+        With the identical error string and ``retryable=False`` but no
+        ``ambiguous_delivery``, ``_is_retryable_error`` matches "network" /
+        "connectionreset" and the base layer re-sends anyway: 1 initial + 2
+        retries + 1 delivery-failure notice = 4 sends.  If this ever drops to
+        1, the flag has become redundant and the extra field can go.
+        """
+        adapter = _StubAdapter()
+        err = SendResult(success=False, error=self.AMBIGUOUS_ERROR, retryable=False)
+        adapter._send_results = [err, err, err, SendResult(success=True)]
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert not result.success
+        assert len(adapter._send_calls) == 4
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_delivery_on_a_retry_stops_immediately(self):
+        """Sibling site: the in-loop check must return, not break.
+
+        Breaking out of the retry loop falls through to the plain-text
+        fallback, which is itself a send — so an ambiguous result observed on
+        a retry has to return straight away.
+        """
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="httpx.ConnectError: connection refused"),
+            SendResult(
+                success=False,
+                error=self.AMBIGUOUS_ERROR,
+                ambiguous_delivery=True,
+            ),
+            SendResult(success=True, message_id="should_not_be_reached"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert not result.success
+        # 1 initial + 1 retry, then stop. No second retry, no plain-text
+        # fallback, no delivery-failure notice.
+        assert len(adapter._send_calls) == 2
+        assert result.error == self.AMBIGUOUS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_delivery_skips_plain_text_fallback(self):
+        """A formatting-shaped error string does not re-enable the fallback."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(
+                success=False,
+                error="Bad Request: can't parse entities",
+                ambiguous_delivery=True,
+            ),
+            SendResult(success=True, message_id="should_not_be_reached"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", "**bold**", max_retries=2, base_delay=0)
+        assert not result.success
+        assert len(adapter._send_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_default_is_false_so_existing_adapters_are_unaffected(self):
+        """The new field defaults off — adapters that don't set it keep retrying."""
+        assert SendResult(success=False, error="boom").ambiguous_delivery is False
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="httpx.ConnectError: connection refused"),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert result.success
+        assert len(adapter._send_calls) == 2
+
+
+# ---------------------------------------------------------------------------
 # _send_with_retry — retry_after honor
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_telegram_send_network_idempotence.py
+++ b/tests/gateway/test_telegram_send_network_idempotence.py
@@ -1,0 +1,251 @@
+"""Telegram send idempotence for post-write NetworkErrors (#64238).
+
+The legacy ``TelegramAdapter.send()`` retry loop used to handle only
+``TimedOut`` carefully — a generic ``TimedOut`` may have reached Telegram, so
+it is re-raised instead of blindly re-sent. But a *non-timeout* ``NetworkError``
+(connection reset / ``RemoteProtocolError`` / ``ReadError``) raised **after the
+request body was written** is exactly as ambiguous: Telegram may have already
+accepted the message. The old code fell through to a blind in-loop resend (up to
+3x) and additionally reported the failure as ``retryable=True``, so the
+gateway's ``_send_with_retry`` re-sent it up to 2 more times — duplicating the
+message in the chat.
+
+These tests pin the idempotence contract:
+
+* a post-write ``NetworkError`` is NOT retried in-loop and surfaces as
+  ``retryable=False`` (so neither the adapter loop nor the gateway re-sends);
+* a *connect-phase* failure (ConnectError / connection refused / DNS) is still
+  retried and stays retryable — the request demonstrably never left the
+  process, so re-sending cannot duplicate;
+* an httpx pool timeout still drains the pool and retries (unchanged).
+
+The first case fails on ``main`` (3 in-loop sends + ``retryable=True``) and
+passes after the fix.
+"""
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (mod.error.NetworkError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+def _ensure_real_telegram_constants():
+    """Give ``telegram.constants`` real ``ChatType``/``ParseMode`` values.
+
+    This module imports the Telegram adapter at module scope, and the adapter
+    binds ``from telegram.constants import ParseMode, ChatType`` once, caching
+    both as module globals for the whole session. When the real library is
+    absent, ``tests/gateway/conftest.py`` registers a single ``MagicMock`` as
+    *both* ``telegram`` and ``telegram.constants``, but configures the values
+    on ``mod.constants.ChatType`` — a different attribute than the
+    ``mod.ChatType`` that ``from telegram.constants import ChatType`` actually
+    resolves. The adapter would therefore cache a bare mock, and sibling suites
+    that compare a chat's ``type`` against ``adapter.ChatType.SUPERGROUP``
+    (``test_telegram_thread_fallback.py``) would see every chat fall through to
+    ``"dm"``.
+
+    Set the attributes on whatever object is registered, so no module identity
+    is swapped and the stubbed exception classes other suites already imported
+    keep working.
+    """
+    constants = sys.modules.get("telegram.constants")
+    if constants is None or getattr(constants, "__file__", None) is not None:
+        return  # Not registered, or the real library — leave it alone.
+    if isinstance(getattr(constants, "ChatType", None), SimpleNamespace):
+        return  # Already normalized by an earlier import of this module.
+    constants.ChatType = SimpleNamespace(
+        PRIVATE="private",
+        GROUP="group",
+        SUPERGROUP="supergroup",
+        CHANNEL="channel",
+    )
+    constants.ParseMode = SimpleNamespace(
+        MARKDOWN="Markdown",
+        MARKDOWN_V2="MarkdownV2",
+        HTML="HTML",
+    )
+
+
+_ensure_telegram_mock()
+_ensure_real_telegram_constants()
+
+from telegram.error import NetworkError, TimedOut  # noqa: E402
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+class ConnectError(Exception):
+    """Stand-in for ``httpx.ConnectError`` — matched by the class-name marker."""
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._bot = MagicMock()
+    return adapter
+
+
+def _fail_with(exc: BaseException) -> AsyncMock:
+    return AsyncMock(side_effect=exc)
+
+
+# ---------------------------------------------------------------------------
+# Post-write NetworkError: must NOT be re-sent (idempotence)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        NetworkError("Connection reset by peer"),
+        NetworkError("Server disconnected mid-response (RemoteProtocolError)"),
+        NetworkError("httpx.ReadError: connection broken while reading response"),
+    ],
+)
+async def test_post_write_network_error_not_resent(exc):
+    """A non-timeout NetworkError after the body was written propagates on the
+    first attempt (no in-loop resend) and is reported non-retryable so the
+    gateway layer does not re-send it either."""
+    adapter = _make_adapter()
+    adapter._bot.send_message = _fail_with(exc)
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ):
+        result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    # No blind in-loop retry: exactly one underlying send attempt.
+    assert adapter._bot.send_message.await_count == 1
+    # Non-retryable → gateway _send_with_retry() will not re-send it.
+    assert result.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_post_write_network_error_via_cause_chain_not_resent():
+    """Even when the ambiguous failure is a wrapped cause (PTB wraps the httpx
+    error), a non-connect-phase chain must not be treated as connect-phase."""
+    adapter = _make_adapter()
+    err = NetworkError("network error while sending")
+    err.__cause__ = RuntimeError("Server disconnected without sending a response")
+    adapter._bot.send_message = _fail_with(err)
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ):
+        result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 1
+    assert result.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Connect-phase failures: still retried, still retryable (no over-broadening)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: NetworkError("Connect error: [Errno 111] Connection refused"),
+        lambda: NetworkError("getaddrinfo failed: name or service not known"),
+    ],
+)
+async def test_connect_phase_network_error_is_retried(exc_factory):
+    """A pre-write connection failure never left the process, so re-sending is
+    safe: the loop still retries (3 attempts) and the failure stays retryable."""
+    adapter = _make_adapter()
+    adapter._bot.send_message = _fail_with(exc_factory())
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ):
+        result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 3
+    assert result.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_connect_error_via_cause_chain_is_retried():
+    """A NetworkError wrapping an httpx.ConnectError (matched by class name on
+    the __cause__ chain) is connect-phase → retried and retryable."""
+    adapter = _make_adapter()
+    err = NetworkError("network error")
+    # The connect-phase signal is only on the wrapped cause (class name
+    # "ConnectError"), exactly as PTB wraps an httpx.ConnectError.
+    err.__cause__ = ConnectError("[Errno 111] Connection refused")
+    adapter._bot.send_message = _fail_with(err)
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ):
+        result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 3
+    assert result.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# Generic TimedOut: unchanged (already non-retryable, no resend)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_generic_timed_out_still_not_resent():
+    """Regression guard: the pre-existing TimedOut behavior is preserved — a
+    plain TimedOut still raises on the first attempt and is non-retryable."""
+    adapter = _make_adapter()
+    adapter._bot.send_message = _fail_with(TimedOut("Timed out"))
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ):
+        result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 1
+    assert result.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Pool timeout: unchanged (drains the pool and retries)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pool_timeout_still_drains_and_retries():
+    """Regression guard: an httpx pool timeout is explicitly 'not sent to
+    Telegram', so the loop still drains the pool and retries (retryable)."""
+    adapter = _make_adapter()
+    pool_err = TimedOut(
+        "Pool timeout: All connections in the connection pool are occupied. "
+        "Request was *not* sent to Telegram."
+    )
+    adapter._bot.send_message = _fail_with(pool_err)
+    adapter._drain_general_connections_after_pool_timeout = AsyncMock()
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ):
+        result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 3
+    assert adapter._drain_general_connections_after_pool_timeout.await_count == 3
+    assert result.retryable is True

--- a/tests/gateway/test_telegram_send_network_idempotence.py
+++ b/tests/gateway/test_telegram_send_network_idempotence.py
@@ -10,17 +10,31 @@ accepted the message. The old code fell through to a blind in-loop resend (up to
 gateway's ``_send_with_retry`` re-sent it up to 2 more times — duplicating the
 message in the chat.
 
+``retryable=False`` alone cannot stop the gateway, because
+``BasePlatformAdapter._send_with_retry`` computes
+``is_network = result.retryable or self._is_retryable_error(error_str)`` and
+``_RETRYABLE_ERROR_PATTERNS`` contains both ``"network"`` and
+``"connectionreset"`` — the OR discards the adapter's answer. The adapter
+therefore also sets the explicit ``SendResult.ambiguous_delivery`` flag, which
+the base layer honors unconditionally (before ``is_network`` is computed, and
+again inside the retry loop).
+
 These tests pin the idempotence contract:
 
 * a post-write ``NetworkError`` is NOT retried in-loop and surfaces as
-  ``retryable=False`` (so neither the adapter loop nor the gateway re-sends);
+  ``retryable=False`` **and** ``ambiguous_delivery=True`` (so neither the
+  adapter loop nor the gateway re-sends);
+* the same holds for the Bot API 10.1 ``sendRichMessage`` path;
 * a *connect-phase* failure (ConnectError / connection refused / DNS) is still
   retried and stays retryable — the request demonstrably never left the
   process, so re-sending cannot duplicate;
-* an httpx pool timeout still drains the pool and retries (unchanged).
+* an httpx pool timeout still drains the pool and retries (unchanged);
+* end-to-end through ``_send_with_retry``, an ambiguous failure produces
+  exactly ONE underlying send.
 
-The first case fails on ``main`` (3 in-loop sends + ``retryable=True``) and
-passes after the fix.
+The first case fails on ``main`` (3 in-loop sends + ``retryable=True`` + 2 more
+gateway sends) and passes after the fix.  The base-layer unit coverage for the
+flag itself lives in ``tests/gateway/test_send_retry.py``.
 """
 import sys
 import types
@@ -133,6 +147,10 @@ async def test_post_write_network_error_not_resent(exc):
     assert adapter._bot.send_message.await_count == 1
     # Non-retryable → gateway _send_with_retry() will not re-send it.
     assert result.retryable is False
+    # ...and `retryable=False` alone is not enough: _is_retryable_error()
+    # matches "network"/"connectionreset" in the error text and ORs it away.
+    # The explicit flag is what the base layer actually honors.
+    assert result.ambiguous_delivery is True
 
 
 @pytest.mark.asyncio
@@ -152,6 +170,7 @@ async def test_post_write_network_error_via_cause_chain_not_resent():
     assert result.success is False
     assert adapter._bot.send_message.await_count == 1
     assert result.retryable is False
+    assert result.ambiguous_delivery is True
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +199,9 @@ async def test_connect_phase_network_error_is_retried(exc_factory):
     assert result.success is False
     assert adapter._bot.send_message.await_count == 3
     assert result.retryable is True
+    # Nothing left the process, so delivery is NOT ambiguous — the base layer
+    # must stay free to retry.
+    assert result.ambiguous_delivery is False
 
 
 @pytest.mark.asyncio
@@ -201,6 +223,7 @@ async def test_connect_error_via_cause_chain_is_retried():
     assert result.success is False
     assert adapter._bot.send_message.await_count == 3
     assert result.retryable is True
+    assert result.ambiguous_delivery is False
 
 
 # ---------------------------------------------------------------------------
@@ -222,6 +245,10 @@ async def test_generic_timed_out_still_not_resent():
     assert result.success is False
     assert adapter._bot.send_message.await_count == 1
     assert result.retryable is False
+    # A generic read timeout is ambiguous for the same reason. Previously this
+    # was only stopped by the base layer's `_is_timeout_error` substring scan of
+    # the (redacted) error text; the flag makes it explicit and text-independent.
+    assert result.ambiguous_delivery is True
 
 
 # ---------------------------------------------------------------------------
@@ -249,3 +276,113 @@ async def test_pool_timeout_still_drains_and_retries():
     assert adapter._bot.send_message.await_count == 3
     assert adapter._drain_general_connections_after_pool_timeout.await_count == 3
     assert result.retryable is True
+    # PTB says the request was explicitly NOT sent, so delivery is unambiguous.
+    assert result.ambiguous_delivery is False
+
+
+# ---------------------------------------------------------------------------
+# Cross-layer: the gateway retry wrapper must not re-send either
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_with_retry_does_not_resend_post_write_network_error():
+    """The bug teknium1 flagged, end-to-end.
+
+    Before the fix the adapter's ``retryable=False`` was ORed away by
+    ``_send_with_retry``'s ``self._is_retryable_error(error_str)`` (the error
+    text contains both "network" and "connection reset"), so the gateway
+    re-sent the payload twice more and then posted a delivery-failure notice —
+    up to three duplicate messages plus a bogus "delivery failed" notice for a
+    message the user had already received.
+    """
+    adapter = _make_adapter()
+    adapter._bot.send_message = _fail_with(
+        NetworkError("NetworkError: connection reset by peer")
+    )
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ), patch("asyncio.sleep", new=AsyncMock()):
+        result = await adapter._send_with_retry("123", "hello", max_retries=2, base_delay=0)
+
+    assert result.success is False
+    assert result.ambiguous_delivery is True
+    # Exactly ONE underlying send: no gateway retry, no plain-text fallback,
+    # and no "Message delivery failed after multiple attempts" notice (which
+    # would itself be a fourth send).
+    assert adapter._bot.send_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_still_retries_connect_phase_failures():
+    """Control: the flag must not turn every network failure into a no-retry.
+
+    A connect-phase failure never left the process, so the gateway still gets
+    its retries — 3 adapter-loop attempts per ``send()`` call, across the
+    initial call plus 2 gateway retries plus the delivery-failure notice.
+    """
+    adapter = _make_adapter()
+    adapter._bot.send_message = _fail_with(
+        NetworkError("Connect error: [Errno 111] Connection refused")
+    )
+
+    with patch(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", new=AsyncMock()
+    ), patch("asyncio.sleep", new=AsyncMock()):
+        result = await adapter._send_with_retry("123", "hello", max_retries=2, base_delay=0)
+
+    assert result.success is False
+    assert result.ambiguous_delivery is False
+    assert adapter._bot.send_message.await_count > 1
+
+
+# ---------------------------------------------------------------------------
+# Sibling site: the Bot API 10.1 sendRichMessage path has the same bug
+# ---------------------------------------------------------------------------
+
+def _make_rich_adapter() -> TelegramAdapter:
+    """Adapter wired for the rich-send path (``sendRichMessage``)."""
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="***", extra={"rich_messages": True})
+    )
+    bot = MagicMock()
+    # An AsyncMock makes inspect.iscoroutinefunction() true, which is what
+    # _bot_supports_rich() checks.
+    bot.do_api_request = AsyncMock(return_value={"message_id": 1})
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+    return adapter
+
+
+RICH_CONTENT = "## Results\n\n| Case | Status |\n|---|---|\n| rich | ok |"
+
+
+@pytest.mark.asyncio
+async def test_rich_post_write_network_error_is_ambiguous():
+    """``_send_rich_message`` had the identical ``not is_timeout`` computation:
+    a post-write NetworkError came back ``retryable=True``, so the base layer
+    re-sent it. It is now non-retryable and flagged ambiguous."""
+    adapter = _make_rich_adapter()
+    adapter._bot.do_api_request = _fail_with(NetworkError("Connection reset by peer"))
+
+    result = await adapter.send("123", RICH_CONTENT)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.ambiguous_delivery is True
+    # And no legacy resend of the same payload.
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rich_send_with_retry_sends_exactly_once():
+    adapter = _make_rich_adapter()
+    adapter._bot.do_api_request = _fail_with(NetworkError("Connection reset by peer"))
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        result = await adapter._send_with_retry("123", RICH_CONTENT, max_retries=2, base_delay=0)
+
+    assert result.success is False
+    assert adapter._bot.do_api_request.await_count == 1
+    adapter._bot.send_message.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

The Telegram adapter's legacy `send()` retry loop blindly re-sends on a **non-timeout `NetworkError`** (connection reset / `httpx.ReadError` / `RemoteProtocolError`). When such an error is raised *after* the HTTP request body was written — common under sustained flood-control pressure — Telegram may have already accepted the message, so the retry produces a **duplicate message**. The outer handler compounded this by reporting the failure `retryable=True`, so the gateway's `_send_with_retry` re-sent it up to two more times (up to ~6 copies total).

This extends the existing connect-phase idempotence principle from `TimedOut` to any `NetworkError`. It mirrors `_looks_like_connect_timeout` (docstring: "A plain Telegram TimedOut may mean the request reached Telegram and should not be re-sent.") and the gateway's `_is_timeout_error` ("Timeout errors are NOT retryable … the request may have already been delivered"). Only failures that demonstrably happened **before** the request left the process — connect/DNS/refused/`ConnectError`, or an httpx pool timeout PTB reports as "not sent to Telegram" — are re-sent.

Same bug class was already addressed on other platforms: the Signal duplicate-send fix (`e26393ffc`, regression #51463) and the WeCom duplicate report (#14061).

## Related Issue

Fixes #64238

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - Add `_looks_like_connect_error(error)`, mirroring `_looks_like_connect_timeout`: walks the `__cause__`/`__context__` chain for pre-write connection failures (`httpx.ConnectError`, connection refused, DNS/`getaddrinfo`). Deliberately does **not** match connection-reset / broken-pipe / protocol errors, which are ambiguous post-write failures.
  - Broaden the in-loop raise guard so a `NetworkError` (incl. its `TimedOut` subclass) that is neither pool-timeout nor connect-phase raises instead of resending.
  - Mark that same class of error `retryable=False` in the outer `except` so the gateway retry layer (`_send_with_retry`) does not re-introduce the duplicate.
- `tests/gateway/test_telegram_send_network_idempotence.py` — new regression tests (post-write not re-sent + `retryable=False`; connect-phase and pool-timeout still retried).
- `tests/gateway/test_telegram_thread_fallback.py` — update `test_send_retries_*` to use a connect-phase error for the "still retried" case, matching the new contract.

## How to Test

1. `pytest tests/gateway/test_telegram_send_network_idempotence.py -q` — passes with the fix; the post-write cases **fail on `main`** (message re-sent 3x in-loop and `retryable=True`).
2. `pytest tests/gateway/test_telegram_thread_fallback.py -q` — connect-phase network errors still retry; timeout/pool paths unchanged.

Regression proof (before/after): with the production hunk reverted, the post-write `NetworkError` tests fail (`send_message.await_count == 3`, `retryable=True`); with the fix they pass (`await_count == 1`, `retryable=False`). Connect-phase / generic-`TimedOut` / pool-timeout guard tests pass both ways, confirming no over-broadening.

## Related / Positioning

Scope is intentionally kept to the Telegram adapter to stay surgical. The gateway sibling `gateway/platforms/base.py::_is_retryable_error` / `_RETRYABLE_ERROR_PATTERNS` is the layer that would otherwise re-send; rather than widen the cross-platform retry classifier here, the adapter now surfaces the post-write failure as non-retryable, which closes the duplicate at both layers (the tight 3x in-loop resend **and** the gateway's `_send_with_retry`). Happy to widen `_is_retryable_error` to treat post-write connection resets non-retryably platform-wide as a follow-up if preferred.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched-area tests (`tests/gateway/test_telegram_*`) and they pass; combined-run telegram failures reproduce on clean `main` (pre-existing shared-`sys.modules`-mock isolation artifact)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (python-telegram-bot mocked, per the existing telegram test suite pattern)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — new helper is documented via docstring; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — string/class-name matching only, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A