### PR TITLE
fix(chat-completions): normalize OpenAI-compatible tool call shapes

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,6 +10,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 from typing import Any, Dict
+import json
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
@@ -650,6 +651,68 @@ class ChatCompletionsTransport(ProviderTransport):
 
         return api_kwargs
 
+    @staticmethod
+    def _get_tool_call_value(obj: Any, key: str, default: Any = None) -> Any:
+        """Read *key* from *obj*, supporting both attribute and dict access."""
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return getattr(obj, key, default)
+
+    @staticmethod
+    def _normalize_tool_call_arguments(arguments: Any) -> str:
+        """Normalize tool call arguments to a JSON string.
+
+        ``ToolCall.arguments`` is documented as ``str  # JSON string`` and
+        all downstream consumers expect it.  Provider / gateway responses
+        may arrive with dict, list, empty, or non-string arguments.
+        """
+        if not arguments or (isinstance(arguments, str) and not arguments.strip()):
+            return "{}"
+        if isinstance(arguments, (dict, list)):
+            return json.dumps(arguments, ensure_ascii=False)
+        if isinstance(arguments, str):
+            return arguments
+        return str(arguments)
+
+    @staticmethod
+    def _normalize_chat_completion_tool_call(tc: Any) -> ToolCall:
+        """Normalize a single tool call to the internal ``ToolCall`` shape.
+
+        Supports SDK object (attribute access) and OpenAI-compatible
+        gateway / provider dict responses.  ``extra_content`` (Gemini
+        thought_signature) is preserved in ``provider_data``.
+        """
+        _get = ChatCompletionsTransport._get_tool_call_value
+        _norm = ChatCompletionsTransport._normalize_tool_call_arguments
+
+        tc_id = _get(tc, "id") or _get(tc, "call_id")
+        fn = _get(tc, "function", {})
+        name = _get(fn, "name", "")
+        arguments = _norm(_get(fn, "arguments"))
+
+        # Preserve provider-specific extras on the tool call.
+        # Gemini 3 thinking models attach extra_content with
+        # thought_signature — without replay on the next turn the API
+        # rejects the request with 400.
+        tc_provider_data: dict[str, Any] = {}
+        extra = _get(tc, "extra_content", None)
+        if extra is None and hasattr(tc, "model_extra"):
+            extra = (tc.model_extra if isinstance(tc.model_extra, dict) else {}).get("extra_content")
+        if extra is not None:
+            if hasattr(extra, "model_dump"):
+                try:
+                    extra = extra.model_dump()
+                except Exception:
+                    pass
+            tc_provider_data["extra_content"] = extra
+
+        return ToolCall(
+            id=tc_id,
+            name=name,
+            arguments=arguments,
+            provider_data=tc_provider_data or None,
+        )
+
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
         """Normalize OpenAI ChatCompletion to NormalizedResponse.
 
@@ -669,31 +732,10 @@ class ChatCompletionsTransport(ProviderTransport):
 
         tool_calls = None
         if msg.tool_calls:
-            tool_calls = []
-            for tc in msg.tool_calls:
-                # Preserve provider-specific extras on the tool call.
-                # Gemini 3 thinking models attach extra_content with
-                # thought_signature — without replay on the next turn the API
-                # rejects the request with 400.
-                tc_provider_data: dict[str, Any] = {}
-                extra = getattr(tc, "extra_content", None)
-                if extra is None and hasattr(tc, "model_extra"):
-                    extra = (tc.model_extra if isinstance(tc.model_extra, dict) else {}).get("extra_content")
-                if extra is not None:
-                    if hasattr(extra, "model_dump"):
-                        try:
-                            extra = extra.model_dump()
-                        except Exception:
-                            pass
-                    tc_provider_data["extra_content"] = extra
-                tool_calls.append(
-                    ToolCall(
-                        id=tc.id,
-                        name=tc.function.name,
-                        arguments=tc.function.arguments,
-                        provider_data=tc_provider_data or None,
-                    )
-                )
+            tool_calls = [
+                self._normalize_chat_completion_tool_call(tc)
+                for tc in msg.tool_calls
+            ]
 
         usage = None
         if hasattr(response, "usage") and response.usage:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1099,6 +1099,128 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"refusal": "cannot continue"}
 
 
+class TestChatCompletionsToolCallNormalization:
+    """Tool call shape normalization: dict-shaped tool calls, dict/list/empty
+    arguments, and regression coverage for SDK object shape."""
+
+    @staticmethod
+    def _response_with_tool_calls(tool_calls, finish_reason="tool_calls"):
+        """Build a minimal chat-completions-style response from raw dicts."""
+        return type(
+            "_FakeResponse",
+            (),
+            {
+                "choices": [
+                    type(
+                        "_FakeChoice",
+                        (),
+                        {
+                            "message": type(
+                                "_FakeMessage",
+                                (),
+                                {
+                                    "content": None,
+                                    "tool_calls": tool_calls,
+                                    "reasoning_content": None,
+                                },
+                            )(),
+                            "finish_reason": finish_reason,
+                        },
+                    )()
+                ],
+                "usage": None,
+            },
+        )()
+
+    def test_dict_shaped_tool_call_accepted(self, transport):
+        """A dict-shaped tool call (not an SDK object) must be normalized."""
+        r = self._response_with_tool_calls([
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "arguments": {"cmd": "pwd"},
+                },
+            },
+        ])
+        nr = transport.normalize_response(r)
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].id == "call_1"
+        assert nr.tool_calls[0].name == "terminal"
+        import json
+        assert json.loads(nr.tool_calls[0].arguments) == {"cmd": "pwd"}
+
+    def test_dict_function_list_arguments_becomes_json_string(self, transport):
+        """list arguments must serialize to JSON string, not Python repr."""
+        r = self._response_with_tool_calls([
+            {
+                "id": "call_2",
+                "type": "function",
+                "function": {
+                    "name": "batch",
+                    "arguments": ["a", "b"],
+                },
+            },
+        ])
+        nr = transport.normalize_response(r)
+        import json
+        assert json.loads(nr.tool_calls[0].arguments) == ["a", "b"]
+
+    def test_sdk_object_shape_no_regression(self, transport):
+        """Existing SDK object-shape responses must still normalize."""
+        from types import SimpleNamespace
+        tc = SimpleNamespace(
+            id="call_3",
+            function=SimpleNamespace(
+                name="read_file",
+                arguments='{"path": "README.md"}',
+            ),
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=[tc], reasoning_content=None),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls[0].id == "call_3"
+        assert nr.tool_calls[0].name == "read_file"
+        assert nr.tool_calls[0].arguments == '{"path": "README.md"}'
+
+    def test_dict_tool_call_extra_content_preserved(self, transport):
+        """extra_content on dict-shaped tool calls must survive normalization."""
+        r = self._response_with_tool_calls([
+            {
+                "id": "call_4",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+                "extra_content": {"google": {"thought_signature": "SIG_123"}},
+            },
+        ])
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls[0].provider_data == {
+            "extra_content": {"google": {"thought_signature": "SIG_123"}}
+        }
+
+    def test_empty_arguments_normalized_to_empty_object(self, transport):
+        """None / empty arguments must normalize to '{}'."""
+        for empty_val in (None, "   "):
+            r = self._response_with_tool_calls([
+                {
+                    "id": "call_5",
+                    "type": "function",
+                    "function": {
+                        "name": "noop",
+                        "arguments": empty_val,
+                    },
+                },
+            ])
+            nr = transport.normalize_response(r)
+            assert nr.tool_calls[0].arguments == "{}", f"empty_val={empty_val!r}"
+
+
 class TestChatCompletionsCacheStats:
 
     def test_no_usage(self, transport):


### PR DESCRIPTION
 Accept dict-shaped tool calls and functions in normalize_response() so OpenAI-compatible
  transport layer.  Also normalize dict, list, and empty arguments to valid JSON strings
  instead of leaking provider shape differences into the agent loop.

  Hermes supports many OpenAI-compatible providers and gateways. These providers follow the
   OpenAI Chat Completions wire schema, but responses may arrive as plain dicts (from proxy
   gateways, community endpoints, or non-SDK HTTP clients) rather than SDK objects with
  attribute access. The `ChatCompletionsTransport.normalize_response()` currently accesses
  `tc.id`, `tc.function.name`, and `tc.function.arguments` as attributes — which fails with
   `AttributeError` on dict-shaped responses.

  This PR adds shape normalization at the transport layer so the agent loop never sees
  provider-specific shape quirks. Three small private helpers handle dict/attribute dual
  access and argument serialization:

  - `_get_tool_call_value(obj, key)` — reads a field from either a dict or an object
  - `_normalize_tool_call_arguments(arguments)` — normalizes dict/list/empty to JSON string
  - `_normalize_chat_completion_tool_call(tc)` — normalizes a single tool call with
  extra_content preservation

  ---
  Related Issue：
  N/A

  ---
  Type of Change：勾选 🐛 Bug fix

  ---
  Changes Made：
  - `agent/transports/chat_completions.py` — 3 new private helpers + refactored tool-call
  loop in normalize_response()
  - `tests/agent/transports/test_chat_completions.py` — 5 new tests in
  TestChatCompletionsToolCallNormalization

  ---
  How to Test：
  1. pytest
  tests/agent/transports/test_chat_completions.py::TestChatCompletionsToolCallNormalization
   -v
  2. pytest tests/agent/transports/test_chat_completions.py -q
  3. pytest tests/agent/transports/test_types.py -q

  ---
  Checklist — Code：
  - I've read the Contributing Guide
  - My commit messages follow Conventional Commits
  - I searched for existing PRs
  - My PR contains only changes related to this fix
  - I've run tests and all pass
  - I've added tests for my changes
  - I've tested on my platform: macOS 15

  ---
  Checklist — Documentation & Housekeeping：
  - I've updated relevant documentation — N/A
  - I've updated cli-config.yaml.example — N/A
  - I've updated CONTRIBUTING.md or AGENTS.md — N/A
  - I've considered cross-platform impact — N/A
  - I've updated tool descriptions/schemas — N/A