### PR TITLE
fix(browser): safely reap orphaned Chromium sessions

### DIFF
--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -65,6 +65,82 @@ class TestBrowserCleanup:
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
 
+    def test_explicit_session_forwards_verified_daemon_start_guard(self, tmp_path):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-1",
+            "bb_session_id": None,
+        }
+        socket_dir = tmp_path / "agent-browser-sess-1"
+        socket_dir.mkdir()
+        (socket_dir / "sess-1.pid").write_text("12345")
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True}),
+            patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)),
+            patch("gateway.status._pid_exists", side_effect=[True, False]),
+            patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=777),
+            patch("tools.process_registry.ProcessRegistry._terminate_host_pid") as terminate,
+            patch("tools.browser_tool._reap_session_chromium"),
+            patch("tools.browser_tool._remove_browser_socket_dir_if_safe") as remove_socket,
+        ):
+            browser_tool.cleanup_browser("task-1")
+
+        terminate.assert_called_once_with(12345, expected_start=777)
+        remove_socket.assert_called_once_with(str(socket_dir), "sess-1")
+
+    def test_explicit_session_preserves_metadata_when_daemon_unverifiable(self, tmp_path):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-1",
+            "bb_session_id": None,
+        }
+        socket_dir = tmp_path / "agent-browser-sess-1"
+        socket_dir.mkdir()
+        (socket_dir / "sess-1.pid").write_text("12345")
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True}),
+            patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)),
+            patch("gateway.status._pid_exists", return_value=True),
+            patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=None),
+            patch("tools.process_registry.ProcessRegistry._terminate_host_pid") as terminate,
+            patch("tools.browser_tool._reap_session_chromium"),
+            patch("tools.browser_tool._remove_browser_socket_dir_if_safe") as remove_socket,
+        ):
+            browser_tool.cleanup_browser("task-1")
+
+        terminate.assert_not_called()
+        remove_socket.assert_not_called()
+        assert socket_dir.exists()
+
+    def test_explicit_session_preserves_metadata_when_daemon_survives(self, tmp_path):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-1",
+            "bb_session_id": None,
+        }
+        socket_dir = tmp_path / "agent-browser-sess-1"
+        socket_dir.mkdir()
+        (socket_dir / "sess-1.pid").write_text("12345")
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True}),
+            patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)),
+            patch("gateway.status._pid_exists", side_effect=[True, True]),
+            patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=777),
+            patch("tools.process_registry.ProcessRegistry._terminate_host_pid") as terminate,
+            patch("tools.browser_tool._reap_session_chromium"),
+            patch("tools.browser_tool._remove_browser_socket_dir_if_safe") as remove_socket,
+        ):
+            browser_tool.cleanup_browser("task-1")
+
+        terminate.assert_called_once_with(12345, expected_start=777)
+        remove_socket.assert_not_called()
+        assert socket_dir.exists()
 
     def test_emergency_cleanup_clears_all_tracking_state(self):
         browser_tool = self.browser_tool
@@ -75,10 +151,18 @@ class TestBrowserCleanup:
         browser_tool._session_last_activity["task-2"] = 2.0
         browser_tool._recording_sessions.update({"task-1", "task-2"})
 
-        with patch("tools.browser_tool.cleanup_all_browsers") as mock_cleanup_all:
+        with (
+            patch("tools.browser_tool.cleanup_all_browsers") as mock_cleanup_all,
+            patch("tools.browser_tool._reap_orphaned_browser_chromes") as mock_chrome_reaper,
+            patch("tools.browser_tool._reap_orphaned_browser_sessions") as mock_daemon_reaper,
+        ):
             browser_tool._emergency_cleanup_all_sessions()
 
         mock_cleanup_all.assert_called_once_with()
+        mock_chrome_reaper.assert_called_once_with(
+            min_age_seconds=browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT
+        )
+        mock_daemon_reaper.assert_called_once_with()
         assert browser_tool._active_sessions == {}
         assert browser_tool._session_last_activity == {}
         assert browser_tool._recording_sessions == set()

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -177,9 +177,11 @@ class TestRunBrowserCommandPathConstruction:
 
         assert captured_cmd is not None
         assert captured_cmd[0] == browser_path
