### PR TITLE
fix(shell_hooks): detect and heal _registered desync after plugin reload

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -246,6 +246,18 @@ def register_from_config(
 
     manager = get_plugin_manager()
 
+    # Cross-check _registered against the live PluginManager.  When
+    # discover_and_load(force=True) clears manager._hooks (e.g. during
+    # dashboard re-init, plugin rescan, or mid-process provider refresh),
+    # _registered still carries stale entries and every subsequent
+    # registration becomes a silent no-op — hooks are "registered" in
+    # memory but never fire.  Detect and heal that desync here.
+    with _registered_lock:
+        if _registered:
+            _events = {key[0] for key in _registered}
+            if not any(manager._hooks.get(ev) for ev in _events):
+                _registered.clear()
+
     # Idempotence + allowlist read happen under the lock; the TTY
     # prompt runs outside so other threads aren't parked on a blocking
     # input().  Mutation re-takes the lock with a defensive idempotence


### PR DESCRIPTION
## Problem

When `discover_and_load(force=True)` clears `manager._hooks` (during dashboard re-init, plugin rescan, or mid-process provider refresh), the module-level `_registered` set retains stale entries. Every subsequent call to `register_from_config()` sees the key already in `_registered` and becomes a silent no-op — hooks appear "registered" in memory but never actually fire.

This is a **silent failure** with no warning or error. The only symptom is that shell hooks stop working, which is extremely hard to diagnose.

## Root Cause

`_registered` is a module-level cache in `agent/shell_hooks.py` that tracks `(event, matcher, command)` tuples to prevent duplicate registration. But it has no awareness of the PluginManager lifecycle — when plugins are reloaded and `manager._hooks` is cleared, `_registered` is not.

## Fix

Add a cross-check in `register_from_config()` after obtaining the PluginManager:

```python
with _registered_lock:
    if _registered:
        _events = {key[0] for key in _registered}
        if not any(manager._hooks.get(ev) for ev in _events):
            _registered.clear()
```

If `_registered` has entries but none of their event types exist in `manager._hooks`, clear `_registered` so hooks can be re-registered.

## Testing

- Verified that after `discover_and_load(force=True)`, the next `register_from_config()` successfully re-registers hooks
- Thread-safe: uses existing `_registered_lock`
- No-op in normal operation: only triggers when desync is detected
