### PR TITLE
fix(providers): scope think to Ollama endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4298,6 +4298,7 @@ def _retry_same_provider_sync(
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
         task=task,
+        api_key=resolved_api_key,
     )
     # Preserve per-request attribution headers (e.g. Copilot's
     # ``x-initiator: user``) across the rebuilt-client retry — dropping them
@@ -4370,6 +4371,7 @@ async def _retry_same_provider_async(
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
         task=task,
+        api_key=resolved_api_key,
     )
     # Preserve per-request attribution headers across the rebuilt-client
     # retry — see the sync variant above (#60293).
@@ -4696,7 +4698,10 @@ def _call_fallback_candidate_sync(
         temperature=temperature, max_tokens=max_tokens,
         tools=fallback_tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
-        base_url=destination.base_url, task=task)
+        base_url=destination.base_url,
+        task=task,
+        api_key=getattr(fb_client, "api_key", None),
+    )
     try:
         return _validate_llm_response(
             _relay_sync_completion(
@@ -4741,7 +4746,10 @@ def _call_fallback_candidate_sync(
                     tools=retry_tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
-                    base_url=retry_destination.base_url, task=task)
+                    base_url=retry_destination.base_url,
+                    task=task,
+                    api_key=getattr(retry_client, "api_key", None),
+                )
                 try:
                     return _validate_llm_response(
                         _relay_sync_completion(
@@ -4802,7 +4810,10 @@ async def _call_fallback_candidate_async(
         temperature=temperature, max_tokens=max_tokens,
         tools=fallback_tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
-        base_url=destination.base_url, task=task)
+        base_url=destination.base_url,
+        task=task,
+        api_key=getattr(fb_client, "api_key", None),
+    )
     try:
         return _validate_llm_response(
             await _relay_async_completion(
@@ -4848,7 +4859,10 @@ async def _call_fallback_candidate_async(
                     tools=retry_tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
-                    base_url=retry_destination.base_url, task=task)
+                    base_url=retry_destination.base_url,
+                    task=task,
+                    api_key=getattr(retry_client, "api_key", None),
+                )
                 try:
                     return _validate_llm_response(
                         await _relay_async_completion(
@@ -7745,6 +7759,7 @@ def _build_call_kwargs(
     reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None,
     task: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -8598,7 +8613,8 @@ def call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_base_info or resolved_base_url, task=task)
+        base_url=_base_info or resolved_base_url, task=task,
+        api_key=resolved_api_key or getattr(client, "api_key", None))
     if extra_headers:
         kwargs["extra_headers"] = dict(extra_headers)
 
@@ -9310,7 +9326,8 @@ async def async_call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_client_base or resolved_base_url, task=task)
+        base_url=_client_base or resolved_base_url, task=task,
+        api_key=resolved_api_key or getattr(client, "api_key", None))
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7885,6 +7885,7 @@ def _build_call_kwargs(
                     supports_reasoning=reasoning_config is not None,
                     model=model,
                     base_url=effective_base,
+                    api_key=api_key if isinstance(api_key, str) else "",
                 )
             )
             profile_reasoning_extra = profile_reasoning_extra or {}

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1330,6 +1330,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
+            api_key=agent.api_key if isinstance(agent.api_key, str) else "",
             ollama_num_ctx=agent._ollama_num_ctx,
             # Context forwarded to profile hooks:
             provider_preferences=_prefs or None,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -586,6 +586,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 qwen_session_metadata=params.get("qwen_session_metadata"),
                 model=model,
                 base_url=params.get("base_url"),
+                api_key=params.get("api_key"),
                 ollama_num_ctx=params.get("ollama_num_ctx"),
                 session_id=params.get("session_id"),
             )

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -4,9 +4,8 @@ Covers any endpoint registered as provider="custom", including local
 Ollama instances and OpenAI-compatible reasoning endpoints (GLM-5.2 on
 Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
-  - reasoning_config disabled → top-level reasoning_effort="none"
-    (Ollama /v1/chat/completions ignores think=False — ollama#14820)
-    + extra_body.think = False for /api/chat and proxies
+  - reasoning_config disabled on a verified Ollama endpoint → top-level
+    reasoning_effort="none" + extra_body.think = False
   - reasoning_config enabled + effort → top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
@@ -16,6 +15,18 @@ from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+def _is_verified_ollama_endpoint(base_url: str | None, api_key: str = "") -> bool:
+    """Return true only when the endpoint passes the shared Ollama probe."""
+    if not base_url:
+        return False
+    try:
+        from agent.model_metadata import detect_local_server_type
+
+        return detect_local_server_type(base_url, api_key=api_key) == "ollama"
+    except Exception:
+        return False
 
 
 class CustomProfile(ProviderProfile):
@@ -37,10 +48,10 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Reasoning / thinking control for custom OpenAI-compatible endpoints
-        # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
+        # Reasoning / thinking control for custom OpenAI-compatible endpoints.
         #
-        #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
+        #   - disabled verified Ollama → reasoning_effort="none" and
+        #     extra_body.think = False
         #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
         #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
         #     expect (GLM documents "high" and "max"; "max" is its default).
@@ -55,14 +66,16 @@ class CustomProfile(ProviderProfile):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
-                # Ollama's /v1/chat/completions silently ignores
-                # extra_body.think (only /api/chat honours it — ollama#14820)
-                # but respects the top-level reasoning_effort field, so both
-                # are needed to actually stop a thinking-capable model from
-                # reasoning (#25758). Endpoints that recognize neither simply
-                # ignore them.
-                top_level["reasoning_effort"] = "none"
-                extra_body["think"] = False
+                if _is_verified_ollama_endpoint(
+                    ctx.get("base_url"), str(ctx.get("api_key") or "")
+                ):
+                    # Ollama's /v1/chat/completions silently ignores
+                    # extra_body.think (only /api/chat honours it — ollama#14820)
+                    # but respects the top-level reasoning_effort field, so both
+                    # are needed to actually stop a thinking-capable model from
+                    # reasoning (#25758).
+                    top_level["reasoning_effort"] = "none"
+                    extra_body["think"] = False
             elif _effort:
                 top_level["reasoning_effort"] = _effort
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -6,9 +6,8 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
   - reasoning_config disabled on a verified Ollama endpoint → top-level
     reasoning_effort="none" + extra_body.think = False
-  - reasoning_config enabled + effort → top-level reasoning_effort
-    (the native OpenAI-compatible format GLM/ARK expect; unset omits it
-    so the endpoint's server default applies)
+  - reasoning_config effort → top-level reasoning_effort on a verified
+    Ollama endpoint only (unset omits it so the server default applies)
 """
 
 from typing import Any
@@ -48,20 +47,20 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Reasoning / thinking control for custom OpenAI-compatible endpoints.
+        # The disabled-reasoning controls are Ollama-specific.  ``custom`` is
+        # also used for arbitrary OpenAI-compatible relays (including Groq),
+        # which can reject either ``think=False`` or
+        # ``reasoning_effort="none"``.  Do not infer Ollama from a URL
+        # substring or its default port: emit those fields only after the
+        # shared endpoint probe identifies Ollama.
         #
-        #   - disabled verified Ollama → reasoning_effort="none" and
-        #     extra_body.think = False
-        #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
-        #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
-        #     expect (GLM documents "high" and "max"; "max" is its default).
-        #   - enabled + no effort  → omit both, so the endpoint applies its own
-        #     server-side default (do NOT force a level the user didn't pick).
+        #   - disabled → reasoning_effort="none" and extra_body.think=False
+        #   - enabled + effort → top-level reasoning_effort
+        #   - enabled + no effort → omit both, preserving the server default
         #
-        # We deliberately do NOT emit ``think=True`` on enable: it is an
-        # Ollama-only flag and thinking is already server-default-on for these
-        # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
-        # recognize it. Mirrors the DeepSeek/Zai profile precedent.
+        # Enabled ``reasoning_effort`` remains a generic OpenAI-compatible
+        # control used by custom reasoning APIs such as GLM/ARK.  We
+        # deliberately do NOT emit ``think=True`` on enable.
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
@@ -70,10 +69,9 @@ class CustomProfile(ProviderProfile):
                     ctx.get("base_url"), str(ctx.get("api_key") or "")
                 ):
                     # Ollama's /v1/chat/completions silently ignores
-                    # extra_body.think (only /api/chat honours it — ollama#14820)
-                    # but respects the top-level reasoning_effort field, so both
-                    # are needed to actually stop a thinking-capable model from
-                    # reasoning (#25758).
+                    # extra_body.think (only /api/chat honours it —
+                    # ollama#14820) but respects the top-level field, so both
+                    # are needed to stop a thinking-capable model (#25758).
                     top_level["reasoning_effort"] = "none"
                     extra_body["think"] = False
             elif _effort:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2740,6 +2740,30 @@ class TestAuxiliaryProviderProfileReasoning:
 
 
 
+    def test_custom_verified_ollama_uses_auxiliary_api_key_for_disabled_reasoning(self, monkeypatch):
+        probe_calls = []
+
+        def _is_ollama(url, *, api_key=""):
+            probe_calls.append((url, api_key))
+            return "ollama"
+
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type", _is_ollama,
+        )
+        base_url = "http://127.0.0.1:11434/v1"
+        kwargs = _build_call_kwargs(
+            "custom",
+            "qwen3",
+            [{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False},
+            base_url=base_url,
+            api_key="auxiliary-test-key",
+        )
+
+        assert probe_calls == [(base_url, "auxiliary-test-key")]
+        assert kwargs["reasoning_effort"] == "none"
+        assert kwargs["extra_body"]["think"] is False
+
     @pytest.mark.asyncio
     async def test_async_call_llm_preserves_profile_reasoning_kwargs(self):
         response = SimpleNamespace(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2739,6 +2739,21 @@ class TestAuxiliaryProviderProfileReasoning:
         assert "thinking" not in kwargs.get("extra_body", {})
 
 
+    def test_custom_groq_endpoint_omits_ollama_reasoning_controls(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: None
+        )
+        kwargs = _build_call_kwargs(
+            "custom",
+            "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False, "effort": "none"},
+            base_url="https://api.groq.com/openai/v1",
+        )
+
+        assert "reasoning_effort" not in kwargs
+        assert "reasoning" not in kwargs.get("extra_body", {})
+        assert "think" not in kwargs.get("extra_body", {})
 
     def test_custom_verified_ollama_uses_auxiliary_api_key_for_disabled_reasoning(self, monkeypatch):
         probe_calls = []

--- a/tests/agent/test_probe_cache_followups.py
+++ b/tests/agent/test_probe_cache_followups.py
@@ -159,6 +159,30 @@ class TestDetectLocalServerTypeCache:
         with patch("httpx.Client", return_value=swap_client):
             assert detect_local_server_type("http://127.0.0.1:11434") == "lm-studio"
 
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://not-ollama.example/v1",
+            "http://127.0.0.1:11434/v1",
+        ],
+        ids=["url-containing-ollama", "non-ollama-port-11434"],
+    )
+    def test_non_ollama_name_or_port_does_not_identify_ollama(self, base_url):
+        """Ollama requires the /api/tags response shape, not URL heuristics."""
+        from agent.model_metadata import detect_local_server_type
+
+        miss = MagicMock()
+        miss.status_code = 404
+        client = MagicMock()
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+        client.get.return_value = miss
+
+        with patch("httpx.Client", return_value=client):
+            assert detect_local_server_type(base_url) is None
+
+        assert any(call.args[0].endswith("/api/tags") for call in client.get.call_args_list)
+
 
 class TestLocalhostIPv4SiblingSites:
     """#37595 widened: every probe helper rewrites localhost→127.0.0.1,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -220,16 +220,21 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["options"]["num_ctx"] == 32768
 
-    def test_custom_think_false(self, transport):
+    def test_custom_verified_ollama_sends_disabled_controls(self, transport, monkeypatch):
         from providers import get_provider_profile
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: "ollama"
+        )
         profile = get_provider_profile("custom")
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="qwen3", messages=msgs,
             provider_profile=profile,
+            base_url="http://127.0.0.1:11434/v1",
             reasoning_config={"effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+        assert kw["reasoning_effort"] == "none"
 
 
 

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -7,7 +7,9 @@ nothing when reasoning was *enabled*, so a configured ``reasoning_effort``
 was silently dropped for every custom endpoint.
 
 These tests pin the wire-shape contract:
-  - disabled            → extra_body.think = False
+  - disabled verified Ollama → extra_body.think = False + top-level
+                                reasoning_effort="none"
+  - disabled generic relay → omit both disabled-reasoning controls
   - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
                           format GLM/ARK expect), passed through verbatim
                           including ``max``/``xhigh``
@@ -48,7 +50,7 @@ class TestCustomReasoningWireShape:
         assert eb == {}
         assert tl == {}
 
-    def test_disabled_sends_think_false(self, custom_profile):
+    def test_disabled_verified_ollama_sends_disabled_controls(self, custom_profile, monkeypatch):
         """enabled=False → reasoning_effort='none' top-level + think=False.
 
         Both fields are required: Ollama's /v1/chat/completions silently
@@ -56,19 +58,46 @@ class TestCustomReasoningWireShape:
         but respects top-level reasoning_effort (#25758). think=False stays
         for proxies and the native /api/chat path.
         """
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: "ollama"
+        )
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": False}, model="glm-5.2"
+            reasoning_config={"enabled": False}, model="glm-5.2", base_url="http://127.0.0.1:11434/v1"
         )
         assert eb == {"think": False}
         assert tl == {"reasoning_effort": "none"}
 
-    def test_effort_none_sends_think_false(self, custom_profile):
-        """effort='none' is the disable alias → same dual emission."""
-        eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "none"}, model="glm-5.2"
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.groq.com/openai/v1",
+            "https://not-ollama.example/v1",
+            "http://127.0.0.1:11434/v1",
+        ],
+        ids=["groq", "url-containing-ollama", "non-ollama-port-11434"],
+    )
+    def test_disabled_non_ollama_endpoint_omits_both_controls(
+        self, custom_profile, monkeypatch, base_url
+    ):
+        """Only a positive Ollama probe may enable either disabled control."""
+        probe_calls = []
+
+        def _not_ollama(url, *, api_key=""):
+            probe_calls.append((url, api_key))
+            return None
+
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type", _not_ollama
         )
-        assert eb == {"think": False}
-        assert tl == {"reasoning_effort": "none"}
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+            model="glm-5.2",
+            base_url=base_url,
+            api_key="custom-key",
+        )
+        assert "think" not in eb
+        assert "reasoning_effort" not in tl
+        assert probe_calls == [(base_url, "custom-key")]
 
     @pytest.mark.parametrize(
         "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -1,18 +1,15 @@
 """Unit tests for the custom provider profile's reasoning wiring.
 
 ``provider=custom`` covers any OpenAI-compatible endpoint the user points
-Hermes at — local Ollama, vLLM, llama.cpp, and hosted reasoning APIs like
-GLM-5.2 on Volcengine ARK. Before #57601's salvage, ``CustomProfile`` emitted
-nothing when reasoning was *enabled*, so a configured ``reasoning_effort``
-was silently dropped for every custom endpoint.
+Hermes at — local Ollama as well as arbitrary hosted or self-hosted relays.
+Ollama's disabled-reasoning controls must never be forwarded to those other
+endpoints.
 
 These tests pin the wire-shape contract:
   - disabled verified Ollama → extra_body.think = False + top-level
                                 reasoning_effort="none"
-  - disabled generic relay → omit both disabled-reasoning controls
-  - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
-                          format GLM/ARK expect), passed through verbatim
-                          including ``max``/``xhigh``
+  - disabled generic relay (including Groq) → omit Ollama-only controls
+  - enabled + effort → top-level reasoning_effort for any custom endpoint
   - enabled + no effort → nothing emitted (endpoint's server default applies)
   - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
 """
@@ -50,7 +47,9 @@ class TestCustomReasoningWireShape:
         assert eb == {}
         assert tl == {}
 
-    def test_disabled_verified_ollama_sends_disabled_controls(self, custom_profile, monkeypatch):
+    def test_disabled_verified_ollama_sends_disabled_controls(
+        self, custom_profile, monkeypatch
+    ):
         """enabled=False → reasoning_effort='none' top-level + think=False.
 
         Both fields are required: Ollama's /v1/chat/completions silently
@@ -59,10 +58,13 @@ class TestCustomReasoningWireShape:
         for proxies and the native /api/chat path.
         """
         monkeypatch.setattr(
-            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: "ollama"
+            "agent.model_metadata.detect_local_server_type",
+            lambda *_args, **_kwargs: "ollama",
         )
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": False}, model="glm-5.2", base_url="http://127.0.0.1:11434/v1"
+            reasoning_config={"enabled": False},
+            model="glm-5.2",
+            base_url="http://127.0.0.1:11434/v1",
         )
         assert eb == {"think": False}
         assert tl == {"reasoning_effort": "none"}
