### PR TITLE
fix(state): enforce synchronous=FULL on macOS to prevent btree corruption

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -366,8 +366,10 @@ def _enforce_macos_synchronous_full(conn: sqlite3.Connection) -> None:
     DB with half-written btree pages → ``btreeInitPage error 11``.
 
     WAL mode's durability guarantee assumes the OS honors fsync barriers;
-    macOS does not unless we explicitly set ``synchronous=FULL`` (which
-    issues ``fsync()`` *and* ``F_FULLFSYNC`` via checkpoint_fullfsync=1).
+    macOS does not unless we explicitly set ``synchronous=FULL``, which issues
+    a real ``fsync()`` on every transaction commit.  The ``F_FULLFSYNC``
+    barrier at checkpoint boundaries is handled separately by
+    :func:`_apply_macos_checkpoint_barrier`.
 
     This function is called after any successful WAL activation (either
     from ``apply_wal_with_fallback()`` setting a fresh WAL or when probing

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -356,6 +356,34 @@ def _apply_macos_checkpoint_barrier(conn: sqlite3.Connection) -> None:
         pass
 
 
+def _enforce_macos_synchronous_full(conn: sqlite3.Connection) -> None:
+    """Enforce ``PRAGMA synchronous=FULL`` on macOS to prevent btree corruption.
+
+    On Darwin, the default ``synchronous=NORMAL`` only calls ``fsync()``,
+    which Apple's fsync(2) man page explicitly states does *not* guarantee
+    data-on-platter or write-ordering. During a WAL checkpoint race with
+    process termination (e.g., launchd shutdown), this can leave the main
+    DB with half-written btree pages → ``btreeInitPage error 11``.
+
+    WAL mode's durability guarantee assumes the OS honors fsync barriers;
+    macOS does not unless we explicitly set ``synchronous=FULL`` (which
+    issues ``fsync()`` *and* ``F_FULLFSYNC`` via checkpoint_fullfsync=1).
+
+    This function is called after any successful WAL activation (either
+    from ``apply_wal_with_fallback()`` setting a fresh WAL or when probing
+    an existing WAL mode). It ensures macOS connections always use FULL
+    synchronous mode, even if a prior connection set ``synchronous=NORMAL``.
+
+    Best-effort: never raises.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        conn.execute("PRAGMA synchronous=FULL")
+    except sqlite3.OperationalError:
+        pass
+
+
 def apply_wal_with_fallback(
     conn: sqlite3.Connection,
     *,
@@ -387,6 +415,7 @@ def apply_wal_with_fallback(
         current_mode = conn.execute("PRAGMA journal_mode").fetchone()
         if current_mode and current_mode[0] == "wal":
             _apply_macos_checkpoint_barrier(conn)
+            _enforce_macos_synchronous_full(conn)
             return "wal"
     except sqlite3.OperationalError:
         pass
@@ -394,6 +423,7 @@ def apply_wal_with_fallback(
     try:
         conn.execute("PRAGMA journal_mode=WAL")
         _apply_macos_checkpoint_barrier(conn)
+        _enforce_macos_synchronous_full(conn)
         return "wal"
     except sqlite3.OperationalError as exc:
         msg = str(exc).lower()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5180,6 +5180,75 @@ class TestApplyWalProbe:
         assert not any("checkpoint_fullfsync" in sql for sql in conn.executed), (
             "checkpoint_fullfsync must not be issued off macOS"
         )
+        assert not any("synchronous=FULL" in sql for sql in conn.executed), (
+            "synchronous=FULL must not be issued off macOS"
+        )
+
+    def test_macos_synchronous_full_enforced_fresh(self, tmp_path, monkeypatch):
+        """On Darwin, apply_wal_with_fallback enforces synchronous=FULL (issue #63531)."""
+        import sqlite3
+        import hermes_state
+        from hermes_state import apply_wal_with_fallback
+
+        class _TracingConn(sqlite3.Connection):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.executed = []
+
+            def execute(self, sql, params=()):
+                self.executed.append(sql)
+                return super().execute(sql, params)
+
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+
+        db_path = tmp_path / "macos_fresh_sync.db"
+        conn = _TracingConn(str(db_path))
+        try:
+            result = apply_wal_with_fallback(conn)
+        finally:
+            conn.close()
+
+        assert result == "wal"
+        assert any("synchronous=FULL" in sql for sql in conn.executed), (
+            "synchronous=FULL must be enforced on macOS"
+        )
+
+    def test_macos_synchronous_full_enforced_already_wal(self, tmp_path, monkeypatch):
+        """synchronous=FULL is enforced even when DB is already in WAL mode (issue #63531)."""
+        import sqlite3
+        import hermes_state
+        from hermes_state import apply_wal_with_fallback
+
+        class _TracingConn(sqlite3.Connection):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.executed = []
+
+            def execute(self, sql, params=()):
+                self.executed.append(sql)
+                return super().execute(sql, params)
+
+        # Prime the file into WAL mode first (simulating an existing WAL DB).
+        db_path = tmp_path / "macos_wal_sync.db"
+        with sqlite3.connect(str(db_path)) as seed:
+            seed.execute("PRAGMA journal_mode=WAL")
+
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+
+        conn = _TracingConn(str(db_path))
+        try:
+            result = apply_wal_with_fallback(conn)
+        finally:
+            conn.close()
+
+        assert result == "wal"
+        # The early-return path for existing WAL must also enforce synchronous=FULL.
+        assert any("synchronous=FULL" in sql for sql in conn.executed), (
+            "synchronous=FULL must be enforced even on existing WAL DBs"
+        )
+        assert not any("journal_mode=WAL" in sql for sql in conn.executed), (
+            "set-pragma must not run when already in WAL mode"
+        )
 
     def test_apply_wal_concurrent_connects_no_eio(self, tmp_path):
         """20 threads calling connect() on the same DB must not see disk I/O error."""


### PR DESCRIPTION
## Summary

Always enforce `PRAGMA synchronous=FULL` on macOS after WAL activation, preventing btree page corruption when WAL checkpoints race with process termination (launchd shutdown).

## Changes

- `hermes_state.py`: Added `_enforce_macos_synchronous_full()` — sets `synchronous=FULL` on Darwin after any successful WAL activation (both fresh and existing-WAL paths in `apply_wal_with_fallback()`)
- `tests/test_hermes_state.py`: 2 new tests (fresh WAL, existing WAL) + 1 updated test (non-macOS negative assertion)
- `hermes_state.py` (follow-up): Fixed docstring — `synchronous=FULL` issues plain `fsync()`, not `F_FULLFSYNC`; the `F_FULLFSYNC` barrier comes from the separate `checkpoint_fullfsync=1` PRAGMA set by `_apply_macos_checkpoint_barrier()`

## Root cause

`apply_wal_with_fallback()` skipped setting `synchronous=FULL` when the DB was already in WAL mode (early-return path). The SQLite WAL default is `synchronous=NORMAL`, which on macOS only calls `fsync()` — Apple's `fsync(2)` does not guarantee data-on-platter. During a WAL checkpoint race with process termination, this leaves half-written btree pages → `btreeInitPage error 11`.

The original `_apply_macos_checkpoint_barrier` (commit 52d774f0f) assumed `synchronous=FULL` was already the WAL default. It isn't reliably — the default depends on the SQLite build. This PR makes it explicit at the shared chokepoint, covering all 5 callers of `apply_wal_with_fallback()` (SessionDB, kanban_db, projects_db, api_server response_store, holographic memory_store).

## Validation

| | Before | After |
|---|---|---|
| Fresh WAL on macOS | synchronous=NORMAL (default) | synchronous=FULL |
| Existing WAL on macOS | synchronous=NORMAL (skipped) | synchronous=FULL |
| Non-macOS | unchanged | unchanged |

- 12/12 TestApplyWalProbe tests pass
- 28/28 WAL fallback + probe tests pass
- E2E: SessionDB real-import test confirms `synchronous=2 (FULL)` + `checkpoint_fullfsync=1`

Salvage of #63550 by @liuhao1024. Closes #63531.
