### PR TITLE
feat(picker): model.picker hide+order config, applied on every picker surface

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -121,6 +121,7 @@ def build_models_payload(
     refresh: bool = False,
     probe_custom_providers: bool = True,
     probe_current_custom_provider: bool = False,
+    apply_picker_prefs: bool = False,
     max_models: int | None = None,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
@@ -165,6 +166,13 @@ def build_models_payload(
       false, still live-probe the current custom endpoint. This keeps normal
       GUI/TUI picker opens fast while making the active custom provider's model
       list match the classic CLI picker.
+    - ``apply_picker_prefs``: apply the user's ``model.picker`` config
+      (``hide`` + ``order``), exactly as the interactive CLI/Discord picker
+      (:func:`hermes_cli.model_switch.list_picker_providers`) already does. Off
+      by default so non-picker consumers see the full set; desktop/TUI picker
+      opens set it True so every picker surface honors the same config. Purely
+      cosmetic — typed ``/model <slug>/...`` and every provider stay reachable;
+      the currently-active provider is never hidden.
     """
     from hermes_cli.model_switch import list_authenticated_providers
 
@@ -247,6 +255,8 @@ def build_models_payload(
         _apply_picker_hints(rows)
     if canonical_order:
         rows = _reorder_canonical(rows)
+    if apply_picker_prefs:
+        rows = _apply_desktop_picker_prefs(rows, current_provider=ctx.current_provider)
     if pricing:
         _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
     if capabilities:
@@ -257,6 +267,31 @@ def build_models_payload(
         "model": ctx.current_model,
         "provider": ctx.current_provider,
     }
+
+
+def _apply_desktop_picker_prefs(
+    rows: list[dict], *, current_provider: str = ""
+) -> list[dict]:
+    """Apply the interactive-picker ``model.picker`` prefs to payload rows.
+
+    Brings the desktop/TUI ``build_models_payload`` picker in line with the
+    CLI/Discord ``list_picker_providers`` picker by applying the user's
+    ``model.picker`` ``hide`` + ``order`` config. Delegates to the same
+    ``_apply_picker_preferences`` helper ``list_picker_providers`` uses, so the
+    two surfaces can never drift. Cosmetic only: the currently-active provider
+    is never hidden, and typed ``/model <slug>/...`` reaches every provider
+    regardless. Best-effort — any failure returns ``rows`` unchanged.
+    """
+    try:
+        from hermes_cli.model_switch import _apply_picker_preferences
+    except Exception:
+        return rows
+    try:
+        return _apply_picker_preferences(
+            rows, current_provider=str(current_provider or "").strip().lower()
+        )
+    except Exception:
+        return rows
 
 
 def _apply_capabilities(rows: list[dict]) -> None:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2495,4 +2495,76 @@ def list_picker_providers(
             continue
         filtered.append(p)
 
-    return filtered
+    return _apply_picker_preferences(
+        filtered, current_provider=str(current_provider or "").strip().lower()
+    )
+
+
+def _apply_picker_preferences(
+    rows: List[dict], *, current_provider: str = ""
+) -> List[dict]:
+    """Apply the user's ``model.picker`` config (hide + order) to picker rows.
+
+    Two optional, purely-cosmetic config knobs let a user tailor the
+    interactive ``/model`` dropdown without changing which providers are
+    *usable* (typed ``/model <slug>/...`` and every provider stay reachable
+    regardless):
+
+    ```yaml
+    model:
+      picker:
+        hide:  [openai-api, anthropic]        # slugs to drop from the dropdown
+        order: [anthropic, openai-codex, ...]  # front-anchored display order
+    ```
+
+    - ``hide``: drop matching provider rows (by slug, case-insensitive). The
+      **currently-active** provider is NEVER hidden — you must always be able
+      to see/switch off what you're on. Unknown slugs are ignored.
+    - ``order``: rows whose slug appears here are moved to the front in the
+      given order; every other row keeps its original relative order after
+      them. Unknown slugs in ``order`` are ignored (no empty rows). Rows not
+      listed are NOT hidden — ordering and hiding are independent.
+
+    Missing/malformed config is a no-op (returns ``rows`` unchanged); this
+    never raises into the picker path.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        picker_cfg = ((load_config().get("model") or {}).get("picker") or {})
+    except Exception:
+        return rows
+    if not isinstance(picker_cfg, dict):
+        return rows
+
+    _cur = str(current_provider or "").strip().lower()
+
+    hide = picker_cfg.get("hide") or []
+    if isinstance(hide, (list, tuple)):
+        hide_set = {str(s).strip().lower() for s in hide if str(s).strip()}
+        if hide_set:
+            rows = [
+                r for r in rows
+                if str(r.get("slug", "")).strip().lower() not in hide_set
+                or str(r.get("slug", "")).strip().lower() == _cur  # never hide current
+            ]
+
+    order = picker_cfg.get("order") or []
+    if isinstance(order, (list, tuple)) and order:
+        rank = {
+            str(s).strip().lower(): i
+            for i, s in enumerate(order)
+            if str(s).strip()
+        }
+        # Stable sort: listed slugs by their rank (front), unlisted keep their
+        # original order after them. The fallback sentinel is len(order)+1 —
+        # strictly greater than any real rank index (which is < len(order))
+        # even when `order` contains blank entries filtered out of `rank`.
+        rows = sorted(
+            rows,
+            key=lambda r: rank.get(
+                str(r.get("slug", "")).strip().lower(), len(order) + 1
+            ),
+        )
+
+    return rows

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5545,6 +5545,7 @@ def get_model_options(
                 refresh=bool(refresh),
                 probe_custom_providers=bool(refresh),
                 probe_current_custom_provider=not bool(refresh),
+                apply_picker_prefs=True,
             )
     except HTTPException:
         raise

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -994,3 +994,63 @@ def test_list_authenticated_providers_refresh_busts_cache():
         assert clear.call_count == 0
         model_switch.list_authenticated_providers(refresh=True)
         assert clear.call_count == 1
+
+
+# ─── apply_picker_prefs (desktop/TUI picker parity) ────────────────────
+
+
+def _pref_rows():
+    def row(slug, name):
+        return {
+            "slug": slug, "name": name, "models": ["m1"], "total_models": 1,
+            "is_current": False, "is_user_defined": False, "source": "built-in",
+        }
+    return [
+        row("openrouter", "OpenRouter"),
+        row("anthropic", "Anthropic"),
+        row("openai-api", "OpenAI API"),
+        row("openai-codex", "OpenAI Codex"),
+    ]
+
+
+def test_apply_picker_prefs_off_by_default_keeps_hidden(monkeypatch):
+    ctx = _empty_ctx(provider="openrouter", model="m1", base_url="")
+    cfg = {"model": {"picker": {"hide": ["anthropic", "openai-api"]}}}
+    with _list_auth_returning(_pref_rows()), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        payload = build_models_payload(ctx)  # default apply_picker_prefs=False
+    slugs = [r["slug"] for r in payload["providers"]]
+    assert "anthropic" in slugs
+    assert "openai-api" in slugs
+
+
+def test_apply_picker_prefs_hides_and_orders(monkeypatch):
+    """apply_picker_prefs=True mirrors list_picker_providers: apply the
+    model.picker hide + order config on the desktop payload path too."""
+    ctx = _empty_ctx(provider="openrouter", model="m1", base_url="")
+    cfg = {
+        "model": {
+            "picker": {
+                "hide": ["anthropic", "openai-api"],
+                "order": ["openai-codex", "openrouter"],
+            }
+        }
+    }
+    with _list_auth_returning(_pref_rows()), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        payload = build_models_payload(ctx, apply_picker_prefs=True)
+    slugs = [r["slug"] for r in payload["providers"]]
+    assert "anthropic" not in slugs
+    assert "openai-api" not in slugs
+    # ordered per config; unlisted rows (auto-added moa) trail after
+    assert [s for s in slugs if s != "moa"] == ["openai-codex", "openrouter"]
+
+
+def test_apply_picker_prefs_never_hides_current(monkeypatch):
+    ctx = _empty_ctx(provider="anthropic", model="m1", base_url="")
+    cfg = {"model": {"picker": {"hide": ["anthropic"]}}}
+    with _list_auth_returning(_pref_rows()), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        payload = build_models_payload(ctx, apply_picker_prefs=True)
+    slugs = [r["slug"] for r in payload["providers"]]
+    assert "anthropic" in slugs  # current provider stays visible

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -293,3 +293,82 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     assert row["slug"] == "custom:ollama"
     assert row["is_current"] is True
     assert row["models"] == ["glm-5.1", "qwen3"]
+
+
+# ─── model.picker hide + order preferences ─────────────────────────────
+
+
+def test_picker_hide_drops_configured_slugs(monkeypatch):
+    """model.picker.hide drops matching provider rows from the picker."""
+    base = [
+        _make_provider("anthropic", models=["claude-opus-4-7"]),
+        _make_provider("openai-api", models=["gpt-5"]),
+        _make_provider("openrouter", models=["m1"]),
+    ]
+    cfg = {"model": {"picker": {"hide": ["openai-api", "anthropic"]}}}
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [("m1", "M1")])
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert [p["slug"] for p in result] == ["openrouter"]
+
+
+def test_picker_hide_never_hides_current_provider(monkeypatch):
+    """The currently-active provider is never hidden, even if in the hide set."""
+    base = [
+        _make_provider("anthropic", models=["claude-opus-4-7"], is_current=True),
+        _make_provider("openrouter", models=["m1"]),
+    ]
+    cfg = {"model": {"picker": {"hide": ["anthropic"]}}}
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [("m1", "M1")])
+
+    result = model_switch.list_picker_providers(
+        current_provider="anthropic", max_models=50,
+    )
+
+    assert "anthropic" in [p["slug"] for p in result]
+
+
+def test_picker_order_front_anchors_listed_slugs(monkeypatch):
+    """model.picker.order moves listed slugs to the front; unlisted keep order."""
+    base = [
+        _make_provider("openrouter", models=["m1"]),
+        _make_provider("anthropic", models=["claude-opus-4-7"]),
+        _make_provider("gemini", models=["gemini-3-flash-preview"]),
+    ]
+    cfg = {"model": {"picker": {"order": ["anthropic", "gemini"]}}}
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [("m1", "M1")])
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    # listed slugs front-anchored in config order; unlisted (openrouter) trails
+    assert [p["slug"] for p in result] == ["anthropic", "gemini", "openrouter"]
+
+
+def test_picker_prefs_absent_config_is_noop(monkeypatch):
+    """No model.picker config => rows returned unchanged."""
+    base = [
+        _make_provider("openrouter", models=["m1"]),
+        _make_provider("anthropic", models=["claude-opus-4-7"]),
+    ]
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [("m1", "M1")])
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert [p["slug"] for p in result] == ["openrouter", "anthropic"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12975,6 +12975,7 @@ def _(rid, params: dict) -> dict:
             refresh=bool(params.get("refresh")),
             probe_custom_providers=bool(params.get("refresh")),
             probe_current_custom_provider=not bool(params.get("refresh")),
+            apply_picker_prefs=True,
         )
         return _ok(rid, payload)
     except Exception as e:


### PR DESCRIPTION
## Summary

Adds two optional, purely-cosmetic `model.picker` config knobs so users can curate their `/model` picker without changing which providers are usable:

```yaml
model:
  picker:
    hide:  [openai-api, anthropic]        # slugs to drop from the dropdown
    order: [anthropic, openai-codex, ...]  # front-anchored display order
```

- **`hide`** drops matching provider rows (case-insensitive). The currently-active provider is **never** hidden — you must always be able to see/switch off what you're on.
- **`order`** front-anchors the listed slugs in the given order; unlisted rows keep their relative order after them. Ordering and hiding are independent.
- Missing/malformed config is a no-op.

## Why

On installs with many providers (relays, custom endpoints, aggregators), the picker dropdown gets crowded — and on Discord the native select menu caps at 25 options, so real providers fall off the end. There was no way to hide a provider you never pick or pin your favorites to the top.

## What changed

- New `_apply_picker_preferences()` in `model_switch.py`, applied by `list_picker_providers` (the interactive CLI/Discord picker).
- New `apply_picker_prefs` flag on `build_models_payload` (inventory.py), wired into the desktop `/api/model/options` and TUI `model.options` handlers — so the **desktop/TUI Models picker honors the same config** instead of only the gateway picker. (Previously the two picker code paths diverged: the desktop path never applied any picker preferences.)

Purely cosmetic: typed `/model <slug>/...` and every provider stay reachable regardless. Opt-in, defaults to no-op.

## Tests

7 new: 4 in `test_list_picker_providers.py` (hide, order, never-hide-current, absent-config no-op) + 3 in `test_inventory.py` (desktop `apply_picker_prefs` flag: off-by-default, hide+order, never-hide-current). Mutation-checked. Full picker+inventory suites green (one pre-existing unrelated failure from a local-ollama env bleed, fails identically on `main`).