@@ -79,7 +81,7 @@ class TestCustomReasoningWireShape:
     def test_disabled_non_ollama_endpoint_omits_both_controls(
         self, custom_profile, monkeypatch, base_url
     ):
-        """Only a positive Ollama probe may enable either disabled control."""
+        """Only a positive Ollama probe may enable disabled controls."""
         probe_calls = []
 
         def _not_ollama(url, *, api_key=""):
@@ -90,7 +92,7 @@ class TestCustomReasoningWireShape:
             "agent.model_metadata.detect_local_server_type", _not_ollama
         )
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "none"},
+            reasoning_config={"enabled": False, "effort": "none"},
             model="glm-5.2",
             base_url=base_url,
             api_key="custom-key",
@@ -103,25 +105,30 @@ class TestCustomReasoningWireShape:
         "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]
     )
     def test_enabled_effort_goes_top_level(self, custom_profile, effort):
-        """enabled + effort → TOP-LEVEL reasoning_effort, passed through verbatim.
-
-        GLM-5.2/ARK and OpenAI-compatible reasoning APIs read reasoning_effort
-        as a top-level string, not nested in extra_body. ``max`` is GLM's
-        native deep-reasoning level and must survive.
-        """
+        """Explicit enabled effort stays available to custom reasoning APIs."""
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": effort}, model="glm-5.2"
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.2",
         )
         assert tl == {"reasoning_effort": effort}
         assert "reasoning_effort" not in eb
         assert "think" not in eb
 
