### PR TITLE
fix(agent): stop <think> leak after thinking-only retry flush

### DIFF
--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -208,19 +208,29 @@ class StreamingThinkScrubber:
         discarded — leaking partial reasoning is worse than a
         truncated answer.  Otherwise the held-back partial-tag tail is
         emitted verbatim (it turned out not to be a real tag prefix).
+
+        Always treats the next ``feed()`` as a fresh stream boundary.
+        Intra-turn retries (thinking-only prefill, empty-response
+        retry) flush then stream again without calling ``reset()``;
+        leaving ``_last_emitted_ended_newline`` False made a new
+        stream's opening ``<think>`` look mid-line and leak into the
+        visible reply.
         """
         if self._in_block:
             self._buf = ""
             self._in_block = False
+            # Next feed() is a new stream — start-of-stream is a boundary.
+            self._last_emitted_ended_newline = True
             return ""
         tail = self._buf
         self._buf = ""
+        # Same for the non-block path: do NOT derive the boundary flag
+        # from the flushed tail (e.g. a held-back '<').  End-of-stream
+        # means the next feed() starts a new model response.
+        self._last_emitted_ended_newline = True
         if not tail:
             return ""
-        tail = self._strip_orphan_close_tags(tail)
-        if tail:
-            self._last_emitted_ended_newline = tail.endswith("\n")
-        return tail
+        return self._strip_orphan_close_tags(tail)
 
     # ── internal helpers ───────────────────────────────────────────────
 

--- a/tests/agent/test_think_scrubber.py
+++ b/tests/agent/test_think_scrubber.py
@@ -192,6 +192,32 @@ class TestFlushBehaviour:
         s = StreamingThinkScrubber()
         assert s.flush() == ""
 
+    def test_flush_restores_stream_start_boundary(self) -> None:
+        """End-of-stream flush must re-arm block-boundary gating.
+
+        Thinking-only / empty-response retries flush then stream again
+        without ``reset()``.  If flush left ``_last_emitted_ended_newline``
+        False (e.g. after emitting a held-back ``<``), the next stream's
+        opening ``<think>`` looked mid-line and leaked into the UI.
+        """
+        s = StreamingThinkScrubber()
+        assert s.feed("word") == "word"
+        assert s._last_emitted_ended_newline is False
+        assert s.flush() == ""
+        assert s._last_emitted_ended_newline is True
+        assert (
+            _drive(s, ["<think>", "secret reasoning", "</think>", "Visible answer"])
+            == "Visible answer"
+        )
+
+    def test_flush_partial_tag_tail_does_not_poison_next_stream(self) -> None:
+        """Flushing a held-back ``<`` must not make the next open tag leak."""
+        s = StreamingThinkScrubber()
+        s.feed("word<")
+        assert s.flush() == "<"
+        assert s._last_emitted_ended_newline is True
+        assert _drive(s, ["<think>hidden</think>Hello"]) == "Hello"
+
 
 class TestRealisticStreaming:
     """Character-by-character streaming must work as well as larger chunks."""


### PR DESCRIPTION
## Summary
- `StreamingThinkScrubber.flush()` left `_last_emitted_ended_newline` stale after end-of-stream flush.
- Thinking-only / empty-response retries flush then stream again without `reset()`, so the next stream's opening `<think>` looked mid-line and leaked into the visible reply (common with Ollama in-content thinking tags).
- `flush()` now always re-arms start-of-stream boundary gating; regression tests cover the flush-then-retry path.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_think_scrubber.py -q` (33 passed)
- [ ] Ollama model that emits in-content `<think>`: force a thinking-only first response, confirm the retry no longer shows `<think>…` in the UI
