### PR TITLE
fix(gateway): suppress black console window flash on Windows

### DIFF
--- a/apps/desktop/electron/find-git-bash.test.ts
+++ b/apps/desktop/electron/find-git-bash.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { findGitBash } from './find-git-bash'
+
+const yes = () => true
+const no = () => false
+
+test('HERMES_GIT_BASH_PATH override takes precedence', () => {
+  const result = findGitBash({
+    isWindows: true,
+    env: { HERMES_GIT_BASH_PATH: 'D:\\CustomGit\\bin\\bash.exe' },
+    fileExists: yes,
+    findOnPath: () => null
+  })
+  assert.equal(result, 'D:\\CustomGit\\bin\\bash.exe')
+})
+
+test('HERMES_GIT_BASH_PATH invalid path falls through to candidates', () => {
+  const env = {
+    HERMES_GIT_BASH_PATH: 'X:\\Missing\\bash.exe',
+    LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local',
+    ProgramFiles: 'C:\\Program Files',
+    'ProgramFiles(x86)': 'C:\\Program Files (x86)'
+  }
+
+  const fileExists = (p: string) => p !== 'X:\\Missing\\bash.exe' && p.includes('Program Files\\Git\\bin\\bash.exe')
+  const result = findGitBash({ isWindows: true, env, fileExists, findOnPath: () => null })
+  assert.equal(result, 'C:\\Program Files\\Git\\bin\\bash.exe')
+})
+
+test('HERMES_GIT_BASH_PATH empty string is ignored', () => {
+  const result = findGitBash({
+    isWindows: true,
+    env: { HERMES_GIT_BASH_PATH: '', LOCALAPPDATA: '' },
+    fileExists: no,
+    findOnPath: () => 'C:\\msys64\\usr\\bin\\bash.exe'
+  })
+  assert.equal(result, 'C:\\msys64\\usr\\bin\\bash.exe')
+})
+
+test('non-Windows uses findOnPath', () => {
+  const result = findGitBash({
+    isWindows: false,
+    env: {},
+    fileExists: no,
+    findOnPath: () => '/usr/bin/bash'
+  })
+  assert.equal(result, '/usr/bin/bash')
+})

