### PR TITLE
fix: clean up evicted memory providers (salvage of #63703 + review fixes)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16608,7 +16608,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if agent is None:
             return
         try:
-            if hasattr(agent, "release_clients") and hasattr(agent, "shutdown_memory_provider"):
+            if hasattr(agent, "shutdown_memory_provider"):
                 # Soft cache eviction must not hard-close terminal/browser/bg
                 # process state, but memory providers are tied to this Python
                 # AIAgent instance. Providers such as MemOS own keepalive

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15942,7 +15942,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None, int | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -15956,10 +15956,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                stat = path.stat()
+                mtime_ns = stat.st_mtime_ns
+                size = stat.st_size
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                size = None
+            memo_key = (str(path), mtime_ns, size)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)
@@ -16604,6 +16607,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if agent is None:
             return
+        try:
+            if hasattr(agent, "release_clients") and hasattr(agent, "shutdown_memory_provider"):
+                # Soft cache eviction must not hard-close terminal/browser/bg
+                # process state, but memory providers are tied to this Python
+                # AIAgent instance. Providers such as MemOS own keepalive
+                # threads and stdio bridge subprocesses; leaving them alive
+                # leaks one bridge per evicted cached agent. Pass the current
+                # transcript when available, matching _cleanup_agent_resources.
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
+        except Exception:
+            pass
         try:
             if hasattr(agent, "release_clients"):
                 agent.release_clients()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16615,11 +16615,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # threads and stdio bridge subprocesses; leaving them alive
                 # leaks one bridge per evicted cached agent. Pass the current
                 # transcript when available, matching _cleanup_agent_resources.
+                #
+                # finalize_session=False: soft eviction is, by design, not a
+                # real session boundary (see _commit_memory_before_soft_evict's
+                # docstring) — only the provider transport gets torn down
+                # here. For finalizable sessions, _commit_then_release_soft
+                # already ran commit_memory_session() (which fires
+                # on_session_end() without a transport teardown) immediately
+                # before this call. Passing finalize_session=True here would
+                # fire on_session_end() a second time for the same
+                # transcript, double-ingesting it into any external memory
+                # backend that treats session-end as a one-shot event.
                 session_messages = getattr(agent, "_session_messages", None)
                 if isinstance(session_messages, list):
-                    agent.shutdown_memory_provider(session_messages)
+                    agent.shutdown_memory_provider(session_messages, finalize_session=False)
                 else:
-                    agent.shutdown_memory_provider()
+                    agent.shutdown_memory_provider(finalize_session=False)
         except Exception:
             pass
         try:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -98,7 +98,12 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
 
     # 1. Bundled providers (plugins/memory/<name>/)
     if _MEMORY_PLUGINS_DIR.is_dir():
-        for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
+        try:
+            bundled_children = sorted(_MEMORY_PLUGINS_DIR.iterdir())
+        except OSError as exc:
+            logger.debug("Skipping inaccessible bundled memory provider dir %s: %s", _MEMORY_PLUGINS_DIR, exc)
+            bundled_children = []
+        for child in bundled_children:
             if child.name.startswith(("_", ".")):
                 continue
             try:
@@ -115,7 +120,12 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     # 2. User-installed providers ($HERMES_HOME/plugins/<name>/)
     user_dir = _get_user_plugins_dir()
     if user_dir:
-        for child in sorted(user_dir.iterdir()):
+        try:
+            user_children = sorted(user_dir.iterdir())
+        except OSError as exc:
+            logger.debug("Skipping inaccessible user memory provider dir %s: %s", user_dir, exc)
+            user_children = []
+        for child in user_children:
             if child.name.startswith(("_", ".")):
                 continue
             try:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -99,9 +99,15 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     # 1. Bundled providers (plugins/memory/<name>/)
     if _MEMORY_PLUGINS_DIR.is_dir():
         for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
+            if child.name.startswith(("_", ".")):
                 continue
-            if not (child / "__init__.py").exists():
+            try:
+                is_dir = child.is_dir()
+                has_init = (child / "__init__.py").exists()
+            except OSError as exc:
+                logger.debug("Skipping inaccessible bundled memory provider %s: %s", child, exc)
+                continue
+            if not is_dir or not has_init:
                 continue
             seen.add(child.name)
             dirs.append((child.name, child))
