### PR TITLE
fix(agent): recover tools from truncated scratchpads

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4411,34 +4411,48 @@ def run_conversation(
                         pass
             
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
-            # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
-            if has_incomplete_scratchpad(assistant_message.content or ""):
+            # Recover structured calls; retry text-only truncation up to 2 times.
+            incomplete_scratchpad = has_incomplete_scratchpad(assistant_message.content or "")
+            if incomplete_scratchpad and assistant_message.tool_calls:
+                # A structured tool call is represented independently even
+                # when the adjacent free-form reasoning was truncated. Drop
+                # the unclosed tail before persistence/replay, then use the
+                # normal validation and approval path.
+                visible_prefix, _, _ = assistant_message.content.partition(
+                    "<REASONING_SCRATCHPAD>"
+                )
+                assistant_message.content = visible_prefix.rstrip()
+                agent._buffer_vprint(
+                    "⚠️  Incomplete <REASONING_SCRATCHPAD> detected; "
+                    f"recovering {len(assistant_message.tool_calls)} structured tool call(s)"
+                )
+            elif incomplete_scratchpad:
                 agent._incomplete_scratchpad_retries += 1
-                
+
                 agent._buffer_vprint("⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
-                
+
                 if agent._incomplete_scratchpad_retries <= 2:
                     agent._buffer_vprint(f"🔄 Retrying API call ({agent._incomplete_scratchpad_retries}/2)...")
                     # Don't add the broken message, just retry
                     continue
-                else:
-                    # Max retries - discard this turn and save as partial
-                    agent._flush_status_buffer()
-                    agent._vprint(f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.", force=True)
-                    agent._incomplete_scratchpad_retries = 0
-                    
-                    rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
-                    agent._cleanup_task_resources(effective_task_id)
-                    agent._persist_session(messages, conversation_history)
-                    
-                    return {
-                        "final_response": "Incomplete REASONING_SCRATCHPAD after 2 retries",
-                        "messages": rolled_back_messages,
-                        "api_calls": api_call_count,
-                        "completed": False,
-                        "partial": True,
-                        "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
-                    }
+
+                # Max retries - discard this turn and save as partial
+                agent._flush_status_buffer()
+                agent._vprint(f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.", force=True)
+                agent._incomplete_scratchpad_retries = 0
+
+                rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
+                agent._cleanup_task_resources(effective_task_id)
+                agent._persist_session(messages, conversation_history)
+
+                return {
+                    "final_response": "Incomplete REASONING_SCRATCHPAD after 2 retries",
+                    "messages": rolled_back_messages,
+                    "api_calls": api_call_count,
+                    "completed": False,
+                    "partial": True,
+                    "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
+                }
             
             # Reset incomplete scratchpad counter on clean response
             agent._incomplete_scratchpad_retries = 0

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4211,6 +4211,85 @@ class TestRunConversation:
         assert result["final_response"] == "Done searching"
         assert mock_handle_function_call.call_args.args[:2] == ("web_search", {})
 
+    def test_incomplete_scratchpad_preserves_structured_tool_call(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(
+            content="Visible preface\n<REASONING_SCRATCHPAD>Need current data",
+            finish_reason="tool_calls",
+            tool_calls=[tc],
+        )
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done searching"
+        assert result["api_calls"] == 2
+        mock_handle_function_call.assert_called_once()
+        replay_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        recovered = next(msg for msg in replay_messages if msg.get("tool_calls"))
+        assert recovered["content"] == "Visible preface"
+        assert "REASONING_SCRATCHPAD" not in recovered["content"]
+
+    def test_incomplete_scratchpad_does_not_execute_non_object_tool_call(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(
+            name="web_search",
+            arguments="[]",
+            call_id="c1",
+        )
+        resp1 = _mock_response(
+            content="<REASONING_SCRATCHPAD>Need current data",
+            finish_reason="tool_calls",
+            tool_calls=[tc],
+        )
+        resp2 = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Recovered"
+        assert result["api_calls"] == 2
+        mock_handle_function_call.assert_not_called()
+        replay_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        tool_result = next(msg for msg in replay_messages if msg.get("role") == "tool")
+        assert "Invalid tool arguments" in tool_result["content"]
+
+    def test_incomplete_scratchpad_without_tool_calls_still_fails_bounded(self, agent):
+        self._setup_agent(agent)
+        incomplete = _mock_response(
+            content="<REASONING_SCRATCHPAD>Still thinking",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.return_value = incomplete
+
+        with (
+            patch("run_agent.handle_function_call") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hard question")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["api_calls"] == 3
+        assert agent.client.chat.completions.create.call_count == 3
+        mock_handle_function_call.assert_not_called()
+
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")


### PR DESCRIPTION
## Summary

- preserve provider-emitted structured tool calls when adjacent `<REASONING_SCRATCHPAD>` text is truncated
- remove the unclosed reasoning tail before the assistant turn is persisted or replayed, while retaining any visible prefix
- route recovered calls through the existing tool-name, JSON-object, scope, guardrail, and approval paths
- keep the existing two-retry / partial-failure behavior for text-only incomplete scratchpads

## Root cause

`run_conversation()` checked the free-form scratchpad before its structured `assistant_message.tool_calls`. Any unclosed scratchpad caused an unconditional retry and discarded the whole response, even when the provider had already returned a complete, independently structured tool call. After the retry, the useful action was gone.

The recovery is intentionally narrow: only a non-empty structured tool-call list bypasses the scratchpad retry. Hermes strips the unclosed text tail and then enters its normal tool pipeline. Invalid names and arguments are still rejected there, and tools still require the same configured approvals.

## Current-main proof

An isolated mocked response with an unclosed scratchpad plus a complete `web_search({})` call produced:

```text
{'final_response': 'Done', 'api_calls': 2, 'tool_calls_executed': 0}
```

After this change, the same proof produces:

```text
{'final_response': 'Done', 'api_calls': 2, 'tool_calls_executed': 1}
```

The follow-up request contains the tool call and result but no unclosed `REASONING_SCRATCHPAD` text.

## Validation

- isolated mocked-provider before/after proof under a temporary `HERMES_HOME`
- `uv run --extra dev pytest tests/run_agent/test_run_agent.py::TestRunConversation -q` (`53 passed`)
- `uv run --extra dev pytest tests/run_agent/test_run_agent.py -q` (`425 passed`)
- `uv run --extra dev ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- `git diff --check`
- Hermes contribution publish gate, overlap adjudication, metadata scan, and gitleaks

## Overlap audit

PR #11743 handles false positives from quoted/code-form scratchpad tag mentions. The other open `REASONING_SCRATCHPAD` matches affect title sanitization, UI token normalization, trajectory coverage, or list-valued session logging. None handles a true incomplete scratchpad response carrying structured tool calls.

Fixes #11153