-        assert captured_cmd[1:5] == [
+        assert captured_cmd[1:7] == [
             "--session",
             "test-session",
+            "--profile",
+            str(tmp_path / "agent-browser-test-session" / "agent-browser-chrome-test-session"),
             "--json",
             "navigate",
         ]

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -344,9 +344,11 @@ class TestRunBrowserCommandPathConstruction:
 
         assert captured_cmd is not None
         assert captured_cmd[0] == browser_path
-        assert captured_cmd[1:5] == [
+        assert captured_cmd[1:7] == [
             "--session",
             "test-session",
+            "--profile",
+            str(tmp_path / "agent-browser-test-session" / "agent-browser-chrome-test-session"),
             "--json",
             "navigate",
         ]
@@ -404,7 +406,14 @@ class TestRunBrowserCommandPathConstruction:
             "/opt/hermes/node/bin/npx", "--ignore-scripts", "--prefer-offline", "-y",
             AGENT_BROWSER_NPX_SPEC,
         ]
-        assert captured_cmd[5:9] == ["--session", "test-session", "--json", "navigate"]
+        assert captured_cmd[5:11] == [
+            "--session",
+            "test-session",
+            "--profile",
+            str(tmp_path / "agent-browser-test-session" / "agent-browser-chrome-test-session"),
+            "--json",
+            "navigate",
+        ]
 
     def test_subprocess_path_includes_termux_fallback_dirs(self, tmp_path):
         """Termux fallback dirs should survive browser PATH rebuilding."""

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -2,6 +2,9 @@
 daemons whose Python parent exited without cleaning up."""
 
 import os
+import threading
+import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -64,25 +67,22 @@ class TestReapOrphanedBrowserSessions:
     def test_alive_legacy_daemon_is_reaped(self, fake_tmpdir):
         """Alive, untracked, legacy (no owner_pid) daemon is reaped.
 
-        Post-#21561 the liveness probe goes through
-        ``gateway.status._pid_exists`` (which wraps ``psutil.pid_exists``
-        because ``os.kill(pid, 0)`` is a footgun on Windows — bpo-14484).
-        With no owner_pid file and no tracked-name entry, the reaper
-        terminates the daemon (and its process tree) and removes its socket
-        dir regardless of whether termination succeeded (best-effort
-        semantics).
+        The liveness probe uses the cross-platform gateway helper. With no
+        owner_pid and no tracked-name entry, the reaper terminates the verified
+        daemon tree. It removes metadata only after confirming the daemon is
+        gone and no process references the managed profile.
         """
         from tools.browser_tool import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(fake_tmpdir, "h_perm1234567", pid=12345)
-
         terminate_calls = []
 
-        def mock_terminate(pid):
+        def mock_terminate(pid, *, expected_start=None):
+            assert expected_start == 777
             terminate_calls.append(pid)
 
-        with patch("gateway.status._pid_exists", return_value=True), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+        with patch("gateway.status._pid_exists", side_effect=[True, False]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=777), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
@@ -135,6 +135,40 @@ class TestOwnerPidCrossProcess:
         assert 12345 not in kill_calls
         assert d.exists()
 
+    def test_corrupt_owner_pid_is_preserved_fail_closed(self, fake_tmpdir):
+        """Present but corrupt owner metadata is never treated as unowned legacy."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session_name = "h_corrupt_own"
+        d = _make_socket_dir(fake_tmpdir, session_name, pid=12345)
+        (d / f"{session_name}.owner_pid").write_text("not-a-pid")
+        kill_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: kill_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert kill_calls == []
+        assert d.exists()
+
+    def test_partial_owner_pid_fails_closed_even_when_untracked(self, fake_tmpdir):
+        """A concurrent reader seeing partial metadata must not look unowned."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session_name = "h_partial_owner"
+        d = _make_socket_dir(fake_tmpdir, session_name, pid=12345)
+        (d / f"{session_name}.owner_pid").write_text("")
+        terminate_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=777), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert terminate_calls == []
+        assert d.exists()
 
     def test_owner_pid_permission_error_treated_as_alive(self, fake_tmpdir):
         """Owner PID owned by another user → treat as alive.
@@ -165,6 +199,81 @@ class TestOwnerPidCrossProcess:
         assert d.exists()
 
 
+    def test_write_owner_pid_publishes_by_atomic_replace(self, fake_tmpdir):
+        """Readers see the old complete value until the new value is published."""
+        import tools.browser_tool as bt
+
+        session_name = "h_atomic_owner"
+        socket_dir = fake_tmpdir / f"agent-browser-{session_name}"
+        socket_dir.mkdir()
+        owner_file = socket_dir / f"{session_name}.owner_pid"
+        owner_file.write_text("11111")
+        values_seen_at_replace = []
+        real_replace = os.replace
+
+        def observed_replace(src, dst):
+            assert Path(src).parent == socket_dir
+            assert Path(dst).parent == socket_dir
+            values_seen_at_replace.append(owner_file.read_text())
+            real_replace(src, dst)
+
+        with patch("os.replace", side_effect=observed_replace):
+            bt._write_owner_pid(str(socket_dir), session_name)
+
+        assert values_seen_at_replace == ["11111"]
+        assert owner_file.read_text() == str(os.getpid())
+        assert list(socket_dir.glob(f".{session_name}.owner_pid.*")) == []
+
+    def test_concurrent_owner_pid_reader_never_observes_partial_content(
+        self, fake_tmpdir
+    ):
+        import tools.browser_tool as bt
+
+        session_name = "h_concurrent_owner"
+        socket_dir = fake_tmpdir / f"agent-browser-{session_name}"
+        socket_dir.mkdir()
+        owner_file = socket_dir / f"{session_name}.owner_pid"
+        owner_file.write_text("11111")
+        stop = threading.Event()
+        reader_ready = threading.Event()
+        first_read = threading.Event()
+        writes_active = threading.Event()
+        overlapping_read = threading.Event()
+        invalid_values = []
+        read_count = []
+
+        def reader():
+            reader_ready.set()
+            while not stop.is_set():
+                try:
+                    value = owner_file.read_text().strip()
+                except OSError as exc:
+                    invalid_values.append(type(exc).__name__)
+                    continue
+                read_count.append(value)
+                first_read.set()
+                if writes_active.is_set():
+                    overlapping_read.set()
+                if not value.isdigit():
+                    invalid_values.append(value)
+
+        thread = threading.Thread(target=reader)
+        thread.start()
+        assert reader_ready.wait(timeout=1)
+        assert first_read.wait(timeout=1)
+        try:
+            writes_active.set()
+            for _ in range(100):
+                bt._write_owner_pid(str(socket_dir), session_name)
+            assert overlapping_read.wait(timeout=1)
+        finally:
+            stop.set()
+            thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        assert read_count
+        assert invalid_values == []
+
     def test_write_owner_pid_swallows_oserror(self, fake_tmpdir, monkeypatch):
         """OSError (e.g. permission denied) doesn't propagate — the reaper
         falls back to the legacy tracked_names heuristic in that case.
@@ -176,8 +285,9 @@ class TestOwnerPidCrossProcess:
 
         monkeypatch.setattr("builtins.open", raise_oserror)
 
-        # Must not raise
+        # Must not raise or leave a partially published temporary file.
         bt._write_owner_pid(str(fake_tmpdir), "h_readonly123")
+        assert list(fake_tmpdir.glob(".h_readonly123.owner_pid.*")) == []
 
     def test_run_browser_command_calls_write_owner_pid(
         self, fake_tmpdir, monkeypatch
@@ -266,7 +376,8 @@ class TestReaperIdentityGuard:
                 raise psutil.AccessDenied(pid)
             return fake_proc
 
-        with patch("psutil.Process", side_effect=_factory):
+        with patch("gateway.status.get_process_start_time", return_value=777), \
+             patch("psutil.Process", side_effect=_factory):
             return _verify_reapable_browser_daemon(
                 daemon_pid, socket_dir, session_name)
 
@@ -277,7 +388,7 @@ class TestReaperIdentityGuard:
             cmdline=["agent-browser", "open", "--session", "h_sess123456",
                      "--socket-dir", socket_dir],
         )
-        assert self._run(proc, socket_dir) is True
+        assert self._run(proc, socket_dir) == 777
 
     def test_daemon_bound_via_environ_is_reapable(self):
         socket_dir = "/tmp/agent-browser-h_sess123456"
@@ -286,7 +397,7 @@ class TestReaperIdentityGuard:
             cmdline=["agent-browser-linux-x64", "daemon"],  # no dir in cmd
             environ={"AGENT_BROWSER_SOCKET_DIR": socket_dir},
         )
-        assert self._run(proc, socket_dir) is True
+        assert self._run(proc, socket_dir) == 777
 
 
     def test_recycled_pid_browser_not_bound_to_our_dir_is_refused(self):
@@ -303,7 +414,7 @@ class TestReaperIdentityGuard:
             environ={"AGENT_BROWSER_SOCKET_DIR":
                      "/tmp/agent-browser-h_OTHER999"},
         )
-        assert self._run(proc, socket_dir) is False
+        assert self._run(proc, socket_dir) is None
 
 
     def test_planted_pid_survives_full_reaper_path(self, fake_tmpdir):
@@ -321,13 +432,322 @@ class TestReaperIdentityGuard:
         proc = self._FakeProc(name="sleep", cmdline=["/bin/sleep", "600"])
 
         with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status.get_process_start_time", return_value=777), \
              patch("psutil.Process", return_value=proc), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
-                   side_effect=lambda pid: terminate_calls.append(pid)):
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
             _reap_orphaned_browser_sessions()
 
         assert terminate_calls == [], "planted non-browser PID must not be killed"
         assert d.exists(), "socket dir retained for a later sweep"
+
+    def test_verified_daemon_kill_uses_kernel_start_guard(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_guardedkill", pid=12345)
+        terminate_calls = []
+        # First liveness check sees the daemon; the post-kill check sees it gone.
+        with patch("gateway.status._pid_exists", side_effect=[True, False]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon",
+                   return_value=24680), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert terminate_calls == [((12345,), {"expected_start": 24680})]
+        assert not d.exists()
+
+    def test_surviving_daemon_preserves_socket_metadata(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_daemonsurvives", pid=12345)
+        terminate_calls = []
+        with patch("gateway.status._pid_exists", side_effect=[True, True]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon",
+                   return_value=24680), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert terminate_calls == [((12345,), {"expected_start": 24680})]
+        assert d.exists()
+
+
+class TestOrphanedChromiumReaper:
+    """Security boundaries for Hermes-owned managed Chromium profiles."""
+
+    class _FakeProc:
+        def __init__(self, pid, cmdline, *, age=600, parent=None,
+                     name="chrome", username="alex"):
+            self.pid = pid
+            self.info = {
+                "pid": pid,
+                "name": name,
+                "cmdline": cmdline,
+                "create_time": time.time() - age,
+            }
+            self._parent = parent
+            self._username = username
+
+        def parent(self):
+            return self._parent
+
+        def name(self):
+            return self.info["name"]
+
+        def cmdline(self):
+            return self.info["cmdline"]
+
+        def create_time(self):
+            return self.info["create_time"]
+
+        def username(self):
+            return self._username
+
+    def _session(self, tmpdir, session="h_owned"):
+        socket_dir = tmpdir / f"agent-browser-{session}"
+        socket_dir.mkdir()
+        (socket_dir / f"{session}.owner_pid").write_text("999999")
+        profile = socket_dir / f"agent-browser-chrome-{session}"
+        profile.mkdir()
+        return session, socket_dir, profile
+
+    def _chrome(self, profile, *, pid=321, age=600, parent=None,
+                username="alex", extra=None):
+        cmdline = ["/usr/bin/chromium", f"--user-data-dir={profile}", "--headless=new"]
+        if extra:
+            cmdline.extend(extra)
+        return self._FakeProc(pid, cmdline, age=age, parent=parent,
+                              username=username)
+
+    def _process_patches(self, proc, terminated, *, current_user="alex",
+                         survives=False, kernel_start=777):
+        import psutil
+
+        current = self._FakeProc(os.getpid(), ["python"], username=current_user)
+
+        def lookup(pid):
+            if pid == os.getpid():
+                return current
+            if pid == proc.pid:
+                if terminated and not survives:
+                    raise psutil.NoSuchProcess(pid)
+                return proc
+            raise psutil.NoSuchProcess(pid)
+
+        def terminate(pid, *, expected_start=None):
+            assert pid == proc.pid
+            assert expected_start == kernel_start
+            terminated.append(pid)
+
+        def iter_processes(*_args, **_kwargs):
+            if terminated and not survives:
+                return []
+            return [proc]
+
+        return (
+            patch("psutil.process_iter", side_effect=iter_processes),
+            patch("psutil.Process", side_effect=lookup),
+            patch("gateway.status.get_process_start_time", return_value=kernel_start),
+            patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                  side_effect=terminate),
+        )
+
+    def test_exact_dead_owner_session_is_reaped_with_start_guard(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            assert _reap_session_chromium(
+                str(socket_dir), session, min_age_seconds=120
+            ) == 1
+        assert terminated == [proc.pid]
+        assert not profile.exists()
+
+    def test_young_process_is_preserved(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile, age=30)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            assert _reap_session_chromium(
+                str(socket_dir), session, min_age_seconds=120
+            ) == 0
+        assert terminated == []
+        assert profile.exists()
+
+    def test_live_agent_browser_parent_is_preserved(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        parent = self._FakeProc(111, ["agent-browser", "daemon"],
+                                name="agent-browser")
+        proc = self._chrome(profile, parent=parent)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == []
+        assert profile.exists()
+
+    def test_cross_platform_username_mismatch_is_preserved(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile, username="other-user")
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == []
+        assert profile.exists()
+
+    def test_duplicate_user_data_dir_is_rejected(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile, extra=["--user-data-dir=/tmp/other"])
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == []
+        assert profile.exists()
+
+    def test_surviving_same_process_preserves_profile(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(
+            proc, terminated, survives=True
+        )
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == [proc.pid]
+        assert profile.exists()
+
+    def test_symlinked_profile_is_rejected(self, fake_tmpdir):
+        from tools.browser_tool import _managed_chrome_profile
+
+        session = "h_symlink"
+        socket_dir = fake_tmpdir / f"agent-browser-{session}"
+        socket_dir.mkdir()
+        target = fake_tmpdir / "target"
+        target.mkdir()
+        (socket_dir / f"agent-browser-chrome-{session}").symlink_to(
+            target, target_is_directory=True
+        )
+        assert _managed_chrome_profile(str(socket_dir), session) is None
+        assert target.exists()
+
+    def test_unreadable_final_process_scan_preserves_socket(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+
+        class _UnreadableProc:
+            info = {"name": "chromium", "cmdline": None}
+
+        with patch("psutil.process_iter", return_value=[_UnreadableProc()]):
+            assert bt._remove_browser_socket_dir_if_safe(
+                str(socket_dir), session
+            ) is False
+
+        assert socket_dir.exists()
+        assert profile.exists()
+
+    def test_unreadable_unrelated_process_does_not_block_cleanup(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session, socket_dir, _ = self._session(fake_tmpdir)
+
+        class _UnrelatedProc:
+            info = {"name": "sleep", "cmdline": None}
+
+        with patch("psutil.process_iter", return_value=[_UnrelatedProc()]):
+            assert bt._remove_browser_socket_dir_if_safe(
+                str(socket_dir), session
+            ) is True
+
+        assert not socket_dir.exists()
+
+    def test_global_scan_requires_dead_owner_metadata(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session, socket_dir, _ = self._session(fake_tmpdir)
+        calls = []
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch.object(bt, "_reap_session_chromium",
+                          side_effect=lambda *a, **k: calls.append((a, k)) or 0):
+            bt._reap_orphaned_browser_chromes(min_age_seconds=120)
+        assert calls == [((str(socket_dir), session), {"min_age_seconds": 120})]
+
+    def test_global_scan_preserves_live_owner(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        self._session(fake_tmpdir)
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch.object(bt, "_reap_session_chromium") as reap:
+            bt._reap_orphaned_browser_chromes(min_age_seconds=120)
+        reap.assert_not_called()
+
+    def test_dead_daemon_cleanup_preserves_socket_for_bound_young_chromium(
+        self, fake_tmpdir
+    ):
+        """The later daemon sweep may not erase a profile Chrome preserved."""
+        import tools.browser_tool as bt
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        daemon_pid = 4242
+        (socket_dir / f"{session}.pid").write_text(str(daemon_pid))
+        proc = self._chrome(profile, age=30)
+        terminated = []
+        liveness_checks = []
+
+        def pid_exists(pid):
+            liveness_checks.append(pid)
+            return False  # both the Hermes owner and daemon are dead
+
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4, \
+             patch("gateway.status._pid_exists", side_effect=pid_exists):
+            bt._reap_orphaned_browser_chromes(min_age_seconds=120)
+            bt._reap_orphaned_browser_sessions()
+
+        assert terminated == []
+        assert liveness_checks == [999999, 999999, daemon_pid]
+        assert socket_dir.exists()
+        assert profile.exists()
+
+    def test_cleanup_thread_scans_chrome_before_daemon_with_timeout(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_cleanup_running", False)
+        calls = []
+        monkeypatch.setattr(
+            bt, "_reap_orphaned_browser_chromes",
+            lambda *, min_age_seconds: calls.append(("chrome", min_age_seconds)),
+        )
+        monkeypatch.setattr(
+            bt, "_reap_orphaned_browser_sessions",
+            lambda: calls.append(("daemon", None)),
+        )
+        bt._browser_cleanup_thread_worker()
+        assert calls == [
+            ("chrome", bt.BROWSER_SESSION_INACTIVITY_TIMEOUT),
+            ("daemon", None),
+        ]
 
 
 class TestEmergencyCleanupRunsReaper:
@@ -340,18 +760,23 @@ class TestEmergencyCleanupRunsReaper:
         # Reset the _cleanup_done flag so the cleanup actually runs
         monkeypatch.setattr(bt, "_cleanup_done", False)
 
-        reaper_called = []
-        orig_reaper = bt._reap_orphaned_browser_sessions
+        daemon_reaper_called = []
+        chrome_reaper_called = []
+        monkeypatch.setattr(
+            bt,
+            "_reap_orphaned_browser_sessions",
+            lambda: daemon_reaper_called.append(True),
+        )
+        monkeypatch.setattr(
+            bt,
+            "_reap_orphaned_browser_chromes",
+            lambda *, min_age_seconds: chrome_reaper_called.append(
+                min_age_seconds
+            ),
+        )
 
-        def _spy_reaper():
-            reaper_called.append(True)
-            orig_reaper()
-
-        monkeypatch.setattr(bt, "_reap_orphaned_browser_sessions", _spy_reaper)
-
-        # No active sessions — reaper should still run
+        # No active sessions — both isolated reaper hooks should still run.
         bt._emergency_cleanup_all_sessions()
 
-        assert reaper_called, (
-            "Reaper must run on exit even with no active sessions"
-        )
+        assert daemon_reaper_called
+        assert chrome_reaper_called == [bt.BROWSER_SESSION_INACTIVITY_TIMEOUT]

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -2,7 +2,9 @@
 daemons whose Python parent exited without cleaning up."""
 
 import os
+import threading
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -65,25 +67,22 @@ class TestReapOrphanedBrowserSessions:
     def test_alive_legacy_daemon_is_reaped(self, fake_tmpdir):
         """Alive, untracked, legacy (no owner_pid) daemon is reaped.
 
-        Post-#21561 the liveness probe goes through
-        ``gateway.status._pid_exists`` (which wraps ``psutil.pid_exists``
-        because ``os.kill(pid, 0)`` is a footgun on Windows — bpo-14484).
-        With no owner_pid file and no tracked-name entry, the reaper
-        terminates the daemon (and its process tree) and removes its socket
-        dir regardless of whether termination succeeded (best-effort
-        semantics).
+        The liveness probe uses the cross-platform gateway helper. With no
+        owner_pid and no tracked-name entry, the reaper terminates the verified
+        daemon tree. It removes metadata only after confirming the daemon is
+        gone and no process references the managed profile.
         """
         from tools.browser_tool import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(fake_tmpdir, "h_perm1234567", pid=12345)
-
         terminate_calls = []
 
-        def mock_terminate(pid):
+        def mock_terminate(pid, *, expected_start=None):
+            assert expected_start == 777
             terminate_calls.append(pid)
 
-        with patch("gateway.status._pid_exists", return_value=True), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+        with patch("gateway.status._pid_exists", side_effect=[True, False]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=777), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
@@ -136,6 +135,40 @@ class TestOwnerPidCrossProcess:
         assert 12345 not in kill_calls
         assert d.exists()
 
+    def test_corrupt_owner_pid_is_preserved_fail_closed(self, fake_tmpdir):
+        """Present but corrupt owner metadata is never treated as unowned legacy."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session_name = "h_corrupt_own"
+        d = _make_socket_dir(fake_tmpdir, session_name, pid=12345)
+        (d / f"{session_name}.owner_pid").write_text("not-a-pid")
+        kill_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: kill_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert kill_calls == []
+        assert d.exists()
+
+    def test_partial_owner_pid_fails_closed_even_when_untracked(self, fake_tmpdir):
+        """A concurrent reader seeing partial metadata must not look unowned."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session_name = "h_partial_owner"
+        d = _make_socket_dir(fake_tmpdir, session_name, pid=12345)
+        (d / f"{session_name}.owner_pid").write_text("")
+        terminate_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=777), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert terminate_calls == []
+        assert d.exists()
 
     def test_owner_pid_permission_error_treated_as_alive(self, fake_tmpdir):
         """Owner PID owned by another user → treat as alive.
@@ -166,6 +199,81 @@ class TestOwnerPidCrossProcess:
         assert d.exists()
 
 
+    def test_write_owner_pid_publishes_by_atomic_replace(self, fake_tmpdir):
+        """Readers see the old complete value until the new value is published."""
+        import tools.browser_tool as bt
+
+        session_name = "h_atomic_owner"
+        socket_dir = fake_tmpdir / f"agent-browser-{session_name}"
+        socket_dir.mkdir()
+        owner_file = socket_dir / f"{session_name}.owner_pid"
+        owner_file.write_text("11111")
+        values_seen_at_replace = []
+        real_replace = os.replace
+
+        def observed_replace(src, dst):
+            assert Path(src).parent == socket_dir
+            assert Path(dst).parent == socket_dir
+            values_seen_at_replace.append(owner_file.read_text())
+            real_replace(src, dst)
+
+        with patch("os.replace", side_effect=observed_replace):
+            bt._write_owner_pid(str(socket_dir), session_name)
+
+        assert values_seen_at_replace == ["11111"]
+        assert owner_file.read_text() == str(os.getpid())
+        assert list(socket_dir.glob(f".{session_name}.owner_pid.*")) == []
+
+    def test_concurrent_owner_pid_reader_never_observes_partial_content(
+        self, fake_tmpdir
+    ):
+        import tools.browser_tool as bt
+
+        session_name = "h_concurrent_owner"
+        socket_dir = fake_tmpdir / f"agent-browser-{session_name}"
+        socket_dir.mkdir()
+        owner_file = socket_dir / f"{session_name}.owner_pid"
+        owner_file.write_text("11111")
+        stop = threading.Event()
+        reader_ready = threading.Event()
+        first_read = threading.Event()
+        writes_active = threading.Event()
+        overlapping_read = threading.Event()
+        invalid_values = []
+        read_count = []
+
+        def reader():
+            reader_ready.set()
+            while not stop.is_set():
+                try:
+                    value = owner_file.read_text().strip()
+                except OSError as exc:
+                    invalid_values.append(type(exc).__name__)
+                    continue
+                read_count.append(value)
+                first_read.set()
+                if writes_active.is_set():
+                    overlapping_read.set()
+                if not value.isdigit():
+                    invalid_values.append(value)
+
+        thread = threading.Thread(target=reader)
+        thread.start()
+        assert reader_ready.wait(timeout=1)
+        assert first_read.wait(timeout=1)
+        try:
+            writes_active.set()
+            for _ in range(100):
+                bt._write_owner_pid(str(socket_dir), session_name)
+            assert overlapping_read.wait(timeout=1)
+        finally:
+            stop.set()
+            thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        assert read_count
+        assert invalid_values == []
+
     def test_write_owner_pid_swallows_oserror(self, fake_tmpdir, monkeypatch):
         """OSError (e.g. permission denied) doesn't propagate — the reaper
         falls back to the legacy tracked_names heuristic in that case.
