### PR TITLE
fix(moa): drop empty user turns from the advisory view (strict-provider 400)

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -501,8 +501,20 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 # a placeholder so the reference knows a non-text turn
                 # happened.
                 text = "[user sent non-text content (e.g. an image attachment)]"
-            if text.strip():
-                last_user_content = text
+            if not text.strip():
+                # Genuinely empty user turn (content="" / None). It carries
+                # nothing advisory, and strict providers (Kimi/Moonshot, ZAI,
+                # and others that enforce non-empty user content) reject it
+                # with 400 "message ... with role 'user' must not be empty" —
+                # the same way the assistant branch below drops turns with no
+                # parts. Lenient providers (DeepSeek) accept the empty turn,
+                # which is why a MoA fan-out would fail on one reference and
+                # pass on another for the identical rendered view. The
+                # advisory view is already not strictly alternating (adjacent
+                # assistant turns occur in every tool loop), so dropping a
+                # contentless turn is safe.
+                continue
+            last_user_content = text
             rendered.append({"role": "user", "content": text})
         elif role == "assistant":
             parts: list[str] = []

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -491,7 +491,7 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if role == "system":
             continue
         if role == "user":
-            if not text.strip() and content not in (None, "", []):
+            if not text.strip() and isinstance(content, list) and content:
                 # Structured content with no extractable text (e.g. an
                 # image-only turn). Emitting an empty user message would be
                 # dropped/rejected by strict providers (Anthropic 400s on
@@ -499,7 +499,9 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 # mode), and silently skipping the turn would break
                 # user/assistant alternation in the advisory view. Substitute
                 # a placeholder so the reference knows a non-text turn
-                # happened.
+                # happened. Only structured content qualifies — an empty or
+                # whitespace-only STRING turn carries nothing and is dropped
+                # below instead.
                 text = "[user sent non-text content (e.g. an image attachment)]"
             if not text.strip():
                 # Genuinely empty user turn (content="" / None). It carries

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "jake.long.vu@vucar.net": "jakelongvu-bot",  # PR #36683 partial salvage (approval: honor canonical approvals.timeout in gateway waits)

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -392,6 +392,44 @@ def test_reference_messages_fresh_user_turn_ends_on_that_user():
     assert view[-1] == {"role": "user", "content": "q2 current"}
 
 
+def test_reference_messages_drops_empty_user_turns():
+    """Empty user turns must not leak into the advisory view.
+
+    A user message whose content is "" or a non-string/multimodal payload
+    (flattened to "" by the text-extraction step) carries nothing advisory.
+    Strict providers (Kimi/Moonshot and others that enforce non-empty user
+    content) reject such a message with
+    400 "message ... with role 'user' must not be empty", while lenient
+    providers (DeepSeek) accept it — so a fan-out over the identical rendered
+    view fails on one reference and passes on another. The renderer must emit
+    NO empty user turn, mirroring how empty assistant turns are dropped.
+    """
+    from agent.moa_loop import _reference_messages
+
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "real question"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"function": {"name": "read_file", "arguments": '{"path":"c.yaml"}'}}
+        ]},
+        {"role": "tool", "content": "some result"},
+        {"role": "user", "content": ""},  # empty string user turn
+        {"role": "user", "content": [{"type": "text", "text": "multimodal"}]},  # non-string -> ""
+    ]
+
+    view = _reference_messages(messages)
+
+    # No user turn in the view may be empty/whitespace-only.
+    empty_users = [
+        m for m in view
+        if m.get("role") == "user" and not str(m.get("content", "")).strip()
+    ]
+    assert empty_users == [], f"empty user turn leaked into advisory view: {empty_users}"
+    # The real user prompt survives and the view still ends on a user turn.
+    assert view[0] == {"role": "user", "content": "real question"}
+    assert view[-1]["role"] == "user"
+
+
 def test_run_reference_prepends_advisory_system_prompt(monkeypatch):
     """Each reference call gets the advisory-role system prompt first.
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1241,3 +1241,27 @@ def test_reference_guidance_appends_text_part_to_decorated_trailing_user():
     assert content[0] == marked_part
     # The guidance rides as a trailing text part outside the cached span.
     assert content[1] == {"type": "text", "text": "\n\nREFERENCE BLOCK"}
+
+
+def test_reference_messages_drops_whitespace_only_string_user_turn():
+    """A whitespace-only STRING user turn is dropped, not placeholdered.
+
+    The non-text placeholder exists for structured content (image-only turns)
+    where a real turn happened that the reference should know about. A bare
+    whitespace string carries nothing — emitting it would 400 strict
+    providers (Kimi/Moonshot 'role user must not be empty'), and
+    placeholdering it would fabricate an attachment that never existed.
+    """
+    from agent.moa_loop import _reference_messages
+
+    messages = [
+        {"role": "user", "content": "   "},
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": "real"},
+    ]
+
+    view = _reference_messages(messages)
+
+    assert view[0] == {"role": "assistant", "content": "a"}
+    assert view[-1] == {"role": "user", "content": "real"}
+    assert all(str(m["content"]).strip() for m in view)


### PR DESCRIPTION
## Summary

Empty user turns no longer leak into the MoA advisory view — strict providers (Kimi/Moonshot `400 role 'user' must not be empty`, ZAI error 1213) rejected them while lenient providers accepted the identical view, so one advisor in a fan-out failed and another passed. Fixes #58464.

Salvages @neo-claw-bot's #58465 (earliest correct fix, Jul 4 — cherry-picked with authorship preserved) onto current main, plus a follow-up commit scoping the interaction with the non-text placeholder that landed in #64319.

## Changes

- `agent/moa_loop.py` (contributor commit, @neo-claw-bot): drop user turns whose extracted text is empty/whitespace-only, mirroring the existing empty-assistant-turn drop. The end-on-user invariant is preserved — the synthetic advisory marker still terminates the view.
- `agent/moa_loop.py` (follow-up): the image-only placeholder from #64319 now fires only for genuinely structured content (`isinstance(content, list)`); a whitespace-only STRING turn is dropped instead of being placeholdered as a fabricated "attachment".
- Tests: contributor's regression test (no empty user turn in view, ends on user) + a whitespace-only-string test.

## Validation

| Case | Before | After |
|---|---|---|
| `content=""` user turn in history | emitted verbatim → Kimi/ZAI 400 | dropped |
| whitespace-only string turn | placeholdered as fake attachment (post-#64319) | dropped |
| image-only structured turn | placeholder (correct) | placeholder (unchanged) |
| trailing empty user turn | — | view still ends on synthetic advisory marker (verified) |
| all-empty transcript | — | degenerates to `[]` (verified) |

34/34 tests green (`scripts/run_tests.sh tests/run_agent/test_moa_loop_mode.py`). Live probe (`live_moa_reference_probe.py`, `closed` preset, real provider wire): both advisors OK — ends-on-user, advisory system prompt, rendered tool state, zero refusals, zero 400s.

Note: dropping is safe for alternation here — the advisory view is already non-alternating by design (adjacent assistant turns occur in every tool loop).

## Infographic

![moa-empty-user-filter](https://v3b.fal.media/files/b/0aa237b6/Cpd7GyR0z71Vsx4MdC9jZ_AiW754DE.png)
