### PR TITLE
refactor: compress system prompts and clean stale tool results from c…

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -792,7 +792,17 @@ def run_conversation(
         api_messages = []
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
-
+            
+            # clear not current loop tool results AND their originating calls.
+            # Skipping old tool results without stripping the corresponding
+            # tool_calls from old assistant messages causes the pre-call
+            # sanitizer to inject "[Result unavailable]" stubs.
+            if msg.get("role") == "tool" and idx < current_turn_user_idx:
+                continue
+            if msg.get("role") == "assistant" and idx < current_turn_user_idx:
+                if api_msg.get("tool_calls"):
+                    api_msg.pop("tool_calls", None)
+  
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks
             # with target="user_message" (the default).  Both are


### PR DESCRIPTION
Summary

Token optimization with two changes:

1. Clean stale tool results from conversation loop (agent/conversation_loop.py)

• Strip tool results from prior conversation turns (not current loop)
• Also remove the corresponding tool_calls from old assistant messages
• Without stripping both, the pre-call sanitizer injects [Result unavailable] stubs, wasting tokens and confusing the model

2. Compress system prompt guidance blocks (agent/prompt_builder.py)

• Condensed all prompt guidance sections (~30-40% reduction, ~500 tokens per API call)
• Preserved all behavioral directives while removing redundant explanations
• Key optimizations: merge related directives, remove verbose examples, keep critical rules

Impact

• ~500 tokens saved per API call from prompt compression
• Additional savings from stale tool result cleanup on multi-turn conversations
• No behavioral changes — all functional directives preserved

Test Plan

• Run: python -m pytest tests/ -o addopts= -q
• Verify agent behavior with compressed prompts
• Test multi-turn conversations to verify stale result cleanup