### PR TITLE
fix: honor approvals.timeout for ACP edit approval prompts (#63302)

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -22,6 +22,10 @@ from typing import Any, Callable
 logger = logging.getLogger(__name__)
 
 
+class EditApprovalTimeout(Exception):
+    """Raised when an ACP edit approval request times out."""
+
+
 @dataclass(frozen=True)
 class EditProposal:
     """A proposed single-file edit that can be shown to an ACP client."""
@@ -252,6 +256,9 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
 
     try:
         approved = bool(requester(proposal))
+    except EditApprovalTimeout as exc:
+        logger.warning("ACP edit approval timed out: %s", exc)
+        return json.dumps({"error": str(exc)}, ensure_ascii=False)
     except Exception as exc:
         logger.warning("ACP edit approval requester failed: %s", exc)
         approved = False
@@ -325,9 +332,17 @@ def make_acp_edit_approval_requester(
             return False
         try:
             response = future.result(timeout=timeout)
-        except (FutureTimeout, Exception) as exc:
+        except FutureTimeout:
             future.cancel()
-            logger.warning("Edit approval request timed out or failed: %s", exc)
+            logger.warning(
+                "Edit approval request timed out after %ss", timeout,
+            )
+            raise EditApprovalTimeout(
+                f"Edit approval timed out after {timeout}s; file was not modified."
+            ) from None
+        except Exception as exc:
+            future.cancel()
+            logger.warning("Edit approval request failed: %s", exc)
             return False
         outcome = getattr(response, "outcome", None)
         return (

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1421,11 +1421,17 @@ class HermesACPAgent(acp.Agent):
             approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
             try:
                 from acp_adapter.edit_approval import make_acp_edit_approval_requester
+                from hermes_cli.config import load_config
+
+                _edit_timeout = int(
+                    load_config().get("approvals", {}).get("timeout", 60)
+                )
 
                 edit_approval_requester = make_acp_edit_approval_requester(
                     conn.request_permission,
                     loop,
                     session_id,
+                    timeout=_edit_timeout,
                     auto_approve_getter=lambda: self._edit_approval_policy_for_state(state),
                 )
             except Exception:


### PR DESCRIPTION
## Summary

The ACP edit approval flow (the permission prompt IDEs like Zed/VS Code show for `write_file` / `patch` diffs) used a hardcoded 60-second timeout. The documented `approvals.timeout` config key had no effect — users who set it to a longer value (e.g. 86400s) still got edits fail-closing at 60s.

## Root Cause

`make_acp_edit_approval_requester()` in `acp_adapter/edit_approval.py` accepts a `timeout` parameter but defaults to `60.0`. The caller in `acp_adapter/server.py` (line 1425) never passes the user-configured timeout — it relies on the default.

The CLI's approval flow reads `approvals.timeout` from config via `CLI_CONFIG.get('approvals', {}).get('timeout', 60)`. The ACP path has no equivalent read.

## Fix

Two changes:

1. **Read config timeout** — In `acp_adapter/server.py`, read `approvals.timeout` from the loaded config and pass it to `make_acp_edit_approval_requester()`.

2. **Distinguish timeout from denial** — Introduce `EditApprovalTimeout` exception. When the future times out, the requester now raises this exception instead of silently returning `False`. The caller (`maybe_require_edit_approval`) catches it and returns a clear error: _"Edit approval timed out after Ns"_ instead of the misleading _"Edit approval denied by ACP client"_.

## Testing

- `ruff check acp_adapter/edit_approval.py acp_adapter/server.py` — all checks passed
- Existing ACP tests: pre-existing failure (missing `acp` module in test env), unrelated to this change

Fixes #63302