### PR TITLE
fix(discord): render markdown tables as fenced box-drawing tables

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,27 @@
+fix(discord): render markdown tables as fenced box-drawing tables
+
+## Problem
+
+Discord does not render GitHub-flavored markdown pipe tables. The Discord adapter currently converts outbound tables to bold-heading + bullet groups (`convert_table_to_bullets`), which loses the tabular shape entirely: column relationships disappear, and multi-column comparisons (scores, benchmarks, config matrices) become long vertical lists that are hard to scan. Discord *does* render fenced code blocks in a monospace font, so a properly aligned ASCII table survives intact — including in narrow mobile views.
+
+## Change
+
+- `gateway/platforms/helpers.py`
+  - Extracted the fence-aware table scan loop (previously the body of `convert_table_to_bullets`) into `_convert_tables(text, render_block)` so both renderers share one detector. Detection semantics are unchanged: a header row containing `|` immediately followed by a delimiter row matching `TABLE_SEPARATOR_RE`, with tables inside existing fenced code blocks left untouched.
+  - Added `convert_table_to_codeblock()`: renders each detected table as a box-drawing (`┌─┬─┐ │ … └─┴─┘`) table inside a code fence. Column widths are computed with an East-Asian-width-aware `_display_width()` so CJK full/wide characters (width 2 in monospace fonts) keep columns aligned. Ragged rows are padded or clipped to the header's column count.
+  - `convert_table_to_bullets()` keeps its exact behavior (Telegram still uses it) and now delegates to the shared scanner.
+- `plugins/platforms/discord/adapter.py`: `format_message()` now calls `convert_table_to_codeblock()` instead of `convert_table_to_bullets()`.
+
+## Correctness notes
+
+- Tables already inside fenced code blocks are preserved verbatim (`_convert_tables` tracks fence state), so preformatted examples are never re-rendered.
+- `TABLE_SEPARATOR_RE` requires at least one internal `|` in the delimiter row, so `---` horizontal rules and single-column pseudo-tables are not converted; prose containing a lone `|` short-circuits untouched.
+- Long converted tables can exceed Discord's 2000-character message limit; `BasePlatformAdapter.truncate_message()` already splits on code-block boundaries and re-opens fences per chunk, so every chunk stays balanced (covered by a new test).
+- Telegram behavior is unchanged: it imports `convert_table_to_bullets` and the shared primitives, all of which keep their signatures and output.
+
+## Tests
+
+- `tests/gateway/test_table_helpers.py`: new `TestConvertTableToCodeblock` — basic conversion, fenced-block preservation (both a whole-message fence and a fence preceding a real table), CJK alignment (all table lines have identical display width), ragged-row padding/clipping, pipe-in-prose and horizontal-rule non-matches, single-column non-conversion.
+- `tests/gateway/test_discord_send.py`: `format_message()` end-to-end conversion, and a >2000-char generated table chunked by `truncate_message()` with every chunk under the limit and containing balanced fences.
+- `tests/gateway/test_discord_format.py`: `test_table_converted_to_bullets` updated to `test_table_converted_to_codeblock`, asserting the new fenced-table output; the plain-text, fenced-block, and empty-string cases are unchanged.
+- Suites run: `tests/gateway/` plus the discord/telegram plugin and tool tests. The gateway suite shows the same 36 environment-dependent failures (host-filesystem path completion, Telegram/Feishu SDK version drift, host session state) on this branch and on an unmodified `main` checkout; every test this PR adds or touches passes.

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -10,8 +10,9 @@ import json
 import logging
 import re
 import time
+import unicodedata
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Callable, Dict
 
 from utils import atomic_json_write
 
@@ -294,10 +295,11 @@ def redact_phone(phone: str) -> str:
     return phone[:4] + "****" + phone[-4:]
 
 
-# ─── GFM Markdown Table → Bullet Conversion ─────────────────────────────────
-# Shared by Discord and Telegram adapters.  Discord calls
-# convert_table_to_bullets() directly; Telegram imports the primitives
-# but keeps its own MarkdownV2-aware renderer.
+# ─── GFM Markdown Table Conversion ───────────────────────────────────────────
+# Shared by Discord and Telegram adapters.  Neither platform renders GFM pipe
+# tables natively.  Telegram calls convert_table_to_bullets(); Discord calls
+# convert_table_to_codeblock(), because Discord renders fenced code blocks in
+# a monospace font where a box-drawing table stays aligned.
 
 
 # Matches a GFM table delimiter row: optional outer pipes, cells of dashes
