### PR TITLE
fix(agent): strip reasoning replay fields for strict chat-completions providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2106,6 +2106,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # Build API messages, stripping internal-only fields
         # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
         _needs_sanitize = agent._should_sanitize_tool_calls()
+        from agent.transports.chat_completions import _base_url_consumes_reasoning_details
+        _strip_reasoning_details = not _base_url_consumes_reasoning_details(agent.base_url)
         api_messages = []
         for msg in messages:
             api_msg = msg.copy()
@@ -2121,6 +2123,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # tool_name (SQLite FTS bookkeeping), the codex_* reasoning carriers,
             # timestamp (preserved on gateway user replay entries for the
             # stale-confirmation expiry check — #47868 rejection class),
+            # reasoning_details (kept only for endpoints that consume the
+            # replay — OpenRouter/Nous; strict providers reject it),
             # and every Hermes-internal underscore-prefixed scaffolding key.
             for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items", "timestamp"):
                 api_msg.pop(schema_foreign, None)
@@ -2133,6 +2137,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # sidecar-carrying message and re-prefilling the whole transcript
             # at exactly the moment the context is largest.
             substitute_api_content(api_msg)
+            if _strip_reasoning_details:
+                api_msg.pop("reasoning_details", None)
             for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
                 api_msg.pop(internal_key, None)
             if _needs_sanitize:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1525,7 +1525,9 @@ def run_conversation(
                             _sanitize_model = _agg_slot["model"]
                 agent._sanitize_tool_calls_for_strict_api(api_msg, model=_sanitize_model)
             # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
-            # The signature field helps maintain reasoning continuity
+            # The signature field helps maintain reasoning continuity.
+            # ChatCompletionsTransport.convert_messages() strips it per-endpoint:
+            # strict providers reject it with 400 "Extra inputs are not permitted".
             api_messages.append(api_msg)
 
         # Build the final system message: cached prompt + ephemeral system prompt.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -16,6 +16,7 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from utils import base_url_host_matches
 
 
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
@@ -128,6 +129,25 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+def _base_url_consumes_reasoning_details(base_url: Any) -> bool:
+    """True when the target endpoint consumes replayed ``reasoning_details``.
+
+    ``reasoning_details`` is OpenRouter's unified reasoning format: OpenRouter
+    (and the OpenRouter-compatible Nous portal) read it from assistant replay
+    messages to maintain reasoning continuity across turns, so it must stay on
+    the wire for those routes. It is not part of the OpenAI Chat Completions
+    message schema, and strict providers (Fireworks, Mistral, ...) reject any
+    payload containing it with HTTP 400 ``Extra inputs are not permitted``, so
+    it must be stripped for every other endpoint — including strict endpoints
+    that inherit it from an OpenRouter turn earlier in a mixed-provider
+    session. Unknown/empty base URLs strip (the safe default).
+    """
+    url = str(base_url or "")
+    return base_url_host_matches(url, "openrouter.ai") or base_url_host_matches(
+        url, "nousresearch.com"
+    )
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -148,6 +168,19 @@ class ChatCompletionsTransport(ProviderTransport):
         - Codex Responses API fields: ``codex_reasoning_items`` /
           ``codex_message_items`` on the message, ``call_id`` /
           ``response_item_id`` on ``tool_calls`` entries.
+        - ``reasoning`` on assistant messages — trajectory-only reasoning
+          text, never part of any provider's request schema. Stripped
+          unconditionally, mirroring the main-loop replay build in
+          ``run_conversation()``.
+        - ``reasoning_details`` on assistant messages — OpenRouter's
+          structured reasoning replay format. Kept when the outgoing
+          ``base_url`` is an endpoint that consumes it for multi-turn
+          reasoning continuity (OpenRouter, Nous); stripped for every other
+          endpoint, where strict providers reject any payload containing it
+          with ``Extra inputs are not permitted`` — including endpoints that
+          inherit the field from an OpenRouter turn earlier in a
+          mixed-provider session. Only the wire copy is stripped; persisted
+          history keeps the fields for future replay.
         - ``extra_content`` on ``tool_calls`` (Gemini thought_signature) —
           stripped unless the outgoing ``model`` is itself Gemini-family.
           Gemini 3 thinking models attach it for replay, but strict providers
@@ -177,6 +210,9 @@ class ChatCompletionsTransport(ProviderTransport):
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
         )
