### PR TITLE
fix(config): parse structured config values

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8188,8 +8188,25 @@ def set_config_value(key: str, value: str):
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
-        if value.lower() in {'true', 'yes', 'on'}:
+    default_value = _default_value_for_key(key)
+    if isinstance(default_value, list):
+        try:
+            parsed_value = fast_safe_load(value)
+        except Exception:
+            parsed_value = None
+        if not isinstance(parsed_value, list):
+            print(
+                f"Cannot set '{key}': expected a list value (for example, '[\"item\"]')",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        coerced_value = parsed_value
+    elif not isinstance(default_value, str):
+        if value.lstrip().startswith(("[", "{")):
+            parsed_value = fast_safe_load(value)
+            if isinstance(parsed_value, (list, dict)):
+                coerced_value = parsed_value
+        elif value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:
             coerced_value = False

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8113,18 +8113,40 @@ def edit_config():
     subprocess.run([editor, str(config_path)])
 
 
-def _default_value_for_key(dotted_key: str):
-    """Return the leaf value declared for *dotted_key* in ``DEFAULT_CONFIG``.
+_CONFIG_KEY_MISSING = object()
 
-    Unknown keys and non-leaf paths return ``None`` so they retain the legacy
-    best-effort coercion used by ``config set``.
-    """
+
+def _default_value_for_key(dotted_key: str):
+    """Return the value declared for *dotted_key* or a missing-key sentinel."""
     node = DEFAULT_CONFIG
     for part in dotted_key.split("."):
         if not isinstance(node, dict) or part not in node:
-            return None
+            return _CONFIG_KEY_MISSING
         node = node[part]
-    return node if not isinstance(node, dict) else None
+    return node
+
+
+def _is_json_compatible(value: Any) -> bool:
+    """Return whether a structured config value can be mirrored to env safely."""
+    stack = [value]
+    seen: set[int] = set()
+    while stack:
+        node = stack.pop()
+        if not isinstance(node, (list, dict)) or id(node) in seen:
+            continue
+        seen.add(id(node))
+        if isinstance(node, dict):
+            if any(not isinstance(key, str) for key in node):
+                return False
+            stack.extend(node.values())
+        else:
+            stack.extend(node)
+
+    try:
+        json.dumps(value, allow_nan=False)
+    except (TypeError, ValueError, RecursionError):
+        return False
+    return True
 
 
 def set_config_value(key: str, value: str):
@@ -8189,23 +8211,61 @@ def set_config_value(key: str, value: str):
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
     default_value = _default_value_for_key(key)
-    if isinstance(default_value, list):
+    if isinstance(default_value, (list, dict)):
         try:
             parsed_value = fast_safe_load(value)
         except Exception:
             parsed_value = None
-        if not isinstance(parsed_value, list):
+        expected_type = type(default_value)
+        expected_name = "list" if expected_type is list else "mapping"
+        if not isinstance(parsed_value, expected_type):
             print(
-                f"Cannot set '{key}': expected a list value (for example, '[\"item\"]')",
+                f"Cannot set '{key}': expected a {expected_name} value",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not _is_json_compatible(parsed_value):
+            print(
+                f"Cannot set '{key}': expected a JSON-compatible {expected_name} value",
                 file=sys.stderr,
             )
             sys.exit(1)
         coerced_value = parsed_value
     elif not isinstance(default_value, str):
         if value.lstrip().startswith(("[", "{")):
-            parsed_value = fast_safe_load(value)
-            if isinstance(parsed_value, (list, dict)):
-                coerced_value = parsed_value
+            if default_value is not _CONFIG_KEY_MISSING:
+                if default_value is None:
+                    expected = "a scalar"
+                elif isinstance(default_value, bool):
+                    expected = "a boolean"
+                elif isinstance(default_value, int):
+                    expected = "an integer"
+                elif isinstance(default_value, float):
+                    expected = "a number"
+                else:
+                    expected = f"a {type(default_value).__name__}"
+                print(
+                    f"Cannot set '{key}': expected {expected} value",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            try:
+                parsed_value = fast_safe_load(value)
+            except Exception:
+                parsed_value = None
+            if not isinstance(parsed_value, (list, dict)):
+                print(
+                    f"Cannot set '{key}': expected a list or mapping value",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if not _is_json_compatible(parsed_value):
+                print(
+                    f"Cannot set '{key}': expected a JSON-compatible list or mapping value",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            coerced_value = parsed_value
         elif value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -290,6 +290,40 @@ class TestStringTypedConfigValues:
 
 
 # ---------------------------------------------------------------------------
+# Structured config values — regression tests for #64323
+# ---------------------------------------------------------------------------
+
+class TestStructuredConfigValues:
+    def test_list_typed_value_is_saved_as_a_list(self, _isolated_hermes_home):
+        set_config_value(
+            "terminal.docker_volumes",
+            '["/tmp/demo-host:/client:rw"]',
+        )
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["terminal"]["docker_volumes"] == [
+            "/tmp/demo-host:/client:rw"
+        ]
+
+    def test_mapping_literal_is_saved_as_a_mapping(self, _isolated_hermes_home):
+        set_config_value("custom.settings", '{"mode": "strict"}')
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["custom"]["settings"] == {"mode": "strict"}
+
+    def test_malformed_list_value_is_rejected_cleanly(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("terminal.docker_volumes", '["unterminated"')
+
+        assert "expected a list value" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
 # Secret redaction in display output (issue #50245)
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -322,6 +322,117 @@ class TestStructuredConfigValues:
         assert "expected a list value" in capsys.readouterr().err
         assert not (_isolated_hermes_home / "config.yaml").exists()
 
+    def test_known_scalar_rejects_structured_value(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("terminal.timeout", '{"oops": 1}')
+
+        assert "expected an integer value" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+    def test_known_nullable_scalar_rejects_structured_value(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("cron.max_parallel_jobs", '{"oops": 1}')
+
+        assert "expected a scalar value" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+    def test_malformed_unknown_mapping_is_rejected_cleanly(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("custom.settings", '{"unterminated"')
+
+        assert "expected a list or mapping" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+    def test_non_json_list_value_is_rejected_before_writing(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("terminal.docker_volumes", "[2026-01-01]")
+
+        assert "JSON-compatible list" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+    def test_non_finite_list_value_is_rejected_before_writing(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("terminal.docker_volumes", "[.nan]")
+
+        assert "JSON-compatible list" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+    def test_mapping_with_non_string_key_is_rejected_before_writing(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("terminal.docker_env", "{1: value}")
+
+        assert "JSON-compatible mapping" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+    def test_recursive_list_value_is_rejected_before_writing(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit):
+            set_config_value("terminal.docker_volumes", "&items [*items]")
+
+        assert "JSON-compatible list" in capsys.readouterr().err
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+
+    def test_list_value_is_mirrored_to_env_as_json(self, _isolated_hermes_home):
+        set_config_value("terminal.docker_volumes", '["/tmp/src:/workspace:rw"]')
+
+        import json
+        from dotenv import dotenv_values
+
+        parsed = dotenv_values(_isolated_hermes_home / ".env")
+        raw_value = parsed["TERMINAL_DOCKER_VOLUMES"]
+        assert raw_value is not None
+        assert json.loads(raw_value) == [
+            "/tmp/src:/workspace:rw"
+        ]
+
+    def test_structured_looking_string_setting_remains_a_string(
+        self, _isolated_hermes_home
+    ):
+        set_config_value("approvals.mode", "[manual]")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["approvals"]["mode"] == "[manual]"
+
+    def test_known_mapping_is_saved_and_mirrored(self, _isolated_hermes_home):
+        set_config_value("terminal.docker_env", '{"MODE": "strict"}')
+
+        import json
+        import yaml
+        from dotenv import dotenv_values
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["terminal"]["docker_env"] == {"MODE": "strict"}
+        raw_value = dotenv_values(_isolated_hermes_home / ".env")["TERMINAL_DOCKER_ENV"]
+        assert raw_value is not None
+        assert json.loads(raw_value) == {"MODE": "strict"}
+
+    def test_known_mapping_rejects_list_value(self, _isolated_hermes_home, capsys):
+        with pytest.raises(SystemExit):
+            set_config_value("terminal.docker_env", '["MODE=strict"]')
+
+        assert "expected a mapping value" in capsys.readouterr().err
+
+    def test_unknown_flow_list_is_saved_as_a_list(self, _isolated_hermes_home):
+        set_config_value("custom.items", '["one", "two"]')
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["custom"]["items"] == ["one", "two"]
+
 
 # ---------------------------------------------------------------------------
 # Secret redaction in display output (issue #50245)


### PR DESCRIPTION
## Summary
- parse list-typed `hermes config set` values into real YAML lists instead of quoted strings
- accept flow-style list and mapping literals for unknown keys and enforce declared types for known list/mapping settings
- reject structured input for known scalar and nullable-scalar settings
- reject malformed, recursive, non-finite, non-string-keyed, and otherwise non-JSON-compatible structured values before writing either `config.yaml` or `.env`
- preserve string-typed settings and verify terminal env mirroring round-trips through dotenv + JSON

## Root cause

`set_config_value()` only coerced booleans and numbers. A command such as:

```bash
hermes config set terminal.docker_volumes '["/tmp/demo-host:/client:rw"]'
```

therefore persisted a quoted YAML scalar rather than the documented list shape.

For `terminal.docker_volumes`, the canonical terminal config-to-env bridge can recover a valid JSON array at runtime; this PR fixes the persisted type at the write boundary rather than relying on that downstream recovery path. It also validates the declared default type so structured input cannot corrupt scalar settings such as `terminal.timeout`.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_set_config_value.py tests/tools/test_terminal_config_env_sync.py -q` — 223 passed
- `uv run ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py`
- `git diff --check upstream/main...HEAD`
- end-to-end CLI smoke with temporary `HERMES_HOME` values confirmed:
  - a valid volume list reloads as a Python `list`
  - a YAML date value is rejected before `config.yaml` is created

Fixes #64323
