### PR TITLE
fix(sanitize): drop tool_calls key when dedup removes all calls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2635,8 +2635,10 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 if cid:
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
-            if len(kept_tcs) != len(msg.get("tool_calls") or []):
+            if kept_tcs:
                 msg = {**msg, "tool_calls": kept_tcs}
+            elif len(kept_tcs) != len(msg.get("tool_calls") or []):
+                msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -770,3 +770,48 @@ def test_sanitize_preserves_populated_tool_calls():
     out = sanitize_api_messages(list(messages))
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
+def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
+    """When dedup removes ALL tool_calls from an assistant message,
+    the key is dropped instead of writing tool_calls: [].
+
+    DeepSeek v4 and newer OpenAI reject empty tool_calls with HTTP 400.
+    The dedup pass introduced by #58327 can produce this state when
+    all tool_call_ids are duplicates of earlier messages in a long
+    history. The fix (#64335) drops the key entirely rather than
+    writing an empty array.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    # Simulate a long conversation where the same tool_call_id appears
+    # in multiple assistant messages (e.g., crash/resume glitch or
+    # compression window re-emission). The first occurrence is kept,
+    # later duplicates are removed.
+    messages = [
+        {"role": "user", "content": "step 1"},
+        {"role": "assistant", "content": "running",
+         "tool_calls": [{"id": "call_A", "type": "function",
+                         "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "result 1"},
+        # Simulate a later assistant message that reuses call_A
+        # (this would be invalid, but the dedup pass handles it)
+        {"role": "assistant", "content": "retrying",
+         "tool_calls": [{"id": "call_A", "type": "function",
+                         "function": {"name": "foo", "arguments": "{}"}}]},
+    ]
+
+    out = sanitize_api_messages(list(messages))
+
+    # First assistant should keep tool_calls (first occurrence)
+    assistant1 = [m for m in out if m.get("role") == "assistant"][0]
+    assert "tool_calls" in assistant1
+    assert len(assistant1["tool_calls"]) == 1
+    assert assistant1["tool_calls"][0]["id"] == "call_A"
+
+    # Second assistant should have tool_calls key DROPPED
+    # (all tool_calls were deduped as duplicates of call_A)
+    assistant2 = [m for m in out if m.get("role") == "assistant"][1]
+    assert "tool_calls" not in assistant2
+    # Content should be preserved
+    assert assistant2["content"] == "retrying"


### PR DESCRIPTION
## What does this PR do?

Fixes an HTTP 400 error from DeepSeek v4 and newer OpenAI providers when `sanitize_api_messages()` produces an empty `tool_calls: []` array after deduplicating all tool_calls in a message.

The dedup pass introduced by #58327 removes duplicate `tool_call_id`s to comply with provider requirements. However, when ALL tool_calls in a message are duplicates of earlier messages in a long conversation history, the pass writes `tool_calls: []`. Strict providers reject this with HTTP 400: "Invalid 'messages[N].tool_calls': empty array."

This fix drops the `tool_calls` key entirely when all tool_calls are removed by deduplication, treating the empty key as "no tool calls" rather than an invalid empty array.


## Related Issue

Fixes #64335


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)


## Changes Made

- **agent/agent_runtime_helpers.py** (~line 2638): Modified dedup logic
  - When `kept_tcs` is non-empty: update `tool_calls` with deduplicated list (preserves existing behavior)
  - When `kept_tcs` is empty and original message had tool_calls: remove `tool_calls` key (new fix)
  - When `kept_tcs` is empty and original message had no tool_calls: no change (preserves existing behavior)

- **tests/run_agent/test_message_sequence_repair.py**: Added regression test
  - `test_sanitize_dedup_drops_tool_calls_key_when_all_removed()` validates the fix


## How to Test

1. Run the new regression test:
   ```bash
   python -m pytest tests/run_agent/test_message_sequence_repair.py::test_sanitize_dedup_drops_tool_calls_key_when_all_removed -xvs
   ```
   Expected: Test passes, confirming tool_calls key is dropped when dedup removes all calls.

2. Run all sanitize-related tests to ensure no regressions:
   ```bash
   python -m pytest tests/run_agent/test_message_sequence_repair.py -k "sanitize" -xvs
   ```
   Expected: All 8 tests pass.

3. Verify the fix logic manually:
   ```python
   from agent.agent_runtime_helpers import sanitize_api_messages
   messages = [
       {"role": "assistant", "content": "first", "tool_calls": [{"id": "A", "type": "function", "function": {"name": "foo"}}]},
       {"role": "tool", "tool_call_id": "A", "content": "result"},
       # Later message with duplicate tool_call_id
       {"role": "assistant", "content": "retry", "tool_calls": [{"id": "A", "type": "function", "function": {"name": "foo"}}]},
   ]
   out = sanitize_api_messages(messages)
   # First assistant should have tool_calls (first occurrence kept)
   # Second assistant should have NO tool_calls key (all were duplicates)
   ```
   Expected: Second assistant message has no `tool_calls` key, content preserved as "retry".


## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (development environment)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
