### PR TITLE
fix(feishu): keep topic replies and media in threads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -66,12 +66,14 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     if thread_id is None:
         return None
     metadata = {"thread_id": thread_id}
+    anchor = reply_to_message_id or getattr(source, "message_id", None)
+    if anchor is not None and _platform_name(getattr(source, "platform", None)) != "telegram":
+        metadata["reply_to_message_id"] = str(anchor)
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
             metadata["direct_messages_topic_id"] = tid
-        anchor = reply_to_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
     return metadata

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -67,9 +67,10 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         return None
     metadata = {"thread_id": thread_id}
     anchor = reply_to_message_id or getattr(source, "message_id", None)
-    if anchor is not None and _platform_name(getattr(source, "platform", None)) != "telegram":
+    platform = _platform_name(getattr(source, "platform", None))
+    if anchor is not None and platform == "feishu":
         metadata["reply_to_message_id"] = str(anchor)
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+    if platform == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
@@ -104,8 +105,11 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu" and thread_id:
+        # Feishu topic replies must target the triggering message and set
+        # reply_in_thread=true. Replying to the parent/root can be rejected
+        # with 99992402 and must never spill into the parent chat.
+        return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14464,6 +14464,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if thread_id is None:
             return None
         metadata: Dict[str, Any] = {"thread_id": thread_id}
+        platform_name = str(getattr(platform, "value", platform) or "").lower()
+        if reply_to_message_id is not None and platform_name != "telegram":
+            metadata["reply_to_message_id"] = str(reply_to_message_id)
         if self._is_telegram_dm_topic_target(
             platform,
             chat_id,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -243,6 +243,7 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+_FEISHU_TOPIC_REPLY_INVALID_CODE = 99992402  # invalid topic reply fields; never fall back to parent chat
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -4624,34 +4625,27 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
+        if reply_in_thread:
+            raise RuntimeError(
+                "Feishu topic send requires a reply message id; "
+                "refusing to fall back to the parent chat"
             )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
+
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod
@@ -4828,6 +4822,18 @@ class FeishuAdapter(BasePlatformAdapter):
                         )
                 return response
             except Exception as exc:
+                if (
+                    (metadata or {}).get("thread_id")
+                    and (
+                        getattr(exc, "code", None) == _FEISHU_TOPIC_REPLY_INVALID_CODE
+                        or f"[{_FEISHU_TOPIC_REPLY_INVALID_CODE}]" in str(exc)
+                    )
+                ):
+                    logger.error(
+                        "[Feishu] Topic reply rejected with %s; refusing parent-chat fallback",
+                        _FEISHU_TOPIC_REPLY_INVALID_CODE,
+                    )
+                    raise
                 last_error = exc
                 if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
                     raise

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -483,6 +483,59 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertEqual(call_kwargs["extra_ua_tags"], ["channel"],
                          "extra_ua_tags must be ['channel'] to enable group event routing")
 
