### PR TITLE
fix(anthropic): resolve OAuth for reference-only pool entries

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2646,7 +2646,16 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
 
     pool_present, entry = _select_pool_entry("anthropic")
     if pool_present and entry is not None:
-        token = explicit_api_key or _pool_runtime_api_key(entry)
+        pool_token = _pool_runtime_api_key(entry)
+        if pool_token:
+            token = explicit_api_key or pool_token
+        else:
+            # A reference-only pool entry (for example env:CLAUDE_CODE_OAUTH_TOKEN)
+            # can be selectable without embedding runtime credentials. Discard
+            # the empty entry, including its base URL, before choosing between
+            # an explicit key and the normal OAuth/credentials-file resolver.
+            entry = None
+            token = explicit_api_key or resolve_anthropic_token()
     else:
         # Pool absent, OR pool present but no usable entry (expired token +
         # stale refresh_token, all entries exhausted, etc). Fall through to the

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -658,6 +658,52 @@ class TestAnthropicOAuthFlag:
         assert model == "claude-haiku-4-5-20251001"
         assert mock_build.call_args.args[0] == "sk-ant-oat01-pooled"
 
+    def test_empty_pool_entry_falls_back_to_oauth_resolver(self):
+        class _Entry:
+            access_token = None
+            base_url = "https://reference-only.invalid"
+
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, _Entry())),
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="cc-oauth-token") as mock_resolve,
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+        ):
+            from agent.auxiliary_client import _try_anthropic
+
+            client, model = _try_anthropic()
+
+        assert client is not None
+        assert model == "claude-haiku-4-5-20251001"
+        mock_resolve.assert_called_once_with()
+        assert mock_build.call_args.args == (
+            "cc-oauth-token",
+            "https://api.anthropic.com",
+        )
+
+    def test_empty_pool_entry_with_explicit_key_discards_pool_base_url(self):
+        class _Entry:
+            access_token = None
+            base_url = "https://reference-only.invalid"
+
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, _Entry())),
+            patch(
+                "agent.anthropic_adapter.resolve_anthropic_token",
+                side_effect=AssertionError("explicit key should avoid resolver"),
+            ),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+        ):
+            from agent.auxiliary_client import _try_anthropic
+
+            client, model = _try_anthropic(explicit_api_key="explicit-test-key")
+
+        assert client is not None
+        assert model == "claude-haiku-4-5-20251001"
+        assert mock_build.call_args.args == (
+            "explicit-test-key",
+            "https://api.anthropic.com",
+        )
+
 
 class TestBuildCodexClient:
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):


### PR DESCRIPTION
## Summary
- treat a selected Anthropic pool entry without a runtime token as reference-only
- discard that empty entry and its base URL before choosing an explicit key or the normal OAuth resolver
- retain pool precedence and pool base URL only when the selected entry actually contains a runtime token
- add regressions for both OAuth fallback and explicit-key handling

## Root cause
`_try_anthropic()` originally used `resolve_anthropic_token()` only when no pool entry was selected. A selectable `env:CLAUDE_CODE_OAUTH_TOKEN` reference without an embedded token therefore wedged fallback activation even though valid Claude Code OAuth credentials were available.

The first fix combined `explicit_api_key` with the pool token before checking whether the pool entry itself was empty. That allowed an explicit key to mask a reference-only entry and inherit its stale or untrusted base URL. This revision validates the pool token separately and clears the entry before credential selection.

## Verification
- reference-only OAuth and explicit-key regressions on current `origin/main`: 2 passed
- `tests/run_agent/test_run_agent.py -k 'fallback and anthropic'`: 7 passed
- full auxiliary-client suite on the installed runtime base: 302 passed
- current `origin/main` baseline comparison: the same unrelated local-environment failures occur with and without this patch (`pytest-asyncio` absent and local `pydantic_core` ABI mismatch); this patch adds passing coverage and no new failures
- live API-server continuity smoke recovered the prior WhatsApp context and called Clay MCP after gateway reload
