### PR TITLE
fix(desktop): keep turn notifications generic

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -458,7 +458,9 @@ export function useMessageStream({
       }
 
       dispatchNativeNotification({
-        body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
+        // Keep OS notification-center history generic: assistant replies can
+        // contain private transcript text, credentials, or tool output snippets.
+        body: translateNow('notifications.native.turnDoneBody'),
         kind: 'turnDone',
         sessionId,
         title: translateNow('notifications.native.turnDoneTitle')

--- a/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
@@ -6,10 +6,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type { TodoItem } from '@/lib/todos'
+import { dispatchNativeNotification } from '@/store/native-notifications'
+import type * as NativeNotifications from '@/store/native-notifications'
 import { $todosBySession, clearSessionTodos, setSessionTodos } from '@/store/todos'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
+
+vi.mock('@/store/native-notifications', async importOriginal => {
+  const actual = await importOriginal<typeof NativeNotifications>()
+
+  return {
+    ...actual,
+    dispatchNativeNotification: vi.fn()
+  }
+})
 
 const SID = 'session-1'
 const todo = (id: string, status: TodoItem['status']): TodoItem => ({ content: `task ${id}`, id, status })
@@ -70,6 +81,29 @@ describe('useMessageStream turn-end todo cleanup', () => {
     complete()
 
     expect($todosBySession.get()[SID]).toBeUndefined()
+  })
+
+  it('uses generic native notification text instead of assistant response previews', async () => {
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { text: 'private assistant reply with sensitive transcript details' },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(dispatchNativeNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining('private assistant reply'),
+        kind: 'turnDone',
+        sessionId: SID
+      })
+    )
+    expect(dispatchNativeNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.not.stringContaining('sensitive transcript details') })
+    )
   })
 
   it('keeps a finished list on completion so its linger shows the final checkmarks', async () => {


### PR DESCRIPTION
## Summary

- stop Desktop turn-complete native notifications from previewing assistant response text
- keep notification-center history generic while preserving the existing notification title/body translation path
- add a regression test that completion text is not passed into the native notification payload

## Tests

```text
npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
# 1 test file passed, 4 tests passed

npm --workspace apps/desktop run typecheck
# passed

cd apps/desktop && npx eslint src/app/session/hooks/use-message-stream/index.ts src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
# passed
```

## Preflight

- searched open PRs for overlapping Desktop notification/badge work; PR #44626 is related but broader/conflicting, this is a small privacy hardening extracted from that direction
- scanned the diff for user-specific/private terms: clean
- scanned the diff for secret-like values: clean
- independent review found one lint issue in the test, fixed before publishing
