### PR TITLE
fix(tools): require 'action' in memory tool schema validation

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -915,3 +915,13 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+class TestRequiredFields:
+    """Test that MEMORY_SCHEMA correctly declares required fields (issue #64291)."""
+
+    def test_action_is_required_in_schema(self):
+        """action must be in top-level required fields to catch malformed calls early."""
+        required = MEMORY_SCHEMA["parameters"]["required"]
+        assert "target" in required, "target is always required"
+        assert "action" in required, "action must be required to catch missing action at schema validation"

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1124,7 +1124,7 @@ MEMORY_SCHEMA = {
                 },
             },
         },
-        "required": ["target"],
+        "required": ["target", "action"],
     },
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a schema validation gap where the memory tool accepts malformed calls missing the `action` parameter. Previously, only `target` was validated at the schema layer, causing incomplete calls to fail deep in the handler with a confusing "Unknown action 'None'" error. This wastes an API call and provides no clear signal about why the call was malformed.

This PR adds `action` to the top-level `required` array, so missing action is caught early with a clear "missing required parameter" error.

## Related Issue

Fixes #64291

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py`: Add `"action"` to `MEMORY_SCHEMA["parameters"]["required"]`
- `tests/tools/test_memory_tool.py`: Add regression test `TestRequiredFields.test_action_is_required_in_schema`

## How to Test

1. Run the new regression test:
   ```bash
   pytest tests/tools/test_memory_tool.py::TestRequiredFields -v
   ```
   Observed result: test passes, confirming action is in required array

2. Verify existing tests still pass:
   ```bash
   pytest tests/tools/test_memory_tool.py -q
   ```
   Observed result: 86 tests pass (including the new one)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (schema change is the fix)
