### PR TITLE
fix(shell_hooks): use explicit UTF-8 encoding with errors='replace'

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -464,7 +464,8 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
             input=stdin_json,
             capture_output=True,
             timeout=spec.timeout,
-            text=True,
+            encoding='utf-8',
+            errors='replace',
             shell=False,
             **_popen_kwargs,
         )


### PR DESCRIPTION
## Problem

On Windows, `text=True` in `subprocess.run()` defaults to the system's ANSI codepage (e.g., GBK/CP936 on Chinese Windows). When shell hook scripts output characters outside this codepage, `subprocess.run` raises `UnicodeDecodeError`, causing the hook to silently fail.

## Fix

Replace `text=True` with explicit `encoding='utf-8', errors='replace'` in `_spawn()` (shell_hooks.py:467).

- `encoding='utf-8'`: consistent cross-platform behavior
- `errors='replace'`: graceful degradation instead of crash on invalid bytes

## Before/After

```python
# Before
subprocess.run(argv, input=stdin_json, capture_output=True,
               timeout=spec.timeout, text=True, shell=False, **_popen_kwargs)

# After
subprocess.run(argv, input=stdin_json, capture_output=True,
               timeout=spec.timeout, encoding='utf-8', errors='replace',
               shell=False, **_popen_kwargs)
```

## Testing

- Verified that `_spawn()` no longer crashes on non-ASCII hook output on Windows (Chinese locale)
- Backward compatible: `encoding='utf-8'` + `errors='replace'` is a superset of `text=True` behavior on UTF-8 systems
