### PR TITLE
fix(gateway): redact credentials from inbound message logging

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,7 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
+from agent.redact import redact_sensitive_text
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -10862,7 +10863,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         logger.info(
             "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
             _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
+            source.chat_id or "unknown",
+            redact_sensitive_text(_msg_preview, force=True),
+            _reply_id,
+            redact_sensitive_text(_reply_txt, force=True),
         )
 
         # Get or create session

--- a/tests/gateway/test_inbound_message_redaction.py
+++ b/tests/gateway/test_inbound_message_redaction.py
@@ -1,0 +1,227 @@
+"""Test inbound message credential redaction (issue #64351).
+
+When a user pastes credentials into a chat (e.g., a Google OAuth client_secret
+paste), the gateway logs the inbound message body at INFO level. Without this
+fix, credentials are written to logs in cleartext and later collected by
+`hermes debug share`, potentially leaking to a public paste service.
+
+This fix applies `redact_sensitive_text(force=True)` to message preview and
+reply_text fields before logging, redacting well-known credential patterns
+(sk-, ghp_, AIza, ya29., GOCSPX-, etc.) while preserving non-sensitive context
+for debugging.
+
+Credential fixtures are synthetic (benign prefix + run of X's) to avoid false
+positives in secret scanners, matching the redactor regexes so tests stay
+meaningful without containing real keys.
+"""
+
+import logging
+import sys
+import types
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, SessionSource
+
+# Synthetic, scanner-safe credential fixtures. Each matches redactor regexes.
+_FAKE_GHP = "ghp_" + "X" * 36
+_FAKE_OPENAI = "sk-proj-" + "X" * 40
+_FAKE_JWT = "eyJ" + "X" * 20 + "." + "eyJ" + "X" * 24 + "." + "X" * 30
+_FAKE_GOOGLE_SECRET = "GOCSPX-" + "X" * 28
+_FAKE_YANDEX = "ya29." + "X" * 80
+
+
+def _bootstrap(monkeypatch, tmp_path):
+    """Minimal GatewayRunner setup."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    config = GatewayConfig()
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.has_platform_message_id.return_value = False
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    return runner
+
+
+class TestInboundMessageRedaction:
+    """Regression tests for inbound message logging credential redaction."""
+
+    def test_redacts_github_pat_in_message_text(self, monkeypatch, tmp_path, caplog):
+        """Message text containing a GitHub PAT must be redacted."""
+        import sys
+
+        runner = _bootstrap(monkeypatch, tmp_path)
+
+        event = MessageEvent(
+            text=f"help me use this token {_FAKE_GHP}",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="private",
+                user_id="user123",
+            ),
+            message_id="msg-1",
+        )
+
+        with caplog.at_level(logging.INFO):
+            # Call the handler (bypass sentinel guard for test)
+            import asyncio
+
+            async def _test():
+                return await runner._handle_message_with_agent(event, event.source, "test", 1)
+
+            asyncio.run(_test())
+
+        # Verify credential was redacted from log
+        assert any(_FAKE_GHP not in record.message for record in caplog.records)
+        # Verify context preserved
+        assert any("telegram" in record.message for record in caplog.records)
+
+    def test_redacts_openai_key_in_reply_text(self, monkeypatch, tmp_path, caplog):
+        """Reply text containing an OpenAI key must be redacted."""
+        import sys
+
+        runner = _bootstrap(monkeypatch, tmp_path)
+
+        event = MessageEvent(
+            text="check this",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="private",
+                user_id="user123",
+            ),
+            message_id="msg-1",
+        )
+        event.reply_to_message_id = 456
+        event.reply_to_text = f"use this key {_FAKE_OPENAI}"
+
+        with caplog.at_level(logging.INFO):
+            import asyncio
+
+            async def _test():
+                return await runner._handle_message_with_agent(event, event.source, "test", 1)
+
+            asyncio.run(_test())
+
+        # Verify credential was redacted
+        assert any(_FAKE_OPENAI not in record.message for record in caplog.records)
+        # Verify reply metadata preserved
+        assert any("reply_to_id=456" in record.message for record in caplog.records)
+
+    def test_redacts_google_oauth_client_secret(self, monkeypatch, tmp_path, caplog):
+        """Google OAuth client_secret must be redacted (issue #64351 case)."""
+        import sys
+
+        runner = _bootstrap(monkeypatch, tmp_path)
+
+        event = MessageEvent(
+            text=f'{{"client_secret": "{_FAKE_GOOGLE_SECRET}", "client_id": "test"}}',
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="private",
+                user_id="user123",
+            ),
+            message_id="msg-1",
+        )
+
+        with caplog.at_level(logging.INFO):
+            import asyncio
+
+            async def _test():
+                return await runner._handle_message_with_agent(event, event.source, "test", 1)
+
+            asyncio.run(_test())
+
+        # Verify client_secret was redacted
+        assert any(_FAKE_GOOGLE_SECRET not in record.message for record in caplog.records)
+
+    def test_clean_message_passes_through(self, monkeypatch, tmp_path, caplog):
+        """Non-sensitive message text must pass through unchanged."""
+        import sys
+
+        runner = _bootstrap(monkeypatch, tmp_path)
+
+        event = MessageEvent(
+            text="hello world",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="private",
+                user_id="user123",
+            ),
+            message_id="msg-1",
+        )
+
+        with caplog.at_level(logging.INFO):
+            import asyncio
+
+            async def _test():
+                return await runner._handle_message_with_agent(event, event.source, "test", 1)
+
+            asyncio.run(_test())
+
+        # Verify full message preserved
+        assert any("hello world" in record.message for record in caplog.records)
+
+    def test_forces_redaction_when_globally_disabled(self, monkeypatch, tmp_path, caplog):
+        """force=True must redact even if security.redact_secrets is off."""
+        import sys
+
+        runner = _bootstrap(monkeypatch, tmp_path)
+
+        event = MessageEvent(
+            text=f"token {_FAKE_GHP}",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="private",
+                user_id="user123",
+            ),
+            message_id="msg-1",
+        )
+
+        # Disable global redaction
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False, raising=False)
+
+        with caplog.at_level(logging.INFO):
+            import asyncio
+
+            async def _test():
+                return await runner._handle_message_with_agent(event, event.source, "test", 1)
+
+            asyncio.run(_test())
+
+        # force=True bypasses global setting
+        assert any(_FAKE_GHP not in record.message for record in caplog.records)


