### PR TITLE
fix(turn_finalizer): include traceback in on_session_end hook failure log

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -541,6 +541,6 @@ def finalize_turn(
             platform=getattr(agent, "platform", None) or "",
         )
     except Exception as exc:
-        logger.warning("on_session_end hook failed: %s", exc)
+        logger.warning("on_session_end hook failed: %s", exc, exc_info=True)
 
     return result


### PR DESCRIPTION
Add exc_info=True to logger.warning so the full traceback is captured when on_session_end hooks fail.