### PR TITLE
fix: preserve cron email subjects and attachments

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+from datetime import datetime
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -1459,6 +1460,46 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+_EMAIL_SUBJECT_DIRECTIVE_RE = re.compile(r"^\s*(?:Subject|Email-Subject)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+
+
+def _extract_email_subject_from_content(content: str) -> tuple[Optional[str], str]:
+    """Extract a leading Subject directive from cron output, if present."""
+    lines = (content or "").splitlines()
+    if not lines:
+        return None, content or ""
+    match = _EMAIL_SUBJECT_DIRECTIVE_RE.match(lines[0])
+    if not match:
+        return None, content or ""
+    subject = match.group(1).strip() or None
+    cleaned = "\n".join(lines[1:]).lstrip("\n")
+    return subject, cleaned
+
+
+def _render_email_subject_template(job: dict) -> Optional[str]:
+    """Render optional job-level email_subject_template for email delivery."""
+    template = (job.get("email_subject_template") or "").strip()
+    if not template:
+        return None
+    try:
+        from zoneinfo import ZoneInfo
+        now = datetime.now(ZoneInfo("America/New_York"))
+    except Exception:
+        now = datetime.now()
+    month_day_year = f"{now.strftime('%B')} {now.day}, {now.year}"
+    weekday_date = f"{now.strftime('%A')}, {month_day_year}"
+    try:
+        return template.format(
+            date=month_day_year,
+            weekday=now.strftime("%A"),
+            weekday_date=weekday_date,
+            iso_date=now.date().isoformat(),
+        )
+    except Exception:
+        logger.warning("Job '%s': invalid email_subject_template=%r", job.get("id", "?"), template)
+        return None
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1505,6 +1546,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
     except Exception:
         pass
+
+    # Resolve explicit email subjects before adding the cron wrapper. This keeps
+    # `Subject: ...` directives out of the visible body and lets email adapters
+    # set a real SMTP Subject header instead of falling back to "Hermes Agent".
+    email_subject, content = _extract_email_subject_from_content(content)
+    if not email_subject:
+        email_subject = _render_email_subject_template(job)
 
     if wrap_response:
         task_name = job.get("name", job["id"])
@@ -1774,6 +1822,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
 
+            # Email is special: the live adapter path goes through DeliveryRouter
+            # and adapter.send(..., metadata=route_metadata). Carry the resolved
+            # SMTP subject and extracted MEDIA files in that metadata so the
+            # email adapter sends ONE multipart MIME message instead of a text
+            # email plus a separate attachment/fallback email.
+            if email_subject:
+                route_metadata["subject"] = email_subject
+            if platform == Platform.EMAIL and media_files:
+                route_metadata["media_files"] = media_files
+
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
                 # Route through the gateway's DeliveryRouter so the live send
@@ -1785,7 +1843,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
                 timed_out = False
-                if text_to_send:
+                if text_to_send or (platform == Platform.EMAIL and media_files):
                     from agent.async_utils import safe_schedule_threadsafe
 
                     router = DeliveryRouter(config, adapters)
@@ -1928,7 +1986,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # payload is already assumed delivered (#38922).  Record the
                 # skipped attachments so the drop is visible rather than silently
                 # lost.
-                if adapter_ok and not timed_out and media_files:
+                if adapter_ok and not timed_out and media_files and platform != Platform.EMAIL:
                     _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
@@ -1997,7 +2055,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, subject=email_subject)
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -2026,7 +2084,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, subject=email_subject))
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -66,6 +66,33 @@ MAX_MESSAGE_LENGTH = 50_000
 
 SMTP_CONNECT_TIMEOUT = 30
 
+_SUBJECT_DIRECTIVE_RE = re.compile(r"^\s*(?:Subject|Email-Subject)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+
+
+def _extract_subject_directive(body: str) -> tuple[Optional[str], str]:
+    """Return (subject, body_without_directive) for a leading subject line."""
+    lines = (body or "").splitlines()
+    if not lines:
+        return None, body or ""
+    match = _SUBJECT_DIRECTIVE_RE.match(lines[0])
+    if not match:
+        return None, body or ""
+    subject = match.group(1).strip()
+    remainder = "\n".join(lines[1:]).lstrip("\n")
+    return subject or None, remainder
+
+
+def _subject_from_metadata(metadata: Optional[Dict[str, Any]], body: str) -> tuple[Optional[str], str]:
+    """Resolve an explicit email subject from metadata or body directive."""
+    subject = None
+    if metadata:
+        raw = metadata.get("subject") or metadata.get("email_subject")
+        if raw:
+            subject = str(raw).strip()
+    directive_subject, cleaned_body = _extract_subject_directive(body)
+    return subject or directive_subject, cleaned_body
+
+
 
 def _create_ipv4_connection(
     host: str,
@@ -899,10 +926,14 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an email reply to the given address."""
         try:
+            subject_override, cleaned_content = _subject_from_metadata(metadata, content)
+            raw_media_files = (metadata or {}).get("media_files") or []
+            attachment_paths = [str(path) for path, _is_voice in raw_media_files if Path(str(path)).exists()]
             loop = asyncio.get_running_loop()
-            message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
-            )
+            if attachment_paths:
+                message_id = await loop.run_in_executor(None, self._send_email_with_attachments, chat_id, cleaned_content, attachment_paths, subject_override, reply_to)
+            else:
+                message_id = await loop.run_in_executor(None, self._send_email, chat_id, cleaned_content, reply_to, subject_override)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error("[Email] Send failed to %s: %s", chat_id, e)
@@ -923,6 +954,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        subject_override: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
@@ -931,8 +963,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+        subject = subject_override or ctx.get("subject", "Hermes Agent")
+        if not subject_override and not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
@@ -1038,6 +1070,8 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        subject_override: Optional[str] = None,
+        reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -1045,12 +1079,12 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+        subject = subject_override or ctx.get("subject", "Hermes Agent")
+        if not subject_override and not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
+        original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
@@ -1195,13 +1229,16 @@ async def _standalone_send(
     thread_id=None,
     media_files=None,
     force_document=False,
+    subject=None,
 ):
-    """Out-of-process Email delivery via SMTP (one-shot). Implements the
-    standalone_sender_fn contract; replaces the legacy _send_email helper."""
+    """Out-of-process Email delivery via SMTP (one-shot).
+
+    Supports a caller-provided subject and native MIME attachments so cron jobs
+    can deliver one email with a PDF attached instead of separate text/file
+    messages.
+    """
     import smtplib
     import ssl as _ssl
-    from email.mime.text import MIMEText
-    from email.utils import formatdate
 
     extra = getattr(pconfig, "extra", {}) or {}
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
@@ -1216,17 +1253,36 @@ async def _standalone_send(
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
 
     try:
-        msg = MIMEText(message, "plain", "utf-8")
+        directive_subject, cleaned_message = _extract_subject_directive(message)
+        resolved_subject = (subject or directive_subject or "Hermes Agent").strip()
+        msg = MIMEMultipart()
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        msg["Subject"] = resolved_subject
         msg["Date"] = formatdate(localtime=True)
 
+        if cleaned_message.strip():
+            msg.attach(MIMEText(cleaned_message, "plain", "utf-8"))
+
+        for media_path, _is_voice in (media_files or []):
+            p = Path(str(media_path))
+            if not p.exists():
+                logger.warning("[Email] Skipping missing attachment: %s", p)
+                continue
+            with open(p, "rb") as f:
+                part = MIMEBase("application", "octet-stream")
+                part.set_payload(f.read())
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", f"attachment; filename={p.name}")
+                msg.attach(part)
+
         server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
-        server.login(address, password)
-        server.send_message(msg)
-        server.quit()
+        try:
+            server.starttls(context=_ssl.create_default_context())
+            server.login(address, password)
+            server.send_message(msg)
+        finally:
+            server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}
     except Exception as e:
         try:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -736,6 +736,141 @@ class TestDeliverResultWrapping:
         # Media files should be forwarded separately
         assert kwargs["media_files"] == [(str(media_path), False)]
 
+    def test_email_delivery_passes_subject_and_media_to_standalone_sender(self, tmp_path, monkeypatch):
+        """Email cron delivery should strip Subject/MEDIA directives and pass
+        subject + attachments to the standalone email sender in one call."""
+        from gateway.config import Platform
+
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "daily-brief.pdf", b"%PDF-1.4\n")
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.EMAIL: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            job = {
+                "id": "brief-job",
+                "deliver": "origin",
+                "origin": {"platform": "email", "chat_id": "austin@example.com"},
+            }
+            _deliver_result(
+                job,
+                f"Subject: Daily Meeting Prep — Tuesday, July 14, 2026\n\nAttached.\nMEDIA:{media_path}",
+            )
+
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        assert "Subject:" not in args[3]
+        assert "MEDIA:" not in args[3]
+        assert kwargs["subject"] == "Daily Meeting Prep — Tuesday, July 14, 2026"
+        assert kwargs["media_files"] == [(str(media_path), False)]
+
+    def test_live_email_adapter_receives_subject_and_media_metadata(self, tmp_path, monkeypatch):
+        """The live gateway email path must receive subject/media metadata so
+        it can send one multipart MIME email instead of split/default-subject mail."""
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "daily-brief.pdf", b"%PDF-1.4\n")
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.EMAIL: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as _e:  # noqa: BLE001
+                future.set_exception(_e)
+            return future
+
+        job = {
+            "id": "brief-job",
+            "deliver": "origin",
+            "origin": {"platform": "email", "chat_id": "austin@example.com"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                f"Subject: Daily Meeting Prep — Tuesday, July 14, 2026\n\nAttached.\nMEDIA:{media_path}",
+                adapters={Platform.EMAIL: adapter},
+                loop=loop,
+            )
+
+        adapter.send.assert_called_once()
+        args, kwargs = adapter.send.call_args
+        assert "Subject:" not in args[1]
+        assert "MEDIA:" not in args[1]
+        metadata = kwargs["metadata"]
+        assert metadata["subject"] == "Daily Meeting Prep — Tuesday, July 14, 2026"
+        assert metadata["media_files"] == [(str(media_path), False)]
+
+    def test_live_email_attachment_only_output_uses_adapter_send(self, tmp_path, monkeypatch):
+        """Email cron output with only Subject + MEDIA should still send one
+        multipart email via EmailAdapter.send, even when wrapping is disabled."""
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "daily-brief.pdf", b"%PDF-1.4\n")
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.EMAIL: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as _e:  # noqa: BLE001
+                future.set_exception(_e)
+            return future
+
+        job = {
+            "id": "brief-job",
+            "deliver": "origin",
+            "origin": {"platform": "email", "chat_id": "austin@example.com"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                f"Subject: Daily Meeting Prep — Tuesday, July 14, 2026\nMEDIA:{media_path}",
+                adapters={Platform.EMAIL: adapter},
+                loop=loop,
+            )
+
+        adapter.send.assert_called_once()
+        args, kwargs = adapter.send.call_args
+        assert args[1] == ""
+        metadata = kwargs["metadata"]
+        assert metadata["subject"] == "Daily Meeting Prep — Tuesday, July 14, 2026"
+        assert metadata["media_files"] == [(str(media_path), False)]
+
     def test_live_adapter_sends_media_as_attachments(self, tmp_path, monkeypatch):
         """When a live adapter is available, MEDIA files should be sent as native
         platform attachments (e.g., Discord voice, Telegram audio) rather than

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -891,6 +891,46 @@ class TestSendMethods(unittest.TestCase):
             mock_server.send_message.assert_called_once()
             mock_server.quit.assert_called_once()
 
+    def test_send_with_metadata_subject_and_attachment_builds_one_mime_email(self):
+        """EmailAdapter.send should turn subject/media metadata into one
+        multipart SMTP message with the requested subject and attachment."""
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4\nbrief")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                result = asyncio.run(adapter.send(
+                    "user@test.com",
+                    "",
+                    metadata={
+                        "subject": "Daily Meeting Prep — Tuesday, July 14, 2026",
+                        "media_files": [(tmp_path, False)],
+                    },
+                ))
+
+                self.assertTrue(result.success)
+                mock_server.send_message.assert_called_once()
+                sent_msg = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent_msg["Subject"], "Daily Meeting Prep — Tuesday, July 14, 2026")
+                parts = list(sent_msg.walk())
+                attachments = [
+                    p for p in parts
+                    if "attachment" in str(p.get("Content-Disposition", ""))
+                ]
+                self.assertEqual(len(attachments), 1)
+                disposition = attachments[0].get("Content-Disposition", "") or ""
+                self.assertIn(os.path.basename(tmp_path), disposition)
+        finally:
+            os.unlink(tmp_path)
+
     def test_send_failure_returns_error(self):
         """SMTP failure should return SendResult with error."""
         import asyncio

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -774,7 +774,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, subject=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1096,6 +1096,26 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 return result
             last_result = result
         return last_result
