### PR TITLE
feat(gateway): attest effective startup config

### DIFF
--- a/docs/contracts/gateway-effective-config-v1.example.json
+++ b/docs/contracts/gateway-effective-config-v1.example.json
@@ -1,0 +1,29 @@
+{
+  "gateway_state": "running",
+  "pid": 42002,
+  "start_time": 1234.5,
+  "effective_config": {
+    "schema": 1,
+    "complete": true,
+    "loaded_at": "2026-07-14T12:00:00.000Z",
+    "pid": 42002,
+    "start_time": 1234.5,
+    "profiles": {
+      "default": {
+        "profile_path": "/Agents/Neo/.hermes/profiles/neo",
+        "config_path": "/Agents/Neo/.hermes/profiles/neo/config.yaml",
+        "config_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "primary": {
+          "provider": "openai-codex",
+          "model": "gpt-5.5"
+        },
+        "fallbacks": [
+          {
+            "provider": "xai-oauth",
+            "model": "grok-4.3"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -8,9 +8,12 @@ Handles loading and validating configuration for:
 - Delivery preferences
 """
 
+import copy
+import json
 import logging
 import os
-import json
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Callable
@@ -973,9 +976,28 @@ class GatewayConfig:
         return "public"
 
 
+_config_yaml_snapshot_override: ContextVar[Optional[dict]] = ContextVar(
+    "gateway_config_yaml_snapshot", default=None
+)
+
+
+@contextmanager
+def _gateway_config_yaml_snapshot(config_yaml: dict):
+    """Make one parsed YAML snapshot visible to the canonical no-arg loader."""
+    token = _config_yaml_snapshot_override.set(config_yaml)
+    try:
+        yield
+    finally:
+        _config_yaml_snapshot_override.reset(token)
+
+
 def load_gateway_config() -> GatewayConfig:
     """
     Load gateway configuration from multiple sources.
+
+    Startup may pin an exact parsed byte snapshot through the private context
+    manager above, avoiding a second config.yaml read without changing this
+    loader's established no-argument contract.
 
     Priority (highest to lowest):
     1. Environment variables
@@ -1003,10 +1025,14 @@ def load_gateway_config() -> GatewayConfig:
     # Primary source: config.yaml
     try:
         import yaml
+        config_yaml = _config_yaml_snapshot_override.get()
         config_yaml_path = _home / "config.yaml"
-        if config_yaml_path.exists():
-            with open(config_yaml_path, encoding="utf-8") as f:
-                yaml_cfg = yaml.safe_load(f) or {}
+        if config_yaml is not None or config_yaml_path.exists():
+            if config_yaml is not None:
+                yaml_cfg = copy.deepcopy(config_yaml)
+            else:
+                with open(config_yaml_path, encoding="utf-8") as f:
+                    yaml_cfg = yaml.safe_load(f) or {}
 
             # Managed scope: overlay administrator-pinned values so the gateway
             # honors them too. This loader builds its own dict instead of going

--- a/gateway/config_attestation.py
+++ b/gateway/config_attestation.py
@@ -1,0 +1,90 @@
+"""Sanitized provenance for gateway startup configuration."""
+
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermes_cli.fallback_config import get_fallback_chain
+
+
+@dataclass(frozen=True)
+class ProfileConfigSnapshot:
+    """One immutable-on-disk config read and its derived runtime views."""
+
+    parsed: dict[str, Any]
+    normalized: dict[str, Any]
+    effective: dict[str, Any]
+    attestation: dict[str, Any]
+    loaded_at: str
+
+
+def load_profile_config_snapshot(profile_home: Path) -> ProfileConfigSnapshot:
+    """Read config once and derive both runtime input and sanitized provenance."""
+    profile_path = profile_home.resolve()
+    config_path = (profile_path / "config.yaml").resolve()
+    config_bytes = config_path.read_bytes()
+    loaded_at = datetime.now(timezone.utc).isoformat()
+    parsed = yaml.safe_load(config_bytes.decode("utf-8-sig")) or {}
+    if not isinstance(parsed, dict):
+        raise ValueError("config.yaml top level must be a mapping")
+
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _expand_env_vars, _normalize_root_model_keys
+
+    normalized = managed_scope.apply_managed_overlay(deepcopy(parsed))
+    normalized = _normalize_root_model_keys(normalized)
+    effective = _expand_env_vars(deepcopy(normalized))
+    if not isinstance(effective, dict):
+        raise ValueError("effective config must be a mapping")
+
+    # Model selection and per-turn fallback refresh use the normalized config
+    # path (`_load_gateway_config`), not the env-expanded runtime-helper view.
+    # Attest the values that those actual model paths consume.
+    model_config = normalized.get("model", {})
+    if isinstance(model_config, str):
+        provider = ""
+        model = model_config.strip()
+    elif isinstance(model_config, dict):
+        provider = str(model_config.get("provider") or "").strip()
+        model = str(
+            model_config.get("default") or model_config.get("model") or ""
+        ).strip()
+    else:
+        provider = ""
+        model = ""
+
+    fallbacks = [
+        {
+            "provider": str(entry.get("provider") or "").strip(),
+            "model": str(entry.get("model") or "").strip(),
+        }
+        for entry in get_fallback_chain(normalized)
+    ]
+
+    attestation = {
+        "profile_path": str(profile_path),
+        "config_path": str(config_path),
+        "config_sha256": hashlib.sha256(config_bytes).hexdigest(),
+        "primary": {"provider": provider, "model": model},
+        "fallbacks": fallbacks,
+    }
+    return ProfileConfigSnapshot(
+        parsed=deepcopy(parsed),
+        normalized=normalized,
+        effective=effective,
+        attestation=attestation,
+        loaded_at=loaded_at,
+    )
+
+
+__all__ = [
+    "ProfileConfigSnapshot",
+    "load_profile_config_snapshot",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -41,7 +41,7 @@ import threading
 import time
 import sqlite3
 from collections import OrderedDict
-from contextvars import copy_context
+from contextvars import ContextVar, copy_context
 from pathlib import Path
 from datetime import datetime
 from typing import Callable, Dict, Optional, Any, List, Union
@@ -2340,66 +2340,34 @@ def _gateway_config_home() -> Path:
     return _hermes_home
 
 
+_startup_config_snapshot_override: ContextVar[Any | None] = ContextVar(
+    "gateway_startup_config_snapshot", default=None
+)
+
+
+def _load_gateway_config_snapshot():
+    """Load the exact config byte snapshot used by gateway runtime helpers."""
+    from gateway.config_attestation import load_profile_config_snapshot
+
+    return load_profile_config_snapshot(_gateway_config_home())
+
+
 def _load_gateway_config() -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error.
 
-    Uses the module-level ``_hermes_home`` (so tests that monkeypatch it
-    still see their fixture) and shares the mtime-keyed raw-yaml cache
-    from ``hermes_cli.config.read_raw_config`` when the paths match.
-
-    Managed scope is overlaid on the result (via the shared helper) so the
-    gateway honors administrator-pinned values — neither read_raw_config nor a
-    direct yaml.safe_load carries the managed merge on its own. Fail-open.
+    The snapshot loader owns reading, managed-scope overlay, and model-key
+    normalization so runtime values and startup provenance share one source.
+    During runner construction, every startup helper receives the same pinned
+    snapshot through a context-local override. Fail-open.
     """
-    config_home = _gateway_config_home()
-    config_path = config_home / 'config.yaml'
-    raw: dict = {}
-    used_canonical = False
+    snapshot = _startup_config_snapshot_override.get()
+    if snapshot is not None:
+        return snapshot.normalized
     try:
-        from hermes_cli.config import get_config_path, read_raw_config
-        # Fast path: if _hermes_home agrees with the canonical config
-        # location, reuse the shared cache. Otherwise fall through to a
-        # direct read (keeps test fixtures with a monkeypatched
-        # _hermes_home working).
-        if config_path == get_config_path():
-            raw = read_raw_config()
-            used_canonical = True
+        return _load_gateway_config_snapshot().normalized
     except Exception:
-        pass
-
-    if not used_canonical:
-        try:
-            if config_path.exists():
-                import yaml
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    raw = yaml.safe_load(f) or {}
-        except Exception:
-            logger.debug("Could not load gateway config from %s", config_path)
-            raw = {}
-
-    # Overlay managed scope. read_raw_config() returns the user's raw YAML
-    # WITHOUT the managed merge (that lives in load_config/_load_config_impl),
-    # so the overlay is required on both paths for the gateway to honor pinned
-    # values. Helper is fail-open and a no-op when no managed scope exists.
-    try:
-        from hermes_cli import managed_scope
-        raw = managed_scope.apply_managed_overlay(raw if isinstance(raw, dict) else {})
-    except Exception:
-        pass
-    if not isinstance(raw, dict):
+        logger.debug("Could not load gateway config", exc_info=True)
         return {}
-    # Canonicalize model-id aliases (model.name / model.model → model.default)
-    # and migrate stale root-level provider/base_url into the model section.
-    # The gateway bypasses load_config() (it reads raw YAML for speed), so the
-    # normalization that load_config() applies must be replayed here or the
-    # gateway would resolve an empty model for ``model: {name: <id>}`` configs
-    # while the CLI resolves it correctly. See issue #34500. Fail-open.
-    try:
-        from hermes_cli.config import _normalize_root_model_keys
-        raw = _normalize_root_model_keys(raw)
-    except Exception:
-        pass
-    return raw
 
 
 def _load_gateway_runtime_config() -> dict:
@@ -2413,7 +2381,13 @@ def _load_gateway_runtime_config() -> dict:
     Expansion failures are intentionally NOT swallowed — silently returning
     the unexpanded dict would mask the very bug this helper exists to fix.
     """
-    cfg = _load_gateway_config()
+    snapshot = _startup_config_snapshot_override.get()
+    if snapshot is not None:
+        return snapshot.effective
+    try:
+        return _load_gateway_config_snapshot().effective
+    except Exception:
+        cfg = _load_gateway_config()
     if not isinstance(cfg, dict) or not cfg:
         return {}
     from hermes_cli.config import _expand_env_vars
@@ -2831,7 +2805,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
-        self.config = config or load_gateway_config()
+        try:
+            startup_snapshot = _load_gateway_config_snapshot()
+        except Exception:
+            startup_snapshot = None
+            logger.warning("Could not capture primary startup config", exc_info=True)
+        if config is not None:
+            self.config = config
+        elif startup_snapshot is not None:
+            from gateway.config import _gateway_config_yaml_snapshot
+
+            with _gateway_config_yaml_snapshot(startup_snapshot.parsed):
+                self.config = load_gateway_config()
+        else:
+            self.config = load_gateway_config()
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            active_profile = get_active_profile_name() or "default"
+        except Exception:
+            active_profile = "default"
+        self._startup_config_profiles: dict[str, dict[str, Any]] = {}
+        self._startup_config_loaded_at: Optional[str] = None
+        if startup_snapshot is not None:
+            self._startup_config_profiles[active_profile] = startup_snapshot.attestation
+            self._startup_config_loaded_at = startup_snapshot.loaded_at
         # Mark the process as a profile multiplexer when configured. This flips
         # agent.secret_scope.get_secret() to fail-closed on any unscoped
         # credential read, so a missed migration crashes loudly instead of
@@ -2853,16 +2851,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Load ephemeral config from config.yaml / env vars.
         # Both are injected at API-call time only and never persisted.
-        self._prefill_messages = self._load_prefill_messages()
-        self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
-        self._reasoning_config = self._load_reasoning_config()
-        self._service_tier = self._load_service_tier()
-        self._show_reasoning = self._load_show_reasoning()
-        self._busy_input_mode = self._load_busy_input_mode()
-        self._busy_text_mode = self._load_busy_text_mode()
-        self._restart_drain_timeout = self._load_restart_drain_timeout()
-        self._provider_routing = self._load_provider_routing()
-        self._fallback_model = self._load_fallback_model()
+        snapshot_token = _startup_config_snapshot_override.set(startup_snapshot)
+        try:
+            self._prefill_messages = self._load_prefill_messages()
+            self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
+            self._reasoning_config = self._load_reasoning_config()
+            self._service_tier = self._load_service_tier()
+            self._show_reasoning = self._load_show_reasoning()
+            self._busy_input_mode = self._load_busy_input_mode()
+            self._busy_text_mode = self._load_busy_text_mode()
+            self._restart_drain_timeout = self._load_restart_drain_timeout()
+            self._provider_routing = self._load_provider_routing()
+            self._fallback_model = self._load_fallback_model()
+        finally:
+            _startup_config_snapshot_override.reset(snapshot_token)
 
         # Wire process registry into session store for reset protection.
         # A background process older than the configured threshold (default 24h,
@@ -4544,17 +4546,54 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("goal continuation: active-state recheck failed: %s", exc)
             return False
 
-    def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
+    def _update_runtime_status(
+        self,
+        gateway_state: Optional[str] = None,
+        exit_reason: Optional[str] = None,
+        *,
+        publish_effective_config: bool = False,
+    ) -> None:
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(
+            status_fields: dict[str, Any] = dict(
                 gateway_state=gateway_state,
                 exit_reason=exit_reason,
                 restart_requested=self._restart_requested,
                 active_agents=self._active_work_count(),
             )
+            if publish_effective_config:
+                status_fields["effective_config"] = (
+                    self._build_startup_effective_config_receipt()
+                )
+            write_runtime_status(**status_fields)
         except Exception:
-            pass
+            logger.error(
+                "Unexpected failure updating gateway runtime status",
+                exc_info=True,
+            )
+
+    def _build_startup_effective_config_receipt(self) -> dict[str, Any]:
+        """Return a profile-complete, credential-free startup config receipt."""
+        from gateway.status import get_process_start_time
+        from hermes_cli.profiles import get_active_profile_name, profiles_to_serve
+
+        multiplex = bool(getattr(self.config, "multiplex_profiles", False))
+        if multiplex:
+            expected_profiles = {
+                profile_name for profile_name, _ in profiles_to_serve(multiplex=True)
+            }
+        else:
+            expected_profiles = {get_active_profile_name() or "default"}
+        profiles = dict(self._startup_config_profiles)
+
+        return {
+            "schema": 1,
+            "complete": expected_profiles == set(profiles),
+            "loaded_at": self._startup_config_loaded_at,
+            "pid": os.getpid(),
+            "start_time": get_process_start_time(os.getpid()),
+            "profiles": profiles,
+        }
 
     def _persist_active_agents(self) -> None:
         """Persist the live in-flight agent count to ``gateway_state.json``.
@@ -5045,12 +5084,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _load_provider_routing() -> dict:
         """Load OpenRouter provider routing preferences from config.yaml."""
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
-                return cfg.get("provider_routing", {}) or {}
+            cfg = _load_gateway_runtime_config()
+            return cfg.get("provider_routing", {}) or {}
         except Exception:
             pass
         return {}
@@ -5064,14 +5099,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         when both keys are present.
         """
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
-                fb = get_fallback_chain(cfg)
-                if fb:
-                    return fb
+            cfg = _load_gateway_config()
+            fb = get_fallback_chain(cfg)
+            if fb:
+                return fb
         except Exception:
             pass
         return None
@@ -6865,7 +6896,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(gateway_state="starting", exit_reason=None)
+            write_runtime_status(
+                gateway_state="starting",
+                exit_reason=None,
+                effective_config=None,
+            )
         except Exception:
             pass
 
@@ -6979,7 +7014,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             try:
                 from gateway.status import write_runtime_status
-                write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
+                write_runtime_status(
+                    gateway_state="startup_failed",
+                    exit_reason=reason,
+                    effective_config=None,
+                )
             except Exception:
                 pass
             self._request_clean_exit(reason)
@@ -7252,7 +7291,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.error("Gateway multiplexer config error: %s", reason)
             try:
                 from gateway.status import write_runtime_status
-                write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
+                write_runtime_status(
+                    gateway_state="startup_failed",
+                    exit_reason=reason,
+                    effective_config=None,
+                )
             except Exception:
                 pass
             self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
@@ -7268,7 +7311,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.error("Gateway hit a non-retryable startup conflict: %s", reason)
                 try:
                     from gateway.status import write_runtime_status
-                    write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
+                    write_runtime_status(
+                        gateway_state="startup_failed",
+                        exit_reason=reason,
+                        effective_config=None,
+                    )
                 except Exception:
                     pass
                 self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
@@ -7324,7 +7371,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._wire_teams_pipeline_runtime()
 
         self._running = True
-        self._update_runtime_status("running")
+        self._update_runtime_status("running", publish_effective_config=True)
         
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
@@ -8627,11 +8674,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self, profile_name: str, profile_home: "Path", claimed: Dict[tuple, str]
     ) -> int:
         """Create+connect one profile's adapters under its runtime scope."""
-        from gateway.config import load_gateway_config
+        from gateway.config import _gateway_config_yaml_snapshot, load_gateway_config
+        from gateway.config_attestation import load_profile_config_snapshot
 
-        with _profile_runtime_scope(profile_home):
-            profile_cfg = load_gateway_config()
+        profile_path = Path(profile_home)
+        profile_snapshot = None
+        if (profile_path / "config.yaml").is_file():
+            profile_snapshot = load_profile_config_snapshot(profile_path)
+        with _profile_runtime_scope(profile_path):
+            if profile_snapshot is None:
+                # Preserve gateway.json and built-in defaults when this profile
+                # has no config.yaml. There is no config snapshot to attest.
+                profile_cfg = load_gateway_config()
+            else:
+                with _gateway_config_yaml_snapshot(profile_snapshot.parsed):
+                    profile_cfg = load_gateway_config()
             violation = _own_policy_open_startup_violation(profile_cfg)
+        if profile_snapshot is not None:
+            profiles = getattr(self, "_startup_config_profiles", None)
+            if profiles is None:
+                profiles = {}
+                self._startup_config_profiles = profiles
+            profiles[profile_name] = profile_snapshot.attestation
+            if getattr(self, "_startup_config_loaded_at", None) is None:
+                self._startup_config_loaded_at = profile_snapshot.loaded_at
         if violation:
             raise MultiplexConfigError(
                 f"Profile '{profile_name}' enables {violation}. "
@@ -20591,6 +20657,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         acquire_gateway_runtime_lock,
         get_running_pid,
         get_process_start_time,
+        is_gateway_runtime_lock_active,
         release_gateway_runtime_lock,
         remove_pid_file,
         terminate_pid,
@@ -20766,7 +20833,40 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if _stderr_level < logging.getLogger().level:
             logging.getLogger().setLevel(_stderr_level)
 
-    runner = GatewayRunner(config)
+    try:
+        runner = GatewayRunner(config)
+    except Exception:
+        logger.error("Gateway runner construction failed", exc_info=True)
+        failure_lock_acquired = False
+        try:
+            # We have not reached the normal runtime-lock acquisition yet.
+            # Claim it temporarily before mutating shared status: if another
+            # contender won startup, its lock makes this fail and its receipt
+            # must remain untouched.
+            if not is_gateway_runtime_lock_active():
+                failure_lock_acquired = acquire_gateway_runtime_lock()
+            if failure_lock_acquired:
+                from gateway.status import write_runtime_status
+
+                write_runtime_status(
+                    gateway_state="startup_failed",
+                    exit_reason="Gateway runner construction failed",
+                    effective_config=None,
+                )
+            else:
+                logger.info(
+                    "Not persisting constructor failure because another "
+                    "gateway owns the runtime lock"
+                )
+        except Exception:
+            logger.error(
+                "Could not persist gateway construction failure",
+                exc_info=True,
+            )
+        finally:
+            if failure_lock_acquired:
+                release_gateway_runtime_lock()
+        return False
     
     # Track whether an unexpected signal initiated the shutdown. When an
     # unexpected SIGTERM kills the gateway, we exit non-zero so service

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -805,6 +805,7 @@ def write_runtime_status(
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
     served_profiles: Any = _UNSET,
+    effective_config: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
@@ -819,6 +820,8 @@ def write_runtime_status(
 
     if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state
+        if gateway_state in {"starting", "startup_failed"} and effective_config is _UNSET:
+            payload["effective_config"] = None
     if exit_reason is not _UNSET:
         payload["exit_reason"] = exit_reason
     if restart_requested is not _UNSET:
@@ -830,6 +833,8 @@ def write_runtime_status(
         # for a single-profile gateway. Lets `hermes status` show per-profile
         # coverage without a second probe.
         payload["served_profiles"] = list(served_profiles or [])
+    if effective_config is not _UNSET:
+        payload["effective_config"] = effective_config
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})

--- a/tests/gateway/test_effective_config_attestation.py
+++ b/tests/gateway/test_effective_config_attestation.py
@@ -1,0 +1,471 @@
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import gateway.run as gateway_run
+import gateway.config as gateway_config
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner, _resolve_gateway_model, start_gateway
+from gateway.status import read_runtime_status, write_runtime_status
+
+
+def _all_mapping_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from _all_mapping_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from _all_mapping_keys(nested)
+
+
+def test_running_gateway_attests_exact_sanitized_profile_config(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_bytes = (
+        b"model:\n"
+        b"  provider: openrouter\n"
+        b"  default: openai/gpt-5.5\n"
+        b"  api_key: primary-secret-value\n"
+        b"  base_url: https://user:password@example.invalid/v1\n"
+        b"fallback_providers:\n"
+        b"  - provider: anthropic\n"
+        b"    model: claude-sonnet-4\n"
+        b"    api_key: fallback-secret-value\n"
+        b"    key_env: FALLBACK_API_KEY\n"
+        b"    headers:\n"
+        b"      Authorization: bearer-secret-value\n"
+    )
+    (home / "config.yaml").write_bytes(config_bytes)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(GatewayConfig(platforms={}, sessions_dir=home / "sessions"))
+    snapshot_loaded_at = runner._startup_config_loaded_at
+
+    assert asyncio.run(runner.start()) is True
+
+    state = read_runtime_status()
+    receipt = state["effective_config"]
+    assert state["gateway_state"] == "running"
+    assert receipt["schema"] == 1
+    assert receipt["complete"] is True
+    assert receipt["pid"] == os.getpid() == state["pid"]
+    assert receipt["start_time"] == state["start_time"]
+    assert receipt["loaded_at"] == snapshot_loaded_at
+    assert receipt["profiles"] == {
+        "default": {
+            "profile_path": str(home.resolve()),
+            "config_path": str((home / "config.yaml").resolve()),
+            "config_sha256": hashlib.sha256(config_bytes).hexdigest(),
+            "primary": {"provider": "openrouter", "model": "openai/gpt-5.5"},
+            "fallbacks": [{"provider": "anthropic", "model": "claude-sonnet-4"}],
+        }
+    }
+
+    forbidden_keys = {
+        "api_key",
+        "key_env",
+        "api_key_env",
+        "base_url",
+        "headers",
+        "token",
+        "secret",
+        "password",
+        "command",
+        "args",
+        "credential_pool",
+    }
+    assert forbidden_keys.isdisjoint(_all_mapping_keys(receipt))
+    serialized = json.dumps(receipt)
+    for secret in (
+        "primary-secret-value",
+        "fallback-secret-value",
+        "bearer-secret-value",
+        "user:password",
+        "FALLBACK_API_KEY",
+    ):
+        assert secret not in serialized
+
+
+def test_single_profile_receipt_uses_explicit_custom_hermes_home(monkeypatch, tmp_path):
+    home = tmp_path / "fleet-managed-agent-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n  provider: nous\n  default: hermes-4\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(GatewayConfig(platforms={}, sessions_dir=home / "sessions"))
+
+    assert asyncio.run(runner.start()) is True
+
+    receipt = read_runtime_status()["effective_config"]
+    assert receipt["complete"] is True
+    assert receipt["profiles"]["default"]["profile_path"] == str(home.resolve())
+    assert receipt["profiles"]["default"]["config_path"] == str(
+        (home / "config.yaml").resolve()
+    )
+
+
+def test_config_bom_is_decoded_but_original_bytes_are_hashed(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_bytes = (
+        b"\xef\xbb\xbfmodel:\n  provider: openrouter\n  default: bom/model\n"
+    )
+    (home / "config.yaml").write_bytes(config_bytes)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(GatewayConfig(platforms={}, sessions_dir=home / "sessions"))
+
+    assert asyncio.run(runner.start()) is True
+
+    profile = read_runtime_status()["effective_config"]["profiles"]["default"]
+    assert profile["config_sha256"] == hashlib.sha256(config_bytes).hexdigest()
+    assert profile["primary"] == {
+        "provider": "openrouter",
+        "model": "bom/model",
+    }
+
+
+def test_multiplex_receipt_is_keyed_by_every_profile(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    coder_home = home / "profiles" / "coder"
+    coder_home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: openai/gpt-5.5\n",
+        encoding="utf-8",
+    )
+    (coder_home / "config.yaml").write_text(
+        "model:\n  provider: anthropic\n  default: claude-sonnet-4\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(
+        GatewayConfig(
+            platforms={},
+            sessions_dir=home / "sessions",
+            multiplex_profiles=True,
+        )
+    )
+
+    assert asyncio.run(runner.start()) is True
+
+    receipt = read_runtime_status()["effective_config"]
+    assert receipt["complete"] is True
+    assert set(receipt["profiles"]) == {"default", "coder"}
+    assert receipt["profiles"]["default"]["primary"] == {
+        "provider": "openrouter",
+        "model": "openai/gpt-5.5",
+    }
+    assert receipt["profiles"]["coder"]["profile_path"] == str(coder_home.resolve())
+    assert receipt["profiles"]["coder"]["primary"] == {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4",
+    }
+
+
+def test_failed_secondary_config_load_cannot_claim_complete(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    broken_home = home / "profiles" / "broken"
+    broken_home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: openai/gpt-5.5\n",
+        encoding="utf-8",
+    )
+    (broken_home / "config.yaml").write_text("model: [", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(
+        GatewayConfig(
+            platforms={},
+            sessions_dir=home / "sessions",
+            multiplex_profiles=True,
+        )
+    )
+
+    assert asyncio.run(runner.start()) is True
+
+    state = read_runtime_status()
+    receipt = state["effective_config"]
+    assert state["gateway_state"] == "running"
+    assert receipt["complete"] is False
+    assert set(receipt["profiles"]) == {"default"}
+
+
+def test_multiplex_receipt_keeps_secondary_snapshot_consumed_at_startup(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / ".hermes"
+    coder_home = home / "profiles" / "coder"
+    coder_home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "model:\n  provider: primary\n  default: primary/model\n",
+        encoding="utf-8",
+    )
+    coder_config = coder_home / "config.yaml"
+    original = b"model:\n  provider: first\n  default: first/model\n"
+    replacement = b"model:\n  provider: second\n  default: second/model\n"
+    coder_config.write_bytes(original)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(
+        GatewayConfig(
+            platforms={},
+            sessions_dir=home / "sessions",
+            multiplex_profiles=True,
+        )
+    )
+    original_start = runner._start_one_profile_adapters
+
+    async def start_then_replace(profile_name, profile_home, claimed):
+        result = await original_start(profile_name, profile_home, claimed)
+        coder_config.write_bytes(replacement)
+        return result
+
+    monkeypatch.setattr(runner, "_start_one_profile_adapters", start_then_replace)
+
+    assert asyncio.run(runner.start()) is True
+
+    profile = read_runtime_status()["effective_config"]["profiles"]["coder"]
+    assert profile["config_sha256"] == hashlib.sha256(original).hexdigest()
+    assert profile["primary"] == {"provider": "first", "model": "first/model"}
+    assert coder_config.read_bytes() == replacement
+
+
+def test_secondary_without_config_yaml_uses_fallback_without_attestation(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / ".hermes"
+    legacy_home = home / "profiles" / "legacy"
+    legacy_home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "model:\n  provider: primary\n  default: primary/model\n",
+        encoding="utf-8",
+    )
+    (legacy_home / "gateway.json").write_text(
+        '{"always_log_local": false}', encoding="utf-8"
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(
+        GatewayConfig(
+            platforms={},
+            sessions_dir=home / "sessions",
+            multiplex_profiles=True,
+        )
+    )
+    real_load_gateway_config = gateway_config.load_gateway_config
+    loaded_fallback_values = []
+
+    def track_gateway_config_fallback():
+        loaded = real_load_gateway_config()
+        loaded_fallback_values.append(loaded.always_log_local)
+        return loaded
+
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config", track_gateway_config_fallback
+    )
+
+    assert asyncio.run(runner.start()) is True
+
+    receipt = read_runtime_status()["effective_config"]
+    assert loaded_fallback_values == [False]
+    assert receipt["complete"] is False
+    assert set(receipt["profiles"]) == {"default"}
+
+
+def test_failed_startup_never_publishes_effective_config(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: openai/gpt-5.5\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("YUANBAO_ALLOW_ALL_USERS", raising=False)
+
+    runner = GatewayRunner(
+        GatewayConfig(
+            platforms={
+                Platform.YUANBAO: PlatformConfig(
+                    enabled=True,
+                    extra={"dm_policy": "open"},
+                ),
+            },
+            sessions_dir=home / "sessions",
+        )
+    )
+
+    assert asyncio.run(runner.start()) is True
+
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+    assert state["effective_config"] is None
+
+
+def test_public_startup_clears_stale_receipt_when_runner_construction_fails(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+    gateway_config = GatewayConfig(platforms={}, sessions_dir=home / "sessions")
+    write_runtime_status(
+        gateway_state="running",
+        effective_config={"schema": 1, "profiles": {"stale": {}}},
+    )
+    monkeypatch.setattr("gateway.code_skew.record_boot_fingerprint", lambda: None)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.is_gateway_runtime_lock_active", lambda: False)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda **kwargs: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.security_audit_startup.log_startup_security_warnings",
+        lambda **kwargs: None,
+    )
+
+    def fail_constructor(config):
+        raise RuntimeError("constructor failed")
+
+    monkeypatch.setattr("gateway.run.GatewayRunner", fail_constructor)
+
+    assert asyncio.run(start_gateway(gateway_config, verbosity=None)) is False
+
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+    assert state["effective_config"] is None
+
+
+def test_constructor_failing_contender_preserves_live_owner_receipt(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+    owner_receipt = {"schema": 1, "profiles": {"owner": {"config_sha256": "abc"}}}
+    write_runtime_status(gateway_state="running", effective_config=owner_receipt)
+    monkeypatch.setattr("gateway.code_skew.record_boot_fingerprint", lambda: None)
+    # Both contenders passed the initial PID check; the winner then acquired
+    # the authoritative runtime lock before this contender's constructor failed.
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.is_gateway_runtime_lock_active", lambda: True)
+    monkeypatch.setattr(
+        "gateway.status.acquire_gateway_runtime_lock",
+        lambda: (_ for _ in ()).throw(AssertionError("must not steal owner lock")),
+    )
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda **kwargs: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.security_audit_startup.log_startup_security_warnings",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner",
+        lambda config: (_ for _ in ()).throw(RuntimeError("constructor failed")),
+    )
+
+    assert asyncio.run(
+        start_gateway(
+            GatewayConfig(platforms={}, sessions_dir=home / "sessions"),
+            verbosity=None,
+        )
+    ) is False
+
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    assert state["effective_config"] == owner_receipt
+
+
+def test_receipt_uses_config_snapshot_consumed_by_runtime(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    loaded_bytes = (
+        b"model:\n  provider: first\n  default: first/model\n"
+        b"agent:\n  system_prompt: original startup prompt\n"
+    )
+    replacement_bytes = (
+        b"model:\n  provider: second\n  default: second/model\n"
+        b"agent:\n  system_prompt: replacement prompt\n"
+    )
+    config_path.write_bytes(loaded_bytes)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(GatewayConfig(platforms={}, sessions_dir=home / "sessions"))
+    assert runner._ephemeral_system_prompt == "original startup prompt"
+
+    # Mutate disk after the real runtime load but before the running receipt.
+    config_path.write_bytes(replacement_bytes)
+
+    assert asyncio.run(runner.start()) is True
+
+    profile = read_runtime_status()["effective_config"]["profiles"]["default"]
+    assert profile["config_sha256"] == hashlib.sha256(loaded_bytes).hexdigest()
+    assert profile["primary"] == {"provider": "first", "model": "first/model"}
+    assert config_path.read_bytes() == replacement_bytes
+
+
+def test_attested_model_matches_normalized_runtime_model_path(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: ${RUNTIME_MODEL}\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: ${FALLBACK_MODEL}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("RUNTIME_MODEL", "expanded/model")
+    monkeypatch.setenv("FALLBACK_MODEL", "expanded/fallback")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(GatewayConfig(platforms={}, sessions_dir=home / "sessions"))
+    startup_snapshot = gateway_run._load_gateway_config_snapshot()
+    token = gateway_run._startup_config_snapshot_override.set(
+        startup_snapshot
+    )
+    try:
+        runtime_model = _resolve_gateway_model()
+        runtime_fallbacks = runner._load_fallback_model()
+    finally:
+        gateway_run._startup_config_snapshot_override.reset(token)
+
+    assert asyncio.run(runner.start()) is True
+
+    profile = read_runtime_status()["effective_config"]["profiles"]["default"]
+    assert runtime_model == "${RUNTIME_MODEL}"
+    assert profile["primary"] == {
+        "provider": "openrouter",
+        "model": runtime_model,
+    }
+    assert runtime_fallbacks == [
+        {"provider": "openrouter", "model": "${FALLBACK_MODEL}"}
+    ]
+    assert profile["fallbacks"] == runtime_fallbacks

--- a/tests/gateway/test_effective_config_attestation.py
+++ b/tests/gateway/test_effective_config_attestation.py
@@ -469,3 +469,44 @@ def test_attested_model_matches_normalized_runtime_model_path(monkeypatch, tmp_p
         {"provider": "openrouter", "model": "${FALLBACK_MODEL}"}
     ]
     assert profile["fallbacks"] == runtime_fallbacks
+
+
+def test_gateway_receipt_matches_fleet_v1_contract_example(monkeypatch, tmp_path):
+    """Keep Hermes' producer shape executable against Fleet's public contract."""
+    contract_path = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "contracts"
+        / "gateway-effective-config-v1.example.json"
+    )
+    contract_state = json.loads(contract_path.read_text(encoding="utf-8"))
+    contract_receipt = contract_state["effective_config"]
+    contract_profile = contract_receipt["profiles"]["default"]
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: gpt-5.5\n"
+        "fallback_providers:\n"
+        "  - provider: xai-oauth\n    model: grok-4.3\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.run._hermes_home", home)
+
+    runner = GatewayRunner(GatewayConfig(platforms={}, sessions_dir=home / "sessions"))
+    assert asyncio.run(runner.start()) is True
+
+    runtime_state = read_runtime_status()
+    runtime_receipt = runtime_state["effective_config"]
+    runtime_profile = runtime_receipt["profiles"]["default"]
+    assert contract_state["gateway_state"] == runtime_state["gateway_state"] == "running"
+    assert set(runtime_receipt) == set(contract_receipt)
+    assert set(runtime_profile) == set(contract_profile)
+    assert runtime_receipt["schema"] == contract_receipt["schema"] == 1
+    assert runtime_receipt["complete"] is contract_receipt["complete"] is True
+    assert isinstance(runtime_receipt["pid"], type(contract_receipt["pid"]))
+    assert isinstance(runtime_receipt["start_time"], (int, float))
+    assert isinstance(contract_receipt["start_time"], (int, float))
+    assert isinstance(runtime_receipt["loaded_at"], type(contract_receipt["loaded_at"]))
+    assert isinstance(runtime_profile["fallbacks"], type(contract_profile["fallbacks"]))

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -460,6 +460,44 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid()
         assert payload["start_time"] == 2000
 
+    def test_starting_runtime_status_clears_stale_effective_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000,
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+            "platforms": {},
+            "effective_config": {
+                "schema": 1,
+                "complete": True,
+                "profiles": {"default": {"config_sha256": "stale"}},
+            },
+        }))
+
+        status.write_runtime_status(gateway_state="starting")
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "starting"
+        assert payload["pid"] == os.getpid()
+        assert payload["effective_config"] is None
+
+    def test_startup_failed_runtime_status_clears_stale_effective_config(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status.write_runtime_status(
+            gateway_state="running",
+            effective_config={"schema": 1, "profiles": {"default": {}}},
+        )
+
+        status.write_runtime_status(gateway_state="startup_failed")
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "startup_failed"
+        assert payload["effective_config"] is None
+
     def test_runtime_status_running_pid_rejects_stale_record_for_supervisor_pid(self, monkeypatch):
         """Regression: stale profile runtime state must not mark s6 supervisors live.
 


### PR DESCRIPTION
## Summary

- publish a schema-versioned, secret-free effective gateway configuration receipt at startup
- expose the receipt through gateway status for exact Fleet runtime attestation
- publish the synthetic v1 producer contract consumed by Fleet and test it against a real temporary GatewayRunner

## Verification

- `uv run --extra dev pytest -q tests/gateway/test_effective_config_attestation.py tests/gateway/test_status.py` — 109 passed
- `uv run --extra dev ruff check tests/gateway/test_effective_config_attestation.py` — passed
- `git diff --check` — passed
- contract SHA-256: `5c1e37fae1c516ad3b1acbb969089bc714676fe82e9cf7096ca58ab9aff9dae2`
- independent review: no blockers; fixture is synthetic and gitleaks found no credentials

## Proof

Non-visual gateway contract change; screenshots are not applicable. Executable producer proof is in `tests/gateway/test_effective_config_attestation.py`, which starts a real temporary runner and checks the emitted receipt against `docs/contracts/gateway-effective-config-v1.example.json`.

## Safety

No live profiles, credentials, or agent state were read or changed.