### PR TITLE
fix(hindsight): make hindsight_retain acknowledgement reflect sync vs async response

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1717,9 +1717,16 @@ class HindsightMemoryProvider(MemoryProvider):
                 item.pop("retain_async", None)
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)
-                self._run_hindsight_operation(
+                response = self._run_hindsight_operation(
                     lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
                 )
+                if getattr(response, "var_async", False):
+                    logger.debug("Tool hindsight_retain: queued, operation_id=%s",
+                                 response.operation_id)
+                    return json.dumps({
+                        "result": "Memory queued.",
+                        "operation_id": response.operation_id,
+                    })
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -78,7 +78,9 @@ def _make_mock_client():
     client.areflect = AsyncMock(
         return_value=SimpleNamespace(text="Synthesized answer")
     )
-    client.aretain_batch = AsyncMock()
+    client.aretain_batch = AsyncMock(
+        return_value=SimpleNamespace(var_async=False, operation_id=None)
+    )
     client.aclose = AsyncMock()
     return client
 
@@ -651,6 +653,16 @@ class TestToolHandlers:
         # bank_id/retain_async are call-level args, never item keys.
         assert "bank_id" not in item
         assert "retain_async" not in item
+
+    def test_retain_async_response_reports_queued(self, provider):
+        provider._client.aretain_batch.return_value = SimpleNamespace(
+            var_async=True, operation_id="op-123"
+        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": "user likes dark mode"}
+        ))
+        assert result["result"] == "Memory queued."
+        assert result["operation_id"] == "op-123"
 
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])


### PR DESCRIPTION
## What does this PR do?

The manual `hindsight_retain` tool discards the `RetainResponse` from `aretain_batch()` and unconditionally returns `"Memory stored successfully."`. That is correct today (the tool submits synchronously, non-2xx raises), but if the tool gains async submission (#61442), the same hard-coded message would describe queue acceptance as completed storage.

This captures the response and branches on it: when the server reports an async operation, the tool returns `"Memory queued."` plus the `operation_id`; otherwise the acknowledgement is unchanged. No behavior change for the current synchronous path — existing exception handling remains the failure path. Field names (`var_async`, `operation_id`) verified against `RetainResponse` in hindsight-client 0.6.1.

## Related Issue

Fixes #64326

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: capture the `RetainResponse` in the `hindsight_retain` handler; return `Memory queued.` + `operation_id` when `var_async` is set
- `tests/plugins/memory/test_hindsight_provider.py`: `aretain_batch` mock now returns a sync-shaped response; new `test_retain_async_response_reports_queued` covers the async acknowledgement

## How to Test

1. `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py` — 117 passed
2. Sync path covered by the existing `test_retain_success`; async path by the new `test_retain_async_response_reports_queued`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite via `scripts/run_tests.sh` — 40398 passed; 16 pre-existing env failures on my machine (NixOS, no `/bin/bash`), identical on clean main
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux 6.18)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (response shape only changes on a code path that doesn't exist yet)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (no file I/O, process, or terminal handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (schema unchanged; only the acknowledgement payload gains a field in the async case)