@@ -177,8 +285,9 @@ class TestOwnerPidCrossProcess:
 
         monkeypatch.setattr("builtins.open", raise_oserror)
 
-        # Must not raise
+        # Must not raise or leave a partially published temporary file.
         bt._write_owner_pid(str(fake_tmpdir), "h_readonly123")
+        assert list(fake_tmpdir.glob(".h_readonly123.owner_pid.*")) == []
 
     def test_run_browser_command_calls_write_owner_pid(
         self, fake_tmpdir, monkeypatch
@@ -267,7 +376,8 @@ class TestReaperIdentityGuard:
                 raise psutil.AccessDenied(pid)
             return fake_proc
 
-        with patch("psutil.Process", side_effect=_factory):
+        with patch("gateway.status.get_process_start_time", return_value=777), \
+             patch("psutil.Process", side_effect=_factory):
             return _verify_reapable_browser_daemon(
                 daemon_pid, socket_dir, session_name)
 
@@ -278,7 +388,7 @@ class TestReaperIdentityGuard:
             cmdline=["agent-browser", "open", "--session", "h_sess123456",
                      "--socket-dir", socket_dir],
         )
-        assert self._run(proc, socket_dir) is True
+        assert self._run(proc, socket_dir) == 777
 
     def test_daemon_bound_via_environ_is_reapable(self):
         socket_dir = "/tmp/agent-browser-h_sess123456"
@@ -287,7 +397,7 @@ class TestReaperIdentityGuard:
             cmdline=["agent-browser-linux-x64", "daemon"],  # no dir in cmd
             environ={"AGENT_BROWSER_SOCKET_DIR": socket_dir},
         )
-        assert self._run(proc, socket_dir) is True
+        assert self._run(proc, socket_dir) == 777
 
 
     def test_recycled_pid_browser_not_bound_to_our_dir_is_refused(self):
@@ -304,7 +414,7 @@ class TestReaperIdentityGuard:
             environ={"AGENT_BROWSER_SOCKET_DIR":
                      "/tmp/agent-browser-h_OTHER999"},
         )
-        assert self._run(proc, socket_dir) is False
+        assert self._run(proc, socket_dir) is None
 
 
     def test_planted_pid_survives_full_reaper_path(self, fake_tmpdir):
@@ -322,13 +432,322 @@ class TestReaperIdentityGuard:
         proc = self._FakeProc(name="sleep", cmdline=["/bin/sleep", "600"])
 
         with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status.get_process_start_time", return_value=777), \
              patch("psutil.Process", return_value=proc), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
-                   side_effect=lambda pid: terminate_calls.append(pid)):
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
             _reap_orphaned_browser_sessions()
 
         assert terminate_calls == [], "planted non-browser PID must not be killed"
         assert d.exists(), "socket dir retained for a later sweep"