+    def test_enabled_without_effort_emits_nothing(self, custom_profile):
+        """enabled but no effort → omit; do NOT force a level the user didn't pick."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True},
+            model="glm-5.2",
+        )
+        assert eb == {}
+        assert tl == {}
 
     def test_does_not_force_think_true_on_enable(self, custom_profile):
         """We must never send think=True on enable — it's Ollama-only and
-        would 400 on GLM/vLLM endpoints that don't recognize it."""
+        the server already defaults to thinking on."""
         eb, _ = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "high"}, model="glm-5.2"
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
         )
         assert eb.get("think") is not True
 
@@ -136,3 +143,11 @@ class TestCustomReasoningWithNumCtx:
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
 
+    def test_num_ctx_with_effort(self, custom_profile):
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            ollama_num_ctx=8192,
+            model="qwen3",
+        )
+        assert eb == {"options": {"num_ctx": 8192}}
+        assert tl == {"reasoning_effort": "high"}

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -161,12 +161,32 @@ class TestCustomOllamaParity:
         )
         assert kw["extra_body"]["options"]["num_ctx"] == 131072
 
-    def test_think_false_when_disabled(self, transport):
+    def test_verified_ollama_sends_disabled_reasoning_controls(self, transport, monkeypatch):
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: "ollama"
+        )
         kw = transport.build_kwargs(
             model="qwen3:72b",
             messages=_simple_messages(),
             tools=None,
             provider_profile=get_provider_profile("custom"),
+            base_url="http://127.0.0.1:11434/v1",
             reasoning_config={"enabled": False, "effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+        assert kw["reasoning_effort"] == "none"
+
+    def test_groq_custom_endpoint_omits_disabled_reasoning_controls(self, transport, monkeypatch):
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: None
+        )
+        kw = transport.build_kwargs(
+            model="qwen3:72b",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("custom"),
+            base_url="https://api.groq.com/openai/v1",
+            reasoning_config={"enabled": False, "effort": "none"},
+        )
+        assert "think" not in kw.get("extra_body", {})
+        assert "reasoning_effort" not in kw

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -161,9 +161,12 @@ class TestCustomOllamaParity:
         )
         assert kw["extra_body"]["options"]["num_ctx"] == 131072
 
-    def test_verified_ollama_sends_disabled_reasoning_controls(self, transport, monkeypatch):
+    def test_verified_ollama_sends_disabled_reasoning_controls(
+        self, transport, monkeypatch
+    ):
         monkeypatch.setattr(
-            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: "ollama"
+            "agent.model_metadata.detect_local_server_type",
+            lambda *_args, **_kwargs: "ollama",
         )
         kw = transport.build_kwargs(
             model="qwen3:72b",
@@ -176,9 +179,12 @@ class TestCustomOllamaParity:
         assert kw["extra_body"]["think"] is False
         assert kw["reasoning_effort"] == "none"
 
-    def test_groq_custom_endpoint_omits_disabled_reasoning_controls(self, transport, monkeypatch):
+    def test_groq_custom_endpoint_omits_disabled_reasoning_controls(
+        self, transport, monkeypatch
+    ):
         monkeypatch.setattr(
-            "agent.model_metadata.detect_local_server_type", lambda *_args, **_kwargs: None
+            "agent.model_metadata.detect_local_server_type",
+            lambda *_args, **_kwargs: None,
         )
         kw = transport.build_kwargs(
             model="qwen3:72b",
@@ -190,3 +196,21 @@ class TestCustomOllamaParity:
         )
         assert "think" not in kw.get("extra_body", {})
         assert "reasoning_effort" not in kw
+
+    def test_groq_custom_endpoint_preserves_enabled_reasoning_effort(
+        self, transport, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.model_metadata.detect_local_server_type",
+            lambda *_args, **_kwargs: None,
+        )
+        kw = transport.build_kwargs(
+            model="llama-3.3-70b-versatile",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("custom"),
+            base_url="https://api.groq.com/openai/v1",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert "think" not in kw.get("extra_body", {})
+        assert kw["reasoning_effort"] == "high"


### PR DESCRIPTION
## What does this PR do?

Restricts Ollama-only disabled-reasoning controls to endpoints positively identified as Ollama.

When reasoning is disabled, a verified Ollama endpoint receives both `extra_body.think=false` and top-level `reasoning_effort="none"`. Generic OpenAI-compatible custom relays receive neither field, while explicit enabled reasoning effort remains available for custom reasoning APIs. Ollama detection uses the existing `/api/tags` probe instead of URL substrings or port numbers.

## Related Issue

Fixes #11237.

Related/overlapping work:

- #11520 targets the same unsupported-`think` symptom but identifies Ollama from URL text/port. This PR uses positive `/api/tags` detection to avoid misclassifying arbitrary relays.
- #63315 gates enabled reasoning controls on Ollama model capabilities. This PR instead scopes the disabled-control path and protects non-Ollama custom relays.
- #64608 added the current top-level disabled `reasoning_effort` behavior; this PR scopes that field under the same verified-Ollama predicate as `think`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/custom/__init__.py`: identify Ollama through `detect_local_server_type(base_url, api_key)`; scope both disabled controls to verified Ollama endpoints.
- `agent/chat_completion_helpers.py` and `agent/transports/chat_completions.py`: thread the API key through provider-profile and retry/fallback request construction.
- `agent/auxiliary_client.py`: keep auxiliary request construction in parity with the main transport path.
- Tests under `tests/agent/`, `tests/plugins/model_providers/`, and `tests/providers/`: cover Ollama, misleading URLs/ports, generic relays, API-key propagation, auxiliary requests, and retry/transport parity.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/model_providers/test_custom_profile.py tests/providers/test_transport_parity.py tests/agent/transports/test_chat_completions.py tests/agent/test_auxiliary_client.py tests/agent/test_probe_cache_followups.py -q`.
2. Verify a positively identified Ollama endpoint with reasoning disabled receives `think=false` and `reasoning_effort="none"`.
3. Verify generic relays—including URLs containing `ollama` or using port 11434 without a valid `/api/tags` response—receive neither disabled field.

Focused result: **240 passed**.

Additional checks: `ruff check .`, `git diff --check`, and `scripts/check-windows-footguns.py --all` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused affected suites pass; the full GitHub Actions matrix is awaiting maintainer approval)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing interface or behavior documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent Python change; Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

N/A — regression coverage and command results are listed above.

## AI Assistance

OpenAI — GPT-5 via Codex CLI (implementation assistance, test execution, and PR-description drafting).