### PR TITLE
fix: skip standing goal continuation on failed agent turns (#63180)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10368,14 +10368,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # broken judge never breaks normal message handling.
             try:
                 _final_text = ""
+                _turn_failed = False
                 if isinstance(_agent_result, dict):
                     _final_text = str(_agent_result.get("final_response") or "")
+                    _turn_failed = bool(_agent_result.get("failed"))
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
-                # on error. Let the user drive the next turn.
-                if _final_text.strip():
+                # on error.  Also skip when the provider explicitly marked
+                # the turn as failed: the normalized error text is non-empty
+                # but doesn't represent a successful agent response. (#63180)
+                if _final_text.strip() and not _turn_failed:
                     try:
                         session_entry = await self.async_session_store.get_or_create_session(source)
                     except Exception:


### PR DESCRIPTION
## Summary

When a provider/model failure produces a non-empty error string as `final_response`, the standing goal continuation hook treated it as a successful turn and enqueued a synthetic continuation. This created a self-sustaining loop: each failure triggered the goal judge, which said "continue", which enqueued another turn that failed again.

## Root Cause

The goal continuation guard at `gateway/run.py` line 10378 only checks:

```python
if _final_text.strip():
```

When a provider fails, the error is normalized into a non-empty `final_response` string (e.g. `"Error rendering prompt with jinja template: No user query found in messages."`). The check passes, the goal judge runs, returns `continue`, and another synthetic continuation is enqueued — repeating until the session balloons.

The existing comment on line 10355 acknowledges the problem for empty responses but missed the case where failed turns produce non-empty error text.

## Fix

Check the `failed` flag on the agent result dict before running the goal continuation:

```python
if _final_text.strip() and not _turn_failed:
```

Failed turns now skip the judge entirely and let the user drive the next turn. The `failed` flag is already set by the error-normalization path at line 19819.

## Testing

- `ruff check gateway/run.py` — all checks passed
- The fix is a single conditional addition; no new code paths

Fixes #63180