### PR TITLE
fix: guard memory tool against missing action and operations (#64291)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -997,6 +997,17 @@ def memory_tool(
         return json.dumps(result, ensure_ascii=False)
 
     # --- Single-op path ---------------------------------------------------
+    # Reject calls that provide neither action (single-op) nor operations
+    # (batch).  Without this guard the dispatch falls through to the generic
+    # "Unknown action 'None'" error, which gives the model no signal about
+    # *why* the call was malformed and can trigger repeated retries. (#64291)
+    if not action and not operations:
+        return tool_error(
+            "Missing required parameter: provide 'action' (add/replace/remove) "
+            "or 'operations' (batch list). Got neither.",
+            success=False,
+        )
+
     # Validate required params BEFORE the gate so an invalid write is rejected
     # immediately instead of being staged and only failing at approve time.
     if action == "add" and not content:


### PR DESCRIPTION
## Summary

When both `action` (single-op) and `operations` (batch) are omitted from a `memory` tool call, the dispatch chain falls through every if/elif guard and hits the generic else branch:

```
Unknown action 'None'. Use: add, replace, remove
```

This gives the model no signal about *why* the call was malformed and can trigger repeated retries of the same broken call.

## Root Cause

The memory tool has two call shapes:
- **Single-op**: `{target, action, content?, old_text?}`
- **Batch**: `{target, operations: [{action, content?, old_text?}, ...]}`

When neither `action` nor `operations` is provided, the code skips the batch path (line 990: `if operations:` → False) and then skips every single-op validation (each checks `action == "add"` etc. → all False). It reaches the catch-all else at line 1031 which produces the confusing `Unknown action 'None'` error.

## Fix

Add an explicit guard before the single-op dispatch chain that rejects calls providing neither parameter with a clear, actionable error message.

## Testing

- `pytest tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py` — all 88 tests pass
- `ruff check tools/memory_tool.py` — clean

Fixes #64291