+
+    def test_verified_daemon_kill_uses_kernel_start_guard(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_guardedkill", pid=12345)
+        terminate_calls = []
+        # First liveness check sees the daemon; the post-kill check sees it gone.
+        with patch("gateway.status._pid_exists", side_effect=[True, False]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon",
+                   return_value=24680), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert terminate_calls == [((12345,), {"expected_start": 24680})]
+        assert not d.exists()
+
+    def test_surviving_daemon_preserves_socket_metadata(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_daemonsurvives", pid=12345)
+        terminate_calls = []
+        with patch("gateway.status._pid_exists", side_effect=[True, True]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon",
+                   return_value=24680), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda *args, **kwargs: terminate_calls.append((args, kwargs))):
+            _reap_orphaned_browser_sessions()
+
+        assert terminate_calls == [((12345,), {"expected_start": 24680})]
+        assert d.exists()
+
+
+class TestOrphanedChromiumReaper:
+    """Security boundaries for Hermes-owned managed Chromium profiles."""
+
+    class _FakeProc:
+        def __init__(self, pid, cmdline, *, age=600, parent=None,
+                     name="chrome", username="alex"):
+            self.pid = pid
+            self.info = {
+                "pid": pid,
+                "name": name,
+                "cmdline": cmdline,
+                "create_time": time.time() - age,
+            }
+            self._parent = parent
+            self._username = username
+
+        def parent(self):
+            return self._parent
+
+        def name(self):
+            return self.info["name"]
+
+        def cmdline(self):
+            return self.info["cmdline"]
+
+        def create_time(self):
+            return self.info["create_time"]
+
+        def username(self):
+            return self._username
+
+    def _session(self, tmpdir, session="h_owned"):
+        socket_dir = tmpdir / f"agent-browser-{session}"
+        socket_dir.mkdir()
+        (socket_dir / f"{session}.owner_pid").write_text("999999")
+        profile = socket_dir / f"agent-browser-chrome-{session}"
+        profile.mkdir()
+        return session, socket_dir, profile
+
+    def _chrome(self, profile, *, pid=321, age=600, parent=None,
+                username="alex", extra=None):
+        cmdline = ["/usr/bin/chromium", f"--user-data-dir={profile}", "--headless=new"]
+        if extra:
+            cmdline.extend(extra)
+        return self._FakeProc(pid, cmdline, age=age, parent=parent,
+                              username=username)
+
+    def _process_patches(self, proc, terminated, *, current_user="alex",
+                         survives=False, kernel_start=777):
+        import psutil
+
+        current = self._FakeProc(os.getpid(), ["python"], username=current_user)
+
+        def lookup(pid):
+            if pid == os.getpid():
+                return current
+            if pid == proc.pid:
+                if terminated and not survives:
+                    raise psutil.NoSuchProcess(pid)
+                return proc
+            raise psutil.NoSuchProcess(pid)
+
+        def terminate(pid, *, expected_start=None):
+            assert pid == proc.pid
+            assert expected_start == kernel_start
+            terminated.append(pid)
+
+        def iter_processes(*_args, **_kwargs):
+            if terminated and not survives:
+                return []
+            return [proc]
+
+        return (
+            patch("psutil.process_iter", side_effect=iter_processes),
+            patch("psutil.Process", side_effect=lookup),
+            patch("gateway.status.get_process_start_time", return_value=kernel_start),
+            patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                  side_effect=terminate),
+        )
+
+    def test_exact_dead_owner_session_is_reaped_with_start_guard(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            assert _reap_session_chromium(
+                str(socket_dir), session, min_age_seconds=120
+            ) == 1
+        assert terminated == [proc.pid]
+        assert not profile.exists()
+
+    def test_young_process_is_preserved(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile, age=30)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            assert _reap_session_chromium(
+                str(socket_dir), session, min_age_seconds=120
+            ) == 0
+        assert terminated == []
+        assert profile.exists()
+
+    def test_live_agent_browser_parent_is_preserved(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        parent = self._FakeProc(111, ["agent-browser", "daemon"],
+                                name="agent-browser")
+        proc = self._chrome(profile, parent=parent)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == []
+        assert profile.exists()
+
+    def test_cross_platform_username_mismatch_is_preserved(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile, username="other-user")
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == []
+        assert profile.exists()
+
+    def test_duplicate_user_data_dir_is_rejected(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile, extra=["--user-data-dir=/tmp/other"])
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == []
+        assert profile.exists()
+
+    def test_surviving_same_process_preserves_profile(self, fake_tmpdir):
+        from tools.browser_tool import _reap_session_chromium
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        proc = self._chrome(profile)
+        terminated = []
+        p1, p2, p3, p4 = self._process_patches(
+            proc, terminated, survives=True
+        )
+        with p1, p2, p3, p4:
+            _reap_session_chromium(str(socket_dir), session,
+                                    min_age_seconds=0)
+        assert terminated == [proc.pid]
+        assert profile.exists()
+
+    def test_symlinked_profile_is_rejected(self, fake_tmpdir):
+        from tools.browser_tool import _managed_chrome_profile
+
+        session = "h_symlink"
+        socket_dir = fake_tmpdir / f"agent-browser-{session}"
+        socket_dir.mkdir()
+        target = fake_tmpdir / "target"
+        target.mkdir()
+        (socket_dir / f"agent-browser-chrome-{session}").symlink_to(
+            target, target_is_directory=True
+        )
+        assert _managed_chrome_profile(str(socket_dir), session) is None
+        assert target.exists()
+
+    def test_unreadable_final_process_scan_preserves_socket(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+
+        class _UnreadableProc:
+            info = {"name": "chromium", "cmdline": None}
+
+        with patch("psutil.process_iter", return_value=[_UnreadableProc()]):
+            assert bt._remove_browser_socket_dir_if_safe(
+                str(socket_dir), session
+            ) is False
+
+        assert socket_dir.exists()
+        assert profile.exists()
+
+    def test_unreadable_unrelated_process_does_not_block_cleanup(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session, socket_dir, _ = self._session(fake_tmpdir)
+
+        class _UnrelatedProc:
+            info = {"name": "sleep", "cmdline": None}
+
+        with patch("psutil.process_iter", return_value=[_UnrelatedProc()]):
+            assert bt._remove_browser_socket_dir_if_safe(
+                str(socket_dir), session
+            ) is True
+
+        assert not socket_dir.exists()
+
+    def test_global_scan_requires_dead_owner_metadata(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session, socket_dir, _ = self._session(fake_tmpdir)
+        calls = []
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch.object(bt, "_reap_session_chromium",
+                          side_effect=lambda *a, **k: calls.append((a, k)) or 0):
+            bt._reap_orphaned_browser_chromes(min_age_seconds=120)
+        assert calls == [((str(socket_dir), session), {"min_age_seconds": 120})]
+
+    def test_global_scan_preserves_live_owner(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        self._session(fake_tmpdir)
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch.object(bt, "_reap_session_chromium") as reap:
+            bt._reap_orphaned_browser_chromes(min_age_seconds=120)
+        reap.assert_not_called()
+
+    def test_dead_daemon_cleanup_preserves_socket_for_bound_young_chromium(
+        self, fake_tmpdir
+    ):
+        """The later daemon sweep may not erase a profile Chrome preserved."""
+        import tools.browser_tool as bt
+
+        session, socket_dir, profile = self._session(fake_tmpdir)
+        daemon_pid = 4242
+        (socket_dir / f"{session}.pid").write_text(str(daemon_pid))
+        proc = self._chrome(profile, age=30)
+        terminated = []
+        liveness_checks = []
+
+        def pid_exists(pid):
+            liveness_checks.append(pid)
+            return False  # both the Hermes owner and daemon are dead
+
+        p1, p2, p3, p4 = self._process_patches(proc, terminated)
+        with p1, p2, p3, p4, \
+             patch("gateway.status._pid_exists", side_effect=pid_exists):
+            bt._reap_orphaned_browser_chromes(min_age_seconds=120)
+            bt._reap_orphaned_browser_sessions()
+
+        assert terminated == []
+        assert liveness_checks == [999999, 999999, daemon_pid]
+        assert socket_dir.exists()
+        assert profile.exists()
+
+    def test_cleanup_thread_scans_chrome_before_daemon_with_timeout(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_cleanup_running", False)
+        calls = []
+        monkeypatch.setattr(
+            bt, "_reap_orphaned_browser_chromes",
+            lambda *, min_age_seconds: calls.append(("chrome", min_age_seconds)),
+        )
+        monkeypatch.setattr(
+            bt, "_reap_orphaned_browser_sessions",
+            lambda: calls.append(("daemon", None)),
+        )
+        bt._browser_cleanup_thread_worker()
+        assert calls == [
+            ("chrome", bt.BROWSER_SESSION_INACTIVITY_TIMEOUT),
+            ("daemon", None),
+        ]
 
 
 class TestEmergencyCleanupRunsReaper:
@@ -341,21 +760,26 @@ class TestEmergencyCleanupRunsReaper:
         # Reset the _cleanup_done flag so the cleanup actually runs
         monkeypatch.setattr(bt, "_cleanup_done", False)
 
-        reaper_called = []
-        orig_reaper = bt._reap_orphaned_browser_sessions
+        daemon_reaper_called = []
+        chrome_reaper_called = []
+        monkeypatch.setattr(
+            bt,
+            "_reap_orphaned_browser_sessions",
+            lambda: daemon_reaper_called.append(True),
+        )
+        monkeypatch.setattr(
+            bt,
+            "_reap_orphaned_browser_chromes",
+            lambda *, min_age_seconds: chrome_reaper_called.append(
+                min_age_seconds
+            ),
+        )
 
-        def _spy_reaper():
-            reaper_called.append(True)
-            orig_reaper()
-
-        monkeypatch.setattr(bt, "_reap_orphaned_browser_sessions", _spy_reaper)
-
-        # No active sessions — reaper should still run
+        # No active sessions — both isolated reaper hooks should still run.
         bt._emergency_cleanup_all_sessions()
 
-        assert reaper_called, (
-            "Reaper must run on exit even with no active sessions"
-        )
+        assert daemon_reaper_called
+        assert chrome_reaper_called == [bt.BROWSER_SESSION_INACTIVITY_TIMEOUT]
 
 
 def _age_socket_dir(d, seconds):
@@ -445,10 +869,10 @@ class TestLeakedDaemonWithLiveOwner:
         _age_socket_dir(d, BROWSER_ORPHAN_GRACE_SECONDS + 600)
         kill_calls = []
 
-        with patch("gateway.status._pid_exists", return_value=True), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+        with patch("gateway.status._pid_exists", side_effect=[True, True, False]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=24680), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
-                   side_effect=kill_calls.append):
+                   side_effect=lambda pid, **_kwargs: kill_calls.append(pid)):
             _reap_orphaned_browser_sessions()
 
         assert 12345 in kill_calls
@@ -519,9 +943,9 @@ class TestLeakedDaemonWithLiveOwner:
         kill_calls = []
 
         with patch("gateway.status._pid_exists", return_value=True), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=False), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=None), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
-                   side_effect=kill_calls.append):
+                   side_effect=lambda pid, **_kwargs: kill_calls.append(pid)):
             _reap_orphaned_browser_sessions()
 
         assert 12345 not in kill_calls
@@ -541,6 +965,7 @@ class TestPeriodicOrphanReap:
 
         cycles_to_run = 21
         reap_calls = []
+        chrome_reap_calls = []
         remaining = {"n": cycles_to_run}
 
         def fake_cleanup():
@@ -553,6 +978,10 @@ class TestPeriodicOrphanReap:
         try:
             with patch("tools.browser_tool._reap_orphaned_browser_sessions",
                        side_effect=lambda: reap_calls.append(1)), \
+                 patch("tools.browser_tool._reap_orphaned_browser_chromes",
+                       side_effect=lambda *, min_age_seconds: chrome_reap_calls.append(
+                           min_age_seconds
+                       )), \
                  patch("tools.browser_tool._cleanup_inactive_browser_sessions",
                        side_effect=fake_cleanup), \
                  patch("tools.browser_tool.time.sleep"):
@@ -563,4 +992,6 @@ class TestPeriodicOrphanReap:
         every = max(1, round(bt.BROWSER_ORPHAN_REAP_INTERVAL / 30))
         expected = len([c for c in range(cycles_to_run) if c % every == 0])
         assert len(reap_calls) == expected
+        assert len(chrome_reap_calls) == expected
+        assert set(chrome_reap_calls) == {bt.BROWSER_SESSION_INACTIVITY_TIMEOUT}
         assert len(reap_calls) > 1, "startup-only reap would give exactly 1"

--- a/tests/tools/test_browser_orphan_reaper_integration.py
+++ b/tests/tools/test_browser_orphan_reaper_integration.py
@@ -1,0 +1,114 @@
+"""Linux integration test for the start-time guard on
+``ProcessRegistry._terminate_host_pid``.
+
+Unlike ``tests/tools/test_browser_orphan_reaper.py`` (which mocks the process
+lifecycle), this exercises the REAL start-time revalidation and signaling path
+against a live, disposable child process:
+
+  * a *mismatched* kernel-start fingerprint must never terminate the PID
+    (protection against a recycled PID number landing on an unrelated process), and
+  * a *matching* fingerprint must follow the intended cleanup path.
+"""
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+from tools.process_registry import ProcessRegistry
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason=(
+        "Real-process start-time reaping is /proc-specific "
+        "(get_process_start_time reads /proc/<pid>/stat)"
+    ),
+)
+
+
+@pytest.fixture
+def disposable_child():
+    """Factory yielding real, harmless, long-sleeping child processes.
+
+    Every spawned child is force-killed and reaped on teardown, so no process
+    leaks and no zombie survives even when a test asserts and fails partway.
+    """
+    spawned: list[subprocess.Popen] = []
+
+    def _spawn() -> subprocess.Popen:
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(300)"]
+        )
+        spawned.append(child)
+        # Wait until the kernel has the process registered so /proc start-time
+        # is readable before the test captures the fingerprint.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if ProcessRegistry._is_host_pid_alive(child.pid):
+                break
+            time.sleep(0.02)
+        return child
+
+    yield _spawn
+
+    for child in spawned:
+        try:
+            if child.poll() is None:
+                child.kill()
+        except OSError:
+            pass
+        try:
+            child.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _wait_terminated(child: subprocess.Popen, timeout: float = 5.0) -> bool:
+    """Return True once the child has exited, else False at timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if child.poll() is not None:
+            return True
+        time.sleep(0.05)
+    return child.poll() is not None
+
+
+def test_matching_start_time_terminates_child(disposable_child):
+    """A matching kernel-start fingerprint follows the cleanup path and kills it."""
+    child = disposable_child()
+    real = ProcessRegistry._safe_host_start_time(child.pid)
+    assert real is not None  # sanity: procfs handed us a real fingerprint
+
+    ProcessRegistry._terminate_host_pid(child.pid, expected_start=real)
+
+    assert _wait_terminated(child), (
+        "matching fingerprint must terminate the child via the cleanup path"
+    )
+
+
+def test_mismatched_start_time_refuses_to_terminate(disposable_child):
+    """A mismatched fingerprint must never signal the PID (recycled-PID guard)."""
+    child = disposable_child()
+    real = ProcessRegistry._safe_host_start_time(child.pid)
+    assert real is not None
+
+    # ``real + 1`` is guaranteed different: a process's /proc start-time is fixed
+    # for its whole lifetime, so this can never collide with the true value.
+    ProcessRegistry._terminate_host_pid(child.pid, expected_start=real + 1)
+
+    assert child.poll() is None, "a mismatched fingerprint must NOT signal the child"
+    time.sleep(0.3)
+    assert child.poll() is None, (
+        "child must still be alive after a beat — no signal was sent"
+    )
+
+
+def test_identity_helper_matches_real_and_rejects_wrong(disposable_child):
+    """``_host_pid_is_ours`` accepts the true fingerprint and rejects a wrong one."""
+    child = disposable_child()
+    real = ProcessRegistry._safe_host_start_time(child.pid)
+    assert real is not None
+
+    assert ProcessRegistry._host_pid_is_ours(child.pid, real) is True
+    assert ProcessRegistry._host_pid_is_ours(child.pid, real + 1) is False

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1738,6 +1738,9 @@ def _emergency_cleanup_all_sessions():
     # never used the browser — uses owner_pid liveness to avoid reaping
     # daemons owned by other live hermes processes.
     try:
+        _reap_orphaned_browser_chromes(
+            min_age_seconds=BROWSER_SESSION_INACTIVITY_TIMEOUT
+        )
         _reap_orphaned_browser_sessions()
     except Exception as e:
         logger.debug("Orphan reap on exit failed: %s", e)
@@ -1793,44 +1796,38 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
     an OSError here just falls back to the legacy ``tracked_names``
     heuristic in the reaper.
     """
+    temp_path: Optional[str] = None
     try:
         path = os.path.join(socket_dir, f"{session_name}.owner_pid")
-        with open(path, "w", encoding="utf-8") as f:
+        fd, temp_path = tempfile.mkstemp(
+            prefix=f".{session_name}.owner_pid.", dir=socket_dir
+        )
+        os.close(fd)
+        with open(temp_path, "w", encoding="utf-8") as f:
             f.write(str(os.getpid()))
+            f.flush()
+        os.replace(temp_path, path)
+        temp_path = None
     except OSError as exc:
         logger.debug("Could not write owner_pid file for %s: %s",
                      session_name, exc)
+    finally:
+        if temp_path is not None:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
 
 
 def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
-                                    session_name: str) -> bool:
-    """Confirm a live PID is genuinely *this* session's agent-browser daemon.
+                                    session_name: str) -> Optional[int]:
+    """Return a verified daemon kernel-start fingerprint, or fail closed.
 
