### PR TITLE
fix(cron): make model resolution precedence explicit

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -987,6 +987,7 @@ def _compute_provider_model_snapshots(
     model: Any,
     base_url: Any,
     no_agent: Any,
+    inherit_model_config: Any = False,
 ) -> Tuple[Optional[str], Optional[str]]:
     """Snapshot unpinned inference axes for the provider/model drift guard.
 
@@ -1001,7 +1002,7 @@ def _compute_provider_model_snapshots(
         base_url,
         strip_trailing_slash=True,
     )
-    if bool(no_agent):
+    if bool(no_agent) or bool(inherit_model_config):
         return None, None
 
     provider_snapshot: Optional[str] = None
@@ -1026,13 +1027,16 @@ def _compute_provider_model_snapshots(
     return provider_snapshot, model_snapshot
 
 
-def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Optional[str], Optional[str], bool]:
+def _normalized_inference_axes(
+    job: Dict[str, Any],
+) -> Tuple[Optional[str], Optional[str], Optional[str], bool, bool]:
     """Return the stored inference-routing fields in their semantic form."""
     return (
         _normalize_job_optional_text(job.get("provider")),
         _normalize_job_optional_text(job.get("model")),
         _normalize_job_optional_text(job.get("base_url"), strip_trailing_slash=True),
         bool(job.get("no_agent")),
+        bool(job.get("inherit_model_config")),
     )
 
 
@@ -1048,6 +1052,7 @@ def create_job(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    inherit_model_config: bool = False,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
@@ -1071,6 +1076,9 @@ def create_job(
         model: Optional per-job model override
         provider: Optional per-job provider override
         base_url: Optional per-job base URL override
+        inherit_model_config: When True, deliberately follow the active
+                profile's provider, model, endpoint, and credentials at every
+                run. Explicit inference overrides must be omitted.
         script: Optional path to a script whose stdout feeds the job. With
                 ``no_agent=True`` the script IS the job — its stdout is
                 delivered verbatim. Without ``no_agent``, its stdout is
@@ -1123,6 +1131,7 @@ def create_job(
     normalized_model = _normalize_job_optional_text(model)
     normalized_provider = _normalize_job_optional_text(provider)
     normalized_base_url = _normalize_job_optional_text(base_url, strip_trailing_slash=True)
+    normalized_inherit_model_config = bool(inherit_model_config)
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
@@ -1138,6 +1147,15 @@ def create_job(
         raise ValueError(
             "no_agent=True requires a script — with no agent and no script "
             "there is nothing for the job to run."
+        )
+
+    if normalized_inherit_model_config and any(
+        value is not None
+        for value in (normalized_provider, normalized_model, normalized_base_url)
+    ):
+        raise ValueError(
+            "inherit_model_config=True cannot be combined with provider, model, "
+            "or base_url overrides"
         )
 
     # Normalize context_from: accept str or list of str, store as list or None
@@ -1165,6 +1183,7 @@ def create_job(
         model=normalized_model,
         base_url=normalized_base_url,
         no_agent=normalized_no_agent,
+        inherit_model_config=normalized_inherit_model_config,
     )
 
     next_run_at = compute_next_run(parsed_schedule)
@@ -1195,6 +1214,7 @@ def create_job(
         "provider_snapshot": provider_snapshot,
         "model_snapshot": model_snapshot,
         "base_url": normalized_base_url,
+        "inherit_model_config": normalized_inherit_model_config,
         "script": normalized_script,
         "no_agent": normalized_no_agent,
         "context_from": context_from,
@@ -1319,7 +1339,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
-                {"provider", "model", "base_url", "no_agent"}.intersection(updates)
+                {
+                    "provider",
+                    "model",
+                    "base_url",
+                    "no_agent",
+                    "inherit_model_config",
+                }.intersection(updates)
             ) and _normalized_inference_axes(updated) != previous_inference_axes
 
             if "skills" in updates or "skill" in updates:
@@ -1370,6 +1396,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     model=updated.get("model"),
                     base_url=updated.get("base_url"),
                     no_agent=updated.get("no_agent"),
+                    inherit_model_config=updated.get("inherit_model_config"),
                 )
                 updated["provider_snapshot"] = provider_snapshot
                 updated["model_snapshot"] = model_snapshot

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3093,16 +3093,28 @@ def run_job(
         # Back-compat: an axis with no snapshot (pre-existing jobs, no_agent, or
         # any axis whose creation-time resolution failed) behaves exactly as
         # before — the guard never engages for it. Pinned axes are unaffected.
+        # ``inherit_model_config`` is an explicit opt-in to this drift. It is
+        # deliberately distinct from legacy unpinned jobs, which retain the
+        # fail-closed spend protection above.
+        _allow_inherited_drift = bool(job.get("inherit_model_config"))
         _drift: list[str] = []
         _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
-        if _provider_snapshot and not (job.get("provider") or "").strip():
+        if (
+            not _allow_inherited_drift
+            and _provider_snapshot
+            and not (job.get("provider") or "").strip()
+        ):
             _current_provider = str(runtime.get("provider") or "").strip().lower()
             if _current_provider and _current_provider != _provider_snapshot:
                 _drift.append(
                     f"provider '{_provider_snapshot}' -> '{_current_provider}'"
                 )
         _model_snapshot = (job.get("model_snapshot") or "").strip().lower()
-        if _model_snapshot and not (job.get("model") or "").strip():
+        if (
+            not _allow_inherited_drift
+            and _model_snapshot
+            and not (job.get("model") or "").strip()
+        ):
             _current_model = str(model or "").strip().lower()
             if _current_model and _current_model != _model_snapshot:
                 _drift.append(

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -153,6 +153,21 @@ class TestProviderDriftGuard:
         assert error is None
         assert agent_constructed is True
 
+    def test_explicit_inheritance_accepts_provider_drift(self, tmp_path):
+        """A user opt-in to live profile config bypasses the spend guard."""
+        job = _base_job(
+            provider_snapshot="openrouter",
+            inherit_model_config=True,
+        )
+
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider(job, "nous", tmp_path)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert agent_constructed is True
+
 
 class TestCreateJobSnapshot:
     """create_job captures provider_snapshot for unpinned agent jobs only."""
@@ -241,6 +256,22 @@ class TestCreateJobSnapshot:
             )
         assert job["model"] == "my-model"
         assert job["model_snapshot"] is None
+
+    def test_inherited_config_skips_both_snapshots(self, monkeypatch):
+        jobs = self._isolate_storage(monkeypatch)
+        resolver = MagicMock(return_value={"provider": "openrouter"})
+
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider", resolver):
+            job = jobs.create_job(
+                prompt="do a thing",
+                schedule="every 1 hour",
+                inherit_model_config=True,
+            )
+
+        assert job["inherit_model_config"] is True
+        assert job["provider_snapshot"] is None
+        assert job["model_snapshot"] is None
+        resolver.assert_not_called()
 
 
 def _run_with_current_provider_and_model(job, current_provider, current_model, tmp_path):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,91 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_inherit_mode_tracks_profile_without_snapshots(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                inherit_model_config=True,
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["inherit_model_config"] is True
+        from cron.jobs import get_job
+
+        stored = get_job(created["job_id"])
+        assert stored["provider"] is None
+        assert stored["model"] is None
+        assert stored["base_url"] is None
+        assert stored["provider_snapshot"] is None
+        assert stored["model_snapshot"] is None
+
+    def test_enabling_inherit_mode_atomically_clears_overrides(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                provider="custom",
+                model="qwen3",
+                base_url="http://localhost:11434/v1",
+            )
+        )
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                inherit_model_config=True,
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["inherit_model_config"] is True
+        assert updated["job"]["provider"] is None
+        assert updated["job"]["model"] is None
+        assert updated["job"]["base_url"] is None
+
+    def test_explicit_override_disables_inherit_mode(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                inherit_model_config=True,
+            )
+        )
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                provider="openrouter",
+                model="openai/gpt-5",
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["inherit_model_config"] is False
+        assert updated["job"]["provider"] == "openrouter"
+        assert updated["job"]["model"] == "openai/gpt-5"
+
+    def test_inherit_mode_rejects_simultaneous_override(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                inherit_model_config=True,
+                model="openai/gpt-5",
+            )
+        )
+
+        assert result["success"] is False
+        assert "cannot be combined" in result["error"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 
@@ -579,6 +664,45 @@ class TestResolveModelOverride:
         assert provider == "custom:cliproxy"
         assert model == "gpt-5.4"
 
+    def test_agent_model_override_forwards_local_endpoint(self, monkeypatch):
+        """The nested model contract must not drop Ollama's routing URL."""
+        from tools.cronjob_tools import registry
+
+        captured = {}
+
+        def fake_cronjob(**kwargs):
+            captured.update(kwargs)
+            return json.dumps({"success": True})
+
+        monkeypatch.setattr("tools.cronjob_tools.cronjob", fake_cronjob)
+        entry = registry.get_entry("cronjob")
+        assert entry is not None
+
+        result = json.loads(
+            entry.handler(
+                {
+                    "action": "create",
+                    "model": {
+                        "provider": "ollama",
+                        "model": "qwen3",
+                        "base_url": "http://localhost:11434/v1/",
+                    },
+                }
+            )
+        )
+
+        assert result["success"] is True
+        assert captured["provider"] == "ollama"
+        assert captured["model"] == "qwen3"
+        assert captured["base_url"] == "http://localhost:11434/v1/"
+
+    def test_schema_exposes_inherit_mode_and_override_endpoint(self):
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+
+        properties = CRONJOB_SCHEMA["parameters"]["properties"]
+        assert properties["inherit_model_config"]["type"] == "boolean"
+        assert properties["model"]["properties"]["base_url"]["type"] == "string"
+
 
 class TestLocalDeliveryNotice:
     """#51568 — TUI/CLI cron jobs are local-only; surface that at create time
@@ -694,6 +818,9 @@ class TestValidateCronBaseUrl:
     def test_bare_custom_allows_any_base_url(self):
         # Bare 'custom' is inline/host-derived BYOK — no stored secret to leak.
         assert self._v("custom", "https://anything.example/v1") is None
+
+    def test_local_provider_alias_allows_its_explicit_endpoint(self):
+        assert self._v("ollama", "http://localhost:11434/v1") is None
 
     def test_no_base_url_is_allowed(self):
         assert self._v("custom:legit", None) is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -478,7 +478,7 @@ def _validate_cron_base_url(
             resolve_requested_provider,
             _get_named_custom_provider,
         )
-        from hermes_cli.auth import PROVIDER_REGISTRY
+        from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider
         from utils import base_url_host_matches, base_url_hostname
     except Exception:
         # Can't resolve provider metadata -> fail closed.
@@ -508,9 +508,16 @@ def _validate_cron_base_url(
         )
     try:
         resolved = resolve_requested_provider(prov)
+        canonical = resolve_provider(resolved)
     except Exception:
-        resolved = prov
-    pconfig = PROVIDER_REGISTRY.get(resolved) if isinstance(resolved, str) else None
+        canonical = prov
+    if canonical == "custom":
+        # Local-server aliases such as ``ollama`` and ``vllm`` resolve to the
+        # same keyless/host-gated custom runtime as bare ``custom``. Treat them
+        # identically here so the endpoint required to override a cloud-backed
+        # profile is not rejected by the security guard.
+        return None
+    pconfig = PROVIDER_REGISTRY.get(canonical) if isinstance(canonical, str) else None
     known_host = base_url_hostname(getattr(pconfig, "inference_base_url", "") if pconfig else "")
     if known_host and base_url_host_matches(bu, known_host):
         return None
@@ -578,6 +585,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "inherit_model_config": bool(job.get("inherit_model_config")),
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -670,6 +678,7 @@ def cronjob(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    inherit_model_config: Optional[bool] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
@@ -684,6 +693,15 @@ def cronjob(
 
     try:
         normalized = (action or "").strip().lower()
+
+        if inherit_model_config is True and any(
+            value is not None for value in (model, provider, base_url)
+        ):
+            return tool_error(
+                "inherit_model_config=True cannot be combined with model, "
+                "provider, or base_url overrides",
+                success=False,
+            )
 
         if normalized == "create":
             if not schedule:
@@ -744,6 +762,7 @@ def cronjob(
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                inherit_model_config=bool(inherit_model_config),
                 script=_normalize_optional_job_value(script),
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
@@ -869,12 +888,35 @@ def cronjob(
                 canonical_skills = _canonical_skills(skill, skills)
                 updates["skills"] = canonical_skills
                 updates["skill"] = canonical_skills[0] if canonical_skills else None
-            if model is not None:
-                updates["model"] = _normalize_optional_job_value(model)
-            if provider is not None:
-                updates["provider"] = _normalize_optional_job_value(provider)
-            if base_url is not None:
-                updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+            inference_override_supplied = any(
+                value is not None for value in (model, provider, base_url)
+            )
+            if inherit_model_config is True:
+                # Inheritance and overrides are mutually exclusive modes. Clear
+                # every pinned axis atomically so no stale endpoint/provider can
+                # shadow the active profile at the next run.
+                updates.update(
+                    {
+                        "model": None,
+                        "provider": None,
+                        "base_url": None,
+                        "inherit_model_config": True,
+                    }
+                )
+            else:
+                if model is not None:
+                    updates["model"] = _normalize_optional_job_value(model)
+                if provider is not None:
+                    updates["provider"] = _normalize_optional_job_value(provider)
+                if base_url is not None:
+                    updates["base_url"] = _normalize_optional_job_value(
+                        base_url, strip_trailing_slash=True
+                    )
+                if inference_override_supplied:
+                    # Supplying any explicit axis selects override mode.
+                    updates["inherit_model_config"] = False
+                elif inherit_model_config is False:
+                    updates["inherit_model_config"] = False
             # Re-validate the EFFECTIVE provider/base_url on EVERY update, not
             # only when this update supplies provider/base_url. A job persisted
             # before this guard (or written directly to the jobs store) may
@@ -1024,7 +1066,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "model": {
                 "type": "object",
-                "description": "Optional per-job model override. If provider is omitted, the current main provider is pinned at creation time so the job stays stable.",
+                "description": "Optional per-job inference override. If provider is omitted, the current main provider is pinned at creation time so the job stays stable. For local/custom providers, include base_url so execution does not fall back to the active profile endpoint.",
                 "properties": {
                     "provider": {
                         "type": "string",
@@ -1033,9 +1075,17 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                     "model": {
                         "type": "string",
                         "description": "Model name (e.g. 'anthropic/claude-sonnet-4', 'claude-sonnet-4')"
+                    },
+                    "base_url": {
+                        "type": "string",
+                        "description": "Endpoint for this override (for example 'http://localhost:11434/v1' for local Ollama). Required when the provider name alone does not identify a configured endpoint."
                     }
                 },
                 "required": ["model"]
+            },
+            "inherit_model_config": {
+                "type": "boolean",
+                "description": "Explicitly opt this job into following the active profile's provider, model, endpoint, and current credentials at every run. Unlike a legacy unpinned job, profile provider/model changes are accepted instead of failing closed on drift. On update, True atomically clears existing model/provider/base_url overrides; supplying an override later disables inheritance."
             },
             "script": {
                 "type": "string",
@@ -1133,7 +1183,8 @@ registry.register(
         skills=args.get("skills"),
         model=_mo[1],
         provider=_mo[0] or args.get("provider"),
-        base_url=args.get("base_url"),
+        base_url=(args.get("model") or {}).get("base_url") or args.get("base_url"),
+        inherit_model_config=args.get("inherit_model_config"),
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -22,7 +22,7 @@ Cron jobs can:
 All of this is available to Hermes itself through the `cronjob` tool, so you can create, pause, edit, and remove jobs by asking in plain language — no CLI required.
 
 :::tip
-At creation, an unpinned job (one you don't give an explicit `provider`/`model`) follows the global default selected by `hermes model` — and Hermes **snapshots** that provider and model on the job. If the global default later changes, the job **fails closed**: it skips the run, makes no inference call, and sends an alert telling you to pin the provider/model explicitly (`cronjob action=update job_id=… provider=… model=…`) to proceed. This prevents an unattended job from silently inheriting a switch to a paid provider/model and spending money you didn't intend (#44585). To make a job deliberately track your global default, pin it to the new values after changing them. `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
+At creation, an unpinned job (one you don't give an explicit `provider`/`model`) follows the global default selected by `hermes model` — and Hermes **snapshots** that provider and model on the job. If the global default later changes, the job **fails closed**: it skips the run, makes no inference call, and sends an alert telling you to pin the provider/model explicitly (`cronjob action=update job_id=… provider=… model=…`) to proceed. This prevents an unattended job from silently inheriting a switch to a paid provider/model and spending money you didn't intend (#44585). To deliberately track profile changes instead, create or update the job with `inherit_model_config=true`; this explicit opt-in reloads the active profile's provider, model, endpoint, and credentials on every run. `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
 :::
 
 :::warning
@@ -588,6 +588,23 @@ cronjob(action="run", job_id="...")
 cronjob(action="remove", job_id="...")
 ```
 
+Choose exactly one inference mode for an agent-backed job:
+
+```python
+# Follow changes to the active profile, including rotated credentials.
+cronjob(action="create", prompt="...", schedule="every 1h",
+        inherit_model_config=True)
+
+# Pin a different provider/model/endpoint for this job.
+cronjob(action="create", prompt="...", schedule="every 1h",
+        model={"provider": "ollama", "model": "qwen3",
+               "base_url": "http://localhost:11434/v1"})
+```
+
+Inheritance and explicit overrides are mutually exclusive. Enabling inheritance
+on an existing job clears its stored `provider`, `model`, and `base_url`
+overrides atomically; setting an override later disables inheritance.
+
 For `update`, pass `skills=[]` to remove all attached skills.
 
 ## Toolsets available to cron jobs
@@ -736,7 +753,7 @@ Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to 
 Ask the agent to manage jobs through the `cronjob` tool, `hermes cron edit`, or `/cron` — not by patching `jobs.json` directly. Direct edits can fail silently when [file write safety](../security.md#file-write-safety) blocks the path (for example when `HERMES_WRITE_SAFE_ROOT` is set), and the [file-mutation verifier](../configuration.md#file-mutation-verifier) footer is the authoritative signal that nothing was saved.
 :::
 
-Jobs may store `model` and `provider` as `null`. When those fields are omitted, Hermes resolves them at execution time from the global configuration. They only appear in the job record when a per-job override is set.
+Jobs may store `model` and `provider` as `null`. When those fields are omitted, Hermes resolves them at execution time from the global configuration. By default, creation-time snapshots still stop a later provider/model change from silently changing spend. Jobs with `inherit_model_config: true` explicitly accept that drift and always use the current profile configuration. Explicit per-job overrides are stored directly instead.
 
 The storage uses atomic file writes so interrupted writes do not leave a partially written job file behind.
 


### PR DESCRIPTION
Cron jobs can now explicitly follow live profile model configuration or pin a complete provider/model/endpoint override without ambiguous fallback routing.

## What does this PR do?

This introduces an explicit `inherit_model_config` mode and completes the existing per-job override object with `base_url`, while preserving the fail-closed behavior of legacy unpinned jobs.

## Shared root cause

- Cron flattened model selection into nullable `provider`, `model`, and `base_url` fields without recording whether null meant deliberate live inheritance or merely an unpinned legacy job.
- The agent-facing `model` override accepted provider/model but dropped the endpoint, so a local alias such as Ollama could be resolved against the active cloud profile instead of its intended local endpoint.
- `cron/jobs.py`, `cron/scheduler.py`, and `tools/cronjob_tools.py` now share one precedence contract: explicit inheritance follows current profile configuration; explicit overrides win and carry their endpoint; legacy omission keeps creation snapshots and fails closed on drift.

## How this fixes each issue

- #39196: `inherit_model_config=true` deliberately reloads the active profile's provider, model, endpoint, and rotated credentials at execution time. Enabling it atomically clears stored overrides and bypasses drift rejection only for this explicit opt-in.
- #46506: the model override schema now carries `base_url`, and local aliases such as `ollama` are recognized by the endpoint security validator as custom/keyless runtimes, so an Ollama job can route to `http://localhost:11434/v1` even when the profile default is OpenRouter.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added persisted `inherit_model_config` semantics and snapshot handling in `cron/jobs.py`.
- Allowed explicitly inherited jobs through the existing scheduler drift guard while retaining fail-closed defaults in `cron/scheduler.py`.
- Added endpoint propagation, mutually exclusive update transitions, schema descriptions, and local-alias validation in `tools/cronjob_tools.py`.
- Added execution, storage-transition, schema, endpoint-forwarding, and security-validator regression tests.
- Documented inherited and overridden cron inference modes.

## How to Test

1. Run `HERMES_HOME=/tmp/hermes-cron-test pytest tests/cron/test_cron_provider_pin.py tests/tools/test_cronjob_tools.py -q --timeout=60` (100 passed locally).
2. Run changed-file Ruff checks (passed).
3. Run `python scripts/check-windows-footguns.py --diff origin/main` (passed).
4. The prescribed full suite was attempted but aborted during collection because the local Homebrew Python lacks optional `fastapi` and cannot auto-install into an externally managed environment. The broader cron subset reached 142 passes before the pre-existing `tests/cron/test_cron_script.py::TestRunJobScript::test_script_timeout` hit the repository live-system guard while cleaning up its spawned process. Neither environment failure involved a changed test; the complete changed-module suite is green.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I checked the supplied issue/PR context and repository history for overlapping work.
- [x] My PR contains only changes related to this fix/feature.
- [ ] The entire `pytest tests/ -q` suite passes locally (blocked at collection by missing optional dashboard dependencies; covering tests pass as detailed above).
- [x] I've added tests for my changes.
- [x] I've tested on macOS darwin-arm64.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] `cli-config.yaml.example` update is N/A; no profile config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; architecture and workflows are unchanged.
- [x] I've considered cross-platform impact; the Windows-footgun check passes.
- [x] I've updated the cron tool description/schema.

## Screenshots / Logs

Not applicable; this is a scheduler/tool contract change covered by automated tests.

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #39196
Refs #46506

<!-- autocontrib:worker-id=pr-spanning-89aadaed kind=pr-open -->