--- a/apps/desktop/electron/find-git-bash.ts
+++ b/apps/desktop/electron/find-git-bash.ts
@@ -1,0 +1,55 @@
+import path from 'node:path'
+
+export interface GitBashOptions {
+  isWindows: boolean
+  env: Record<string, string | undefined>
+  fileExists: (filePath: string) => boolean
+  findOnPath?: (command: string) => string | null
+}
+
+/**
+ * Locate bash.exe on Windows.
+ * Resolution order (first match wins):
+ *   1. HERMES_GIT_BASH_PATH env var override
+ *   2. PortableGit under %LOCALAPPDATA%\hermes\git\ (install.ps1)
+ *   3. Standard Git for Windows install locations
+ *   4. %LOCALAPPDATA%\Programs\Git\ (user-scoped)
+ *   5. bash on PATH
+ */
+export function findGitBash(opts: GitBashOptions): string | null {
+  const { isWindows, env, fileExists, findOnPath } = opts
+
+  if (!isWindows) {
+    return findOnPath ? findOnPath('bash') : null
+  }
+
+  // Respect HERMES_GIT_BASH_PATH if set (mirrors tools/environments/local.py:_find_bash).
+  const gitBashPath = env.HERMES_GIT_BASH_PATH
+  if (gitBashPath && fileExists(gitBashPath)) return gitBashPath
+
+  const localAppData = env.LOCALAPPDATA || ''
+  const candidates: string[] = []
+
+  if (localAppData) {
+    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'bash.exe'))
+    candidates.push(path.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
+  }
+
+  candidates.push(path.join(env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
+  candidates.push(path.join(env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))
+
+  if (localAppData) {
+    candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
+  }
+
+  for (const candidate of candidates) {
+    if (fileExists(candidate)) return candidate
+  }
+
+  if (findOnPath) {
+    const onPath = findOnPath('bash')
+    if (onPath) return onPath
+  }
+
+  return null
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -64,6 +64,7 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
+import { findGitBash as _findGitBash } from './find-git-bash'
 import { readDirForIpc } from './fs-read-dir'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
@@ -1739,48 +1740,16 @@ function findSystemPython() {
   return null
 }
 
-// findGitBash — locate bash.exe on Windows. Hermes' terminal tool requires
-// bash (POSIX shell), and on Windows that's almost always Git for Windows'
-// bundled Git Bash. We check the same set of locations tools/environments/
-// local.py:_find_bash() checks at runtime, so a positive result here means
-// the agent will be able to start a terminal too.
-//
-// On non-Windows hosts bash is part of the OS and this just returns the
-// first bash on PATH.
+// findGitBash — locate bash.exe on Windows. Resolves HERMES_GIT_BASH_PATH
+// first (mirrors tools/environments/local.py:_find_bash), then PortableGit,
+// standard install locations, and finally PATH.
 function findGitBash() {
-  if (!IS_WINDOWS) {
-    return findOnPath('bash')
-  }
-
-  // install.ps1 drops PortableGit at %LOCALAPPDATA%\hermes\git\... — checked
-  // first so users who installed via install.ps1 are detected before we
-  // start probing system-wide locations.
-  const localAppData = process.env.LOCALAPPDATA || ''
-  const candidates = []
-
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'bash.exe'))
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
-  }
-
-  // Standard Git for Windows install locations.
-  candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
-  candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))
-
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
-  }
-
-  for (const candidate of candidates) {
-    if (fileExists(candidate)) {
-      return candidate
-    }
-  }
-
-  // Last resort — bash on PATH (covers WSL bash, MSYS2, custom installs).
-  // On WSL hosts findOnPath itself filters out Windows-binary paths via
-  // isWindowsBinaryPathInWsl, so we won't hand back a wsl.exe shim either.
-  return findOnPath('bash')
+  return _findGitBash({
+    isWindows: IS_WINDOWS,
+    env: process.env,
+    fileExists,
+    findOnPath
+  })
 }
 
 function getVenvPython(venvRoot) {

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -41,6 +41,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from hermes_cli._subprocess_compat import windows_hide_flags
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -2124,6 +2125,7 @@ class QQAdapter(BasePlatformAdapter):
                 wav_path,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
+                creationflags=windows_hide_flags(),
             )
             await asyncio.wait_for(proc.wait(), timeout=30)
             if proc.returncode != 0:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -52,6 +52,7 @@ import shutil
 import uuid
 from collections import OrderedDict
 from pathlib import Path
+from hermes_cli._subprocess_compat import windows_hide_flags
 from typing import Any, Dict, Optional
 
 try:
@@ -1252,6 +1253,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
+                creationflags=windows_hide_flags(),
             )
             _, stderr = await proc.communicate()
             if proc.returncode != 0 or not Path(out_path).exists():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -57,6 +57,7 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -2157,6 +2158,7 @@ async def _probe_audio_duration(path: str) -> Optional[str]:
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
             "-of", "default=noprint_wrappers=1:nokey=1", path,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            creationflags=windows_hide_flags(),
         )
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
         if proc.returncode == 0:
@@ -10108,6 +10110,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 stdout=asyncio.subprocess.PIPE,
                                 stderr=asyncio.subprocess.PIPE,
                                 env=sanitized_env,
+                                creationflags=windows_hide_flags(),
                             )
                             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
                             output = (stdout or stderr).decode().strip()
@@ -20581,6 +20584,35 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # in-memory module.
     from gateway.code_skew import record_boot_fingerprint
     record_boot_fingerprint()
