### PR TITLE
fix(langfuse): reject right-prefix template keys, not just wrong prefixes

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -79,6 +79,33 @@ _LANGFUSE_KEY_PREFIXES: Dict[str, str] = {
     "HERMES_LANGFUSE_SECRET_KEY": "sk-lf-",
 }
 
+# Template values that carry the RIGHT prefix but are still placeholders.
+# The docs (plugin README, website env-var reference) show the keys as
+# literally ``pk-lf-...`` / ``sk-lf-...`` — pasting that passes the prefix
+# check above and reproduces the exact silent failure the guard exists to
+# catch (#51399 and its six duplicates, all filed AFTER the prefix guard
+# merged).
+#
+# Matched against the lowercased remainder AFTER the prefix:
+# ``_PLACEHOLDER_REMAINDERS`` by whole-value equality (ellipsis/asterisks
+# and the empty remainder of a bare prefix), ``_PLACEHOLDER_FRAGMENTS`` by
+# substring. Fragments cannot false-positive on real keys: Langfuse issues
+# UUID-shaped remainders (hex digits + dashes), and every fragment below
+# contains at least one non-hex letter.
+_PLACEHOLDER_REMAINDERS = frozenset({"", "...", "***"})
+_PLACEHOLDER_FRAGMENTS = (
+    "placeholder",
+    "your-",
+    "your_",
+    "changeme",
+    "change-me",
+    "test-key",
+    "example",
+    "unset",
+    "dummy",
+    "xxx",
+)
+
 
 def _env(name: str, default: str = "") -> str:
     return os.environ.get(name, default).strip()
@@ -138,12 +165,25 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
     expected = _LANGFUSE_KEY_PREFIXES.get(env_name, "")
     if not expected:
         return None
-    if value.startswith(expected):
-        return None
-    return (
-        f"{env_name}={_redact_key_preview(value)} "
-        f"(expected {expected!r} prefix)"
-    )
+    if not value.startswith(expected):
+        return (
+            f"{env_name}={_redact_key_preview(value)} "
+            f"(expected {expected!r} prefix)"
+        )
+    # Right prefix, but is the rest of it a leftover template? ``pk-lf-...``
+    # pasted straight from the docs sails through the prefix check and then
+    # fails exactly like #23823: the SDK accepts it at construction time and
+    # drops every trace at flush time, silently.
+    remainder = value[len(expected):].lower()
+    if remainder in _PLACEHOLDER_REMAINDERS or any(
+        fragment in remainder for fragment in _PLACEHOLDER_FRAGMENTS
+    ):
+        return (
+            f"{env_name}={_redact_key_preview(value)} "
+            f"(has the {expected!r} prefix but looks like a template value, "
+            f"not an issued key)"
+        )
+    return None
 
 
 def _get_langfuse() -> Optional[Langfuse]:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -522,6 +522,58 @@ class TestPlaceholderKeyDetection:
         plugin = self._fresh_plugin()
         assert plugin._validate_langfuse_key("HERMES_LANGFUSE_BASE_URL", "anything") is None
 
+    @pytest.mark.parametrize(
+        ("env_name", "value"),
+        [
+            # The docs' own copy-paste templates (README, website env-var
+            # reference show the keys as literally ``pk-lf-...``) — the
+            # exact values behind #51399 and its duplicates.
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-..."),
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-..."),
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-***"),
+            # Bare prefix with nothing after it.
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-"),
+            # Common template fragments, case-insensitive.
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-placeholder"),
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-PLACEHOLDER"),
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-your-secret-key"),
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-test-key"),
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-xxxxxxxxxxxx"),
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-changeme"),
+        ],
+    )
+    def test_validate_langfuse_key_rejects_right_prefix_templates(
+        self, monkeypatch, env_name, value
+    ):
+        """A leftover template that happens to carry the documented prefix
+        must be rejected — the prefix-only check let these through, which is
+        why the placeholder reports kept coming after the original guard
+        merged (#51399 and its six duplicates)."""
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin()
+        msg = plugin._validate_langfuse_key(env_name, value)
+        assert msg is not None, f"{value!r} must be rejected as a template"
+        assert env_name in msg
+        assert "template" in msg
+
+    @pytest.mark.parametrize(
+        ("env_name", "value"),
+        [
+            # Langfuse issues UUID-shaped remainders — hex digits + dashes.
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-1234abcd-12ab-4cd9-9f00-aabbccddeeff"),
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-9f8e7d6c-5b4a-4321-8765-0123456789ab"),
+        ],
+    )
+    def test_validate_langfuse_key_accepts_real_shaped_keys(
+        self, monkeypatch, env_name, value
+    ):
+        """Real issued keys (UUID remainder) must keep passing: every
+        placeholder fragment contains a non-hex letter, so a hex-and-dashes
+        remainder can never be flagged."""
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin()
+        assert plugin._validate_langfuse_key(env_name, value) is None
+
     # -- end-to-end _get_langfuse() behaviour --------------------------------
     # These tests pass `monkeypatch` to _fresh_plugin() so the helper can
     # stub out `Langfuse` (the optional SDK).  Without that, every call
@@ -558,6 +610,24 @@ class TestPlaceholderKeyDetection:
         assert "sk-lf-" in text
         # The valid public value must NOT appear.
         assert "'pk-lf-" not in text
+        assert _FakeLangfuse.instances == []
+
+    def test_docs_template_keys_warn_and_skip(self, monkeypatch, caplog):
+        """The literal copy-paste from the plugin README / website docs
+        (``pk-lf-...`` / ``sk-lf-...``) must warn and short-circuit instead
+        of constructing a client that silently drops every trace — the
+        failure mode reported over and over in #51399's duplicate chain."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-...")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-...")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        text = caplog.text
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in text
+        assert "HERMES_LANGFUSE_SECRET_KEY" in text
+        assert "template" in text
+        # Never constructed the SDK client — short-circuited before that.
         assert _FakeLangfuse.instances == []
 
     def test_both_placeholders_one_warning_with_both_keys(self, monkeypatch, caplog):


### PR DESCRIPTION
## What does this PR do?

The placeholder guard from #26320 checks only that credentials start with `pk-lf-` / `sk-lf-`. But the plugin README and the website env-var reference both print the keys as literally `pk-lf-...` / `sk-lf-...` — and that exact copy-paste passes the prefix check on today's `main`: the SDK constructs a client without complaint and every trace dies at flush time with zero log output, which is precisely the silent failure the guard was built to catch. The new regression test proves it (`test_docs_template_keys_warn_and_skip` fails on `main`).

`_validate_langfuse_key()` now looks past the prefix. A remainder that *is* a template (`...`, `***`, empty — i.e. a bare prefix) or *contains* an unambiguous template fragment (`placeholder`, `your-`, `test-key`, `changeme`, `example`, `unset`, `dummy`, `xxx`) gets the same one-shot warning and `_INIT_FAILED` short-circuit as a wrong-prefix value. False positives are structurally impossible for issued keys: Langfuse remainders are UUID-shaped (hex digits and dashes), and every fragment in the list contains at least one non-hex letter — a property the tests pin. A side effect worth noting: the docs' own `pk-lf-...` template is now caught, so the copy-paste footgun closes without touching the docs or their translations.

Context on the report chain: #51399 has six duplicates filed after #26320 merged. Some of that stream is likely version lag (triage noted "the fix ships once a release tag carries #26320"), so I'm not claiming every duplicate hit this exact hole — but the hole itself is real and test-proven above, and it's the most likely paste value in existence.

Deliberately out of scope, two things: (1) surfacing runtime ingestion failures — #62882 is already reworking that path, and this PR stays clear of it; (2) the adjacent gap Bartok9 described on #52389: a *revoked or invalid* key with a real UUID shape can't be caught statically at all — that needs a live auth probe (e.g. the SDK's `auth_check()`) with its own network/offline tradeoffs, and deserves its own PR.

## Related Issue

Fixes #51399

Duplicate chain (all marked duplicates of #51399 by triage; canonical original #22763 is closed): #52377, #52389, #57949, #60308, #60961, #63787.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/observability/langfuse/__init__.py` — `_validate_langfuse_key()` gains a remainder check after the existing prefix check: whole-value templates by exact match, conservative fragments by substring, case-insensitive; new `_PLACEHOLDER_REMAINDERS` / `_PLACEHOLDER_FRAGMENTS` constants with the false-positive reasoning documented inline
- `tests/plugins/test_langfuse_plugin.py` — 13 new tests in the existing `TestPlaceholderKeyDetection` class: 10 parametrized right-prefix templates rejected (including the docs' literal `pk-lf-...`), 2 UUID-shaped real keys still accepted, and an end-to-end `_get_langfuse()` case proving the docs copy-paste now warns and never constructs a client

## How to Test

1. `HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...` + `HERMES_LANGFUSE_SECRET_KEY=sk-lf-...` (the literal values from the plugin README), run any traced operation.
2. Before: plugin initializes silently, Langfuse dashboard stays empty. After: one-shot warning naming both env vars ("has the 'pk-lf-' prefix but looks like a template value"), plugin short-circuits.
3. Real keys (`pk-lf-<uuid>`): behavior unchanged.
4. `pytest tests/plugins/test_langfuse_plugin.py -q` — 61 passed; the 11 new rejection tests fail on `main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (checked all 37 closed + 21 open langfuse PRs: the only prior attempt at this validator, #60974, was author-closed unreviewed after 3 minutes; open #62882 targets a different root cause — cross-thread OTEL tokens — in a different region of the file)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suite: `tests/plugins/test_langfuse_plugin.py` — 61 passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A by design: the docs' `pk-lf-...` template is now *caught* by the guard, closing the copy-paste footgun without churning docs and their translations
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — platform-neutral string validation
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Fail-before / pass-after on today's `main`:

```
# without the fix
FAILED ...test_validate_langfuse_key_rejects_right_prefix_templates[...pk-lf-...] (x10)
FAILED ...test_docs_template_keys_warn_and_skip
11 failed, 50 passed

# with the fix
61 passed
```