-    The orphan reaper scans world-writable, predictably-named temp paths
-    (``/tmp/agent-browser-h_*`` etc.) and reads a daemon PID from a ``.pid``
-    file we do not write ourselves — the agent-browser daemon writes it.  A
-    same-user actor can therefore plant a fake socket dir whose ``.pid`` points
-    at an arbitrary victim process, or a recycled PID can land on an unrelated
-    process after the real daemon exits.  Either way, terminating that PID
-    (a *tree* kill via ``_terminate_host_pid``) is an arbitrary-process DoS.
-
-    Before reaping we require, via ``psutil`` (a hard dependency, cross-platform
-    for same-user processes — the only processes the reaper can signal):
-
-      1. **Identity** — the process looks like agent-browser: ``agent-browser``
-         appears in its name or command line.
-      2. **Binding** — the process is bound to *this* session's socket dir: the
-         socket dir path (or its basename) appears in the command line, or in
-         ``AGENT_BROWSER_SOCKET_DIR`` in the process environment.
-
-    Requirement (2) is the real spoof defense: a planted process pointing at a
-    victim PID will not have the victim's cmdline/environ referencing our
-    socket dir.  An attacker would need a process that genuinely embeds this
-    exact session path — i.e. a real daemon they already own and could signal
-    directly.  Fail-closed: any ambiguity (unreadable cmdline, no match) means
-    we refuse to reap and leave the process and its socket dir alone.
-
-    Returns ``True`` only when both checks pass.
+    The PID comes from metadata inside a predictable temporary directory. A
+    planted file or PID reuse must never turn the tree-termination helper into
+    an arbitrary-process kill. Capture the kernel start time before inspecting
+    identity, require an agent-browser process bound to this exact socket
+    directory, and return the fingerprint for revalidation at signal time.
     """
     try:
         import psutil
@@ -1839,30 +1836,33 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
             "Refusing to reap browser daemon PID %d (session %s): "
             "psutil unavailable for identity verification",
             daemon_pid, session_name)
-        return False
+        return None
+
+    from gateway.status import get_process_start_time
+    expected_start = get_process_start_time(daemon_pid)
+    if expected_start is None:
+        return None
 
     try:
         proc = psutil.Process(daemon_pid)
         name = (proc.name() or "").lower()
         cmdline = " ".join(proc.cmdline() or []).lower()
     except psutil.NoSuchProcess:
-        # Vanished between the liveness check and now — nothing to reap.
-        return False
+        return None
     except (psutil.AccessDenied, OSError) as exc:
         logger.warning(
             "Refusing to reap browser daemon PID %d (session %s): "
             "could not read process identity (%s)",
             daemon_pid, session_name, exc)
-        return False
+        return None
 
     looks_like_browser = "agent-browser" in name or "agent-browser" in cmdline
     if not looks_like_browser:
         logger.warning(
             "Refusing to reap PID %d (session %s): not an agent-browser "
             "process (name=%r)", daemon_pid, session_name, name)
-        return False
+        return None
 
-    # Binding check: the live process must reference *this* socket dir.
     socket_dir_l = socket_dir.lower()
     socket_base_l = os.path.basename(socket_dir).lower()
     bound = socket_dir_l in cmdline or (
@@ -1874,8 +1874,6 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
             bound = bool(env_dir) and os.path.normpath(env_dir) == \
                 os.path.normpath(socket_dir)
         except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
-            # environ() can be denied even same-user on some platforms.
-            # cmdline already failed to bind — fail closed.
             bound = False
 
     if not bound:
@@ -1883,9 +1881,9 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
             "Refusing to reap agent-browser PID %d: not bound to session "
             "socket dir %s (possible recycled PID or planted pid file)",
             daemon_pid, socket_dir)
-        return False
+        return None
 
-    return True
+    return expected_start
 
 
 def _socket_dir_idle_seconds(socket_dir: str) -> Optional[float]:
@@ -1974,101 +1972,368 @@ def _reap_orphaned_browser_sessions():
         if not session_name:
             continue
 
-        # Ownership check: prefer owner_pid file (cross-process safe).
+        # Present-but-unreadable metadata fails closed. Only a genuinely absent
+        # owner file may use the legacy in-process fallback.
         owner_pid_file = os.path.join(socket_dir, f"{session_name}.owner_pid")
+        owner_metadata_present = os.path.lexists(owner_pid_file)
         owner_pid: Optional[int] = None
-        owner_alive: Optional[bool] = None  # None = owner_pid missing/unreadable
-        if os.path.isfile(owner_pid_file):
+        owner_alive: Optional[bool] = None
+        if owner_metadata_present:
+            if os.path.islink(owner_pid_file) or not os.path.isfile(owner_pid_file):
+                continue
             try:
                 owner_pid = int(Path(owner_pid_file).read_text(encoding="utf-8").strip())
-                # ``os.kill(pid, 0)`` is NOT a no-op on Windows (bpo-14484).
-                # Use the cross-platform existence check.
+                if owner_pid <= 0:
+                    raise ValueError("owner PID must be positive")
                 from gateway.status import _pid_exists
                 owner_alive = _pid_exists(owner_pid)
             except (ValueError, OSError):
-                owner_pid = None
-                owner_alive = None  # corrupt file — fall through
+                # Present-but-corrupt metadata is ambiguous, not legacy.
+                continue
 
         if owner_alive is True:
-            # Owner is alive.  Normally that means the session belongs to a
-            # live hermes process and must not be touched — but "owner alive"
-            # alone made leaked daemons immortal: if the owner lost its
-            # in-memory tracking (any exception path between spawn and
-            # registration), nothing would ever reap the daemon, and the
-            # daemon-side AGENT_BROWSER_IDLE_TIMEOUT_MS does not fire when the
-            # daemon itself is wedged (e.g. Chrome's framework was swapped out
-            # from under it by an auto-update).
-            #
-            # So: still trust live tracking, but fall back to idle age.
+            # Owner is alive. Normally that means the session belongs to a
+            # live Hermes process and must not be touched, but a daemon that
+            # fell out of that process's in-memory tracking would otherwise
+            # become immortal. Preserve tracked/fresh/unknown-age sessions and
+            # allow only an untracked daemon beyond the large grace window to
+            # continue through the full identity and PID-start guards below.
             if session_name in tracked_names:
                 continue
 
             idle_s = _socket_dir_idle_seconds(socket_dir)
             if idle_s is None or idle_s < BROWSER_ORPHAN_GRACE_SECONDS:
-                # Unknown age, or still within the grace window — fail safe.
                 continue
 
             logger.warning(
                 "Browser session %s has a live owner (PID %s) but is untracked "
                 "and idle for %ds (grace %ds) — treating as leaked and reaping",
                 session_name, owner_pid, int(idle_s),
-                BROWSER_ORPHAN_GRACE_SECONDS)
-            # fall through to the reap path below
+                BROWSER_ORPHAN_GRACE_SECONDS,
+            )
+        elif not owner_metadata_present and session_name in tracked_names:
+            # Only genuinely absent metadata may use this legacy fallback.
+            continue
 
-        if owner_alive is None:
-            # No owner_pid file (legacy daemon).  Fall back to in-process
-            # tracking: if this process knows about the session, leave alone.
-            if session_name in tracked_names:
-                continue
-
-        # owner_alive is False (dead owner) OR legacy daemon not tracked here.
+        # The owner is dead, or this is an untracked legacy session.
         pid_file = os.path.join(socket_dir, f"{session_name}.pid")
         if not os.path.isfile(pid_file):
-            # No daemon PID file — just a stale dir, remove it
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            _remove_browser_socket_dir_if_safe(socket_dir, session_name)
             continue
 
         try:
             daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
         except (ValueError, OSError):
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            _remove_browser_socket_dir_if_safe(socket_dir, session_name)
             continue
 
-        # Check if the daemon is still alive. ``os.kill(pid, 0)`` on Windows
-        # is NOT a no-op — use the handle-based existence check.
         from gateway.status import _pid_exists
         if not _pid_exists(daemon_pid):
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            _remove_browser_socket_dir_if_safe(socket_dir, session_name)
             continue
 
-        # The PID is live — but the .pid file lives in a world-writable,
-        # predictably-named temp dir we don't write ourselves, and PIDs get
-        # recycled after the real daemon exits.  Verify the process really is
-        # *this* session's agent-browser daemon before tree-killing it; refuse
-        # otherwise (don't touch the process, leave the socket dir for a later
-        # sweep once the imposter PID is gone).  Fixes the arbitrary same-user
-        # process DoS in issue #14073.
-        if not _verify_reapable_browser_daemon(
-                daemon_pid, socket_dir, session_name):
+        expected_start = _verify_reapable_browser_daemon(
+            daemon_pid, socket_dir, session_name
+        )
+        if expected_start is None:
             continue
 
-        # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.
-        # Use the process-tree termination helper so Chromium children
-        # (renderer, GPU, etc.) are cleaned up, not just the daemon parent.
         try:
             from tools.process_registry import ProcessRegistry
-            ProcessRegistry._terminate_host_pid(daemon_pid)
-            logger.info("Reaped orphaned browser daemon PID %d (session %s)",
-                        daemon_pid, session_name)
-            reaped += 1
-        except (ProcessLookupError, PermissionError, OSError):
+            ProcessRegistry._terminate_host_pid(
+                daemon_pid, expected_start=expected_start
+            )
+        except ProcessLookupError:
             pass
+        except (PermissionError, OSError):
+            continue
 
-        # Clean up the socket directory
-        shutil.rmtree(socket_dir, ignore_errors=True)
+        # The termination helper may refuse a recycled PID without raising.
+        # Revalidate liveness before deleting the discovery metadata/profile.
+        if _pid_exists(daemon_pid):
+            logger.warning(
+                "Browser daemon PID %d survived cleanup; preserving socket dir %s",
+                daemon_pid, socket_dir,
+            )
+            continue
+
+        logger.info("Reaped orphaned browser daemon PID %d (session %s)",
+                    daemon_pid, session_name)
+        reaped += 1
+        _remove_browser_socket_dir_if_safe(socket_dir, session_name)
 
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)
+
+
+def _managed_chrome_profile(socket_dir: str, session_name: str) -> Optional[Path]:
+    """Return this Hermes session's managed Chromium profile path.
+
+    New local sessions pass this path through agent-browser's official
+    ``--profile`` option.  Keeping the profile beneath the unique, mode-0700
+    Hermes socket directory gives cleanup a durable ownership binding even if
+    both the CLI and daemon disappear before Chromium exits.
+    """
+    try:
+        socket_path = Path(socket_dir)
+        temp_root = Path(_socket_safe_tmpdir()).resolve(strict=False)
+        if socket_path.is_symlink():
+            return None
+        resolved_socket = socket_path.resolve(strict=False)
+        if resolved_socket.parent != temp_root:
+            return None
+        if resolved_socket.name != f"agent-browser-{session_name}":
+            return None
+        profile = resolved_socket / f"agent-browser-chrome-{session_name}"
+        if profile.is_symlink():
+            return None
+        if profile.resolve(strict=False).parent != resolved_socket:
+            return None
+        return profile
+    except (OSError, RuntimeError):
+        return None
+
+
+def _managed_profile_in_use(profile: Path) -> bool:
+    """Return whether any process still names *profile*; ambiguity preserves it."""
+    try:
+        import psutil
+        processes = psutil.process_iter(["name", "cmdline"])
+    except Exception:
+        return True
+
+    try:
+        for proc in processes:
+            raw_cmdline = proc.info.get("cmdline")
+            if raw_cmdline is None:
+                name = str(proc.info.get("name") or "").lower()
+                if not name or any(
+                    marker in name
+                    for marker in ("chrome", "chromium", "agent-browser")
+                ):
+                    return True
+                continue
+            cmdline = [str(arg) for arg in raw_cmdline]
+            try:
+                if any(
+                    Path(value).expanduser().resolve(strict=False) == profile
+                    for value in _cmdline_profile_values(cmdline)
+                ):
+                    return True
+            except (OSError, RuntimeError):
+                continue
+    except Exception:
+        return True
+    return False
+
+
+def _remove_browser_socket_dir_if_safe(socket_dir: str, session_name: str) -> bool:
+    """Remove session metadata only when no process still references its profile."""
+    profile = _managed_chrome_profile(socket_dir, session_name)
+    if profile is None or _managed_profile_in_use(profile):
+        logger.warning(
+            "Preserving browser socket dir %s: managed profile may still be in use",
+            socket_dir,
+        )
+        return False
+    try:
+        shutil.rmtree(socket_dir)
+    except OSError as exc:
+        logger.warning("Could not remove browser socket dir %s: %s", socket_dir, exc)
+        return False
+    return not os.path.exists(socket_dir)
+
+
+def _cmdline_profile_values(cmdline: List[str]) -> List[str]:
+    values: List[str] = []
+    for index, arg in enumerate(cmdline):
+        if arg.startswith("--user-data-dir="):
+            values.append(arg.split("=", 1)[1])
+        elif arg == "--user-data-dir" and index + 1 < len(cmdline):
+            values.append(cmdline[index + 1])
+    return values
+
+
+def _cmdline_uses_profile(cmdline: List[str], expected_profile: Path) -> bool:
+    """Require exactly one user-data-dir and bind it to *expected_profile*."""
+    values = _cmdline_profile_values(cmdline)
+    if len(values) != 1:
+        return False
+    try:
+        if expected_profile.is_symlink():
+            return False
+        return Path(values[0]).expanduser().resolve(strict=False) == expected_profile
+    except (OSError, RuntimeError):
+        return False
+
+
+def _has_live_agent_browser_ancestor(proc: Any) -> bool:
+    """Return True when *proc* is still owned by a live agent-browser daemon.
+
+    Fail closed: an unreadable ancestor is treated as live so cleanup never
+    kills a browser tree whose ownership cannot be established.
+    """
+    try:
+        parent = proc.parent()
+        for _ in range(8):
+            if parent is None:
+                return False
+            name = (parent.name() or "").lower()
+            cmdline = [str(arg) for arg in (parent.cmdline() or [])]
+            executable_args = [os.path.basename(arg).lower() for arg in cmdline[:2]]
+            if "agent-browser" in name or any(
+                "agent-browser" in arg for arg in executable_args
+            ):
+                return True
+            parent = parent.parent()
+    except Exception:
+        return True
+    return False
+
+
+def _reap_session_chromium(
+    socket_dir: str, session_name: str, *, min_age_seconds: float
+) -> int:
+    """Reap only Chromium bound to one positively-owned Hermes session.
+
+    Identity, username, start time, command line, profile path, and ancestry are
+    revalidated immediately before termination.  Any ambiguity fails closed.
+    """
+    try:
+        import psutil
+    except ImportError:
+        logger.warning("Cannot scan managed Chromium processes: psutil unavailable")
+        return 0
+
+    profile = _managed_chrome_profile(socket_dir, session_name)
+    if profile is None:
+        return 0
+    try:
+        current_username = psutil.Process(os.getpid()).username()
+    except Exception:
+        return 0
+
+    now = time.time()
+    reaped = 0
+    try:
+        processes = psutil.process_iter(["pid", "name", "cmdline", "create_time"])
+    except Exception as exc:
+        logger.debug("Could not enumerate managed Chromium processes: %s", exc)
+        return 0
+
+    for proc in processes:
+        try:
+            info = proc.info
+            pid = int(info["pid"])
+            cmdline = [str(arg) for arg in (info.get("cmdline") or [])]
+            name = str(info.get("name") or "").lower()
+            executable = os.path.basename(cmdline[0]).lower() if cmdline else ""
+            if not ("chrome" in name or "chromium" in name or
+                    "chrome" in executable or "chromium" in executable):
+                continue
+            if any(arg.startswith("--type=") for arg in cmdline):
+                continue
+            if not _cmdline_uses_profile(cmdline, profile):
+                # Ambiguous/duplicate flags are never killable, but if any value
+                # resolves to our profile the directory is still in use and must
+                # not be removed as stale.
+                continue
+
+            expected_start = float(info.get("create_time") or 0.0)
+            if expected_start <= 0 or now - expected_start < max(float(min_age_seconds), 0.0):
+                continue
+            from gateway.status import get_process_start_time
+            expected_kernel_start = get_process_start_time(pid)
+            if expected_kernel_start is None:
+                continue
+            if proc.username() != current_username:
+                continue
+            if _has_live_agent_browser_ancestor(proc):
+                continue
+
+            # Kill-boundary revalidation protects against PID reuse and path
+            # replacement between enumeration and termination.
+            current = psutil.Process(pid)
+            if abs(float(current.create_time()) - expected_start) > 0.001:
+                continue
+            if current.username() != current_username:
+                continue
+            current_cmdline = [str(arg) for arg in (current.cmdline() or [])]
+            if not _cmdline_uses_profile(current_cmdline, profile):
+                continue
+            if _has_live_agent_browser_ancestor(current):
+                continue
+
+            from tools.process_registry import ProcessRegistry
+            ProcessRegistry._terminate_host_pid(
+                pid, expected_start=expected_kernel_start
+            )
+
+            try:
+                survivor = psutil.Process(pid)
+                if abs(float(survivor.create_time()) - expected_start) <= 0.001:
+                    logger.warning(
+                        "Managed Chromium PID %d survived cleanup; preserving profile %s",
+                        pid, profile.name,
+                    )
+                    continue
+            except psutil.NoSuchProcess:
+                pass
+
+            logger.info(
+                "Reaped orphaned managed Chromium PID %d (session %s)",
+                pid, session_name,
+            )
+            reaped += 1
+        except Exception:
+            continue
+
+    # Re-scan after all termination attempts. Any process role that still names
+    # the profile (root, renderer, GPU, or ambiguous duplicate flags) preserves
+    # it; profile deletion is a single postcondition, never a per-PID side effect.
+    profile_in_use = _managed_profile_in_use(profile)
+
+    if not profile_in_use and profile.exists() and not profile.is_symlink():
+        try:
+            profile_age = now - profile.stat().st_mtime
+            if reaped or profile_age >= max(float(min_age_seconds), 0.0):
+                shutil.rmtree(profile)
+            if profile.exists():
+                logger.warning("Managed profile still exists after cleanup: %s", profile)
+        except OSError as exc:
+            logger.warning("Could not remove stale managed profile %s: %s", profile, exc)
+    return reaped
+
+
+def _reap_orphaned_browser_chromes(*, min_age_seconds: float) -> None:
+    """Reap stale Chromium only from dead-owner Hermes socket directories."""
+    import glob
+
+    reaped = 0
+    tmpdir = _socket_safe_tmpdir()
+    patterns = ["agent-browser-h_*", "agent-browser-cdp_*", "agent-browser-hermes_*"]
+    for pattern in patterns:
+        for socket_dir in glob.glob(os.path.join(tmpdir, pattern)):
+            session_name = os.path.basename(socket_dir).removeprefix("agent-browser-")
+            if not session_name:
+                continue
+            owner_file = Path(socket_dir) / f"{session_name}.owner_pid"
+            # Managed Chromium ownership was introduced with owner_pid metadata.
+            # Legacy/unreadable directories are not safe enough to process-kill.
+            if not owner_file.is_file() or owner_file.is_symlink():
+                continue
+            try:
+                owner_pid = int(owner_file.read_text(encoding="utf-8").strip())
+                from gateway.status import _pid_exists
+                if _pid_exists(owner_pid):
+                    continue
+            except (OSError, ValueError):
+                continue
+            reaped += _reap_session_chromium(
+                socket_dir, session_name, min_age_seconds=min_age_seconds
+            )
+    if reaped:
+        logger.info("Reaped %d orphaned managed Chromium tree(s)", reaped)
 
 
 def _browser_cleanup_thread_worker():
@@ -2088,10 +2353,23 @@ def _browser_cleanup_thread_worker():
     reap_every_cycles = max(1, round(BROWSER_ORPHAN_REAP_INTERVAL / 30))
     cycle = 0
 
+    # Run once even when the loop is being invoked only for startup/exit tests,
+    # then repeat on the interval for long-lived Hermes processes.
+    try:
+        _reap_orphaned_browser_chromes(
+            min_age_seconds=BROWSER_SESSION_INACTIVITY_TIMEOUT
+        )
+        _reap_orphaned_browser_sessions()
+    except Exception as e:
+        logger.warning("Orphan reap error: %s", e)
+
     while _cleanup_running:
-        # cycle 0 is the startup reap; then every reap_every_cycles.
-        if cycle % reap_every_cycles == 0:
+        # The startup pass ran above; repeat both scanners after each interval.
+        if cycle > 0 and cycle % reap_every_cycles == 0:
             try:
+                _reap_orphaned_browser_chromes(
+                    min_age_seconds=BROWSER_SESSION_INACTIVITY_TIMEOUT
+                )
                 _reap_orphaned_browser_sessions()
             except Exception as e:
                 logger.warning("Orphan reap error: %s", e)
@@ -2839,6 +3117,16 @@ def _run_browser_command(
         logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
 
+    # Give each task its own socket directory to prevent concurrency conflicts.
+    # The managed Chromium profile lives beneath that same unique directory, so
+    # session-end and crash recovery never need a host-global Chrome scan.
+    task_socket_dir = os.path.join(
+        _socket_safe_tmpdir(),
+        f"agent-browser-{session_info['session_name']}"
+    )
+    os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
+    browser_env = _build_browser_env()
+
     # Build the command with the appropriate backend flag.
     # Cloud mode: --cdp <websocket_url> connects to Browserbase.
     # Local mode: --session <name> launches a local headless Chromium.
@@ -2849,10 +3137,19 @@ def _run_browser_command(
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
     else:
-        # Local mode — launch Chromium (headless by default, headed when configured)
+        # Local mode — launch Chromium (headless by default, headed when configured).
+        # Respect an explicit persistent user profile; otherwise use a
+        # Hermes-owned ephemeral profile under this session's socket directory.
         backend_args = ["--session", session_info["session_name"]]
         if _is_headed_mode():
             backend_args.append("--headed")
+        if not browser_env.get("AGENT_BROWSER_PROFILE"):
+            managed_profile = _managed_chrome_profile(
+                task_socket_dir, session_info["session_name"]
+            )
+            if managed_profile is not None:
+                backend_args += ["--profile", str(managed_profile)]
+                session_info["managed_chrome_profile"] = str(managed_profile)
 
     # Lightpanda engine injection (local mode only, agent-browser v0.25.3+).
     # Use the resolved session backend rather than global cloud-provider state:
@@ -2880,21 +3177,11 @@ def _run_browser_command(
     ] + args
 
     try:
-        # Give each task its own socket directory to prevent concurrency conflicts.
-        # Without this, parallel workers fight over the same default socket path,
-        # causing "Failed to create socket directory: Permission denied" errors.
-        task_socket_dir = os.path.join(
-            _socket_safe_tmpdir(),
-            f"agent-browser-{session_info['session_name']}"
-        )
-        os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
         # Record this hermes PID as the session owner (cross-process safe
         # orphan detection — see _write_owner_pid).
         _write_owner_pid(task_socket_dir, session_info['session_name'])
         logger.debug("browser cmd=%s task=%s socket_dir=%s (%d chars)",
                      command, task_id, task_socket_dir, len(task_socket_dir))
-
-        browser_env = _build_browser_env()
 
         # Ensure subprocesses inherit the same browser-specific PATH fallbacks
         # used during CLI discovery.
@@ -4991,22 +5278,53 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                 except Exception as e:
                     logger.warning("Could not close cloud browser session: %s", e)
 
-        # Kill the daemon process and clean up socket directory
+        # Kill only this session's verified daemon, then reap only the Chromium
+        # bound to this session's managed profile before removing its directory.
         session_name = session_info.get("session_name", "")
         if session_name:
             socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{session_name}")
             if os.path.exists(socket_dir):
-                # agent-browser writes {session}.pid in the socket dir
                 pid_file = os.path.join(socket_dir, f"{session_name}.pid")
-                if os.path.isfile(pid_file):
+                daemon_gone = not os.path.isfile(pid_file)
+                if not daemon_gone:
                     try:
+                        from gateway.status import _pid_exists
                         from tools.process_registry import ProcessRegistry
                         daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
-                        ProcessRegistry._terminate_host_pid(daemon_pid)
-                        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
-                    except (ProcessLookupError, ValueError, PermissionError, OSError):
-                        logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
-                shutil.rmtree(socket_dir, ignore_errors=True)
+                        if not _pid_exists(daemon_pid):
+                            daemon_gone = True
+                        else:
+                            expected_start = _verify_reapable_browser_daemon(
+                                daemon_pid, socket_dir, session_name
+                            )
+                            if expected_start is not None:
+                                ProcessRegistry._terminate_host_pid(
+                                    daemon_pid, expected_start=expected_start
+                                )
+                                daemon_gone = not _pid_exists(daemon_pid)
+                                if daemon_gone:
+                                    logger.debug(
+                                        "Killed verified daemon pid %s for %s",
+                                        daemon_pid, session_name,
+                                    )
+                    except ProcessLookupError:
+                        daemon_gone = True
+                    except (ValueError, PermissionError, OSError):
+                        logger.debug(
+                            "Could not kill daemon pid for %s (revalidation failed)",
+                            session_name,
+                        )
+
+                _reap_session_chromium(
+                    socket_dir, session_name, min_age_seconds=0
+                )
+                if daemon_gone:
+                    _remove_browser_socket_dir_if_safe(socket_dir, session_name)
+                else:
+                    logger.warning(
+                        "Preserving browser socket dir %s because its daemon may survive",
+                        socket_dir,
+                    )
 
         logger.debug("Removed task %s from active sessions", task_id)
     else:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1601,6 +1601,9 @@ def _emergency_cleanup_all_sessions():
     # never used the browser — uses owner_pid liveness to avoid reaping
     # daemons owned by other live hermes processes.
     try:
+        _reap_orphaned_browser_chromes(
+            min_age_seconds=BROWSER_SESSION_INACTIVITY_TIMEOUT
+        )
         _reap_orphaned_browser_sessions()
     except Exception as e:
         logger.debug("Orphan reap on exit failed: %s", e)
@@ -1656,44 +1659,38 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
     an OSError here just falls back to the legacy ``tracked_names``
     heuristic in the reaper.
     """
