### PR TITLE
fix(update): keep root npm deps across both of update's npm installs (#64354)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8233,39 +8233,35 @@ def _update_node_dependencies() -> None:
     # With a single workspace lockfile the root install would cover ALL
     # workspaces — but apps/desktop pulls in Electron as a devDependency,
     # and its postinstall downloads a ~200MB binary.  Most users don't
-    # need desktop during `hermes update`, so we install root-only first
-    # then add just the workspaces the CLI/TUI/web build actually requires.
-    # Desktop deps are installed on demand by the desktop launcher
+    # need desktop during `hermes update`, so we install the repo root plus
+    # just the workspaces the CLI/TUI/web build actually requires.  Desktop
+    # deps are installed on demand by the desktop launcher
     # (see _desktop_build_needed).
+    #
+    # This must be a SINGLE npm invocation (--include-workspace-root rather
+    # than a root-only pass followed by a workspace-scoped pass): the helper
+    # prefers `npm ci`, which deletes node_modules before reifying the
+    # requested tree, so a second scoped pass silently wipes the root-only
+    # deps (agent-browser, @streamdown) installed by the first while still
+    # exiting 0.  See #64354.
     print("→ Updating Node.js dependencies...")
     extra_args = ["--no-fund", "--no-audit", "--progress=false"]
 
     nixos_env = with_hermes_node_path(_nixos_build_env())
 
-    # Step 1: root install (no workspace recursion).
     # NOTE: capture_output=False here is deliberate (#18840) — optional
     # postinstall scripts (e.g. @askjo/camofox-browser's browser-binary fetch)
     # print download progress, and capturing it makes a long download look
     # hung. The chatty npm-deprecation noise during `hermes update` comes from
     # the *desktop* build, not this step; that one is captured to update.log.
