### PR TITLE
fix: propagate reasoning_effort to DeepSeek direct API

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -900,6 +900,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     )
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
+    _is_deepseek = base_url_host_matches(agent._base_url_lower, "api.deepseek.com")
 
     # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
     # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -1016,6 +1017,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         is_kimi=_is_kimi,
         is_tokenhub=_is_tokenhub,
         is_lmstudio=_is_lmstudio,
+        is_deepseek=_is_deepseek,
         is_custom_provider=agent.provider == "custom",
         ollama_num_ctx=agent._ollama_num_ctx,
         provider_preferences=_prefs or None,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -402,6 +402,26 @@ class ChatCompletionsTransport(ProviderTransport):
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
+        # DeepSeek: top-level reasoning_effort (OpenAI-native, not extra_body).
+        # DeepSeek API only supports "high" (default) and "max". All other
+        # levels are compatibility-mapped per the DeepSeek API docs:
+        #   low/medium → high, xhigh → max.
+        # Thinking toggle defaults to enabled; only explicit "none" disables it.
+        if params.get("is_deepseek", False):
+            _ds_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _ds_thinking_off:
+                _ds_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in {"xhigh", "max", "ultra"}:
+                        _ds_effort = "max"
+                    # low/medium/high/minimal all map to "high"
+                api_kwargs["reasoning_effort"] = _ds_effort
+
         # Tencent TokenHub: top-level reasoning_effort (unless thinking disabled)
         if is_tokenhub:
             _tokenhub_thinking_off = bool(
@@ -466,6 +486,15 @@ class ChatCompletionsTransport(ProviderTransport):
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
             }
+
+        # DeepSeek extra_body.thinking (thinking toggle; reasoning_effort is top-level above)
+        if params.get("is_deepseek", False):
+            _ds_thinking = "disabled" if (
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            ) else "enabled"
+            extra_body["thinking"] = {"type": _ds_thinking}
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,
         # so skip emitting extra_body.reasoning for it.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1164,3 +1164,123 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         )
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
+
+
+class TestDeepSeekReasoningEffort:
+    """DeepSeek direct API: reasoning_effort as top-level param + thinking toggle.
+
+    DeepSeek's native API (api.deepseek.com) uses OpenAI-style top-level
+    ``reasoning_effort`` (not extra_body.reasoning). Before this, the
+    web UI dropdown had zero effect on direct DeepSeek calls."""
+
+    DS_BASE_URL = "https://api.deepseek.com/v1"
+
+    # ── effort level mapping ──────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "effort,expected",
+        [
+            ("high", "high"),
+            ("minimal", "high"),
+            ("low", "high"),
+            ("medium", "high"),
+            ("xhigh", "max"),
+            ("max", "max"),
+            ("ultra", "max"),
+        ],
+    )
+    def test_reasoning_effort_top_level(self, transport, effort, expected):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_deepseek=True,
+            base_url=self.DS_BASE_URL,
+            reasoning_config={"enabled": True, "effort": effort},
+            max_tokens=None,
+        )
+        assert kw.get("reasoning_effort") == expected, (
+            f"effort={effort} -> expected reasoning_effort={expected}, "
+            f"got {kw.get('reasoning_effort')}"
+        )
+
+    # ── thinking toggle ───────────────────────────────────────────────
+
+    def test_thinking_enabled_when_reasoning_on(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_deepseek=True,
+            base_url=self.DS_BASE_URL,
+            reasoning_config={"enabled": True, "effort": "high"},
+            max_tokens=None,
+        )
+        assert kw["extra_body"]["thinking"]["type"] == "enabled"
+
+    def test_thinking_disabled_when_reasoning_off(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_deepseek=True,
+            base_url=self.DS_BASE_URL,
+            reasoning_config={"enabled": False},
+            max_tokens=None,
+        )
+        assert kw["extra_body"]["thinking"]["type"] == "disabled"
+        # No reasoning_effort when thinking is off
+        assert "reasoning_effort" not in kw
+
+    # ── regression guards ─────────────────────────────────────────────
+
+    def test_no_effect_when_not_deepseek(self, transport):
+        """Non-DeepSeek providers must NOT get DeepSeek-specific params."""
+        kw = transport.build_kwargs(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_deepseek=False,
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": True, "effort": "high"},
+            max_tokens=None,
+        )
+        assert "reasoning_effort" not in kw
+        if "extra_body" in kw:
+            assert "thinking" not in kw["extra_body"], (
+                "DeepSeek thinking toggle leaked to non-DeepSeek provider"
+            )
+
+    def test_no_is_deepseek_flag_no_effect(self, transport):
+        """Without is_deepseek flag, DeepSeek params must not appear (back compat)."""
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            # is_deepseek omitted
+            base_url=self.DS_BASE_URL,
+            reasoning_config={"enabled": True, "effort": "high"},
+            max_tokens=None,
+        )
+        assert "reasoning_effort" not in kw, (
+            "reasoning_effort leaked without is_deepseek flag"
+        )
+
+    def test_reasoning_effort_not_in_extra_body(self, transport):
+        """DeepSeek uses top-level reasoning_effort, NOT extra_body.reasoning."""
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_deepseek=True,
+            base_url=self.DS_BASE_URL,
+            reasoning_config={"enabled": True, "effort": "high"},
+            max_tokens=None,
+        )
+        assert kw.get("reasoning_effort") == "high"
+        # Must NOT duplicate in extra_body.reasoning
+        if "extra_body" in kw:
+            assert "reasoning" not in kw["extra_body"], (
+                "DeepSeek puts reasoning_effort as top-level param, "
+                "not in extra_body.reasoning"
+            )


### PR DESCRIPTION
## Problem

DeepSeek native API (api.deepseek.com) uses OpenAI-style top-level `reasoning_effort` + `extra_body.thinking`, but hermes-agent only supported `extra_body.reasoning` (OpenRouter format), which is gated behind `"openrouter" in base_url`. On direct DeepSeek connections, the `reasoning_effort` config was saved to `config.yaml` but **never sent to the API** — the WebUI dropdown had zero effect.

## Fix

- **agent/transports/chat_completions.py**: Add DeepSeek-specific `reasoning_effort` (top-level) and thinking toggle (`extra_body`) in the legacy `build_kwargs` path, following the same pattern as Kimi and TokenHub
- **agent/chat_completion_helpers.py**: Add `is_deepseek` detection via `base_url_host_matches("api.deepseek.com")`
- **tests**: 12 parametrized + regression tests (effort mapping, thinking toggle, back-compat guards)

## Effort Mapping (per DeepSeek API docs)

| Hermes effort | DeepSeek API |
|---|---|
| none | thinking disabled |
| minimal / low / medium / high | `"high"` |
| xhigh / max / ultra | `"max"` |

## Test Results

```
tests/agent/transports/test_chat_completions.py ... 100 passed (12 new)
```

Closes: n/a (new feature)