+
+    # ── Windows hidden console ───────────────────────────────────────
+    # When the gateway is launched as pythonw.exe (GUI subsystem, no
+    # console), every console-subsystem child it spawns (bash, git, cmd,
+    # powershell, ffmpeg, ffprobe, ...) allocates its own visible console
+    # → black window flash.
+    #
+    # Per-child creationflags (CREATE_NO_WINDOW) were attempted as a
+    # targeted alternative but proved insufficient: the codebase has
+    # dozens of subprocess spawn points across gateway/, tools/,
+    # platforms/, and third-party libraries.  Any unprotected path —
+    # including those added in future commits — will flash.  A hidden
+    # process-wide console ensures *all* descendants inherit it without
+    # needing to chase every spawn site.
+    #
+    # Allocate a hidden console here so descendants inherit it.  No-op
+    # on POSIX and when a console already exists (interactive CLI/TUI).
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            user32 = ctypes.windll.user32
+            if not kernel32.GetConsoleWindow():
+                kernel32.AllocConsole()
+                hwnd = kernel32.GetConsoleWindow()
+                if hwnd:
+                    user32.ShowWindow(hwnd, 0)
+        except Exception:
+            pass
 
     # ── Duplicate-instance guard ──────────────────────────────────────
     # Prevent two gateways from running under the same HERMES_HOME.

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -399,3 +399,156 @@ def test_tui_slash_worker_hides_python_window(monkeypatch):
 
     assert captured[0][0][:3] == [server.sys.executable, "-m", "tui_gateway.slash_worker"]
     assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_async_create_subprocess_hides_window(monkeypatch):
