### PR TITLE
fix(plugins): support standalone model-provider distribution

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -450,7 +450,7 @@ def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
 def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, str]:
     """Clone Git plugin into ``~/.hermes/plugins``.
 
-    Returns ``(target_dir, installed_manifest, canonical_name)``.
+    Returns ``(target_dir, installed_manifest, lifecycle_key)``.
     Raises ``PluginOperationError`` on failure.
     """
     import tempfile
@@ -503,7 +503,19 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
         )
 
         try:
+            # Validate the manifest-controlled leaf before adding a fixed
+            # category.  Passing the combined key directly with
+            # ``allow_subdir=True`` would let a malicious manifest smuggle in
+            # extra path segments.
             target = _sanitize_plugin_name(plugin_name, plugins_dir)
+            install_key = plugin_name
+            if manifest.get("kind") == "model-provider":
+                install_key = f"model-providers/{plugin_name}"
+                target = _sanitize_plugin_name(
+                    install_key,
+                    plugins_dir,
+                    allow_subdir=True,
+                )
         except ValueError as e:
             raise PluginOperationError(str(e)) from e
 
@@ -529,10 +541,11 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
             if not force:
                 raise PluginOperationError(
                     f"Plugin '{plugin_name}' already exists. Use force reinstall "
-                    f"or run `hermes plugins update {plugin_name}`.",
+                    f"or run `hermes plugins update {install_key}`.",
                 )
             shutil.rmtree(target)
 
+        target.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(tmp_target), str(target))
 
     has_yaml = (target / "plugin.yaml").exists() or (target / "plugin.yml").exists()
@@ -546,8 +559,7 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
 
     _copy_example_files(target, Console())
     installed_manifest = _read_manifest(target)
