### PR TITLE
fix(whatsapp): reap bridge process on disconnect

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -423,6 +423,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # "Fatal whatsapp adapter error" plus dispatch a fatal-error
         # notification before the normal "✓ whatsapp disconnected" fires.
         self._shutting_down: bool = False
+        self._bridge_force_termination_requested: bool = False
 
         # Text debounce batching (mirrors Telegram adapter pattern).
         # WhatsApp often delivers multiple messages in rapid succession
@@ -757,13 +758,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return None
 
         # Planned shutdown: disconnect() sets _shutting_down before it sends
-        # SIGTERM to the bridge, so a returncode of -15 (SIGTERM), -2 (SIGINT),
-        # or 0 (clean exit) at that point is expected, not a crash. Treat it
-        # as informational and skip the fatal-error path.
+        # SIGTERM to the bridge. Graceful exits and any exit observed after
+        # Hermes requests forced termination are expected, not crashes.
         # getattr-with-default keeps tests that construct the adapter via
         # ``WhatsAppAdapter.__new__`` (bypassing __init__) working without
         # every _make_adapter() helper having to seed the attribute.
-        if getattr(self, "_shutting_down", False) and returncode in {0, -2, -15}:
+        planned_shutdown_exit = returncode in {0, -2, -15} or getattr(
+            self, "_bridge_force_termination_requested", False
+        )
+        if getattr(self, "_shutting_down", False) and planned_shutdown_exit:
             logger.info(
                 "[%s] Bridge exited during shutdown (code %d).",
                 self.name,
@@ -785,18 +788,29 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # path (which runs from other tasks like send() and the poll loop)
         # doesn't race us and report the intentional termination as fatal.
         self._shutting_down = True
+        self._bridge_force_termination_requested = False
         if self._bridge_process:
             try:
                 try:
                     _terminate_bridge_process(self._bridge_process, force=False)
                 except (ProcessLookupError, PermissionError):
                     self._bridge_process.terminate()
-                await asyncio.sleep(1)
-                if self._bridge_process.poll() is None:
+                try:
+                    await asyncio.to_thread(self._bridge_process.wait, timeout=1)
+                except subprocess.TimeoutExpired:
+                    self._bridge_force_termination_requested = True
                     try:
                         _terminate_bridge_process(self._bridge_process, force=True)
                     except (ProcessLookupError, PermissionError):
                         self._bridge_process.kill()
+                    try:
+                        await asyncio.to_thread(self._bridge_process.wait, timeout=1)
+                    except subprocess.TimeoutExpired:
+                        logger.warning(
+                            "[%s] Bridge process %d did not exit after forced termination",
+                            self.name,
+                            self._bridge_process.pid,
+                        )
             except Exception as e:
                 print(f"[{self.name}] Error stopping bridge: {e}")
         else:

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -13,9 +13,12 @@ Regression tests for two bugs in WhatsAppAdapter.connect():
 """
 
 import asyncio
+import os
 import signal
+import subprocess
+import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -568,6 +571,132 @@ class TestKillPortProcess:
 
 class TestHttpSessionLifecycle:
     """Verify persistent aiohttp.ClientSession is created and cleaned up."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_reaps_bridge_after_forced_termination(self):
+        """A bridge that ignores SIGTERM must be killed and wait()ed.
+
+        Merely signalling the managed Node child can leave it as a zombie
+        until the gateway exits.  Disconnect must reap both the graceful and
+        forced termination paths within its bounded shutdown budget.
+        """
+        adapter = _make_adapter()
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="node", timeout=1),
+            -getattr(signal, "SIGKILL", signal.SIGTERM),
+        ]
+        adapter._bridge_process = mock_proc
+        adapter._poll_task = None
+        adapter._http_session = None
+        adapter._running = True
+        adapter._session_lock_identity = None
+
+        with patch(
+            "plugins.platforms.whatsapp.adapter._terminate_bridge_process"
+        ) as terminate:
+            await adapter.disconnect()
+
+        assert terminate.call_args_list == [
+            call(mock_proc, force=False),
+            call(mock_proc, force=True),
+        ]
+        assert mock_proc.wait.call_args_list == [
+            call(timeout=1),
+            call(timeout=1),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_forced_disconnect_is_not_reported_as_fatal_by_poll_task(self):
+        adapter = _make_adapter()
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.returncode = None
+        mock_proc.poll.side_effect = lambda: mock_proc.returncode
+        mock_proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="node", timeout=1),
+            -getattr(signal, "SIGKILL", signal.SIGTERM),
+        ]
+        adapter._bridge_process = mock_proc
+        adapter._http_session = None
+        adapter._running = True
+        adapter._session_lock_identity = None
+        observed_exit = asyncio.Event()
+
+        async def poll_like_loop():
+            while True:
+                await adapter._check_managed_bridge_exit()
+                if mock_proc.returncode is not None:
+                    observed_exit.set()
+                await asyncio.sleep(0)
+
+        async def yielding_to_thread(func, *args, **kwargs):
+            try:
+                result = func(*args, **kwargs)
+            except Exception:
+                await asyncio.sleep(0)
+                raise
+            await asyncio.sleep(0)
+            return result
+
+        def terminate(proc, *, force=False):
+            if force:
+                proc.returncode = -getattr(signal, "SIGKILL", signal.SIGTERM)
+
+        adapter._poll_task = asyncio.create_task(poll_like_loop())
+        with patch(
+            "plugins.platforms.whatsapp.adapter._terminate_bridge_process",
+            side_effect=terminate,
+        ), patch(
+            "plugins.platforms.whatsapp.adapter.asyncio.to_thread",
+            side_effect=yielding_to_thread,
+        ):
+            await adapter.disconnect()
+
+        assert observed_exit.is_set()
+        assert adapter.fatal_error_code is None
+        fatal_handler.assert_not_awaited()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX signal/reap contract")
+    @pytest.mark.asyncio
+    async def test_disconnect_reaps_sigterm_ignoring_bridge_process(self):
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import signal,time; "
+                    "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                    "print('ready', flush=True); time.sleep(30)"
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert proc.stdout is not None
+            assert await asyncio.to_thread(proc.stdout.readline) == "ready\n"
+            adapter = _make_adapter()
+            adapter._bridge_process = proc
+            adapter._poll_task = None
+            adapter._http_session = None
+            adapter._running = True
+            adapter._session_lock_identity = None
+
+            await adapter.disconnect()
+
+            assert proc.returncode == -signal.SIGKILL
+            with pytest.raises(ChildProcessError):
+                os.waitpid(proc.pid, os.WNOHANG)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            if proc.stdout is not None:
+                proc.stdout.close()
 
     @pytest.mark.asyncio
     async def test_disconnect_uses_taskkill_tree_on_windows(self):