+
+    # --- Email: send one MIME message with optional attachments and subject ---
+    # The generic fallback would either drop MEDIA attachments or send text and
+    # media as separate messages. Email needs a single multipart message so a
+    # cron PDF brief arrives as one email with the correct Subject header.
+    if platform == Platform.EMAIL:
+        from gateway.platform_registry import platform_registry as _pr_email
+        from hermes_cli.plugins import discover_plugins as _dp_email
+        _dp_email()
+        _email_entry = _pr_email.get("email")
+        if _email_entry is None or _email_entry.standalone_sender_fn is None:
+            return {"error": "Email plugin not registered or missing standalone_sender_fn"}
+        return await _email_entry.standalone_sender_fn(
+            pconfig,
+            chat_id,
+            message,
+            thread_id=thread_id,
+            media_files=media_files,
+            subject=subject,
+        )
 
     # --- Non-media platforms ---
     if media_files and not message.strip():


### PR DESCRIPTION
## Summary
- Extract cron email Subject/Email-Subject directives before wrapping delivery output
- Carry resolved email subjects and MEDIA attachments through both live gateway and standalone email delivery paths
- Send email MEDIA attachments as one multipart MIME message instead of splitting body and file delivery
- Add regression coverage for standalone and live email cron delivery paths

## Test plan
- scripts/run_tests.sh tests/cron/test_scheduler.py -k 'email_delivery_passes_subject_and_media_to_standalone_sender or live_email_adapter_receives_subject_and_media_metadata' -v --tb=short

## Notes
This fixes a recurring daily meeting-prep brief regression after updates: one PDF email with a weekday/date subject, not split messages or a generic subject.