### PR TITLE
fix(tests): patch catalog urlopen wrapper in gemini probe tests

### DIFF
--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -949,7 +949,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models(
@@ -965,7 +965,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models("provider-key", "https://api.example.com/v1")


### PR DESCRIPTION
## Summary
Fixes the 2 tests breaking CI slice 7/8 on every run of main and every open PR: the gemini probe tests mock a code path `probe_api_models` no longer uses.

Root cause: the tests (added in b8eb89f5c) patch `hermes_cli.models.urllib.request.urlopen`, but `probe_api_models` routes all catalog requests through the `_urlopen_model_catalog_request` wrapper (`open_credentialed_url` from the urllib_security hardening series). The mock is never invoked, so `mock_urlopen.call_args` is `None` → `TypeError: 'NoneType' object is not subscriptable`.

## Changes
- `tests/hermes_cli/test_model_validation.py`: point the two patches at `hermes_cli.models._urlopen_model_catalog_request` — the same target every sibling test in `TestProbeApiModelsUserAgent` already uses. 2 lines, test-only.

## Validation
| | Before | After |
|---|---|---|
| `tests/hermes_cli/test_model_validation.py` | 87 passed, 2 failed | 89 passed, 0 failed |

Verified failing on clean `origin/main` (226e8de82) before the change.

## Infographic

![gemini-probe-test-fix](https://v3b.fal.media/files/b/0aa23339/nMBo0YkxfdYI9NAuQW5UY_X2p1dE5Y.png)
