### PR TITLE
feat(telemetry): opt-in per-turn waterfall tracing (HERMES_TURN_TRACE)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,33 @@
+feat(telemetry): opt-in per-turn waterfall tracing (HERMES_TURN_TRACE)
+
+## Problem
+
+When a turn feels slow there is no way to tell where the time went. A single user message crosses the gateway asyncio loop, the run_sync executor, the per-LLM-call worker, and concurrent tool executor threads; existing logs record isolated durations at best, so hermes-added overhead (persistence, compression preflight, context assembly, inter-tool delays, delivery) cannot be separated from model inference time, and regressions in the non-LLM portion of the turn go unnoticed until they are large.
+
+## Change
+
+Adds an opt-in, zero-dependency tracing instrument:
+
+- `agent/turn_trace.py` — span collector gated by `HERMES_TURN_TRACE=1` (default off). One JSON line per turn is appended to `~/.hermes/logs/turn_traces.jsonl` (override: `HERMES_TURN_TRACE_FILE`; 64 MB single-rotation cap; single `O_APPEND` write per record so a gateway daemon and a CLI run can share the sink). Spans store absolute wall-clock start/end; parent/child nesting is derived at render time from interval containment, so cross-thread and overlapping (concurrent tool batch) spans need no stack bookkeeping.
+- `agent/turn_trace_render.py` — `python -m agent.turn_trace_render` renders traces as a terminal waterfall (plus `--summary` cross-turn aggregation and `--html` export; `--demo` renders a built-in sample).
+- Span sites across the turn lifecycle: gateway ingest / session resolve / transcript load / hygiene / agent setup; turn prologue (system-prompt restore, early persist, compression preflight, pre-LLM hook, memory prefetch); per-iteration context assembly, request setup, LLM call (with TTFT and error attempts), accounting; tool batches including per-tool calls and the inter-tool delay sleep; verify gates; finalize children (trajectory, persist, post hooks, memory dispatch, resource cleanup); gateway persist; transport delivery.
+
+Trace ownership: for gateway turns the runner `begin()`s the trace at message ingress and the platform adapter `finish()`es it after delivery, so the record covers the full ingress-to-delivery interval; CLI turns begin/finish inside `run_conversation`. Because a turn crosses threads, the trace is carried explicitly — bound to objects the instrumentation sites already share (the event, its `SessionSource`, the agent instance) with a thread-local current as a same-thread convenience — never via ambient globals that could bleed across concurrent sessions.
+
+## Correctness notes
+
+- **Default off is a strict no-op**: every site is guarded by `trace is not None` (or the no-op-safe `turn_trace.span()` which returns a shared null context manager), so the disabled cost is one env/attribute check per site. No behavior change when disabled.
+- **Tracing can never break a turn**: sink emission catches all exceptions (unwritable sink, non-serializable tags fall back to `str`), `bind()` swallows `setattr` failures on slotted objects, and span context managers record-and-reraise without altering control flow.
+- **Pre-dispatch event replacement**: the `pre_gateway_dispatch` hook loop may swap the runner's event for a `dataclasses.replace` copy (prepend/rewrite directives), while the adapter's finish site holds the original event. The trace is therefore also bound to the shared `SessionSource`; finish sites resolve event-then-source and clear the source binding afterwards so a stale trace cannot leak into a later turn on a reused source.
+- **Lifecycle safety**: `finish()` is idempotent and first-status-wins; adapter cancel/error paths and a belt-and-braces `finally` all funnel through it. Cached agents outlive the turn, so the gateway clears the agent binding in a `finally`; pooled executor threads adopt the trace on entry (a previous turn's trace is already finished and inert). Span appends are lock-protected for concurrent tool executors, and `finish()` snapshots spans/tags before serializing.
+- Inline dispatches that bypass the adapter's background processing (bypass commands, clarify text-intercept, kanban watcher synthetic events) own the finish themselves so those records are not dropped.
+
+## Tests
+
+`tests/agent/test_turn_trace.py` (22 tests): disabled-path no-ops, full-cycle JSONL emission, idempotent finish, post-finish spans ignored, span sorting, bind/resolve precedence (explicit > bound > thread-local), worker-thread adoption, unwritable-sink survival, error tagging and re-raise, non-serializable tag fallback, concurrent span appends, and renderer demo mode.
+
+Suites run on this branch: `tests/agent` (5490 passed), `tests/gateway` + `tests/plugins` + `tests/run_agent` + `tests/scripts` (12876 passed) — failure sets are identical to a clean checkout of `main` run in the same environment (environment-dependent and order-dependent failures only; every difference between the two runs passes repeatedly when run standalone on this branch). `tests/run_agent` alone on this branch: 1974 passed, 0 failed.
+
+## Measured impact
+
+Used in production to attribute a "turns feel ~30% slower" report to concrete, fixable causes — first-call prompt-cache loss costing ~20 s per turn at 150k context, fixed 1.0 s inter-tool delay sleeps, ~19 ms-per-call HTTP client rebuilds, and synchronous persistence/accounting work sitting on the turn thread — findings that seeded the follow-up perf PRs #64169–#64172. When disabled (the default), overhead is a single env check per instrumentation site; when enabled, per-turn cost is one JSON serialization and one appending write.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2264,6 +2264,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # ``request_client_holder["diag"]`` for closure access.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
+        # Also stamped on the agent so the turn-trace retrofit in
+        # conversation_loop can tag ttft_ms on the llm.call span (the
+        # conversation loop clears this per attempt).
+        agent._last_stream_diag = _diag
         stream = request_client.chat.completions.create(**stream_kwargs)
 
         # Some OpenAI-compatible adapters (for example copilot-acp, and the MoA
@@ -2628,6 +2632,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
+        # Also stamped on the agent so the turn-trace retrofit in
+        # conversation_loop can tag ttft_ms on the llm.call span (the
+        # conversation loop clears this per attempt).
+        agent._last_stream_diag = _diag
         # Defensive: strip Responses-only kwargs (instructions, input, ...)
         # that can leak in under an api_mode-flip race. The Anthropic SDK
         # raises a non-retryable TypeError on them, killing the turn. See

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,6 +32,7 @@ from agent.conversation_compression import conversation_history_after_compressio
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
+from agent import turn_trace
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
@@ -531,6 +532,93 @@ def run_conversation(
     persist_user_timestamp: Optional[float] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
+    """Public entry — wraps ``_run_conversation_impl`` with per-turn tracing.
+
+    Trace ownership (see ``agent/turn_trace.py``): when a gateway already
+    began a trace and bound it to ``agent`` before dispatching here, this
+    function only adopts it for the current thread; the gateway finishes it
+    after delivery.  CLI/direct callers have no bound trace, so this function
+    begins and finishes one itself.  When tracing is disabled everything here
+    is a cheap no-op passthrough.
+    """
+    trace = turn_trace.get_bound(agent)
+    owner = False
+    if trace is None:
+        if turn_trace.enabled():
+            trace = turn_trace.begin(
+                key=agent.session_id or None,
+                platform=getattr(agent, "platform", None) or "cli",
+                session_key=agent.session_id or "",
+            )
+            owner = trace is not None
+            if owner:
+                turn_trace.bind(agent, trace)
+    else:
+        # Gateway-owned trace: make it current for THIS (run_sync worker) thread.
+        turn_trace.adopt(trace)
+    if trace is None:
+        return _run_conversation_impl(
+            agent, user_message, system_message, conversation_history, task_id,
+            stream_callback, persist_user_message, persist_user_timestamp,
+            moa_config,
+        )
+    _turn_started = time.time()
+    _result = None
+    try:
+        _result = _run_conversation_impl(
+            agent, user_message, system_message, conversation_history, task_id,
+            stream_callback, persist_user_message, persist_user_timestamp,
+            moa_config,
+        )
+        return _result
+    finally:
+        try:
+            # The loop body exits through many early `return` paths that skip
+            # its own post-loop close/tagging; close the in-flight iteration
+            # span and backfill exit_reason here so those turns still render.
+            _pending_iter = getattr(trace, "_pending_iteration", None)
+            if _pending_iter:
+                trace.add_span("iteration", _pending_iter[0], time.time(), i=_pending_iter[1])
+                trace._pending_iteration = None
+            if "exit_reason" not in trace.tags:
+                if _result is None:
+                    trace.tag(exit_reason="exception")
+                else:
+                    _err = _result.get("error") if isinstance(_result, dict) else None
+                    trace.tag(exit_reason=f"early_return({str(_err)[:80]})" if _err else "early_return")
+        except Exception:
+            pass
+        try:
+            _turn_tags = {
+                "model": agent.model,
+                "iterations": getattr(agent, "_api_call_count", 0),
+                "turn_id": getattr(agent, "_current_turn_id", "") or "",
+            }
+            # tool_calls / exit_reason are accumulated as trace-level tags by
+            # the loop body (they are locals there); surface them on the span.
+            for _k in ("tool_calls", "exit_reason"):
+                if _k in trace.tags:
+                    _turn_tags[_k] = trace.tags[_k]
+            trace.add_span("turn", _turn_started, time.time(), **_turn_tags)
+        except Exception:
+            pass
+        if owner:
+            trace.finish()
+            turn_trace.bind(agent, None)
+            turn_trace.adopt(None)
+
+
+def _run_conversation_impl(
+    agent,
+    user_message: str,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[str] = None,
+    persist_user_timestamp: Optional[float] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
 
@@ -602,6 +690,16 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    # Per-turn trace (None when tracing is disabled) — resolved once; every
+    # instrumentation site below is skipped/no-op when this is None.
+    _tt = turn_trace.get_bound(agent)
+    _iter_started = None  # start of the in-flight `iteration` span
+    # Monotonic pass ordinal for `iteration` spans. api_call_count is NOT
+    # unique per pass: the pre-API compression path refunds it (continue) and
+    # the interrupt check breaks before it increments, both of which would
+    # produce two spans tagged with the same i.
+    _iter_pass = 0
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
@@ -641,6 +739,20 @@ def run_conversation(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        # Close the previous pass's `iteration` span and open the next one.
+        # Retrofitted from timestamps (no context manager) because the loop
+        # body exits through many continue/break/return paths.
+        if _tt is not None:
+            _iter_now = time.time()
+            if _iter_started is not None:
+                _tt.add_span("iteration", _iter_started, _iter_now, i=_iter_pass)
+            _iter_started = _iter_now
+            _iter_pass += 1
+            # Mirrored onto the trace so the run_conversation wrapper's
+            # finally can close the in-flight span on the loop's early
+            # `return` paths, which bypass the post-loop close below.
+            _tt._pending_iteration = (_iter_started, _iter_pass)
+
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -757,6 +869,7 @@ def run_conversation(
         # Note: Reasoning is embedded in content via <think> tags for trajectory storage.
         # However, providers like Moonshot AI require a separate 'reasoning_content' field
         # on assistant messages with tool_calls. We handle both cases here.
+        _ctx_asm_started = time.time() if _tt is not None else None
         request_logger = getattr(agent, "logger", None) or logging.getLogger(__name__)
         repaired_tool_calls = agent._sanitize_tool_call_arguments(
             messages,
@@ -984,6 +1097,8 @@ def run_conversation(
         request_pressure_tokens = estimate_request_tokens_rough(
             api_messages, tools=agent.tools or None
         )
+        if _ctx_asm_started is not None:
+            _tt.add_span("iteration.context_assemble", _ctx_asm_started, time.time())
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, request_pressure_tokens
@@ -1116,6 +1231,7 @@ def run_conversation(
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
         api_kwargs = None  # Guard against UnboundLocalError in except handler
+        _llm_call_started = None  # trace: start of the in-flight llm.call attempt
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
 
@@ -1171,6 +1287,7 @@ def run_conversation(
                     pass  # Never let rate guard break the agent loop
 
             try:
+                _req_setup_started = time.time() if _tt is not None else None
                 agent._reset_stream_delivery_tracking()
                 # api_messages is built once, before this retry loop, while the
                 # primary provider is active.  A mid-conversation fallback can
@@ -1280,6 +1397,9 @@ def run_conversation(
                 if env_var_enabled("HERMES_DUMP_REQUESTS"):
                     agent._dump_api_request_debug(api_kwargs, reason="preflight")
 
+                if _req_setup_started is not None:
+                    _tt.add_span("iteration.request_setup", _req_setup_started, time.time())
+
                 # Always prefer the streaming path — even without stream
                 # consumers.  Streaming gives us fine-grained health
                 # checking (90s stale-stream detection, 60s read timeout)
@@ -1349,6 +1469,13 @@ def run_conversation(
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 
+                _llm_call_started = None
+                if _tt is not None:
+                    _llm_call_started = time.time()
+                    # Cleared per attempt so a stale diag from a previous
+                    # streaming call can't leak a wrong ttft_ms onto this one.
+                    agent._last_stream_diag = None
+
                 response = run_llm_execution_middleware(
                     api_kwargs,
                     _perform_api_call,
@@ -1367,7 +1494,24 @@ def run_conversation(
                 )
                 
                 api_duration = time.time() - api_start_time
-                
+
+                # The API call itself ran on a worker thread; retrofit the span
+                # from timings measured here to avoid adopt() plumbing there.
+                if _llm_call_started is not None:
+                    try:
+                        _llm_tags = {"api_request_id": api_request_id, "model": agent.model}
+                        _sd = getattr(agent, "_last_stream_diag", None)
+                        if isinstance(_sd, dict) and _sd.get("first_chunk_at"):
+                            _llm_tags["ttft_ms"] = round(
+                                (_sd["first_chunk_at"] - _sd["started_at"]) * 1000.0, 1
+                            )
+                        _tt.add_span("llm.call", _llm_call_started, time.time(), **_llm_tags)
+                    except Exception:
+                        pass
+                    # Consumed: a later exception in this try (post-response
+                    # processing) must not retrofit a second llm.call span.
+                    _llm_call_started = None
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:
@@ -2074,6 +2218,7 @@ def run_conversation(
                         }
                 
                 # Track actual token usage from response for context management
+                _acct_started = time.time() if _tt is not None else None
                 if hasattr(response, 'usage') and response.usage:
                     canonical_usage = normalize_usage(
                         response.usage,
@@ -2296,6 +2441,18 @@ def run_conversation(
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
                 
+                if _acct_started is not None:
+                    try:
+                        _acct_tags = {}
+                        if (hasattr(response, "usage") and response.usage
+                                and canonical_usage.cache_read_tokens and prompt_tokens):
+                            _acct_tags["cache_pct"] = round(
+                                100.0 * canonical_usage.cache_read_tokens / prompt_tokens, 1
+                            )
+                    except Exception:
+                        _acct_tags = {}
+                    _tt.add_span("llm.accounting", _acct_started, time.time(), **_acct_tags)
+
                 _retry.has_retried_429 = False  # Reset on success
                 # Note: don't clear the retry buffer here — an "API call
                 # success" only means we got bytes back, not that we got
@@ -2315,6 +2472,17 @@ def run_conversation(
                 break  # Success, exit retry loop
 
             except InterruptedError:
+                # Retrofit the llm.call span for the interrupted attempt so
+                # its (possibly long) wall time isn't misread as hermes
+                # overhead in the waterfall.
+                if _llm_call_started is not None:
+                    try:
+                        _tt.add_span("llm.call", _llm_call_started, time.time(),
+                                     api_request_id=api_request_id, model=agent.model,
+                                     error="InterruptedError")
+                    except Exception:
+                        pass
+                    _llm_call_started = None
                 if thinking_spinner:
                     thinking_spinner.stop("")
                     thinking_spinner = None
@@ -2340,6 +2508,16 @@ def run_conversation(
                 break
 
             except Exception as api_error:
+                # Retrofit the llm.call span for the failed attempt (retried
+                # or not) so its wall time isn't misread as hermes overhead.
+                if _llm_call_started is not None:
+                    try:
+                        _tt.add_span("llm.call", _llm_call_started, time.time(),
+                                     api_request_id=api_request_id, model=agent.model,
+                                     error=type(api_error).__name__)
+                    except Exception:
+                        pass
+                    _llm_call_started = None
                 # Stop spinner silently — retry status is buffered and
                 # only flushed when every retry+fallback is exhausted.
                 if thinking_spinner:
@@ -5223,6 +5401,7 @@ def run_conversation(
                 ):
                     messages.pop()
 
+                _verify_gate_started = time.time() if _tt is not None else None
                 try:
                     from agent.verification_stop import (
                         build_verify_on_stop_nudge,
@@ -5274,6 +5453,9 @@ def run_conversation(
                     # from unrelated error/recovery exits. (#61631)
                     _pending_verification_response = final_response
                     final_response = None
+                    if _verify_gate_started is not None:
+                        _tt.add_span("turn.verify_gate", _verify_gate_started, time.time(),
+                                     nudge_fired=True)
                     continue
 
                 # User verification-loop gate: when the agent edited code this
@@ -5327,6 +5509,9 @@ def run_conversation(
                                  agent._pre_verify_nudges)
                     _pending_verification_response = final_response
                     final_response = None
+                    if _verify_gate_started is not None:
+                        _tt.add_span("turn.verify_gate", _verify_gate_started, time.time(),
+                                     nudge_fired=True)
                     continue
 
                 # ── Kanban worker terminal-tool stop guard ─────────────
@@ -5375,6 +5560,9 @@ def run_conversation(
                     _pending_verification_response = final_response
                     final_response = None
                     continue
+
+                if _verify_gate_started is not None:
+                    _tt.add_span("turn.verify_gate", _verify_gate_started, time.time())
 
                 messages.append(final_msg)
                 
@@ -5440,6 +5628,17 @@ def run_conversation(
                 messages.append({"role": "assistant", "content": final_response})
                 break
     
+    if _tt is not None:
+        if _iter_started is not None:
+            _tt.add_span("iteration", _iter_started, time.time(), i=_iter_pass)
+        _tt._pending_iteration = None
+        try:
+            # Trace-level tag; the run_conversation wrapper copies it onto the
+            # root `turn` span (exit reason is a local of this function).
+            _tt.tag(exit_reason=_turn_exit_reason)
+        except Exception:
+            pass
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
@@ -5461,6 +5660,10 @@ def run_conversation(
         _pending_verification_response=_pending_verification_response,
     )
 
+
+# run_conversation is a thin tracing wrapper; expose the real body to
+# inspect.getsource/signature (source-inspecting tests count code in it).
+run_conversation.__wrapped__ = _run_conversation_impl
 
 
 __all__ = ["run_conversation"]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -21,6 +21,7 @@ import threading
 import time
 from typing import Any, Optional
 
+from agent import turn_trace
 from agent.display import (
     KawaiiSpinner,
     build_tool_preview as _build_tool_preview,
@@ -569,6 +570,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     agent._current_tool = tool_names_str
     agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
 
+    # Turn trace captured ONCE at fan-out. Workers must not resolve it via
+    # get_bound(agent) at completion time: a worker abandoned on deadline or
+    # interrupt (shutdown(wait=False) below) can outlive this batch and would
+    # otherwise inject its tools.call span into the NEXT turn's trace bound to
+    # the same cached agent instance.
+    _tt_batch = turn_trace.get_bound(agent)
+
     def _run_tool(index, tool_call, function_name, function_args, middleware_trace):
         """Worker function executed in a thread."""
         # Register this worker tid so the agent can fan out an interrupt
@@ -628,6 +636,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 duration = time.time() - start
                 logger.info("tool %s cancelled (%.2fs)", function_name, duration)
                 results[index] = (function_name, function_args, result, duration, True, False, middleware_trace)
+                # Worker threads never adopt() the trace — use the batch's
+                # own trace captured at fan-out (see comment there).
+                if _tt_batch is not None:
+                    _tt_batch.add_span("tools.call", start, time.time(), tool=function_name,
+                                       execute_ms=round(duration * 1000.0, 1), error="cancelled")
                 return
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
@@ -639,6 +652,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             else:
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
             results[index] = (function_name, function_args, result, duration, is_error, False, middleware_trace)
+            # Worker threads never adopt() the trace — use the batch's own
+            # trace captured at fan-out (see comment there).
+            if _tt_batch is not None:
+                _tt_batch.add_span("tools.call", start, time.time(), tool=function_name,
+                                   execute_ms=round(duration * 1000.0, 1))
         finally:
             # Tear down worker-tid tracking.  Clear any interrupt bit we may
             # have set so the next task scheduled onto this recycled tid
@@ -1033,6 +1051,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    # Per-turn trace (None when tracing is disabled).
+    _tt = turn_trace.get_bound(agent)
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
@@ -1057,6 +1077,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             break
 
         function_name = tool_call.function.name
+        _call_started = time.time() if _tt is not None else None
 
         function_args, malformed_args_result = _parse_tool_arguments(
             tool_call.function.arguments
@@ -1183,6 +1204,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent.tool_start_callback(tool_call.id, function_name, display_args)
             except Exception as cb_err:
                 logging.debug(f"Tool start callback error: {cb_err}")
+
+        _ckpt_started = time.time() if _tt is not None else None
 
         # Checkpoint: snapshot working dir before file-mutating tools
         if not _execution_blocked and function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
@@ -1682,10 +1705,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
             except Exception as cb_err:
                 logging.debug("Tool output risk callback error: %s", cb_err)
+        _flush_started = time.time() if _tt is not None else None
         _flush_session_db_after_tool_progress(
             agent,
             messages,
             stage=f"tool result {function_name}",
+        )
+        _flush_ms = (
+            round((time.time() - _flush_started) * 1000.0, 1)
+            if _flush_started is not None else None
         )
 
         # ── Per-tool /steer drain ───────────────────────────────────
@@ -1693,6 +1721,19 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # injection lands as soon as a tool finishes — not after the
         # entire batch.  The model sees it on the next API iteration.
         agent._apply_pending_steer_to_tool_results(messages, 1)
+
+        # Retrofitted (no context manager): the loop body exits through
+        # several continue/break paths before reaching here.
+        if _call_started is not None:
+            try:
+                _tt.add_span(
+                    "tools.call", _call_started, time.time(), tool=function_name,
+                    checkpoint_ms=round((tool_start_time - _ckpt_started) * 1000.0, 1),
+                    execute_ms=round(tool_duration * 1000.0, 1),
+                    flush_ms=_flush_ms,
+                )
+            except Exception:
+                pass
 
         if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             if agent.verbose_logging:
@@ -1722,7 +1763,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             break
 
         if agent.tool_delay > 0 and i < len(assistant_message.tool_calls):
-            time.sleep(agent.tool_delay)
+            # Own span so the (default 1.0s) inter-tool sleep is visible
+            # in the waterfall rather than blending into tools.call.
+            with turn_trace.span("tools.delay", trace=_tt):
+                time.sleep(agent.tool_delay)
 
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools_seq = len(assistant_message.tool_calls)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -24,10 +24,12 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from agent import turn_trace
 from agent.conversation_compression import conversation_history_after_compression
 from agent.iteration_budget import IterationBudget
 from agent.model_metadata import (
@@ -140,6 +142,10 @@ def build_turn_context(
     ``conversation_loop`` module are passed in explicitly to keep this module
     free of an import cycle with ``agent.conversation_loop``.
     """
+    # Per-turn trace (None when tracing is disabled).
+    _tt = turn_trace.get_bound(agent)
+    _prologue_started = time.time() if _tt is not None else None
+
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 
@@ -365,14 +371,16 @@ def build_turn_context(
         )
 
     # ── System prompt (cached per session for prefix caching) ──
-    if agent._cached_system_prompt is None:
-        restore_or_build_system_prompt(agent, system_message, conversation_history)
+    _sp_rebuilt = agent._cached_system_prompt is None
+    with turn_trace.span("prologue.system_prompt", trace=_tt, rebuilt=_sp_rebuilt):
+        if _sp_rebuilt:
+            restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     active_system_prompt = agent._cached_system_prompt
 
     # Create the DB session row now that _cached_system_prompt is populated, so
     # the persisted snapshot is written non-NULL on the first turn (Issue
-    # #45499). Keep row creation and the marker-based append in the same
+# #45499). Keep row creation and the marker-based append in the same
     # per-agent critical section as CLI close persistence.
     persist_lock = getattr(agent, "_session_persist_lock", None)
 
@@ -381,29 +389,32 @@ def build_turn_context(
         agent._persist_session(messages, conversation_history)
 
     # Crash-resilience: persist the inbound user turn as soon as the session row exists.
-    try:
-        if persist_lock is None:
-            _ensure_and_persist()
-        else:
-            with persist_lock:
+    with turn_trace.span("prologue.persist_early", trace=_tt):
+        try:
+            if persist_lock is None:
                 _ensure_and_persist()
-    except Exception:
-        logger.warning(
-            "Early turn-start session persistence failed for session=%s",
-            agent.session_id or "none",
-            exc_info=True,
-        )
-    finally:
-        # Keep an unmarked staged input available to a later close retry if the
-        # normal persistence attempt failed. Once the marker is present, the
-        # close path must no longer treat it as a pre-worker UI input.
-        if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
-            agent._pending_cli_user_message = None
+            else:
+                with persist_lock:
+                    _ensure_and_persist()
+        except Exception:
+            logger.warning(
+                "Early turn-start session persistence failed for session=%s",
+                agent.session_id or "none",
+                exc_info=True,
+            )
+        finally:
+            # Keep an unmarked staged input available to a later close retry if the
+            # normal persistence attempt failed. Once the marker is present, the
+            # close path must no longer treat it as a pre-worker UI input.
+            if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
+                agent._pending_cli_user_message = None
 
     # ── Preflight context compression ──
     # Gate the (expensive) full token estimate behind a cheap pre-check.
     # See ``_should_run_preflight_estimate`` for the OR semantics that fix
     # issue #27405 (a few very large messages slipping past the count gate).
+    _cpf_started = time.time() if _tt is not None else None
+    _cpf_compressed = False
     if agent.compression_enabled and _should_run_preflight_estimate(
         messages,
         agent.context_compressor.protect_first_n,
@@ -471,6 +482,7 @@ def build_turn_context(
                 getattr(agent, "codex_app_server_auto_compaction", "native"),
             )
         elif _compressor.should_compress(_preflight_tokens):
+            _cpf_compressed = True
             logger.info(
                 "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                 f"{_preflight_tokens:,}",
@@ -514,8 +526,13 @@ def build_turn_context(
                 if not _compressor.should_compress(_preflight_tokens):
                     break
 
+    if _cpf_started is not None:
+        _tt.add_span("prologue.compression_preflight", _cpf_started, time.time(),
+                     compressed=_cpf_compressed)
+
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
+    _hook_started = time.time() if _tt is not None else None
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
@@ -566,6 +583,8 @@ def build_turn_context(
             plugin_user_context = "\n\n".join(_ctx_parts)
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
+    if _hook_started is not None:
+        _tt.add_span("prologue.pre_llm_hook", _hook_started, time.time())
 
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
@@ -597,11 +616,16 @@ def build_turn_context(
     # External memory provider: prefetch once before the tool loop.
     ext_prefetch_cache = ""
     if agent._memory_manager:
-        try:
-            _query = original_user_message if isinstance(original_user_message, str) else ""
-            ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
-        except Exception:
-            pass
+        with turn_trace.span("prologue.memory_prefetch", trace=_tt) as _mp_span:
+            try:
+                _query = original_user_message if isinstance(original_user_message, str) else ""
+                ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+            except Exception:
+                pass
+            _mp_span.tag(decision="hit" if ext_prefetch_cache else "empty")
+
+    if _prologue_started is not None:
+        _tt.add_span("turn.prologue", _prologue_started, time.time())
 
     return TurnContext(
         user_message=user_message,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -23,7 +23,9 @@ keep the exact logger name (``"agent.conversation_loop"``).
 from __future__ import annotations
 
 import os
+import time
 
+from agent import turn_trace
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 
 
@@ -50,6 +52,10 @@ def finalize_turn(
     loop). See module docstring.
     """
     from agent.conversation_loop import logger
+
+    # Per-turn trace (None when tracing is disabled).
+    _tt = turn_trace.get_bound(agent)
+    _finalize_started = time.time() if _tt is not None else None
 
     budget_exhausted = (
         api_call_count >= agent.max_iterations
@@ -171,23 +177,26 @@ def finalize_turn(
 
     # Save trajectory if enabled.  ``user_message`` may be a multimodal
     # list of parts; the trajectory format wants a plain string.
-    try:
-        agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
-    except Exception as _save_err:
-        _cleanup_errors.append(f"save_trajectory: {_save_err}")
-        logger.error("finalize_turn: _save_trajectory failed: %s", _save_err, exc_info=True)
+    with turn_trace.span("finalize.trajectory", trace=_tt):
+        try:
+            agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
+        except Exception as _save_err:
+            _cleanup_errors.append(f"save_trajectory: {_save_err}")
+            logger.error("finalize_turn: _save_trajectory failed: %s", _save_err, exc_info=True)
 
     # Clean up VM and browser for this task after conversation completes
-    try:
-        agent._cleanup_task_resources(effective_task_id)
-    except Exception as _cleanup_err:
-        _cleanup_errors.append(f"cleanup_task_resources: {_cleanup_err}")
-        logger.error("finalize_turn: _cleanup_task_resources failed: %s", _cleanup_err, exc_info=True)
+    with turn_trace.span("finalize.resource_cleanup", trace=_tt):
+        try:
+            agent._cleanup_task_resources(effective_task_id)
+        except Exception as _cleanup_err:
+            _cleanup_errors.append(f"cleanup_task_resources: {_cleanup_err}")
+            logger.error("finalize_turn: _cleanup_task_resources failed: %s", _cleanup_err, exc_info=True)
 
     # Persist session to both JSON log and SQLite only after private retry
     # scaffolding has been removed. Otherwise a later user "continue" turn
     # can replay assistant("(empty)") / recovery nudges and fall into the
     # same empty-response loop again.
+    _persist_started = time.time() if _tt is not None else None
     try:
         agent._drop_trailing_empty_response_scaffolding(messages)
 
@@ -241,6 +250,8 @@ def finalize_turn(
     except Exception as _persist_err:
         _cleanup_errors.append(f"persist_session: {_persist_err}")
         logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)
+    if _persist_started is not None:
+        _tt.add_span("finalize.persist", _persist_started, time.time())
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.
@@ -301,6 +312,7 @@ def finalize_turn(
     # Gate: only applied when a real text response exists for this
     # turn and the user didn't interrupt.  Empty/interrupted turns
     # already have other surface text that shouldn't be augmented.
+    _hooks_started = time.time() if _tt is not None else None
     if final_response and not interrupted:
         try:
             _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
@@ -465,6 +477,8 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if _hooks_started is not None:
+        _tt.add_span("finalize.post_hooks", _hooks_started, time.time())
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Surface any post-loop cleanup failures so the caller can distinguish a
@@ -499,6 +513,7 @@ def finalize_turn(
         agent._iters_since_skill = 0
 
     # External memory provider: sync the completed turn + queue next prefetch.
+    _md_started = time.time() if _tt is not None else None
     agent._sync_external_memory_for_turn(
         original_user_message=original_user_message,
         final_response=final_response,
@@ -542,5 +557,10 @@ def finalize_turn(
         )
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)
+
+    if _md_started is not None:
+        _tt.add_span("finalize.memory_dispatch", _md_started, time.time())
+    if _finalize_started is not None:
+        _tt.add_span("turn.finalize", _finalize_started, time.time())
 
     return result

--- a/agent/turn_trace.py
+++ b/agent/turn_trace.py
@@ -1,0 +1,239 @@
+"""Per-turn waterfall tracing.
+
+Records timing spans for everything hermes does around the LLM call in a turn
+(gateway ingress, prologue, context assembly, LLM calls, tool dispatch,
+finalize, delivery) and emits ONE JSON line per turn to a rotating
+``~/.hermes/logs/turn_traces.jsonl`` sink, so turns can be rendered as a
+waterfall and hermes-added overhead separated from model inference time.
+
+Activation: ``HERMES_TURN_TRACE=1`` (also ``true``/``on``). When disabled every
+entry point is a cheap no-op. Sink override: ``HERMES_TURN_TRACE_FILE``.
+
+Threading model: a turn crosses threads (gateway asyncio loop -> run_sync
+worker -> per-LLM-call worker -> concurrent tool executors), so the trace is
+carried explicitly — instrumentation sites bind the trace to the object they
+already share (the agent instance) via :func:`bind` / :func:`get_bound`, with a
+thread-local *current* as a convenience for same-thread nesting. Spans store
+absolute wall-clock start/end; parent/child nesting is derived at render time
+from interval containment, so cross-thread and overlapping (concurrent tool
+batch) spans need no stack bookkeeping.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+_TRUTHY = ("1", "true", "on", "yes")
+
+# Single rotation keeps the sink bounded without a logging-handler dependency.
+_MAX_SINK_BYTES = 64 * 1024 * 1024
+
+_write_lock = threading.Lock()
+_tls = threading.local()
+
+
+def enabled() -> bool:
+    return os.environ.get("HERMES_TURN_TRACE", "").strip().lower() in _TRUTHY
+
+
+def sink_path() -> str:
+    override = os.environ.get("HERMES_TURN_TRACE_FILE", "").strip()
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(os.path.expanduser("~"), ".hermes", "logs", "turn_traces.jsonl")
+
+
+class Span:
+    __slots__ = ("name", "start", "end", "thread", "tags")
+
+    def __init__(self, name: str, start: float, end: float, thread: str, tags: Dict[str, Any]):
+        self.name = name
+        self.start = start
+        self.end = end
+        self.thread = thread
+        self.tags = tags
+
+    def to_wire(self, t0: float) -> Dict[str, Any]:
+        wire: Dict[str, Any] = {
+            "n": self.name,
+            "t0": round((self.start - t0) * 1000.0, 2),
+            "d": round((self.end - self.start) * 1000.0, 2),
+            "th": self.thread,
+        }
+        if self.tags:
+            wire["tags"] = self.tags
+        return wire
+
+
+class _SpanHandle:
+    """Context manager for an in-flight span; ``tag()`` adds attributes late."""
+
+    __slots__ = ("_trace", "name", "tags", "_start")
+
+    def __init__(self, trace: "TurnTrace", name: str, tags: Dict[str, Any]):
+        self._trace = trace
+        self.name = name
+        self.tags = tags
+        self._start = time.time()
+
+    def tag(self, **tags: Any) -> "_SpanHandle":
+        self.tags.update(tags)
+        return self
+
+    def __enter__(self) -> "_SpanHandle":
+        self._start = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if exc_type is not None:
+            self.tags.setdefault("error", exc_type.__name__)
+        self._trace.add_span(self.name, self._start, time.time(), **self.tags)
+
+
+class _NullSpan:
+    __slots__ = ()
+
+    def tag(self, **tags: Any) -> "_NullSpan":
+        return self
+
+    def __enter__(self) -> "_NullSpan":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+_NULL_SPAN = _NullSpan()
+
+
+class TurnTrace:
+    """Mutable collector for one turn; thread-safe span appends."""
+
+    def __init__(self, key: Optional[str] = None, started_at: Optional[float] = None, **tags: Any):
+        self.trace_id = uuid.uuid4().hex[:12]
+        self.key = key or self.trace_id
+        self.started_at = started_at if started_at is not None else time.time()
+        self.tags: Dict[str, Any] = dict(tags)
+        self._spans: List[Span] = []
+        self._lock = threading.Lock()
+        self._finished = False
+
+    def span(self, name: str, **tags: Any) -> _SpanHandle:
+        return _SpanHandle(self, name, tags)
+
+    def add_span(self, name: str, start: float, end: float, **tags: Any) -> None:
+        """Retrofit a span from timings measured elsewhere (e.g. api_duration)."""
+        s = Span(name, start, end, threading.current_thread().name, tags)
+        with self._lock:
+            self._spans.append(s)
+
+    def mark(self, name: str, at: Optional[float] = None, **tags: Any) -> None:
+        """Point-in-time event (zero-duration span)."""
+        ts = at if at is not None else time.time()
+        self.add_span(name, ts, ts, **tags)
+
+    def tag(self, **tags: Any) -> None:
+        with self._lock:
+            self.tags.update(tags)
+
+    def finish(self, **tags: Any) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            if self._finished:
+                return None
+            self._finished = True
+            self.tags.update(tags)
+            spans = list(self._spans)
+            # Snapshot: another thread (e.g. the run_sync executor after a
+            # cancel) can still tag() while json.dumps iterates the record.
+            final_tags = dict(self.tags)
+        ended_at = time.time()
+        record = {
+            "schema": 1,
+            "trace_id": self.trace_id,
+            "key": self.key,
+            "started_at": round(self.started_at, 3),
+            "duration_ms": round((ended_at - self.started_at) * 1000.0, 2),
+            "tags": final_tags,
+            "spans": [s.to_wire(self.started_at) for s in sorted(spans, key=lambda s: s.start)],
+        }
+        _emit(record)
+        return record
+
+
+def _emit(record: Dict[str, Any]) -> None:
+    try:
+        path = sink_path()
+        data = (json.dumps(record, ensure_ascii=False, default=str) + "\n").encode("utf-8")
+        with _write_lock:
+            parent = os.path.dirname(path)
+            if parent:  # bare relative sink filename: dirname is "" — append to CWD
+                os.makedirs(parent, exist_ok=True)
+            try:
+                if os.path.getsize(path) > _MAX_SINK_BYTES:
+                    os.replace(path, path + ".1")
+            except OSError:
+                pass
+            # Single O_APPEND write: atomic per record even when the gateway
+            # daemon and a CLI run share the default sink.
+            fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+            try:
+                os.write(fd, data)
+            finally:
+                os.close(fd)
+    except Exception:
+        # Tracing must never break a turn.
+        pass
+
+
+# --- carrying the trace ------------------------------------------------------
+
+_BIND_ATTR = "_hermes_turn_trace"
+
+
+def begin(key: Optional[str] = None, started_at: Optional[float] = None, **tags: Any) -> Optional[TurnTrace]:
+    """Start a trace (returns None when tracing is disabled)."""
+    if not enabled():
+        return None
+    trace = TurnTrace(key=key, started_at=started_at, **tags)
+    adopt(trace)
+    return trace
+
+
+def adopt(trace: Optional[TurnTrace]) -> None:
+    """Make ``trace`` current for THIS thread (worker-thread entry points)."""
+    _tls.trace = trace
+
+
+def current() -> Optional[TurnTrace]:
+    return getattr(_tls, "trace", None)
+
+
+def bind(obj: Any, trace: Optional[TurnTrace]) -> None:
+    """Attach the trace to a shared object (typically the agent instance)."""
+    try:
+        setattr(obj, _BIND_ATTR, trace)
+    except Exception:
+        pass
+
+
+def get_bound(obj: Any) -> Optional[TurnTrace]:
+    return getattr(obj, _BIND_ATTR, None)
+
+
+def span(name: str, trace: Optional[TurnTrace] = None, obj: Any = None, **tags: Any):
+    """No-op-safe span: resolves trace from arg, bound object, or thread-local."""
+    t = trace or (get_bound(obj) if obj is not None else None) or current()
+    if t is None or t._finished:
+        return _NULL_SPAN
+    return t.span(name, **tags)
+
+
+def mark(name: str, trace: Optional[TurnTrace] = None, obj: Any = None, **tags: Any) -> None:
+    t = trace or (get_bound(obj) if obj is not None else None) or current()
+    if t is not None and not t._finished:
+        t.mark(name, **tags)

--- a/agent/turn_trace_render.py
+++ b/agent/turn_trace_render.py
@@ -1,0 +1,613 @@
+"""Waterfall renderer for per-turn traces emitted by :mod:`agent.turn_trace`.
+
+Reads the JSONL sink (one record per turn) and renders each selected trace as
+an indented terminal waterfall — nesting derived from interval containment,
+bars drawn over the turn timeline with sub-cell unicode blocks, model time
+(``llm.call``) separated from hermes overhead. Also provides an aggregate
+``--summary`` table and a self-contained interactive ``--html`` export.
+
+Usage::
+
+    python -m agent.turn_trace_render [--file PATH] [--last N] [--trace ID]
+        [--min-ms F] [--width N] [--summary] [--html OUT] [--no-color] [--demo]
+
+Stdlib only; pure reader — never touches the live tracing hot path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html as _html
+import json
+import os
+import random
+import shutil
+import sys
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import turn_trace
+
+# Parent = smallest span fully containing this one, within this slack (ms).
+_SLACK_MS = 1.0
+
+# Left-anchored partial blocks for the trailing bar cell (~1/8 .. 8/8).
+_BLOCKS = "▏▎▍▌▊█"
+
+_DUR_W = 10  # "  1234.5ms"
+
+
+# --- data model ---------------------------------------------------------------
+
+
+class Node:
+    __slots__ = ("name", "t0", "d", "tags", "thread", "parent", "children", "depth")
+
+    def __init__(self, wire: Dict[str, Any]):
+        self.name = str(wire.get("n", "?"))
+        self.t0 = _f(wire.get("t0", 0.0))
+        self.d = max(0.0, _f(wire.get("d", 0.0)))
+        tags = wire.get("tags")
+        self.tags: Dict[str, Any] = tags if isinstance(tags, dict) else {}
+        self.thread = str(wire.get("th", ""))
+        self.parent: Optional["Node"] = None
+        self.children: List["Node"] = []
+        self.depth = 0
+
+    @property
+    def end(self) -> float:
+        return self.t0 + self.d
+
+    @property
+    def self_ms(self) -> float:
+        # Subtract the UNION of child intervals, not their sum: concurrent
+        # children overlap, and summing would zero out the parent's real
+        # dispatch/collection overhead.
+        covered = 0.0
+        cursor = self.t0
+        for c in sorted(self.children, key=lambda c: c.t0):
+            lo, hi = max(c.t0, cursor), min(c.end, self.end)
+            if hi > lo:
+                covered += hi - lo
+                cursor = hi
+        return max(0.0, self.d - covered)
+
+    def is_hot(self) -> bool:
+        return self.name == "tools.delay" or bool(self.tags.get("error"))
+
+
+def _f(v: Any) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def build_tree(span_wires: List[Any]) -> List[Node]:
+    """Return all nodes sorted by start, with parent/children/depth assigned.
+
+    Parent = smallest (by duration) other span that contains this one within
+    ``_SLACK_MS``; equal-duration ties resolve to the earlier-sorted span so
+    identical intervals cannot parent each other cyclically.
+    """
+    nodes = [Node(w) for w in span_wires if isinstance(w, dict)]
+    nodes.sort(key=lambda n: (n.t0, -n.d))
+    for i, s in enumerate(nodes):
+        best: Optional[Node] = None
+        for j, p in enumerate(nodes):
+            if j == i or p.d < s.d or (p.d == s.d and j > i):
+                continue
+            if p.t0 - _SLACK_MS <= s.t0 and s.end <= p.end + _SLACK_MS:
+                if best is None or p.d < best.d:
+                    best = p
+        s.parent = best
+    for n in nodes:
+        if n.parent is not None:
+            n.parent.children.append(n)
+    for n in nodes:
+        d, p = 0, n.parent
+        while p is not None:
+            d, p = d + 1, p.parent
+        n.depth = d
+    return nodes
+
+
+def visible_rows(nodes: List[Node], min_ms: float) -> List[Node]:
+    """Depth-first row order (children already sorted by start), filtered."""
+    roots = [n for n in nodes if n.parent is None]
+    out: List[Node] = []
+
+    def walk(n: Node) -> None:
+        if n.d >= min_ms:
+            out.append(n)
+        for c in n.children:
+            walk(c)
+
+    for r in roots:
+        walk(r)
+    return out
+
+
+# --- loading -------------------------------------------------------------------
+
+
+def load_traces(path: str) -> List[Dict[str, Any]]:
+    traces: List[Dict[str, Any]] = []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for i, line in enumerate(fh, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    if isinstance(rec, dict) and isinstance(rec.get("spans"), list):
+                        traces.append(rec)
+                    else:
+                        raise ValueError("not a trace record")
+                except Exception:
+                    sys.stderr.write(f"turn_trace_render: skipped corrupt line {i} in {path}\n")
+    except OSError as e:
+        sys.stderr.write(f"turn_trace_render: cannot read {path}: {e}\n")
+    return traces
+
+
+def select_traces(traces: List[Dict[str, Any]], trace_id: Optional[str], last: int) -> List[Dict[str, Any]]:
+    if trace_id:
+        return [t for t in traces if str(t.get("trace_id", "")).startswith(trace_id)]
+    return traces[-max(1, last):]
+
+
+# --- terminal rendering ---------------------------------------------------------
+
+
+class _Colors:
+    def __init__(self, on: bool):
+        self.model = "\x1b[34m" if on else ""
+        self.over = "\x1b[32m" if on else ""
+        self.hot = "\x1b[31;1m" if on else ""
+        self.dim = "\x1b[2m" if on else ""
+        self.bold = "\x1b[1m" if on else ""
+        self.reset = "\x1b[0m" if on else ""
+
+
+def _fmt_val(v: Any) -> str:
+    if isinstance(v, float):
+        return f"{v:g}"
+    return str(v)
+
+
+def _fmt_tags(tags: Dict[str, Any], limit: int = 0) -> str:
+    s = " ".join(f"{k}={_fmt_val(v)}" for k, v in tags.items())
+    if limit and len(s) > limit:
+        s = s[: max(0, limit - 1)] + "…"
+    return s
+
+
+def _bar(t0: float, d: float, total: float, width: int) -> Tuple[str, str, str]:
+    """(lead spaces, block chars, trailing pad) for one timeline row."""
+    scale = width / max(total, 0.001)
+    x0, x1 = t0 * scale, (t0 + d) * scale
+    i0 = min(width - 1, max(0, int(round(x0))))
+    cells = x1 - i0
+    if cells <= 0:
+        blocks = _BLOCKS[0]
+    else:
+        full = min(width - i0, int(cells))
+        frac = cells - full
+        blocks = _BLOCKS[-1] * full
+        if frac > 0 and i0 + full < width:
+            blocks += _BLOCKS[min(len(_BLOCKS) - 1, int(frac * len(_BLOCKS)))]
+        if not blocks:
+            blocks = _BLOCKS[0]
+    pad = max(0, width - i0 - len(blocks))
+    return " " * i0, blocks, " " * pad
+
+
+def _trace_stats(nodes: List[Node], duration_ms: float) -> Tuple[float, float]:
+    """(model_ms, overhead_ms) — model = sum of llm.call durations."""
+    model = sum(n.d for n in nodes if n.name == "llm.call")
+    return model, max(0.0, duration_ms - model)
+
+
+def render_waterfall(rec: Dict[str, Any], min_ms: float, width: int, colors: _Colors, out=None) -> None:
+    out = out or sys.stdout
+    c = colors
+    nodes = build_tree(rec.get("spans", []))
+    total = max(_f(rec.get("duration_ms", 0.0)), max((n.end for n in nodes), default=0.0), 0.001)
+    started = _f(rec.get("started_at", 0.0))
+    when = datetime.fromtimestamp(started).strftime("%Y-%m-%d %H:%M:%S") if started else "?"
+    tags = rec.get("tags") if isinstance(rec.get("tags"), dict) else {}
+
+    out.write(
+        f"{c.bold}── trace {rec.get('trace_id', '?')}{c.reset}  key={rec.get('key', '?')}"
+        f"  {when}  total {total:.1f}ms\n"
+    )
+    if tags:
+        out.write(f"   {c.dim}{_fmt_tags(tags)}{c.reset}\n")
+
+    rows = visible_rows(nodes, min_ms)
+    if not rows:
+        out.write("   (no spans" + ("" if nodes else " recorded") + f" >= {min_ms:g}ms)\n")
+    else:
+        name_w = min(40, max(16, max(len("  " * r.depth + r.name) for r in rows)))
+        tag_strs = [_fmt_tags(r.tags, 32) for r in rows]
+        tag_w = min(32, max(len(s) for s in tag_strs))
+        bar_w = max(16, width - name_w - _DUR_W - tag_w - 5)
+        for r, ts in zip(rows, tag_strs):
+            label = "  " * r.depth + r.name
+            if len(label) > name_w:
+                label = label[: name_w - 1] + "…"
+            lead, blocks, pad = _bar(r.t0, r.d, total, bar_w)
+            col = c.hot if r.is_hot() else (c.model if r.name == "llm.call" else c.over)
+            out.write(
+                f" {label:<{name_w}} {lead}{col}{blocks}{c.reset}{pad}"
+                f" {r.d:>{_DUR_W - 2}.1f}ms {c.dim}{ts}{c.reset}\n"
+            )
+
+    model, over = _trace_stats(nodes, total)
+    mp, op = 100.0 * model / total, 100.0 * over / total
+    out.write(
+        f"   total {total:.1f}ms   {c.model}model {model:.1f}ms ({mp:.1f}%){c.reset}"
+        f"   {c.over}hermes overhead {over:.1f}ms ({op:.1f}%){c.reset}\n"
+    )
+    top = sorted((n for n in nodes if n.name != "llm.call"), key=lambda n: n.self_ms, reverse=True)[:5]
+    if top:
+        parts = "  ".join(f"{n.name} {n.self_ms:.1f}" for n in top)
+        out.write(f"   top overhead self-time (ms): {parts}\n")
+    out.write("\n")
+
+
+# --- summary --------------------------------------------------------------------
+
+
+def _pctl(sorted_vals: List[float], p: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    k = (len(sorted_vals) - 1) * p
+    lo, hi = int(k), min(int(k) + 1, len(sorted_vals) - 1)
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (k - lo)
+
+
+def summarize(traces: List[Dict[str, Any]]) -> Dict[str, Any]:
+    per_name: Dict[str, Dict[str, Any]] = {}
+    model_pcts: List[float] = []
+    turn_ms: List[float] = []
+    for rec in traces:
+        nodes = build_tree(rec.get("spans", []))
+        total = max(_f(rec.get("duration_ms", 0.0)), max((n.end for n in nodes), default=0.0), 0.001)
+        turn_ms.append(total)
+        model, _ = _trace_stats(nodes, total)
+        model_pcts.append(100.0 * model / total)
+        self_by_name: Dict[str, float] = {}
+        for n in nodes:
+            st = per_name.setdefault(n.name, {"count": 0, "durs": [], "shares": [], "self_total": 0.0})
+            st["count"] += 1
+            st["durs"].append(n.d)
+            self_by_name[n.name] = self_by_name.get(n.name, 0.0) + n.self_ms
+        for name, self_ms in self_by_name.items():
+            per_name[name]["shares"].append(100.0 * self_ms / total)
+            per_name[name]["self_total"] += self_ms
+    return {
+        "n_traces": len(traces),
+        "turn_ms": turn_ms,
+        "model_pcts": model_pcts,
+        "per_name": per_name,
+    }
+
+
+def summary_rows(agg: Dict[str, Any]) -> List[Tuple[str, float, float, float, float]]:
+    """(name, count/turn, p50, p95, mean self%) sorted by pooled self-time."""
+    n = max(1, agg["n_traces"])
+    rows = []
+    for name, st in agg["per_name"].items():
+        durs = sorted(st["durs"])
+        shares = st["shares"]
+        rows.append(
+            (
+                name,
+                st["count"] / n,
+                _pctl(durs, 0.5),
+                _pctl(durs, 0.95),
+                sum(shares) / len(shares) if shares else 0.0,
+            )
+        )
+    rows.sort(key=lambda r: agg["per_name"][r[0]]["self_total"], reverse=True)
+    return rows
+
+
+def render_summary(traces: List[Dict[str, Any]], colors: _Colors, out=None) -> None:
+    out = out or sys.stdout
+    c = colors
+    agg = summarize(traces)
+    if not agg["n_traces"]:
+        out.write("no traces selected\n")
+        return
+    rows = summary_rows(agg)
+    name_w = max(4, max((len(r[0]) for r in rows), default=4))
+    out.write(f"{c.bold}summary over {agg['n_traces']} trace(s){c.reset}\n")
+    hdr = f" {'span':<{name_w}} {'n/turn':>7} {'p50 ms':>9} {'p95 ms':>9} {'self%':>7}"
+    out.write(hdr + "\n")
+    out.write(" " + "-" * (len(hdr) - 1) + "\n")
+    for name, cnt, p50, p95, share in rows:
+        out.write(f" {name:<{name_w}} {cnt:>7.1f} {p50:>9.1f} {p95:>9.1f} {share:>6.1f}%\n")
+    mean_turn = sum(agg["turn_ms"]) / agg["n_traces"]
+    mean_model = sum(agg["model_pcts"]) / agg["n_traces"]
+    out.write(
+        f"\n mean turn {mean_turn:.1f}ms   {c.model}model {mean_model:.1f}%{c.reset}"
+        f"   {c.over}hermes overhead {100.0 - mean_model:.1f}%{c.reset}\n"
+    )
+
+
+# --- html export ------------------------------------------------------------------
+
+_HTML_CSS = """
+:root { --bg:#ffffff; --fg:#1b1f24; --muted:#5b6470; --track:#eceff3; --border:#d7dce2;
+        --model:#3b82f6; --over:#10b981; --hot:#ef4444; }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#101418; --fg:#e4e8ec; --muted:#8b96a3; --track:#1d232b; --border:#2c343e; }
+}
+body { background:var(--bg); color:var(--fg); font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
+       max-width:1100px; margin:2rem auto; padding:0 1rem; }
+h1 { font-size:1.15rem; } h2 { font-size:1rem; margin:1.6rem 0 .4rem; }
+.meta { color:var(--muted); margin:.15rem 0 .6rem; }
+.row { display:grid; grid-template-columns:280px 1fr 90px; gap:8px; align-items:center; padding:1px 0; }
+.row.haskids .nm { cursor:pointer; }
+.nm { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; padding-left:calc(var(--depth)*14px); }
+.tw { display:inline-block; width:1em; color:var(--muted); }
+.track { position:relative; height:12px; background:var(--track); border-radius:3px; }
+.bar { position:absolute; top:0; height:100%; border-radius:2px; background:var(--over); min-width:2px; }
+.bar.model { background:var(--model); } .bar.hot { background:var(--hot); }
+.dur { text-align:right; font-variant-numeric:tabular-nums; color:var(--muted); }
+.footer { color:var(--muted); margin:.4rem 0 1.2rem; }
+.legend span { margin-right:1.2rem; }
+.dot { display:inline-block; width:.7em; height:.7em; border-radius:2px; margin-right:.35em; vertical-align:baseline; }
+table { border-collapse:collapse; margin:.6rem 0 1.5rem; }
+th, td { padding:3px 12px; border-bottom:1px solid var(--border); text-align:right; }
+th:first-child, td:first-child { text-align:left; }
+"""
+
+_HTML_JS = """
+document.querySelectorAll('.rows').forEach(function (root) {
+  var rows = Array.prototype.slice.call(root.querySelectorAll('.row'));
+  function kids(id) { return rows.filter(function (r) { return r.dataset.parent === id; }); }
+  function hideAll(id) {
+    kids(id).forEach(function (r) { r.style.display = 'none'; hideAll(r.dataset.id); });
+  }
+  function showKids(id) {
+    kids(id).forEach(function (r) {
+      r.style.display = '';
+      if (!r.classList.contains('collapsed')) showKids(r.dataset.id);
+    });
+  }
+  rows.forEach(function (r) {
+    if (!r.classList.contains('haskids')) return;
+    r.addEventListener('click', function () {
+      var closed = r.classList.toggle('collapsed');
+      r.querySelector('.tw').textContent = closed ? '\\u25b8' : '\\u25be';
+      if (closed) hideAll(r.dataset.id); else showKids(r.dataset.id);
+    });
+  });
+});
+"""
+
+
+def render_html(traces: List[Dict[str, Any]], min_ms: float, path: str) -> None:
+    e = _html.escape
+    parts: List[str] = []
+    parts.append(f"<style>{_HTML_CSS}</style>")
+    parts.append("<h1>hermes turn traces</h1>")
+    parts.append(
+        '<p class="legend"><span><i class="dot" style="background:var(--model)"></i>model (llm.call)</span>'
+        '<span><i class="dot" style="background:var(--over)"></i>hermes overhead</span>'
+        '<span><i class="dot" style="background:var(--hot)"></i>tools.delay / error</span>'
+        "<span>click a row to collapse its children</span></p>"
+    )
+    for rec in traces:
+        nodes = build_tree(rec.get("spans", []))
+        total = max(_f(rec.get("duration_ms", 0.0)), max((n.end for n in nodes), default=0.0), 0.001)
+        started = _f(rec.get("started_at", 0.0))
+        when = datetime.fromtimestamp(started).strftime("%Y-%m-%d %H:%M:%S") if started else "?"
+        tags = rec.get("tags") if isinstance(rec.get("tags"), dict) else {}
+        model, over = _trace_stats(nodes, total)
+        parts.append(f"<h2>trace {e(str(rec.get('trace_id', '?')))} &mdash; key={e(str(rec.get('key', '?')))}</h2>")
+        parts.append(f'<div class="meta">{e(when)} &middot; total {total:.1f}ms &middot; {e(_fmt_tags(tags))}</div>')
+        rows = visible_rows(nodes, min_ms)
+        ids = {id(n): str(i) for i, n in enumerate(rows)}
+        parts.append('<div class="rows">')
+        for n in rows:
+            rid = ids[id(n)]
+            pid = ids.get(id(n.parent), "") if n.parent is not None else ""
+            has_kids = any(c.d >= min_ms for c in n.children)
+            cls = "model" if n.name == "llm.call" else ("hot" if n.is_hot() else "")
+            left = 100.0 * n.t0 / total
+            w = max(0.05, 100.0 * n.d / total)
+            tip = f"{n.name}  {n.d:.1f}ms  @{n.t0:.1f}ms"
+            if n.tags:
+                tip += "\n" + "\n".join(f"{k}={_fmt_val(v)}" for k, v in n.tags.items())
+            tw = "▾" if has_kids else "&nbsp;"
+            parts.append(
+                f'<div class="row{" haskids" if has_kids else ""}" data-id="{rid}" data-parent="{pid}"'
+                f' style="--depth:{n.depth}" title="{e(tip)}">'
+                f'<span class="nm"><span class="tw">{tw}</span>{e(n.name)}</span>'
+                f'<span class="track"><span class="bar {cls}" style="left:{left:.3f}%;width:{w:.3f}%"></span></span>'
+                f'<span class="dur">{n.d:.1f}ms</span></div>'
+            )
+        parts.append("</div>")
+        mp = 100.0 * model / total
+        parts.append(
+            f'<div class="footer">model {model:.1f}ms ({mp:.1f}%) &middot; '
+            f"hermes overhead {over:.1f}ms ({100.0 - mp:.1f}%)</div>"
+        )
+    agg = summarize(traces)
+    if agg["n_traces"]:
+        parts.append(f"<h2>summary over {agg['n_traces']} trace(s)</h2>")
+        parts.append("<table><tr><th>span</th><th>n/turn</th><th>p50 ms</th><th>p95 ms</th><th>self%</th></tr>")
+        for name, cnt, p50, p95, share in summary_rows(agg):
+            parts.append(
+                f"<tr><td>{e(name)}</td><td>{cnt:.1f}</td><td>{p50:.1f}</td>"
+                f"<td>{p95:.1f}</td><td>{share:.1f}%</td></tr>"
+            )
+        parts.append("</table>")
+        mean_model = sum(agg["model_pcts"]) / agg["n_traces"]
+        parts.append(
+            f'<div class="footer">mean split: model {mean_model:.1f}% / overhead {100.0 - mean_model:.1f}%</div>'
+        )
+    parts.append(f"<script>{_HTML_JS}</script>")
+    doc = "<!doctype html><meta charset='utf-8'><title>turn traces</title>" + "".join(parts)
+    with open(os.path.expanduser(path), "w", encoding="utf-8") as fh:
+        fh.write(doc)
+
+
+# --- demo data --------------------------------------------------------------------
+
+
+def demo_traces(n: int = 3, seed: int = 7) -> List[Dict[str, Any]]:
+    """Synthetic-but-realistic traces so the renderer is testable without data."""
+    rng = random.Random(seed)
+    out = []
+    base = time.time() - 3600.0
+    for k in range(n):
+        spans: List[Dict[str, Any]] = []
+
+        def add(name: str, t0: float, d: float, **tags: Any) -> None:
+            w: Dict[str, Any] = {"n": name, "t0": round(t0, 2), "d": round(d, 2), "th": "demo"}
+            if tags:
+                w["tags"] = tags
+            spans.append(w)
+
+        # gateway ingress (~400ms)
+        add("gateway.session_resolve", 4, 38)
+        add("gateway.transcript_load", 46, rng.uniform(90, 150))
+        add("gateway.hygiene", 205, 32)
+        add("gateway.agent_setup", 242, rng.uniform(110, 150), rebuild=(k == 0))
+        add("gateway.ingest", 0, 400, platform="telegram", session_key=f"demo:{k}")
+
+        # prologue (~180ms)
+        t = 402.0
+        add("prologue.system_prompt", t + 2, 55, rebuilt=(k == 0))
+        add("prologue.persist_early", t + 60, 26)
+        add("prologue.compression_preflight", t + 88, 9, compressed=False)
+        add("prologue.pre_llm_hook", t + 99, 11)
+        add("prologue.memory_prefetch", t + 112, 62, decision="skip")
+        add("turn.prologue", t, 180)
+        t += 184
+
+        tool_calls = 0
+        for i in range(1, 4):
+            it0 = t
+            ca = rng.uniform(18, 55)
+            add("iteration.context_assemble", t, ca)
+            t += ca + 2
+            add("iteration.request_setup", t, 8)
+            t += 10
+            add("llm.client_create", t, 3)
+            t += 4
+            llm = rng.uniform(2000, 6000)
+            add(
+                "llm.call", t, llm,
+                api_request_id=f"req_{k}{i}{rng.randrange(16**6):06x}",
+                ttft_ms=round(rng.uniform(400, 1200)),
+                cache_pct=round(rng.uniform(40, 95), 1),
+                model="claude-opus-4",
+            )
+            t += llm + 1
+            add("llm.accounting", t, 5)
+            t += 7
+            if i < 3:
+                b0 = t
+                ncalls = rng.choice((1, 2))
+                for _ in range(ncalls):
+                    ex = rng.uniform(120, 700)
+                    add(
+                        "tools.call", t, ex + 40, tool=rng.choice(("terminal", "web_search", "read_file")),
+                        checkpoint_ms=round(rng.uniform(2, 15), 1), execute_ms=round(ex, 1),
+                        flush_ms=round(rng.uniform(5, 25), 1),
+                    )
+                    t += ex + 42
+                    tool_calls += 1
+                add("tools.delay", t, 1000)
+                t += 1001
+                add("tools.batch", b0, t - b0 - 1, count=ncalls, mode="sequential")
+            add("iteration", it0, t - it0, i=i)
+            t += 2
+        add("turn.verify_gate", t, 12, nudge_fired=False)
+        t += 14
+
+        f0 = t
+        add("finalize.trajectory", t + 2, 80)
+        add("finalize.resource_cleanup", t + 85, 28)
+        add("finalize.persist", t + 116, 120)
+        add("finalize.post_hooks", t + 240, 18)
+        add("finalize.memory_dispatch", t + 260, 38)
+        add("turn.finalize", f0, 300)
+        t = f0 + 302
+        add(
+            "turn", 400, t - 400,
+            turn_id=f"turn_{k}", model="claude-opus-4", iterations=3,
+            tool_calls=tool_calls, exit_reason="end_turn",
+        )
+        add("gateway.persist", t + 2, 250)
+        add("transport.delivery", t + 256, rng.uniform(40, 90))
+        end = t + 350
+
+        out.append(
+            {
+                "schema": 1,
+                "trace_id": "".join(rng.choice("0123456789abcdef") for _ in range(12)),
+                "key": f"demo:{k}",
+                "started_at": round(base + k * 120.0, 3),
+                "duration_ms": round(end, 2),
+                "tags": {
+                    "platform": "telegram", "model": "claude-opus-4", "iterations": 3,
+                    "tool_calls": tool_calls, "exit_reason": "end_turn",
+                },
+                "spans": sorted(spans, key=lambda s: s["t0"]),
+            }
+        )
+    return out
+
+
+# --- cli ----------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(prog="python -m agent.turn_trace_render", description=__doc__.split("\n")[0])
+    ap.add_argument("--file", default=None, help="trace jsonl (default: the turn_trace sink)")
+    ap.add_argument("--last", type=int, default=1, help="render the last N traces (default 1)")
+    ap.add_argument("--trace", default=None, help="select by trace_id (prefix match)")
+    ap.add_argument("--min-ms", type=float, default=1.0, help="hide spans shorter than this (default 1.0)")
+    ap.add_argument("--width", type=int, default=0, help="output width (default: terminal width)")
+    ap.add_argument("--summary", action="store_true", help="aggregate table instead of waterfalls")
+    ap.add_argument("--html", default=None, metavar="PATH", help="write a self-contained interactive HTML file")
+    ap.add_argument("--no-color", action="store_true", help="disable ANSI color")
+    ap.add_argument("--demo", action="store_true", help="render embedded synthetic traces (no sink needed)")
+    args = ap.parse_args(argv)
+
+    if args.demo:
+        traces = demo_traces()
+    else:
+        traces = load_traces(os.path.expanduser(args.file) if args.file else turn_trace.sink_path())
+    selected = select_traces(traces, args.trace, args.last)
+    if not selected:
+        sys.stderr.write("turn_trace_render: no matching traces\n")
+        return 1
+
+    width = args.width or shutil.get_terminal_size((120, 24)).columns
+    color_on = not args.no_color and "NO_COLOR" not in os.environ and sys.stdout.isatty()
+    colors = _Colors(color_on)
+
+    if args.html:
+        render_html(selected, args.min_ms, args.html)
+        print(f"wrote {args.html} ({len(selected)} trace(s))")
+    if args.summary:
+        render_summary(selected, colors)
+    elif not args.html:
+        for rec in selected:
+            render_waterfall(rec, args.min_ms, width, colors)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -502,6 +502,13 @@ from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
+try:
+    # Turn-waterfall tracing (no-op unless HERMES_TURN_TRACE is set).  Guarded
+    # so base.py stays importable without the agent package.
+    from agent import turn_trace as _turn_trace_mod
+except Exception:  # pragma: no cover
+    _turn_trace_mod = None
+
 
 GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Secure secret entry is not supported over messaging. "
@@ -4561,6 +4568,25 @@ class BasePlatformAdapter(ABC):
             return
         self._start_session_processing(pending_event, session_key)
 
+    def _finish_inline_turn_trace(self, event: MessageEvent) -> None:
+        """Finish (idempotent) a turn trace begun for an inline dispatch.
+
+        Call sites that await ``self._message_handler(event)`` OUTSIDE
+        ``_process_message_background`` (bypass commands, the clarify
+        text-intercept) own the trace lifecycle themselves: nothing downstream
+        finishes a trace the runner began and bound to the event, so without
+        this the record would be dropped un-emitted.
+        """
+        try:
+            _t = _turn_trace_mod.get_bound(event) if _turn_trace_mod is not None else None
+            if _t is None and _turn_trace_mod is not None:
+                _t = _turn_trace_mod.get_bound(getattr(event, "source", None))
+            if _t is not None:
+                _t.finish(status="ok")
+                _turn_trace_mod.bind(getattr(event, "source", None), None)
+        except Exception:
+            pass
+
     async def _dispatch_active_session_command(
         self,
         event: MessageEvent,
@@ -4635,6 +4661,8 @@ class BasePlatformAdapter(ABC):
                 else:
                     self._release_session_guard(session_key, guard=command_guard)
             raise
+        finally:
+            self._finish_inline_turn_trace(event)
 
         await self._drain_pending_after_session_command(session_key, command_guard)
 
@@ -4728,6 +4756,8 @@ class BasePlatformAdapter(ABC):
                             )
                 except Exception as e:
                     logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
+                finally:
+                    self._finish_inline_turn_trace(event)
                 return
 
             # Clarify reply bypass: if the agent is blocked on a
@@ -4784,6 +4814,8 @@ class BasePlatformAdapter(ABC):
                             "[%s] Clarify text-intercept dispatch failed: %s",
                             self.name, e, exc_info=True,
                         )
+                    finally:
+                        self._finish_inline_turn_trace(event)
                     return
 
             if self._busy_session_handler is not None:
@@ -4908,12 +4940,41 @@ class BasePlatformAdapter(ABC):
                 typing_task,
                 metadata=_thread_metadata,
             )
-        
+
+        def _resolve_turn_trace():
+            # The runner binds the trace to the event AND to event.source: the
+            # pre-dispatch hook loop may have swapped the runner's event for a
+            # dataclasses.replace copy (prepend/rewrite directives), in which
+            # case only the shared SessionSource still carries the binding.
+            if _turn_trace_mod is None:
+                return None
+            _t = _turn_trace_mod.get_bound(event)
+            if _t is None:
+                _t = _turn_trace_mod.get_bound(getattr(event, "source", None))
+            return _t
+
+        def _finish_turn_trace(status: str) -> None:
+            # Gateway owns the turn-trace lifecycle: the runner begin()s it at
+            # message ingress and binds it to this event; delivery timing and
+            # the (idempotent, first-status-wins) finish() happen here so the
+            # trace covers the full ingress → delivery interval.  Clear the
+            # source binding afterwards — SessionSource can outlive the event,
+            # and a stale trace must not leak into a later turn.
+            try:
+                _t = _resolve_turn_trace()
+                if _t is not None:
+                    _t.finish(status=status)
+                    _turn_trace_mod.bind(getattr(event, "source", None), None)
+            except Exception:
+                pass
+
+        _turn_trace = None
         try:
             await self._run_processing_hook("on_processing_start", event)
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            _turn_trace = _resolve_turn_trace()
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -4946,6 +5007,7 @@ class BasePlatformAdapter(ABC):
                 response = None
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+            _delivery_start = time.time() if _turn_trace is not None else 0.0
             if response:
                 # Capture [[as_document]] before extract_media strips it, so the
                 # dispatch partition below can route image-extension files
@@ -5205,6 +5267,16 @@ class BasePlatformAdapter(ABC):
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
 
+            if _turn_trace is not None:
+                if response:
+                    _turn_trace.add_span(
+                        "transport.delivery", _delivery_start, time.time(),
+                        delivered=delivery_succeeded,
+                    )
+                _turn_trace.finish(status="ok")
+                if _turn_trace_mod is not None:
+                    _turn_trace_mod.bind(getattr(event, "source", None), None)
+
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             await self._run_processing_hook(
@@ -5258,6 +5330,7 @@ class BasePlatformAdapter(ABC):
                 return  # Drain task owns the session now.
                 
         except asyncio.CancelledError:
+            _finish_turn_trace("cancelled")
             current_task = asyncio.current_task()
             outcome = ProcessingOutcome.CANCELLED
             if current_task is None or current_task not in self._expected_cancelled_tasks:
@@ -5265,6 +5338,7 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook("on_processing_complete", event, outcome)
             raise
         except Exception as e:
+            _finish_turn_trace("error")
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
@@ -5287,6 +5361,10 @@ class BasePlatformAdapter(ABC):
                     self.name, notify_err, exc_info=True,
                 )  # Last resort — don't let error reporting crash the handler
         finally:
+            # Belt-and-braces: every exit path above already finished the
+            # trace (finish() is idempotent, so this only fires if one was
+            # somehow missed).
+            _finish_turn_trace("error")
             # Stop typing before any deferred callback work.  Post-delivery
             # callbacks may perform platform I/O; a stuck callback must not
             # leave the typing refresh task running indefinitely.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -52,6 +52,7 @@ from typing import Callable, Dict, Optional, Any, List, Union
 # `gateway.run.fetch_account_usage` as a module-level attribute. The
 # gateway is a long-running daemon, so its boot cost matters less than
 # preserving the established test-patch surface.
+from agent import turn_trace
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
@@ -7711,7 +7712,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # adapter.handle_message would spawn a background task and we'd
         # lose synchronous error visibility; calling _handle_message inline
         # keeps the success/failure path observable for the watcher.
-        response_text = await self._handle_message(synthetic_event)
+        try:
+            response_text = await self._handle_message(synthetic_event)
+        finally:
+            # Inline dispatch bypasses the adapter's
+            # _process_message_background — the only place turn traces begun
+            # in _handle_message_with_agent are normally finished — so this
+            # caller owns finish() (idempotent) for the bound trace.
+            try:
+                _handoff_trace = turn_trace.get_bound(synthetic_event)
+                if _handoff_trace is None:
+                    # Pre-dispatch hooks may have replaced the runner's event
+                    # copy; the shared SessionSource still carries the binding.
+                    _handoff_trace = turn_trace.get_bound(
+                        getattr(synthetic_event, "source", None)
+                    )
+                if _handoff_trace is not None:
+                    _handoff_trace.finish(status="ok")
+                    turn_trace.bind(getattr(synthetic_event, "source", None), None)
+            except Exception:
+                pass
         if not response_text:
             # Streaming may have already delivered the response inline.
             # Either way, agent ran without raising — count as success.
@@ -10890,6 +10910,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
         )
 
+        # Turn trace: gateway owns begin(); finish() happens in the adapter's
+        # _process_message_background after delivery (bound to the event so it
+        # is reachable there).  None when HERMES_TURN_TRACE is unset — every
+        # use below is guarded.  Carried in locals/bound objects, never via
+        # thread-local: this coroutine shares the event loop thread with
+        # concurrent sessions.
+        _trace = turn_trace.begin(
+            key=_quick_key, started_at=_msg_start_time, platform=_platform_name,
+        )
+        if _trace is not None:
+            turn_trace.bind(event, _trace)
+            # The pre-dispatch hook loop may swap `event` for a copy
+            # (dataclasses.replace on prepend/rewrite directives), but the
+            # adapter's finish site still holds the ORIGINAL event.  The
+            # SessionSource object survives the replace, so bind it as the
+            # durable carrier; adapters resolve event-then-source and clear
+            # both after finish.
+            turn_trace.bind(source, _trace)
+            try:
+                _dbnc_ts = getattr(event, "_hermes_debounce_enqueue_ts", None)
+                if _dbnc_ts:
+                    _trace.mark("transport.inbound_debounce", at=float(_dbnc_ts))
+                    _trace.tag(debounce_ms=round(
+                        (_msg_start_time - float(_dbnc_ts)) * 1000.0, 1,
+                    ))
+            except Exception:
+                pass
+        _t_span = time.time() if _trace is not None else 0.0
+
         # Get or create session
         # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
         # last-active topic so a cross-topic Reply or stripped plain reply
@@ -11006,6 +11055,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await asyncio.to_thread(self._record_telegram_topic_binding, source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
+        if _trace is not None:
+            _trace.add_span("gateway.session_resolve", _t_span, time.time())
+            _trace.tag(session_key=session_key)
         # Capture and immediately consume was_auto_reset so it does not
         # re-fire on subsequent messages — preventing the cleanup from
         # wiping model/reasoning overrides set between turns (Closes #48031).
@@ -11176,8 +11228,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("[Gateway] Failed to auto-load skill(s) %s: %s", _skill_names, e)
 
         # Load conversation history from transcript
+        _t_span = time.time() if _trace is not None else 0.0
         history = await self.async_session_store.load_transcript(session_entry.session_id)
-        
+        if _trace is not None:
+            _trace.add_span("gateway.transcript_load", _t_span, time.time())
+            _t_span = time.time()
+
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
         #
@@ -11583,6 +11639,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Session hygiene auto-compress failed: %s", e
                         )
 
+        if _trace is not None:
+            _trace.add_span("gateway.hygiene", _t_span, time.time())
+
         # First-message onboarding -- only on the very first interaction ever
         if not history and not await self.async_session_store.has_any_sessions():
             # Default first-contact note: a brief self-introduction.
@@ -11754,7 +11813,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                turn_trace_obj=_trace,
             )
+            _t_persist = time.time() if _trace is not None else 0.0
 
             # Stop persistent typing indicator now that the agent is done.
             # Slack AI status is scoped to a thread/workspace, so preserve the
@@ -12263,6 +12324,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key, session_entry.session_id
             )
 
+            if _trace is not None:
+                _trace.add_span("gateway.persist", _t_persist, time.time())
+
             # Intentional silence is a delivery decision, not a transcript
             # mutation.  The agent's [SILENT]/NO_REPLY assistant turn above is
             # still persisted in session history so later turns keep normal
@@ -12338,6 +12402,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
             logger.exception("Agent error in session %s", session_key)
+            if _trace is not None:
+                _trace.tag(gateway_error=type(e).__name__)
             # Crash-resilience for failures that happen before AIAgent enters
             # run_conversation() (for example: provider/httpx client init
             # failures). In that path the agent cannot persist the current
@@ -17200,6 +17266,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        turn_trace_obj: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -17218,6 +17285,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                turn_trace_obj=turn_trace_obj,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -17229,6 +17297,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                turn_trace_obj=turn_trace_obj,
             )
 
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
@@ -17261,6 +17330,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        turn_trace_obj: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -17276,6 +17346,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
+            if turn_trace_obj is not None:
+                turn_trace_obj.add_span(
+                    "gateway.ingest", turn_trace_obj.started_at, time.time(),
+                    platform=source.platform.value if source.platform else "",
+                    session_key=session_key,
+                )
             return await self._run_agent_via_proxy(
                 message=message,
                 context_prompt=context_prompt,
@@ -18231,6 +18307,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # `_resolve_turn_agent_config(message, …)`.
             nonlocal message
 
+            # Executor-thread entry: make the turn trace this thread's current
+            # so same-thread instrumentation resolves it before the agent is
+            # bound.  (Executor threads are pooled; a previous turn's trace is
+            # already finished and therefore inert.)
+            if turn_trace_obj is not None:
+                turn_trace.adopt(turn_trace_obj)
+
             # session_key is propagated via contextvars in _set_session_env()
             # (_SESSION_KEY) and via set_current_session_key() (_approval_session_key)
             # below — both concurrency-safe and inherited by tool worker threads.
@@ -18408,6 +18491,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     log_message="interim_assistant_callback scheduling error",
                 )
 
+            _t_setup = time.time() if turn_trace_obj is not None else 0.0
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
 
             # Check agent cache — reuse the AIAgent from the previous message
@@ -18592,6 +18676,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
+
+            if turn_trace_obj is not None:
+                turn_trace_obj.add_span(
+                    "gateway.agent_setup", _t_setup, time.time(),
+                    rebuild=not reused_cached_agent,
+                )
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
@@ -19119,6 +19209,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
+                # Bind the trace to the agent instance so agent-side spans
+                # resolve it (run_conversation sees a bound trace and does not
+                # begin/finish its own).  Cached agents outlive the turn, so
+                # the finally below MUST clear the binding — a stale trace
+                # must not leak into the next turn.
+                if turn_trace_obj is not None:
+                    turn_trace.bind(agent, turn_trace_obj)
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
                 # content list. Consume-and-clear so subsequent turns on the same
@@ -19178,6 +19275,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception:
                     pass
                 reset_current_session_key(_approval_session_token)
+                if turn_trace_obj is not None:
+                    turn_trace.bind(agent, None)
             result_holder[0] = result
 
             # Signal the stream consumer that the agent is done
@@ -19735,6 +19834,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _agent_warning_raw = _float_env("HERMES_AGENT_TIMEOUT_WARNING", 900)
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
+            # gateway.ingest envelope: message ingress up to the run_sync
+            # dispatch.  (gateway.agent_setup happens inside the worker and
+            # renders as a sibling — interval containment, not a stack.)
+            if turn_trace_obj is not None:
+                turn_trace_obj.add_span(
+                    "gateway.ingest", turn_trace_obj.started_at, time.time(),
+                    platform=source.platform.value if source.platform else "",
+                    session_key=session_key,
+                )
             _executor_task = asyncio.ensure_future(
                 self._run_in_executor_with_context(run_sync)
             )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -18,6 +18,7 @@ import html as _html
 import re
 import threading
 from contextvars import ContextVar
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -7916,6 +7917,9 @@ class TelegramAdapter(BasePlatformAdapter):
         chunk_len = len(event.text or "")
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            # First-chunk enqueue time; the gateway runner uses it to surface
+            # the debounce delay in turn traces (transport.inbound_debounce).
+            event._hermes_debounce_enqueue_ts = time.time()  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event
         else:
             # Append text from the follow-up chunk

--- a/run_agent.py
+++ b/run_agent.py
@@ -113,6 +113,7 @@ from agent.process_bootstrap import (
     _SafeWriter,  # noqa: F401  # re-exported for tests that `from run_agent import _SafeWriter`
     _get_proxy_for_base_url,
 )
+from agent import turn_trace
 from agent.iteration_budget import IterationBudget
 
 
@@ -4157,30 +4158,33 @@ class AIAgent:
     def _create_request_openai_client(self, *, reason: str, api_kwargs: Optional[dict] = None) -> Any:
         from unittest.mock import Mock
 
-        primary_client = self._ensure_primary_openai_client(reason=reason)
-        if self.provider == "moa":
-            return primary_client
-        if isinstance(primary_client, Mock):
-            return primary_client
-        with self._openai_client_lock():
-            request_kwargs = dict(self._client_kwargs)
-        # Per-request OpenAI-wire clients (used by both the non-streaming
-        # chat-completions path and the streaming chat-completions path
-        # in `_interruptible_api_call`) should not run the SDK's built-in
-        # retry loop: the agent's outer loop owns retries with credential
-        # rotation, provider fallback, and backoff that the SDK can't
-        # see. Leaving SDK retries on (default 2) compounds with our outer
-        # retries and lets a single hung provider request stretch to ~3x
-        # the per-call timeout before our stale detector reports it.
-        # Shared/primary clients and Anthropic / Bedrock paths are
-        # unaffected (they don't go through here).
-        request_kwargs["max_retries"] = 0
-        if (
-            base_url_host_matches(str(request_kwargs.get("base_url", "")), "githubcopilot.com")
-            and self._api_kwargs_have_image_parts(api_kwargs or {})
-        ):
-            request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
-        return self._create_openai_client(request_kwargs, reason=reason, shared=False)
+        # obj=self: this can run on a per-LLM-call worker thread, where the
+        # thread-local trace is not adopted — resolve via the bound agent.
+        with turn_trace.span("llm.client_create", obj=self):
+            primary_client = self._ensure_primary_openai_client(reason=reason)
+            if self.provider == "moa":
+                return primary_client
+            if isinstance(primary_client, Mock):
+                return primary_client
+            with self._openai_client_lock():
+                request_kwargs = dict(self._client_kwargs)
+            # Per-request OpenAI-wire clients (used by both the non-streaming
+            # chat-completions path and the streaming chat-completions path
+            # in `_interruptible_api_call`) should not run the SDK's built-in
+            # retry loop: the agent's outer loop owns retries with credential
+            # rotation, provider fallback, and backoff that the SDK can't
+            # see. Leaving SDK retries on (default 2) compounds with our outer
+            # retries and lets a single hung provider request stretch to ~3x
+            # the per-call timeout before our stale detector reports it.
+            # Shared/primary clients and Anthropic / Bedrock paths are
+            # unaffected (they don't go through here).
+            request_kwargs["max_retries"] = 0
+            if (
+                base_url_host_matches(str(request_kwargs.get("base_url", "")), "githubcopilot.com")
+                and self._api_kwargs_have_image_parts(api_kwargs or {})
+            ):
+                request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
+            return self._create_openai_client(request_kwargs, reason=reason, shared=False)
 
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)
@@ -5724,32 +5728,45 @@ class AIAgent:
         """
         tool_calls = assistant_message.tool_calls
 
+        # Per-turn trace: running tool_calls total lives in the trace tags so
+        # the run_conversation wrapper can copy it onto the root `turn` span.
+        _tt = turn_trace.get_bound(self)
+        if _tt is not None:
+            try:
+                _tt.tag(tool_calls=_tt.tags.get("tool_calls", 0) + len(tool_calls))
+            except Exception:
+                pass
+
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:
             if len(tool_calls) <= 1:
-                return self._execute_tool_calls_sequential(
-                    assistant_message, messages, effective_task_id, api_call_count
-                )
+                with turn_trace.span("tools.batch", trace=_tt, count=len(tool_calls), mode="sequential"):
+                    return self._execute_tool_calls_sequential(
+                        assistant_message, messages, effective_task_id, api_call_count
+                    )
 
             from agent.tool_dispatch_helpers import _plan_tool_batch_segments
             segments = _plan_tool_batch_segments(tool_calls)
 
             if len(segments) == 1:
                 kind = segments[0][0]
-                if kind == "parallel":
-                    return self._execute_tool_calls_concurrent(
+                _mode = "parallel" if kind == "parallel" else "sequential"
+                with turn_trace.span("tools.batch", trace=_tt, count=len(tool_calls), mode=_mode):
+                    if kind == "parallel":
+                        return self._execute_tool_calls_concurrent(
+                            assistant_message, messages, effective_task_id, api_call_count
+                        )
+                    return self._execute_tool_calls_sequential(
                         assistant_message, messages, effective_task_id, api_call_count
                     )
-                return self._execute_tool_calls_sequential(
-                    assistant_message, messages, effective_task_id, api_call_count
-                )
 
             from agent.tool_executor import execute_tool_calls_segmented
-            return execute_tool_calls_segmented(
-                self, assistant_message, messages, effective_task_id, api_call_count,
-                segments=segments,
-            )
+            with turn_trace.span("tools.batch", trace=_tt, count=len(tool_calls), mode="segmented"):
+                return execute_tool_calls_segmented(
+                    self, assistant_message, messages, effective_task_id, api_call_count,
+                    segments=segments,
+                )
         finally:
             self._executing_tools = False
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
+    "qlskssk@gmail.com": "Soju06",  # agent turn-latency perf PRs
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)

--- a/tests/agent/test_turn_trace.py
+++ b/tests/agent/test_turn_trace.py
@@ -1,0 +1,330 @@
+"""Tests for agent.turn_trace (per-turn waterfall tracing).
+
+Covers the env gate (everything is a no-op when HERMES_TURN_TRACE is unset),
+the single-JSON-line-per-turn sink contract, trace carrying across threads
+(bind/get_bound, adopt), and error tolerance (tracing must never raise into
+the turn).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from agent import turn_trace
+from agent.turn_trace import _NULL_SPAN, TurnTrace
+
+
+class _Carrier:
+    """Stand-in for the shared object (agent instance) traces bind to."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_trace_state(monkeypatch):
+    """Isolate env gate and thread-local current between tests."""
+    monkeypatch.delenv("HERMES_TURN_TRACE", raising=False)
+    monkeypatch.delenv("HERMES_TURN_TRACE_FILE", raising=False)
+    turn_trace.adopt(None)
+    yield
+    turn_trace.adopt(None)
+
+
+@pytest.fixture
+def sink(tmp_path, monkeypatch):
+    """Enable tracing with the sink redirected into tmp_path."""
+    path = tmp_path / "turn_traces.jsonl"
+    monkeypatch.setenv("HERMES_TURN_TRACE", "1")
+    monkeypatch.setenv("HERMES_TURN_TRACE_FILE", str(path))
+    return path
+
+
+def _read_records(path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines]
+
+
+# ---------------------------------------------------------------------------
+# Disabled by default
+# ---------------------------------------------------------------------------
+
+class TestDisabled:
+    def test_enabled_false_when_env_unset(self):
+        assert turn_trace.enabled() is False
+
+    def test_begin_returns_none(self):
+        assert turn_trace.begin(key="k", platform="test") is None
+
+    def test_span_without_trace_is_working_noop(self):
+        handle = turn_trace.span("x")
+        assert handle is _NULL_SPAN
+        # Must behave as a full context manager with a chainable tag().
+        with turn_trace.span("x", foo=1) as h:
+            assert h.tag(bar=2) is h
+
+    def test_mark_without_trace_is_noop(self):
+        turn_trace.mark("x", foo=1)  # must not raise
+
+    def test_null_span_swallows_nothing(self):
+        # Exceptions still propagate through the null span.
+        with pytest.raises(ValueError):
+            with turn_trace.span("x"):
+                raise ValueError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Enabled: full begin -> span -> finish cycle
+# ---------------------------------------------------------------------------
+
+class TestEnabled:
+    def test_full_cycle_emits_one_json_line(self, sink):
+        trace = turn_trace.begin(key="sess:1", platform="test")
+        assert isinstance(trace, TurnTrace)
+        assert turn_trace.current() is trace
+
+        trace.tag(model="fake-model")
+        with turn_trace.span("iteration", trace=trace, i=1) as h:
+            time.sleep(0.01)
+            h.tag(late="yes")
+        turn_trace.mark("event", trace=trace, kind="ping")
+
+        record = trace.finish(exit_reason="done")
+        assert record is not None
+
+        records = _read_records(sink)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec == record
+        assert rec["schema"] == 1
+        assert rec["key"] == "sess:1"
+        assert rec["tags"] == {
+            "platform": "test",
+            "model": "fake-model",
+            "exit_reason": "done",
+        }
+
+        by_name = {s["n"]: s for s in rec["spans"]}
+        assert set(by_name) == {"iteration", "event"}
+
+        span = by_name["iteration"]
+        assert span["tags"] == {"i": 1, "late": "yes"}
+        # t0/d are relative milliseconds; the sleep(0.01) must be visible
+        # but the whole test ran in well under a second.
+        assert 0 <= span["t0"] < 1000
+        assert 10 <= span["d"] < 1000
+
+        mark = by_name["event"]
+        assert mark["d"] == 0
+        assert mark["tags"] == {"kind": "ping"}
+
+        assert rec["duration_ms"] >= span["d"]
+
+    def test_finish_is_idempotent(self, sink):
+        trace = turn_trace.begin(key="k")
+        assert trace.finish() is not None
+        assert trace.finish() is None
+        assert len(_read_records(sink)) == 1
+
+    def test_span_after_finish_is_noop(self, sink):
+        trace = turn_trace.begin(key="k")
+        trace.finish()
+        assert turn_trace.span("late", trace=trace) is _NULL_SPAN
+        turn_trace.mark("late", trace=trace)
+        assert len(_read_records(sink)) == 1
+        assert _read_records(sink)[0]["spans"] == []
+
+    def test_add_span_retrofit(self, sink):
+        trace = turn_trace.begin(key="k")
+        start = trace.started_at + 0.100
+        end = start + 0.250
+        trace.add_span("llm.call", start, end, model="fake")
+        rec = trace.finish()
+
+        spans = rec["spans"]
+        assert len(spans) == 1
+        assert spans[0]["n"] == "llm.call"
+        assert spans[0]["t0"] == pytest.approx(100.0, abs=0.5)
+        assert spans[0]["d"] == pytest.approx(250.0, abs=0.5)
+        assert spans[0]["tags"] == {"model": "fake"}
+
+    def test_spans_sorted_by_start(self, sink):
+        trace = turn_trace.begin(key="k")
+        t0 = trace.started_at
+        trace.add_span("second", t0 + 0.2, t0 + 0.3)
+        trace.add_span("first", t0 + 0.1, t0 + 0.4)
+        rec = trace.finish()
+        assert [s["n"] for s in rec["spans"]] == ["first", "second"]
+
+
+# ---------------------------------------------------------------------------
+# Carrying the trace: bind / get_bound / adopt
+# ---------------------------------------------------------------------------
+
+class TestCarrying:
+    def test_bind_and_get_bound(self):
+        obj = _Carrier()
+        assert turn_trace.get_bound(obj) is None
+        trace = TurnTrace(key="k")
+        turn_trace.bind(obj, trace)
+        assert turn_trace.get_bound(obj) is trace
+
+    def test_span_resolves_bound_object(self, sink):
+        obj = _Carrier()
+        trace = TurnTrace(key="k")
+        turn_trace.bind(obj, trace)
+        # No thread-local current (begin() was not used).
+        assert turn_trace.current() is None
+
+        with turn_trace.span("gateway.ingest", obj=obj, platform="test"):
+            pass
+        rec = trace.finish()
+        assert [s["n"] for s in rec["spans"]] == ["gateway.ingest"]
+
+    def test_bind_none_clears(self):
+        obj = _Carrier()
+        trace = TurnTrace(key="k")
+        turn_trace.bind(obj, trace)
+        turn_trace.bind(obj, None)
+        assert turn_trace.get_bound(obj) is None
+        assert turn_trace.span("x", obj=obj) is _NULL_SPAN
+
+    def test_bind_swallows_setattr_failure(self):
+        # e.g. objects with __slots__ — must not raise.
+        turn_trace.bind(object(), TurnTrace(key="k"))
+
+    def test_explicit_trace_wins_over_bound_and_current(self, sink):
+        obj = _Carrier()
+        bound = TurnTrace(key="bound")
+        explicit = turn_trace.begin(key="explicit")  # also becomes current
+        turn_trace.bind(obj, bound)
+
+        with turn_trace.span("x", trace=explicit, obj=obj):
+            pass
+        assert len(explicit.finish()["spans"]) == 1
+        assert len(bound.finish()["spans"]) == 0
+
+    def test_adopt_makes_trace_current_in_worker_thread(self, sink):
+        trace = TurnTrace(key="k")
+        results = {}
+
+        def adopting_worker():
+            turn_trace.adopt(trace)
+            results["adopting"] = turn_trace.current()
+            with turn_trace.span("tools.call", tool="x"):
+                pass
+
+        def non_adopting_worker():
+            results["non_adopting_current"] = turn_trace.current()
+            results["non_adopting_span"] = turn_trace.span("orphan")
+
+        t1 = threading.Thread(target=adopting_worker)
+        t2 = threading.Thread(target=non_adopting_worker)
+        t1.start(); t1.join()
+        t2.start(); t2.join()
+
+        assert results["adopting"] is trace
+        # Thread-local does not leak into a thread that never adopted.
+        assert results["non_adopting_current"] is None
+        assert results["non_adopting_span"] is _NULL_SPAN
+
+        rec = trace.finish()
+        assert [s["n"] for s in rec["spans"]] == ["tools.call"]
+
+
+# ---------------------------------------------------------------------------
+# Error tolerance
+# ---------------------------------------------------------------------------
+
+class TestErrorTolerance:
+    def test_finish_survives_unwritable_sink(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_TURN_TRACE", "1")
+        # A directory is not appendable — the emit must swallow the error.
+        monkeypatch.setenv("HERMES_TURN_TRACE_FILE", str(tmp_path))
+        trace = turn_trace.begin(key="k")
+        record = trace.finish()  # must not raise
+        assert record is not None
+
+    def test_span_records_error_tag_and_reraises(self, sink):
+        trace = turn_trace.begin(key="k")
+        with pytest.raises(RuntimeError, match="boom"):
+            with turn_trace.span("tools.call", trace=trace, tool="x"):
+                raise RuntimeError("boom")
+
+        rec = trace.finish()
+        spans = rec["spans"]
+        assert len(spans) == 1
+        assert spans[0]["tags"]["error"] == "RuntimeError"
+        assert spans[0]["tags"]["tool"] == "x"
+
+    def test_span_error_tag_does_not_clobber_explicit(self, sink):
+        trace = turn_trace.begin(key="k")
+        with pytest.raises(RuntimeError):
+            with turn_trace.span("x", trace=trace) as h:
+                h.tag(error="Custom")
+                raise RuntimeError("boom")
+        assert trace.finish()["spans"][0]["tags"]["error"] == "Custom"
+
+    def test_non_serializable_tag_falls_back_to_str(self, sink):
+        trace = turn_trace.begin(key="k")
+        trace.tag(weird=object())
+        rec = trace.finish()
+        assert rec is not None
+        # default=str in the sink keeps the emitted line valid JSON.
+        records = _read_records(sink)
+        assert len(records) == 1
+        assert isinstance(records[0]["tags"]["weird"], str)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+class TestConcurrency:
+    def test_concurrent_span_appends_all_land(self, sink):
+        trace = turn_trace.begin(key="k")
+        n = 16
+        barrier = threading.Barrier(n)
+
+        def worker(i: int):
+            turn_trace.adopt(trace)
+            barrier.wait()
+            with turn_trace.span("tools.call", tool=f"t{i}"):
+                time.sleep(0.001)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        trace.finish()
+        records = _read_records(sink)
+        assert len(records) == 1
+        spans = records[0]["spans"]
+        assert len(spans) == n
+        assert {s["tags"]["tool"] for s in spans} == {f"t{i}" for i in range(n)}
+        assert all(s["n"] == "tools.call" for s in spans)
+
+
+# ---------------------------------------------------------------------------
+# Renderer smoke test
+# ---------------------------------------------------------------------------
+
+class TestRenderer:
+    def test_demo_mode_renders(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        proc = subprocess.run(
+            [sys.executable, "-m", "agent.turn_trace_render", "--demo", "--no-color"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert proc.returncode == 0, proc.stderr
+        # The demo traces carry the contract's root span name.
+        assert "turn" in proc.stdout


### PR DESCRIPTION
## Problem

When a turn feels slow there is no way to tell where the time went. A single user message crosses the gateway asyncio loop, the run_sync executor, the per-LLM-call worker, and concurrent tool executor threads; existing logs record isolated durations at best, so hermes-added overhead (persistence, compression preflight, context assembly, inter-tool delays, delivery) cannot be separated from model inference time, and regressions in the non-LLM portion of the turn go unnoticed until they are large.

## Change

Adds an opt-in, zero-dependency tracing instrument:

- `agent/turn_trace.py` — span collector gated by `HERMES_TURN_TRACE=1` (default off). One JSON line per turn is appended to `~/.hermes/logs/turn_traces.jsonl` (override: `HERMES_TURN_TRACE_FILE`; 64 MB single-rotation cap; single `O_APPEND` write per record so a gateway daemon and a CLI run can share the sink). Spans store absolute wall-clock start/end; parent/child nesting is derived at render time from interval containment, so cross-thread and overlapping (concurrent tool batch) spans need no stack bookkeeping.
- `agent/turn_trace_render.py` — `python -m agent.turn_trace_render` renders traces as a terminal waterfall (plus `--summary` cross-turn aggregation and `--html` export; `--demo` renders a built-in sample).
- Span sites across the turn lifecycle: gateway ingest / session resolve / transcript load / hygiene / agent setup; turn prologue (system-prompt restore, early persist, compression preflight, pre-LLM hook, memory prefetch); per-iteration context assembly, request setup, LLM call (with TTFT and error attempts), accounting; tool batches including per-tool calls and the inter-tool delay sleep; verify gates; finalize children (trajectory, persist, post hooks, memory dispatch, resource cleanup); gateway persist; transport delivery.

Trace ownership: for gateway turns the runner `begin()`s the trace at message ingress and the platform adapter `finish()`es it after delivery, so the record covers the full ingress-to-delivery interval; CLI turns begin/finish inside `run_conversation`. Because a turn crosses threads, the trace is carried explicitly — bound to objects the instrumentation sites already share (the event, its `SessionSource`, the agent instance) with a thread-local current as a same-thread convenience — never via ambient globals that could bleed across concurrent sessions.

## Correctness notes

- **Default off is a strict no-op**: every site is guarded by `trace is not None` (or the no-op-safe `turn_trace.span()` which returns a shared null context manager), so the disabled cost is one env/attribute check per site. No behavior change when disabled.
- **Tracing can never break a turn**: sink emission catches all exceptions (unwritable sink, non-serializable tags fall back to `str`), `bind()` swallows `setattr` failures on slotted objects, and span context managers record-and-reraise without altering control flow.
- **Pre-dispatch event replacement**: the `pre_gateway_dispatch` hook loop may swap the runner's event for a `dataclasses.replace` copy (prepend/rewrite directives), while the adapter's finish site holds the original event. The trace is therefore also bound to the shared `SessionSource`; finish sites resolve event-then-source and clear the source binding afterwards so a stale trace cannot leak into a later turn on a reused source.
- **Lifecycle safety**: `finish()` is idempotent and first-status-wins; adapter cancel/error paths and a belt-and-braces `finally` all funnel through it. Cached agents outlive the turn, so the gateway clears the agent binding in a `finally`; pooled executor threads adopt the trace on entry (a previous turn's trace is already finished and inert). Span appends are lock-protected for concurrent tool executors, and `finish()` snapshots spans/tags before serializing.
- Inline dispatches that bypass the adapter's background processing (bypass commands, clarify text-intercept, kanban watcher synthetic events) own the finish themselves so those records are not dropped.

## Tests

`tests/agent/test_turn_trace.py` (22 tests): disabled-path no-ops, full-cycle JSONL emission, idempotent finish, post-finish spans ignored, span sorting, bind/resolve precedence (explicit > bound > thread-local), worker-thread adoption, unwritable-sink survival, error tagging and re-raise, non-serializable tag fallback, concurrent span appends, and renderer demo mode.

Suites run on this branch: `tests/agent` (5490 passed), `tests/gateway` + `tests/plugins` + `tests/run_agent` + `tests/scripts` (12876 passed) — failure sets are identical to a clean checkout of `main` run in the same environment (environment-dependent and order-dependent failures only; every difference between the two runs passes repeatedly when run standalone on this branch). `tests/run_agent` alone on this branch: 1974 passed, 0 failed.

## Measured impact

Used in production to attribute a "turns feel ~30% slower" report to concrete, fixable causes — first-call prompt-cache loss costing ~20 s per turn at 150k context, fixed 1.0 s inter-tool delay sleeps, ~19 ms-per-call HTTP client rebuilds, and synchronous persistence/accounting work sitting on the turn thread — findings that seeded the follow-up perf PRs #64169–#64172. When disabled (the default), overhead is a single env check per instrumentation site; when enabled, per-turn cost is one JSON serialization and one appending write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
