### PR TITLE
fix(auxiliary_client): add backward compatibility for build_keepalive_http_client import

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -102,7 +102,6 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
-from agent.process_bootstrap import build_keepalive_http_client
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -162,15 +161,26 @@ def _openai_http_client_kwargs(
     async_mode: bool = False,
 ) -> Dict[str, Any]:
     """Inject keepalive httpx client with env-only proxy (not macOS system proxy)."""
-    client = build_keepalive_http_client(
-        str(base_url or ""),
-        async_mode=async_mode,
-        verify=_resolve_aux_verify(base_url),
-    )
+    try:
+        from agent.process_bootstrap import build_keepalive_http_client
+        client = build_keepalive_http_client(
+            str(base_url or ""),
+            async_mode=async_mode,
+            verify=_resolve_aux_verify(base_url),
+        )
+    except (ImportError, AttributeError):
+        # Fallback for older hermes-agent versions without build_keepalive_http_client.
+        # This can happen when Desktop users run with stale code (#64333).
+        # Without the keepalive client, auxiliary calls use the OpenAI SDK's default
+        # httpx client, which respects macOS system proxy (less predictable for env-only
+        # proxy use) and has no pool-level keepalive expiry (connections may live longer).
+        # This is a graceful degradation — functionality still works, just with slightly
+        # different proxy/keepalive behavior.
+        client = None
+    
     if client is None:
         return {}
     return {"http_client": client}
-
 
 def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     kwargs = {**_openai_http_client_kwargs(base_url), **kwargs}


### PR DESCRIPTION
## What does this PR do?

Moves the `build_keepalive_http_client` import from module level to inside `_openai_http_client_kwargs()`, and wraps it in a try-except block. This provides backward compatibility for users running stale hermes-agent installations where `build_keepalive_http_client` does not exist in `agent/process_bootstrap.py`.

When the import fails (older code), the function returns an empty dict, allowing auxiliary calls to proceed with the OpenAI SDK's default httpx client. This is a graceful degradation — functionality still works, just with slightly different proxy/keepalive behavior.

## Related Issue

Fixes #64333

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Moved `build_keepalive_http_client` import from module level (line 105) to inside `_openai_http_client_kwargs()` function (line 164), wrapped in try-except to handle ImportError/AttributeError gracefully

## How to Test

1. Normal path: Verify auxiliary calls work with current code (build_keepalive_http_client exists)
2. Fallback path: Temporarily delete `build_keepalive_http_client` from `agent.process_bootstrap.py` and verify auxiliary calls still work (returns empty dict, uses default client)
3. Run existing tests: `pytest tests/agent/test_auxiliary_client_azure_foundry.py -v` — all pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/agent/test_auxiliary_client_azure_foundry.py -v` and all tests pass
- [x] I've tested on my platform: macOS 15.7.3 (ARM64)

### Documentation & Housekeeping

- [x] N/A
