### PR TITLE
perf(delegate): narrow default child toolsets

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1917,6 +1917,49 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
             ["web", "browser", "mcp-MiniMax"],
         )
 
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_agent_defaults_to_minimal_toolsets(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file", "web", "skills", "mcp-MiniMax"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Test default toolsets",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["enabled_toolsets"],
+            ["terminal", "file", "web"],
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_agent_explicit_empty_toolsets_stays_empty(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file", "web", "mcp-MiniMax"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Test empty toolsets",
+                context=None,
+                toolsets=[],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(MockAgent.call_args[1]["enabled_toolsets"], [])
+
     @patch(
         "tools.delegate_tool._load_config",
         return_value={"inherit_mcp_toolsets": False},

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1099,17 +1099,14 @@ def _build_child_agent(
 
     delegation_cfg = _load_config()
 
-    # When no explicit toolsets given, inherit from parent's enabled toolsets
-    # so disabled tools (e.g. web) don't leak to subagents.
-    # Note: enabled_toolsets=None means "all tools enabled" (the default),
-    # so we must derive effective toolsets from the parent's loaded tools.
+    # ── Toolset resolution ──────────────────────────────────────────────
+    # Resolve what toolsets the parent actually has available.
     parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
     if parent_enabled is not None:
         parent_toolsets = set(parent_enabled)
     elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
         # enabled_toolsets is None (all tools) — derive from loaded tool names
         import model_tools
-
         parent_toolsets = {
             ts
             for name in parent_agent.valid_tool_names
@@ -1118,23 +1115,27 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
-        # Intersect with parent — subagent must not gain tools the parent lacks.
-        # Expand composite toolsets (e.g. hermes-cli) so that individual
-        # toolset names (e.g. web, terminal) are recognised during intersection.
-        expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
-        if _get_inherit_mcp_toolsets():
-            child_toolsets = _preserve_parent_mcp_toolsets(
-                child_toolsets, parent_toolsets
-            )
-        child_toolsets = _strip_blocked_tools(child_toolsets)
-    elif parent_agent and parent_enabled is not None:
-        child_toolsets = _strip_blocked_tools(parent_enabled)
-    elif parent_toolsets:
-        child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
+    # Determine the child's toolsets, defaulting to a minimal set (DEFAULT_TOOLSETS)
+    # instead of inheriting everything from the parent. This reduces the
+    # subagent's tool surface and context overhead.
+    expanded_parent = _expand_parent_toolsets(parent_toolsets)
+    if toolsets is not None:
+        # Explicit request (could be an empty list or a list of names)
+        if toolsets:
+            child_toolsets = [t for t in toolsets if t in expanded_parent]
+            if _get_inherit_mcp_toolsets():
+                child_toolsets = _preserve_parent_mcp_toolsets(
+                    child_toolsets, parent_toolsets
+                )
+        else:
+            # toolsets=[] -> empty list request must remain empty
+            child_toolsets = []
     else:
-        child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+        # Default case (toolsets is None) -> use DEFAULT_TOOLSETS narrowed
+        # by what the parent itself is allowed to use.
+        child_toolsets = [t for t in DEFAULT_TOOLSETS if t in expanded_parent]
+
+    child_toolsets = _strip_blocked_tools(child_toolsets)
 
     # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
     # removed.  The re-add is unconditional on parent-toolset membership because


### PR DESCRIPTION
## Summary

This PR addresses the child-toolset portion of #11431: delegated children should not inherit every optional toolset from the parent by default.

- When `toolsets` is omitted, the child receives the existing `DEFAULT_TOOLSETS` (`terminal`, `file`, and `web`), intersected with the parent's allowed surface.
- Explicit non-empty toolset requests keep the existing parent intersection and MCP-preservation behavior.
- An explicit `toolsets=[]` remains empty, including when the parent has MCP toolsets.
- The public `delegate_task` schema and removed `delegation.default_toolsets` config are unchanged.

## Measured Result

We ran autoresearch with Weco against the actual child-agent tool schema:

- Baseline: `25,955` schema bytes, `12` tools
- Best valid result: `12,581` schema bytes, `6` tools
- Reduction: `51.5%`

Public Weco run: [child tool-schema autoresearch](https://dashboard.weco.ai/share/lP77h22czFenhLZDo4Sr_TYBMe6iBNhv)

## Validation

- Strict evaluator checks default scope, explicit toolsets, empty-toolset/MCP behavior, blocked tools, public-schema stability, base revision, diff scope, and whitespace.
- `200` focused tests passed.
- `uvx ruff check --fix .` passed.

This is intentionally limited to the tool-surface part of #11431. It does not change child shutdown, persistence, or compaction behavior.

Refs #11431