@@ -110,7 +116,14 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     user_dir = _get_user_plugins_dir()
     if user_dir:
         for child in sorted(user_dir.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
+            if child.name.startswith(("_", ".")):
+                continue
+            try:
+                is_dir = child.is_dir()
+            except OSError as exc:
+                logger.debug("Skipping inaccessible user memory provider %s: %s", child, exc)
+                continue
+            if not is_dir:
                 continue
             if child.name in seen:
                 continue  # bundled takes precedence

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1961,6 +1961,21 @@ class HindsightMemoryProvider(MemoryProvider):
         # / "Unclosed connector" warnings reported in #11923. The loop
         # runs on a daemon thread and is reclaimed on process exit;
         # per-session cleanup happens via self._client.aclose() above.
+        #
+        # Unregister the atexit hook now that shutdown has run to completion.
+        # Without this, the bound _atexit_shutdown callback keeps this
+        # already-torn-down instance reachable from atexit's internal
+        # registry until process exit — e.g. a gateway soft-evicting this
+        # provider's owning agent would otherwise retain every evicted
+        # instance for the life of the process. atexit.unregister() is a
+        # documented no-op when the callback was never registered (an
+        # idle-embedded provider that never called _register_atexit), so
+        # this is safe to call unconditionally.
+        try:
+            atexit.unregister(self._atexit_shutdown)
+        except Exception:
+            pass
+        self._atexit_registered = False
 
 
 def register(ctx) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3435,7 +3435,10 @@ class AIAgent:
           - process_registry entries for task_id (user's bg shells)
           - terminal sandbox for task_id (cwd, env, shell state)
           - browser daemon for task_id (open tabs, cookies)
-          - memory provider (has its own lifecycle; keeps running)
+          - memory provider transport; gateway soft-eviction closes it
+            separately before calling this method, because providers such as
+            MemOS own per-agent bridge subprocesses that must not outlive the
+            evicted AIAgent instance.
 
         We DO close:
           - OpenAI/httpx client pool (big chunk of held memory + sockets;

--- a/run_agent.py
+++ b/run_agent.py
@@ -3312,25 +3312,40 @@ class AIAgent:
             "budget_max": self.iteration_budget.max_total,
         }
 
-    def shutdown_memory_provider(self, messages: list = None) -> None:
-        """Shut down the memory provider and context engine — call at actual session boundaries.
+    def shutdown_memory_provider(self, messages: list = None, *, finalize_session: bool = True) -> None:
+        """Shut down the memory provider and context engine.
 
         This calls on_session_end() then shutdown_all() on the memory
         manager, and on_session_end() on the context engine.
         NOT called per-turn — only at CLI exit, /reset, gateway
         session expiry, etc.
+
+        finalize_session: When False, skip both on_session_end() calls and
+        only tear down provider transports (shutdown_all()). Use this ONLY
+        when on_session_end() has already fired for this transcript via a
+        separate path — e.g. gateway soft cache eviction of a finalizable
+        session already runs commit_memory_session() (which fires
+        on_session_end() without a transport teardown) before this method
+        tears down the transport. Without finalize_session=False there, the
+        transcript would be finalized twice — once via commit_memory_session
+        and once here — double-ingesting it into external memory backends
+        that treat on_session_end as a one-shot event (e.g. full-session
+        ingestion). Callers passing False must be certain on_session_end
+        already ran for this transcript; otherwise real extraction is
+        silently skipped.
         """
         if self._memory_manager:
-            try:
-                self._memory_manager.on_session_end(messages or [])
-            except Exception as e:
-                logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
+            if finalize_session:
+                try:
+                    self._memory_manager.on_session_end(messages or [])
+                except Exception as e:
+                    logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
             try:
                 self._memory_manager.shutdown_all()
             except Exception:
                 pass
         # Notify context engine of session end (flush DAG, close DBs, etc.)
-        if hasattr(self, "context_compressor") and self.context_compressor:
+        if finalize_session and hasattr(self, "context_compressor") and self.context_compressor:
             try:
                 self.context_compressor.on_session_end(
                     self.session_id or "",

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -537,6 +537,32 @@ class TestUserInstalledProviderDiscovery:
         names = [n for n, _, _ in providers]
         assert "notmemory" not in names
 
+    def test_discover_survives_inaccessible_user_plugins_dir(self, monkeypatch):
+        """discover_memory_providers() must not crash if the user plugins dir
+        itself becomes inaccessible mid-scan (permission change, race
+        deletion, or a symlink to a now-missing target).
+
+        Regression: _iter_provider_dirs() called user_dir.iterdir() unguarded;
+        an OSError from the directory itself (not a child) aborted discovery
+        entirely instead of just skipping the user-installed providers.
+        """
+        from plugins.memory import discover_memory_providers
+
+        class _BrokenDir:
+            def __bool__(self):
+                return True
+
+            def iterdir(self):
+                raise OSError("simulated: directory disappeared mid-scan")
+
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: _BrokenDir(),
+        )
+        providers = discover_memory_providers()
+        names = [n for n, _, _ in providers]
+        assert "holographic" in names  # bundled providers still discovered
+
     def test_load_user_plugin_with_relative_import(self, tmp_path, monkeypatch):
         """User plugins may import sibling modules with relative imports.
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -762,6 +762,32 @@ class TestAgentCacheBoundedGrowth:
         assert commit_calls == []       # no premature extraction
         assert old_agent in release_calls  # still released
 
+    def test_soft_eviction_releases_clients_and_memory_provider_only(self):
+        """Soft cache eviction closes memory transports without full tool teardown.
+
+        Cached agents can be rebuilt later with the same session/task id, so
+        soft eviction must preserve terminal/browser/background-process state
+        by avoiding the hard _cleanup_agent_resources path.  But memory
+        providers such as MemOS own keepalive threads and stdio bridge child
+        processes; leaving them alive leaks one bridge per cache eviction.
+        """
+        runner = self._bounded_runner()
+        cleanup_calls: list = []
+        runner._cleanup_agent_resources = lambda agent: cleanup_calls.append(agent)
+
+        agent = self._fake_agent()
+        transcript = [{"role": "user", "content": "hello"}]
+        agent._session_messages = transcript
+        agent.release_clients = MagicMock()
+        agent.shutdown_memory_provider = MagicMock()
+
+        runner._release_evicted_agent_soft(agent)
+
+        agent.release_clients.assert_called_once_with()
+        agent.shutdown_memory_provider.assert_called_once_with(transcript)
+        assert cleanup_calls == []
+        assert agent._session_messages == []
+
     def test_idle_ttl_sweep_evicts_stale_agents(self, monkeypatch):
         """_sweep_idle_cached_agents removes agents idle past the TTL."""
         from gateway import run as gw_run

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -788,6 +788,30 @@ class TestAgentCacheBoundedGrowth:
         assert cleanup_calls == []
         assert agent._session_messages == []
 
+    def test_soft_eviction_shuts_down_memory_provider_without_release_clients(self):
+        """shutdown_memory_provider() must not be gated on release_clients existing.
+
+        Regression test: the shutdown call was previously guarded by
+        ``hasattr(agent, "release_clients") and hasattr(agent, "shutdown_memory_provider")``,
+        so a stub/agent exposing only shutdown_memory_provider would silently
+        skip memory-provider cleanup on soft eviction.
+        """
+        runner = self._bounded_runner()
+        cleanup_calls: list = []
+        runner._cleanup_agent_resources = lambda agent: cleanup_calls.append(agent)
+
+        agent = MagicMock(spec=["shutdown_memory_provider", "_session_messages"])
+        agent._session_messages = None
+
+        runner._release_evicted_agent_soft(agent)
+
+        agent.shutdown_memory_provider.assert_called_once_with()
+        # release_clients is absent, so the second cleanup step falls back to
+        # the "older agent instance" hard-teardown path — unrelated to this
+        # fix, but asserted here so the test doesn't rely on that fallback
+        # also happening to call shutdown_memory_provider.
+        assert cleanup_calls == [agent]
+
     def test_idle_ttl_sweep_evicts_stale_agents(self, monkeypatch):
         """_sweep_idle_cached_agents removes agents idle past the TTL."""
         from gateway import run as gw_run

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -784,7 +784,7 @@ class TestAgentCacheBoundedGrowth:
         runner._release_evicted_agent_soft(agent)
 
         agent.release_clients.assert_called_once_with()
-        agent.shutdown_memory_provider.assert_called_once_with(transcript)
+        agent.shutdown_memory_provider.assert_called_once_with(transcript, finalize_session=False)
         assert cleanup_calls == []
         assert agent._session_messages == []
 
@@ -805,7 +805,7 @@ class TestAgentCacheBoundedGrowth:
 
         runner._release_evicted_agent_soft(agent)
 
-        agent.shutdown_memory_provider.assert_called_once_with()
+        agent.shutdown_memory_provider.assert_called_once_with(finalize_session=False)
         # release_clients is absent, so the second cleanup step falls back to
         # the "older agent instance" hard-teardown path — unrelated to this
         # fix, but asserted here so the test doesn't rely on that fallback

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1187,6 +1187,35 @@ class TestShutdownRace:
         provider.shutdown()
         assert provider._shutting_down.is_set()
 
+    def test_shutdown_unregisters_atexit_hook(self, provider, monkeypatch):
+        """Explicit shutdown() must unregister the atexit hook so this
+        already-torn-down instance isn't kept reachable from atexit's
+        internal registry until process exit — e.g. a gateway soft-evicting
+        this provider's owning agent would otherwise retain every evicted
+        instance for the life of the process."""
+        import atexit
+
+        # _register_atexit() only fires lazily, on the first real retain
+        # (see _ensure_writer()/_register_atexit() in sync_turn), not at
+        # initialize() time — exercise that path first.
+        provider.sync_turn("a", "b")
+        assert provider._atexit_registered is True
+        unregister_calls = []
+        monkeypatch.setattr(atexit, "unregister", lambda fn: unregister_calls.append(fn))
+
+        provider.shutdown()
+
+        assert unregister_calls == [provider._atexit_shutdown]
+        assert provider._atexit_registered is False
+
+    def test_shutdown_unregister_is_a_safe_no_op_when_never_registered(self, provider):
+        """atexit.unregister() on a callback that was never registered is a
+        documented no-op — shutdown() must not raise even when
+        _register_atexit() never ran for this instance."""
+        provider._atexit_registered = False
+        provider.shutdown()  # must not raise
+        assert provider._atexit_registered is False
+
 
 # ---------------------------------------------------------------------------
 # on_session_switch — flush + prefetch reset behavior

--- a/tests/run_agent/test_shutdown_memory_provider_finalize_session.py
+++ b/tests/run_agent/test_shutdown_memory_provider_finalize_session.py
@@ -1,0 +1,129 @@
+"""Regression tests for AIAgent.shutdown_memory_provider's finalize_session param.
+
+Gateway soft cache eviction of a finalizable session runs two steps back to
+back: commit_memory_session() (fires on_session_end() to extract memory
+without a transport teardown), then shutdown_memory_provider() (tears down
+the transport). Before finalize_session existed, the second call ALSO fired
+on_session_end() — double-finalizing the same transcript, which double-ingests
+it into any external memory backend that treats session-end as a one-shot
+event (e.g. full-session ingestion). finalize_session=False lets the second
+call skip on_session_end() and only tear down the transport.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _make_minimal_agent(memory_manager, context_compressor, session_id="abc"):
+    """Build an object with just enough surface for shutdown_memory_provider
+    (and, where used, commit_memory_session) to run — AIAgent.__init__ is too
+    heavy for a focused unit test."""
+    from run_agent import AIAgent
+
+    obj = SimpleNamespace(
+        _memory_manager=memory_manager,
+        context_compressor=context_compressor,
+        session_id=session_id,
+    )
+    obj.shutdown_memory_provider = AIAgent.shutdown_memory_provider.__get__(obj)
+    obj.commit_memory_session = AIAgent.commit_memory_session.__get__(obj)
+    return obj
+
+
+def test_default_finalize_session_true_preserves_prior_behavior():
+    """No finalize_session kwarg == full finalization, unchanged from before
+    the parameter existed (CLI exit, /reset, gateway session expiry, etc.)."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-1")
+
+    msgs = [{"role": "user", "content": "hi"}]
+    agent.shutdown_memory_provider(msgs)
+
+    mm.on_session_end.assert_called_once_with(msgs)
+    mm.shutdown_all.assert_called_once_with()
+    ctx.on_session_end.assert_called_once_with("sess-1", msgs)
+
+
+def test_finalize_session_false_skips_on_session_end_but_tears_down_transport():
+    """finalize_session=False: on_session_end() is skipped on both the memory
+    manager and the context engine, but shutdown_all() (transport teardown)
+    still fires — a resumable soft eviction still frees the client/keepalive
+    resources, it just doesn't re-finalize the session."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-2")
+
+    msgs = [{"role": "user", "content": "hi"}]
+    agent.shutdown_memory_provider(msgs, finalize_session=False)
+
+    mm.on_session_end.assert_not_called()
+    mm.shutdown_all.assert_called_once_with()
+    ctx.on_session_end.assert_not_called()
+
+
+def test_ordinary_resumable_eviction_calls_on_session_end_zero_times():
+    """A resumable soft eviction (no prior commit_memory_session) must call
+    on_session_end() zero times — cal88's suggested case #1. It is not a real
+    session boundary, so nothing should be finalized at all."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-3")
+
+    # Soft eviction path: only the transport-only call runs, exactly as
+    # gateway/run.py's _release_evicted_agent_soft does for every eviction.
+    agent.shutdown_memory_provider(finalize_session=False)
+
+    mm.on_session_end.assert_not_called()
+    ctx.on_session_end.assert_not_called()
+    mm.shutdown_all.assert_called_once_with()
+
+
+def test_finalizable_eviction_calls_on_session_end_exactly_once():
+    """A finalizable LRU-cap eviction runs commit_memory_session() (fires
+    on_session_end) THEN shutdown_memory_provider(finalize_session=False)
+    (transport-only) — cal88's suggested case #2. on_session_end() must fire
+    exactly once total across both calls, not twice."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-4")
+
+    msgs = [{"role": "user", "content": "hi"}]
+    # Mirrors gateway/run.py's _commit_then_release_soft: commit first,
+    # then the transport-only release.
+    agent.commit_memory_session(msgs)
+    agent.shutdown_memory_provider(msgs, finalize_session=False)
+
+    assert mm.on_session_end.call_count == 1
+    assert ctx.on_session_end.call_count == 1
+    mm.shutdown_all.assert_called_once_with()
+
+
+def test_repeated_transport_only_shutdown_is_idempotent_re_finalization():
+    """Calling the transport-only path twice (e.g. a retried eviction) must
+    never fire on_session_end() — cal88's suggested case #4. shutdown_all()
+    firing twice is the provider's own responsibility to tolerate; this
+    only asserts finalization itself stays at zero."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-5")
+
+    agent.shutdown_memory_provider(finalize_session=False)
+    agent.shutdown_memory_provider(finalize_session=False)
+
+    mm.on_session_end.assert_not_called()
+    ctx.on_session_end.assert_not_called()
+    assert mm.shutdown_all.call_count == 2
+
+
+def test_finalize_session_false_tolerates_missing_memory_manager():
+    """No external memory provider configured — finalize_session=False must
+    not raise, and the context engine hook is still skipped."""
+    ctx = MagicMock()
+    agent = _make_minimal_agent(None, ctx, session_id="sess-6")
+
+    agent.shutdown_memory_provider(finalize_session=False)
+
+    ctx.on_session_end.assert_not_called()


