### PR TITLE
fix(memory): drain accepted provider work before shutdown

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -39,10 +39,9 @@ from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
 
-# How long shutdown_all() waits for in-flight background sync/prefetch work
-# to drain before abandoning it. A wedged provider must never block process
-# teardown indefinitely — the worker threads are daemon, so anything still
-# running past this window dies with the interpreter.
+# How long shutdown_all() waits for its daemon finalizer. The finalizer keeps
+# draining every accepted task before provider shutdown, while a wedged daemon
+# worker still cannot block process teardown indefinitely.
 _SYNC_DRAIN_TIMEOUT_S = 5.0
 _EXTERNAL_PREFETCH_TIMEOUT_S = 8.0
 
@@ -388,10 +387,15 @@ class MemoryManager:
         # _submit_background() and the sync_all/queue_prefetch_all rationale.
         self._sync_executor: Optional[ThreadPoolExecutor] = None
         self._sync_executor_lock = threading.Lock()
-        # Futures are tracked by durability class so shutdown can give writes
-        # a bounded FIFO drain, then explicitly report anything abandoned.
+        # Shutdown linearizes with submission under _sync_executor_lock. Once
+        # closed, the manager never creates a replacement worker. Futures are
+        # tracked by durability class so shutdown can report anything abandoned.
+        self._background_closed = False
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_started = False
+        self._shutdown_finalizer: Optional[threading.Thread] = None
+        self._sync_drain_complete = threading.Event()
         self._background_futures: Dict[Future, str] = {}
-        self._shutting_down = False
         self._shutdown_drain_state: Dict[str, Any] = {
             "status": "not_started",
             "abandoned_writes": 0,
@@ -695,39 +699,49 @@ class MemoryManager:
 
     # -- Background dispatch -------------------------------------------------
 
-    def _submit_background(self, fn, *, kind: str = "write") -> None:
-        """Queue ``fn`` on the serialized worker and track its durability class."""
-        executor = self._get_sync_executor()
-        if executor is None:
-            if self._shutting_down:
-                logger.warning("Memory manager is shutting down; rejecting late %s task", kind)
-                return
-            # Creation failure outside shutdown: preserve the historical
-            # fail-safe behavior and run the operation inline.
+    def _submit_background(self, fn, *, kind: str = "write") -> bool:
+        """Submit ``fn`` atomically with respect to manager shutdown.
+
+        Returns True only when the single worker accepted the work. Creation
+        or submission failure rejects the task rather than running provider
+        code inline outside lifecycle tracking. The accepted future is
+        tracked by durability class so shutdown can report anything abandoned.
+        """
+        with self._sync_executor_lock:
+            executor = self._get_sync_executor_locked()
+            if executor is None:
+                return False
             try:
-                fn()
-            except Exception as e:  # pragma: no cover - fn guards internally
-                logger.debug("Inline memory background task failed: %s", e)
-            return
-        try:
-            # Make submit+tracking atomic with the shutdown snapshot. The
-            # callback is attached after releasing the lock because an already
-            # completed future invokes callbacks synchronously.
-            with self._sync_executor_lock:
-                if self._shutting_down:
-                    logger.warning("Memory manager is shutting down; rejecting late %s task", kind)
-                    return
                 future = executor.submit(fn)
-                self._background_futures[future] = kind
-            future.add_done_callback(self._forget_background_future)
-        except RuntimeError:
-            if self._shutting_down:
-                logger.warning("Memory manager shut down during %s submission; task rejected", kind)
-                return
+            except Exception as e:
+                logger.warning("Memory background task submission failed: %s", e)
+                return False
+            self._background_futures[future] = kind
+        # Attach the callback after releasing the lock: an already-completed
+        # future invokes callbacks synchronously.
+        future.add_done_callback(self._forget_background_future)
+        return True
+
+    def _get_sync_executor_locked(self) -> Optional[ThreadPoolExecutor]:
+        """Return/create the worker while ``_sync_executor_lock`` is held."""
+        if self._background_closed:
+            return None
+        if self._sync_executor is None:
             try:
-                fn()
-            except Exception as e:  # pragma: no cover - fn guards internally
-                logger.debug("Inline memory background task failed: %s", e)
+                # Daemon workers (see tools.daemon_pool): a provider wedged
+                # on a network call must never block interpreter exit —
+                # stdlib ThreadPoolExecutor's atexit hook would join it
+                # unconditionally even after shutdown(wait=False).
+                from tools.daemon_pool import DaemonThreadPoolExecutor
+
+                self._sync_executor = DaemonThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="mem-sync",
+                )
+            except Exception as e:  # pragma: no cover - resource exhaustion
+                logger.warning("Failed to create memory sync executor: %s", e)
+                return None
+        return self._sync_executor
 
     def _forget_background_future(self, future: Future) -> None:
         with self._sync_executor_lock:
@@ -735,44 +749,38 @@ class MemoryManager:
 
     def _get_sync_executor(self) -> Optional[ThreadPoolExecutor]:
         """Lazily create the single-worker background executor."""
-        if self._shutting_down:
-            return None
-        if self._sync_executor is not None:
-            return self._sync_executor
         with self._sync_executor_lock:
-            if self._shutting_down:
-                return None
-            if self._sync_executor is None:
-                try:
-                    # Daemon workers (see tools.daemon_pool): a provider wedged
-                    # on a network call must never block interpreter exit.
-                    from tools.daemon_pool import DaemonThreadPoolExecutor
-                    self._sync_executor = DaemonThreadPoolExecutor(
-                        max_workers=1,
-                        thread_name_prefix="mem-sync",
-                    )
-                except Exception as e:  # pragma: no cover - resource exhaustion
-                    logger.warning("Failed to create memory sync executor: %s", e)
-                    return None
-            return self._sync_executor
+            return self._get_sync_executor_locked()
 
     def flush_pending(self, timeout: Optional[float] = None) -> bool:
         """Block until queued sync/prefetch work has drained.
 
         Single-worker executor means submitting a sentinel and waiting on
-        it guarantees every previously-submitted task has run. Returns
-        True if the barrier completed within ``timeout`` (or no executor
-        exists), False on timeout. Used at real session boundaries and by
-        tests that need to assert provider state deterministically.
+        it guarantees every previously-submitted task has run. Barrier
+        submission linearizes with executor detachment under the submission
+        lock. Once shutdown has detached the executor, callers wait on the
+        explicit drain-complete signal instead. Returns True only when the
+        relevant barrier completed within ``timeout`` (or no executor has
+        ever existed), and False on timeout or barrier submission failure.
         """
-        executor = self._sync_executor
-        if executor is None:
-            return True
-        try:
-            fut = executor.submit(lambda: None)
-        except RuntimeError:
-            # Executor already shut down — nothing pending.
-            return True
+        drain_complete = None
+        with self._sync_executor_lock:
+            if self._background_closed:
+                drain_complete = self._sync_drain_complete
+                fut = None
+            else:
+                executor = self._sync_executor
+                if executor is None:
+                    return True
+                try:
+                    fut = executor.submit(lambda: None)
+                except RuntimeError as e:
+                    logger.warning("Memory flush barrier submission failed: %s", e)
+                    return False
+
+        if drain_complete is not None:
+            return drain_complete.wait(timeout=timeout)
+
         try:
             fut.result(timeout=timeout)
             return True
@@ -898,9 +906,9 @@ class MemoryManager:
         worker gives both properties at a single chokepoint: the caller returns
         immediately, and the worker's FIFO order serializes end→switch against
         every other provider write (per-turn ``sync_all``, prefetches), which
