### PR TITLE
feat(mcp-catalog): add robotsshop Trust Index (x402 settlement truth)

### DIFF
--- a/optional-mcps/robotsshop/manifest.yaml
+++ b/optional-mcps/robotsshop/manifest.yaml
@@ -1,0 +1,83 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+#
+# Schema version 1.
+manifest_version: 1
+
+name: robotsshop
+description: >-
+  RobotsShop Trust Index — x402 settlement truth for agents (free payTo
+  mismatches, free→paid onramp, free trips). stdio FastMCP; no API key required
+  for free tools.
+
+source: https://github.com/AnalogHubris/robotsshop-mcp
+
+# How to launch the server once installed. The keys here map 1:1 to the
+# `mcp_servers.<name>` block written into ~/.hermes/config.yaml by the
+# existing `_save_mcp_server()` helper in hermes_cli/mcp_config.py.
+transport:
+  type: stdio
+  # For git-installed servers, ${INSTALL_DIR} is substituted at install time
+  # with the path the catalog cloned the repo into. The catalog never
+  # auto-updates: the user re-runs `hermes mcp install official/robotsshop` to
+  # refresh.
+  command: "${INSTALL_DIR}/.venv/bin/python"
+  args:
+    - "${INSTALL_DIR}/trust_index_mcp.py"
+  env:
+    # Public free API (no key). Override only if self-hosting a mirror.
+    TRUST_INDEX_API: "https://api.robotsshop.io"
+
+# Optional install step. Omit for npm/uvx servers where transport.command
+# is the install (`npx -y package`). Use for repos that need a local clone
+# + dependency install.
+install:
+  type: git
+  url: https://github.com/AnalogHubris/robotsshop-mcp.git
+  # Pinned per catalog dependency policy: full commit SHA (branches and tags
+  # can be moved; SHAs cannot), and the pinned commit must be at least
+  # 2 weeks old at pin time — same supply-chain rules as pyproject
+  # dependencies. NOTE (2026-07-15 rebase): package shipped 2026-07-14 so this
+  # pin is younger than the usual 2-week cooldown. Free tools only, no secrets,
+  # public HTTPS API. Maintainers may hold merge until the pin ages or grant a
+  # one-time waiver. Bumping the pin is a PR to this manifest.
+  # Commit: chore: pin catalog ref after docs commit (2026-07-14)
+  ref: 6f88737bbbda06984faa69931b8cc87104597556
+  # Bootstrap commands run inside the cloned directory after clone.
+  bootstrap:
+    - "python3 -m venv .venv"
+    - ".venv/bin/pip install -r requirements.txt"
+
+# Authentication. Three shapes:
+#   type: api_key  — prompt for env vars, write to ~/.hermes/.env
+#   type: oauth    — provider-mediated or remote MCP native OAuth (case 1/2)
+#   type: none     — no credentials needed
+auth:
+  type: none
+
+# Tool selection at install time:
+# Free tools only. Paid depth is HTTP x402 outside this MCP (see paid_routes_help).
+# payto_mismatches is an alias of mismatches — leave off default to save schema tokens.
+tools:
+  default_enabled:
+    - onramp
+    - mismatches
+    - stats
+    - leaderboard
+    - lookup
+    - free_trips
+    - paid_routes_help
+
+post_install: |
+  RobotsShop Trust Index talks to the public API (default
+  https://api.robotsshop.io). Free tools never attach payment. Paid depth is
+  HTTP x402 (Base USDC) — see paid_routes_help.
+
+  Suggested habit: onramp → mismatches → lookup before spending USDC on an
+  endpoint.
+
+  Site: https://robotsshop.io
+  Repo: https://github.com/AnalogHubris/robotsshop-mcp
+  Contact: hello@robotsshop.io
+
+  Start a new Hermes session (or /reload-mcp) to load tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,6 +371,31 @@ override-dependencies = [
 exclude-newer = "14 days"
 exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false }
 
+[tool.setuptools.data-files]
+# i18n catalogs. locales/ is a bare data directory (no __init__.py), so it is
+# neither a package (packages.find) nor package-data (which attaches to a
+# package). data-files ships it in the wheel; MANIFEST.in `graft locales`
+# ships it in the sdist. Without this, sealed installs (pip wheel, Nix store
+# venv) drop the catalogs and gateway/CLI commands surface raw i18n keys like
+# `gateway.reset.header_default` (#27632, #35374, #23943).
+locales = ["locales/*.yaml"]
+# Shipped MCP catalog (optional-mcps/<name>/manifest.yaml). Same bare-data-dir
+# case as locales: data-files ships it in the wheel, `graft optional-mcps` in
+# MANIFEST.in ships it in the sdist. Without this, `hermes mcp catalog` and the
+# dashboard catalog screen come up empty on packaged installs even though the
+# manifests exist in the repo (hermes_cli/mcp_catalog.py:_catalog_root resolves
+# the packaged dir; list_catalog() returns [] when it's missing).
+#
+# data-files flattens every glob match into its single target dir, so each
+# catalog entry needs its OWN target to preserve the per-entry directory the
+# catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
+# manifests into one colliding optional-mcps/manifest.yaml). One target per
+# entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
+"optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
+"optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/robotsshop" = ["optional-mcps/robotsshop/manifest.yaml"]
+
+
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's
 # sealed venv is missing hermes_constants, run_agent, etc.


### PR DESCRIPTION
stdio FastMCP for free payTo integrity / onramp / free trips before agents spend on x402 endpoints. auth: none. Installs from public AnalogHubris/robotsshop-mcp.

Refs: https://github.com/NousResearch/hermes-agent/issues/64182#issuecomment-4967233269

## What does this PR do?

Adds **RobotsShop Trust Index** to the official optional MCP catalog so Hermes agents can install free x402 settlement-truth tools (`mismatches`, `onramp`, `free_trips`, etc.) with `auth: none`.

stdio FastMCP · public API `https://api.robotsshop.io` · no secrets required.

## Related Issue

Community catalog candidate discussed on:
https://github.com/NousResearch/hermes-agent/issues/64182#issuecomment-4967233269

Not a plugin-interface expansion request — catalog entry only.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/robotsshop/manifest.yaml` — git install, free tool defaults, pin SHA `6f88737bbbda06984faa69931b8cc87104597556`
- Packaging: `optional-mcps/robotsshop` included in `[tool.setuptools.data-files]` (commit `732bbab`) so wheels ship the manifest

## Supply-chain / pin age

Catalog pin cooldown is 2 weeks. Package shipped 2026-07-14; pin ages clean ~2026-07-28. Happy to wait for cooldown or accept maintainer waiver. Free tools only (`auth: none`).

## How to Test

```bash
# after merge / from this branch checkout:
hermes mcp install official/robotsshop
# or pre-merge manual:
git clone https://github.com/AnalogHubris/robotsshop-mcp.git
cd robotsshop-mcp && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
hermes mcp add robotsshop --command "$(pwd)/.venv/bin/python"   --args "$(pwd)/trust_index_mcp.py"   --env TRUST_INDEX_API=https://api.robotsshop.io
```

Then in a session: `onramp` / `mismatches` / `free_trips`.

Also: https://robotsshop.io/mcp.html

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (manifest-only catalog entry)
- [x] I've added tests for my changes — N/A (manifest-only)
- [x] I've tested on my platform: macOS (manual MCP install path)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (post_install text in manifest)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A