@@ -376,10 +378,72 @@ def _render_table_block(table_block: list[str]) -> str:
     return "\n\n".join(rendered_groups)
 
 
-def convert_table_to_bullets(text: str) -> str:
-    """Rewrite GFM pipe tables into bold-heading + bullet groups.
+def _display_width(text: str) -> int:
+    """Return monospace display width, treating CJK full/wide chars as width 2."""
+    width = 0
+    for ch in text:
+        width += 2 if unicodedata.east_asian_width(ch) in {"F", "W"} else 1
+    return width
 
-    Tables inside fenced code blocks are left alone.
+
+def _pad_display_width(text: str, target_width: int) -> str:
+    """Pad *text* with spaces up to *target_width* display columns."""
+    padding = target_width - _display_width(text)
+    return text + (" " * padding if padding > 0 else "")
+
+
+def _render_table_codeblock(table_block: list[str]) -> str:
+    """Render a detected GFM table as a fenced box-drawing table."""
+    if len(table_block) < 2:
+        return "\n".join(table_block)
+
+    headers = split_markdown_table_row(table_block[0])
+    if len(headers) < 2:
+        return "\n".join(table_block)
+
+    num_cols = len(headers)
+    rows: list[list[str]] = []
+    for row_line in table_block[2:]:
+        row = split_markdown_table_row(row_line)
+        if len(row) < num_cols:
+            row.extend([""] * (num_cols - len(row)))
+        elif len(row) > num_cols:
+            row = row[:num_cols]
+        rows.append(row)
+
+    col_widths = [max(3, _display_width(header)) for header in headers]
+    for row in rows:
+        for index, cell in enumerate(row):
+            col_widths[index] = max(col_widths[index], _display_width(cell))
+
+    def border(left: str, middle: str, right: str) -> str:
+        return left + middle.join("─" * (width + 2) for width in col_widths) + right
+
+    def data_row(cells: list[str]) -> str:
+        padded = [
+            " " + _pad_display_width(cell, col_widths[index]) + " "
+            for index, cell in enumerate(cells)
+        ]
+        return "│" + "│".join(padded) + "│"
+
+    rendered = [
+        border("┌", "┬", "┐"),
+        data_row(headers),
+        border("├", "┼", "┤"),
+    ]
+    rendered.extend(data_row(row) for row in rows)
+    rendered.append(border("└", "┴", "┘"))
+
+    return "```\n" + "\n".join(rendered) + "\n```"
+
+
+def _convert_tables(text: str, render_block: Callable[[list[str]], str]) -> str:
+    """Rewrite each GFM pipe table in *text* with *render_block*.
+
+    A table is a header row containing '|' immediately followed by a
+    delimiter row matching :data:`TABLE_SEPARATOR_RE`, plus any contiguous
+    data rows.  Tables inside fenced code blocks are left alone so
+    preformatted examples stay stable.
     """
     if '|' not in text or '-' not in text:
         return text
@@ -412,7 +476,7 @@ def convert_table_to_bullets(text: str) -> str:
             while j < len(lines) and is_table_row(lines[j]):
                 table_block.append(lines[j])
                 j += 1
-            out.append(_render_table_block(table_block))
+            out.append(render_block(table_block))
             i = j
             continue
 
@@ -420,6 +484,22 @@ def convert_table_to_bullets(text: str) -> str:
         i += 1
 
     return '\n'.join(out)
+
+
+def convert_table_to_bullets(text: str) -> str:
+    """Rewrite GFM pipe tables into bold-heading + bullet groups.
+
+    Tables inside fenced code blocks are left alone.
+    """
+    return _convert_tables(text, _render_table_block)
+
+
+def convert_table_to_codeblock(text: str) -> str:
+    """Rewrite GFM pipe tables into fenced box-drawing tables.
+
+    Tables inside fenced code blocks are left alone.
+    """
+    return _convert_tables(text, _render_table_codeblock)
 
 
 # ─── Mention-pattern compilation ─────────────────────────────────────────────

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -121,7 +121,7 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 
-from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
+from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_codeblock
 from utils import atomic_json_write, env_float, env_int
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -5197,12 +5197,14 @@ class DiscordAdapter(BasePlatformAdapter):
     def format_message(self, content: str) -> str:
         """Format message for Discord.
 