+        strip_reasoning_details = not _base_url_consumes_reasoning_details(
+            kwargs.get("base_url")
+        )
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -188,6 +224,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or "reasoning" in msg
+                or (strip_reasoning_details and "reasoning_details" in msg)
             ):
                 needs_sanitize = True
                 break
@@ -231,6 +269,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — leak into strict providers
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or "reasoning" in msg
+                or (strip_reasoning_details and "reasoning_details" in msg)
             ):
                 out_msg = mutable_msg()
                 out_msg.pop("codex_reasoning_items", None)
@@ -239,6 +279,9 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("effect_disposition", None)
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
                 out_msg.pop("api_content", None)  # persist-what-you-send sidecar
+                out_msg.pop("reasoning", None)
+                if strip_reasoning_details:
+                    out_msg.pop("reasoning_details", None)
 
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
@@ -330,8 +373,12 @@ class ChatCompletionsTransport(ProviderTransport):
         """
         # Codex sanitization: drop reasoning_items / call_id / response_item_id.
         # Pass model so the Gemini thought_signature (extra_content) is kept for
-        # Gemini targets and stripped for strict non-Gemini providers.
-        sanitized = self.convert_messages(messages, model=model)
+        # Gemini targets and stripped for strict non-Gemini providers, and
+        # base_url so reasoning_details is kept for endpoints that consume
+        # the replay (OpenRouter, Nous) and stripped for strict ones.
+        sanitized = self.convert_messages(
+            messages, model=model, base_url=params.get("base_url")
+        )
 
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -53,6 +53,78 @@ class TestChatCompletionsBasic:
 
 
 
+    def _msg_with_reasoning_fields(self):
+        return [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok",
+             "reasoning": "trajectory reasoning text",
+             "reasoning_details": [
+                 {"type": "thinking", "thinking": "deep", "signature": "sig_1"}
+             ]},
+        ]
+
+    def test_convert_messages_strips_reasoning_fields_for_strict_provider(self, transport):
+        """`reasoning` / `reasoning_details` are OpenRouter reasoning-replay
+        fields, not part of the OpenAI Chat Completions message schema. Strict
+        providers (Fireworks, Mistral) reject payloads containing them with
+        HTTP 400 'Extra inputs are not permitted' — including stale fields
+        inherited from an OpenRouter turn in a mixed-provider session.
+        """
+        msgs = self._msg_with_reasoning_fields()
+        result = transport.convert_messages(
+            msgs, base_url="https://api.fireworks.ai/inference/v1"
+        )
+        assert "reasoning" not in result[1]
+        assert "reasoning_details" not in result[1]
+        assert result[1]["content"] == "ok"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["reasoning"] == "trajectory reasoning text"
+        assert msgs[1]["reasoning_details"][0]["signature"] == "sig_1"
+
+    def test_convert_messages_strips_reasoning_fields_when_base_url_unknown(self, transport):
+        """Default (no base_url supplied) is to strip — safe for strict providers."""
+        msgs = self._msg_with_reasoning_fields()
+        result = transport.convert_messages(msgs)
+        assert "reasoning" not in result[1]
+        assert "reasoning_details" not in result[1]
+
+    def test_convert_messages_keeps_reasoning_details_for_openrouter(self, transport):
+        """OpenRouter (and the OpenRouter-compatible Nous portal) consume
+        replayed `reasoning_details` for multi-turn reasoning continuity —
+        e.g. signed Anthropic thinking blocks on tool-call turns. Keep that
+        field on the wire for those endpoints; trajectory-only `reasoning`
+        is still stripped everywhere, mirroring the main-loop replay build.
+        """
+        for base_url in (
+            "https://openrouter.ai/api/v1",
+            "https://inference-api.nousresearch.com/v1",
+        ):
+            msgs = self._msg_with_reasoning_fields()
+            result = transport.convert_messages(msgs, base_url=base_url)
+            assert result[1]["reasoning_details"][0]["signature"] == "sig_1", base_url
+            assert "reasoning" not in result[1], base_url
+            # Original list untouched (copy-on-write)
+            assert msgs[1]["reasoning"] == "trajectory reasoning text", base_url
+
+    def test_convert_messages_strips_tool_name(self, transport):
+        """Internal `tool_name` (used for FTS indexing in the SQLite store) is
+        not part of the OpenAI Chat Completions schema. Strict providers like
+        Moonshot/Kimi reject it with HTTP 400 'Extra inputs are not permitted'.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "execute_code", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "tool_name": "execute_code",
+             "content": "result"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "tool_name" not in result[2]
+        assert result[2]["content"] == "result"
+        assert result[2]["tool_call_id"] == "call_1"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[2]["tool_name"] == "execute_code"
 
 
     def test_convert_messages_strips_timestamp(self, transport):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2366,6 +2366,77 @@ class TestHandleMaxIterations:
         assert messages[2]["tool_name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
+    def test_summary_strips_reasoning_details_for_strict_provider(self, agent):
+        """Regression: the max-iterations summary request hand-builds its
+        messages and calls chat.completions.create() directly, bypassing
+        ChatCompletionsTransport.convert_messages() — so it must mirror the
+        reasoning-replay strip: reasoning_details is OpenRouter's replay
+        format and strict providers (Fireworks, Mistral) reject it with
+        'Extra inputs are not permitted'; trajectory-only reasoning must
+        never reach the wire at all."""
+        agent.base_url = "https://api.fireworks.ai/inference/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "fireworks"
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "do stuff"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning": "trajectory reasoning text",
+                "reasoning_details": [{"type": "thinking", "signature": "sig_1"}],
+            },
+        ]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get("messages", [])
+        for m in sent_msgs:
+            assert "reasoning" not in m, m
+            assert "reasoning_details" not in m, m
+        # Internal history is untouched — the path copies each message.
+        assert messages[1]["reasoning"] == "trajectory reasoning text"
+        assert messages[1]["reasoning_details"] == [{"type": "thinking", "signature": "sig_1"}]
+
+    def test_summary_keeps_reasoning_details_for_openrouter(self, agent):
+        """OpenRouter consumes replayed reasoning_details for multi-turn
+        reasoning continuity — the summary path must keep the field for it,
+        while still dropping trajectory-only reasoning."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "openrouter"
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "do stuff"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning": "trajectory reasoning text",
+                "reasoning_details": [{"type": "thinking", "signature": "sig_1"}],
+            },
+        ]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get("messages", [])
+        assistant_sent = [m for m in sent_msgs if m.get("role") == "assistant"]
+        assert assistant_sent, sent_msgs
+        assert assistant_sent[0]["reasoning_details"] == [
+            {"type": "thinking", "signature": "sig_1"}
+        ]
+        assert "reasoning" not in assistant_sent[0]
+
+    def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
+        agent.base_url = "https://api.openai.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "openai"
+        agent.providers_allowed = ["Anthropic"]
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
 
 
 

--- a/tests/run_agent/test_strict_api_validation.py
+++ b/tests/run_agent/test_strict_api_validation.py
@@ -91,6 +91,74 @@ class TestStrictApiValidation:
         assert tool_call["id"] == "call_123"
         assert tool_call["function"]["name"] == "terminal"
 
+    def test_reasoning_fields_stripped_for_strict_provider(self, monkeypatch):
+        """Strict chat_completions requests must not carry reasoning replay
+        fields — providers like Fireworks/Mistral reject them with HTTP 400
+        'Extra inputs are not permitted'. Only the wire copy is stripped;
+        persisted history keeps the fields for future replay.
+        """
+        agent = _make_agent(
+            monkeypatch,
+            "fireworks",
+            api_mode="chat_completions",
+            base_url="https://api.fireworks.ai/inference/v1",
+        )
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning": "trajectory-only reasoning",
+                "reasoning_content": "provider-facing reasoning",
+                "reasoning_details": [
+                    {"signature": "sig_1", "type": "thinking"}
+                ],
+            },
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assistant_msg = kwargs["messages"][1]
+        assert "reasoning" not in assistant_msg
+        assert "reasoning_details" not in assistant_msg
+        # reasoning_content is a provider-schema field (DeepSeek/Kimi
+        # echo-back) reconciled elsewhere — not this sanitizer's job.
+        assert assistant_msg["reasoning_content"] == "provider-facing reasoning"
+        # History untouched — future turns can still replay reasoning state.
+        assert messages[1]["reasoning"] == "trajectory-only reasoning"
+        assert messages[1]["reasoning_details"] == [
+            {"signature": "sig_1", "type": "thinking"}
+        ]
+
+    def test_reasoning_details_kept_for_openrouter_replay(self, monkeypatch):
+        """OpenRouter consumes replayed reasoning_details for multi-turn
+        reasoning continuity — the strict-provider strip must not apply
+        there. Trajectory-only reasoning is still stripped unconditionally.
+        """
+        agent = _make_agent(monkeypatch, "openrouter")
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning": "trajectory-only reasoning",
+                "reasoning_details": [
+                    {"signature": "sig_1", "type": "thinking"}
+                ],
+            },
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assistant_msg = kwargs["messages"][1]
+        assert assistant_msg["reasoning_details"] == [
+            {"signature": "sig_1", "type": "thinking"}
+        ]
+        assert "reasoning" not in assistant_msg
+        assert messages[1]["reasoning"] == "trajectory-only reasoning"
+
     def test_codex_preserves_fields_for_replay(self, monkeypatch):
         """Codex mode should preserve fields for Responses API replay."""
         agent = _make_agent(monkeypatch, "openrouter")


### PR DESCRIPTION
## Problem

Assistant messages in agent history can carry two non-standard reasoning replay fields: `reasoning` (trajectory reasoning text) and `reasoning_details` (OpenRouter's unified structured-reasoning format, e.g. signed Anthropic thinking blocks). `reasoning_details` is deliberately kept on API-bound messages so OpenRouter can maintain multi-turn reasoning continuity — but it is not part of the OpenAI Chat Completions message schema, and it currently reaches **every** chat-completions endpoint.

Strict OpenAI-compatible providers (Fireworks, Mistral, and many self-hosted/proxy gateways) reject any request whose replayed assistant messages contain these fields with HTTP 400 `Extra inputs are not permitted, field: 'messages[N].reasoning_details'`. Once a session contains such a turn, every subsequent request fails. The common trigger is a mixed-provider session: turns produced via OpenRouter (or an Anthropic reasoning model) persist `reasoning_details`, and a model switch or fallback to a strict direct provider makes the whole history unreplayable. The existing reactive recovery only fires on Anthropic-flavored `thinking_signature` error text, so these generic 400s classify as non-retryable format errors — and even when recovery applies, it costs a failed round trip per session.

## Change

- `ChatCompletionsTransport.convert_messages()` now strips `reasoning` / `reasoning_details` from the wire copy of messages, gated on the target endpoint via a new `_base_url_consumes_reasoning_details()` helper: the fields are kept for endpoints that consume the replay (`openrouter.ai`, `nousresearch.com`) and stripped for everything else, including when no `base_url` is supplied (safe default for strict providers). This mirrors the existing keep/strip pattern used for the Gemini `extra_content` thought_signature.
- `build_kwargs()` passes `base_url` through to `convert_messages()` (it is already provided by both the profile and legacy call paths).
- The max-iterations summary path in `agent/chat_completion_helpers.py` hand-builds messages and bypasses the transport; it already mirrored the other schema-foreign strips (`tool_name`, `codex_*`, `timestamp`) but leaked `reasoning_details`. The same gated strip is mirrored there.

## Correctness notes

- OpenRouter/Nous behavior is unchanged: `reasoning_details` is still replayed for reasoning continuity (signed Anthropic thinking blocks on tool-call turns require it). A new test pins this.
- Only the wire copy is sanitized — `convert_messages()` uses the existing copy-on-write scheme, so persisted history keeps the fields and future turns on routes that consume them can still replay reasoning state. A test asserts the source list is untouched.
- `reasoning` was already popped on the main-loop `api_messages` build for all providers ("trajectory storage only"); stripping it in the transport extends the same guarantee to direct `_build_api_kwargs()` entry points without changing main-loop behavior.
- `reasoning_content` is intentionally not touched: it is a provider-schema echo-back field (DeepSeek/Kimi thinking mode) reconciled per-provider by `reapply_reasoning_echo_for_provider()`.

## Tests

New:
- `tests/agent/transports/test_chat_completions.py`: strips `reasoning`/`reasoning_details` for a strict base_url and when base_url is unknown; keeps them for `openrouter.ai` / `inference-api.nousresearch.com`; source messages never mutated.
- `tests/run_agent/test_strict_api_validation.py`: end-to-end through `_build_api_kwargs()` — stripped for a Fireworks agent (history retained, `reasoning_content` untouched), kept for an OpenRouter agent.

Runs (all green):
- `tests/agent/transports/`, `tests/run_agent/test_strict_api_validation.py`
- `tests/run_agent/test_provider_parity.py`, `test_deepseek_reasoning_content_echo.py`, `test_thinking_only_sanitizer.py`, `test_thinking_sig_recovery_persistence.py`, `test_deepseek_v4_thinking_live.py`, `tests/agent/test_compressed_summary_metadata.py`, `tests/plugins/model_providers/`
- Full `tests/agent/` + `tests/run_agent/` (one pre-existing environment-dependent failure in `tests/agent/lsp/test_broken_set.py` reproduces identically on a clean checkout of `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
