### PR TITLE
Add strict JSON output for chat automation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -39,7 +39,7 @@ import uuid
 import textwrap
 from collections import deque
 from urllib.parse import unquote, urlparse
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -15799,6 +15799,7 @@ def main(
     max_turns: int = None,
     verbose: Optional[bool] = None,
     quiet: bool = False,
+    json_output: bool = False,
     compact: bool = False,
     list_tools: bool = False,
     list_toolsets: bool = False,
@@ -15826,6 +15827,7 @@ def main(
         base_url: Base URL for the API
         max_turns: Maximum tool-calling iterations (default: 60)
         verbose: Enable verbose logging
+        json_output: Emit one versioned JSON result object; implies quiet mode
         compact: Use compact display mode
         list_tools: List available tools and exit
         list_toolsets: List available toolsets and exit
@@ -16072,9 +16074,20 @@ def main(
     except Exception:
         pass  # signal handler may fail in restricted environments
     
+    if json_output:
+        quiet = True
+
     # Handle single query mode
     if query or image:
-        if not cli._claim_active_session("cli", stderr=bool(quiet)):
+        if json_output:
+            with open(os.devnull, "w", encoding="utf-8") as _sink:
+                with redirect_stdout(_sink), redirect_stderr(_sink):
+                    _session_claimed = cli._claim_active_session("cli", stderr=True)
+        else:
+            _session_claimed = cli._claim_active_session("cli", stderr=bool(quiet))
+        if not _session_claimed:
+            if json_output:
+                print("Hermes JSON chat failed", file=sys.stderr)
             sys.exit(1)
         try:
             query, single_query_images = _collect_query_images(query, image)
@@ -16119,7 +16132,15 @@ def main(
                 # Quiet mode: suppress banner, spinner, tool previews.
                 # Only print the final response and parseable session info.
                 cli.tool_progress_mode = "off"
-                if cli._ensure_runtime_credentials():
+                cli.show_reasoning = False
+                cli.streaming_enabled = False
+                if json_output:
+                    with open(os.devnull, "w", encoding="utf-8") as _sink:
+                        with redirect_stdout(_sink), redirect_stderr(_sink):
+                            _credentials_ok = cli._ensure_runtime_credentials()
+                else:
+                    _credentials_ok = cli._ensure_runtime_credentials()
+                if _credentials_ok:
                     effective_query: Any = query
                     if single_query_images or single_query_image_urls:
                         # Honour the same image-routing decision used by the
@@ -16178,27 +16199,53 @@ def main(
                     turn_route = cli._resolve_turn_agent_config(effective_query)
                     if turn_route["signature"] != cli._active_agent_route_signature:
                         cli.agent = None
-                    if cli._init_agent(
-                        model_override=turn_route["model"],
-                        runtime_override=turn_route["runtime"],
-                        request_overrides=turn_route.get("request_overrides"),
-                    ):
+                    if json_output:
+                        with open(os.devnull, "w", encoding="utf-8") as _sink:
+                            with redirect_stdout(_sink), redirect_stderr(_sink):
+                                _agent_ready = cli._init_agent(
+                                    model_override=turn_route["model"],
+                                    runtime_override=turn_route["runtime"],
+                                    request_overrides=turn_route.get("request_overrides"),
+                                )
+                    else:
+                        _agent_ready = cli._init_agent(
+                            model_override=turn_route["model"],
+                            runtime_override=turn_route["runtime"],
+                            request_overrides=turn_route.get("request_overrides"),
+                        )
+                    if _agent_ready:
                         cli.agent.quiet_mode = True
                         cli.agent.suppress_status_output = True
-                        # Suppress streaming display callbacks so stdout stays
-                        # machine-readable (no styled "Hermes" box, no tool-gen
-                        # status lines).  The response is printed once below.
-                        cli.agent.stream_delta_callback = None
-                        cli.agent.tool_gen_callback = None
+                        # Programmatic modes have no terminal UI. Disable every
+                        # callback that can render reasoning or tool activity.
+                        for _callback in (
+                            "reasoning_callback",
+                            "tool_progress_callback",
+                            "tool_start_callback",
+                            "tool_complete_callback",
+                            "stream_delta_callback",
+                            "tool_gen_callback",
+                        ):
+                            setattr(cli.agent, _callback, None)
                         try:
-                            result = cli.agent.run_conversation(
-                                user_message=effective_query,
-                                conversation_history=cli.conversation_history,
-                            )
+                            with open(os.devnull, "w", encoding="utf-8") as _sink:
+                                with redirect_stdout(_sink), redirect_stderr(_sink):
+                                    result = cli.agent.run_conversation(
+                                        user_message=effective_query,
+                                        conversation_history=cli.conversation_history,
+                                    )
                         except KeyboardInterrupt:
                             _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
-                            print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+                            if json_output:
+                                print("Hermes JSON chat interrupted", file=sys.stderr)
+                            else:
+                                print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
                             sys.exit(130)
+                        except Exception:
+                            if json_output:
+                                print("Hermes JSON chat failed", file=sys.stderr)
+                                sys.exit(1)
+                            raise
                         # Sync session_id if mid-run compression created a
                         # continuation session. The exit line below reports
                         # session_id to stderr for automation wrappers; without
@@ -16213,11 +16260,28 @@ def main(
                         # (e.g. invalid model slug → provider 4xx). Mirrors the
                         # interactive CLI path. Write to stderr so piped stdout
                         # stays clean for automation wrappers.
-                        if (
+                        _failed = isinstance(result, dict) and bool(
+                            result.get("failed") or result.get("partial")
+                        )
+                        if json_output and (_failed or not cli.session_id):
+                            print("Hermes JSON chat failed", file=sys.stderr)
+                        elif json_output:
+                            print(
+                                json.dumps(
+                                    {
+                                        "protocol": "hermes.chat.result.v1",
+                                        "reply": response,
+                                        "session_id": cli.session_id,
+                                    },
+                                    ensure_ascii=False,
+                                    separators=(",", ":"),
+                                )
+                            )
+                        elif (
                             not response
                             and isinstance(result, dict)
                             and result.get("error")
-                            and (result.get("failed") or result.get("partial"))
+                            and _failed
                         ):
                             print(f"Error: {result['error']}", file=sys.stderr)
                         elif response:
@@ -16230,14 +16294,15 @@ def main(
                         # out (→ sticky block). Gated on the env vars the
                         # dispatcher sets in `_default_spawn`; a no-op for every
                         # normal worker and every non-kanban `-q` run.
-                        if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
+                        if not json_output and os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
                             try:
                                 _run_kanban_goal_loop_q(cli, response)
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)
 
                         # Session ID goes to stderr so piped stdout is clean.
-                        print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+                        if not json_output:
+                            print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
 
                         # Ensure proper exit code for automation wrappers.
                         #
@@ -16252,7 +16317,7 @@ def main(
                         # permanently block the card. Non-kanban runs keep the
                         # plain 0/1 contract automation wrappers expect.
                         _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
+                        if _failed:
                             _exit_code = 1
                             if os.environ.get("HERMES_KANBAN_TASK") and result.get(
                                 "failure_reason"
@@ -16266,7 +16331,9 @@ def main(
                                     _exit_code = 1
                         sys.exit(_exit_code)
 
-                # Exit with error code if credentials or agent init fails
+                # Exit with error code if credentials or agent init fails.
+                if json_output:
+                    print("Hermes JSON chat failed", file=sys.stderr)
                 sys.exit(1)
             else:
                 # Single-query mode (`hermes chat -q "…"`): skip the welcome

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -331,6 +331,15 @@ def build_top_level_parser():
         help="Quiet mode for programmatic use: suppress banner, spinner, and tool previews. Only output the final response and session info.",
     )
     chat_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help=(
+            "Emit one hermes.chat.result.v1 JSON object containing reply and "
+            "session_id; implies --quiet."
+        ),
+    )
+    chat_parser.add_argument(
         "--resume",
         "-r",
         metavar="SESSION_ID",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2248,7 +2248,10 @@ def _resolve_use_tui(args) -> bool:
 
 def cmd_chat(args):
     """Run interactive chat CLI."""
-    use_tui = _resolve_use_tui(args)
+    json_output = getattr(args, "json_output", False)
+    if json_output:
+        args.quiet = True
+    use_tui = False if json_output else _resolve_use_tui(args)
 
     _apply_safe_mode(args)
 
@@ -2299,11 +2302,12 @@ def cmd_chat(args):
             from hermes_state import SessionDB
 
             _saved_cwd = ((SessionDB().get_session(args.resume) or {}).get("cwd") or "").strip()
-            if _saved_cwd and not os.path.isdir(_saved_cwd):
+            if _saved_cwd and not os.path.isdir(_saved_cwd) and not json_output:
                 print(f"⚠ session's recorded dir is gone ({_saved_cwd}); staying in {os.getcwd()}")
             elif _saved_cwd and os.path.realpath(_saved_cwd) != os.path.realpath(os.getcwd()):
                 os.chdir(_saved_cwd)
-                print(f"↪ restored workspace dir: {_saved_cwd}")
+                if not json_output:
+                    print(f"↪ restored workspace dir: {_saved_cwd}")
         except Exception:
             pass  # never let cwd-restore break a resume
 
@@ -2318,7 +2322,7 @@ def cmd_chat(args):
         from hermes_cli.config import load_config as _load_config_for_xai_check
 
         _retired_xai_refs = find_retired_xai_refs(_load_config_for_xai_check())
-        if _retired_xai_refs:
+        if _retired_xai_refs and not json_output:
             sys.stderr.write(
                 f"\033[33m⚠ xAI retires {len(_retired_xai_refs)} model(s) "
                 f"in your config on {RETIREMENT_DATE}:\033[0m\n"
@@ -2437,6 +2441,7 @@ def cmd_chat(args):
         "skills": getattr(args, "skills", None),
         "verbose": getattr(args, "verbose", None),
         "quiet": getattr(args, "quiet", False),
+        "json_output": json_output,
         "query": args.query,
         "image": getattr(args, "image", None),
         "resume": getattr(args, "resume", None),

--- a/tests/cli/test_json_chat_output.py
+++ b/tests/cli/test_json_chat_output.py
@@ -1,0 +1,141 @@
+"""Behavior tests for the versioned ``hermes chat --json`` contract."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import cli as cli_module
+
+
+CALLBACKS = (
+    "reasoning_callback",
+    "tool_progress_callback",
+    "tool_start_callback",
+    "tool_complete_callback",
+    "stream_delta_callback",
+    "tool_gen_callback",
+)
+
+
+class _FakeAgent:
+    def __init__(self, result, *, rotated_session_id=None):
+        self.result = result
+        self.session_id = rotated_session_id
+        for callback in CALLBACKS:
+            setattr(self, callback, lambda: print("callback leak"))
+
+    def run_conversation(self, **_kwargs):
+        assert all(getattr(self, callback) is None for callback in CALLBACKS)
+        print("reasoning leak")
+        raise_or_result = self.result
+        if isinstance(raise_or_result, Exception):
+            raise raise_or_result
+        return raise_or_result
+
+
+def _fake_cli_class(result, *, session_id="20260714_new", rotated_session_id=None):
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.session_id = session_id
+            self.conversation_history = []
+            self._active_agent_route_signature = None
+            self.agent = None
+            self.provider = "openrouter"
+            self.model = "z-ai/glm-5.2"
+
+        def _claim_active_session(self, *_args, **_kwargs):
+            print("claim leak")
+            return True
+
+        def _ensure_runtime_credentials(self):
+            print("credential leak")
+            return True
+
+        def _resolve_turn_agent_config(self, _query):
+            return {
+                "signature": "json-test",
+                "model": "z-ai/glm-5.2",
+                "runtime": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            print("initialization leak")
+            self.agent = _FakeAgent(
+                result,
+                rotated_session_id=rotated_session_id or self.session_id,
+            )
+            return True
+
+        def _release_active_session(self):
+            return None
+
+    return FakeCLI
+
+
+def _run_json(monkeypatch, capsys, result, **fake_kwargs):
+    monkeypatch.setattr(cli_module, "HermesCLI", _fake_cli_class(result, **fake_kwargs))
+    monkeypatch.setattr(cli_module, "_finalize_single_query", lambda _cli: None)
+    monkeypatch.setattr(cli_module.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("signal.signal", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(
+            query="Reply exactly: EMAIL-BRIDGE-OK",
+            toolsets="composio",
+            json_output=True,
+        )
+
+    return exc.value.code, capsys.readouterr()
+
+
+def test_json_output_is_one_exact_object_despite_noisy_agent(monkeypatch, capsys):
+    code, captured = _run_json(
+        monkeypatch,
+        capsys,
+        {"final_response": "EMAIL-BRIDGE-OK"},
+    )
+
+    assert code == 0
+    assert captured.err == ""
+    assert captured.out.count("\n") == 1
+    assert json.loads(captured.out) == {
+        "protocol": "hermes.chat.result.v1",
+        "reply": "EMAIL-BRIDGE-OK",
+        "session_id": "20260714_new",
+    }
+
+
+def test_json_output_reports_rotated_resumed_session(monkeypatch, capsys):
+    code, captured = _run_json(
+        monkeypatch,
+        capsys,
+        {"final_response": "continued"},
+        session_id="20260714_parent",
+        rotated_session_id="20260714_child",
+    )
+
+    assert code == 0
+    assert json.loads(captured.out)["session_id"] == "20260714_child"
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"final_response": "", "failed": True, "error": "provider secret"},
+        RuntimeError("secret traceback detail"),
+    ],
+)
+def test_json_failure_emits_no_success_object(monkeypatch, capsys, result):
+    code, captured = _run_json(monkeypatch, capsys, result)
+
+    assert code == 1
+    assert captured.out == ""
+    assert captured.err == "Hermes JSON chat failed\n"
+
+
+def test_json_allows_an_empty_reply(monkeypatch, capsys):
+    code, captured = _run_json(monkeypatch, capsys, {"final_response": ""})
+
+    assert code == 0
+    assert json.loads(captured.out)["reply"] == ""

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -109,6 +109,44 @@ class TestChatVerboseArg:
         assert "verbose" not in captured
 
 
+class TestChatJsonArg:
+    def test_json_flag_is_parsed(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        args = parser.parse_args(["chat", "--json"])
+
+        assert args.json_output is True
+
+    def test_cmd_chat_forwards_json_and_implies_quiet(self, monkeypatch):
+        import types
+
+        import hermes_cli.main as main_mod
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, chat_parser = build_top_level_parser()
+        chat_parser.set_defaults(func=main_mod.cmd_chat)
+        args = parser.parse_args(["chat", "--json"])
+        captured = {}
+        fake_cli = types.ModuleType("cli")
+        fake_cli.main = lambda **kwargs: captured.update(kwargs)
+        fake_banner = types.ModuleType("hermes_cli.banner")
+        fake_banner.prefetch_update_check = lambda: None
+        fake_skills_sync = types.ModuleType("tools.skills_sync")
+        fake_skills_sync.sync_skills = lambda quiet=True: None
+
+        monkeypatch.setitem(sys.modules, "cli", fake_cli)
+        monkeypatch.setitem(sys.modules, "hermes_cli.banner", fake_banner)
+        monkeypatch.setitem(sys.modules, "tools.skills_sync", fake_skills_sync)
+        monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+        monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+
+        main_mod.cmd_chat(args)
+
+        assert captured["json_output"] is True
+        assert captured["quiet"] is True
+
+
 class TestYoloEnvVar:
     """Verify --yolo sets HERMES_YOLO_MODE regardless of flag position.
 


### PR DESCRIPTION
## Summary
- add `hermes chat --json` with a versioned `hermes.chat.result.v1` result
- suppress reasoning, streaming, tool progress, and incidental process output
- emit no success JSON on failures and preserve existing non-JSON behavior

## Tests
- `scripts/run_tests.sh tests/cli/test_json_chat_output.py tests/hermes_cli/test_argparse_flag_propagation.py tests/cli/test_resume_quiet_stderr.py -j 3`
- targeted Ruff checks