### PR DESCRIPTION
## What does this PR do?

Reaps the managed WhatsApp bridge subprocess during `WhatsAppAdapter.disconnect()` instead of only signaling it.

The adapter now waits off the event loop for up to one second after graceful process-tree termination. If the bridge does not exit, it force-terminates the tree and waits once more. This keeps the path bounded while ensuring the direct Node child is collected rather than left as a zombie during gateway shutdown.

## Related Issue

Fixes #64155

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace the fixed post-termination sleep with bounded `Popen.wait()` calls executed through `asyncio.to_thread`.
- Force-terminate and reap bridges that ignore the graceful signal.
- Log when a process still does not exit after forced termination.
- Suppress fatal bridge-exit notifications only when Hermes itself requested forced termination, preserving OOM/crash reporting.
- Add mock contract coverage, a concurrent poll-race regression, and a POSIX real-child regression using a subprocess that ignores SIGTERM.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_gateway_process_exit.py -q`.
2. Confirm all 50 lifecycle tests pass.
3. The real-process regression starts a child that ignores SIGTERM, verifies disconnect escalates to SIGKILL, and verifies `waitpid` reports the child has already been reaped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted lifecycle tests were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 (POSIX subprocess behavior)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior-only bug fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the existing Windows process-tree path remains covered; the real-child test is POSIX-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_gateway_process_exit.py -q
50 passed, 0 failed
```

The focused suite also passed three additional consecutive runs. Ruff and `git diff --check` pass. No Debian/systemd integration environment was available; the PR intentionally fixes only the concrete managed WhatsApp child termination/reap path.
