### PR TITLE
fix(desktop): recover root boundary from assistant-ui lookup races

### DIFF
--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
@@ -15,6 +15,12 @@ function Boom({ error }: { error: Error | null }): null {
 
 const lookupError = new Error('useClientLookup: Index 2 out of bounds (length: 2)')
 
+const lookupErrors = [
+  ['useClientLookup', lookupError],
+  ['tapClientLookup', new Error('tapClientLookup: Index 2 out of bounds (length: 2)')],
+  ['tapClientResource', new Error('tapClientResource: Index 2 out of bounds (length: 2)')]
+] as const
+
 describe('MessageRenderBoundary', () => {
   it('renders children when nothing throws', () => {
     render(
@@ -26,12 +32,12 @@ describe('MessageRenderBoundary', () => {
     expect(screen.getByText('content')).toBeTruthy()
   })
 
-  it('swallows the transient useClientLookup out-of-bounds store race', () => {
+  it.each(lookupErrors)('swallows the transient %s out-of-bounds store race', (_label, error) => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     const { container } = render(
       <MessageRenderBoundary resetKey="a">
-        <Boom error={lookupError} />
+        <Boom error={error} />
       </MessageRenderBoundary>
     )
 

--- a/apps/desktop/src/components/error-boundary.test.tsx
+++ b/apps/desktop/src/components/error-boundary.test.tsx
@@ -1,0 +1,108 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ErrorBoundary } from './error-boundary'
+
+const TAP_LOOKUP_ERROR = new Error('tapClientLookup: Index 6 out of bounds (length: 2)')
+const RELOAD_WINDOW = { name: 'Reload window', role: 'button' } as const
+
+function makeBomb(box: { error: Error | null }) {
+  return function Bomb() {
+    if (box.error) {
+      throw box.error
+    }
+
+    return <div>recovered</div>
+  }
+}
+
+const recoveryWarningCount = (calls: unknown[][]) =>
+  calls.filter(call => call.some(value => String(value).includes('auto-recovering from tapClientLookup'))).length
+
+describe('ErrorBoundary tapClientLookup recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('recovers the root boundary after a transient lookup race clears', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <ErrorBoundary label="root">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    box.error = null
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    expect(screen.queryByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeNull()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
+  })
+
+  it('stops retrying a persistent lookup error after the recovery budget is exhausted', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <ErrorBoundary label="root">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      act(() => vi.runOnlyPendingTimers())
+    }
+
+    expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(3)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not auto-recover the same error in a scoped boundary', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const Bomb = makeBomb({ error: TAP_LOOKUP_ERROR })
+
+    render(
+      <ErrorBoundary fallback={() => <div>scoped fallback</div>} label="thread">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    act(() => vi.runAllTimers())
+
+    expect(screen.getByText('scoped fallback')).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(0)
+  })
+
+  it.each([
+    ['a renamed lookup error', new Error('useClientLookup: Index 6 out of bounds (length: 2)')],
+    ['an unrelated render error', new Error('some unrelated application error')]
+  ])('does not auto-recover %s at root', (_label, error) => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error }
+    const Bomb = makeBomb(box)
+
+    render(
+      <ErrorBoundary label="root">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    act(() => vi.runAllTimers())
+
+    expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/error-boundary.test.tsx
+++ b/apps/desktop/src/components/error-boundary.test.tsx
@@ -1,7 +1,8 @@
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ErrorBoundary } from './error-boundary'
+import { ErrorBoundary, RootErrorBoundary } from './error-boundary'
 
 const CURRENT_LOOKUP_ERROR = new Error('useClientLookup: Index 6 out of bounds (length: 2)')
 const RELOAD_WINDOW = { name: 'Reload window', role: 'button' } as const
@@ -22,6 +23,7 @@ const recoveryWarningCount = (calls: unknown[][]) =>
 describe('ErrorBoundary assistant-ui lookup recovery', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    vi.setSystemTime(0)
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
   })
 
@@ -35,15 +37,15 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
     ['the current useClientLookup error', CURRENT_LOOKUP_ERROR],
     ['the legacy tapClientLookup error', new Error('tapClientLookup: Index 6 out of bounds (length: 2)')],
     ['the legacy tapClientResource error', new Error('tapClientResource: Index 6 out of bounds (length: 2)')]
-  ])('recovers the root boundary after %s clears', (_label, error) => {
+  ])('recovers the production root composition without StrictMode after %s clears', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const box: { error: Error | null } = { error }
     const Bomb = makeBomb(box)
 
     render(
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <Bomb />
-      </ErrorBoundary>
+      </RootErrorBoundary>
     )
 
     box.error = null
@@ -54,15 +56,36 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
     expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
   })
 
+  it('recovers the production root composition when StrictMode replays its mount lifecycle', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <StrictMode>
+        <RootErrorBoundary>
+          <Bomb />
+        </RootErrorBoundary>
+      </StrictMode>
+    )
+
+    box.error = null
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('stops retrying a persistent lookup error after the recovery budget is exhausted', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
     const Bomb = makeBomb(box)
 
     render(
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <Bomb />
-      </ErrorBoundary>
+      </RootErrorBoundary>
     )
 
     for (let attempt = 0; attempt < 4; attempt += 1) {
@@ -72,6 +95,91 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
     expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
     expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(3)
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('starts a fresh automatic recovery budget at the 5 second window boundary', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    const view = render(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      box.error = null
+      act(() => vi.runOnlyPendingTimers())
+      expect(screen.getByText('recovered')).toBeTruthy()
+
+      if (attempt < 2) {
+        box.error = CURRENT_LOOKUP_ERROR
+        view.rerender(
+          <RootErrorBoundary>
+            <Bomb />
+          </RootErrorBoundary>
+        )
+      }
+    }
+
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(3)
+    act(() => vi.advanceTimersByTime(5_000))
+
+    box.error = CURRENT_LOOKUP_ERROR
+    view.rerender(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    box.error = null
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(4)
+  })
+
+  it('manual retry replaces an active timer, resets the budget, and can exhaust again', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
+    const Bomb = makeBomb(box)
+
+    render(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+
+    expect(vi.getTimerCount()).toBe(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(vi.getTimerCount()).toBe(1)
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      act(() => vi.runOnlyPendingTimers())
+    }
+
+    expect(screen.getByRole(RELOAD_WINDOW.role, { name: RELOAD_WINDOW.name })).toBeTruthy()
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(4)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels an owned automatic recovery timer when unmounted', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const Bomb = makeBomb({ error: CURRENT_LOOKUP_ERROR })
+
+    const view = render(
+      <RootErrorBoundary>
+        <Bomb />
+      </RootErrorBoundary>
+    )
+
+    expect(vi.getTimerCount()).toBe(1)
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+    act(() => vi.runAllTimers())
+    expect(recoveryWarningCount(warnSpy.mock.calls)).toBe(1)
   })
 
   it('does not auto-recover the same error in a scoped boundary', () => {
@@ -91,17 +199,17 @@ describe('ErrorBoundary assistant-ui lookup recovery', () => {
   })
 
   it.each([
+    ['a differently cased classifier near-miss', new Error('UseClientLookup: Index 6 out of bounds (length: 2)')],
     ['a non-bounds lookup error', new Error('useClientLookup: Key "missing" not found')],
     ['an unrelated render error', new Error('some unrelated application error')]
   ])('does not auto-recover %s at root', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const box: { error: Error | null } = { error }
-    const Bomb = makeBomb(box)
+    const Bomb = makeBomb({ error })
 
     render(
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <Bomb />
-      </ErrorBoundary>
+      </RootErrorBoundary>
     )
 
     act(() => vi.runAllTimers())

--- a/apps/desktop/src/components/error-boundary.test.tsx
+++ b/apps/desktop/src/components/error-boundary.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ErrorBoundary } from './error-boundary'
 
-const TAP_LOOKUP_ERROR = new Error('tapClientLookup: Index 6 out of bounds (length: 2)')
+const CURRENT_LOOKUP_ERROR = new Error('useClientLookup: Index 6 out of bounds (length: 2)')
 const RELOAD_WINDOW = { name: 'Reload window', role: 'button' } as const
 
 function makeBomb(box: { error: Error | null }) {
@@ -17,9 +17,9 @@ function makeBomb(box: { error: Error | null }) {
 }
 
 const recoveryWarningCount = (calls: unknown[][]) =>
-  calls.filter(call => call.some(value => String(value).includes('auto-recovering from tapClientLookup'))).length
+  calls.filter(call => call.some(value => String(value).includes('auto-recovering from assistant-ui lookup'))).length
 
-describe('ErrorBoundary tapClientLookup recovery', () => {
+describe('ErrorBoundary assistant-ui lookup recovery', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
@@ -31,9 +31,13 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
     vi.restoreAllMocks()
   })
 
-  it('recovers the root boundary after a transient lookup race clears', () => {
+  it.each([
+    ['the current useClientLookup error', CURRENT_LOOKUP_ERROR],
+    ['the legacy tapClientLookup error', new Error('tapClientLookup: Index 6 out of bounds (length: 2)')],
+    ['the legacy tapClientResource error', new Error('tapClientResource: Index 6 out of bounds (length: 2)')]
+  ])('recovers the root boundary after %s clears', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const box: { error: Error | null } = { error }
     const Bomb = makeBomb(box)
 
     render(
@@ -52,7 +56,7 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
 
   it('stops retrying a persistent lookup error after the recovery budget is exhausted', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const box: { error: Error | null } = { error: TAP_LOOKUP_ERROR }
+    const box: { error: Error | null } = { error: CURRENT_LOOKUP_ERROR }
     const Bomb = makeBomb(box)
 
     render(
@@ -72,7 +76,7 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
 
   it('does not auto-recover the same error in a scoped boundary', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const Bomb = makeBomb({ error: TAP_LOOKUP_ERROR })
+    const Bomb = makeBomb({ error: CURRENT_LOOKUP_ERROR })
 
     render(
       <ErrorBoundary fallback={() => <div>scoped fallback</div>} label="thread">
@@ -87,7 +91,7 @@ describe('ErrorBoundary tapClientLookup recovery', () => {
   })
 
   it.each([
-    ['a renamed lookup error', new Error('useClientLookup: Index 6 out of bounds (length: 2)')],
+    ['a non-bounds lookup error', new Error('useClientLookup: Key "missing" not found')],
     ['an unrelated render error', new Error('some unrelated application error')]
   ])('does not auto-recover %s at root', (_label, error) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -20,8 +20,20 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
+// Some assistant-ui lookup races escape the message-local boundary and reach
+// the root. Retry only that exact transient error class, never arbitrary render
+// failures, and cap retries so a persistent failure still exposes the fallback.
+const TAP_CLIENT_LOOKUP_ERROR = /^tapClientLookup: Index \d+\s+out of bounds \(length:\s*\d+\)$/i
+const MAX_AUTO_RECOVERIES = 3
+const AUTO_RECOVERY_WINDOW_MS = 5_000
+
+const isTransientTapClientLookupError = (error: Error): boolean => TAP_CLIENT_LOOKUP_ERROR.test(error.message)
+
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
+  private autoRecoveryCount = 0
+  private autoRecoveryTimer: number | null = null
+  private autoRecoveryWindowStart = 0
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { error }
@@ -31,9 +43,51 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     const tag = this.props.label ? `[error-boundary:${this.props.label}]` : '[error-boundary]'
     console.error(tag, error, info.componentStack)
     this.props.onError?.(error, info)
+
+    if (this.props.label === 'root' && isTransientTapClientLookupError(error) && this.takeAutoRecoveryAttempt()) {
+      console.warn(`${tag} auto-recovering from tapClientLookup render race`, error.message)
+      this.scheduleAutoRecovery()
+    }
+  }
+
+  componentWillUnmount() {
+    this.clearAutoRecoveryTimer()
   }
 
   reset = () => {
+    this.clearAutoRecoveryTimer()
+    this.autoRecoveryCount = 0
+    this.autoRecoveryWindowStart = 0
+    this.setState({ error: null })
+  }
+
+  private takeAutoRecoveryAttempt(): boolean {
+    const now = Date.now()
+
+    if (now - this.autoRecoveryWindowStart > AUTO_RECOVERY_WINDOW_MS) {
+      this.autoRecoveryWindowStart = now
+      this.autoRecoveryCount = 0
+    }
+
+    this.autoRecoveryCount += 1
+
+    return this.autoRecoveryCount <= MAX_AUTO_RECOVERIES
+  }
+
+  private clearAutoRecoveryTimer() {
+    if (this.autoRecoveryTimer !== null) {
+      window.clearTimeout(this.autoRecoveryTimer)
+      this.autoRecoveryTimer = null
+    }
+  }
+
+  private scheduleAutoRecovery() {
+    this.clearAutoRecoveryTimer()
+    this.autoRecoveryTimer = window.setTimeout(this.autoRecover, 0)
+  }
+
+  private autoRecover = () => {
+    this.autoRecoveryTimer = null
     this.setState({ error: null })
   }
 

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -23,7 +23,7 @@ interface ErrorBoundaryState {
 // Some assistant-ui lookup races escape the message-local boundary and reach
 // the root. Retry only that exact transient error class, never arbitrary render
 // failures, and cap retries so a persistent failure still exposes the fallback.
-const ASSISTANT_UI_LOOKUP_ERROR = /(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/i
+const ASSISTANT_UI_LOOKUP_ERROR = /(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/
 const MAX_AUTO_RECOVERIES = 3
 const AUTO_RECOVERY_WINDOW_MS = 5_000
 
@@ -32,11 +32,21 @@ const isTransientAssistantUiLookupError = (error: Error): boolean => ASSISTANT_U
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
   private autoRecoveryCount = 0
+  private autoRecoveryPending = false
   private autoRecoveryTimer: number | null = null
   private autoRecoveryWindowStart = 0
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { error }
+  }
+
+  componentDidMount() {
+    // StrictMode replays mount lifecycles in development. Its synthetic
+    // componentWillUnmount clears the timer scheduled by componentDidCatch,
+    // so restore the still-owned recovery on the matching remount.
+    if (this.autoRecoveryPending && this.autoRecoveryTimer === null) {
+      this.scheduleAutoRecovery()
+    }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
@@ -46,6 +56,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     if (this.props.label === 'root' && isTransientAssistantUiLookupError(error) && this.takeAutoRecoveryAttempt()) {
       console.warn(`${tag} auto-recovering from assistant-ui lookup render race`, error.message)
+      this.autoRecoveryPending = true
       this.scheduleAutoRecovery()
     }
   }
@@ -56,6 +67,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   reset = () => {
     this.clearAutoRecoveryTimer()
+    this.autoRecoveryPending = false
     this.autoRecoveryCount = 0
     this.autoRecoveryWindowStart = 0
     this.setState({ error: null })
@@ -64,7 +76,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   private takeAutoRecoveryAttempt(): boolean {
     const now = Date.now()
 
-    if (now - this.autoRecoveryWindowStart > AUTO_RECOVERY_WINDOW_MS) {
+    if (this.autoRecoveryCount === 0 || now - this.autoRecoveryWindowStart >= AUTO_RECOVERY_WINDOW_MS) {
       this.autoRecoveryWindowStart = now
       this.autoRecoveryCount = 0
     }
@@ -88,6 +100,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   private autoRecover = () => {
     this.autoRecoveryTimer = null
+    this.autoRecoveryPending = false
     this.setState({ error: null })
   }
 
@@ -104,6 +117,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     return <RootErrorFallback error={error} reset={this.reset} />
   }
+}
+
+export function RootErrorBoundary({ children }: { children: ReactNode }) {
+  return <ErrorBoundary label="root">{children}</ErrorBoundary>
 }
 
 function RootErrorFallback({ error, reset }: ErrorBoundaryFallbackProps) {

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -23,11 +23,11 @@ interface ErrorBoundaryState {
 // Some assistant-ui lookup races escape the message-local boundary and reach
 // the root. Retry only that exact transient error class, never arbitrary render
 // failures, and cap retries so a persistent failure still exposes the fallback.
-const TAP_CLIENT_LOOKUP_ERROR = /^tapClientLookup: Index \d+\s+out of bounds \(length:\s*\d+\)$/i
+const ASSISTANT_UI_LOOKUP_ERROR = /(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/i
 const MAX_AUTO_RECOVERIES = 3
 const AUTO_RECOVERY_WINDOW_MS = 5_000
 
-const isTransientTapClientLookupError = (error: Error): boolean => TAP_CLIENT_LOOKUP_ERROR.test(error.message)
+const isTransientAssistantUiLookupError = (error: Error): boolean => ASSISTANT_UI_LOOKUP_ERROR.test(error.message)
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
@@ -44,8 +44,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     console.error(tag, error, info.componentStack)
     this.props.onError?.(error, info)
 
-    if (this.props.label === 'root' && isTransientTapClientLookupError(error) && this.takeAutoRecoveryAttempt()) {
-      console.warn(`${tag} auto-recovering from tapClientLookup render race`, error.message)
+    if (this.props.label === 'root' && isTransientAssistantUiLookupError(error) && this.takeAutoRecoveryAttempt()) {
+      console.warn(`${tag} auto-recovering from assistant-ui lookup render race`, error.message)
       this.scheduleAutoRecovery()
     }
   }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -19,7 +19,7 @@ import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router'
 
 import App from './app'
-import { ErrorBoundary } from './components/error-boundary'
+import { RootErrorBoundary } from './components/error-boundary'
 import { HapticsProvider } from './components/haptics-provider'
 import { RootTooltipProvider } from './components/ui/tooltip'
 import { I18nProvider } from './i18n'
@@ -48,7 +48,7 @@ if (winParam === 'overlay') {
 } else {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
-      <ErrorBoundary label="root">
+      <RootErrorBoundary>
         <QueryClientProvider client={queryClient}>
           <I18nProvider>
             <ThemeProvider>
@@ -76,7 +76,7 @@ if (winParam === 'overlay') {
             </ThemeProvider>
           </I18nProvider>
         </QueryClientProvider>
-      </ErrorBoundary>
+      </RootErrorBoundary>
     </StrictMode>
   )
 }


### PR DESCRIPTION
## What does this PR do?

Restores a narrow, bounded recovery path for the Desktop root error boundary when the known transient assistant-ui lookup race escapes the existing message-local boundary.

The root boundary recognizes the same current-and-legacy error family as `MessageRenderBoundary`:

```text
/(useClientLookup|tapClient(Lookup|Resource)).*out of bounds/
```

Eligible root failures retry on the next timer turn so React can reconcile against the current store snapshot. Recovery remains intentionally limited to three automatic attempts in a five-second window; persistent failures remain visible and manually retryable.

This refresh also fixes a React development `StrictMode` lifecycle bug found while exercising the real root composition: the synthetic unmount cleared the timer scheduled by `componentDidCatch`, but the replayed mount did not restore it. The boundary now retains recovery ownership separately from the timer handle and reschedules only that owned attempt on remount. Real unmount still cancels the timer.

Rebased exactly onto `origin/main` `05f5df6bdb7cfcec57aadc9ac93d7a08c684cd5d`. Local immutable candidate: `6800a1399434e06e733f18068177df974e52a3b7`.

## Related Issue

Fixes #64308. Related to the broader assistant-ui race tracked by #45403.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/error-boundary.tsx`
  - matches only the current/legacy assistant-ui lookup out-of-bounds family;
  - preserves an owned recovery across a `StrictMode` synthetic unmount without weakening real-unmount cleanup;
  - resets the bounded recovery window at the exact five-second boundary;
  - keeps manual reset responsible for cancelling an active timer and starting a fresh budget;
  - exposes the narrowly scoped `RootErrorBoundary` composition so only the real root owner can auto-recover.
- `apps/desktop/src/main.tsx`
  - uses `RootErrorBoundary` in the real Desktop root under `StrictMode`.
- `apps/desktop/src/components/error-boundary.test.tsx`
  - covers transient recovery, persistent budget exhaustion, five-second window reset, manual reset with an active timer followed by renewed exhaustion, pending-timer unmount cleanup, scoped-boundary exclusion, classifier near misses, real root composition under test/development `StrictMode`, and production-style composition without `StrictMode`.
- `apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx`
  - proves classifier parity for `useClientLookup`, `tapClientLookup`, and `tapClientResource` without introducing a shared speculative classifier framework.

## How to Test

1. Install committed workspace dependencies in development mode.
2. Run the focused root and message-local boundary tests.
3. Run Desktop typecheck and ESLint on the touched TypeScript files.
4. Run the production Desktop build and final diff/status checks.

Commands run locally:

```bash
NODE_ENV=development npm ci --include=dev

NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-pr-64310-focused-final.json' \
  npm --workspace apps/desktop exec -- vitest run --project ui \
  src/components/error-boundary.test.tsx \
  src/components/assistant-ui/message-render-boundary.test.tsx

NODE_ENV=test npm --workspace apps/desktop run typecheck

NODE_ENV=test npm --workspace apps/desktop exec -- eslint \
  src/components/error-boundary.tsx \
  src/components/error-boundary.test.tsx \
  src/components/assistant-ui/message-render-boundary.test.tsx \
  src/main.tsx

npm --workspace apps/desktop exec -- prettier --check \
  src/components/error-boundary.tsx \
  src/components/error-boundary.test.tsx \
  src/components/assistant-ui/message-render-boundary.test.tsx \
  src/main.tsx

NODE_ENV=production npm --workspace apps/desktop run build

git diff --check 05f5df6bdb7cfcec57aadc9ac93d7a08c684cd5d..HEAD
git status --porcelain=v1
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — not repeated during this local-only refresh of the existing PR
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop-only TypeScript change; focused Vitest, typecheck, ESLint, Prettier, and production build passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux 7.1.5, Node.js 25.4.0, npm 11.7.0

### Documentation & Housekeeping

- [x] Relevant documentation N/A — no user-facing workflow or configuration changed
- [x] `cli-config.yaml.example` N/A — no configuration changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no architecture or contributor workflow changed
- [x] Cross-platform impact considered — browser timer and React boundary behavior are renderer-platform independent
- [x] Tool descriptions/schemas N/A — no tool behavior changed

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

- StrictMode red proof before the lifecycle fix: focused root test file reported **1 failed, 7 passed**; the fallback remained visible because the synthetic unmount had cleared the recovery timer.
- Final focused boundary tests: **2 files passed, 18 tests passed**.
- Desktop typecheck: passed.
- ESLint on all four touched TypeScript/TSX files: passed with no warnings.
- Prettier check on all four touched TypeScript/TSX files: passed.
- Production build for exact candidate `6800a1399434e06e733f18068177df974e52a3b7`: passed; `assert-dist-built` confirmed renderer assets and the build stamp recorded `6800a1399434`.
- Final diff check: passed; Git porcelain is empty.
- Non-blocking inherited build warnings: deprecated `advancedChunks`, one generated-CSS optimizer warning, the existing Tabler large-barrel warning, and an ineffective dynamic-import warning for `open-session.ts`.
- `npm ci` reported 28 audit findings in the resolved dependency graph; no dependency or lockfile changes are included in this PR.
- Full Desktop UI/Electron suites were not rerun for this local refresh; the required focused lifecycle matrix and prescribed typecheck/lint/build gates above are the evidence for this candidate.
