### PR TITLE
fix(sanitizer): validate and sanitize non-standard JSON Schema type strings

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -745,6 +745,28 @@ def test_strip_slash_enum_none_returns_zero():
     assert stripped == 0
 
 
+def test_invalid_type_string_replaced_with_object():
+    """Non-standard type strings (e.g., "custom", "undefined") are replaced with "object".
+    
+    This addresses the bug where MCP servers emit tool schemas with non-primitive
+    type values in nested properties. Anthropic's API validates against the JSON Schema
+    metaschema and rejects any type value not in the primitive set, returning HTTP 400.
+    """
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "payload": {"type": "custom"},  # <-- invalid, should become "object"
+            "config": {"type": "undefined"},  # <-- invalid, should become "object"
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    payload = out[0]["function"]["parameters"]["properties"]["payload"]
+    assert payload["type"] == "object"
+    config = out[0]["function"]["parameters"]["properties"]["config"]
+    assert config["type"] == "object"
+
+
+
 def test_strip_slash_enum_ignores_non_string_enum_values():
     """Integer/boolean enum values can't contain '/' — leave them alone."""
     tools = [_tool("t", {
@@ -759,3 +781,24 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+def test_invalid_type_string_replaced_with_object():
+    """Non-standard type strings (e.g., "custom", "undefined") are replaced with "object".
+    
+    This addresses the bug where MCP servers emit tool schemas with non-primitive
+    type values in nested properties. Anthropic's API validates against the JSON Schema
+    metaschema and rejects any type value not in the primitive set, returning HTTP 400.
+    """
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "payload": {"type": "custom"},  # <-- invalid, should become "object"
+            "config": {"type": "undefined"},  # <-- invalid, should become "object"
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    payload = out[0]["function"]["parameters"]["properties"]["payload"]
+    assert payload["type"] == "object"
+    config = out[0]["function"]["parameters"]["properties"]["config"]
+    assert config["type"] == "object"
+
+

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -304,6 +304,19 @@ def _sanitize_node(node: Any, path: str) -> Any:
             # otherwise an empty/garbage array → object fallback.
             out["type"] = "null" if has_null else "object"
             continue
+        
+        # Validate and sanitize type strings (e.g., "custom", "undefined").
+        # Anthropic and other strict providers reject non-primitive types.
+        if key == "type" and isinstance(value, str):
+            valid_types = {"object", "string", "number", "integer", "boolean", "array", "null"}
+            if value not in valid_types:
+                logger.debug(
+                    "schema_sanitizer[%s]: replacing invalid type %r with 'object'",
+                    path, value,
+                )
+                out["type"] = "object"
+                continue
+
 
         if key in {"properties", "$defs", "definitions"} and isinstance(value, dict):
             out[key] = {


### PR DESCRIPTION
## What does this PR do?

MCP servers may emit tool schemas with non-primitive type values (e.g., `"type": "custom"`, `"type": "undefined"`) in nested properties. Anthropic's API validates tool schemas against the JSON Schema metaschema and rejects any type value not in the primitive set (`object`, `string`, `number`, `integer`, `boolean`, `array`, `null`), returning HTTP 400 and blocking the entire conversation.

This PR adds validation in `_sanitize_node()` for type strings, replacing invalid types with `"object"` to maintain schema validity while preserving structure. This is a targeted fix that applies the same defensive pattern already used for type arrays.

## Related Issue

Fixes #64312

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py`: Add type string validation in `_sanitize_node()` (lines 308-319)
- `tests/tools/test_schema_sanitizer.py`: Add test `test_invalid_type_string_replaced_with_object()` to verify invalid types are replaced with `"object"`

## How to Test

1. Run the new test: `pytest tests/tools/test_schema_sanitizer.py -k "invalid_type_string"`
   - Expected: Test passes, confirming that `"custom"` and `"undefined"` types are replaced with `"object"`

2. Run the full test suite for schema sanitizer: `pytest tests/tools/test_schema_sanitizer.py -v`
   - Expected: All 48 tests pass

3. Verify the fix handles the reported scenario:
   ```python
   from tools.schema_sanitizer import sanitize_tool_schemas
   
   tools = [{
       "type": "function",
       "function": {
           "name": "test_tool",
           "parameters": {
               "type": "object",
               "properties": {
                   "config": {"type": "custom"}  # Invalid non-primitive type
               }
           }
       }
   }]
   
   sanitized = sanitize_tool_schemas(tools)
   # The invalid "custom" type is replaced with "object"
   assert sanitized[0]["function"]["parameters"]["properties"]["config"]["type"] == "object"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
