### PR TITLE
feat(plugins): dreaming memory consolidation (config.yaml re-scope)

### DIFF
--- a/plugins/dreaming/README.md
+++ b/plugins/dreaming/README.md
@@ -1,0 +1,108 @@
+# Dreaming — automatic memory consolidation
+
+Reference implementation from [Willow 2.0](https://github.com/rudi193-cmd/willow-2.0), adapted to the Hermes plugin interface. Addresses [issue #25309](https://github.com/NousResearch/hermes-agent/issues/25309).
+
+## What it does
+
+Three-phase pipeline that runs automatically during idle periods:
+
+| Phase | What happens |
+|---|---|
+| **Light Sleep** | Scans recent session transcripts, deduplicates by content hash, scores candidates using weighted criteria |
+| **REM** | Calls a local LLM (Ollama) to extract themes and write a narrative diary entry to `DREAMS.md` |
+| **Deep Sleep** | Promotes high-signal entries to `MEMORY.md`; routes meta-entries (about memory management itself) to `SKILL.md` instead |
+
+## Enablement
+
+Dreaming is opt-in at two levels:
+
+1. **Plugin discovery** — enable the bundled plugin:
+
+```bash
+hermes plugins enable dreaming
+```
+
+2. **Behavioral config** — set `enabled: true` in the plugin-owned config file (see below). The plugin seeds defaults on first load.
+
+## Configuration
+
+Behavioral settings live in **`$HERMES_HOME/dreaming/config.yaml`** (plugin-owned, seeded from `plugins/dreaming/config.yaml` on first enable). You may also override the same keys under a top-level `dreaming:` section in `~/.hermes/config.yaml`.
+
+```yaml
+enabled: false
+
+schedule:
+  min_hours: 24
+  min_sessions: 5
+  poll_seconds: 300
+
+rem:
+  model: mistral:7b
+  base_url: http://localhost:11434
+
+scoring:
+  promote_threshold: 0.55
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Master switch for hooks and the background scheduler |
+| `schedule.min_hours` | `24` | Minimum hours between automatic cycles |
+| `schedule.min_sessions` | `5` | Minimum sessions queued before a cycle runs |
+| `schedule.poll_seconds` | `300` | Background thread poll interval |
+| `rem.model` | `mistral:7b` | Ollama model for REM narrative |
+| `rem.base_url` | `http://localhost:11434` | Ollama base URL |
+| `scoring.promote_threshold` | `0.55` | Score floor for MEMORY.md promotion |
+
+Per Hermes policy, non-secret behavioral settings belong in `config.yaml` — not new `HERMES_DREAM_*` environment variables.
+
+## Scoring
+
+Candidates are scored before promotion using these weights (from the issue spec):
+
+| Dimension | Weight |
+|---|---|
+| Relevance | 30% |
+| Frequency | 24% |
+| Query diversity | 15% |
+| Recency | 15% |
+| Consolidation (novelty vs existing) | 10% |
+| Conceptual richness | 6% |
+
+Promotion uses `scoring.promote_threshold` (default **0.55**). Candidates below threshold appear in the dream diary but are not written to `MEMORY.md`.
+
+## Meta-entry filter
+
+Entries about memory management itself (e.g. "memory is full", "update SKILL.md", "memory capacity") are detected and routed to `SKILL.md` rather than `MEMORY.md`. This addresses the most common source of memory rot described in [#25309](https://github.com/NousResearch/hermes-agent/issues/25309#issuecomment-4638538182).
+
+## Slash commands
+
+```
+/dream            show status + last diary entry
+/dream run        force a consolidation cycle immediately
+/dream status     show hours since last cycle, sessions queued, ready state
+/dream diary      show the last dream diary entry
+```
+
+## File layout
+
+```
+{HERMES_HOME}/
+  dreaming/
+    config.yaml           ← plugin-owned behavioral settings
+  MEMORY.md               ← promoted entries appended here
+  SKILL.md                ← meta-entries routed here
+  DREAMS.md               ← REM narrative diary
+  dreams/
+    staging.jsonl         ← candidates queued from session_end hooks
+    state.json            ← last_dream_at, sessions_since_dream
+    lock                  ← present while a cycle is running
+```
+
+## Without Ollama
+
+If Ollama is unavailable the REM phase falls back to a structured bullet-point summary. All other phases (Light Sleep, Deep Sleep, diary write) work without it.
+
+## Relationship to Willow 2.0
+
+In Willow this runs as `dream_run` (SAP MCP tool) + `dream_check` (gate) + `scripts/sleep_consolidation.py` (nightly batch) + `tension_scan` for semantic deduplication. The Hermes plugin is a standalone port — no Willow dependency.

--- a/plugins/dreaming/__init__.py
+++ b/plugins/dreaming/__init__.py
@@ -44,7 +44,6 @@ class _DreamThread(threading.Thread):
                 if _schedule.dream_check(
                     min_hours=sched["min_hours"],
                     min_sessions=sched["min_sessions"],
-                    cfg=cfg,
                 ):
                     _schedule.dream_run(cfg=cfg)
             except Exception:
@@ -57,13 +56,29 @@ class _DreamThread(threading.Thread):
 _thread: _DreamThread | None = None
 
 
-def _on_session_end(ctx) -> None:
-    """Enqueue the completed session's transcript for consolidation."""
-    transcript = getattr(ctx, "transcript", None) or []
-    if not transcript:
+def _on_post_llm_call(
+    *,
+    user_message: str = "",
+    assistant_response: str = "",
+    **_: object,
+) -> None:
+    """Persist transcript-bearing turns without counting each as a session."""
+    transcript = [
+        {"role": "user", "content": user_message},
+        {"role": "assistant", "content": assistant_response},
+    ]
+    if not user_message and not assistant_response:
         return
     try:
-        _schedule.enqueue_session(transcript)
+        _schedule.enqueue_session(transcript, count_session=False)
+    except Exception:
+        pass
+
+
+def _on_session_end(**_: object) -> None:
+    """Record the session boundary after its turns have been staged."""
+    try:
+        _schedule.mark_session_complete()
     except Exception:
         pass
 
@@ -77,12 +92,11 @@ def _disabled_message() -> str:
     )
 
 
-def _handle_slash(argv: list[str], ctx) -> str:
-    sub = argv[0].lstrip("/") if argv else "dream"
-    args = argv[1:] if len(argv) > 1 else []
+def _handle_slash(raw_args: str) -> str:
+    args = raw_args.split() if raw_args else []
     cfg = _config.load_config()
 
-    if sub in ("dream",) and not args:
+    if not args:
         state = _schedule._read_state()
         hours_ago = (time.time() - state["last_dream_at"]) / 3600
         sessions = state.get("sessions_since_dream", 0)
@@ -116,7 +130,6 @@ def _handle_slash(argv: list[str], ctx) -> str:
         ready = _schedule.dream_check(
             min_hours=sched["min_hours"],
             min_sessions=sched["min_sessions"],
-            cfg=cfg,
         )
         return (
             f"Enabled: {'yes' if _config.is_enabled(cfg) else 'no'}\n"
@@ -147,6 +160,7 @@ def register(ctx) -> None:
     if not _config.is_enabled(cfg):
         return
 
+    ctx.register_hook("post_llm_call", _on_post_llm_call)
     ctx.register_hook("on_session_end", _on_session_end)
 
     sched = _config.schedule(cfg)

--- a/plugins/dreaming/__init__.py
+++ b/plugins/dreaming/__init__.py
@@ -1,0 +1,154 @@
+"""
+Dreaming — automatic background memory consolidation for Hermes.
+
+Reference implementation from Willow 2.0 (github.com/rudi193-cmd/willow-2.0).
+Adapted to the Hermes plugin interface.
+
+3-phase pipeline:
+  Light Sleep  — scan recent transcripts, deduplicate, score candidates
+  REM          — extract themes via local LLM, write dream diary
+  Deep Sleep   — promote high-signal entries to MEMORY.md; route meta-entries
+                 to SKILL.md rather than polluting long-term memory
+
+Opt-in: disabled by default. Enable in $HERMES_HOME/dreaming/config.yaml
+(or the dreaming: section of config.yaml) after `hermes plugins enable dreaming`.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+from . import _config, _diary, _schedule
+
+_HELP = """\
+/dream            — show status and last diary entry
+/dream run        — force a consolidation cycle now
+/dream status     — check conditions (hours since last, sessions queued)
+/dream diary      — show the last dream diary entry
+"""
+
+
+class _DreamThread(threading.Thread):
+    def __init__(self, poll_seconds: int) -> None:
+        super().__init__(daemon=True, name="hermes-dreaming")
+        self._poll_seconds = poll_seconds
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        while not self._stop.wait(timeout=self._poll_seconds):
+            try:
+                cfg = _config.load_config()
+                if not _config.is_enabled(cfg):
+                    continue
+                sched = _config.schedule(cfg)
+                if _schedule.dream_check(
+                    min_hours=sched["min_hours"],
+                    min_sessions=sched["min_sessions"],
+                    cfg=cfg,
+                ):
+                    _schedule.dream_run(cfg=cfg)
+            except Exception:
+                pass  # never crash the daemon thread
+
+    def stop(self) -> None:
+        self._stop.set()
+
+
+_thread: _DreamThread | None = None
+
+
+def _on_session_end(ctx) -> None:
+    """Enqueue the completed session's transcript for consolidation."""
+    transcript = getattr(ctx, "transcript", None) or []
+    if not transcript:
+        return
+    try:
+        _schedule.enqueue_session(transcript)
+    except Exception:
+        pass
+
+
+def _disabled_message() -> str:
+    path = _config.user_config_path()
+    return (
+        "Dreaming is disabled. Enable the plugin, then set "
+        f"`enabled: true` in {path} (or under `dreaming:` in config.yaml).\n\n"
+        + _HELP
+    )
+
+
+def _handle_slash(argv: list[str], ctx) -> str:
+    sub = argv[0].lstrip("/") if argv else "dream"
+    args = argv[1:] if len(argv) > 1 else []
+    cfg = _config.load_config()
+
+    if sub in ("dream",) and not args:
+        state = _schedule._read_state()
+        hours_ago = (time.time() - state["last_dream_at"]) / 3600
+        sessions = state.get("sessions_since_dream", 0)
+        last = _diary.last_entry()
+        enabled = "on" if _config.is_enabled(cfg) else "off"
+        lines = [
+            f"**Dreaming ({enabled})** | last cycle: {hours_ago:.1f}h ago | "
+            f"sessions queued: {sessions}",
+        ]
+        if last:
+            lines += ["", last]
+        return "\n".join(lines)
+
+    if args and args[0] == "run":
+        try:
+            result = _schedule.dream_run(force=True, cfg=cfg)
+            return (
+                f"Dream cycle complete. "
+                f"Scanned {result['candidates_scanned']} candidates, "
+                f"promoted {result['promoted']}, "
+                f"routed {result['skipped_meta']} meta-entries to SKILL.md."
+            )
+        except Exception as e:
+            return f"Dream cycle failed: {e}"
+
+    if args and args[0] == "status":
+        state = _schedule._read_state()
+        hours_ago = (time.time() - state["last_dream_at"]) / 3600
+        sessions = state.get("sessions_since_dream", 0)
+        sched = _config.schedule(cfg)
+        ready = _schedule.dream_check(
+            min_hours=sched["min_hours"],
+            min_sessions=sched["min_sessions"],
+            cfg=cfg,
+        )
+        return (
+            f"Enabled: {'yes' if _config.is_enabled(cfg) else 'no'}\n"
+            f"Hours since last dream: {hours_ago:.1f}\n"
+            f"Sessions since last dream: {sessions}\n"
+            f"Ready to dream: {'yes' if ready else 'no'}"
+        )
+
+    if args and args[0] == "diary":
+        entry = _diary.last_entry()
+        return entry if entry else "No dream diary entries yet."
+
+    return _HELP
+
+
+def register(ctx) -> None:
+    global _thread
+
+    _config.ensure_user_config()
+
+    ctx.register_command(
+        "dream",
+        handler=_handle_slash,
+        description="Automatic background memory consolidation — status, force run, diary.",
+    )
+
+    cfg = _config.load_config()
+    if not _config.is_enabled(cfg):
+        return
+
+    ctx.register_hook("on_session_end", _on_session_end)
+
+    sched = _config.schedule(cfg)
+    _thread = _DreamThread(poll_seconds=sched["poll_seconds"])
+    _thread.start()

--- a/plugins/dreaming/_config.py
+++ b/plugins/dreaming/_config.py
@@ -1,0 +1,117 @@
+"""
+Plugin-owned config for dreaming.
+
+Resolution order (later wins):
+  1. Bundled defaults in plugins/dreaming/config.yaml
+  2. $HERMES_HOME/dreaming/config.yaml (seeded on first register)
+  3. dreaming: section in $HERMES_HOME/config.yaml (setup UX override)
+"""
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+_BUNDLED_DEFAULTS = Path(__file__).with_name("config.yaml")
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if (
+            key in merged
+            and isinstance(merged[key], dict)
+            and isinstance(value, dict)
+        ):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8-sig"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def bundled_defaults() -> dict[str, Any]:
+    return _read_yaml(_BUNDLED_DEFAULTS)
+
+
+def user_config_path(hermes_home: str | Path | None = None) -> Path:
+    base = Path(hermes_home) if hermes_home else get_hermes_home()
+    return base / "dreaming" / "config.yaml"
+
+
+def ensure_user_config(hermes_home: str | Path | None = None) -> Path:
+    """Seed $HERMES_HOME/dreaming/config.yaml from bundled defaults if missing."""
+    path = user_config_path(hermes_home)
+    if path.exists():
+        return path
+    defaults = bundled_defaults()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(defaults, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
+    cfg = bundled_defaults()
+    cfg = _deep_merge(cfg, _read_yaml(user_config_path(hermes_home)))
+
+    main_cfg_path = (
+        Path(hermes_home) / "config.yaml"
+        if hermes_home
+        else get_hermes_home() / "config.yaml"
+    )
+    main_section = _read_yaml(main_cfg_path).get("dreaming", {})
+    if isinstance(main_section, dict):
+        cfg = _deep_merge(cfg, main_section)
+    return cfg
+
+
+def is_enabled(cfg: dict[str, Any] | None = None) -> bool:
+    data = cfg if cfg is not None else load_config()
+    return bool(data.get("enabled", False))
+
+
+def schedule(cfg: dict[str, Any]) -> dict[str, Any]:
+    block = cfg.get("schedule", {})
+    if not isinstance(block, dict):
+        block = {}
+    return {
+        "min_hours": float(block.get("min_hours", 24)),
+        "min_sessions": int(block.get("min_sessions", 5)),
+        "poll_seconds": int(block.get("poll_seconds", 300)),
+    }
+
+
+def rem(cfg: dict[str, Any]) -> dict[str, Any]:
+    block = cfg.get("rem", {})
+    if not isinstance(block, dict):
+        block = {}
+    return {
+        "model": str(block.get("model", "mistral:7b")),
+        "base_url": str(block.get("base_url", "http://localhost:11434")).rstrip("/"),
+    }
+
+
+def promote_threshold(cfg: dict[str, Any]) -> float:
+    block = cfg.get("scoring", {})
+    if not isinstance(block, dict):
+        return 0.55
+    try:
+        return float(block.get("promote_threshold", 0.55))
+    except (TypeError, ValueError):
+        return 0.55

--- a/plugins/dreaming/_diary.py
+++ b/plugins/dreaming/_diary.py
@@ -1,0 +1,57 @@
+"""
+DREAMS.md writer — appends REM-phase narrative entries.
+"""
+from __future__ import annotations
+
+import datetime
+import os
+from pathlib import Path
+
+
+def _dreams_path(hermes_home: str | None = None) -> Path:
+    base = Path(hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    return base / "DREAMS.md"
+
+
+def append_entry(
+    narrative: str,
+    promoted: list[str],
+    skipped_meta: list[str],
+    *,
+    hermes_home: str | None = None,
+) -> Path:
+    """Append one dream cycle entry to DREAMS.md. Returns the path written."""
+    path = _dreams_path(hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    lines = [f"\n## Dream cycle — {ts}\n", f"{narrative.strip()}\n"]
+
+    if promoted:
+        lines.append(f"\n**Promoted to MEMORY.md ({len(promoted)}):**\n")
+        for item in promoted:
+            lines.append(f"- {item[:120]}\n")
+
+    if skipped_meta:
+        lines.append(f"\n**Meta-entries routed to SKILL.md ({len(skipped_meta)}):**\n")
+        for item in skipped_meta:
+            lines.append(f"- {item[:120]}\n")
+
+    lines.append("\n---\n")
+
+    with path.open("a", encoding="utf-8") as fh:
+        fh.writelines(lines)
+
+    return path
+
+
+def last_entry(hermes_home: str | None = None) -> str:
+    """Return the text of the most recent dream cycle entry, or empty string."""
+    path = _dreams_path(hermes_home)
+    if not path.exists():
+        return ""
+    content = path.read_text(encoding="utf-8")
+    parts = content.split("## Dream cycle —")
+    if len(parts) < 2:
+        return ""
+    return ("## Dream cycle —" + parts[-1]).strip()

--- a/plugins/dreaming/_schedule.py
+++ b/plugins/dreaming/_schedule.py
@@ -58,6 +58,7 @@ def enqueue_session(
     transcript: list[dict[str, str]],
     *,
     hermes_home: str | None = None,
+    count_session: bool = True,
 ) -> int:
     """
     Extract candidate memories from a session transcript and append to staging.jsonl.
@@ -98,10 +99,16 @@ def enqueue_session(
         for c in candidates:
             fh.write(json.dumps(c) + "\n")
 
+    if count_session:
+        mark_session_complete(hermes_home=hermes_home)
+    return len(candidates)
+
+
+def mark_session_complete(*, hermes_home: str | None = None) -> None:
+    """Increment the completed-session counter after transcript turns are staged."""
     state = _read_state(hermes_home)
     state["sessions_since_dream"] = state.get("sessions_since_dream", 0) + 1
     _write_state(state, hermes_home)
-    return len(candidates)
 
 
 def dream_check(
@@ -127,7 +134,6 @@ def dream_check(
 def dream_run(
     *,
     hermes_home: str | None = None,
-    memory_path: Path | None = None,
     force: bool = False,
     cfg: dict | None = None,
 ) -> dict[str, Any]:
@@ -177,7 +183,7 @@ def dream_run(
         narrative = _rem_narrative([c for c, _ in scored[:30]], cfg=cfg)
 
         # --- Deep Sleep: promote to MEMORY.md ---
-        promoted: list[str] = []
+        eligible: list[str] = []
         skipped_meta: list[str] = []
         to_promote = [c for c, s in scored if s >= promote_threshold]
 
@@ -186,19 +192,15 @@ def dream_run(
             if _score.is_meta_entry(text):
                 skipped_meta.append(text)
             else:
-                promoted.append(text)
+                eligible.append(text)
 
-        if memory_path is None:
+        promoted = _promote_to_memory(eligible)
+
+        if skipped_meta:
             hermes_base = Path(
                 hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes")
             )
-            memory_path = hermes_base / "MEMORY.md"
-
-        if promoted:
-            _write_to_memory(promoted, memory_path)
-
-        if skipped_meta:
-            _write_to_skill(skipped_meta, memory_path.parent / "SKILL.md")
+            _write_to_skill(skipped_meta, hermes_base / "SKILL.md")
 
         # --- Write diary entry ---
         _diary.append_entry(narrative, promoted, skipped_meta, hermes_home=hermes_home)
@@ -265,18 +267,17 @@ def _ollama_narrative(texts: list[str], *, cfg: dict) -> str:
     return body.get("response", "").strip()
 
 
-def _write_to_memory(entries: list[str], path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    existing = path.read_text(encoding="utf-8") if path.exists() else ""
-    new_lines = "\n".join(f"- {e[:200]}" for e in entries)
-    separator = "\n\n<!-- dreaming -->\n"
-    if separator in existing:
-        # append after the dreaming section marker
-        before, _, after = existing.partition(separator)
-        path.write_text(before + separator + new_lines + "\n" + after, encoding="utf-8")
-    else:
-        with path.open("a", encoding="utf-8") as fh:
-            fh.write(separator + new_lines + "\n")
+def _promote_to_memory(entries: list[str]) -> list[str]:
+    """Write through Hermes's bounded, locked, threat-scanning memory store."""
+    from tools.memory_tool import MemoryStore
+
+    store = MemoryStore()
+    promoted: list[str] = []
+    for entry in entries:
+        result = store.add("memory", entry)
+        if result.get("success"):
+            promoted.append(entry)
+    return promoted
 
 
 def _write_to_skill(entries: list[str], path: Path) -> None:

--- a/plugins/dreaming/_schedule.py
+++ b/plugins/dreaming/_schedule.py
@@ -1,0 +1,293 @@
+"""
+Dream scheduler — enqueue, check, and run consolidation cycles.
+
+State lives in {HERMES_HOME}/dreams/:
+  staging.jsonl        one candidate per line, written by on_session_end
+  state.json           last_dream_at, sessions_since_dream
+  lock                 present while a cycle is running
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from . import _config, _diary, _score
+
+_DEFAULT_MIN_HOURS = 24
+_DEFAULT_MIN_SESSIONS = 5
+
+
+def _dreams_dir(hermes_home: str | None = None) -> Path:
+    base = Path(hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    d = base / "dreams"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _staging_path(hermes_home: str | None = None) -> Path:
+    return _dreams_dir(hermes_home) / "staging.jsonl"
+
+
+def _state_path(hermes_home: str | None = None) -> Path:
+    return _dreams_dir(hermes_home) / "state.json"
+
+
+def _lock_path(hermes_home: str | None = None) -> Path:
+    return _dreams_dir(hermes_home) / "lock"
+
+
+def _read_state(hermes_home: str | None = None) -> dict:
+    p = _state_path(hermes_home)
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            pass
+    return {"last_dream_at": 0.0, "sessions_since_dream": 0}
+
+
+def _write_state(state: dict, hermes_home: str | None = None) -> None:
+    _state_path(hermes_home).write_text(json.dumps(state))
+
+
+def enqueue_session(
+    transcript: list[dict[str, str]],
+    *,
+    hermes_home: str | None = None,
+) -> int:
+    """
+    Extract candidate memories from a session transcript and append to staging.jsonl.
+    Returns the number of candidates written.
+    """
+    now = time.time()
+    candidates: list[dict] = []
+    seen: set[str] = set()
+
+    for turn in transcript:
+        role = turn.get("role", "")
+        content = turn.get("content", "").strip()
+        if not content or role not in ("user", "assistant"):
+            continue
+        # Simple heuristic: sentences that are short, declarative, and not questions.
+        for sentence in _split_sentences(content):
+            if len(sentence) < 20 or sentence.endswith("?"):
+                continue
+            key = hashlib.sha1(sentence.lower().encode()).hexdigest()
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append({
+                "text": sentence,
+                "hash": key,
+                "role": role,
+                "created_at": now,
+                "frequency": 1,
+                "query_count": 1,
+                "word_count": len(sentence.split()),
+            })
+
+    if not candidates:
+        return 0
+
+    staging = _staging_path(hermes_home)
+    with staging.open("a", encoding="utf-8") as fh:
+        for c in candidates:
+            fh.write(json.dumps(c) + "\n")
+
+    state = _read_state(hermes_home)
+    state["sessions_since_dream"] = state.get("sessions_since_dream", 0) + 1
+    _write_state(state, hermes_home)
+    return len(candidates)
+
+
+def dream_check(
+    *,
+    hermes_home: str | None = None,
+    min_hours: float = _DEFAULT_MIN_HOURS,
+    min_sessions: int = _DEFAULT_MIN_SESSIONS,
+) -> bool:
+    """Return True if conditions are met to run a dream cycle."""
+    if _lock_path(hermes_home).exists():
+        return False
+    staging = _staging_path(hermes_home)
+    if not staging.exists() or staging.stat().st_size == 0:
+        return False
+    state = _read_state(hermes_home)
+    hours_since = (time.time() - state["last_dream_at"]) / 3600
+    return (
+        hours_since >= min_hours
+        and state.get("sessions_since_dream", 0) >= min_sessions
+    )
+
+
+def dream_run(
+    *,
+    hermes_home: str | None = None,
+    memory_path: Path | None = None,
+    force: bool = False,
+    cfg: dict | None = None,
+) -> dict[str, Any]:
+    """
+    Run one full dream cycle. Returns a summary dict.
+    Raises RuntimeError if a lock is already held and force=False.
+    """
+    lock = _lock_path(hermes_home)
+    if lock.exists() and not force:
+        raise RuntimeError("dream cycle already running")
+    lock.touch()
+
+    cfg = cfg or _config.load_config()
+    promote_threshold = _config.promote_threshold(cfg)
+
+    try:
+        # --- Light Sleep: load, deduplicate, score ---
+        staging = _staging_path(hermes_home)
+        raw: list[dict] = []
+        seen_hashes: set[str] = set()
+
+        if staging.exists():
+            for line in staging.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                h = rec.get("hash", "")
+                if h in seen_hashes:
+                    # merge frequency
+                    for existing in raw:
+                        if existing.get("hash") == h:
+                            existing["frequency"] = existing.get("frequency", 1) + 1
+                            existing["query_count"] = existing.get("query_count", 1) + 1
+                    continue
+                seen_hashes.add(h)
+                raw.append(rec)
+
+        now = time.time()
+        scored = [(c, _score.score(c, now)) for c in raw]
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        # --- REM: theme extraction + narrative ---
+        narrative = _rem_narrative([c for c, _ in scored[:30]], cfg=cfg)
+
+        # --- Deep Sleep: promote to MEMORY.md ---
+        promoted: list[str] = []
+        skipped_meta: list[str] = []
+        to_promote = [c for c, s in scored if s >= promote_threshold]
+
+        for candidate in to_promote:
+            text = candidate["text"]
+            if _score.is_meta_entry(text):
+                skipped_meta.append(text)
+            else:
+                promoted.append(text)
+
+        if memory_path is None:
+            hermes_base = Path(
+                hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes")
+            )
+            memory_path = hermes_base / "MEMORY.md"
+
+        if promoted:
+            _write_to_memory(promoted, memory_path)
+
+        if skipped_meta:
+            _write_to_skill(skipped_meta, memory_path.parent / "SKILL.md")
+
+        # --- Write diary entry ---
+        _diary.append_entry(narrative, promoted, skipped_meta, hermes_home=hermes_home)
+
+        # --- Reset staging and state ---
+        staging.write_text("", encoding="utf-8")
+        state = _read_state(hermes_home)
+        state["last_dream_at"] = now
+        state["sessions_since_dream"] = 0
+        _write_state(state, hermes_home)
+
+        return {
+            "candidates_scanned": len(raw),
+            "promoted": len(promoted),
+            "skipped_meta": len(skipped_meta),
+            "narrative_length": len(narrative),
+        }
+
+    finally:
+        try:
+            lock.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
+def _rem_narrative(candidates: list[dict], *, cfg: dict | None = None) -> str:
+    """Ask a local LLM for theme extraction. Falls back to a structured summary."""
+    texts = [c["text"] for c in candidates if c.get("text")]
+    if not texts:
+        return "No candidates surfaced this cycle."
+
+    try:
+        return _ollama_narrative(texts, cfg=cfg or _config.load_config())
+    except Exception:
+        pass
+
+    # Fallback: structured summary without LLM
+    lines = ["**Themes surfaced this cycle:**\n"]
+    for i, text in enumerate(texts[:10], 1):
+        lines.append(f"{i}. {text[:120]}")
+    return "\n".join(lines)
+
+
+def _ollama_narrative(texts: list[str], *, cfg: dict) -> str:
+    import urllib.request
+
+    rem = _config.rem(cfg)
+    prompt = (
+        "You are a memory consolidation assistant. The following facts were observed "
+        "across recent sessions. Identify 3-5 recurring themes and write a brief "
+        "narrative paragraph (2-4 sentences) summarising what matters most. "
+        "Be concrete, not abstract.\n\nFacts:\n"
+        + "\n".join(f"- {t}" for t in texts[:20])
+    )
+    payload = json.dumps({
+        "model": rem["model"],
+        "prompt": prompt,
+        "stream": False,
+    }).encode()
+    url = rem["base_url"] + "/api/generate"
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = json.loads(resp.read())
+    return body.get("response", "").strip()
+
+
+def _write_to_memory(entries: list[str], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    new_lines = "\n".join(f"- {e[:200]}" for e in entries)
+    separator = "\n\n<!-- dreaming -->\n"
+    if separator in existing:
+        # append after the dreaming section marker
+        before, _, after = existing.partition(separator)
+        path.write_text(before + separator + new_lines + "\n" + after, encoding="utf-8")
+    else:
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(separator + new_lines + "\n")
+
+
+def _write_to_skill(entries: list[str], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("\n<!-- dreaming: meta-entries -->\n")
+        for e in entries:
+            fh.write(f"- {e[:200]}\n")
+
+
+def _split_sentences(text: str) -> list[str]:
+    import re
+    parts = re.split(r"(?<=[.!])\s+", text)
+    return [p.strip() for p in parts if p.strip()]

--- a/plugins/dreaming/_score.py
+++ b/plugins/dreaming/_score.py
@@ -1,0 +1,88 @@
+"""
+Candidate scoring for the Deep Sleep promotion gate.
+
+Weights match the issue spec:
+  relevance          30%
+  frequency          24%
+  query_diversity    15%
+  recency            15%
+  consolidation      10%
+  conceptual_richness 6%
+
+All inputs are normalised to [0.0, 1.0] before weighting.
+"""
+from __future__ import annotations
+
+import math
+import time
+from typing import Any
+
+_WEIGHTS = {
+    "relevance": 0.30,
+    "frequency": 0.24,
+    "query_diversity": 0.15,
+    "recency": 0.15,
+    "consolidation": 0.10,
+    "conceptual_richness": 0.06,
+}
+
+# Keywords that indicate a meta-memory-management entry.
+# These are routed to a skill file rather than promoted to MEMORY.md.
+# Suggested by @vingeraycn in issue #25309.
+_META_KEYWORDS = frozenset([
+    "memory is full", "memory capacity", "memory management",
+    "memory.md", "skill.md", "store in skill", "update skill",
+    "memory limit", "memory overflow",
+])
+
+
+def is_meta_entry(text: str) -> bool:
+    """Return True if this looks like a memory-management meta-entry."""
+    lower = text.lower()
+    return any(kw in lower for kw in _META_KEYWORDS)
+
+
+def score(candidate: dict[str, Any], now: float | None = None) -> float:
+    """
+    Score a staging candidate dict. Returns a float in [0.0, 1.0].
+
+    Expected candidate fields (all optional, defaulted gracefully):
+      text             str   — the memory text
+      relevance        float — semantic relevance score from retrieval [0,1]
+      frequency        int   — times this fact appeared across sessions
+      query_count      int   — distinct queries that surfaced this fact
+      created_at       float — unix timestamp of first observation
+      consolidation    float — similarity to existing MEMORY.md entries [0,1]
+                               (lower = more novel = higher score)
+      word_count       int   — approximate word count of the text
+    """
+    now = now or time.time()
+
+    relevance = float(candidate.get("relevance", 0.5))
+
+    raw_freq = int(candidate.get("frequency", 1))
+    frequency = min(1.0, math.log1p(raw_freq) / math.log1p(20))
+
+    raw_qd = int(candidate.get("query_count", 1))
+    query_diversity = min(1.0, math.log1p(raw_qd) / math.log1p(10))
+
+    age_seconds = now - float(candidate.get("created_at", now))
+    age_days = age_seconds / 86400
+    recency = math.exp(-age_days / 14)  # half-life ~14 days
+
+    # consolidation: 0 = already in MEMORY.md (penalise), 1 = fully novel (reward)
+    existing_sim = float(candidate.get("consolidation", 0.0))
+    consolidation = 1.0 - existing_sim
+
+    raw_wc = int(candidate.get("word_count", len(candidate.get("text", "").split())))
+    conceptual_richness = min(1.0, math.log1p(raw_wc) / math.log1p(80))
+
+    components = {
+        "relevance": relevance,
+        "frequency": frequency,
+        "query_diversity": query_diversity,
+        "recency": recency,
+        "consolidation": consolidation,
+        "conceptual_richness": conceptual_richness,
+    }
+    return sum(_WEIGHTS[k] * v for k, v in components.items())

--- a/plugins/dreaming/config.yaml
+++ b/plugins/dreaming/config.yaml
@@ -1,0 +1,19 @@
+# Default dreaming plugin settings.
+# Copied to $HERMES_HOME/dreaming/config.yaml on first enable when missing.
+#
+# Behavioral settings live here (not in .env). Secrets-only env vars are
+# unchanged — this plugin uses local Ollama by default and has no API keys.
+
+enabled: false
+
+schedule:
+  min_hours: 24
+  min_sessions: 5
+  poll_seconds: 300
+
+rem:
+  model: mistral:7b
+  base_url: http://localhost:11434
+
+scoring:
+  promote_threshold: 0.55

--- a/plugins/dreaming/plugin.yaml
+++ b/plugins/dreaming/plugin.yaml
@@ -1,0 +1,12 @@
+name: dreaming
+version: 0.1.0
+description: >
+  Automatic background memory consolidation inspired by biological sleep cycles.
+  Enqueues session candidates on session_end, then consolidates during idle
+  periods via a 3-phase pipeline: Light Sleep (scan/dedupe/score), REM
+  (theme extraction + dream diary), Deep Sleep (promote to MEMORY.md).
+pip_dependencies: []
+requires_env: []
+hooks:
+  - on_session_end
+opt_in: true

--- a/plugins/dreaming/plugin.yaml
+++ b/plugins/dreaming/plugin.yaml
@@ -2,11 +2,13 @@ name: dreaming
 version: 0.1.0
 description: >
   Automatic background memory consolidation inspired by biological sleep cycles.
-  Enqueues session candidates on session_end, then consolidates during idle
-  periods via a 3-phase pipeline: Light Sleep (scan/dedupe/score), REM
+  Enqueues transcript-bearing turns, records their session boundary, then
+  consolidates during idle periods via a 3-phase pipeline: Light Sleep
+  (scan/dedupe/score), REM
   (theme extraction + dream diary), Deep Sleep (promote to MEMORY.md).
 pip_dependencies: []
 requires_env: []
 hooks:
+  - post_llm_call
   - on_session_end
 opt_in: true

--- a/tests/plugins/test_dreaming_plugin.py
+++ b/tests/plugins/test_dreaming_plugin.py
@@ -225,3 +225,39 @@ class TestDreamingPluginContracts:
         monkeypatch.setattr(plugin._diary, "last_entry", lambda: "last dream")
 
         assert plugin._handle_slash("diary") == "last dream"
+
+
+class TestDreamingBundledDiscovery:
+    def test_loads_via_plugin_manager_when_opted_in(self, _isolate_env, monkeypatch):
+        """E2E: enable in config.yaml + dreaming config, verify PluginManager path."""
+        import sys
+
+        import yaml
+
+        cfg_mod = _load_config_mod()
+        cfg_mod.ensure_user_config(_isolate_env)
+        user_cfg = cfg_mod.user_config_path(_isolate_env)
+        user_cfg.write_text(
+            yaml.safe_dump({"enabled": True}),
+            encoding="utf-8",
+        )
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["dreaming"]}}),
+            encoding="utf-8",
+        )
+
+        for key in list(sys.modules):
+            if key.startswith(("hermes_plugins", "hermes_cli.plugins")):
+                del sys.modules[key]
+
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        loaded = mgr._plugins["dreaming"]
+        assert loaded.enabled
+        assert "post_llm_call" in loaded.hooks_registered
+        assert "on_session_end" in loaded.hooks_registered
+        assert "dream" in loaded.commands_registered
+        assert "dream" in mgr._plugin_commands

--- a/tests/plugins/test_dreaming_plugin.py
+++ b/tests/plugins/test_dreaming_plugin.py
@@ -1,0 +1,126 @@
+"""Tests for the dreaming plugin (config.yaml re-scope)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    yield hermes_home
+
+
+def _ensure_dreaming_package(plugin_dir: Path) -> None:
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    if "hermes_plugins.dreaming" not in sys.modules:
+        dream_pkg = types.ModuleType("hermes_plugins.dreaming")
+        dream_pkg.__path__ = [str(plugin_dir)]
+        sys.modules["hermes_plugins.dreaming"] = dream_pkg
+
+
+def _load_module(name: str, plugin_dir: Path):
+    _ensure_dreaming_package(plugin_dir)
+    spec = importlib.util.spec_from_file_location(
+        f"hermes_plugins.dreaming.{name}",
+        plugin_dir / f"{name}.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.dreaming"
+    qual = f"hermes_plugins.dreaming.{name}"
+    sys.modules[qual] = mod
+    setattr(sys.modules["hermes_plugins.dreaming"], name, mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_config_mod():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugins" / "dreaming"
+    return _load_module("_config", plugin_dir)
+
+
+def _load_schedule_mod():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugins" / "dreaming"
+    _load_module("_config", plugin_dir)
+    _load_module("_score", plugin_dir)
+    _load_module("_diary", plugin_dir)
+    return _load_module("_schedule", plugin_dir)
+
+
+class TestDreamingConfig:
+    def test_ensure_user_config_seeds_defaults(self, _isolate_env):
+        cfg_mod = _load_config_mod()
+        path = cfg_mod.ensure_user_config(_isolate_env)
+        assert path.exists()
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert data["enabled"] is False
+        assert data["schedule"]["min_hours"] == 24
+
+    def test_main_config_yaml_override(self, _isolate_env):
+        cfg_mod = _load_config_mod()
+        cfg_mod.ensure_user_config(_isolate_env)
+        main = _isolate_env / "config.yaml"
+        main.write_text(
+            yaml.safe_dump({"dreaming": {"enabled": True, "schedule": {"min_hours": 6}}}),
+            encoding="utf-8",
+        )
+        loaded = cfg_mod.load_config(_isolate_env)
+        assert loaded["enabled"] is True
+        assert loaded["schedule"]["min_hours"] == 6
+
+    def test_user_config_overrides_bundled_defaults(self, _isolate_env):
+        cfg_mod = _load_config_mod()
+        user_path = cfg_mod.ensure_user_config(_isolate_env)
+        user_path.write_text(
+            yaml.safe_dump({"enabled": True, "rem": {"model": "llama3.2:3b"}}),
+            encoding="utf-8",
+        )
+        rem = cfg_mod.rem(cfg_mod.load_config(_isolate_env))
+        assert rem["model"] == "llama3.2:3b"
+
+
+class TestDreamingSchedule:
+    def test_dream_run_uses_config_threshold(self, _isolate_env, monkeypatch):
+        sched = _load_schedule_mod()
+        cfg_mod = _load_config_mod()
+
+        dreams = _isolate_env / "dreams"
+        dreams.mkdir(parents=True)
+        staging = dreams / "staging.jsonl"
+        candidate = {
+            "text": "The deployment pipeline uses GitHub Actions for CI.",
+            "hash": "abc",
+            "role": "user",
+            "created_at": 1.0,
+            "frequency": 3,
+            "query_count": 2,
+            "word_count": 8,
+        }
+        staging.write_text(json.dumps(candidate) + "\n", encoding="utf-8")
+
+        cfg = cfg_mod.load_config(_isolate_env)
+        cfg["scoring"] = {"promote_threshold": 0.99}
+
+        monkeypatch.setattr(sched, "_rem_narrative", lambda candidates, cfg=None: "themes")
+
+        result = sched.dream_run(force=True, hermes_home=str(_isolate_env), cfg=cfg)
+        assert result["promoted"] == 0
+
+        memory_path = _isolate_env / "MEMORY.md"
+        memory = memory_path.read_text(encoding="utf-8") if memory_path.exists() else ""
+        assert "deployment pipeline" not in memory

--- a/tests/plugins/test_dreaming_plugin.py
+++ b/tests/plugins/test_dreaming_plugin.py
@@ -62,6 +62,24 @@ def _load_schedule_mod():
     return _load_module("_schedule", plugin_dir)
 
 
+def _load_plugin_mod():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugins" / "dreaming"
+    _load_module("_config", plugin_dir)
+    _load_module("_score", plugin_dir)
+    _load_module("_diary", plugin_dir)
+    _load_module("_schedule", plugin_dir)
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.dreaming",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["hermes_plugins.dreaming"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
 class TestDreamingConfig:
     def test_ensure_user_config_seeds_defaults(self, _isolate_env):
         cfg_mod = _load_config_mod()
@@ -124,3 +142,86 @@ class TestDreamingSchedule:
         memory_path = _isolate_env / "MEMORY.md"
         memory = memory_path.read_text(encoding="utf-8") if memory_path.exists() else ""
         assert "deployment pipeline" not in memory
+
+    def test_turn_staging_and_session_count_are_separate(self, _isolate_env):
+        sched = _load_schedule_mod()
+        transcript = [
+            {
+                "role": "user",
+                "content": "The deployment pipeline uses GitHub Actions for CI.",
+            }
+        ]
+
+        assert sched.enqueue_session(
+            transcript,
+            hermes_home=str(_isolate_env),
+            count_session=False,
+        ) == 1
+        assert sched._read_state(str(_isolate_env))["sessions_since_dream"] == 0
+
+        sched.mark_session_complete(hermes_home=str(_isolate_env))
+        assert sched._read_state(str(_isolate_env))["sessions_since_dream"] == 1
+
+    def test_dream_run_uses_guarded_active_memory_store(
+        self, _isolate_env, monkeypatch
+    ):
+        sched = _load_schedule_mod()
+        dreams = _isolate_env / "dreams"
+        dreams.mkdir(parents=True)
+        candidate = {
+            "text": "The deployment pipeline uses GitHub Actions for CI.",
+            "hash": "abc",
+            "role": "user",
+            "created_at": 1.0,
+            "frequency": 3,
+            "query_count": 2,
+            "word_count": 8,
+        }
+        (dreams / "staging.jsonl").write_text(
+            json.dumps(candidate) + "\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(sched._score, "score", lambda candidate, now: 1.0)
+        monkeypatch.setattr(
+            sched, "_rem_narrative", lambda candidates, cfg=None: "themes"
+        )
+
+        result = sched.dream_run(force=True, hermes_home=str(_isolate_env))
+
+        active_memory = _isolate_env / "memories" / "MEMORY.md"
+        assert result["promoted"] == 1
+        assert "deployment pipeline" in active_memory.read_text(encoding="utf-8")
+        assert not (_isolate_env / "MEMORY.md").exists()
+
+
+class TestDreamingPluginContracts:
+    def test_hooks_match_keyword_contract_and_stage_real_turns(self, monkeypatch):
+        plugin = _load_plugin_mod()
+        staged = []
+        completed = []
+        monkeypatch.setattr(
+            plugin._schedule,
+            "enqueue_session",
+            lambda transcript, **kwargs: staged.append((transcript, kwargs)),
+        )
+        monkeypatch.setattr(
+            plugin._schedule,
+            "mark_session_complete",
+            lambda **kwargs: completed.append(kwargs),
+        )
+
+        plugin._on_post_llm_call(
+            session_id="s1",
+            user_message="A sufficiently long user statement.",
+            assistant_response="A sufficiently long assistant statement.",
+        )
+        plugin._on_session_end(session_id="s1", completed=True)
+
+        assert staged[0][1] == {"count_session": False}
+        assert [turn["role"] for turn in staged[0][0]] == ["user", "assistant"]
+        assert completed == [{}]
+
+    def test_slash_handler_accepts_one_raw_argument_string(self, monkeypatch):
+        plugin = _load_plugin_mod()
+        monkeypatch.setattr(plugin._diary, "last_entry", lambda: "last dream")
+
+        assert plugin._handle_slash("diary") == "last dream"


### PR DESCRIPTION
## Summary

Re-opens the #25309 dreaming plugin proposal after #40737 was closed under the `env-var-for-config` policy.

- Behavioral settings live in **plugin-owned** `$HERMES_HOME/dreaming/config.yaml` (seeded from `plugins/dreaming/config.yaml` on first register), with optional `dreaming:` overrides in `~/.hermes/config.yaml`.
- Removes user-facing `HERMES_DREAMING` / `HERMES_DREAM_*` env flags — opt-in is `hermes plugins enable dreaming` + `enabled: true` in config.
- Three-phase pipeline unchanged: Light Sleep (staging/dedupe/score) → REM (Ollama narrative) → Deep Sleep (MEMORY.md promotion, meta-entries → SKILL.md).
- Reference port from [Willow 2.0](https://github.com/rudi193-cmd/willow-2.0) `dream_check` / `dream_run` / `tension_scan` — no runtime dependency.

## Test plan

- [x] `uv run pytest tests/plugins/test_dreaming_plugin.py -q` (4 tests: config seeding, main-config override, REM model override, promote threshold)
- [ ] `hermes plugins enable dreaming` then set `enabled: true` in `$HERMES_HOME/dreaming/config.yaml`
- [ ] `/dream status` and `/dream run` on a profile with staged candidates

Closes the configuration-policy gap called out in the #40737 sweeper comment.


Made with [Cursor](https://cursor.com)