### PR DESCRIPTION
## What does this PR do?

When a user pastes credentials (e.g., a Google OAuth `client_secret.json`) into a chat, the gateway logs the inbound message body at INFO level. Without this fix, credentials are written to logs in cleartext and later collected by `hermes debug share`, which uploads the bundle to a public paste service by default. This is a credential leak risk: if a reporter follows the bug report template and uploads the debug bundle without reviewing, live secrets can be exposed publicly.

This fix applies `redact_sensitive_text(force=True)` to the `msg` and `reply_to_text` fields before logging inbound messages. Well-known credential patterns (sk-, ghp_, AIza, ya29., GOCSPX-, PEM blocks, JWTs, etc.) are redacted while preserving non-sensitive context for debugging (platform, user, chat_id, and safe message prefixes).

The `force=True` parameter ensures redaction fires even if the user has `security.redact_secrets: false` in config.yaml, because inbound message logging is a hard secret-egress boundary.

## Related Issue

Fixes #64351

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: Import `redact_sensitive_text` from `agent.redact` (1 line)
- `gateway/run.py`: Apply `redact_sensitive_text(force=True)` to `_msg_preview` and `_reply_txt` before logging (2 lines changed)
- `tests/gateway/test_inbound_message_redaction.py`: New test file with 5 regression tests covering:
  - GitHub PAT redaction in message text
  - OpenAI key redaction in reply text
  - Google OAuth client_secret redaction (issue #64351 case)
  - Clean message preservation
  - Force-redaction behavior when globally disabled

## How to Test

1. Start a gateway (e.g., Telegram) in a clean environment
2. Paste a credential into a chat:
   ```
   My GitHub PAT is ghp_S1...Pn2T (real token)
   ```
3. Check `~/.hermes/logs/gateway.log`
4. **Expected result**: The log shows `inbound message: platform=telegram ... msg='My GitHub PAT is ghp_S1...Pn2T (real token)'` with the credential redacted to a masked form like `ghp_S1...Pn2T`
5. Run `hermes debug share --local` and inspect the output
6. **Expected result**: The bundle contains the redacted log line, not the plaintext credential

### Run test suite

```bash
pytest tests/gateway/test_inbound_message_redaction.py -v
```

All 5 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A