+    temp_path: Optional[str] = None
     try:
         path = os.path.join(socket_dir, f"{session_name}.owner_pid")
-        with open(path, "w", encoding="utf-8") as f:
+        fd, temp_path = tempfile.mkstemp(
+            prefix=f".{session_name}.owner_pid.", dir=socket_dir
+        )
+        os.close(fd)
+        with open(temp_path, "w", encoding="utf-8") as f:
             f.write(str(os.getpid()))
+            f.flush()
+        os.replace(temp_path, path)
+        temp_path = None
     except OSError as exc:
         logger.debug("Could not write owner_pid file for %s: %s",
                      session_name, exc)
+    finally:
+        if temp_path is not None:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
 
 
 def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
-                                    session_name: str) -> bool:
-    """Confirm a live PID is genuinely *this* session's agent-browser daemon.
+                                    session_name: str) -> Optional[int]:
+    """Return a verified daemon kernel-start fingerprint, or fail closed.
 
-    The orphan reaper scans world-writable, predictably-named temp paths
-    (``/tmp/agent-browser-h_*`` etc.) and reads a daemon PID from a ``.pid``
-    file we do not write ourselves — the agent-browser daemon writes it.  A
-    same-user actor can therefore plant a fake socket dir whose ``.pid`` points
-    at an arbitrary victim process, or a recycled PID can land on an unrelated
-    process after the real daemon exits.  Either way, terminating that PID
-    (a *tree* kill via ``_terminate_host_pid``) is an arbitrary-process DoS.
-
-    Before reaping we require, via ``psutil`` (a hard dependency, cross-platform
-    for same-user processes — the only processes the reaper can signal):
-
-      1. **Identity** — the process looks like agent-browser: ``agent-browser``
-         appears in its name or command line.
-      2. **Binding** — the process is bound to *this* session's socket dir: the
-         socket dir path (or its basename) appears in the command line, or in
-         ``AGENT_BROWSER_SOCKET_DIR`` in the process environment.
-
-    Requirement (2) is the real spoof defense: a planted process pointing at a
-    victim PID will not have the victim's cmdline/environ referencing our
-    socket dir.  An attacker would need a process that genuinely embeds this
-    exact session path — i.e. a real daemon they already own and could signal
-    directly.  Fail-closed: any ambiguity (unreadable cmdline, no match) means
-    we refuse to reap and leave the process and its socket dir alone.
-
-    Returns ``True`` only when both checks pass.
+    The PID comes from metadata inside a predictable temporary directory. A
+    planted file or PID reuse must never turn the tree-termination helper into
+    an arbitrary-process kill. Capture the kernel start time before inspecting
+    identity, require an agent-browser process bound to this exact socket
+    directory, and return the fingerprint for revalidation at signal time.
     """
     try:
         import psutil
@@ -1702,30 +1699,33 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
             "Refusing to reap browser daemon PID %d (session %s): "
             "psutil unavailable for identity verification",
             daemon_pid, session_name)
-        return False
+        return None
+
+    from gateway.status import get_process_start_time
+    expected_start = get_process_start_time(daemon_pid)
+    if expected_start is None:
+        return None
 
     try:
         proc = psutil.Process(daemon_pid)
         name = (proc.name() or "").lower()
         cmdline = " ".join(proc.cmdline() or []).lower()
     except psutil.NoSuchProcess:
-        # Vanished between the liveness check and now — nothing to reap.
-        return False
+        return None
     except (psutil.AccessDenied, OSError) as exc:
         logger.warning(
             "Refusing to reap browser daemon PID %d (session %s): "
             "could not read process identity (%s)",
             daemon_pid, session_name, exc)
-        return False
+        return None
 
     looks_like_browser = "agent-browser" in name or "agent-browser" in cmdline
     if not looks_like_browser:
         logger.warning(
             "Refusing to reap PID %d (session %s): not an agent-browser "
             "process (name=%r)", daemon_pid, session_name, name)
-        return False
+        return None
 
-    # Binding check: the live process must reference *this* socket dir.
     socket_dir_l = socket_dir.lower()
     socket_base_l = os.path.basename(socket_dir).lower()
     bound = socket_dir_l in cmdline or (
@@ -1737,8 +1737,6 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
             bound = bool(env_dir) and os.path.normpath(env_dir) == \
                 os.path.normpath(socket_dir)
         except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
-            # environ() can be denied even same-user on some platforms.
-            # cmdline already failed to bind — fail closed.
             bound = False
 
     if not bound:
@@ -1746,9 +1744,9 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
             "Refusing to reap agent-browser PID %d: not bound to session "
             "socket dir %s (possible recycled PID or planted pid file)",
             daemon_pid, socket_dir)
-        return False
+        return None
 
-    return True
+    return expected_start
 
 
 def _reap_orphaned_browser_sessions():
@@ -1803,77 +1801,342 @@ def _reap_orphaned_browser_sessions():
         if not session_name:
             continue
 
-        # Ownership check: prefer owner_pid file (cross-process safe).
+        # Ownership check: present-but-unreadable metadata fails closed. Only a
+        # genuinely absent owner file may use the legacy in-process fallback.
         owner_pid_file = os.path.join(socket_dir, f"{session_name}.owner_pid")
-        owner_alive: Optional[bool] = None  # None = owner_pid missing/unreadable
-        if os.path.isfile(owner_pid_file):
+        owner_metadata_present = os.path.lexists(owner_pid_file)
+        if owner_metadata_present:
+            if os.path.islink(owner_pid_file) or not os.path.isfile(owner_pid_file):
+                continue
             try:
                 owner_pid = int(Path(owner_pid_file).read_text(encoding="utf-8").strip())
-                # ``os.kill(pid, 0)`` is NOT a no-op on Windows (bpo-14484).
-                # Use the cross-platform existence check.
                 from gateway.status import _pid_exists
-                owner_alive = _pid_exists(owner_pid)
+                if _pid_exists(owner_pid):
+                    continue
             except (ValueError, OSError):
-                owner_alive = None  # corrupt file — fall through
-
-        if owner_alive is True:
-            # Owner is alive — this session belongs to a live hermes process.
+                continue
+        elif session_name in tracked_names:
             continue
 
-        if owner_alive is None:
-            # No owner_pid file (legacy daemon).  Fall back to in-process
-            # tracking: if this process knows about the session, leave alone.
-            if session_name in tracked_names:
-                continue
-
-        # owner_alive is False (dead owner) OR legacy daemon not tracked here.
+        # The owner is dead, or this is an untracked legacy session.
         pid_file = os.path.join(socket_dir, f"{session_name}.pid")
         if not os.path.isfile(pid_file):
-            # No daemon PID file — just a stale dir, remove it
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            _remove_browser_socket_dir_if_safe(socket_dir, session_name)
             continue
 
         try:
             daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
         except (ValueError, OSError):
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            _remove_browser_socket_dir_if_safe(socket_dir, session_name)
             continue
 
-        # Check if the daemon is still alive. ``os.kill(pid, 0)`` on Windows
-        # is NOT a no-op — use the handle-based existence check.
         from gateway.status import _pid_exists
         if not _pid_exists(daemon_pid):
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            _remove_browser_socket_dir_if_safe(socket_dir, session_name)
             continue
 
-        # The PID is live — but the .pid file lives in a world-writable,
-        # predictably-named temp dir we don't write ourselves, and PIDs get
-        # recycled after the real daemon exits.  Verify the process really is
-        # *this* session's agent-browser daemon before tree-killing it; refuse
-        # otherwise (don't touch the process, leave the socket dir for a later
-        # sweep once the imposter PID is gone).  Fixes the arbitrary same-user
-        # process DoS in issue #14073.
-        if not _verify_reapable_browser_daemon(
-                daemon_pid, socket_dir, session_name):
+        expected_start = _verify_reapable_browser_daemon(
+            daemon_pid, socket_dir, session_name
+        )
+        if expected_start is None:
             continue
 
-        # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.
-        # Use the process-tree termination helper so Chromium children
-        # (renderer, GPU, etc.) are cleaned up, not just the daemon parent.
         try:
             from tools.process_registry import ProcessRegistry
-            ProcessRegistry._terminate_host_pid(daemon_pid)
-            logger.info("Reaped orphaned browser daemon PID %d (session %s)",
-                        daemon_pid, session_name)
-            reaped += 1
-        except (ProcessLookupError, PermissionError, OSError):
+            ProcessRegistry._terminate_host_pid(
+                daemon_pid, expected_start=expected_start
+            )
+        except ProcessLookupError:
             pass
+        except (PermissionError, OSError):
+            continue
 
-        # Clean up the socket directory
-        shutil.rmtree(socket_dir, ignore_errors=True)
+        # The termination helper may refuse a recycled PID without raising.
+        # Revalidate liveness before deleting the discovery metadata/profile.
+        if _pid_exists(daemon_pid):
+            logger.warning(
+                "Browser daemon PID %d survived cleanup; preserving socket dir %s",
+                daemon_pid, socket_dir,
+            )
+            continue
+
+        logger.info("Reaped orphaned browser daemon PID %d (session %s)",
+                    daemon_pid, session_name)
+        reaped += 1
+        _remove_browser_socket_dir_if_safe(socket_dir, session_name)
 
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)
+
+
+def _managed_chrome_profile(socket_dir: str, session_name: str) -> Optional[Path]:
+    """Return this Hermes session's managed Chromium profile path.
+
+    New local sessions pass this path through agent-browser's official
+    ``--profile`` option.  Keeping the profile beneath the unique, mode-0700
+    Hermes socket directory gives cleanup a durable ownership binding even if
+    both the CLI and daemon disappear before Chromium exits.
+    """
+    try:
+        socket_path = Path(socket_dir)
+        temp_root = Path(_socket_safe_tmpdir()).resolve(strict=False)
+        if socket_path.is_symlink():
+            return None
+        resolved_socket = socket_path.resolve(strict=False)
+        if resolved_socket.parent != temp_root:
+            return None
+        if resolved_socket.name != f"agent-browser-{session_name}":
+            return None
+        profile = resolved_socket / f"agent-browser-chrome-{session_name}"
+        if profile.is_symlink():
+            return None
+        if profile.resolve(strict=False).parent != resolved_socket:
+            return None
+        return profile
+    except (OSError, RuntimeError):
+        return None
+
+
+def _managed_profile_in_use(profile: Path) -> bool:
+    """Return whether any process still names *profile*; ambiguity preserves it."""
+    try:
+        import psutil
+        processes = psutil.process_iter(["name", "cmdline"])
+    except Exception:
+        return True
+
+    try:
+        for proc in processes:
+            raw_cmdline = proc.info.get("cmdline")
+            if raw_cmdline is None:
+                name = str(proc.info.get("name") or "").lower()
+                if not name or any(
+                    marker in name
+                    for marker in ("chrome", "chromium", "agent-browser")
+                ):
+                    return True
+                continue
+            cmdline = [str(arg) for arg in raw_cmdline]
+            try:
+                if any(
+                    Path(value).expanduser().resolve(strict=False) == profile
+                    for value in _cmdline_profile_values(cmdline)
+                ):
+                    return True
+            except (OSError, RuntimeError):
+                continue
+    except Exception:
+        return True
+    return False
+
+
+def _remove_browser_socket_dir_if_safe(socket_dir: str, session_name: str) -> bool:
+    """Remove session metadata only when no process still references its profile."""
+    profile = _managed_chrome_profile(socket_dir, session_name)
+    if profile is None or _managed_profile_in_use(profile):
+        logger.warning(
+            "Preserving browser socket dir %s: managed profile may still be in use",
+            socket_dir,
+        )
+        return False
+    try:
+        shutil.rmtree(socket_dir)
+    except OSError as exc:
+        logger.warning("Could not remove browser socket dir %s: %s", socket_dir, exc)
+        return False
+    return not os.path.exists(socket_dir)
+
+
+def _cmdline_profile_values(cmdline: List[str]) -> List[str]:
+    values: List[str] = []
+    for index, arg in enumerate(cmdline):
+        if arg.startswith("--user-data-dir="):
+            values.append(arg.split("=", 1)[1])
+        elif arg == "--user-data-dir" and index + 1 < len(cmdline):
+            values.append(cmdline[index + 1])
+    return values
+
+
+def _cmdline_uses_profile(cmdline: List[str], expected_profile: Path) -> bool:
+    """Require exactly one user-data-dir and bind it to *expected_profile*."""
+    values = _cmdline_profile_values(cmdline)
+    if len(values) != 1:
+        return False
+    try:
+        if expected_profile.is_symlink():
+            return False
+        return Path(values[0]).expanduser().resolve(strict=False) == expected_profile
+    except (OSError, RuntimeError):
+        return False
+
+
+def _has_live_agent_browser_ancestor(proc: Any) -> bool:
+    """Return True when *proc* is still owned by a live agent-browser daemon.
+
+    Fail closed: an unreadable ancestor is treated as live so cleanup never
+    kills a browser tree whose ownership cannot be established.
+    """
+    try:
+        parent = proc.parent()
+        for _ in range(8):
+            if parent is None:
+                return False
+            name = (parent.name() or "").lower()
+            cmdline = [str(arg) for arg in (parent.cmdline() or [])]
+            executable_args = [os.path.basename(arg).lower() for arg in cmdline[:2]]
+            if "agent-browser" in name or any(
+                "agent-browser" in arg for arg in executable_args
+            ):
+                return True
+            parent = parent.parent()
+    except Exception:
+        return True
+    return False
+
+
+def _reap_session_chromium(
+    socket_dir: str, session_name: str, *, min_age_seconds: float
+) -> int:
+    """Reap only Chromium bound to one positively-owned Hermes session.
+
+    Identity, username, start time, command line, profile path, and ancestry are
+    revalidated immediately before termination.  Any ambiguity fails closed.
+    """
+    try:
+        import psutil
+    except ImportError:
+        logger.warning("Cannot scan managed Chromium processes: psutil unavailable")
+        return 0
+
+    profile = _managed_chrome_profile(socket_dir, session_name)
+    if profile is None:
+        return 0
+    try:
+        current_username = psutil.Process(os.getpid()).username()
+    except Exception:
+        return 0
+
+    now = time.time()
+    reaped = 0
+    try:
+        processes = psutil.process_iter(["pid", "name", "cmdline", "create_time"])
+    except Exception as exc:
+        logger.debug("Could not enumerate managed Chromium processes: %s", exc)
+        return 0
+
+    for proc in processes:
+        try:
+            info = proc.info
+            pid = int(info["pid"])
+            cmdline = [str(arg) for arg in (info.get("cmdline") or [])]
+            name = str(info.get("name") or "").lower()
+            executable = os.path.basename(cmdline[0]).lower() if cmdline else ""
+            if not ("chrome" in name or "chromium" in name or
+                    "chrome" in executable or "chromium" in executable):
+                continue
+            if any(arg.startswith("--type=") for arg in cmdline):
+                continue
+            if not _cmdline_uses_profile(cmdline, profile):
+                # Ambiguous/duplicate flags are never killable, but if any value
+                # resolves to our profile the directory is still in use and must
+                # not be removed as stale.
+                continue
+
+            expected_start = float(info.get("create_time") or 0.0)
+            if expected_start <= 0 or now - expected_start < max(float(min_age_seconds), 0.0):
+                continue
+            from gateway.status import get_process_start_time
+            expected_kernel_start = get_process_start_time(pid)
+            if expected_kernel_start is None:
+                continue
+            if proc.username() != current_username:
+                continue
+            if _has_live_agent_browser_ancestor(proc):
+                continue
+
+            # Kill-boundary revalidation protects against PID reuse and path
+            # replacement between enumeration and termination.
+            current = psutil.Process(pid)
+            if abs(float(current.create_time()) - expected_start) > 0.001:
+                continue
+            if current.username() != current_username:
+                continue
+            current_cmdline = [str(arg) for arg in (current.cmdline() or [])]
+            if not _cmdline_uses_profile(current_cmdline, profile):
+                continue
+            if _has_live_agent_browser_ancestor(current):
+                continue
+
+            from tools.process_registry import ProcessRegistry
+            ProcessRegistry._terminate_host_pid(
+                pid, expected_start=expected_kernel_start
+            )
+
+            try:
+                survivor = psutil.Process(pid)
+                if abs(float(survivor.create_time()) - expected_start) <= 0.001:
+                    logger.warning(
+                        "Managed Chromium PID %d survived cleanup; preserving profile %s",
+                        pid, profile.name,
+                    )
+                    continue
+            except psutil.NoSuchProcess:
+                pass
+
+            logger.info(
+                "Reaped orphaned managed Chromium PID %d (session %s)",
+                pid, session_name,
+            )
+            reaped += 1
+        except Exception:
+            continue
+
+    # Re-scan after all termination attempts. Any process role that still names
+    # the profile (root, renderer, GPU, or ambiguous duplicate flags) preserves
+    # it; profile deletion is a single postcondition, never a per-PID side effect.
+    profile_in_use = _managed_profile_in_use(profile)
+
+    if not profile_in_use and profile.exists() and not profile.is_symlink():
+        try:
+            profile_age = now - profile.stat().st_mtime
+            if reaped or profile_age >= max(float(min_age_seconds), 0.0):
+                shutil.rmtree(profile)
+            if profile.exists():
+                logger.warning("Managed profile still exists after cleanup: %s", profile)
+        except OSError as exc:
+            logger.warning("Could not remove stale managed profile %s: %s", profile, exc)
+    return reaped
+
+
+def _reap_orphaned_browser_chromes(*, min_age_seconds: float) -> None:
+    """Reap stale Chromium only from dead-owner Hermes socket directories."""
+    import glob
+
+    reaped = 0
+    tmpdir = _socket_safe_tmpdir()
+    patterns = ["agent-browser-h_*", "agent-browser-cdp_*", "agent-browser-hermes_*"]
+    for pattern in patterns:
+        for socket_dir in glob.glob(os.path.join(tmpdir, pattern)):
+            session_name = os.path.basename(socket_dir).removeprefix("agent-browser-")
+            if not session_name:
+                continue
+            owner_file = Path(socket_dir) / f"{session_name}.owner_pid"
+            # Managed Chromium ownership was introduced with owner_pid metadata.
+            # Legacy/unreadable directories are not safe enough to process-kill.
+            if not owner_file.is_file() or owner_file.is_symlink():
+                continue
+            try:
+                owner_pid = int(owner_file.read_text(encoding="utf-8").strip())
+                from gateway.status import _pid_exists
+                if _pid_exists(owner_pid):
+                    continue
+            except (OSError, ValueError):
+                continue
+            reaped += _reap_session_chromium(
+                socket_dir, session_name, min_age_seconds=min_age_seconds
+            )
+    if reaped:
+        logger.info("Reaped %d orphaned managed Chromium tree(s)", reaped)
 
 
 def _browser_cleanup_thread_worker():
@@ -1886,6 +2149,9 @@ def _browser_cleanup_thread_worker():
     """
     # One-time orphan reap on startup
     try:
+        _reap_orphaned_browser_chromes(
+            min_age_seconds=BROWSER_SESSION_INACTIVITY_TIMEOUT
+        )
         _reap_orphaned_browser_sessions()
     except Exception as e:
         logger.warning("Orphan reap error: %s", e)
@@ -2453,6 +2719,16 @@ def _run_browser_command(
         logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
 
+    # Give each task its own socket directory to prevent concurrency conflicts.
+    # The managed Chromium profile lives beneath that same unique directory, so
+    # session-end and crash recovery never need a host-global Chrome scan.
+    task_socket_dir = os.path.join(
+        _socket_safe_tmpdir(),
+        f"agent-browser-{session_info['session_name']}"
+    )
+    os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
+    browser_env = _build_browser_env()
+
     # Build the command with the appropriate backend flag.
     # Cloud mode: --cdp <websocket_url> connects to Browserbase.
     # Local mode: --session <name> launches a local headless Chromium.
@@ -2463,10 +2739,19 @@ def _run_browser_command(
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
     else:
-        # Local mode — launch Chromium (headless by default, headed when configured)
+        # Local mode — launch Chromium (headless by default, headed when configured).
+        # Respect an explicit persistent user profile; otherwise use a
+        # Hermes-owned ephemeral profile under this session's socket directory.
         backend_args = ["--session", session_info["session_name"]]
         if _is_headed_mode():
             backend_args.append("--headed")
+        if not browser_env.get("AGENT_BROWSER_PROFILE"):
+            managed_profile = _managed_chrome_profile(
+                task_socket_dir, session_info["session_name"]
+            )
+            if managed_profile is not None:
+                backend_args += ["--profile", str(managed_profile)]
+                session_info["managed_chrome_profile"] = str(managed_profile)
 
     # Lightpanda engine injection (local mode only, agent-browser v0.25.3+).
     # Use the resolved session backend rather than global cloud-provider state:
@@ -2491,21 +2776,11 @@ def _run_browser_command(
     ] + args
 
     try:
-        # Give each task its own socket directory to prevent concurrency conflicts.
-        # Without this, parallel workers fight over the same default socket path,
-        # causing "Failed to create socket directory: Permission denied" errors.
-        task_socket_dir = os.path.join(
-            _socket_safe_tmpdir(),
-            f"agent-browser-{session_info['session_name']}"
-        )
-        os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
         # Record this hermes PID as the session owner (cross-process safe
         # orphan detection — see _write_owner_pid).
         _write_owner_pid(task_socket_dir, session_info['session_name'])
         logger.debug("browser cmd=%s task=%s socket_dir=%s (%d chars)",
                      command, task_id, task_socket_dir, len(task_socket_dir))
-
-        browser_env = _build_browser_env()
 
         # Ensure subprocesses inherit the same browser-specific PATH fallbacks
         # used during CLI discovery.
@@ -4561,22 +4836,53 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                 except Exception as e:
                     logger.warning("Could not close cloud browser session: %s", e)
 
-        # Kill the daemon process and clean up socket directory
+        # Kill only this session's verified daemon, then reap only the Chromium
+        # bound to this session's managed profile before removing its directory.
         session_name = session_info.get("session_name", "")
         if session_name:
             socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{session_name}")
             if os.path.exists(socket_dir):
-                # agent-browser writes {session}.pid in the socket dir
                 pid_file = os.path.join(socket_dir, f"{session_name}.pid")
-                if os.path.isfile(pid_file):
+                daemon_gone = not os.path.isfile(pid_file)
+                if not daemon_gone:
                     try:
+                        from gateway.status import _pid_exists
                         from tools.process_registry import ProcessRegistry
                         daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
-                        ProcessRegistry._terminate_host_pid(daemon_pid)
-                        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
-                    except (ProcessLookupError, ValueError, PermissionError, OSError):
-                        logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
-                shutil.rmtree(socket_dir, ignore_errors=True)
+                        if not _pid_exists(daemon_pid):
+                            daemon_gone = True
+                        else:
+                            expected_start = _verify_reapable_browser_daemon(
+                                daemon_pid, socket_dir, session_name
+                            )
+                            if expected_start is not None:
+                                ProcessRegistry._terminate_host_pid(
+                                    daemon_pid, expected_start=expected_start
+                                )
+                                daemon_gone = not _pid_exists(daemon_pid)
+                                if daemon_gone:
+                                    logger.debug(
+                                        "Killed verified daemon pid %s for %s",
+                                        daemon_pid, session_name,
+                                    )
+                    except ProcessLookupError:
+                        daemon_gone = True
+                    except (ValueError, PermissionError, OSError):
+                        logger.debug(
+                            "Could not kill daemon pid for %s (revalidation failed)",
+                            session_name,
+                        )
+
+                _reap_session_chromium(
+                    socket_dir, session_name, min_age_seconds=0
+                )
+                if daemon_gone:
+                    _remove_browser_socket_dir_if_safe(socket_dir, session_name)
+                else:
+                    logger.warning(
+                        "Preserving browser socket dir %s because its daemon may survive",
+                        socket_dir,
+                    )
 
         logger.debug("Removed task %s from active sessions", task_id)
     else:


### PR DESCRIPTION
## Summary

Hermes can leave `agent-browser` daemons and managed Chromium processes behind after a crash, SIGKILL, gateway restart, or other unclean shutdown.

The existing orphan cleanup only covered part of that lifecycle. It could lose cross-process ownership state, trust stale or recycled daemon PIDs, and remove socket/profile discovery metadata while a deliberately preserved Chromium process still referenced the managed profile.

This PR makes browser orphan recovery ownership-aware, PID-reuse-safe, and fail-closed.

## What changed

- Publish a per-session `owner_pid` file so concurrent Hermes processes do not reap each other's browser sessions.
- Publish owner metadata with a same-directory temporary file and atomic `os.replace`.
- Bind managed Chromium profiles to the Hermes session directory.
- Reap orphaned Chromium roots using exact managed-profile identity rather than broad browser-name or profile-prefix matching.
- Verify process ownership, executable identity, profile path, ancestry, age, and kernel process start time before signaling.
- Verify live daemon PIDs are actual `agent-browser` processes bound to the expected socket directory.
- Pass the captured kernel start fingerprint to every daemon/Chromium termination boundary to prevent PID-reuse races.
- Run managed-Chromium cleanup before daemon/socket cleanup.
- Delete managed profiles and socket directories only after a final scan proves no surviving process still references them.
- Preserve metadata when ownership, identity, ancestry, command-line visibility, or termination success is ambiguous.
- Run orphan scans during startup/background cleanup, explicit session cleanup, and emergency shutdown cleanup.

## Safety invariants

This implementation intentionally fails closed:

- A planted PID file cannot authorize terminating an arbitrary same-user process.
- A recycled PID is rejected at the signal boundary when its kernel start time no longer matches.
- Empty, partial, corrupt, symlinked, or unreadable owner metadata is treated as ambiguous and preserved.
- Young, cross-user, externally owned, unverifiable, or surviving Chromium processes preserve their profile and discovery metadata.
- Profile deletion is a single postcondition after a final no-reference scan, never a per-PID side effect.
- No broad `pkill`, `killall`, browser-prefix deletion, or unrelated profile cleanup is introduced.

## Tests

Added regression coverage for:

- stale, dead, tracked, cross-process-owned, corrupt, and planted daemon PIDs;
- daemon executable/socket binding and PID-reuse guards;
- global and explicit-session `expected_start` propagation;
- daemon verification failure and post-termination survival;
- exact managed Chromium profile matching;
- process age, user, ancestry, renderer-child, and duplicate-profile handling;
- dead-daemon plus preserved-Chromium behavior through the complete ordered cleanup pipeline;
- final profile-reference scans and surviving processes;
- atomic owner publication, failed temporary-file cleanup, and synchronized concurrent readers;
- partial/corrupt owner metadata failing closed; and
- safe emergency-cleanup test isolation.

Post-refresh verification:

```text
python -m pytest \
  tests/tools/test_browser_orphan_reaper.py \
  tests/tools/test_browser_cleanup.py \
  tests/tools/test_browser_homebrew_paths.py \
  -o addopts= -q
77 passed

python -m pytest tests/tools/test_browser_orphan_reaper_integration.py \
  -o addopts= -q
3 passed

HERMES_TEST_PATHS='tests/tools/test_browser_orphan_reaper.py:tests/tools/test_browser_cleanup.py:tests/tools/test_browser_homebrew_paths.py:tests/tools/test_browser_orphan_reaper_integration.py' \
  python scripts/run_tests_parallel.py
80 passed, 0 failed

ruff check tools/browser_tool.py \
  tests/tools/test_browser_orphan_reaper.py \
  tests/tools/test_browser_cleanup.py \
  tests/tools/test_browser_homebrew_paths.py \
  tests/tools/test_browser_orphan_reaper_integration.py
All checks passed
```

`py_compile` and `git diff --check` also passed. The two-commit replay was content-identical: stable patch ID unchanged and `git range-diff` reported `=` for both commits.

## Scope and risk

The primary risk is platform-specific process inspection behavior. Cleanup is therefore conservative: if the required identity evidence cannot be read, the process and its metadata are retained for a later sweep.

This does not change cloud browser lifecycle behavior or introduce cleanup for unrelated user browser profiles.

Follow-up hardening for #14073 and the cross-platform process-liveness work in #21561.
