### PR TITLE
feat(feishu): reply_in_thread from config.yaml (no .env)

### DIFF
--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2146,6 +2146,47 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_does_not_reply_in_thread_when_setting_is_false(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"reply_in_thread": False}))
+        captured = {}
+
+        class _ReplyAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_ReplyAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hello",
+                    reply_to="om_parent",
+                    metadata={"thread_id": "omt-thread"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_reply")
+        self.assertFalse(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_metadata_reply_target_for_threaded_feishu_topic(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -471,6 +471,20 @@ Additional webhook protections:
 - **Body read timeout:** 30 seconds
 - **Content-Type enforcement:** Only `application/json` is accepted
 
+## Thread Replies
+
+By default, Feishu replies are sent into the message thread when thread metadata is present. To disable threaded replies so that all messages stay in the main conversation:
+
+```yaml
+platforms:
+  feishu:
+    reply_in_thread: false
+```
+
+| Setting | Config key | Default | Description |
+|---------|-----------|---------|-------------|
+| Thread replies | `reply_in_thread` | `true` | Whether to reply in-thread when thread metadata is available |
+
 ## WebSocket Tuning
 
 When using `websocket` mode, you can customize reconnect and ping behavior:


### PR DESCRIPTION
## Summary

Adds `reply_in_thread` as a config.yaml platform setting for Feishu.

## Changes (4 hunks, +6/-1 in `plugins/platforms/feishu/adapter.py`)

1. `FeishuAdapterSettings`: add `reply_in_thread: bool = True`
2. `_load_settings`: read from `extra.get("reply_in_thread", True)` (bridged from YAML by `gateway/config.py:1196`)
3. `_apply_settings`: store as `self._reply_in_thread`
4. Send logic: `reply_in_thread = self._reply_in_thread and bool((metadata or {}).get("thread_id"))`

### Config
```yaml
platforms:
  feishu:
    reply_in_thread: false
```

### Background
Previous attempt (PR #39600) used `FEISHU_REPLY_IN_THREAD` env var — closed per policy (behavioral config → config.yaml, not .env). This re-scopes to config.yaml only.

## Type
- [x] ✨ New feature