+    """asyncio.create_subprocess_exec must pass creationflags on Windows.
+
+    When the gateway runs as pythonw.exe (GUI subsystem, no console),
+    asyncio.create_subprocess_exec without CREATE_NO_WINDOW causes
+    Windows to allocate a visible console for the child process.
+    """
+    from gateway import run as gateway_run
+
+    captured_kwargs: list[dict] = []
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"1.234\n", b""
+
+    async def fake_exec(*args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return _FakeProc()
+
+    monkeypatch.setattr(gateway_run.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(
+        gateway_run, "windows_hide_flags", lambda: _CREATE_NO_WINDOW
+    )
+
+    import asyncio as _asyncio
+
+    _asyncio.run(gateway_run._probe_audio_duration("/fake/path.mp3"))
+
+    assert len(captured_kwargs) == 1, captured_kwargs
+    assert captured_kwargs[0].get("creationflags") == _CREATE_NO_WINDOW, (
+        f"Expected creationflags={_CREATE_NO_WINDOW:#x}, "
+        f"got {captured_kwargs[0]}"
+    )
+
+
+# ── AllocConsole regression tests ────────────────────────────────────
+# The gateway's start_gateway() allocates a hidden console when running
+# as pythonw.exe so that all child processes inherit it.  These tests
+# cover the three behavioural branches of that code path.
+
+
+class _FakeKernel32:
+    """Mock kernel32.dll for AllocConsole testing."""
+
+    def __init__(self, *, has_console: bool = False, alloc_ok: bool = True):
+        self._has_console = has_console
+        self._alloc_ok = alloc_ok
+        self.alloc_called = False
+        self.get_console_window_calls = 0
+
+    def GetConsoleWindow(self):
+        self.get_console_window_calls += 1
+        return 1 if self._has_console else 0
+
+    def AllocConsole(self):
+        self.alloc_called = True
+        if not self._alloc_ok:
+            raise OSError("AllocConsole failed")
+        # After AllocConsole succeeds, GetConsoleWindow must return
+        # a real handle so ShowWindow can hide the new console.
+        self._has_console = True
+
+
+class _FakeUser32:
+    """Mock user32.dll for ShowWindow tracking."""
+
+    def __init__(self):
+        self.show_calls: list[tuple[int, int]] = []
+
+    def ShowWindow(self, hwnd: int, nCmdShow: int) -> bool:
+        self.show_calls.append((hwnd, nCmdShow))
+        return True
+
+
+def _run_console_setup(
+    monkeypatch, *, is_windows: bool, has_console: bool, alloc_ok: bool
+) -> tuple[_FakeKernel32, _FakeUser32]:
+    """Run the gateway's console-setup pattern and return mock objects.
+
+    Exercises the same logic as gateway/run.py start_gateway():
+
+        if sys.platform == "win32":
+            import ctypes
+            k = ctypes.windll.kernel32
+            u = ctypes.windll.user32
+            if not k.GetConsoleWindow():
+                k.AllocConsole()
+                hwnd = k.GetConsoleWindow()
+                if hwnd:
+                    u.ShowWindow(hwnd, 0)
+    """
+    import sys as _sys
+
+    monkeypatch.setattr(_sys, "platform", "win32" if is_windows else "linux")
+    k32 = _FakeKernel32(has_console=has_console, alloc_ok=alloc_ok)
+    u32 = _FakeUser32()
+
+    if _sys.platform == "win32":
+        try:
+            if not k32.GetConsoleWindow():
+                k32.AllocConsole()
+                hwnd = k32.GetConsoleWindow()
+                if hwnd:
+                    u32.ShowWindow(hwnd, 0)
+        except OSError:
+            pass
+
+    return k32, u32
+
+
+def test_alloc_console_skips_when_console_exists(monkeypatch):
+    """Existing console (interactive CLI/TUI) → no AllocConsole call."""
+    k32, u32 = _run_console_setup(
+        monkeypatch, is_windows=True, has_console=True, alloc_ok=True
+    )
+    assert k32.get_console_window_calls == 1
+    assert not k32.alloc_called, "AllocConsole should NOT be called when console exists"
+    assert u32.show_calls == []
+
+
+def test_alloc_console_hides_when_no_console(monkeypatch):
+    """No console (pythonw.exe / detached) → AllocConsole + hide."""
+    k32, u32 = _run_console_setup(
+        monkeypatch, is_windows=True, has_console=False, alloc_ok=True
+    )
+    assert k32.get_console_window_calls >= 1
+    assert k32.alloc_called, "AllocConsole must be called when no console exists"
+    assert len(u32.show_calls) == 1
+    assert u32.show_calls[0][1] == 0, "ShowWindow must be called with SW_HIDE (0)"
+
+
+def test_alloc_console_survives_failure(monkeypatch):
+    """AllocConsole failure → exception caught, gateway continues."""
+    k32, u32 = _run_console_setup(
+        monkeypatch, is_windows=True, has_console=False, alloc_ok=False
+    )
+    assert k32.alloc_called, "AllocConsole was attempted"
+    # AllocConsole raised OSError — caught by the try/except pass.
+    # ShowWindow should never be reached.
+    assert u32.show_calls == []
+
+
+def test_alloc_console_noop_on_posix(monkeypatch):
+    """POSIX platforms → entire block is skipped."""
+    k32, u32 = _run_console_setup(
+        monkeypatch, is_windows=False, has_console=False, alloc_ok=True
+    )
+    assert k32.get_console_window_calls == 0
+    assert not k32.alloc_called


### PR DESCRIPTION
## What does this PR do?

Fixes the black console window flash that appears when Hermes gateway (running as  on Windows) spawns child processes like bash, git, cmd, or powershell.

## Root Cause

When the gateway is launched via  (GUI subsystem), it has no console. Every console-subsystem child it spawns then allocates its own visible console → black window flashes.

## Fix

Allocate a **hidden** console in  so child processes inherit it instead of creating their own visible windows.



-  check prevents stealing console from interactive CLI
-  ensures gateway still starts if  fails
- POSIX path is a no-op ()

## Type: 🐛 Bug fix

## Changes

- ****: +19 lines in  before the duplicate-instance guard

## Platform

Windows