### PR TITLE
fix(desktop): avoid replaying speech on session switch

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
@@ -1,0 +1,124 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { playSpeechText } from '@/lib/voice-playback'
+import { $messages } from '@/store/session'
+import { setVoicePlaybackState } from '@/store/voice-playback'
+import { $autoSpeakReplies } from '@/store/voice-prefs'
+
+import { useAutoSpeakReplies } from './use-auto-speak-replies'
+
+vi.mock('@/lib/voice-playback', () => ({ playSpeechText: vi.fn(() => Promise.resolve(true)) }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+
+interface Reply {
+  id: string
+  pending: boolean
+  text: string
+}
+
+describe('useAutoSpeakReplies', () => {
+  afterEach(() => {
+    cleanup()
+    $autoSpeakReplies.set(false)
+    $messages.set([])
+    setVoicePlaybackState({
+      audioElement: null,
+      messageId: null,
+      sequence: 0,
+      source: null,
+      status: 'idle'
+    })
+    vi.clearAllMocks()
+  })
+
+  it('does not replay history that hydrates after selecting a session', () => {
+    let reply: Reply | null = { id: 'assistant-a', pending: false, text: 'Already heard A' }
+    let spokenId: string | null = null
+
+    const markSpoken = () => {
+      spokenId = reply?.id ?? null
+    }
+
+    const pendingReply = () => (reply?.id === spokenId ? null : reply)
+
+    $autoSpeakReplies.set(true)
+
+    const { rerender } = renderHook(
+      ({ sessionId }) =>
+        useAutoSpeakReplies({
+          busy: false,
+          conversationActive: false,
+          failureLabel: 'Read aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId
+        }),
+      { initialProps: { sessionId: 'session-a' } }
+    )
+
+    rerender({ sessionId: 'session-b' })
+
+    act(() => {
+      reply = { id: 'assistant-b-history', pending: false, text: 'Existing session B reply' }
+      $messages.set([])
+    })
+
+    expect(playSpeechText).not.toHaveBeenCalled()
+
+    act(() => {
+      reply = { id: 'assistant-b-new', pending: true, text: 'A new reply' }
+      $messages.set([])
+    })
+    expect(playSpeechText).not.toHaveBeenCalled()
+
+    act(() => {
+      reply = { id: 'assistant-b-new', pending: false, text: 'A new reply' }
+      $messages.set([])
+    })
+
+    expect(playSpeechText).toHaveBeenCalledOnce()
+    expect(playSpeechText).toHaveBeenCalledWith('A new reply', {
+      messageId: 'assistant-b-new',
+      source: 'read-aloud'
+    })
+  })
+
+  it('speaks an atomic completed reply after a new user turn', () => {
+    let reply: Reply | null = { id: 'assistant-history', pending: false, text: 'Existing reply' }
+    let spokenId: string | null = null
+
+    const markSpoken = () => {
+      spokenId = reply?.id ?? null
+    }
+
+    const pendingReply = () => (reply?.id === spokenId ? null : reply)
+
+    $autoSpeakReplies.set(true)
+
+    const { rerender } = renderHook(
+      ({ busy }) =>
+        useAutoSpeakReplies({
+          busy,
+          conversationActive: false,
+          failureLabel: 'Read aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId: 'session-a'
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    rerender({ busy: true })
+
+    act(() => {
+      reply = { id: 'assistant-new', pending: false, text: 'Atomic reply' }
+      $messages.set([{ id: 'assistant-new', role: 'assistant', content: 'Atomic reply' }] as never)
+    })
+
+    expect(playSpeechText).toHaveBeenCalledWith('Atomic reply', {
+      messageId: 'assistant-new',
+      source: 'read-aloud'
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -14,6 +14,7 @@ interface AutoSpeakReply {
 }
 
 interface UseAutoSpeakReplies {
+  busy: boolean
   conversationActive: boolean
   failureLabel: string
   /** Mark the current last reply spoken — shared dedupe with the conversation consumer. */
@@ -32,6 +33,7 @@ interface UseAutoSpeakReplies {
  * the latest reply, so a backlog collapses to the newest.
  */
 export function useAutoSpeakReplies({
+  busy,
   conversationActive,
   failureLabel,
   markSpoken,
@@ -39,8 +41,15 @@ export function useAutoSpeakReplies({
   sessionId
 }: UseAutoSpeakReplies) {
   const enabled = useStore($autoSpeakReplies)
+  const busyRef = useRef(busy)
+  const freshReplyStarted = useRef(false)
   const latest = useRef({ conversationActive, failureLabel, markSpoken, pendingReply })
+  busyRef.current = busy
   latest.current = { conversationActive, failureLabel, markSpoken, pendingReply }
+
+  if (busy) {
+    freshReplyStarted.current = true
+  }
 
   useEffect(() => {
     if (!enabled) {
@@ -50,15 +59,35 @@ export function useAutoSpeakReplies({
     // Don't read whatever reply already sits at the bottom when the toggle flips
     // on (or a chat opens) — consume it so only later replies are spoken.
     latest.current.markSpoken()
+    freshReplyStarted.current = busyRef.current
+    let waitingForFreshReply = true
 
     const speakLatest = () => {
       const { conversationActive, failureLabel, markSpoken, pendingReply } = latest.current
+      const reply = pendingReply()
+
+      if (waitingForFreshReply && freshReplyStarted.current) {
+        waitingForFreshReply = false
+      }
+
+      // Session history hydrates asynchronously after `sessionId` changes. The
+      // effect's eager mark above can therefore still see the previous session.
+      // Ignore completed replies until this session starts a new turn (or a
+      // pending assistant reply appears), consuming late-arriving history
+      // instead of replaying it.
+      if (waitingForFreshReply && reply) {
+        if (reply.pending) {
+          waitingForFreshReply = false
+        } else {
+          markSpoken()
+
+          return
+        }
+      }
 
       if (conversationActive || $voicePlayback.get().status !== 'idle') {
         return
       }
-
-      const reply = pendingReply()
 
       if (!reply || reply.pending) {
         return

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -140,6 +140,7 @@ export function useComposerVoice({
   }, [t])
 
   useAutoSpeakReplies({
+    busy,
     conversationActive: voiceConversationActive,
     failureLabel: t.assistant.thread.readAloudFailed,
     markSpoken: consumePendingResponse,


### PR DESCRIPTION
## Summary
- prevent auto-TTS from reading an existing assistant reply when selected-session history hydrates asynchronously
- keep auto-speak armed for genuinely new turns, including streamed (`pending`) and atomically completed replies
- preserve voice-conversation and playback ownership while another voice path is active
- add hook-level regression coverage for delayed history hydration and subsequent new replies

## Root cause

The auto-speak effect marks the current last reply as spoken when `sessionId` changes. During sidebar navigation, however, that effect can run before the selected session's messages replace the previous transcript. When stored history arrives later, its last completed assistant reply looks new and is spoken.

The hook now consumes completed history until the selected session starts a real new turn, using the session's `busy` lifecycle and pending replies as freshness signals. This suppresses replayed history without disabling voice for the next streamed or completion-only response.

## Verification
- `npx vitest run --project ui src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx` — 2 passed
- `npx eslint` on the three changed files
- full `npm run check` passed:
  - TypeScript typecheck
  - 1,690 tests passed, 1 skipped
  - macOS app and DMG packaging
  - production renderer and Electron build
- `git diff --check upstream/main...HEAD`

Fixes #64367
