### PR TITLE
fix(agent): close AIAgent instances in 4 more #50197 lifecycle-cleanup gaps

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -233,11 +233,44 @@ class SessionManager:
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
         with self._lock:
-            existed = self._sessions.pop(session_id, None) is not None
+            state = self._sessions.pop(session_id, None)
+        if state is not None:
+            self._close_session_agent(state)
+        existed = state is not None
         db_existed = self._delete_persisted(session_id)
         if existed or db_existed:
             _clear_task_cwd(session_id)
         return existed or db_existed
+
+    @staticmethod
+    def _close_session_agent(state: "SessionState") -> None:
+        """Best-effort teardown for a removed session's AIAgent.
+
+        Mirrors the cleanup performed elsewhere for temporary/cached agents
+        (e.g. ``GatewayRunner._cleanup_agent_resources``): shut down the
+        memory provider (writer threads, bridge subprocesses, HTTP clients),
+        close tool resources (terminal sandbox, browser daemon, background
+        processes), then sweep any auxiliary async clients left behind.
+        Removing a session without this leaks all of the above per session.
+        """
+        agent = getattr(state, "agent", None)
+        if agent is None:
+            return
+        try:
+            if hasattr(agent, "shutdown_memory_provider"):
+                agent.shutdown_memory_provider()
+        except Exception:
+            pass
+        try:
+            if hasattr(agent, "close"):
+                agent.close()
+        except Exception:
+            pass
+        try:
+            from agent.auxiliary_client import cleanup_stale_async_clients
+            cleanup_stale_async_clients()
+        except Exception:
+            pass
 
     def fork_session(self, session_id: str, cwd: str = ".") -> Optional[SessionState]:
         """Deep-copy a session's history into a new session."""
@@ -357,8 +390,11 @@ class SessionManager:
     def cleanup(self) -> None:
         """Remove all sessions (memory and database) and clear task-specific cwd overrides."""
         with self._lock:
+            states = list(self._sessions.values())
             session_ids = list(self._sessions.keys())
             self._sessions.clear()
+        for state in states:
+            self._close_session_agent(state)
         for session_id in session_ids:
             _clear_task_cwd(session_id)
             self._delete_persisted(session_id)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -258,7 +258,17 @@ class SessionManager:
             return
         try:
             if hasattr(agent, "shutdown_memory_provider"):
-                agent.shutdown_memory_provider()
+                # Pass the agent's own conversation transcript so memory
+                # providers' on_session_end hooks see the real messages
+                # instead of the empty default — a no-argument call becomes
+                # on_session_end([]), losing facts from this session.
+                # Mirrors GatewayRunner._cleanup_agent_resources' guarded
+                # forwarding (gateway/run.py).
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
         except Exception:
             pass
         try:

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1985,7 +1985,16 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     finally:
         if review_agent is not None:
             try:
+                review_agent.shutdown_memory_provider()
+            except Exception:
+                pass
+            try:
                 review_agent.close()
+            except Exception:
+                pass
+            try:
+                from agent.auxiliary_client import cleanup_stale_async_clients
+                cleanup_stale_async_clients()
             except Exception:
                 pass
     return result_meta

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1632,6 +1632,7 @@ class CLICommandsMixin:
                 set_secret_capture_callback(self._secret_capture_callback)
             except Exception:
                 pass