### PR DESCRIPTION
Closes #64278

## Summary

Salvage of #63703 by @younghachi (`fix: clean up evicted memory providers`), which is a solid, well-tested fix for the memory-provider leak on gateway soft cache eviction described in #64278 / originally reported in #63703. That PR received an automated review from `copilot-pull-request-reviewer` flagging two real gaps; this PR carries the original commit forward (authorship preserved) and adds fixes for both review comments plus regression tests.

Original PR summary (unchanged):
- Close memory provider transports during soft gateway cache eviction, without invoking hard resource cleanup.
- Include config file size in the gateway cache-busting memo key to avoid stale cache reuse when mtime is insufficient.
- Skip inaccessible memory provider directories/symlinks during provider discovery so one user's private provider path cannot break shared installs.
- Add a regression test for soft eviction closing memory providers while preserving terminal/browser/background process state.

## What this PR adds on top

Addresses both comments left by the automated review on #63703:

1. **`plugins/memory/__init__.py`** — `_iter_provider_dirs()` wrapped `OSError` around the per-child `is_dir()`/`__init__.py` checks, but not around the `iterdir()` call on the provider directory itself. A directory that disappears or becomes unreadable mid-scan (race, permission change, broken symlink target) still aborted discovery entirely, defeating the PR's stated goal of isolating one broken plugin path from the rest of discovery. Now both the bundled and user provider directory listings are wrapped, degrading to "skip that source" instead of raising.

2. **`gateway/run.py`** — `_release_evicted_agent_soft()` gated the memory-provider shutdown call on `hasattr(agent, "release_clients") and hasattr(agent, "shutdown_memory_provider")`, but only the latter is used in that branch. Requiring both made the cleanup easy to accidentally skip for any agent/stub exposing just one of the two methods. Narrowed the gate to only what's actually needed.

3. Added regression tests for both: a `discover_memory_providers()` test that simulates an inaccessible user-plugins directory, and a gateway test verifying `shutdown_memory_provider()` fires even when `release_clients` isn't present on the agent.

## Test Plan

- `python -m pytest tests/agent/test_memory_provider.py -q -o addopts=` → 101 passed
- `python -m pytest tests/gateway/test_agent_cache.py -q -o addopts=` → 80 passed
- `ruff check` on all changed files → clean
- `python scripts/check-windows-footguns.py --all` → clean