+    def test_topic_reply_field_validation_never_falls_back_to_parent_chat(self):
+        """A rejected topic reply must fail instead of leaking into the parent chat."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._send_raw_message = AsyncMock(
+            side_effect=RuntimeError("[99992402] field validation failed")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "99992402"):
+            asyncio.run(
+                adapter._feishu_send_with_retry(
+                    chat_id="oc_chat",
+                    msg_type="text",
+                    payload=json.dumps({"text": "hello"}),
+                    reply_to="om_message",
+                    metadata={
+                        "thread_id": "omt_topic",
+                        "reply_to_message_id": "om_message",
+                    },
+                )
+            )
+
+        adapter._send_raw_message.assert_awaited_once()
+
+    def test_topic_reply_anchor_prefers_triggering_message(self):
+        from gateway.platforms.base import _reply_anchor_for_event
+
+        event = SimpleNamespace(
+            source=SimpleNamespace(platform="feishu", thread_id="omt_topic"),
+            message_id="om_current",
+            reply_to_message_id="om_parent",
+        )
+
+        self.assertEqual(_reply_anchor_for_event(event), "om_current")
+
+    def test_topic_send_without_reply_anchor_refuses_parent_chat(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._client = object()
+
+        with self.assertRaisesRegex(RuntimeError, "refusing to fall back"):
+            asyncio.run(
+                adapter._send_raw_message(
+                    chat_id="oc_chat",
+                    msg_type="text",
+                    payload=json.dumps({"text": "hello"}),
+                    reply_to=None,
+                    metadata={"thread_id": "omt_topic"},
+                )
+            )
+
     @patch.dict(os.environ, {}, clear=True)
     def test_edit_message_updates_existing_feishu_message(self):
         from gateway.config import PlatformConfig

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -486,7 +486,10 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
     assert result["final_response"] == "done"
     assert adapter.sent
     assert adapter.sent[0]["reply_to"] == "om_triggering_user_message"
-    assert adapter.sent[0]["metadata"] == {"thread_id": "topic_17585"}
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "topic_17585",
+        "reply_to_message_id": "om_triggering_user_message",
+    }
     assert adapter.edits
     assert adapter.edits[0]["message_id"] == "progress-1"
 

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -19,8 +19,8 @@ from gateway.session import SessionSource, build_session_key
 
 
 class _MediaRoutingAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="test"), platform)
 
     async def connect(self, *, is_reconnect: bool = False):
         return True
@@ -35,9 +35,9 @@ class _MediaRoutingAdapter(BasePlatformAdapter):
         return {"id": chat_id, "type": "dm"}
 
 
-def _event(thread_id=None):
+def _event(thread_id=None, *, platform=Platform.TELEGRAM, reply_to_message_id=None):
     source = SessionSource(
-        platform=Platform.TELEGRAM,
+        platform=platform,
         chat_id="chat-1",
         chat_type="dm",
         thread_id=thread_id,
@@ -47,6 +47,7 @@ def _event(thread_id=None):
         message_type=MessageType.TEXT,
         source=source,
         message_id="msg-1",
+        reply_to_message_id=reply_to_message_id,
     )
 
 
@@ -121,6 +122,27 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_base_adapter_preserves_feishu_thread_reply_anchor_for_image_media(tmp_path, monkeypatch):
+    adapter = _MediaRoutingAdapter(platform=Platform.FEISHU)
+    event = _event(
+        thread_id="omt-thread",
+        platform=Platform.FEISHU,
+        reply_to_message_id="om-parent",
+    )
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "capture.png")
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media_file}")
+    adapter.send_multiple_images = AsyncMock(return_value=None)
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_multiple_images.assert_awaited_once()
+    assert adapter.send_multiple_images.await_args.kwargs["metadata"] == {
+        "thread_id": "omt-thread",
+        "reply_to_message_id": "om-parent",
+    }
+
+
 def _fake_runner(thread_meta):
     """Build a fake GatewayRunner-like object with the helper methods needed by
     _deliver_media_from_response."""
@@ -129,6 +151,40 @@ def _fake_runner(thread_meta):
         _reply_anchor_for_event=lambda event: None,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_preserves_feishu_thread_reply_anchor_for_image_media(tmp_path, monkeypatch):
+    event = _event(
+        thread_id="omt-thread",
+        platform=Platform.FEISHU,
+        reply_to_message_id="om-parent",
+    )
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "capture.png")
+    adapter = SimpleNamespace(
+        name="feishu",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        GatewayRunner.__new__(GatewayRunner),
+        f"MEDIA:{media_file}",
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    assert adapter.send_multiple_images.await_args.kwargs["metadata"] == {
+        "thread_id": "omt-thread",
+        "reply_to_message_id": "om-parent",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -14,6 +14,7 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import _thread_metadata_for_source
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource, build_session_key
 
@@ -139,8 +140,21 @@ async def test_base_adapter_preserves_feishu_thread_reply_anchor_for_image_media
     adapter.send_multiple_images.assert_awaited_once()
     assert adapter.send_multiple_images.await_args.kwargs["metadata"] == {
         "thread_id": "omt-thread",
-        "reply_to_message_id": "om-parent",
+        "reply_to_message_id": "msg-1",
+        "notify": True,
     }
+
+
+
+def test_thread_metadata_keeps_reply_anchor_feishu_specific():
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="chat-1",
+        chat_type="group",
+        thread_id="thread-1",
+    )
+
+    assert _thread_metadata_for_source(source, "msg-1") == {"thread_id": "thread-1"}
 
 
 def _fake_runner(thread_meta):
@@ -183,7 +197,7 @@ async def test_streaming_delivery_preserves_feishu_thread_reply_anchor_for_image
     adapter.send_multiple_images.assert_awaited_once()
     assert adapter.send_multiple_images.await_args.kwargs["metadata"] == {
         "thread_id": "omt-thread",
-        "reply_to_message_id": "om-parent",
+        "reply_to_message_id": "msg-1",
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Keeps Feishu topic replies and response media inside the triggering topic. This rebases and preserves the original `#39563` contributor commit, then completes the adapter-side fix requested by automated review.

Feishu does not accept `receive_id_type=thread_id`. Topic delivery must use `ReplyMessage` with `reply_in_thread=true` and a real `om_*` message anchor. The previous no-anchor and validation-error paths could silently spill replies into the parent chat or fail with `99992402`.

## Related Issue

Fixes #39526
Resolves the duplicate report #61000
Supersedes #39563 and #55067 while preserving the authored commit from #39563.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: keep `reply_to_message_id` metadata Feishu-specific and anchor topic replies to the triggering message.
- `gateway/run.py`: preserve the reply anchor for post-stream media delivery (original #39563 contribution).
- `plugins/platforms/feishu/adapter.py`: remove the invalid `CreateMessage(receive_id_type=thread_id)` path and refuse parent-chat fallback when a topic anchor is missing or rejected.
- `tests/gateway/test_tts_media_routing.py`: cover base and streaming Feishu media anchors plus cross-platform metadata isolation.
- `tests/gateway/test_run_progress_topics.py`: cover progress delivery with Feishu topic metadata.
- `tests/gateway/test_feishu.py`: cover current-message anchoring, fail-fast `99992402`, and strict no-anchor behavior.

## How to Test

1. In a Feishu topic, send a message that produces text and `MEDIA:<path>` output.
2. Confirm text and media use `ReplyMessage`, carry `reply_in_thread=true`, and remain in the same `omt_*` topic.
3. Confirm missing/invalid topic anchors return a delivery error and never create a parent-chat message.

Focused verification on Windows 11 / Python 3.11:

```text
14 passed in 11.19s
ruff check: All checks passed
py_compile: passed
```

A live Feishu API smoke test also returned a message with the original topic `thread_id` and the expected triggering `parent_id`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs and consolidated the open fixes instead of dropping their work
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 with a live Feishu bot

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing API or config changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow changed
- [x] Cross-platform impact considered; behavior is isolated to Feishu metadata and adapter routing
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Before:

```text
[Feishu] Topic reply rejected with 99992402; falling back to parent chat
```

After, invalid routing fails closed:

```text
[Feishu] Topic reply rejected with 99992402; refusing parent-chat fallback
```
