### PR TITLE
fix(cli): refresh slash completion after deletion

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3365,6 +3365,69 @@ def _estimate_tui_input_height(
     return min(max(visual_lines, 1), max(1, int(max_height or 1)))
 
 
+def _refresh_cli_input_completions_after_deletion(buffer, chars_added: int) -> None:
+    """Re-run prompt completions and suggestions after text is deleted.
+
+    prompt_toolkit's deletion methods clear both pipelines without scheduling
+    replacements. A previous threaded completion may still be winding down, so
+    wait for it before starting completion for the current document.
+    """
+    document = buffer.document
+    if (
+        chars_added >= 0
+        or buffer.completer is None
+        or not document.text_before_cursor.startswith("/")
+    ):
+        return
+
+    import asyncio
+    from prompt_toolkit.application import get_app
+
+    async def _restart_for_current_document() -> None:
+        while buffer.document == document:
+            state = buffer.complete_state
+            if state is not None and state.original_document == document:
+                return
+
+            completions_changed = asyncio.Event()
+            started_for_document = [False]
+
+            def _on_completions_changed(_buffer) -> None:
+                current_state = buffer.complete_state
+                if (
+                    current_state is not None
+                    and current_state.original_document == document
+                ):
+                    started_for_document[0] = True
+                completions_changed.set()
+
+            buffer.on_completions_changed += _on_completions_changed
+            try:
+                # A no-op insert is prompt_toolkit's public autosuggest trigger.
+                buffer.insert_text("")
+                # Explicitly request the completion menu as well. If the prior
+                # threaded completion is still active this request is dropped;
+                # its final change event wakes the loop for one safe retry.
+                buffer.start_completion(select_first=False)
+                await asyncio.sleep(0)
+                current_state = buffer.complete_state
+                if (
+                    started_for_document[0]
+                    or (
+                        current_state is not None
+                        and current_state.original_document == document
+                    )
+                ):
+                    return
+                await completions_changed.wait()
+                if started_for_document[0]:
+                    return
+            finally:
+                buffer.on_completions_changed -= _on_completions_changed
+
+    get_app().create_background_task(_restart_for_current_document())
+
+
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
     """Collect local image attachments for single-query CLI flows."""
     message = query or ""
@@ -14330,6 +14393,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._skip_paste_collapse = False
                 _prev_newline_count[0] = text.count('\n')
                 return
+            _refresh_cli_input_completions_after_deletion(buf, chars_added)
             line_count = text.count('\n')
             newlines_added = line_count - _prev_newline_count[0]
             _prev_newline_count[0] = line_count

--- a/tests/hermes_cli/test_slash_autocomplete_delete.py
+++ b/tests/hermes_cli/test_slash_autocomplete_delete.py
@@ -1,0 +1,112 @@
+"""Behavioral regression tests for classic CLI completion after deletion."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from prompt_toolkit.application import Application
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.completion import ThreadedCompleter
+from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.output import DummyOutput
+from prompt_toolkit.widgets import TextArea
+
+from cli import _refresh_cli_input_completions_after_deletion
+from hermes_cli.commands import SlashCommandAutoSuggest, SlashCommandCompleter
+
+
+async def _wait_for(
+    predicate: Callable[[], bool],
+    timeout: float = 2.0,
+    describe: Callable[[], object] | None = None,
+) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    state = describe() if describe else None
+    raise AssertionError(
+        f"prompt_toolkit state did not update before timeout: {state!r}"
+    )
+
+
+def _completion_texts(input_area: TextArea) -> list[str]:
+    state = input_area.buffer.complete_state
+    return [completion.text for completion in state.completions] if state else []
+
+
+async def _exercise_deletion(delete_input: bytes, *, move_left: bool) -> None:
+    completer = SlashCommandCompleter()
+    input_area = TextArea(
+        multiline=True,
+        completer=ThreadedCompleter(completer),
+        complete_while_typing=True,
+        auto_suggest=SlashCommandAutoSuggest(
+            history_suggest=AutoSuggestFromHistory(),
+            completer=completer,
+        ),
+    )
+    previous_text_length = [0]
+
+    def refresh_after_deletion(buffer) -> None:
+        current_length = len(buffer.text)
+        chars_added = current_length - previous_text_length[0]
+        previous_text_length[0] = current_length
+        _refresh_cli_input_completions_after_deletion(buffer, chars_added)
+
+    input_area.buffer.on_text_changed += refresh_after_deletion
+
+    with create_pipe_input() as pipe_input:
+        app = Application(
+            layout=Layout(input_area),
+            input=pipe_input,
+            output=DummyOutput(),
+        )
+        app_task = asyncio.create_task(app.run_async())
+        try:
+            await asyncio.sleep(0.05)
+            pipe_input.send_text("/reas")
+            await _wait_for(
+                lambda: input_area.buffer.suggestion is not None
+                and input_area.buffer.suggestion.text == "oning"
+                and "reasoning" in _completion_texts(input_area)
+            )
+
+            if move_left:
+                pipe_input.send_bytes(b"\x1b[D")
+                await _wait_for(lambda: input_area.buffer.cursor_position == 4)
+            pipe_input.send_bytes(delete_input)
+
+            await _wait_for(
+                lambda: input_area.text == "/rea"
+                and input_area.buffer.suggestion is not None
+                and input_area.buffer.suggestion.text == "soning"
+                and "reasoning" in _completion_texts(input_area),
+                describe=lambda: (
+                    input_area.text,
+                    input_area.buffer.cursor_position,
+                    input_area.buffer.suggestion,
+                    _completion_texts(input_area),
+                ),
+            )
+        finally:
+            if app.is_running:
+                app.exit()
+            await app_task
+
+
+@pytest.mark.parametrize(
+    ("delete_input", "move_left"),
+    [
+        pytest.param(b"\x7f", False, id="backspace"),
+        pytest.param(b"\x1b[3~", True, id="forward-delete"),
+    ],
+)
+def test_slash_completion_refreshes_after_deletion(
+    delete_input: bytes,
+    move_left: bool,
+) -> None:
+    asyncio.run(_exercise_deletion(delete_input, move_left=move_left))


### PR DESCRIPTION
## What does this PR do?

Restores slash-command completion and ghost-text suggestions after Backspace or forward Delete in the classic CLI.

`prompt_toolkit` clears completion and suggestion state when text is deleted, but unlike insertion it does not schedule either pipeline again. With `ThreadedCompleter`, an immediate completion request can also be ignored while the previous request is still unwinding. This change refreshes only slash-prefixed input after deletion, waits for the old completion state to finish when necessary, and retries only while the document is unchanged.

## Related Issue

Fixes #64110

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Refresh autosuggestions and completions after deletion when the current input is a slash command.
- Avoid racing the one-at-a-time threaded completer by waiting for its completion-change event before retrying.
- Add real `prompt_toolkit` interaction tests for Backspace and forward Delete.

## How to Test

1. On `main`, type `/reas` in classic `hermes chat`, then press Backspace. The input becomes `/rea`, but the suggestion is empty and the completion menu is gone.
2. On this branch, repeat the same action. Ghost text becomes `soning`, and the menu again contains `reasoning`.
3. Run the focused checks below.

Verification on Python 3.11.14 / macOS 26.4.1:

```text
scripts/run_tests.sh tests/hermes_cli/test_slash_autocomplete_delete.py -q
# 2 passed; repeated 5 times (10/10 scenarios passed)

scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/hermes_cli/test_at_context_completion_filter.py tests/hermes_cli/test_path_completion.py tests/hermes_cli/test_slash_autocomplete_delete.py -q
# 212 passed

scripts/run_tests.sh tests/hermes_cli -q
# 8,230 passed; 15 unrelated failures; 3 unrelated files hit the 300s file timeout
# All 15 failing tests reproduce unchanged on origin/main. The timeout files do not overlap this diff.

.venv/bin/ruff check cli.py tests/hermes_cli/test_slash_autocomplete_delete.py
# All checks passed

.venv/bin/python -m compileall -q cli.py tests/hermes_cli/test_slash_autocomplete_delete.py
git diff --check
# passed

.venv/bin/ty check tests/hermes_cli/test_slash_autocomplete_delete.py
# All checks passed
```

The pre-existing CLI-suite failures are in `test_gateway_wsl.py`, `test_resolve_provider_openrouter_pool.py`, `test_signal_handler_kanban_worker.py`, `test_model_validation.py`, `test_service_manager.py`, and `test_urllib_security.py`. The timed-out files are `test_api_key_providers.py`, `test_gateway_service.py`, and `test_model_switch_custom_providers.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: no user-facing documentation change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: no architecture/workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix uses public `prompt_toolkit` buffer events, and tests cover both common terminal deletion sequences
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: no tool changes

## Residual Risk

The refresh is intentionally limited to slash-prefixed input. It does not replace key bindings or change non-slash completion behavior. Terminal escape-sequence mapping can still vary, but both Backspace and the standard forward-Delete sequence exercise the same buffer-level path covered here.

## Screenshots / Logs

Not applicable; this is terminal behavior covered by real `prompt_toolkit` interaction tests.