-        Converts GFM markdown tables to bullet-list groups since Discord
-        does not render pipe tables natively.
+        Discord does not render GFM pipe tables, so convert them to fenced
+        box-drawing tables, which stay aligned in Discord's monospace code
+        blocks. truncate_message() preserves code-block boundaries when a
+        converted table exceeds MAX_MESSAGE_LENGTH.
         """
         if not content:
             return content
-        return convert_table_to_bullets(content)
+        return convert_table_to_codeblock(content)
 
     async def _run_simple_slash(
         self,

--- a/tests/conformance/vectors/discord.json
+++ b/tests/conformance/vectors/discord.json
@@ -2,7 +2,7 @@
   "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
   "oracle": {
     "repo": "NousResearch/hermes-agent",
-    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "commit": "1a38d5c9151ace11f22e52b447cc87bbb341d7af",
     "generator": "scripts/generate_conformance_vectors.py",
     "generator_version": 1
   },
@@ -139,7 +139,7 @@
       "category": "grid",
       "expect": "divergent",
       "input": "| name | value |\n|------|-------|\n| a    | 1     |\n| b    | 2     |",
-      "native_output": "**a**\n• value: 1\n\n**b**\n• value: 2",
+      "native_output": "```\n┌──────┬───────┐\n│ name │ value │\n├──────┼───────┤\n│ a    │ 1     │\n│ b    │ 2     │\n└──────┴───────┘\n```",
       "note": "native converts GFM tables to bullet groups; connector passes raw markdown through (port deferred — parity report Phase 4/oracle section)"
     },
     {
@@ -245,7 +245,7 @@
       "category": "scar",
       "expect": "divergent",
       "input": "| 名前 | 値 |\n|------|----|\n| 中文 | 42 |\n| b    | 2  |",
-      "native_output": "**中文**\n• 値: 42\n\n**b**\n• 値: 2",
+      "native_output": "```\n┌──────┬─────┐\n│ 名前 │ 値  │\n├──────┼─────┤\n│ 中文 │ 42  │\n│ b    │ 2   │\n└──────┴─────┘\n```",
       "note": "same as table-simple"
     },
     {

--- a/tests/gateway/test_discord_format.py
+++ b/tests/gateway/test_discord_format.py
@@ -1,4 +1,4 @@
-"""Discord format_message: tables converted to bullet groups."""
+"""Discord format_message: tables converted to fenced box-drawing tables."""
 
 import types
 import sys
@@ -24,7 +24,7 @@ def _make_discord_adapter():
 
 class TestDiscordFormatMessage:
 
-    def test_table_converted_to_bullets(self):
+    def test_table_converted_to_codeblock(self):
         adapter = _make_discord_adapter()
         text = (
             "Results:\n\n"
@@ -35,10 +35,10 @@ class TestDiscordFormatMessage:
             "\nDone."
         )
         out = adapter.format_message(text)
-        assert "**Alice**" in out
-        assert "• Score: 95" in out
-        assert "**Bob**" in out
-        assert "• Score: 80" in out
+        assert "```\n┌" in out
+        assert "│ Name  │ Score │" in out
+        assert "│ Alice │ 95    │" in out
+        assert "│ Bob   │ 80    │" in out
         assert out.startswith("Results:")
         assert out.rstrip().endswith("Done.")
         assert "|---" not in out

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -73,6 +73,150 @@ def _native_voice_payload(request):
 
 
 @pytest.mark.asyncio
+async def test_send_voice_native_payload_preserves_reply_reference(tmp_path):
+    reference = object()
+    adapter, channel, request = _voice_adapter(reference)
+    audio_path = tmp_path / "reply.ogg"
+    audio_path.write_bytes(b"fake ogg")
+
+    result = await adapter.send_voice("555", str(audio_path), reply_to="99")
+
+    assert result.success
+    assert result.message_id == "777"
+    assert _native_voice_payload(request)["message_reference"] == {
+        "message_id": "99",
+        "fail_if_not_exists": False,
+    }
+    channel.fetch_message.assert_awaited_once_with(99)
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_voice_file_fallback_preserves_reply_reference(tmp_path):
+    reference = object()
+    adapter, channel, _request = _voice_adapter(
+        reference,
+        native_error=RuntimeError("native voice unavailable"),
+    )
+    audio_path = tmp_path / "reply.ogg"
+    audio_path.write_bytes(b"fake ogg")
+
+    result = await adapter.send_voice("555", str(audio_path), reply_to="99")
+
+    assert result.success
+    assert result.message_id == "888"
+    assert channel.send.await_args.kwargs["reference"] is reference
+
+
+@pytest.mark.asyncio
+async def test_send_voice_reply_mode_off_omits_reference(tmp_path):
+    reference = object()
+    adapter, channel, request = _voice_adapter(reference)
+    adapter._reply_to_mode = "off"
+    audio_path = tmp_path / "reply.ogg"
+    audio_path.write_bytes(b"fake ogg")
+
+    result = await adapter.send_voice("555", str(audio_path), reply_to="99")
+
+    assert result.success
+    assert "message_reference" not in _native_voice_payload(request)
+    channel.fetch_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_voice_missing_reply_target_sends_without_reference(tmp_path):
+    adapter, channel, request = _voice_adapter(object())
+    channel.fetch_message.side_effect = RuntimeError("Unknown Message")
+    audio_path = tmp_path / "reply.ogg"
+    audio_path.write_bytes(b"fake ogg")
+
+    result = await adapter.send_voice("555", str(audio_path), reply_to="99")
+
+    assert result.success
+    assert "message_reference" not in _native_voice_payload(request)
+
+
+def test_format_message_converts_markdown_table_to_fenced_ascii_table():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    formatted = adapter.format_message(
+        "Here is a table:\n\n"
+        "| Name  | Score | Grade |\n"
+        "|-------|-------|-------|\n"
+        "| Alice | 95    | A     |\n"
+        "| Bob   | 82    | B     |\n\n"
+        "Done."
+    )
+
+    assert "|-------|" not in formatted
+    assert "```\n┌" in formatted
+    assert "│ Alice │ 95    │ A     │" in formatted
+    assert formatted.endswith("Done.")
+
+
+def test_truncate_message_preserves_generated_table_codeblock_boundaries():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    rows = "\n".join(
+        f"| row-{index:03d} | {'값' * 20} | {'x' * 30} |"
+        for index in range(80)
+    )
+    formatted = adapter.format_message(
+        "| Row | Korean | ASCII |\n"
+        "|-----|--------|-------|\n"
+        f"{rows}"
+    )
+
+    assert len(formatted) > adapter.MAX_MESSAGE_LENGTH
+    chunks = adapter.truncate_message(formatted, adapter.MAX_MESSAGE_LENGTH)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in chunks)
+    assert all(chunk.count("```") % 2 == 0 for chunk in chunks)
+    assert chunks[0].startswith("```\n┌")
+    assert chunks[1].startswith("```\n")
+
+
+@pytest.mark.asyncio
+async def test_send_retries_without_reference_when_reply_target_is_system_message():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    reference_obj = object()
+    ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
+    sent_msg = SimpleNamespace(id=1234)
+    send_calls = []
+
+    async def fake_send(*, content, reference=None):
+        send_calls.append({"content": content, "reference": reference})
+        if len(send_calls) == 1:
+            raise RuntimeError(
+                "400 Bad Request (error code: 50035): Invalid Form Body\n"
+                "In message_reference: Cannot reply to a system message"
+            )
+        return sent_msg
+
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(return_value=ref_msg),
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello", reply_to="99")
+
+    assert result.success is True
+    assert result.message_id == "1234"
+    assert channel.fetch_message.await_count == 1
+    assert channel.send.await_count == 2
+    ref_msg.to_reference.assert_called_once_with(fail_if_not_exists=False)
+    assert send_calls[0]["reference"] is reference_obj
+    assert send_calls[1]["reference"] is None
+
+
+@pytest.mark.asyncio
+
+
 async def test_send_retries_without_reference_when_reply_target_is_deleted():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -1,10 +1,12 @@
-"""Shared GFM table → bullet conversion helpers."""
+"""Shared GFM table conversion helpers."""
 
 from gateway.platforms.helpers import (
     TABLE_SEPARATOR_RE,
+    _display_width,
     is_table_row,
     split_markdown_table_row,
     convert_table_to_bullets,
+    convert_table_to_codeblock,
 )
 
 
@@ -66,5 +68,127 @@ class TestConvertTableToBullets:
         assert "**a**" in out
         assert "• head1: a" not in out
         assert "• head2: b" in out
+
+
+    def test_surrounding_prose_preserved(self):
+        text = (
+            "Scores:\n\n"
+            "| Player | Score |\n"
+            "|--------|-------|\n"
+            "| Alice  | 150   |\n"
+            "\nEnd."
+        )
+        out = convert_table_to_bullets(text)
+        assert out.startswith("Scores:")
+        assert out.endswith("End.")
+
+    def test_table_inside_code_fence_untouched(self):
+        text = "```\n| a | b |\n|---|---|\n| 1 | 2 |\n```"
+        assert convert_table_to_bullets(text) == text
+
+    def test_plain_text_with_pipes_untouched(self):
+        text = "Use the | pipe operator to chain."
+        assert convert_table_to_bullets(text) == text
+
+    def test_horizontal_rule_not_matched(self):
+        text = "Section A\n\n---\n\nSection B"
+        assert convert_table_to_bullets(text) == text
+
+    def test_no_pipe_short_circuits(self):
+        text = "Plain **bold** text."
+        assert convert_table_to_bullets(text) == text
+
+    def test_row_groups_separated_by_blank_line(self):
+        text = (
+            "| A | B |\n"
+            "|---|---|\n"
+            "| x | 1 |\n"
+            "| y | 2 |"
+        )
+        out = convert_table_to_bullets(text)
+        assert "• B: 1\n\n**y**" in out
+        assert "\n\n• " not in out
+
+
+class TestConvertTableToCodeblock:
+
+    def test_basic_table(self):
+        text = (
+            "Here is a table:\n\n"
+            "| Name  | Score | Grade |\n"
+            "|-------|-------|-------|\n"
+            "| Alice | 95    | A     |\n"
+            "| Bob   | 82    | B     |\n\n"
+            "Done."
+        )
+        out = convert_table_to_codeblock(text)
+        assert "|-------|" not in out
+        assert "```\n┌" in out
+        assert "│ Name  │ Score │ Grade │" in out
+        assert "│ Alice │ 95    │ A     │" in out
+        assert out.startswith("Here is a table:")
+        assert out.endswith("Done.")
+
+    def test_table_inside_code_fence_untouched(self):
+        text = "```\n| a | b |\n|---|---|\n| 1 | 2 |\n```"
+        assert convert_table_to_codeblock(text) == text
+
+    def test_fenced_table_kept_while_real_table_converted(self):
+        text = (
+            "```\n"
+            "| Not | A | Table |\n"
+            "|-----|---|-------|\n"
+            "| x   | y | z     |\n"
+            "```\n\n"
+            "| Real | Table |\n"
+            "|------|-------|\n"
+            "| a    | b     |"
+        )
+        out = convert_table_to_codeblock(text)
+        assert "| Not | A | Table |" in out
+        assert "|-----|---|-------|" in out
+        assert "│ Real │ Table │" in out
+        assert "│ a    │ b     │" in out
+        assert out.count("┌") == 1
+
+    def test_cjk_wide_characters_stay_aligned(self):
+        text = (
+            "| 항목 | 설명 |\n"
+            "|------|------|\n"
+            "| CPU  | 중앙처리장치 |\n"
+            "| RAM  | 메모리 |"
+        )
+        out = convert_table_to_codeblock(text)
+        table_lines = [
+            line for line in out.splitlines()
+            if line and line[0] in "┌├└│"
+        ]
+        assert len({_display_width(line) for line in table_lines}) == 1
+        assert "│ CPU  │ 중앙처리장치 │" in out
+        assert "│ RAM  │ 메모리       │" in out
+
+    def test_ragged_rows_padded_and_clipped(self):
+        text = (
+            "| A | B | C |\n"
+            "|---|---|---|\n"
+            "| 1 |\n"
+            "| 2 | 3 | 4 | 5 |"
+        )
+        out = convert_table_to_codeblock(text)
+        assert "│ 1   │     │     │" in out
+        assert "│ 2   │ 3   │ 4   │" in out
+        assert "5" not in out
+
+    def test_plain_text_with_pipes_untouched(self):
+        text = "Use the | operator for bitwise OR."
+        assert convert_table_to_codeblock(text) == text
+
+    def test_horizontal_rule_not_matched(self):
+        text = "Section A\n\n---\n\nSection B"
+        assert convert_table_to_codeblock(text) == text
+
+    def test_single_column_table_untouched(self):
+        text = "| only |\n|------|\n| one  |"
+        assert convert_table_to_codeblock(text) == text
 
 


### PR DESCRIPTION
## Problem

Discord does not render GitHub-flavored markdown pipe tables. The Discord adapter currently converts outbound tables to bold-heading + bullet groups (`convert_table_to_bullets`), which loses the tabular shape entirely: column relationships disappear, and multi-column comparisons (scores, benchmarks, config matrices) become long vertical lists that are hard to scan. Discord *does* render fenced code blocks in a monospace font, so a properly aligned ASCII table survives intact — including in narrow mobile views.

## Change

- `gateway/platforms/helpers.py`
  - Extracted the fence-aware table scan loop (previously the body of `convert_table_to_bullets`) into `_convert_tables(text, render_block)` so both renderers share one detector. Detection semantics are unchanged: a header row containing `|` immediately followed by a delimiter row matching `TABLE_SEPARATOR_RE`, with tables inside existing fenced code blocks left untouched.
  - Added `convert_table_to_codeblock()`: renders each detected table as a box-drawing (`┌─┬─┐ │ … └─┴─┘`) table inside a code fence. Column widths are computed with an East-Asian-width-aware `_display_width()` so CJK full/wide characters (width 2 in monospace fonts) keep columns aligned. Ragged rows are padded or clipped to the header's column count.
  - `convert_table_to_bullets()` keeps its exact behavior (Telegram still uses it) and now delegates to the shared scanner.
- `plugins/platforms/discord/adapter.py`: `format_message()` now calls `convert_table_to_codeblock()` instead of `convert_table_to_bullets()`.

## Correctness notes

- Tables already inside fenced code blocks are preserved verbatim (`_convert_tables` tracks fence state), so preformatted examples are never re-rendered.
- `TABLE_SEPARATOR_RE` requires at least one internal `|` in the delimiter row, so `---` horizontal rules and single-column pseudo-tables are not converted; prose containing a lone `|` short-circuits untouched.
- Long converted tables can exceed Discord's 2000-character message limit; `BasePlatformAdapter.truncate_message()` already splits on code-block boundaries and re-opens fences per chunk, so every chunk stays balanced (covered by a new test).
- Telegram behavior is unchanged: it imports `convert_table_to_bullets` and the shared primitives, all of which keep their signatures and output.

## Tests

- `tests/gateway/test_table_helpers.py`: new `TestConvertTableToCodeblock` — basic conversion, fenced-block preservation (both a whole-message fence and a fence preceding a real table), CJK alignment (all table lines have identical display width), ragged-row padding/clipping, pipe-in-prose and horizontal-rule non-matches, single-column non-conversion.
- `tests/gateway/test_discord_send.py`: `format_message()` end-to-end conversion, and a >2000-char generated table chunked by `truncate_message()` with every chunk under the limit and containing balanced fences.
- `tests/gateway/test_discord_format.py`: `test_table_converted_to_bullets` updated to `test_table_converted_to_codeblock`, asserting the new fenced-table output; the plain-text, fenced-block, and empty-string cases are unchanged.
- Suites run: `tests/gateway/` plus the discord/telegram plugin and tool tests. The gateway suite shows the same 36 environment-dependent failures (host-filesystem path completion, Telegram/Feishu SDK version drift, host session state) on this branch and on an unmodified `main` checkout; every test this PR adds or touches passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