+            bg_agent = None
             try:
                 bg_agent = AIAgent(
                     model=turn_route["model"],
@@ -1732,6 +1733,20 @@ class CLICommandsMixin:
                 print()
                 _cprint(f"  ❌ Background task #{task_num} failed: {e}")
             finally:
+                if bg_agent is not None:
+                    try:
+                        bg_agent.shutdown_memory_provider()
+                    except Exception:
+                        pass
+                    try:
+                        bg_agent.close()
+                    except Exception:
+                        pass
+                    try:
+                        from agent.auxiliary_client import cleanup_stale_async_clients
+                        cleanup_stale_async_clients()
+                    except Exception:
+                        pass
                 try:
                     set_sudo_password_callback(None)
                     set_approval_callback(None)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1735,7 +1735,18 @@ class CLICommandsMixin:
             finally:
                 if bg_agent is not None:
                     try:
-                        bg_agent.shutdown_memory_provider()
+                        # Pass the agent's own conversation transcript so
+                        # memory providers' on_session_end hooks see the
+                        # real messages instead of the empty default — a
+                        # no-argument call becomes on_session_end([]),
+                        # losing facts from this background session.
+                        # Mirrors GatewayRunner._cleanup_agent_resources'
+                        # guarded forwarding (gateway/run.py).
+                        session_messages = getattr(bg_agent, "_session_messages", None)
+                        if isinstance(session_messages, list):
+                            bg_agent.shutdown_memory_provider(session_messages)
+                        else:
+                            bg_agent.shutdown_memory_provider()
                     except Exception:
                         pass
                     try:

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -1060,6 +1060,7 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
     set_doc_client(client)
     set_drive_client(client)
 
+    agent = None
     try:
         model, runtime_kwargs = _resolve_model_and_runtime()
         logger.info("[Feishu-Comment] _run_comment_agent: model=%s provider=%s base_url=%s",
@@ -1103,6 +1104,20 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
         logger.exception("[Feishu-Comment] _run_comment_agent: agent failed: %s", e)
         return ""
     finally:
+        if agent is not None:
+            try:
+                agent.shutdown_memory_provider()
+            except Exception:
+                pass
+            try:
+                agent.close()
+            except Exception:
+                pass
+            try:
+                from agent.auxiliary_client import cleanup_stale_async_clients
+                cleanup_stale_async_clients()
+            except Exception:
+                pass
         set_doc_client(None)
         set_drive_client(None)
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -394,6 +394,29 @@ class TestListAndCleanup:
         # Removing again returns False
         assert manager.remove_session(state.session_id) is False
 
+    def test_cleanup_closes_agents(self, manager):
+        """cleanup() must tear down each session's AIAgent, not just drop it.
+
+        Regression: cleanup() cleared the in-memory session dict without
+        calling shutdown_memory_provider()/close() on the held agents,
+        leaking memory-provider threads, HTTP clients, terminal sandboxes,
+        and browser daemons per removed session (#50197).
+        """
+        s1 = manager.create_session()
+        s2 = manager.create_session()
+        manager.cleanup()
+        s1.agent.shutdown_memory_provider.assert_called_once_with()
+        s1.agent.close.assert_called_once_with()
+        s2.agent.shutdown_memory_provider.assert_called_once_with()
+        s2.agent.close.assert_called_once_with()
+
+    def test_remove_session_closes_agent(self, manager):
+        """remove_session() must tear down the session's AIAgent (#50197)."""
+        state = manager.create_session()
+        manager.remove_session(state.session_id)
+        state.agent.shutdown_memory_provider.assert_called_once_with()
+        state.agent.close.assert_called_once_with()
+
 
 # ---------------------------------------------------------------------------
 # persistence — sessions survive process restarts (via SessionDB)

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -417,6 +417,47 @@ class TestListAndCleanup:
         state.agent.shutdown_memory_provider.assert_called_once_with()
         state.agent.close.assert_called_once_with()
 
+    def test_remove_session_forwards_session_messages_when_present(self):
+        """A no-argument shutdown_memory_provider() call becomes
+        on_session_end([]) in AIAgent.shutdown_memory_provider, losing facts
+        from this session. Forward _session_messages when it's a list,
+        mirroring GatewayRunner._cleanup_agent_resources' guarded forwarding
+        (gateway/run.py)."""
+        calls = []
+        transcript = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+
+        class FakeAgent:
+            def __init__(self):
+                self._session_messages = transcript
+
+            def shutdown_memory_provider(self, messages=None):
+                calls.append(messages)
+
+            def close(self):
+                pass
+
+        manager = SessionManager(agent_factory=FakeAgent)
+        state = manager.create_session()
+        manager.remove_session(state.session_id)
+        assert calls == [transcript]
+
+    def test_remove_session_falls_back_to_no_args_when_session_messages_absent(self):
+        """An agent stub with no _session_messages attribute must still get
+        a plain no-argument call — not crash on a missing attribute."""
+        calls = []
+
+        class FakeAgent:
+            def shutdown_memory_provider(self, messages=None):
+                calls.append(messages)
+
+            def close(self):
+                pass
+
+        manager = SessionManager(agent_factory=FakeAgent)
+        state = manager.create_session()
+        manager.remove_session(state.session_id)
+        assert calls == [None]
+
 
 # ---------------------------------------------------------------------------
 # persistence — sessions survive process restarts (via SessionDB)

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -1442,3 +1442,102 @@ def test_review_fork_merges_slot_extra_body_over_runtime(curator_env, monkeypatc
         },
         "service_tier": "priority",
     }
+
+
+def test_review_agent_shuts_down_memory_provider_on_completion(curator_env, monkeypatch):
+    """_run_llm_review's finally block must tear down the review agent's
+    memory provider, not just call close() (#50197).
+
+    Regression: the finally block called review_agent.close() but never
+    shutdown_memory_provider() or cleanup_stale_async_clients(), leaking
+    memory-provider threads/HTTP clients per curator review pass.
+    """
+    curator = curator_env["curator"]
+    import importlib
+    importlib.reload(curator)
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider": "custom:gateway", "default": "gateway"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "custom",
+            "model": "real-model-id",
+            "api_key": "test-key",
+            "base_url": "https://gateway.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    calls = []
+
+    class _StubAgent:
+        def __init__(self, **_kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self):
+            calls.append("shutdown_memory_provider")
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    cleanup_calls = []
+    monkeypatch.setattr(
+        "agent.auxiliary_client.cleanup_stale_async_clients",
+        lambda: cleanup_calls.append(1),
+    )
+
+    result = curator._run_llm_review("review")
+
+    assert result["error"] is None
+    assert calls == ["shutdown_memory_provider", "close"]
+    assert cleanup_calls == [1]
+
+
+def test_review_agent_cleanup_survives_missing_shutdown_hook(curator_env, monkeypatch):
+    """A review agent stub without shutdown_memory_provider() must not
+    prevent close() from running, and must not raise out of the review."""
+    curator = curator_env["curator"]
+    import importlib
+    importlib.reload(curator)
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider": "custom:gateway", "default": "gateway"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "custom",
+            "model": "real-model-id",
+            "api_key": "test-key",
+            "base_url": "https://gateway.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    calls = []
+
+    class _StubAgentNoShutdownHook:
+        def __init__(self, **_kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "ok"}
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgentNoShutdownHook)
+
+    result = curator._run_llm_review("review")
+
+    assert result["error"] is None
+    assert calls == ["close"]

