### PR TITLE
fix(telegram): require getUpdates progress before polling is healthy

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -84,6 +84,7 @@ AUTHOR_MAP = {
     "blueirobin02@gmail.com": "irresi",  # PR #59048 salvage (gateway: scope reset banners' session info to the serving profile; #59003)
     "jashlee+microsoft@microsoft.com": "s905060",  # PR #57943 salvage (photon: auto-reinstall stale sidecar node_modules when lockfile is newer than npm's install marker; #59169)
     "lohinth25@proton.me": "l0h1nth",  # PR #32210 salvage (mattermost: accept leading-space slash commands from mobile clients; #25184)
+    "roseycomanagement@roseyco.co.uk": "arnispiekus",  # PR #63581 salvage (telegram: require getUpdates progress before polling is healthy; #63243)
     "perkintahmaz50@gmail.com": "devatnull",  # PR #58704 salvage (whatsapp: native Baileys polls, clarify-as-poll, location pins, structured quoted replies, PTT/audio split, bridge_helpers extraction)
     "tim@iteachyouai.com": "tjp2021",  # PR #4097 salvage (copilot: per-turn x-initiator header so user prompts bill as premium requests; #3040)
     "39274208+falkoro@users.noreply.github.com": "falkoro",  # PRs #58519/#58520 salvage (config: env-ref-aware load_config cache invalidation; auxiliary: honor auxiliary.<task>.base_url/api_key with explicit provider arg)

--- a/tests/test_telegram_polling_progress_ptb.py
+++ b/tests/test_telegram_polling_progress_ptb.py
@@ -3,8 +3,7 @@
 import asyncio
 
 import pytest
-
-pytest.importorskip("telegram")  # PTB is an optional dependency; skip if absent.
+pytest.importorskip("telegram", reason="python-telegram-bot not installed")
 from telegram.error import Conflict, TelegramError
 from telegram.request import BaseRequest
 


### PR DESCRIPTION
## Summary
Salvage of #63581 (CI blocked for first-time contributor). Makes Telegram polling health depend on successful getUpdates progress rather than get_me() return. PTB's Updater.start_polling() can return after creating its retry task but before the first getUpdates request succeeds — a cold start or reconnect could log "Connected", clear degraded send protection, and remain alive-but-deaf indefinitely.

## Changes
- Instruments only the dedicated PTB get_updates_request (general Bot API calls cannot mark polling healthy).
- Binds every polling start to an immutable generation inherited by PTB child tasks, so late requests from old pollers cannot affect their replacement.
- Routes cold start, network recovery, and conflict recovery through one bounded start primitive + one owned progress verifier.
- Keeps outbound delivery fail-closed while polling is degraded; only matching-generation HTTP 2xx getUpdates progress clears it and resets counters.
- Fences teardown before recovery can re-arm; cancels and awaits recovery/verifier owners.
- Restores correct health/mode transitions for sequential same-adapter webhook reconnects.
- Preserves persistent 409 retry escalation after start_polling() returns; resets counter only after real polling progress.

## Attribution
Cherry-picked from @arnispiekus's #63581 with authorship preserved. Built on top of #63247 (SilentKnight87) which was merged via #64368.

## Validation
- 22 passed in test_telegram_polling_progress.py
- 7 passed in test_telegram_polling_progress_ptb.py (PTB integration, real request objects)
- 51 passed in test_telegram_network_reconnect.py
- 15 passed in test_telegram_conflict.py
- 9 passed in test_telegram_send_path_health.py
- ruff + py_compile clean
- Note: PTB tests must run in separate processes (subprocess-per-file isolation) — cross-file mock leakage causes failures when run in the same process. CI runs them separately.

## AUTHOR_MAP
Added arnispiekus mapping in a separate chore commit (required for check-attribution).