-    installed_name = installed_manifest.get("name") or target.name
-    return target, installed_manifest, installed_name
+    return target, installed_manifest, install_key
 
 
 def cmd_install(
@@ -557,8 +569,9 @@ def cmd_install(
 ) -> None:
     """Install a plugin from a Git URL or owner/repo shorthand.
 
-    After install, prompt "Enable now? [y/N]" unless *enable* is provided
-    (True = auto-enable without prompting, False = install disabled).
+    General plugins prompt "Enable now? [y/N]" unless *enable* is provided.
+    Model providers are discovered automatically and skip general-plugin
+    activation; installation makes them available but does not select one.
     """
     from rich.console import Console
 
@@ -602,34 +615,40 @@ def cmd_install(
 
     _display_after_install(target, identifier)
 
-    should_enable = enable
-    if should_enable is None:
-        if sys.stdin.isatty() and sys.stdout.isatty():
-            try:
-                answer = input(
-                    f"  Enable '{installed_name}' now? [y/N]: ",
-                ).strip().lower()
-                should_enable = answer in {"y", "yes"}
-            except (EOFError, KeyboardInterrupt):
-                should_enable = False
-        else:
-            should_enable = False
-
-    if should_enable:
-        enabled = _get_enabled_set()
-        disabled = _get_disabled_set()
-        enabled.add(installed_name)
-        disabled.discard(installed_name)
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
+    if installed_manifest.get("kind") == "model-provider":
         console.print(
-            f"[green]✓[/green] Plugin [bold]{installed_name}[/bold] enabled.",
+            "[green]✓[/green] Model provider installed and available for setup."
         )
+        console.print("[dim]Configure or select it with `hermes model`.[/dim]")
     else:
-        console.print(
-            f"[dim]Plugin installed but not enabled. "
-            f"Run `hermes plugins enable {installed_name}` to activate.[/dim]",
-        )
+        should_enable = enable
+        if should_enable is None:
+            if sys.stdin.isatty() and sys.stdout.isatty():
+                try:
+                    answer = input(
+                        f"  Enable '{installed_name}' now? [y/N]: ",
+                    ).strip().lower()
+                    should_enable = answer in {"y", "yes"}
+                except (EOFError, KeyboardInterrupt):
+                    should_enable = False
+            else:
+                should_enable = False
+
+        if should_enable:
+            enabled = _get_enabled_set()
+            disabled = _get_disabled_set()
+            enabled.add(installed_name)
+            disabled.discard(installed_name)
+            _save_enabled_set(enabled)
+            _save_disabled_set(disabled)
+            console.print(
+                f"[green]✓[/green] Plugin [bold]{installed_name}[/bold] enabled.",
+            )
+        else:
+            console.print(
+                f"[dim]Plugin installed but not enabled. "
+                f"Run `hermes plugins enable {installed_name}` to activate.[/dim]",
+            )
 
     console.print("[dim]Restart the gateway for the plugin to take effect:[/dim]")
     console.print("[dim]  hermes gateway restart[/dim]")

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -262,8 +262,10 @@ def _repo_name_from_url(url: str) -> str:
 
 
 def _read_manifest(plugin_dir: Path) -> dict:
-    """Read plugin.yaml and return the parsed dict, or empty dict."""
+    """Read plugin.yaml/plugin.yml and return the parsed dict, or empty dict."""
     manifest_file = plugin_dir / "plugin.yaml"
+    if not manifest_file.exists():
+        manifest_file = plugin_dir / "plugin.yml"
     if not manifest_file.exists():
         return {}
     try:

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,9 +1,10 @@
 """Provider module registry.
 
-Provider profiles can live in two places:
+Provider profiles can live in three places:
 
 1. Bundled plugins: ``plugins/model-providers/<name>/`` (shipped with hermes-agent)
-2. User plugins: ``$HERMES_HOME/plugins/model-providers/<name>/``
+2. Pip packages: ``hermes_agent.model_providers`` entry points
+3. User plugins: ``$HERMES_HOME/plugins/model-providers/<name>/``
 
 Each plugin directory contains:
   - ``__init__.py`` — calls ``register_provider(profile)`` at import
@@ -34,6 +35,7 @@ import importlib
 import importlib.util
 import logging
 import sys
+from importlib import metadata as importlib_metadata
 from pathlib import Path
 
 from providers.base import OMIT_TEMPERATURE, ProviderProfile  # noqa: F401
@@ -43,6 +45,7 @@ logger = logging.getLogger(__name__)
 _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
 _discovered = False
+MODEL_PROVIDER_ENTRY_POINTS_GROUP = "hermes_agent.model_providers"
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
@@ -137,13 +140,48 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
         sys.modules.pop(module_name, None)
 
 
+def _load_entry_point_providers() -> None:
+    """Invoke pip-installed model-provider registration entry points."""
+    try:
+        entry_points = importlib_metadata.entry_points()
+        if hasattr(entry_points, "select"):
+            providers = entry_points.select(
+                group=MODEL_PROVIDER_ENTRY_POINTS_GROUP
+            )
+        elif isinstance(entry_points, dict):
+            providers = entry_points.get(MODEL_PROVIDER_ENTRY_POINTS_GROUP, [])
+        else:
+            providers = [
+                entry_point
+                for entry_point in entry_points
+                if entry_point.group == MODEL_PROVIDER_ENTRY_POINTS_GROUP
+            ]
+    except Exception as exc:
+        logger.warning("Failed to discover packaged provider plugins: %s", exc)
+        return
+
+    for entry_point in sorted(providers, key=lambda item: item.name):
+        try:
+            register = entry_point.load()
+            if not callable(register):
+                raise TypeError("entry point must resolve to a callable")
+            register()
+        except Exception as exc:
+            logger.warning(
+                "Failed to load packaged provider plugin %s: %s",
+                entry_point.name,
+                exc,
+            )
+
+
 def _discover_providers() -> None:
     """Populate the registry by importing every provider plugin.
 
     Order:
       1. Bundled plugins at ``<repo>/plugins/model-providers/<name>/``
-      2. User plugins at ``$HERMES_HOME/plugins/model-providers/<name>/``
-      3. Legacy per-file modules at ``providers/<name>.py`` (back-compat)
+      2. Pip packages in ``hermes_agent.model_providers``
+      3. User plugins at ``$HERMES_HOME/plugins/model-providers/<name>/``
+      4. Legacy per-file modules at ``providers/<name>.py`` (back-compat)
 
     Each step imports its plugins, which call ``register_provider()`` at
     module-level. Later steps win on name collision.
@@ -160,7 +198,10 @@ def _discover_providers() -> None:
                 continue
             _import_plugin_dir(child, "bundled")
 
-    # 2. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
+    # 2. Pip packages — less local than an explicit HERMES_HOME override.
+    _load_entry_point_providers()
+
+    # 3. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
     #    These can override any bundled profile of the same name (last-writer-wins
     #    in register_provider()).
     user_dir = _user_plugins_dir()
@@ -170,7 +211,7 @@ def _discover_providers() -> None:
                 continue
             _import_plugin_dir(child, "user")
 
-    # 3. Legacy single-file profiles at providers/<name>.py. Kept for
+    # 4. Legacy single-file profiles at providers/<name>.py. Kept for
     #    back-compat — if someone drops a ``providers/foo.py`` into an
     #    editable install, it still works without the plugin layout.
     try:

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -656,11 +656,11 @@ class TestModelProviderInstallE2E:
     """Install a model-provider repository into its discovery category."""
 
     @staticmethod
-    def _make_repo(repo_root: Path) -> None:
+    def _make_repo(repo_root: Path, manifest_name: str = "plugin.yaml") -> None:
         import subprocess as sp
 
         repo_root.mkdir(parents=True)
-        (repo_root / "plugin.yaml").write_text(
+        (repo_root / manifest_name).write_text(
             "name: acme-provider\n"
             "kind: model-provider\n"
             "manifest_version: 1\n"
@@ -721,3 +721,25 @@ class TestModelProviderInstallE2E:
         assert profile is not None
         assert profile.name == "acme"
         _clear_provider_caches()
+
+    def test_plugin_yml_uses_model_provider_discovery_path(
+        self, tmp_path, monkeypatch
+    ):
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+
+        from hermes_cli import plugins_cmd as pc
+
+        repo_root = tmp_path / "model-provider-yml-repo"
+        self._make_repo(repo_root, manifest_name="plugin.yml")
+        plugins_dir = tmp_path / "hermes-home" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+
+        target, manifest, key = pc._install_plugin_core(
+            f"file://{repo_root}", force=False
+        )
+
+        assert manifest["kind"] == "model-provider"
+        assert key == "model-providers/acme-provider"
+        assert target == (plugins_dir / key).resolve()

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -255,6 +255,40 @@ class TestCmdInstall:
         mock_move.assert_not_called()
         mock_display_after_install.assert_not_called()
 
+    def test_model_provider_skips_general_enable_state(self, tmp_path):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        target = tmp_path / "plugins" / "model-providers" / "acme-provider"
+        target.mkdir(parents=True)
+        (target / "plugin.yaml").write_text(
+            "name: acme-provider\nkind: model-provider\n"
+        )
+        (target / "__init__.py").write_text("# provider profile\n")
+
+        with (
+            patch(
+                "hermes_cli.plugins_cmd._resolve_git_url",
+                return_value=("https://github.com/acme/provider.git", None),
+            ),
+            patch(
+                "hermes_cli.plugins_cmd._install_plugin_core",
+                return_value=(
+                    target,
+                    {"name": "acme-provider", "kind": "model-provider"},
+                    "model-providers/acme-provider",
+                ),
+            ),
+            patch("hermes_cli.plugins_cmd._prompt_plugin_env_vars"),
+            patch("hermes_cli.plugins_cmd._display_after_install"),
+            patch("hermes_cli.plugins_cmd._get_enabled_set") as get_enabled,
+            patch("hermes_cli.plugins_cmd._get_disabled_set") as get_disabled,
+            patch("builtins.input", side_effect=AssertionError("must not prompt")),
+        ):
+            cmd_install("acme/provider", enable=True)
+
+        get_enabled.assert_not_called()
+        get_disabled.assert_not_called()
+
 
 # ── cmd_update tests ─────────────────────────────────────────────────────────
 
@@ -616,3 +650,74 @@ class TestSubdirInstallE2E:
         identifier = f"file://{repo_root}#does-not-exist"
         with pytest.raises(PluginOperationError, match="does not exist"):
             pc._install_plugin_core(identifier, force=False)
+
+
+class TestModelProviderInstallE2E:
+    """Install a model-provider repository into its discovery category."""
+
+    @staticmethod
+    def _make_repo(repo_root: Path) -> None:
+        import subprocess as sp
+
+        repo_root.mkdir(parents=True)
+        (repo_root / "plugin.yaml").write_text(
+            "name: acme-provider\n"
+            "kind: model-provider\n"
+            "manifest_version: 1\n"
+        )
+        (repo_root / "__init__.py").write_text(
+            "from providers import register_provider\n"
+            "from providers.base import ProviderProfile\n"
+            "register_provider(ProviderProfile(\n"
+            "    name='acme', aliases=('acme-ai',),\n"
+            "    base_url='https://api.acme.invalid/v1',\n"
+            "))\n"
+        )
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+        sp.run(["git", "init", "-q"], cwd=repo_root, check=True, env=env)
+        sp.run(["git", "add", "-A"], cwd=repo_root, check=True, env=env)
+        sp.run(
+            ["git", "commit", "-q", "-m", "init"],
+            cwd=repo_root,
+            check=True,
+            env=env,
+        )
+
+    def test_install_path_is_immediately_discoverable(
+        self, tmp_path, monkeypatch
+    ):
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+
+        from hermes_cli import plugins_cmd as pc
+        from tests.providers.test_plugin_discovery import _clear_provider_caches
+
+        repo_root = tmp_path / "model-provider-repo"
+        self._make_repo(repo_root)
+        hermes_home = tmp_path / "hermes-home"
+        plugins_dir = hermes_home / "plugins"
+        plugins_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+
+        target, manifest, key = pc._install_plugin_core(
+            f"file://{repo_root}", force=False
+        )
+
+        assert manifest["kind"] == "model-provider"
+        assert key == "model-providers/acme-provider"
+        assert target == (plugins_dir / key).resolve()
+
+        _clear_provider_caches()
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("acme-ai")
+        assert profile is not None
+        assert profile.name == "acme"
+        _clear_provider_caches()

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 
 
@@ -119,6 +120,157 @@ def test_user_plugin_overrides_bundled(tmp_path, monkeypatch):
     _clear_provider_caches()
 
 
+def test_pip_entry_point_registers_provider(monkeypatch):
+    """A dedicated pip entry point registers without general-plugin config."""
+    import providers as provider_module
+
+    def register() -> None:
+        provider_module.register_provider(
+            provider_module.ProviderProfile(
+                name="packaged-provider",
+                aliases=("packaged-alias",),
+                base_url="https://packaged.invalid/v1",
+            )
+        )
+
+    entry_point = MagicMock()
+    entry_point.name = "packaged-provider"
+    entry_point.load.return_value = register
+    entry_points = MagicMock()
+    entry_points.select.return_value = [entry_point]
+    monkeypatch.setattr(
+        provider_module.importlib_metadata,
+        "entry_points",
+        lambda: entry_points,
+    )
+
+    _clear_provider_caches()
+    profile = provider_module.get_provider_profile("packaged-alias")
+
+    assert profile is not None
+    assert profile.name == "packaged-provider"
+    entry_points.select.assert_called_once_with(
+        group="hermes_agent.model_providers"
+    )
+    entry_point.load.assert_called_once_with()
+    _clear_provider_caches()
+
+
+def test_broken_pip_entry_point_does_not_block_others(monkeypatch, caplog):
+    """One package failure is isolated from remaining provider packages."""
+    import logging
+
+    import providers as provider_module
+
+    broken = MagicMock()
+    broken.name = "broken-provider"
+    broken.load.side_effect = RuntimeError("broken package")
+
+    def register_working() -> None:
+        provider_module.register_provider(
+            provider_module.ProviderProfile(name="working-packaged-provider")
+        )
+
+    working = MagicMock()
+    working.name = "working-provider"
+    working.load.return_value = register_working
+    entry_points = MagicMock()
+    entry_points.select.return_value = [broken, working]
+    monkeypatch.setattr(
+        provider_module.importlib_metadata,
+        "entry_points",
+        lambda: entry_points,
+    )
+
+    _clear_provider_caches()
+    with caplog.at_level(logging.WARNING, logger="providers"):
+        profile = provider_module.get_provider_profile("working-packaged-provider")
+
+    assert profile is not None
+    assert any(
+        "broken-provider" in record.message and "broken package" in record.message
+        for record in caplog.records
+    )
+    _clear_provider_caches()
+
+
+def test_user_directory_overrides_pip_entry_point(tmp_path, monkeypatch):
+    """The profile-local directory remains more specific than site packages."""
+    import providers as provider_module
+
+    def register_packaged() -> None:
+        provider_module.register_provider(
+            provider_module.ProviderProfile(
+                name="precedence-provider",
+                base_url="https://packaged.invalid/v1",
+            )
+        )
+
+    entry_point = MagicMock()
+    entry_point.name = "precedence-provider"
+    entry_point.load.return_value = register_packaged
+    entry_points = MagicMock()
+    entry_points.select.return_value = [entry_point]
+    monkeypatch.setattr(
+        provider_module.importlib_metadata,
+        "entry_points",
+        lambda: entry_points,
+    )
+
+    hermes_home = tmp_path / "hermes-home"
+    user_plugin = (
+        hermes_home / "plugins" / "model-providers" / "precedence-provider"
+    )
+    user_plugin.mkdir(parents=True)
+    (user_plugin / "__init__.py").write_text(
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        "register_provider(ProviderProfile(\n"
+        "    name='precedence-provider',\n"
+        "    base_url='https://user.invalid/v1',\n"
+        "))\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _clear_provider_caches()
+    profile = provider_module.get_provider_profile("precedence-provider")
+
+    assert profile is not None
+    assert profile.base_url == "https://user.invalid/v1"
+    _clear_provider_caches()
+
+
+def test_general_plugin_manager_skips_model_provider_kind(tmp_path, monkeypatch):
+    """The general PluginManager must NOT import model-provider plugins
+    (providers/__init__.py handles them). It records the manifest only."""
+    from hermes_cli import plugins as plugin_mod
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Create a user-installed plugin with an explicit kind: model-provider.
+    user_plugin = hermes_home / "plugins" / "test-model-provider"
+    user_plugin.mkdir(parents=True)
+    (user_plugin / "plugin.yaml").write_text(
+        "name: test-model-provider\n"
+        "kind: model-provider\n"
+        "version: 0.0.1\n"
+    )
+    (user_plugin / "__init__.py").write_text(
+        # Intentionally broken import — if the general loader tries to
+        # import this module, the test will fail with ImportError.
+        "raise AssertionError('model-provider plugins must not be imported by PluginManager')\n"
+    )
+
+    # Fresh manager
+    manager = plugin_mod.PluginManager()
+    manager.discover_and_load(force=True)
+
+    # The manifest should be recorded but not loaded
+    loaded = manager._plugins.get("test-model-provider")
+    assert loaded is not None
+    assert loaded.manifest.kind == "model-provider"
     # No import means the module must NOT be in the plugins list as a loaded one.
     # We check that the general loader didn't crash and didn't raise from the
     # broken __init__.py.

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -6,7 +6,7 @@ description: "How to build a model provider (inference backend) plugin for Herme
 
 # Building a Model Provider Plugin
 
-Model provider plugins declare an inference backend — an OpenAI-compatible endpoint, an Anthropic Messages server, a Codex-style Responses API, or a Bedrock-native surface — that Hermes can route `AIAgent` calls through. Every built-in provider (OpenRouter, Anthropic, GMI, DeepSeek, Nvidia, …) ships as one of these plugins. Third parties can add their own by dropping a directory under `$HERMES_HOME/plugins/model-providers/` with zero changes to the repo.
+Model provider plugins declare an inference backend — an OpenAI-compatible endpoint, an Anthropic Messages server, a Codex-style Responses API, or a Bedrock-native surface — that Hermes can route `AIAgent` calls through. Every built-in provider (OpenRouter, Anthropic, GMI, DeepSeek, Nvidia, …) ships as one of these plugins. Third parties can add their own from a Git repository, a Python package, or a directory under `$HERMES_HOME/plugins/model-providers/` with zero changes to the repo.
 
 :::tip
 Model provider plugins are the third kind of **provider plugin**. The others are [Memory Provider Plugins](/developer-guide/memory-provider-plugin) (cross-session knowledge) and [Context Engine Plugins](/developer-guide/context-engine-plugin) (context compression strategies). All three follow the same "drop a directory, declare a profile, no repo edits" pattern.
@@ -17,10 +17,11 @@ Model provider plugins are the third kind of **provider plugin**. The others are
 `providers/__init__.py._discover_providers()` runs lazily the first time any code calls `get_provider_profile()` or `list_providers()`. Discovery order:
 
 1. **Bundled plugins** — `<repo>/plugins/model-providers/<name>/` — ship with Hermes
-2. **User plugins** — `$HERMES_HOME/plugins/model-providers/<name>/` — drop in any directory; no restart required for subsequent sessions
-3. **Legacy single-file** — `<repo>/providers/<name>.py` — back-compat for out-of-tree editable installs
+2. **Pip packages** — `hermes_agent.model_providers` entry points
+3. **User plugins** — `$HERMES_HOME/plugins/model-providers/<name>/` — installed from Git or dropped in directly
+4. **Legacy single-file** — `<repo>/providers/<name>.py` — back-compat for out-of-tree editable installs
 
-**User plugins override bundled plugins of the same name** because `register_provider()` is last-writer-wins. Drop a `$HERMES_HOME/plugins/model-providers/gmi/` directory to replace the built-in GMI profile without touching the repo.
+**User plugins override bundled and pip-installed plugins of the same name** because `register_provider()` is last-writer-wins and the explicit profile directory loads after those less-local sources. Drop a `$HERMES_HOME/plugins/model-providers/gmi/` directory to replace the built-in or packaged GMI profile without touching the repo.
 
 ## Directory structure
 
@@ -246,18 +247,48 @@ hermes -z "hello" --provider my-provider -m some-model
 
 The general `PluginManager` (the thing `hermes plugins` operates on) **sees** model-provider plugins but does not import them — `providers/__init__.py` owns their lifecycle. The manager records the manifest for introspection and categorizes by `kind: model-provider`. When you drop an unlabeled user plugin into `$HERMES_HOME/plugins/` that happens to call `register_provider` with a `ProviderProfile`, the manager auto-coerces it to `kind: model-provider` via a source-text heuristic — so the plugin still routes correctly even without `plugin.yaml`.
 
+## Distribute from Git
+
+A standalone repository whose root contains `__init__.py` and a manifest with
+`kind: model-provider` can use Hermes' native plugin lifecycle commands:
+
+```bash
+hermes plugins install owner/repository
+hermes plugins update model-providers/<manifest-name>
+hermes plugins remove model-providers/<manifest-name>
+```
+
+The installer places the checkout at
+`$HERMES_HOME/plugins/model-providers/<manifest-name>/`. Model providers skip
+the general plugin enable prompt: installation makes the profile available,
+while `hermes model` remains the explicit provider-selection step.
+
+For a complete community-maintained repository using this layout, see the
+[Apertis AI provider](https://github.com/apertis-ai/hermes-apertis-provider).
+Community plugins are maintained by their publishers rather than by the Hermes
+Agent project; review their source and release instructions before installing.
+
 ## Distribute via pip
 
-Like any Hermes plugin, model providers can ship as a pip package. Add an entry point to your `pyproject.toml`:
+Model providers use a dedicated entry-point group so provider discovery does
+not import unrelated general plugins. Add a zero-argument registration callable
+to your `pyproject.toml`:
 
 ```toml
-[project.entry-points."hermes_agent.plugins"]
+[project.entry-points."hermes_agent.model_providers"]
 acme-inference = "acme_hermes_plugin:register"
 ```
 
-…where `acme_hermes_plugin:register` is a function that calls `register_provider(profile)`. The general PluginManager picks up entry-point plugins during `discover_and_load()`. For `kind: model-provider` pip plugins, you still need to declare the kind in your manifest (or rely on the source-text heuristic).
+…where `acme_hermes_plugin:register` takes no arguments and calls
+`register_provider(profile)`. Provider discovery invokes this entry point
+automatically; it does not use `plugins.enabled`. A package does not need a
+`plugin.yaml`, although repositories that also support Git or directory installs
+should keep the manifest at their plugin root.
 
-See [Building a Hermes Plugin](/developer-guide/plugins#distribute-via-pip) for the full entry-points setup.
+The general `hermes_agent.plugins` group remains the correct surface for
+non-provider plugins whose `register(ctx)` function consumes a `PluginContext`.
+See [Building a Hermes Plugin](/developer-guide/plugins#distribute-via-pip) for
+that separate contract.
 
 ## Related pages
 


### PR DESCRIPTION
## What does this PR do?

Fixes the two standalone model-provider distribution paths documented by Hermes:

- Git installs with `kind: model-provider` now land in `$HERMES_HOME/plugins/model-providers/<name>/`, which is the directory the provider registry actually scans.
- Python packages can register through a dedicated `hermes_agent.model_providers` entry-point group without going through general-plugin enable state.

This widens the generic plugin surface only. It does not add Apertis or any other third-party provider to the Hermes tree, and it adds no dependency.

## Related Issue

Related to #33752. Per @teknium1's standalone-plugin guidance there, the Apertis implementation remains in [apertis-ai/hermes-apertis-provider](https://github.com/apertis-ai/hermes-apertis-provider); this PR supplies the generic install/discovery contract and documents that repository as a community-maintained example.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route Git-installed model-provider manifests to a validated nested lifecycle key while preserving all other plugin install paths.
- Skip the unrelated general-plugin enable prompt for model providers and direct users to `hermes model`.
- Discover and isolate packaged provider registration entry points, with explicit user-directory overrides retaining precedence.
- Correct the authoring guide's pip contract and add native Git install/update/remove instructions.
- Add focused regression and end-to-end tests for path safety, install discovery, broken entry points, and precedence.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins_cmd_category_discovery.py tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py tests/providers/test_plugin_discovery.py -q` (149 passed locally).
2. Run `ruff check hermes_cli/plugins_cmd.py providers/__init__.py tests/hermes_cli/test_plugins_cmd.py tests/providers/test_plugin_discovery.py`.
3. Install a local `kind: model-provider` Git repository and verify a fresh Hermes process resolves its canonical name and aliases.
4. Build/install a wheel exposing `hermes_agent.model_providers` in an isolated environment and verify provider lookup.

Real canaries passed for both Git installation and an installed Apertis wheel; both resolved `apertis`, its aliases, `https://api.apertis.ai/v1`, and `gpt-5.6-sol`. The install suite covers both `plugin.yaml` and supported `plugin.yml` manifests.

The repository-wide runner was also started, but the current macOS checkout produced 26 unrelated failures by ~3% (for example `tests/agent/test_context_references.py`), so it was stopped. The affected focused suite above is green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open and merged PRs/issues for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (see unrelated full-suite failures above)
- [x] I've added tests for my changes
- [x] I've tested on macOS with Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact; the implementation uses `pathlib` and standard `importlib.metadata`
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

CLI/integration change; no visual surface changed. Focused tests, lint, Git-install canary, and wheel canary are summarized above.