--- a/tests/cli/test_cli_background_agent_cleanup.py
+++ b/tests/cli/test_cli_background_agent_cleanup.py
@@ -1,0 +1,130 @@
+"""Regression tests: /background tasks must tear down their AIAgent (#50197).
+
+_handle_background_command's run_background() worker spawns a fresh AIAgent
+per invocation. Its finally block used to reset callbacks and clear the
+spinner/task-tracking bookkeeping but never called shutdown_memory_provider()
+or close() on the agent itself, leaking a terminal sandbox, browser daemon,
+httpx client, and memory-provider session per /background task.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import cli as cli_module
+from cli import HermesCLI
+
+
+def _make_background_cli_stub():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._approval_state = None
+    cli._approval_deadline = 0
+    cli._approval_lock = threading.Lock()
+    cli._sudo_state = None
+    cli._sudo_deadline = 0
+    cli._modal_input_snapshot = None
+    cli._invalidate = MagicMock()
+    cli._app = None
+    cli._background_task_counter = 0
+    cli._background_tasks = {}
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+    cli._resolve_turn_agent_config = MagicMock(return_value={
+        "model": "test-model",
+        "runtime": {
+            "api_key": "test-key",
+            "base_url": "https://example.test/v1",
+            "provider": "test",
+            "api_mode": "chat_completions",
+        },
+        "request_overrides": None,
+    })
+    cli.max_turns = 90
+    cli.enabled_toolsets = []
+    cli._session_db = None
+    cli.reasoning_config = {}
+    cli.service_tier = None
+    cli._providers_only = None
+    cli._providers_ignore = None
+    cli._providers_order = None
+    cli._provider_sort = None
+    cli._provider_require_params = None
+    cli._provider_data_collection = None
+    cli._openrouter_min_coding_score = None
+    cli._fallback_model = None
+    cli._agent_running = False
+    cli._spinner_text = ""
+    cli.bell_on_complete = False
+    cli.final_response_markdown = "strip"
+    return cli
+
+
+class TestBackgroundCommandAgentCleanup:
+    def _run_and_join(self, cli, cmd):
+        cli._handle_background_command(cmd)
+        for thread in list(cli._background_tasks.values()):
+            thread.join(timeout=10)
+
+    def test_agent_shutdown_and_close_called_on_success(self):
+        cli = _make_background_cli_stub()
+        calls = []
+
+        class FakeAgent:
+            def __init__(self, **_kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **_kwargs):
+                return {"final_response": "done", "messages": []}
+
+            def shutdown_memory_provider(self):
+                calls.append("shutdown_memory_provider")
+
+            def close(self):
+                calls.append("close")
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console, \
+             patch("agent.auxiliary_client.cleanup_stale_async_clients") as mock_cleanup:
+            chat_console.return_value.print = MagicMock()
+            self._run_and_join(cli, "/background do something")
+
+        assert calls == ["shutdown_memory_provider", "close"]
+        mock_cleanup.assert_called_once_with()
+        assert not cli._background_tasks
+
+    def test_agent_shutdown_and_close_called_on_failure(self):
+        """Cleanup must still run when run_conversation() raises."""
+        cli = _make_background_cli_stub()
+        calls = []
+
+        class FakeAgent:
+            def __init__(self, **_kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **_kwargs):
+                raise RuntimeError("boom")
+
+            def shutdown_memory_provider(self):
+                calls.append("shutdown_memory_provider")
+
+            def close(self):
+                calls.append("close")
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"):
+            self._run_and_join(cli, "/background do something")
+
+        assert calls == ["shutdown_memory_provider", "close"]
+
+    def test_no_crash_when_agent_construction_fails(self):
+        """bg_agent stays None if AIAgent() itself raises; finally must not
+        try to close a nonexistent agent."""
+        cli = _make_background_cli_stub()
+
+        with patch.object(cli_module, "AIAgent", side_effect=RuntimeError("no creds")), \
+             patch.object(cli_module, "_cprint"):
+            self._run_and_join(cli, "/background do something")
+
+        assert not cli._background_tasks

--- a/tests/cli/test_cli_background_agent_cleanup.py
+++ b/tests/cli/test_cli_background_agent_cleanup.py
@@ -128,3 +128,66 @@ class TestBackgroundCommandAgentCleanup:
             self._run_and_join(cli, "/background do something")
 
         assert not cli._background_tasks
+
+    def test_shutdown_forwards_session_messages_when_present(self):
+        """A no-argument shutdown_memory_provider() call becomes
+        on_session_end([]) in AIAgent.shutdown_memory_provider, losing facts
+        from this background session. Forward _session_messages when it's a
+        list, mirroring GatewayRunner._cleanup_agent_resources' guarded
+        forwarding (gateway/run.py)."""
+        cli = _make_background_cli_stub()
+        calls = []
+        transcript = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+
+        class FakeAgent:
+            def __init__(self, **_kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+                self._session_messages = transcript
+
+            def run_conversation(self, **_kwargs):
+                return {"final_response": "done", "messages": []}
+
+            def shutdown_memory_provider(self, messages=None):
+                calls.append(messages)
+
+            def close(self):
+                pass
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console, \
+             patch("agent.auxiliary_client.cleanup_stale_async_clients"):
+            chat_console.return_value.print = MagicMock()
+            self._run_and_join(cli, "/background do something")
+
+        assert calls == [transcript]
+
+    def test_shutdown_falls_back_to_no_args_when_session_messages_absent(self):
+        """An agent stub with no _session_messages attribute must still get
+        a plain no-argument call — not crash on a missing attribute."""
+        cli = _make_background_cli_stub()
+        calls = []
+
+        class FakeAgent:
+            def __init__(self, **_kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **_kwargs):
+                return {"final_response": "done", "messages": []}
+
+            def shutdown_memory_provider(self, messages=None):
+                calls.append(messages)
+
+            def close(self):
+                pass
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console, \
+             patch("agent.auxiliary_client.cleanup_stale_async_clients"):
+            chat_console.return_value.print = MagicMock()
+            self._run_and_join(cli, "/background do something")
+
+        assert calls == [None]

--- a/tests/gateway/test_feishu_comment.py
+++ b/tests/gateway/test_feishu_comment.py
@@ -256,5 +256,75 @@ class TestWikiReverseLookup(unittest.TestCase):
         self.assertEqual(second_call_kwargs[1].get("wiki_token") or second_call_kwargs[0][3], "WIKI123")
 
 
+class TestRunCommentAgentCleanup(unittest.TestCase):
+    """_run_comment_agent must tear down the AIAgent it creates (#50197).
+
+    Regression: the finally block only cleared feishu doc/drive client
+    thread-locals; it never called shutdown_memory_provider() or close() on
+    the agent, leaking a terminal sandbox / httpx client / memory-provider
+    session per comment handled.
+    """
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    @patch("plugins.platforms.feishu.feishu_comment._resolve_model_and_runtime")
+    @patch("plugins.platforms.feishu.feishu_comment._load_session_history", return_value=[])
+    @patch("tools.feishu_drive_tool.set_client")
+    @patch("tools.feishu_doc_tool.set_client")
+    def test_agent_is_shut_down_and_closed(
+        self, mock_set_doc, mock_set_drive, mock_load_history, mock_resolve,
+    ):
+        from plugins.platforms.feishu.feishu_comment import _run_comment_agent
+
+        mock_resolve.return_value = ("test-model", {"provider": "test", "api_key": "k"})
+
+        calls = []
+
+        class _StubAgent:
+            def __init__(self, **_kwargs):
+                pass
+
+            def run_conversation(self, *_a, **_kw):
+                return {"final_response": "ok", "api_calls": 1, "messages": []}
+
+            def shutdown_memory_provider(self):
+                calls.append("shutdown_memory_provider")
+
+            def close(self):
+                calls.append("close")
+
+        with patch("run_agent.AIAgent", _StubAgent), \
+             patch("agent.auxiliary_client.cleanup_stale_async_clients") as mock_cleanup:
+            result = _run_comment_agent("do something", client=Mock())
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(calls, ["shutdown_memory_provider", "close"])
+        mock_cleanup.assert_called_once_with()
+
+    @patch("plugins.platforms.feishu.feishu_comment._resolve_model_and_runtime")
+    @patch("plugins.platforms.feishu.feishu_comment._load_session_history", return_value=[])
+    @patch("tools.feishu_drive_tool.set_client")
+    @patch("tools.feishu_doc_tool.set_client")
+    def test_agent_cleanup_runs_even_when_construction_fails(
+        self, mock_set_doc, mock_set_drive, mock_load_history, mock_resolve,
+    ):
+        """Agent construction failing must not skip client thread-local cleanup,
+        and must not raise past _run_comment_agent (best-effort by design)."""
+        from plugins.platforms.feishu.feishu_comment import _run_comment_agent
+
+        mock_resolve.return_value = ("test-model", {"provider": "test", "api_key": "k"})
+
+        def _boom(**_kwargs):
+            raise RuntimeError("construction failed")
+
+        with patch("run_agent.AIAgent", _boom):
+            result = _run_comment_agent("do something", client=Mock())
+
+        self.assertEqual(result, "")
+        mock_set_doc.assert_called_with(None)
+        mock_set_drive.assert_called_with(None)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

#50197 (Codex scan) found 6 locations where an `AIAgent` is created without proper resource cleanup — `shutdown_memory_provider()` + `close()` in a `finally` block — leaking terminal sandboxes, browser daemons, httpx clients, and memory-provider sessions on every call.

Two of the six already have open PRs (`tui_gateway/server.py` and `batch_runner.py`), so this PR covers the remaining four, plus one additional instance of the exact same defect found in `acp_adapter/session.py` while fixing the one #50197 called out there:

1. **`agent/curator.py`** — `_run_llm_review()`'s `finally` block called `close()` but never `shutdown_memory_provider()` or swept auxiliary async clients.
2. **`plugins/platforms/feishu/feishu_comment.py`** — `_run_comment_agent()`'s `finally` block only cleared the doc/drive client thread-locals; the agent itself was never closed.
3. **`hermes_cli/cli_commands_mixin.py`** — `/background`'s `run_background()` worker reset callbacks and cleared the spinner in `finally`, but never closed `bg_agent`.
4. **`acp_adapter/session.py`** — `SessionManager.cleanup()` dropped every `SessionState` (and its `.agent`) without closing them, exactly as #50197 described. While fixing this I found `remove_session()` has the identical bug (not called out in the original issue, since it wasn't in the 6 listed locations, but same class in the same file) — both now route through a shared `_close_session_agent()` helper to avoid duplicating the cleanup logic three times.

All four follow the same best-effort try/except pattern already established in `gateway/run.py`'s `_cleanup_agent_resources()` and `agent/background_review.py` — `shutdown_memory_provider()`, then `close()`, then `agent.auxiliary_client.cleanup_stale_async_clients()`, each independently swallowing exceptions so cleanup failures never mask the original error or block on a hung provider.

## Test Plan

Added regression tests for all four locations (verifying both the happy path and that cleanup still runs when agent construction/execution fails):

- `python -m pytest tests/agent/test_curator.py -q -o addopts=` → 72 passed
- `python -m pytest tests/acp/test_session.py -q -o addopts=` → 47 passed
- `python -m pytest tests/gateway/test_feishu_comment.py -q -o addopts=` → 22 passed
- `python -m pytest tests/cli/test_cli_background_agent_cleanup.py tests/cli/test_cli_approval_ui.py -q -o addopts=` → 28 passed
- `ruff check` on all changed/new files → clean
- `python scripts/check-windows-footguns.py --all` → clean