-    root_args = [*extra_args, "--workspaces=false"]
-    root_result = _run_npm_install_deterministic(
-        npm,
-        PROJECT_ROOT,
-        extra_args=tuple(root_args),
-        capture_output=False,
-        env=nixos_env,
-    )
-    if root_result.returncode != 0:
-        print("  ⚠ npm install failed in repo root")
-        stderr = (root_result.stderr or "").strip() if root_result.stderr else ""
-        if stderr:
-            print(f"    {stderr.splitlines()[-1]}")
-        return
-
-    # Step 2: install only the workspaces update needs (ui-tui, web).
-    # --workspace selects specific workspaces; the rest (desktop) are skipped.
-    ws_args = [*extra_args, "--workspace", "ui-tui", "--workspace", "web"]
+    ws_args = [
+        *extra_args,
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "web",
+        "--include-workspace-root",
+    ]
     ws_result = _run_npm_install_deterministic(
         npm,
         PROJECT_ROOT,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4929,7 +4929,19 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     # would pull in desktop on every web build. See #38772.
     # When web/ has its own package-lock.json, _workspace_root() returns
     # web_dir itself and --workspace would fail.  See #42973.
-    npm_workspace_args: tuple[str, ...] = () if npm_cwd == web_dir else ("--workspace", "web")
+    #
+    # --include-workspace-root is required for the same reason the updater
+    # installs in a single pass (#64354): _run_npm_install_deterministic
+    # prefers `npm ci`, which wipes node_modules and reifies only the tree it
+    # was given.  cmd_update calls _update_node_dependencies() and then us, so
+    # scoping to --workspace web alone deleted the root deps (agent-browser,
+    # @streamdown) that had just been installed a second earlier — both npm
+    # runs exit 0, so update reported success while browser tools were gone.
+    # The flag adds only the root package's own deps, not sibling workspaces,
+    # so desktop/Electron stays excluded as described above.
+    npm_workspace_args: tuple[str, ...] = (
+        () if npm_cwd == web_dir else ("--workspace", "web", "--include-workspace-root")
+    )
     if _is_termux_startup_environment():
         npm_cwd, npm_workspace_args = _termux_workspace_install_context(web_dir)
     r1 = _run_npm_install_deterministic(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8191,6 +8191,27 @@ def _npm_manifests_digest() -> str | None:
     return h.hexdigest()
 
 
+def _root_declared_deps_present() -> bool:
+    """Return True if every dep declared in the root package.json is installed.
+
+    Only ``dependencies`` are checked: ``optionalDependencies`` may be
+    legitimately absent (platform-specific, install-failure-tolerant), and
+    ``devDependencies`` are not something ``hermes update`` guarantees at the
+    repo root. A missing or unparseable manifest returns True — no evidence the
+    deps are missing — so this guard only ever *adds* a reinstall for the
+    concrete pruned-tree case and never strips the cache's existing behaviour.
+    An empty ``dependencies`` (e.g. if root deps are dropped entirely) is
+    vacuously present, so the guard is a no-op there.
+    """
+    root_pkg = PROJECT_ROOT / "package.json"
+    try:
+        deps = json.loads(root_pkg.read_text(encoding="utf-8")).get("dependencies", {})
+    except (OSError, ValueError):
+        return True
+    node_modules = PROJECT_ROOT / "node_modules"
+    return all((node_modules / name).exists() for name in deps)
+
+
 def _npm_lockfile_changed(hermes_root: Path) -> bool:
     current = _npm_manifests_digest()
     if current is None:
@@ -8198,6 +8219,16 @@ def _npm_lockfile_changed(hermes_root: Path) -> bool:
     # Also check that node_modules exists; a matching hash with missing
     # node_modules means the cache was recorded by another checkout.
     if not (PROJECT_ROOT / "node_modules").is_dir():
+        return True
+    # The digest proves the manifests are unchanged, and node_modules exists —
+    # but neither proves the root's own declared deps are actually installed.
+    # A tree pruned by the pre-fix two-pass update (agent-browser/@streamdown
+    # deleted, #64354) still has a node_modules/ and records a matching marker,
+    # so honouring the cache here would skip the repair on exactly the installs
+    # that hit the bug. Verify the root deps are present before trusting it;
+    # this also self-heals trees damaged by any other cause (manual rm, an
+    # older hermes) and is a no-op once root declares no deps.
+    if not _root_declared_deps_present():
         return True
     try:
         # Key the cache by PROJECT_ROOT so parallel worktrees don't collide.

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -207,6 +207,50 @@ class TestCmdUpdateNpmLockfileCache:
 
         assert hm._npm_lockfile_changed(tmp_path) is True
 
+    def test_matching_marker_but_root_dep_pruned_defeats_skip(
+        self, tmp_path, monkeypatch
+    ):
+        """#64354 salvage: a tree pruned by the old two-pass update still has a
+        node_modules/ and a MATCHING marker, but the root's declared deps are
+        gone. Honouring the cache there would skip the repair on exactly the
+        installs that hit the bug, so a missing root dep must defeat the skip."""
+        from hermes_cli import main as hm
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        (tmp_path / "package-lock.json").write_text('{"lockfileVersion": 3}')
+        (tmp_path / "package.json").write_text(
+            '{"dependencies": {"agent-browser": "^0.26.0",'
+            ' "@streamdown/math": "^1.0.2"}}'
+        )
+        (tmp_path / "node_modules").mkdir()
+        hm._record_npm_lockfile_hash(tmp_path)
+
+        # All declared root deps present: the marker is honoured (skip).
+        (tmp_path / "node_modules" / "agent-browser").mkdir()
+        (tmp_path / "node_modules" / "@streamdown").mkdir()
+        (tmp_path / "node_modules" / "@streamdown" / "math").mkdir()
+        assert hm._npm_lockfile_changed(tmp_path) is False
+
+        # A pruned root dep (scoped name included) defeats the otherwise-matching
+        # marker even though node_modules/ still exists.
+        import shutil
+
+        shutil.rmtree(tmp_path / "node_modules" / "agent-browser")
+        assert hm._npm_lockfile_changed(tmp_path) is True
+
+    def test_matching_marker_no_root_deps_is_noop(self, tmp_path, monkeypatch):
+        """When root declares no deps (e.g. #44772 drops them entirely) the
+        presence guard is vacuously satisfied and the cache is still honoured."""
+        from hermes_cli import main as hm
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        (tmp_path / "package-lock.json").write_text('{"lockfileVersion": 3}')
+        (tmp_path / "package.json").write_text('{"dependencies": {}}')
+        (tmp_path / "node_modules").mkdir()
+        hm._record_npm_lockfile_hash(tmp_path)
+
+        assert hm._npm_lockfile_changed(tmp_path) is False
+
     def test_update_skips_npm_when_lockfile_unchanged(self, tmp_path, monkeypatch):
         from hermes_cli import main as hm
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -465,29 +465,21 @@ class TestCmdUpdateBranchFallback:
         ]
 
         # cmd_update runs npm commands in these locations:
-        #   1. repo root  — root-only install (--workspaces=false)
-        #   2. repo root  — workspace install (--workspace ui-tui --workspace web)
-        #   3. web/       — npm ci --silent (if lockfile not at root)
+        #   1. repo root  — single install covering the root plus the
+        #                  ui-tui/web workspaces (--include-workspace-root)
+        #   2. web/       — npm ci --silent (if lockfile not at root)
         #                  via _build_web_ui (subprocess.run)
-        #   4. web/       — npm run build (_run_with_idle_timeout)
+        #   3. web/       — npm run build (_run_with_idle_timeout)
         #
-        # With a single workspace lockfile at the repo root, the root
-        # install covers all workspaces.  The web/ ci call runs from the
-        # workspace root too (parent of web_dir) when the root lockfile
-        # exists.
+        # Root + workspaces must be ONE npm ci invocation (#64354): npm ci
+        # deletes node_modules before reifying the requested tree, so a
+        # workspace-scoped second pass would wipe root-only deps such as
+        # agent-browser while still exiting 0.
         #
         # The root install omits `--silent` and runs without
         # `capture_output` so optional postinstall scripts (e.g.
         # `@askjo/camofox-browser`'s browser-binary fetch) print progress —
         # otherwise long downloads look like a hang (#18840).
-        root_flags = [
-            "/usr/bin/npm",
-            "ci",
-            "--no-fund",
-            "--no-audit",
-            "--progress=false",
-            "--workspaces=false",
-        ]
         ws_flags = [
             "/usr/bin/npm",
             "ci",
@@ -498,15 +490,15 @@ class TestCmdUpdateBranchFallback:
             "ui-tui",
             "--workspace",
             "web",
+            "--include-workspace-root",
         ]
-        assert npm_calls[:2] == [
-            (root_flags, PROJECT_ROOT),
+        assert npm_calls[:1] == [
             (ws_flags, PROJECT_ROOT),
         ]
-        if len(npm_calls) > 2:
+        if len(npm_calls) > 1:
             # The web/ install runs from the workspace root when the root
             # lockfile exists (npm workspaces hoist node_modules upward).
-            assert npm_calls[2:] == [
+            assert npm_calls[1:] == [
                 (["/usr/bin/npm", "ci", "--workspace", "web", "--silent"], PROJECT_ROOT),
             ]
 
@@ -529,7 +521,7 @@ class TestCmdUpdateBranchFallback:
             and call.kwargs.get("cwd") == PROJECT_ROOT
             and "--silent" not in call.args[0]
         ]
-        assert len(root_install_calls) == 2  # root-only + workspace install
+        assert len(root_install_calls) == 1  # single root+workspaces install
         for call in root_install_calls:
             assert call.kwargs.get("capture_output") is False, (
                 "repo-root npm install must stream output "

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -498,8 +498,21 @@ class TestCmdUpdateBranchFallback:
         if len(npm_calls) > 1:
             # The web/ install runs from the workspace root when the root
             # lockfile exists (npm workspaces hoist node_modules upward).
+            # It must also pass --include-workspace-root: it is an `npm ci`
+            # from the same root, so scoping it to web alone would prune the
+            # root deps the call above just installed (#64354).
             assert npm_calls[1:] == [
-                (["/usr/bin/npm", "ci", "--workspace", "web", "--silent"], PROJECT_ROOT),
+                (
+                    [
+                        "/usr/bin/npm",
+                        "ci",
+                        "--workspace",
+                        "web",
+                        "--include-workspace-root",
+                        "--silent",
+                    ],
+                    PROJECT_ROOT,
+                ),
             ]
 
         # The web UI build itself went through the streaming helper.

--- a/tests/hermes_cli/test_update_node_dependencies.py
+++ b/tests/hermes_cli/test_update_node_dependencies.py
@@ -1,0 +1,86 @@
+"""Tests for _update_node_dependencies — single-pass npm install (#64354).
+
+The updater used to run two passes (root-only, then workspace-scoped).
+Both went through _run_npm_install_deterministic, which prefers ``npm ci``;
+``npm ci`` deletes node_modules before reifying the requested tree, so the
+second pass wiped the root-only deps (agent-browser, @streamdown) installed
+by the first while still exiting 0. The fix collapses the install into one
+invocation using --include-workspace-root.
+"""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.main import _update_node_dependencies
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    (tmp_path / "package.json").write_text("{}")
+    return tmp_path
+
+
+def _run_with_mocked_install(project_root, returncode=0, stderr=""):
+    result = subprocess.CompletedProcess([], returncode, stdout="", stderr=stderr)
+    with patch("hermes_cli.main.PROJECT_ROOT", project_root), \
+         patch("hermes_constants.find_node_executable", return_value="/usr/bin/npm"), \
+         patch("hermes_constants.with_hermes_node_path", side_effect=lambda env=None: env or {}), \
+         patch("hermes_cli.main._nixos_build_env", return_value={}), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=result) as mock_install:
+        _update_node_dependencies()
+    return mock_install
+
+
+def test_installs_in_a_single_pass(project_root):
+    """One npm invocation — a second scoped pass would wipe root deps under npm ci."""
+    mock_install = _run_with_mocked_install(project_root)
+    assert mock_install.call_count == 1
+
+
+def test_single_pass_includes_workspace_root_and_selected_workspaces(project_root):
+    """Root deps and ui-tui/web must be reified in the same tree; desktop skipped."""
+    mock_install = _run_with_mocked_install(project_root)
+    extra_args = mock_install.call_args.kwargs["extra_args"]
+
+    assert "--include-workspace-root" in extra_args
+
+    workspaces = [
+        extra_args[i + 1]
+        for i, arg in enumerate(extra_args[:-1])
+        if arg == "--workspace"
+    ]
+    assert workspaces == ["ui-tui", "web"]
+
+    # The old root-only pass must not come back: scoped npm ci prunes what
+    # a --workspaces=false pass installed.
+    assert "--workspaces=false" not in extra_args
+
+
+def test_failure_is_reported(project_root, capsys):
+    _run_with_mocked_install(project_root, returncode=1, stderr="npm ERR! boom")
+    out = capsys.readouterr().out
+    assert "⚠" in out
+
+
+def test_success_message_mentions_root_and_workspaces(project_root, capsys):
+    _run_with_mocked_install(project_root)
+    out = capsys.readouterr().out
+    assert "repo root + ui-tui, web workspaces" in out
+
+
+def test_skips_when_npm_missing(project_root):
+    with patch("hermes_cli.main.PROJECT_ROOT", project_root), \
+         patch("hermes_constants.find_node_executable", return_value=None), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install:
+        _update_node_dependencies()
+    mock_install.assert_not_called()
+
+
+def test_skips_without_package_json(tmp_path):
+    with patch("hermes_cli.main.PROJECT_ROOT", tmp_path), \
+         patch("hermes_constants.find_node_executable", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install:
+        _update_node_dependencies()
+    mock_install.assert_not_called()

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -174,6 +174,37 @@ class TestBuildWebUISkipsWhenFresh:
         assert "--workspace" in install_cmd
         assert install_cmd[install_cmd.index("--workspace") + 1] == "web"
 
+    def test_workspace_scoped_install_keeps_root_deps(self, tmp_path):
+        """--workspace web must carry --include-workspace-root (#64354).
+
+        cmd_update runs _update_node_dependencies() and then _build_web_ui().
+        Both go through _run_npm_install_deterministic, which prefers `npm ci`
+        — and `npm ci` deletes node_modules before reifying only the tree it
+        was given. Scoping this install to web alone therefore pruned the root
+        deps (agent-browser, @streamdown) installed a second earlier, while
+        both npm runs still exited 0, so `hermes update` reported success with
+        browser tools silently missing.
+        """
+        web_dir, _ = _make_web_dir(tmp_path)
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        build_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run, \
+             patch("hermes_cli.main._run_with_idle_timeout", return_value=build_ok):
+            result = _build_web_ui(web_dir)
+        assert result is True
+        install_cmd = mock_run.call_args[0][0]
+        assert "--include-workspace-root" in install_cmd
+        # Only the root's own deps come along — sibling workspaces (notably
+        # apps/desktop, which drags in a ~200MB Electron binary) stay excluded.
+        workspaces = [
+            install_cmd[i + 1]
+            for i, arg in enumerate(install_cmd[:-1])
+            if arg == "--workspace"
+        ]
+        assert workspaces == ["web"]
+
     def test_web_install_omits_workspace_when_web_has_own_lockfile(
         self, tmp_path, monkeypatch
     ):
@@ -269,7 +300,14 @@ class TestBuildWebUISkipsWhenFresh:
 
         assert result is True
         args, kwargs = mock_run.call_args
-        assert args[0] == ["/usr/bin/npm", "ci", "--workspace", "web", "--silent"]
+        assert args[0] == [
+            "/usr/bin/npm",
+            "ci",
+            "--workspace",
+            "web",
+            "--include-workspace-root",
+            "--silent",
+        ]
         assert kwargs["cwd"] == tmp_path
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes update` silently removing the repo-root npm dependencies (`agent-browser`, `@streamdown`) on every run, which breaks browser tools until the user manually reinstalls them.

The root cause is a general one: **`_run_npm_install_deterministic()` prefers `npm ci`, and `npm ci` deletes `node_modules` before reifying only the tree it was given.** Any workspace-scoped install through that helper therefore prunes the repo-root deps. `cmd_update` did this twice, in two different places, so the fix has two halves:

**1. `_update_node_dependencies()` installed in two passes** (root-only via `--workspaces=false`, then `--workspace ui-tui --workspace web`) to avoid pulling Electron via `apps/desktop`. Pass 2's tree is scoped to the workspaces, so it wiped the root-only deps installed by pass 1 and exited 0. Collapsed into a **single** `npm ci` using `--include-workspace-root`.

**2. `_build_web_ui()` then undid the fix a second later.** `cmd_update` calls the two back to back:

```python
_update_node_dependencies()          # installs root + ui-tui + web
_build_web_ui(PROJECT_ROOT / "web")  # npm ci --workspace web  <-- prunes root deps again
```

With no `web/package-lock.json`, `_workspace_root(web_dir)` resolves to the repo root, so this is another root-scoped `npm ci` with only `--workspace web` — deleting the root deps that had just been installed. Both npm runs exit 0, so update printed `✓` while browser tools were gone. It now passes `--include-workspace-root` too.

Fixing only (1) is not enough — the update still ends with root deps missing. That was the state of the first revision of this PR, and it was caught in real use.

The Electron-avoidance the scoping exists for (#38772) is preserved in both places: `--include-workspace-root` adds only the root package's own deps, never sibling workspaces, so `apps/desktop` is still skipped.

The TUI install path (`_tui_need_npm_install`) is **not** affected and is deliberately left alone: it uses `npm install`, which does not prune root deps. Verified explicitly rather than assumed.

## Related Issue

Fixes #64354

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `_update_node_dependencies()`: removed the root-only first pass; the workspace pass now carries `--include-workspace-root`.
- `hermes_cli/main.py` — `_build_web_ui()`: the `--workspace web` install now carries `--include-workspace-root`. The Termux path (`_termux_workspace_install_context`, which sets `--include-workspace-root=false` on purpose) is untouched — it overrides these args afterward.
- `tests/hermes_cli/test_update_node_dependencies.py` — new regression tests: single npm invocation, `--include-workspace-root` + both workspaces present, `--workspaces=false` absent, failure reporting, npm-missing / no-package.json skips.
- `tests/hermes_cli/test_web_ui_build.py` — new `test_workspace_scoped_install_keeps_root_deps`; updated the exact-command assertion in `test_desktop_web_install_uses_existing_workspace_root`.
- `tests/hermes_cli/test_cmd_update.py` — updated `test_update_refreshes_repo_and_tui_node_dependencies`, which pins the whole npm call sequence and so now covers both installs together.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/ -q` — 328 tests touching `cmd_update` / `_build_web_ui` / `_update_node_dependencies` pass.
2. The new tests fail against the unfixed code (3 red, including the `cmd_update` call-sequence test) and pass with it.
3. Isolated repro against a real npm 10.9.8 workspace checkout (root + workspace manifests + the repo lockfile):

   | install | `agent-browser` | `@streamdown/math` | electron / desktop |
   |---|---|---|---|
   | `npm ci --workspace web` (old) | absent | absent | absent |
   | `npm ci --workspace web --include-workspace-root` (new) | **present** | **present** | absent |

4. On a `git` install: `hermes update`, then `ls node_modules/agent-browser` → present, with no manual `npm install`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh tests/hermes_cli/`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: bug + isolated repro verified on Ubuntu 26.04 LTS (x86_64, `git` install); test suite run on Gentoo Linux (x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (`--include-workspace-root` is plain npm CLI behavior, identical across platforms; the Termux path is explicitly preserved)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Isolated repro of the second half — the web build undoing the first half:

```console
$ npm ci --workspace web --silent            # what _build_web_ui used to run
exit=0
agent-browser : NO     <-- pruned, seconds after being installed
@streamdown   : NO
electron      : NO

$ npm ci --workspace web --include-workspace-root --silent    # after this PR
exit=0
agent-browser : YES
@streamdown   : YES
electron      : NO     (desktop still skipped)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
