### PR TITLE
fix(cli): preserve root-only npm deps across hermes update (#64354)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8127,30 +8127,27 @@ def _update_node_dependencies() -> None:
 
     nixos_env = with_hermes_node_path(_nixos_build_env())
 
-    # Step 1: root install (no workspace recursion).
-    # NOTE: capture_output=False here is deliberate (#18840) — optional
-    # postinstall scripts (e.g. @askjo/camofox-browser's browser-binary fetch)
-    # print download progress, and capturing it makes a long download look
-    # hung. The chatty npm-deprecation noise during `hermes update` comes from
-    # the *desktop* build, not this step; that one is captured to update.log.
-    root_args = [*extra_args, "--workspaces=false"]
-    root_result = _run_npm_install_deterministic(
-        npm,
-        PROJECT_ROOT,
-        extra_args=tuple(root_args),
-        capture_output=False,
-        env=nixos_env,
-    )
-    if root_result.returncode != 0:
-        print("  ⚠ npm install failed in repo root")
-        stderr = (root_result.stderr or "").strip() if root_result.stderr else ""
-        if stderr:
-            print(f"    {stderr.splitlines()[-1]}")
-        return
-
-    # Step 2: install only the workspaces update needs (ui-tui, web).
-    # --workspace selects specific workspaces; the rest (desktop) are skipped.
-    ws_args = [*extra_args, "--workspace", "ui-tui", "--workspace", "web"]
+    # Single-pass install: root deps + only the workspaces the CLI/TUI/web
+    # build requires. ``--include-workspace-root`` (``-W``) is critical — without
+    # it, a scoped ``--workspace`` selects a sub-tree that excludes the
+    # root-only packages (``agent-browser``, ``@streamdown/math``), and
+    # ``npm ci`` (which the deterministic helper prefers) wipes ``node_modules``
+    # before reifying, so a follow-on scoped install erases what a previous
+    # root install put there. Single pass avoids the wipe-then-don't-restore
+    # hole (#64354) and is verified to keep ``apps/desktop`` (Electron) out
+    # of the install tree.
+    #
+    # capture_output=False is deliberate (#18840) — optional postinstall
+    # scripts (e.g. @askjo/camofox-browser's browser-binary fetch) print
+    # download progress, and capturing it makes a long download look hung.
+    ws_args = [
+        *extra_args,
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "web",
+        "--include-workspace-root",
+    ]
     ws_result = _run_npm_install_deterministic(
         npm,
         PROJECT_ROOT,
@@ -8158,13 +8155,96 @@ def _update_node_dependencies() -> None:
         capture_output=False,
         env=nixos_env,
     )
-    if ws_result.returncode == 0:
-        print("  ✓ repo root + ui-tui, web workspaces (desktop skipped)")
-    else:
+    if ws_result.returncode != 0:
         print("  ⚠ npm workspace install failed")
         stderr = (ws_result.stderr or "").strip() if ws_result.stderr else ""
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
+        return
+
+    # Hardening: don't claim success if scoped install silently dropped
+    # root-only deps. ``npm ci`` is supposed to reify against the lockfile,
+    # but a follow-on scoped call (or any future regression of the same
+    # shape that #64354 introduced) can leave us with a partial tree while
+    # exit codes stay 0. Asserting the tree is complete prevents the silent
+    # "✓" on a broken browser-tools install (#64354).
+    manifest = _read_root_package_dependencies(PROJECT_ROOT / "package.json")
+    if manifest and not _node_modules_root_deps_present(PROJECT_ROOT, manifest):
+        missing = _missing_root_deps_report(PROJECT_ROOT, manifest)
+        print("  ⚠ npm install completed but root-only dependencies are missing:")
+        for name in missing:
+            print(f"    - {name}")
+        print("    Browser/desktop tooling that depends on these may not work.")
+        return
+
+    print("  ✓ repo root + ui-tui, web workspaces (desktop skipped)")
+
+
+def _read_root_package_dependencies(package_json: Path) -> tuple[str, ...]:
+    """Return root dependency names declared in package.json, or () if unavailable.
+
+    Used by ``_update_node_dependencies`` to verify root-only deps survived a
+    scoped install. Read-only; ignores everything other than the top-level
+    ``dependencies`` key so non-root package metadata can't poison the check.
+    """
+    try:
+        import json as _json
+
+        data = _json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ()
+    deps = data.get("dependencies") if isinstance(data, dict) else None
+    if not isinstance(deps, dict):
+        return ()
+    return tuple(name for name in deps.keys() if isinstance(name, str) and name)
+
+
+_NODE_MODULES_ROOT_PACKAGE_MARKERS = (
+    "package.json",  # legacy marker for npm < 7
+    "node_modules",
+)
+
+
+def _node_modules_root_deps_present(
+    project_root: Path, root_dep_names: tuple[str, ...]
+) -> bool:
+    """Return True iff every root dep materialised under ``node_modules/``.
+
+    We accept either a populated ``node_modules/<name>/`` subtree (npm ≥ 7,
+    hoisted layout) or a flat ``node_modules/<name>/package.json`` (legacy
+    flat layout) — both are real install outcomes. We do NOT treat a bare
+    ``node_modules/<name>`` symlink or shim file as evidence of install
+    success.
+    """
+    if not root_dep_names:
+        return True
+    nm = project_root / "node_modules"
+    for name in root_dep_names:
+        dep_dir = nm / name
+        if not dep_dir.is_dir():
+            return False
+        # A directory alone isn't enough — for the legacy flat layout
+        # a real package installs ``node_modules/<name>/package.json``,
+        # and for hoisted layouts the per-package dir is non-empty. An
+        # empty dir is what a partial / interrupted install leaves.
+        if not any((dep_dir / marker).exists() for marker in _NODE_MODULES_ROOT_PACKAGE_MARKERS):
+            return False
+    return True
+
+
+def _missing_root_deps_report(
+    project_root: Path, root_dep_names: tuple[str, ...]
+) -> list[str]:
+    """List specific root deps missing from ``node_modules/`` after install."""
+    nm = project_root / "node_modules"
+    missing: list[str] = []
+    for name in root_dep_names:
+        dep_dir = nm / name
+        if not dep_dir.is_dir() or not any(
+            (dep_dir / marker).exists() for marker in _NODE_MODULES_ROOT_PACKAGE_MARKERS
+        ):
+            missing.append(name)
+    return missing
 
 
 class _UpdateOutputStream:

--- a/tests/hermes_cli/test_update_node_dependencies_64354.py
+++ b/tests/hermes_cli/test_update_node_dependencies_64354.py
@@ -1,0 +1,292 @@
+"""Regression tests for ``_update_node_dependencies()`` (issue #64354).
+
+The legacy implementation ran two passes through
+``_run_npm_install_deterministic``:
+
+1. ``npm ci --workspaces=false`` → root-only deps
+   (``agent-browser``, ``@streamdown/math``).
+2. ``npm ci --workspace ui-tui --workspace web`` → scoped workspaces.
+
+``npm ci`` wipes ``node_modules`` before reifying, so pass 2 removed what pass
+1 had installed and never restored the root-only deps — both passes exited 0,
+the ``✓`` branch fired, and browser tools were silently broken until the user
+ran ``npm install agent-browser`` by hand. Verified with the minimal repro
+shipped in #64354.
+
+These tests cover (no real npm/network required):
+
+* The single-pass shape: exactly one helper call, with
+  ``--include-workspace-root`` plus both workspace flags, and the legacy
+  ``--workspaces=false`` root-only pass gone.
+* A failing install (non-zero exit) prints ``⚠`` and refrains from ``✓``.
+* ``npm ci`` exits 0 but the resulting ``node_modules/`` is missing every
+  root-only dep — the function must print ``⚠`` listing the missing names
+  instead of claiming success (this is exactly the silent-failure shape that
+  #64354 describes).
+* Happy path: when every declared root dep is present after install, ``✓``
+  still prints (no regression for users with an intact tree).
+* Legacy flat-layout marker (``node_modules/<name>/package.json`` with no
+  nested ``node_modules``) still counts as installed.
+* An empty ``node_modules/<name>/`` directory is the partial / interrupted
+  shape — must be flagged as missing, not mistaken for success.
+* Scoped-only manifest (no top-level ``dependencies`` key) does not crash the
+  check.
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _fake_hermes_constants_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a stub ``hermes_constants`` so ``_update_node_dependencies``
+    can ``from hermes_constants import find_node_executable, with_hermes_node_path``
+    without requiring the real package or a Node install.
+    """
+    stub = types.ModuleType("hermes_constants")
+    stub.find_node_executable = lambda name: f"/usr/bin/{name}"
+
+    def fake_with_hermes_node_path(env):
+        return dict(env)
+
+    stub.with_hermes_node_path = fake_with_hermes_node_path
+    monkeypatch.setitem(sys.modules, "hermes_constants", stub)
+
+
+def _write_pkg(
+    root: Path, deps: dict | None = None, *, name: str = "x"
+) -> None:
+    pkg = {
+        "name": name,
+        "private": True,
+        "scripts": {
+            "install:root": "npm install --workspaces=false",
+            "install:web": "npm install --workspace web",
+            "install:tui": "npm install --workspace ui-tui",
+        },
+    }
+    if deps is not None:
+        pkg["dependencies"] = deps
+    (root / "package.json").write_text(json.dumps(pkg))
+
+
+def _fake_installed(root: Path, dep_name: str, *, nested_node_modules: bool = True) -> None:
+    """Mark a dep as installed in a hoisted-layout shape (the post-npm-7 default)."""
+    dep_dir = root / "node_modules" / dep_name
+    dep_dir.mkdir(parents=True, exist_ok=True)
+    (dep_dir / "package.json").write_text("{}")
+    if nested_node_modules:
+        # Hoisted deps have a nested node_modules sub-dir.
+        (dep_dir / "node_modules").mkdir(exist_ok=True)
+
+
+def _capture_helper(monkeypatch, pkg_main, *, returncode: int, stderr: str = ""):
+    captured: dict = {"calls": 0, "extra_args": None, "capture_output": None}
+
+    def fake(*_args, extra_args=(), capture_output=True, **_kwargs):
+        captured["calls"] += 1
+        captured["extra_args"] = tuple(extra_args)
+        captured["capture_output"] = capture_output
+        return types.SimpleNamespace(returncode=returncode, stderr=stderr, stdout="")
+
+    monkeypatch.setattr(pkg_main, "_run_npm_install_deterministic", fake)
+    return captured
+
+
+@pytest.fixture
+def main_pkg(monkeypatch, tmp_path):
+    """Import the CLI module against our tmp PROJECT_ROOT and stubbed
+    ``hermes_constants``. Returns the loaded module.
+    """
+    _fake_hermes_constants_module(monkeypatch)
+    import hermes_cli.main as pkg_main
+
+    monkeypatch.setattr(pkg_main, "PROJECT_ROOT", tmp_path)
+    return pkg_main
+
+
+# ─── single-pass shape ──────────────────────────────────────────────────────
+
+
+def test_single_pass_uses_include_workspace_root(main_pkg, monkeypatch) -> None:
+    """Exactly one helper call, with --include-workspace-root + both workspaces."""
+    _write_pkg(main_pkg.PROJECT_ROOT, {"agent-browser": "0.0.1"})
+    _fake_installed(main_pkg.PROJECT_ROOT, "agent-browser")
+
+    captured = _capture_helper(monkeypatch, main_pkg, returncode=0)
+    main_pkg._update_node_dependencies()
+
+    assert captured["calls"] == 1, (
+        f"expected single-pass install, got {captured['calls']} calls"
+    )
+    args = captured["extra_args"]
+    # Required flags in any order between --no-* and --workspace
+    for required in (
+        "--include-workspace-root",
+        "--workspace",
+        "ui-tui",
+        "web",
+    ):
+        assert required in args, f"{required!r} missing from {args!r}"
+    assert "--workspaces=false" not in args, (
+        "legacy root-only pass must be gone — its interaction with the scoped "
+        "pass is exactly what introduced #64354"
+    )
+
+
+def test_legacy_root_pass_eliminated_no_double_call(main_pkg, monkeypatch, capsys) -> None:
+    """Belt-and-braces: even when root deps stay around, the helper is hit once, not twice."""
+    _write_pkg(main_pkg.PROJECT_ROOT, {"agent-browser": "0.0.1"})
+    _fake_installed(main_pkg.PROJECT_ROOT, "agent-browser")
+
+    captured = _capture_helper(monkeypatch, main_pkg, returncode=0)
+    main_pkg._update_node_dependencies()
+
+    assert captured["calls"] == 1
+    out = capsys.readouterr().out
+    assert "✓" in out
+    assert "⚠" not in out
+
+
+# ─── install failure path ──────────────────────────────────────────────────
+
+
+def test_install_failure_surfaces_warning(main_pkg, monkeypatch, capsys) -> None:
+    """Non-zero exit → ⚠, last stderr line surfaced, no ✓."""
+    _write_pkg(main_pkg.PROJECT_ROOT, {"agent-browser": "0.0.1"})
+    _capture_helper(
+        monkeypatch, main_pkg, returncode=1, stderr="npm ERR! ERESOLVE\n"
+    )
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "✓" not in out
+    assert "⚠" in out
+    assert "ERESOLVE" in out
+
+
+# ─── silent-drop hardening (#64354 violation) ──────────────────────────────
+
+
+def test_silent_root_drop_emits_warning_listing_missing(
+    main_pkg, monkeypatch, capsys
+) -> None:
+    """npm ci returns 0 but root-only deps are missing → ⚠, list names, no ✓."""
+    _write_pkg(
+        main_pkg.PROJECT_ROOT,
+        {"agent-browser": "0.0.1", "@streamdown/math": "0.0.2"},
+    )
+    _capture_helper(monkeypatch, main_pkg, returncode=0)
+    # node_modules intentionally empty — exactly the #64354 violation.
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "✓" not in out, f"must NOT print ✓ when root deps are missing, got: {out!r}"
+    assert "⚠" in out
+    assert "agent-browser" in out
+    assert "@streamdown/math" in out
+    assert "Browser" in out  # tells the user who is impacted
+
+
+def test_partial_drop_warning_lists_only_missing(main_pkg, monkeypatch, capsys) -> None:
+    """If only one of multiple root deps is missing, the warning names just that one."""
+    _write_pkg(
+        main_pkg.PROJECT_ROOT,
+        {"agent-browser": "0.0.1", "@streamdown/math": "0.0.2"},
+    )
+    _fake_installed(main_pkg.PROJECT_ROOT, "@streamdown/math")  # one present
+    _capture_helper(monkeypatch, main_pkg, returncode=0)
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "✓" not in out
+    assert "⚠" in out
+    assert "agent-browser" in out
+    assert "@streamdown/math" not in out
+
+
+# ─── happy path — don't regress ────────────────────────────────────────────
+
+
+def test_happy_path_when_tree_intact(main_pkg, monkeypatch, capsys) -> None:
+    """When every declared root dep is present after install, ✓ still prints."""
+    _write_pkg(main_pkg.PROJECT_ROOT, {"agent-browser": "0.0.1"})
+    _fake_installed(main_pkg.PROJECT_ROOT, "agent-browser")
+    _capture_helper(monkeypatch, main_pkg, returncode=0)
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "✓" in out
+    assert "⚠" not in out
+
+
+def test_legacy_flat_layout_still_counts_as_installed(
+    main_pkg, monkeypatch, capsys
+) -> None:
+    """npm <7 flat layout: node_modules/<name>/package.json with no nested dir."""
+    _write_pkg(main_pkg.PROJECT_ROOT, {"agent-browser": "0.0.1"})
+    _fake_installed(main_pkg.PROJECT_ROOT, "agent-browser", nested_node_modules=False)
+    _capture_helper(monkeypatch, main_pkg, returncode=0)
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "✓" in out, f"legacy flat layout must count as success, got: {out!r}"
+    assert "⚠" not in out
+
+
+def test_empty_dir_treated_as_missing(main_pkg, monkeypatch, capsys) -> None:
+    """Empty ``node_modules/<name>/`` directory = partial / interrupted install."""
+    _write_pkg(main_pkg.PROJECT_ROOT, {"agent-browser": "0.0.1"})
+    (main_pkg.PROJECT_ROOT / "node_modules" / "agent-browser").mkdir(
+        parents=True, exist_ok=True
+    )
+    # No package.json, no nested node_modules — neither marker present.
+    _capture_helper(monkeypatch, main_pkg, returncode=0)
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "✓" not in out
+    assert "⚠" in out
+    assert "agent-browser" in out
+
+
+def test_no_top_level_dependencies_key_does_not_crash(
+    main_pkg, monkeypatch, capsys
+) -> None:
+    """A package.json without ``dependencies`` short-circuits the check (no ✓ check, no warning)."""
+    _write_pkg(main_pkg.PROJECT_ROOT, deps=None)  # no dependencies key
+    _capture_helper(monkeypatch, main_pkg, returncode=0)
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    # No declared deps → no tree to verify → ✓ prints cleanly.
+    assert "✓" in out
+    assert "⚠" not in out
+
+
+def test_unreadable_manifest_falls_back_to_success(
+    main_pkg, monkeypatch, capsys
+) -> None:
+    """If package.json can't be read, we don't crash — we fall back to ✓ per
+    spec guidance: tree verification is best-effort hardening, not a hard
+    gate that breaks installs on transient FS errors."""
+    _capture_helper(monkeypatch, main_pkg, returncode=0)
+
+    # Make package.json unreadable / invalid JSON.
+    (main_pkg.PROJECT_ROOT / "package.json").write_text("{ not-json")
+
+    main_pkg._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "✓" in out
+    assert "⚠" not in out


### PR DESCRIPTION
## Summary

The ``hermes update`` npm refresh used two passes against the same lockfile: a
root-only install (``--workspaces=false``) followed by a scoped install
(``--workspace ui-tui --workspace web``). Because
``_run_npm_install_deterministic`` prefers ``npm ci`` (which wipes
``node_modules`` before reifying the lockfile it was given), pass 2 erased
what pass 1 had installed and never restored the root-only deps
(``agent-browser``, ``@streamdown/math``). Both passes exited 0, the
``✓ repo root + ui-tui, web workspaces (desktop skipped)`` branch fired,
and browser tools were silently broken until the user ran
``npm install agent-browser`` by hand. Verified against the issue's
isolated minimal repro.

## Changes

- ``hermes_cli/main.py`` — ``_update_node_dependencies``:
  - collapse the two passes into a single ``npm ci --include-workspace-root
    --workspace ui-tui --workspace web``. With ``-W`` the root + selected
    workspaces land in one tree, so there is no intermediate wipe to drop
    root-only deps from. ``apps/desktop`` (Electron) stays out because it
    isn't in either ``--workspace`` flag — the Electron-avoidance the
    two-pass design existed for is preserved.
  - add post-install tree verification: read the root ``package.json``
    ``dependencies`` and assert every entry materialised under
    ``node_modules/``. If a scoped future regression reintroduces the
    silent wipe, we now print a ``⚠`` listing the missing packages
    instead of claiming success.
  - split verification into three focused helpers
    (``_read_root_package_dependencies``, ``_node_modules_root_deps_present``,
    ``_missing_root_deps_report``) so the policy is testable in isolation
    and not entangled with the subprocess plumbing.
- ``tests/hermes_cli/test_update_node_dependencies_64354.py`` — 10 focused
  tests covering: the new single-pass shape (must include
  ``--include-workspace-root`` and must *not* include ``--workspaces=false``),
  install failure propagation, the silent-drop case that #64354 describes
  (now warns), the partial-drop case (warns but lists only the missing
  names), the happy path doesn't regress, legacy flat-layout marker,
  empty ``node_modules/<name>/`` is treated as missing, missing /
  unreadable package.json does not crash the check.

## How to Test

```
python -m pytest tests/hermes_cli/test_update_node_dependencies_64354.py -v
```

All 10 tests pass without npm, network, or a Node install. They stub
``hermes_constants`` (so ``find_node_executable`` resolves to a fake
``npm`` path) and override ``_run_npm_install_deterministic`` /
``PROJECT_ROOT`` to drive the function with synthetic trees.

```
# Manual repro — exact text from #64354
$ npm ci --no-fund --no-audit --progress=false --ignore-scripts \
       --workspaces=false        # old: pass 1
$ npm ci --no-fund --no-audit --progress=false --ignore-scripts \
       --workspace ui-tui --workspace web   # old: pass 2 (wipes pass 1)
$ ls node_modules/agent-browser
# (gone — exit code 0 from both passes)

# New (single pass)
$ npm ci --no-fund --no-audit --progress=false --ignore-scripts \
       --include-workspace-root --workspace ui-tui --workspace web
$ ls node_modules/agent-browser
# package.json present — install survived
```

## Checklist

- [x] Tests pass (10/10 in-process; full ``scripts/run_tests.sh`` is the
      Termux sandbox's pre-existing permission-denied limitation — see
      prior PRs; the test file itself runs cleanly anywhere with a
      real pytest)
- [x] Conventional Commits (``fix(cli): …``)
- [x] Single-purpose, scoped to ``_update_node_dependencies`` and its
      test file
- [x] Cross-platform impact: none — Node-side update path is OS-agnostic
- [x] profile-safe paths: unchanged (no path-resolution touched)
- [x] .env not used for non-credential settings: unchanged

## Risk & Impact

**Low.** Only ``hermes update`` node-refresh path. ``npm ci`` semantics
unchanged (still preferred for lockfile preservation); only the flag
shape changed and a tree-completeness assertion was added. Desktop
(Electron) is still skipped because no ``--workspace apps/desktop``
flag is passed.

Type: Bug fix
Closes: #64354