### PR TITLE
feat(mcp): add Concierge remote MCP (x402 market intel)

### DIFF
--- a/optional-mcps/concierge/manifest.yaml
+++ b/optional-mcps/concierge/manifest.yaml
@@ -1,0 +1,63 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: concierge
+description: Pay-per-call market intelligence + Security Desk (x402 USDC). Macro, wire, DeFi desks, verdict, authorized passive scans. No Concierge API key.
+
+source: https://conc-exe.xyz/docs/integration/hermes
+
+# Remote HTTP MCP — same endpoint as Official MCP Registry (xyz.conc-exe/concierge-intel).
+# No local install; Hermes connects over Streamable HTTP / JSON-RPC at /api/mcp.
+transport:
+  type: http
+  url: https://conc-exe.xyz/api/mcp
+
+auth:
+  type: none
+
+# Curated default for daily desk use. Expanding:
+#   hermes mcp configure concierge
+tools:
+  default_enabled:
+    - concierge_catalog
+    - intel_macro
+    - intel_wire
+    - intel_tvl
+    - intel_verdict
+    - intel_meteora
+    - intel_desk_brief
+    - security_headers
+    - security_scan
+
+post_install: |
+  Concierge MCP is remote HTTP — no local install.
+
+  Paid tools proxy x402. Unpaid tools/call returns a live PAYMENT-REQUIRED challenge.
+  Settlement options:
+    1) pay.sh — `pay setup && pay topup` then `pay curl https://conc-exe.xyz/api/...`
+    2) Retry MCP with arguments.paymentSignature after settle
+    3) Pass creditsWallet / soonHolderWallet (TCX prepaid / holder free tier)
+    4) Hermes x402 / payments skills if installed
+
+  Free MCP tools:
+    concierge_catalog · concierge_prepare_payment
+
+  Free probes:
+    curl -s https://conc-exe.xyz/api/mcp
+    hermes mcp test concierge
+
+  Skill (routes, prices, cron briefs):
+    hermes skills install https://conc-exe.xyz/skills/concierge-hermes/SKILL.md
+
+  Optional agent identity (HTTP `agt_…` + ERC-8004 Identity NFT on Base):
+    Lounge: https://conc-exe.xyz/lounge#agent-identity
+    Docs: https://conc-exe.xyz/docs/api/agent-identity
+    Registration file (agentURI): /api/agent-identity-registration?id=agt_…
+    Prepare / link mint: GET|POST /api/agent-identity-erc8004
+
+  SDK: npm i @conc-exe/agent
+  Docs: https://conc-exe.xyz/docs/integration/hermes
+  Registry: https://registry.modelcontextprotocol.io/?search=xyz.conc-exe%2Fconcierge-intel
+
+  Restart / new Hermes session after install so tools register.


### PR DESCRIPTION
## What

Adds `optional-mcps/concierge` — remote HTTP MCP at `https://conc-exe.xyz/api/mcp`.

Pay-per-call market intelligence + Security Desk. Settlement via x402 USDC (pay.sh / Hermes x402 skills). No Concierge API key. Auth: none.

Curated `tools.default_enabled` for daily desk use (`intel_macro`, `intel_wire`, `intel_tvl`, `intel_verdict`, `intel_meteora`, `intel_desk_brief`, `security_headers`, `security_scan`). Users can expand with `hermes mcp configure concierge`.

## Why

Hermes already supports remote HTTP MCP + x402 payment skills. Concierge is published on the Official MCP Registry as `xyz.conc-exe/concierge-intel` and fits cron / messaging desk briefs (morning macro + wire).

## Test plan

- [x] `hermes mcp add concierge --url https://conc-exe.xyz/api/mcp` (works today without merge)
- [x] After merge: `hermes mcp install concierge` / catalog picker
- [x] `hermes mcp test concierge`
- [x] `curl -s https://conc-exe.xyz/api/mcp`
- [x] Optional: `pay curl https://conc-exe.xyz/api/concierge-intel-macro -d '{}'`

## Links

- Docs: https://conc-exe.xyz/docs/integration/hermes
- Skill: https://conc-exe.xyz/skills/concierge-hermes/SKILL.md
- Registry: https://registry.modelcontextprotocol.io/?search=xyz.conc-exe%2Fconcierge-intel
- Hermes MCP docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp
