### PR TITLE
fix(honcho): use profile_host_key in peers display (dot vs underscore host-key mismatch)

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1007,7 +1007,12 @@ def _all_profile_host_configs() -> list[tuple[str, str, dict]]:
     for p in profiles:
         if p.name == "default":
             continue
-        h = f"{HOST}.{p.name}"
+        # Use the same resolver as the runtime (profile_host_key) so the
+        # display looks up the correct block. The runtime derives host keys
+        # with an underscore separator and sanitization (e.g. "hermes_kristi"),
+        # not a dot ("hermes.kristi"), so a naive f"{HOST}.{p.name}" misses
+        # the real block and falsely shows "(not set)" / the raw host key.
+        h = profile_host_key(p.name)
         results.append((p.name, h, hosts.get(h, {})))
 
     return results


### PR DESCRIPTION
# Bug Report: `hermes honcho peers` shows wrong host block for non-default profiles

## Summary

`hermes honcho peers` displays `(not set)` for the user peer and the raw
host key (e.g. `hermes.kristi`) for the AI peer on any **non-default
profile**, even when that profile's `honcho.json` block is correctly
populated. The runtime uses the correct block — this is a **display-only
bug** in the `peers` command caused by a host-key separator mismatch.

## Environment

- Hermes Agent (gateway + multi-profile setup)
- Memory provider: self-hosted Honcho
- Two profiles: `default` and `kristi`, each with its own Honcho workspace

## Root cause

Two different host-key derivations exist in `plugins/memory/honcho/`:

- **Runtime resolver** — `client.py::profile_host_key()` sanitizes and joins
  with an **underscore**:
  ```python
  return f"{HOST}_{sanitized or 'profile'}"   # -> "hermes_kristi"
  ```
- **Display command** — `cli.py::_all_profile_host_configs()` joined with a
  **dot**:
  ```python
  h = f"{HOST}.{p.name}"                        # -> "hermes.kristi"
  ```

Because the real config block is written under `hermes_kristi` (underscore)
by the runtime resolver, the display command's `hosts.get("hermes.kristi", {})`
returns an empty dict and falls back to `(not set)` / the raw host key.

## Reproduction

1. Create a second profile: `hermes profile create kristi --clone`
2. Configure Honcho for it with a distinct workspace/peer:
   `kristi memory setup` → provider honcho, peer `Kristi`, workspace `kristi`
3. Run `kristi honcho peers` (or `hermes honcho peers`)

**Expected:** `kristi   Kristi   Edna Millay`
**Actual:**   `kristi   (not set)   hermes.kristi`

Confirm the block is actually correct:
```bash
python3 -c "import json; d=json.load(open('~/.hermes/profiles/kristi/honcho.json'.replace('~','/root'))); print(list(d['hosts']))"
# -> ['hermes', 'hermes_kristi']   (underscore, not dot)
```

## Fix

In `plugins/memory/honcho/cli.py::_all_profile_host_configs()`, use the same
resolver the runtime uses instead of hand-building the key:

```diff
     for p in profiles:
         if p.name == "default":
             continue
-        h = f"{HOST}.{p.name}"
+        # Match the runtime resolver (underscore + sanitization), not a dot,
+        # so the display reads the real host block instead of falling back
+        # to "(not set)" / the raw host key.
+        h = profile_host_key(p.name)
         results.append((p.name, h, hosts.get(h, {})))

     return results
```

`profile_host_key` is already imported at the top of `cli.py`, so no new
import is needed. `python -m py_compile` passes.

## Impact

- Severity: low (cosmetic — no data or runtime behavior affected)
- Workspace isolation, peer identity, and memory routing all work correctly;
  only the `peers` summary view is wrong.
- Confusing for multi-profile users verifying isolation, since the one screen
  meant to confirm per-profile identity is the screen that misreports it.

## Suggested test

Add a unit test asserting `_all_profile_host_configs()` returns the block
keyed by `profile_host_key(name)` for a profile with a non-trivial name
(e.g. one requiring sanitization), guarding against the dot/underscore drift.
