### PR TITLE
fix(tests): patch the catalog-request seam in Gemini probe header tests (main CI red)

### DIFF
--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -949,7 +949,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models(
@@ -965,7 +965,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models("provider-key", "https://api.example.com/v1")


### PR DESCRIPTION
## Summary

Fixes the 2 Gemini probe header tests that fail on every current `main` build, breaking CI slice 7/8 for all open PRs.

Root cause is a mock-seam drift between two PRs that crossed in flight: the Gemini client-context tests (authored Jul 9, merged Jul 13 in b8eb89f5c) patch `hermes_cli.models.urllib.request.urlopen`, but `probe_api_models` switched to the `_urlopen_model_catalog_request` → `open_credentialed_url` security seam on Jul 11 (the 1f46145e0 redirect-hardening chain). The mock never intercepts, `mock_urlopen.call_args` is `None`, and both tests fail with `TypeError: 'NoneType' object is not subscriptable`.

## Changes

- `tests/hermes_cli/test_model_validation.py`: the two `TestProbeApiModelsUserAgent` Gemini tests now patch `hermes_cli.models._urlopen_model_catalog_request` — the same seam the sibling UA tests in the class already use.

## Validation

| | Before | After |
|---|---|---|
| `TestProbeApiModelsUserAgent` on origin/main | 2 failed, 2 passed (TypeError) | 4 passed |
| CI slice 7/8 | red on every PR (verified on unrelated MoA PR #64319 and on pristine origin/main in a clean worktree) | expected green |

## Infographic

![gemini-probe-seam](https://v3b.fal.media/files/b/0aa23443/bMvlGXCmQ2g92iuB1bhmp_LdV11J0B.png)
