### PR TITLE
fix(langfuse): include system prompt in generation input (Anthropic system + Codex instructions)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -187,6 +187,24 @@ def _print_nous_entitlement_guidance(agent, capability: str) -> bool:
     return True
 
 
+def _system_prompt_for_hooks(api_kwargs: Any, request_messages: Any) -> Any:
+    """System prompt as actually sent to the provider, for observability hooks.
+
+    Providers move it out of ``messages``: Anthropic Messages uses a separate
+    ``system`` kwarg (str or content-block list), the Responses/Codex API uses
+    top-level ``instructions``; Chat Completions keeps it as ``messages[0]``.
+    Returns None when the request carries no system prompt.
+    """
+    system_prompt = api_kwargs.get("system")
+    if system_prompt is None:
+        system_prompt = api_kwargs.get("instructions")
+    if system_prompt is None and isinstance(request_messages, list) and request_messages:
+        first = request_messages[0]
+        if isinstance(first, dict) and first.get("role") == "system":
+            system_prompt = first.get("content")
+    return system_prompt
+
+
 def _is_nous_inference_route(provider: str, base_url: str) -> bool:
     provider = (provider or "").strip().lower()
     if provider == "nous":
@@ -1214,6 +1232,13 @@ def run_conversation(
                             request_messages = api_kwargs.get("input")
                         if not isinstance(request_messages, list):
                             request_messages = api_messages
+                        # Anthropic (``system``) and Responses/Codex
+                        # (``instructions``) move the system prompt out of
+                        # messages; pass it explicitly for observability
+                        # plugins (Langfuse).
+                        system_prompt_for_hooks = _system_prompt_for_hooks(
+                            api_kwargs, request_messages
+                        )
                         # Shallow-copy the outer list so plugins that retain the
                         # reference for async snapshotting don't observe later
                         # mutations of api_messages.  The inner dicts are not
@@ -1248,6 +1273,7 @@ def run_conversation(
                             request_messages=list(request_messages)
                             if isinstance(request_messages, list)
                             else [],
+                            system_prompt=system_prompt_for_hooks,
                             message_count=len(api_messages),
                             tool_count=len(agent.tools or []),
                             approx_input_tokens=approx_tokens,

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -36,6 +36,10 @@ hermes plugins list                 # observability/langfuse should show "enable
 hermes chat -q "hello"              # then check Langfuse for a "Hermes turn" trace
 ```
 
+Generation observations include the Hermes system prompt when the provider
+uses a separate `system` param (Anthropic Messages API). Open an **LLM call**
+child span to inspect `role: system` (truncated via `HERMES_LANGFUSE_MAX_CHARS`).
+
 ## Optional tuning
 
 ```bash

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -482,6 +482,57 @@ def _coerce_request_messages(
     return [{"role": "user", "content": user_message}]
 
 
+def _serialize_system_prompt(system_prompt: Any) -> Optional[dict[str, Any]]:
+    """Normalize Anthropic/Bedrock ``system`` param or OpenAI-style system content for Langfuse."""
+    if system_prompt is None:
+        return None
+    if isinstance(system_prompt, str):
+        text = system_prompt.strip()
+        if not text:
+            return None
+        return {"role": "system", "content": _safe_value(text)}
+    if isinstance(system_prompt, list):
+        parts: list[str] = []
+        for block in system_prompt:
+            if isinstance(block, dict):
+                # Anthropic blocks carry {"type": "text", "text": ...}; Bedrock
+                # Converse system blocks are {"text": ...} with no "type" key.
+                block_type = block.get("type")
+                if block_type == "text" or (block_type is None and "text" in block):
+                    piece = block.get("text", "")
+                    if isinstance(piece, str) and piece:
+                        parts.append(piece)
+            elif isinstance(block, str) and block:
+                parts.append(block)
+        if not parts:
+            return None
+        return {"role": "system", "content": _safe_value("\n\n".join(parts))}
+    return None
+
+
+def _messages_for_langfuse_input(
+    *,
+    request_messages: Any = None,
+    messages: Any = None,
+    conversation_history: Any = None,
+    user_message: Any = None,
+    system_prompt: Any = None,
+) -> list[dict[str, Any]]:
+    """Build generation input: include Anthropic ``system`` when split out of ``messages``."""
+    raw = _coerce_request_messages(
+        request_messages=request_messages,
+        messages=messages,
+        conversation_history=conversation_history,
+        user_message=user_message,
+    )
+    if raw and raw[0].get("role") == "system":
+        return _serialize_messages(raw)
+    system_msg = _serialize_system_prompt(system_prompt)
+    if system_msg is None:
+        return _serialize_messages(raw)
+    return [system_msg, *_serialize_messages(raw)]
+
+
 def _serialize_messages(messages: Any) -> list[dict[str, Any]]:
     if not isinstance(messages, list):
         return []
@@ -845,6 +896,7 @@ def on_pre_llm_request(
     user_message: Any = None,
     turn_id: str = "",
     api_request_id: str = "",
+    system_prompt: Any = None,
     **_: Any,
 ) -> None:
     client = _get_langfuse()
@@ -857,6 +909,16 @@ def on_pre_llm_request(
         conversation_history=conversation_history,
         user_message=user_message,
     )
+    langfuse_input = _messages_for_langfuse_input(
+        request_messages=request_messages,
+        messages=messages,
+        conversation_history=conversation_history,
+        user_message=user_message,
+        system_prompt=system_prompt,
+    )
+    system_chars = 0
+    if langfuse_input and langfuse_input[0].get("role") == "system":
+        system_chars = len(str(langfuse_input[0].get("content") or ""))
 
     task_key = _trace_key(
         task_id,
@@ -888,18 +950,23 @@ def on_pre_llm_request(
         previous = state.generations.pop(req_key, None)
         if previous is not None:
             _end_observation(previous)
+        gen_metadata = {
+            "provider": provider,
+            "platform": platform,
+            "api_mode": api_mode,
+            "base_url": base_url,
+            "message_count": message_count,
+            "approx_input_tokens": approx_input_tokens,
+        }
+        if system_chars:
+            gen_metadata["system_prompt_chars"] = system_chars
         state.generations[req_key] = _start_child_observation(
             state,
             client=client,
             name=f"LLM call {api_call_count}",
             as_type="generation",
-            input_value=_serialize_messages(input_messages),
-            metadata={
-                "provider": provider,
-                "platform": platform,
-                "api_mode": api_mode,
-                "base_url": base_url,
-            },
+            input_value=langfuse_input,
+            metadata=gen_metadata,
             model=model,
             model_parameters={"api_mode": api_mode, "provider": provider},
         )

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -711,6 +711,33 @@ class TestRequestMessageCoercion:
         ) == [{"role": "user", "content": "h"}]
         assert mod._coerce_request_messages(user_message="u") == [{"role": "user", "content": "u"}]
 
+    def test_messages_for_langfuse_includes_anthropic_system_param(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        out = mod._messages_for_langfuse_input(
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt="You are Hermes.",
+        )
+        assert out[0]["role"] == "system"
+        assert out[0]["content"] == "You are Hermes."
+        assert out[1]["role"] == "user"
+
+    def test_messages_for_langfuse_skips_duplicate_system(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        out = mod._messages_for_langfuse_input(
+            request_messages=[
+                {"role": "system", "content": "already here"},
+                {"role": "user", "content": "hi"},
+            ],
+            system_prompt="ignored when messages include system",
+        )
+        assert out[0]["role"] == "system"
+        assert out[0]["content"] == "already here"
+        assert out[1]["role"] == "user"
+
 
 class TestToolCallOutputBackfill:
     def test_post_tool_call_backfills_matching_turn_tool_call_output(self, monkeypatch):
@@ -1021,3 +1048,256 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+class TestSystemPromptInGenerationInput:
+    """The generation input must carry the system prompt even for providers
+    that move it out of ``messages``: Anthropic Messages (``system`` kwarg)
+    and the Responses/Codex API (``instructions``).  Hermes forwards it to
+    hooks as ``system_prompt``; the plugin prepends a ``role: system`` entry.
+
+    Regression for the trace gap discussed in PR #32175 (Anthropic) and its
+    Codex sibling: without this, hosted traces show conversations without the
+    agent's instructions, skills, and memory."""
+
+    def _make_mod(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _capture_generation(self, mod, monkeypatch):
+        """Route on_pre_llm_request into a seeded TraceState and record the
+        generation observation kwargs."""
+        captured = {}
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        def fake_child(state_, **kw):
+            captured["input"] = kw.get("input_value")
+            captured["metadata"] = kw.get("metadata")
+            return object()
+
+        monkeypatch.setattr(mod, "_start_child_observation", fake_child)
+        return captured
+
+    def _fire(self, mod, *, request_messages, system_prompt=None):
+        kwargs = dict(
+            task_id="task-1",
+            session_id="sess-1",
+            model="m",
+            provider="p",
+            api_mode="codex_responses",
+            api_call_count=1,
+            request_messages=request_messages,
+        )
+        if system_prompt is not None:
+            kwargs["system_prompt"] = system_prompt
+        mod.on_pre_llm_request(**kwargs)
+
+    def test_string_system_prompt_prepended(self, monkeypatch):
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(
+            mod,
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt="You are Hermes.",
+        )
+        assert captured["input"][0]["role"] == "system"
+        assert captured["input"][0]["content"] == "You are Hermes."
+        assert captured["input"][1]["role"] == "user"
+
+    def test_anthropic_block_list_flattened(self, monkeypatch):
+        """Anthropic OAuth mode sends ``system`` as content blocks (with
+        cache_control); the trace should carry the readable text."""
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        blocks = [
+            {"type": "text", "text": "part one", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "part two"},
+        ]
+        self._fire(
+            mod,
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt=blocks,
+        )
+        first = captured["input"][0]
+        assert first["role"] == "system"
+        assert "part one" in first["content"]
+        assert "part two" in first["content"]
+
+    def test_no_duplicate_when_messages_already_carry_system(self, monkeypatch):
+        """chat_completions keeps system in messages[0]; forwarding
+        system_prompt as well must not produce two system entries."""
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(
+            mod,
+            request_messages=[
+                {"role": "system", "content": "You are Hermes."},
+                {"role": "user", "content": "hi"},
+            ],
+            system_prompt="You are Hermes.",
+        )
+        roles = [m["role"] for m in captured["input"]]
+        assert roles.count("system") == 1
+        assert roles[0] == "system"
+
+    def test_absent_system_prompt_keeps_previous_shape(self, monkeypatch):
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(mod, request_messages=[{"role": "user", "content": "hi"}])
+        assert captured["input"][0]["role"] == "user"
+        assert "system_prompt_chars" not in (captured["metadata"] or {})
+
+    def test_system_survives_serialization_window(self, monkeypatch):
+        """_serialize_messages keeps only the last 12 messages; the system
+        prompt must be prepended after windowing so long conversations
+        never drop it."""
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        many = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
+            for i in range(30)
+        ]
+        self._fire(mod, request_messages=many, system_prompt="SYS")
+        assert captured["input"][0]["role"] == "system"
+        # window (12) + prepended system
+        assert len(captured["input"]) == 13
+
+    def test_metadata_records_chars(self, monkeypatch):
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(
+            mod,
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt="You are Hermes.",
+        )
+        assert captured["metadata"]["system_prompt_chars"] == len("You are Hermes.")
+
+
+class TestSystemPromptCrossesHookBoundary:
+    """End-to-end across the hook seam with real transport-built kwargs —
+    the regression coverage PR #32175's review asked for: verify the
+    provider-specific request shape (Anthropic ``system`` kwarg, Codex
+    ``instructions``) actually reaches the Langfuse generation input, with
+    no Hermes internals mocked (only the Langfuse client is faked)."""
+
+    def _make_mod(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _capture_generation(self, mod, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        def fake_child(state_, **kw):
+            captured["input"] = kw.get("input_value")
+            return object()
+
+        monkeypatch.setattr(mod, "_start_child_observation", fake_child)
+        return captured
+
+    def _derive_and_fire(self, mod, api_kwargs, api_messages):
+        """Mirror agent/conversation_loop.py's pre_api_request emission:
+        derive request_messages exactly the way the loop does, derive
+        system_prompt via the loop's helper, and invoke the plugin hook."""
+        from agent.conversation_loop import _system_prompt_for_hooks
+
+        request_messages = api_kwargs.get("messages")
+        if not isinstance(request_messages, list):
+            request_messages = api_kwargs.get("input")
+        if not isinstance(request_messages, list):
+            request_messages = api_messages
+        mod.on_pre_llm_request(
+            task_id="task-1",
+            session_id="sess-1",
+            model="m",
+            provider="p",
+            api_mode="x",
+            api_call_count=1,
+            request_messages=list(request_messages),
+            system_prompt=_system_prompt_for_hooks(api_kwargs, request_messages),
+        )
+
+    def test_codex_instructions_reach_generation_input(self, monkeypatch):
+        from agent.transports.codex import ResponsesApiTransport
+
+        api_messages = [
+            {"role": "system", "content": "SYS-CODEX"},
+            {"role": "user", "content": "hi"},
+        ]
+        api_kwargs = ResponsesApiTransport().build_kwargs("gpt-x", api_messages, None)
+        # Premise: the Responses API moves the system prompt out of the input.
+        assert api_kwargs["instructions"] == "SYS-CODEX"
+        assert all(i.get("role") != "system" for i in api_kwargs["input"] if isinstance(i, dict))
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_messages)
+        assert captured["input"][0]["role"] == "system"
+        assert captured["input"][0]["content"] == "SYS-CODEX"
+
+    def test_anthropic_system_kwarg_reaches_generation_input(self, monkeypatch):
+        from agent.transports.anthropic import AnthropicTransport
+
+        api_messages = [
+            {"role": "system", "content": "SYS-ANTHROPIC"},
+            {"role": "user", "content": "hi"},
+        ]
+        api_kwargs = AnthropicTransport().build_kwargs(
+            "claude-x", api_messages, None, max_tokens=64
+        )
+        # Premise: the Messages API moves the system prompt to a kwarg.
+        assert "system" in api_kwargs
+        assert all(m.get("role") != "system" for m in api_kwargs["messages"])
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_messages)
+        assert captured["input"][0]["role"] == "system"
+        assert "SYS-ANTHROPIC" in captured["input"][0]["content"]
+
+    def test_bedrock_system_kwarg_reaches_generation_input(self, monkeypatch):
+        from agent.transports.bedrock import BedrockTransport
+
+        api_messages = [
+            {"role": "system", "content": "SYS-BEDROCK"},
+            {"role": "user", "content": "hi"},
+        ]
+        api_kwargs = BedrockTransport().build_kwargs(
+            "anthropic.claude-x", api_messages, None, max_tokens=64
+        )
+        # Premise: Bedrock Converse moves system into a separate 'system' kwarg,
+        # shaped as [{"text": ...}] blocks — no "type" key, unlike Anthropic.
+        assert api_kwargs["system"] == [{"text": "SYS-BEDROCK"}]
+        assert all(m.get("role") != "system" for m in api_kwargs["messages"])
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_messages)
+        assert captured["input"][0]["role"] == "system"
+        assert "SYS-BEDROCK" in captured["input"][0]["content"]
+
+    def test_chat_completions_shape_needs_no_fallback(self, monkeypatch):
+        """When system stays in messages[0] (chat_completions), the helper
+        returns it but the plugin must not duplicate the entry."""
+        from agent.conversation_loop import _system_prompt_for_hooks
+
+        api_kwargs = {
+            "messages": [
+                {"role": "system", "content": "SYS-CHAT"},
+                {"role": "user", "content": "hi"},
+            ]
+        }
+        sp = _system_prompt_for_hooks(api_kwargs, api_kwargs["messages"])
+        assert sp == "SYS-CHAT"
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_kwargs["messages"])
+        roles = [m["role"] for m in captured["input"]]
+        assert roles.count("system") == 1


### PR DESCRIPTION
## Summary

Langfuse **LLM call** generation observations show conversations without the agent's system prompt (skills, memory, SOUL, tool guidance) for every provider that moves the system prompt out of `messages`:

- **Anthropic Messages API** → separate `system` kwarg (`agent/anthropic_adapter.py`), reported in #32175
- **Responses/Codex API** → top-level `instructions` (`agent/transports/codex.py:132-139` extracts `messages[0]` into `instructions` and drops it from the payload) — the sibling call path, previously uncovered

The `pre_api_request` hook only forwarded `request_messages`, so traces for both paths looked like conversations with no instructions at all — e.g. a Codex-backed `Hermes turn` whose `LLM call 1` shows 18k prompt tokens but only a one-line user message as input.

This PR salvages #32175 by @db-aeon onto current `main` (cherry-picked so authorship survives, per the AGENTS.md salvage etiquette), then fixes the whole bug class:

- `agent/conversation_loop.py` derives the system prompt the provider actually receives — `api_kwargs["system"]` → `api_kwargs["instructions"]` → `messages[0]` fallback, extracted into a `_system_prompt_for_hooks()` helper — and passes it to `pre_api_request` as `system_prompt`
- `plugins/observability/langfuse` prepends a serialized `role: system` entry to the generation input (after the last-12 window, so long conversations never drop it), flattens Anthropic content-block lists, skips the prepend when `messages[0]` already carries the system role (chat_completions), and records `system_prompt_chars` metadata

## Commits

- **test(langfuse): system prompt must reach generation input across providers** — RED-first coverage: plugin contract (prepend, block-list flatten, no duplication, window-safe, metadata) **plus the cross-hook-boundary regression the #32175 review asked for** — real `ResponsesApiTransport().build_kwargs()` / `AnthropicTransport().build_kwargs()` output flows through the loop's derivation into the plugin hook with no Hermes internals mocked (only the Langfuse client is faked)
- **fix(langfuse): include Anthropic system prompt in generation input** (@db-aeon, cherry-picked from #32175; conflicts with the current middleware/hook block resolved)
- **fix(langfuse): carry Codex/Responses instructions into hook system_prompt** — the Codex sibling path + `_system_prompt_for_hooks()` extraction

## Test plan

- [x] `tests/plugins/test_langfuse_plugin.py` — 59 passed (48 pre-existing + 9 new + 2 from #32175)
- [x] Affected surface: `tests/plugins/`, `tests/hermes_cli/test_plugins.py`, `tests/run_agent/test_run_agent_codex_responses.py` — no regressions vs clean `main`
- [x] `scripts/run_tests.sh` full suite — remaining failures reproduce identically on clean `main` (environment-specific, macOS), zero delta from this change
- [x] E2E against a self-hosted Langfuse: enabled `observability/langfuse`, ran `hermes chat` on an `openai-codex` model — generation input now starts with `role: system` (102,659 chars, `system_prompt_chars` metadata matches); chat_completions sessions unchanged (single system entry, no duplication)

Closes #32175 (supersedes it while preserving its commit; happy to rebase if @db-aeon prefers to land his PR first — this one then shrinks to the Codex path + tests).