-        already share the same worker. If the executor is unavailable,
-        ``_submit_background`` degrades to inline execution — the pre-#16454
-        synchronous behavior, slow but correct.
+        already share the same worker. If the executor is unavailable, the
+        boundary task is rejected with a warning rather than running provider
+        code inline outside lifecycle tracking.
         """
         if not self._providers:
             return
@@ -1142,15 +1150,50 @@ class MemoryManager:
                 )
 
     def shutdown_all(self) -> None:
-        """Shut down all providers (reverse order for clean teardown).
+        """Bounded, idempotent shutdown without closing providers under work.
 
-        Drains the background sync/prefetch executor first (bounded by
-        ``_SYNC_DRAIN_TIMEOUT_S``) so a turn's final sync has a chance to
-        land before providers are torn down. The worker threads are
-        daemon, so anything still wedged past the drain window dies with
-        the interpreter rather than blocking exit.
+        A daemon finalizer waits without a deadline for the detached executor,
+        then closes providers in reverse order. Callers wait only
+        ``_SYNC_DRAIN_TIMEOUT_S`` for that finalizer. Because both the worker
+        and finalizer are daemon threads, process exit may still abandon wedged
+        work after the bounded caller wait.
         """
-        self._drain_sync_executor()
+        with self._shutdown_lock:
+            if not self._shutdown_started:
+                self._shutdown_started = True
+                executor = self._drain_sync_executor()
+
+                def _finalize() -> None:
+                    drained = executor is None or self._bounded_executor_wait(executor)
+                    if not drained:
+                        with self._sync_executor_lock:
+                            tracked = dict(self._background_futures)
+                            not_done = [(f, k) for f, k in tracked.items() if not f.done()]
+                            self._shutdown_drain_state.update(
+                                status="failed",
+                                abandoned_writes=sum(1 for _, k in not_done if k != "prefetch"),
+                                abandoned_prefetches=sum(1 for _, k in not_done if k == "prefetch"),
+                                active_tasks=len(not_done),
+                            )
+                        return
+                    with self._sync_executor_lock:
+                        self._shutdown_drain_state.update(status="drained", active_tasks=0)
+                    self._sync_drain_complete.set()
+                    self._shutdown_providers()
+
+                self._shutdown_finalizer = threading.Thread(
+                    target=_finalize,
+                    daemon=True,
+                    name="memory-shutdown-finalizer",
+                )
+                self._shutdown_finalizer.start()
+            finalizer = self._shutdown_finalizer
+
+        if finalizer is not None and finalizer is not threading.current_thread():
+            finalizer.join(timeout=_SYNC_DRAIN_TIMEOUT_S)
+
+    def _shutdown_providers(self) -> None:
+        """Close providers once, in reverse registration order."""
         for provider in reversed(self._providers):
             try:
                 provider.shutdown()
@@ -1166,10 +1209,10 @@ class MemoryManager:
         with self._sync_executor_lock:
             return dict(self._shutdown_drain_state)
 
-    def _drain_sync_executor(self) -> None:
-        """Give queued FIFO work a bounded chance, then abandon explicitly."""
+    def _drain_sync_executor(self) -> Optional[ThreadPoolExecutor]:
+        """Detach the worker and stop submissions without cancelling its queue."""
         with self._sync_executor_lock:
-            self._shutting_down = True
+            self._background_closed = True
             executor = self._sync_executor
             self._sync_executor = None
             tracked = dict(self._background_futures)
@@ -1180,46 +1223,28 @@ class MemoryManager:
                 "active_tasks": sum(not future.done() for future in tracked),
             }
         if executor is None:
-            return
+            return None
+        try:
+            executor.shutdown(wait=False, cancel_futures=False)
+        except TypeError:
+            # Older Python without cancel_futures kwarg.
+            try:
+                executor.shutdown(wait=False)
+            except Exception as e:  # pragma: no cover
+                logger.debug("Memory sync executor shutdown failed: %s", e)
+        except Exception as e:  # pragma: no cover
+            logger.debug("Memory sync executor shutdown failed: %s", e)
+        return executor
 
-        # shutdown(wait=False) closes submission without touching the FIFO.
-        # Waiting on the tracked futures lets the real single-worker executor
-        # run every queued write/boundary task in order up to the deadline.
-        executor.shutdown(wait=False, cancel_futures=False)
-        _, pending = wait(tuple(tracked), timeout=_SYNC_DRAIN_TIMEOUT_S)
-        if not pending:
-            with self._sync_executor_lock:
-                self._shutdown_drain_state.update(status="drained", active_tasks=0)
-            return
-
-        abandoned_writes = 0
-        abandoned_prefetches = 0
-        active_tasks = 0
-        for future in pending:
-            kind = tracked[future]
-            if future.cancel():
-                if kind == "prefetch":
-                    abandoned_prefetches += 1
-                else:
-                    abandoned_writes += 1
-            else:
-                active_tasks += 1
-
-        with self._sync_executor_lock:
-            self._shutdown_drain_state.update(
-                status="timed_out",
-                abandoned_writes=abandoned_writes,
-                abandoned_prefetches=abandoned_prefetches,
-                active_tasks=active_tasks,
-            )
-        logger.warning(
-            "Memory shutdown drain timed out after %.2fs; abandoning %d queued "
-            "memory write(s) and %d queued prefetch(es); %d active task(s) remain detached",
-            _SYNC_DRAIN_TIMEOUT_S,
-            abandoned_writes,
-            abandoned_prefetches,
-            active_tasks,
-        )
+    @staticmethod
+    def _bounded_executor_wait(executor: ThreadPoolExecutor) -> bool:
+        """Wait for every accepted task from the daemon finalizer thread."""
+        try:
+            executor.shutdown(wait=True)
+        except Exception as e:
+            logger.warning("Memory sync executor drain wait failed: %s", e)
+            return False
+        return True
 
     def initialize_all(self, session_id: str, **kwargs) -> None:
         """Initialize all providers.

--- a/contributors/emails/a@l
+++ b/contributors/emails/a@l
@@ -1,0 +1,2 @@
+yingliang-zhang
+# attribution repair: commits authored with misconfigured local identity (a@l) belong to yingliang-zhang

--- a/contributors/emails/zhangyingliang@outlook.com
+++ b/contributors/emails/zhangyingliang@outlook.com
@@ -1,0 +1,1 @@
+yingliang-zhang

--- a/tests/agent/test_memory_async_sync.py
+++ b/tests/agent/test_memory_async_sync.py
@@ -133,7 +133,14 @@ def test_shutdown_drains_queued_writes_and_boundary_in_fifo_order():
 
 
 def test_shutdown_timeout_abandons_queued_write_with_state_and_log(monkeypatch, caplog):
-    """A wedged active write bounds shutdown and reports queued data loss."""
+    """A wedged active write bounds the shutdown caller; the finalizer drains accepted work.
+
+    The merged shutdown keeps the PR's unbounded daemon finalizer (drain every
+    accepted task before closing providers) while reporting HEAD's drain-state
+    snapshot. The caller returns within ``_SYNC_DRAIN_TIMEOUT_S`` even while a
+    task is wedged; the finalizer keeps draining and reports ``drained`` once
+    the accepted work completes in FIFO order.
+    """
     import agent.memory_manager as memory_manager_module
 
     started = threading.Event()
@@ -159,10 +166,391 @@ def test_shutdown_timeout_abandons_queued_write_with_state_and_log(monkeypatch, 
         mgr.shutdown_all()
         elapsed = time.monotonic() - t0
 
-    state = mgr.shutdown_drain_state
+    # Caller is bounded by _SYNC_DRAIN_TIMEOUT_S even though a task is wedged.
     assert elapsed < 0.5
-    assert state["status"] == "timed_out"
-    assert state["abandoned_writes"] == 1
-    assert "queued" not in calls
-    assert "abandoning 1 queued memory write" in caplog.text
+
+    # The finalizer is still draining at this point (active task wedged), so
+    # the snapshot reports the in-flight drain rather than abandonment.
+    state = mgr.shutdown_drain_state
+    assert state["status"] == "draining"
+    assert state["active_tasks"] >= 1
+
+    # Releasing the wedged task lets the finalizer drain both accepted writes
+    # in FIFO order, then close providers.
     release.set()
+    assert mgr._sync_drain_complete.wait(timeout=5)
+    assert calls == ["active", "queued"]
+    final_state = mgr.shutdown_drain_state
+    assert final_state["status"] == "drained"
+    assert final_state["abandoned_writes"] == 0
+
+
+class _BlockingLifecycleProvider(_SlowProvider):
+    """Provider with observable work and shutdown ordering."""
+
+    def __init__(self):
+        super().__init__(delay=0.0)
+        self.first_started = threading.Event()
+        self.release_first = threading.Event()
+        self.shutdown_called = threading.Event()
+        self.operations = []
+
+    def sync_turn(
+        self,
+        user_content,
+        assistant_content,
+        *,
+        session_id="",
+        messages=None,
+    ):
+        del assistant_content, session_id, messages
+        self.operations.append(f"sync:{user_content}:start")
+        if user_content == "first":
+            self.first_started.set()
+            self.release_first.wait(timeout=5)
+        self.operations.append(f"sync:{user_content}:done")
+
+    def queue_prefetch(self, query, *, session_id=""):
+        del session_id
+        self.operations.append(f"prefetch:{query}")
+
+    def shutdown(self):
+        self.operations.append("shutdown")
+        self.shutdown_called.set()
+
+
+
+def test_flush_submission_linearizes_before_executor_detach():
+    """A barrier accepted before detach remains part of the shutdown drain."""
+    mgr = MemoryManager()
+    provider = _BlockingLifecycleProvider()
+    mgr.add_provider(provider)
+    mgr.sync_all("first", "response")
+    assert provider.first_started.wait(timeout=2)
+
+    executor = mgr._sync_executor
+    assert executor is not None
+    original_submit = executor.submit
+    original_shutdown = executor.shutdown
+    barrier_submit_started = threading.Event()
+    release_barrier_submit = threading.Event()
+    detach_started = threading.Event()
+    shutdown_calling = threading.Event()
+    flush_result = []
+
+    def controlled_submit(fn, *args, **kwargs):
+        if threading.current_thread().name == "memory-flush":
+            barrier_submit_started.set()
+            if not release_barrier_submit.wait(timeout=5):
+                raise AssertionError("barrier submission was not released")
+        return original_submit(fn, *args, **kwargs)
+
+    def observed_shutdown(*args, **kwargs):
+        if kwargs.get("wait") is False:
+            detach_started.set()
+        return original_shutdown(*args, **kwargs)
+
+    executor.submit = controlled_submit
+    executor.shutdown = observed_shutdown
+
+    flush_thread = threading.Thread(
+        target=lambda: flush_result.append(mgr.flush_pending(timeout=2)),
+        name="memory-flush",
+    )
+    shutdown_thread = threading.Thread(
+        target=lambda: (shutdown_calling.set(), mgr.shutdown_all()),
+        name="memory-shutdown-caller",
+    )
+    flush_thread.start()
+    assert barrier_submit_started.wait(timeout=2)
+    shutdown_thread.start()
+    assert shutdown_calling.wait(timeout=2)
+    try:
+        assert not detach_started.wait(timeout=0.1)
+    finally:
+        release_barrier_submit.set()
+        provider.release_first.set()
+
+    flush_thread.join(timeout=2)
+    shutdown_thread.join(timeout=2)
+    assert not flush_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert detach_started.is_set()
+    assert flush_result == [True]
+
+
+def test_flush_after_detach_waits_for_explicit_drain_completion(monkeypatch):
+    """A detached executor is not drained until its final wait succeeds."""
+    import agent.memory_manager as memory_manager_module
+
+    monkeypatch.setattr(memory_manager_module, "_SYNC_DRAIN_TIMEOUT_S", 0.02)
+    mgr = MemoryManager()
+    provider = _BlockingLifecycleProvider()
+    mgr.add_provider(provider)
+    mgr.sync_all("first", "response")
+    assert provider.first_started.wait(timeout=2)
+
+    executor = mgr._sync_executor
+    assert executor is not None
+    original_shutdown = executor.shutdown
+    detach_started = threading.Event()
+    drain_wait_started = threading.Event()
+
+    def observed_shutdown(*args, **kwargs):
+        if kwargs.get("wait") is False:
+            detach_started.set()
+        elif kwargs.get("wait") is True:
+            drain_wait_started.set()
+        return original_shutdown(*args, **kwargs)
+
+    executor.shutdown = observed_shutdown
+    shutdown_thread = threading.Thread(target=mgr.shutdown_all)
+    shutdown_thread.start()
+    try:
+        assert detach_started.wait(timeout=2)
+        assert drain_wait_started.wait(timeout=2)
+        assert mgr.flush_pending(timeout=0.02) is False
+
+        flush_result = []
+        flush_returned = threading.Event()
+
+        def flush_until_drained():
+            flush_result.append(mgr.flush_pending(timeout=2))
+            flush_returned.set()
+
+        flush_thread = threading.Thread(target=flush_until_drained)
+        flush_thread.start()
+        assert not flush_returned.wait(timeout=0.1)
+    finally:
+        provider.release_first.set()
+
+    assert flush_returned.wait(timeout=2)
+    flush_thread.join(timeout=2)
+    shutdown_thread.join(timeout=2)
+    assert flush_result == [True]
+
+
+def test_shutdown_drains_accepted_prefetch_queued_behind_inflight_sync():
+    """Shutdown preserves FIFO work accepted behind an in-flight task."""
+    mgr = MemoryManager()
+    provider = _BlockingLifecycleProvider()
+    mgr.add_provider(provider)
+    mgr.sync_all("first", "response")
+    assert provider.first_started.wait(timeout=2)
+    mgr.queue_prefetch_all("second")
+
+    executor = mgr._sync_executor
+    assert executor is not None
+    shutdown_started = threading.Event()
+    original_shutdown = executor.shutdown
+
+    def observed_shutdown(*args, **kwargs):
+        if kwargs.get("wait") is False:
+            shutdown_started.set()
+        return original_shutdown(*args, **kwargs)
+
+    executor.shutdown = observed_shutdown
+    shutdown_thread = threading.Thread(target=mgr.shutdown_all)
+    shutdown_thread.start()
+    try:
+        assert shutdown_started.wait(timeout=2)
+    finally:
+        provider.release_first.set()
+    shutdown_thread.join(timeout=5)
+
+    assert not shutdown_thread.is_alive()
+    assert provider.operations == [
+        "sync:first:start",
+        "sync:first:done",
+        "prefetch:second",
+        "shutdown",
+    ]
+
+
+def test_shutdown_is_bounded_while_finalizer_continues_to_drain(monkeypatch):
+    """Caller timeout neither closes providers nor cancels accepted work."""
+    import agent.memory_manager as memory_manager_module
+
+    monkeypatch.setattr(memory_manager_module, "_SYNC_DRAIN_TIMEOUT_S", 0.02)
+    mgr = MemoryManager()
+    provider = _BlockingLifecycleProvider()
+    mgr.add_provider(provider)
+    mgr.sync_all("first", "response")
+    assert provider.first_started.wait(timeout=2)
+    mgr.queue_prefetch_all("accepted")
+
+    started = time.monotonic()
+    try:
+        mgr.shutdown_all()
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.5
+        assert not provider.shutdown_called.is_set()
+
+        # Submission after shutdown began must be rejected, not run inline or
+        # accepted by a replacement executor.
+        mgr.sync_all("late", "response")
+    finally:
+        provider.release_first.set()
+
+    assert provider.shutdown_called.wait(timeout=2)
+    assert provider.operations == [
+        "sync:first:start",
+        "sync:first:done",
+        "prefetch:accepted",
+        "shutdown",
+    ]
+
+
+def test_executor_creation_failure_drops_work_without_inline_provider_call(
+    monkeypatch, caplog
+):
+    """Worker creation failure is warned and never runs provider code inline."""
+    import tools.daemon_pool as daemon_pool
+
+    def fail_creation(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("no worker")
+
+    monkeypatch.setattr(daemon_pool, "DaemonThreadPoolExecutor", fail_creation)
+    mgr = MemoryManager()
+    provider = _SlowProvider(delay=0.0)
+    mgr.add_provider(provider)
+
+    with caplog.at_level(logging.WARNING):
+        mgr.sync_all("write", "response")
+
+    assert provider.sync_done is False
+    assert "Failed to create memory sync executor: no worker" in caplog.text
+
+
+def test_executor_submission_failure_drops_work_without_inline_provider_call(caplog):
+    """Worker submission failure is warned and never runs provider code inline."""
+
+    class RejectingExecutor:
+        def submit(self, fn):
+            del fn
+            raise RuntimeError("not accepting")
+
+        def shutdown(self, *args, **kwargs):
+            del args, kwargs
+
+    mgr = MemoryManager()
+    provider = _SlowProvider(delay=0.0)
+    mgr.add_provider(provider)
+    mgr._sync_executor = RejectingExecutor()
+
+    with caplog.at_level(logging.WARNING):
+        mgr.sync_all("write", "response")
+
+    assert provider.sync_done is False
+    assert "Memory background task submission failed: not accepting" in caplog.text
+
+
+def test_executor_drain_failure_leaves_providers_open(caplog):
+    """Failed wait=True cannot authorize closing providers under queued work."""
+
+    class FailingDrainExecutor:
+        def __init__(self):
+            self.accepted = []
+            self.drain_wait_called = threading.Event()
+
+        def submit(self, fn):
+            # Merged _submit_background tracks the returned future by kind, so
+            # submit must hand back a real Future rather than None.
+            from concurrent.futures import Future
+            fut = Future()
+            self.accepted.append((fn, fut))
+            return fut
+
+        def shutdown(self, *, wait=True, **kwargs):
+            del kwargs
+            if wait:
+                self.drain_wait_called.set()
+                raise RuntimeError("drain failed")
+
+    mgr = MemoryManager()
+    provider = _BlockingLifecycleProvider()
+    executor = FailingDrainExecutor()
+    mgr.add_provider(provider)
+    mgr._sync_executor = executor
+    mgr.sync_all("accepted", "response")
+    assert len(executor.accepted) == 1
+
+    with caplog.at_level(logging.WARNING):
+        mgr.shutdown_all()
+
+    assert executor.drain_wait_called.wait(timeout=2)
+    assert provider.first_started.is_set() is False
+    assert provider.shutdown_called.is_set() is False
+    assert mgr._sync_drain_complete.is_set() is False
+    assert "Memory sync executor drain wait failed: drain failed" in caplog.text
+
+
+def test_concurrent_shutdown_is_single_reversed_and_permanently_closed(monkeypatch):
+    """Concurrent callers share one finalizer and close each provider once."""
+    import agent.memory_manager as memory_manager_module
+
+    monkeypatch.setattr(memory_manager_module, "_SYNC_DRAIN_TIMEOUT_S", 0.02)
+    mgr = MemoryManager()
+    shutdown_order = []
+    builtin = _BlockingLifecycleProvider()
+    builtin._name = "builtin"
+    external = _SlowProvider(delay=0.0)
+    external._name = "external"
+    builtin.shutdown = lambda: shutdown_order.append("builtin")
+    external.shutdown = lambda: shutdown_order.append("external")
+    mgr.add_provider(builtin)
+    mgr.add_provider(external)
+    mgr.sync_all("first", "response")
+    assert builtin.first_started.wait(timeout=2)
+
+    executor = mgr._sync_executor
+    assert executor is not None
+    original_shutdown = executor.shutdown
+    executor_shutdown_calls = []
+    drain_wait_started = threading.Event()
+
+    def observed_shutdown(*args, **kwargs):
+        wait = kwargs.get("wait")
+        executor_shutdown_calls.append(wait)
+        if wait is True:
+            drain_wait_started.set()
+        return original_shutdown(*args, **kwargs)
+
+    executor.shutdown = observed_shutdown
+    caller_gate = threading.Barrier(5)
+    caller_errors = []
+
+    def call_shutdown():
+        try:
+            caller_gate.wait(timeout=2)
+            mgr.shutdown_all()
+        except BaseException as exc:
+            caller_errors.append(exc)
+
+    callers = [threading.Thread(target=call_shutdown) for _ in range(4)]
+    for caller in callers:
+        caller.start()
+    caller_gate.wait(timeout=2)
+    try:
+        assert drain_wait_started.wait(timeout=2)
+        for caller in callers:
+            caller.join(timeout=2)
+        assert not any(caller.is_alive() for caller in callers)
+        assert shutdown_order == []
+        finalizer = mgr._shutdown_finalizer
+        assert finalizer is not None
+        assert finalizer.is_alive()
+    finally:
+        builtin.release_first.set()
+
+    finalizer.join(timeout=2)
+    assert not finalizer.is_alive()
+    assert caller_errors == []
+    assert executor_shutdown_calls == [False, True]
+    assert shutdown_order == ["external", "builtin"]
+
+    mgr.sync_all("late", "response")
+    mgr.queue_prefetch_all("late")
+    assert mgr.flush_pending(timeout=0.1) is True
+    assert mgr._sync_executor is None


### PR DESCRIPTION
## Summary

- serialize MemoryManager background provider submissions with shutdown
- drain all accepted FIFO work before closing providers, while keeping callers bounded
- reject executor creation/submission failures instead of running provider code inline

## Problem

The existing fallback could run provider work inline when executor creation or submission failed, outside shutdown tracking. Shutdown could also detach/close resources while accepted work was still queued or in flight.

## Changes

- linearize executor creation, submission, flush barriers, and shutdown detachment
- permanently reject new work once shutdown begins
- use one daemon finalizer to wait for accepted work before reverse-order provider close
- keep `shutdown_all()` callers bounded by the existing timeout
- leave providers open if drain completion cannot be established
- add deterministic event/barrier coverage for both flush/detach orderings, drain exceptions, concurrent shutdown callers, and reverse-order single close

This is complementary to #62046: that PR decides when built-in memory review should run; this PR hardens lifecycle ordering for external provider work already accepted by `MemoryManager`.

## Verification

- `143 passed`:
  - `tests/agent/test_memory_async_sync.py`
  - `tests/agent/test_memory_provider.py`
  - `tests/agent/test_memory_boundary_commit.py`
  - `tests/agent/test_memory_session_switch.py`
  - `tests/agent/test_memory_skill_scaffolding.py`
- independent final review reran `tests/agent/test_memory_async_sync.py`: `14 passed`
- `py_compile`: passed
- `ruff check`: passed
- `git diff --check`: passed

## Residual behavior

A permanently wedged provider may keep the daemon finalizer alive after the bounded caller returns. If executor drain raises, providers intentionally remain open rather than being closed beneath potentially unfinished work.
