### PR TITLE
feat(auth): add SiliconFlow provider preset (#5618)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -434,6 +434,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=(),
         base_url_env_var="BEDROCK_BASE_URL",
     ),
+    "siliconflow": ProviderConfig(
+        id="siliconflow",
+        name="SiliconFlow",
+        auth_type="api_key",
+        inference_base_url="https://api.siliconflow.cn/v1",
+        api_key_env_vars=("SILICONFLOW_API_KEY",),
+        base_url_env_var="SILICONFLOW_BASE_URL",
+    ),
     "azure-foundry": ProviderConfig(
         id="azure-foundry",
         name="Azure Foundry",

--- a/plugins/model-providers/siliconflow/__init__.py
+++ b/plugins/model-providers/siliconflow/__init__.py
@@ -1,0 +1,23 @@
+"""SiliconFlow provider profile.
+
+SiliconFlow (siliconflow.cn) provides an OpenAI-compatible API for
+a wide range of open-source and commercial LLMs, including DeepSeek,
+Qwen, GLM, and many others.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+siliconflow = ProviderProfile(
+    name="siliconflow",
+    aliases=("silicon-flow", "silicon_flow"),
+    env_vars=("SILICONFLOW_API_KEY", "SILICONFLOW_BASE_URL"),
+    base_url="https://api.siliconflow.cn/v1",
+    display_name="SiliconFlow",
+    description="SiliconFlow — OpenAI-compatible API for open-source & commercial LLMs",
+    signup_url="https://cloud.siliconflow.cn/",
+    supports_health_check=True,
+    supports_vision=True,
+)
+
+register_provider(siliconflow)

--- a/plugins/model-providers/siliconflow/plugin.yaml
+++ b/plugins/model-providers/siliconflow/plugin.yaml
@@ -1,0 +1,5 @@
+name: siliconflow-provider
+kind: model-provider
+version: 1.0.0
+description: SiliconFlow
+author: Nous Research


### PR DESCRIPTION
Implements #5618 (WebUI). Adds SiliconFlow to PROVIDER_REGISTRY with plugin metadata so it appears in both CLI and WebUI provider picker.