### PR TITLE
feat(delegation): add blocking wait mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -982,11 +982,13 @@ Enable/disable per platform via `hermes tools` (the curses UI) or the
 
 ## Delegation (`delegate_task`)
 
-`tools/delegate_tool.py` spawns a subagent with an isolated
-context + terminal session. By default the parent waits for the
-child's summary before continuing its own loop. With `background=true`,
-Hermes returns a delegation id immediately and the result re-enters the
-conversation later through the async-delegation completion queue.
+`tools/delegate_tool.py` spawns a subagent with an isolated context and
+terminal session. Model-facing top-level delegations run in the background by
+default: Hermes returns a delegation id immediately and the result re-enters
+the conversation later through the async-delegation completion queue. Set
+`wait=true` when worker results are required before the parent can finalize its
+current turn; batch workers still run concurrently and return one consolidated
+result inline. Nested orchestrator delegations wait automatically.
 
 Two shapes:
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5741,28 +5741,21 @@ class AIAgent:
         invocation paths (concurrent, sequential, inline).
         """
         from tools.delegate_tool import (
+            _model_background_value,
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,
         )
-        # Delegations from the top-level MODEL always run in the background —
-        # the model does not get to choose. delegate_task returns immediately
-        # with a handle (one per task) and each subagent's result re-enters the
-        # conversation as a new message when it finishes. This applies to BOTH
-        # a single task and a fan-out batch (each task becomes its own
-        # independent background subagent). The one exception:
-        #   - A delegation from an ORCHESTRATOR SUBAGENT (depth > 0) stays
-        #     synchronous: the orchestrator needs its workers' results within
-        #     its own turn to compose a summary, and a subagent doesn't own the
-        #     gateway session the async result would route back to.
-        # The schema-level `background` param is intentionally ignored here.
-        _is_subagent = getattr(self, "_delegate_depth", 0) > 0
+        # Top-level model delegations default to background execution. Explicit
+        # wait=true and nested orchestrator calls select the existing synchronous
+        # join path so required worker evidence returns in the current turn. The
+        # deprecated schema-level `background` parameter remains ignored.
         return _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
-            background=(not _is_subagent),
+            background=_model_background_value(function_args, self),
             parent_agent=self,
         )
 

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -607,11 +607,8 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert _drain_one() is None
 
 
-def test_model_dispatch_forces_background():
-    """The MODEL-facing dispatch path forces background=True for any top-level
-    delegation (single task OR batch), and keeps it off for an orchestrator
-    subagent (depth > 0). Direct delegate_task() callers are unaffected (they
-    keep the synchronous default)."""
+def test_model_dispatch_supports_explicit_wait():
+    """Top-level model calls default async but can await material workers."""
     import tools.delegate_tool as dt
     from unittest.mock import MagicMock
 
@@ -620,23 +617,27 @@ def test_model_dispatch_forces_background():
     sub = MagicMock()
     sub._delegate_depth = 1
 
-    # Registry-fallback helper: top-level always background, regardless of
-    # single vs batch; subagent never.
+    # Registry-fallback helper: top-level defaults to background, regardless of
+    # single vs batch; wait=true and nested subagents select synchronous mode.
     assert dt._model_background_value({"goal": "x"}, top) is True
     assert dt._model_background_value(
         {"tasks": [{"goal": "a"}, {"goal": "b"}]}, top
     ) is True
     assert dt._model_background_value({"tasks": [{"goal": "a"}]}, top) is True
+    assert dt._model_background_value({"goal": "x", "wait": True}, top) is False
+    assert dt._model_background_value(
+        {"tasks": [{"goal": "a"}, {"goal": "b"}], "wait": True}, top
+    ) is False
+    assert dt._model_background_value({"goal": "x", "wait": False}, top) is True
     assert dt._model_background_value({"goal": "x"}, sub) is False
+    assert dt._model_background_value({"goal": "x", "wait": True}, sub) is False
     assert dt._model_background_value(
         {"tasks": [{"goal": "a"}, {"goal": "b"}]}, sub
     ) is False
 
 
-def test_run_agent_dispatch_forces_background():
-    """run_agent._dispatch_delegate_task — the live model path — forces
-    background on for any top-level delegation (single OR batch) and off for a
-    subagent."""
+def test_run_agent_dispatch_supports_explicit_wait():
+    """The live model path defaults async and honors wait=true."""
     from unittest.mock import patch
     import run_agent
 
@@ -659,9 +660,18 @@ def test_run_agent_dispatch_forces_background():
         )
         assert captured["background"] is True
 
+        run_agent.AIAgent._dispatch_delegate_task(
+            agent, {"goal": "blocking review", "wait": True}
+        )
+        assert captured["background"] is False
+
         sub = _FakeAgent()
         sub._delegate_depth = 1
         run_agent.AIAgent._dispatch_delegate_task(sub, {"goal": "x"})
+        assert captured["background"] is False
+        run_agent.AIAgent._dispatch_delegate_task(
+            sub, {"goal": "nested blocking review", "wait": True}
+        )
         assert captured["background"] is False
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -71,6 +71,9 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("goal", props)
         self.assertIn("tasks", props)
         self.assertIn("context", props)
+        self.assertIn("wait", props)
+        self.assertEqual(props["wait"]["type"], "boolean")
+        self.assertIn("current turn", props["wait"]["description"])
         # toolsets is intentionally NOT exposed to the model — subagents always
         # inherit the parent's toolsets. Letting the model name toolsets was a
         # capability-selection surface the model should not control.
@@ -2323,6 +2326,41 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_wait_true_selects_synchronous_dispatch(self):
+        """A top-level model can await material workers in its current turn."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "blocking review", "wait": True},
+            )
+
+        self.assertFalse(captured["background"])
+
+    def test_wait_omitted_preserves_background_default(self):
+        """Existing top-level model calls stay asynchronous by default."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(parent, {"goal": "optional audit"})
+
+        self.assertTrue(captured["background"])
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3250,12 +3250,11 @@ def _build_top_level_description() -> str:
         f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
         f"items concurrently for this user (configured via "
         f"delegation.max_concurrent_children in config.yaml). {nesting_clause}\n\n"
-        "BOTH MODES RUN IN THE BACKGROUND. delegate_task returns immediately — "
-        "you and the user keep working, and each subagent's full result "
-        "re-enters the conversation as its own new message when it finishes. A "
-        "batch is just N independent background subagents (N handles, each "
-        "completes on its own). Do NOT wait or poll; just continue with other "
-        "work after dispatching.\n\n"
+        "Both modes run in the background by default: delegate_task returns "
+        "immediately and the completed result re-enters the conversation as a "
+        "new message. Set wait=true when the result is required before your "
+        "current turn can be finalized; the workers still run concurrently, but "
+        "delegate_task waits and returns their consolidated result inline.\n\n"
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
@@ -3435,16 +3434,21 @@ DELEGATE_TASK_SCHEMA = {
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
             },
+            "wait": {
+                "type": "boolean",
+                "description": (
+                    "Set true when these worker results are required before the "
+                    "parent can finalize its current turn. Workers in a batch "
+                    "still run concurrently, but delegate_task waits for all of "
+                    "them and returns one consolidated result inline. Omit or "
+                    "set false for non-blocking background work."
+                ),
+            },
             "background": {
                 "type": "boolean",
                 "description": (
-                    "DEPRECATED / IGNORED. Single-task delegations always run "
-                    "in the background automatically — you do not need to (and "
-                    "cannot) opt in or out. The result re-enters the "
-                    "conversation as a new message when the subagent finishes; "
-                    "just continue working in the meantime. Setting this has no "
-                    "effect; the parameter remains only for backward "
-                    "compatibility."
+                    "DEPRECATED / IGNORED. Use wait=true for blocking delegation. "
+                    "This parameter remains only for backward compatibility."
                 ),
             },
         },
@@ -3460,17 +3464,18 @@ from tools.registry import registry, tool_error
 def _model_background_value(args: dict, parent_agent=None) -> bool:
     """Background flag for the MODEL-facing dispatch path (registry fallback).
 
-    Delegations from the top-level agent always run in the background — the
-    model does not choose. This applies to both a single task and a fan-out
-    batch (each task becomes its own independent background subagent). The one
-    exception is a delegation from an orchestrator subagent (depth > 0), which
-    needs its workers' results within its own turn. The live path is
+    Top-level delegations run in the background by default. ``wait=true`` lets
+    the model mark material workers as a current-turn dependency and selects
+    the existing synchronous join path. Delegations from an orchestrator
+    subagent (depth > 0) also stay synchronous because the orchestrator needs
+    its workers' results within its own turn. The live path is
     ``run_agent._dispatch_delegate_task``; this lambda mirrors it for the rare
     case the intercept is bypassed. Direct Python callers of ``delegate_task``
     keep the historical synchronous default.
     """
     is_subagent = getattr(parent_agent, "_delegate_depth", 0) > 0
-    return not is_subagent
+    should_wait = is_truthy_value(args.get("wait"), default=False)
+    return not (is_subagent or should_wait)
 
 
 _MODEL_HIDDEN_TASK_FIELDS = {"acp_command", "acp_args"}

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -25,7 +25,7 @@ For the full feature reference, see [Subagent Delegation](/user-guide/features/d
 - Mechanical multi-step work with logic between steps → `execute_code`
 - Tasks needing user interaction → subagents can't use `clarify`
 - Quick file edits → do them directly
-- Durable long-running work that must outlive the current turn → `cronjob` or `terminal(background=True, notify_on_complete=True)`. `delegate_task` is **synchronous**: if the parent turn is interrupted, active children are cancelled and their work is discarded.
+- Durable long-running work that must survive session or process shutdown → `cronjob` or `terminal(background=True, notify_on_complete=True)`. Background and waiting `delegate_task` workers are process-local and are cancelled if their owning session closes.
 
 ---
 
@@ -61,10 +61,10 @@ delegate_task(tasks=[
         "context": "Focus on: error correction breakthroughs, real-world use cases, key companies",
         "toolsets": ["web"]
     }
-])
+], wait=True)
 ```
 
-All three run concurrently. Each subagent searches the web independently and returns a summary. The parent agent then synthesizes them into a coherent briefing.
+All three run concurrently. `wait=True` keeps the current turn open until their consolidated result returns, so the parent agent can synthesize one coherent briefing before replying. Omit `wait` for optional work that may re-enter the conversation later.
 
 ---
 
@@ -238,7 +238,8 @@ delegation:
 - **Separate terminals** — each subagent gets its own terminal session with separate working directory and state
 - **No conversation history** — subagents see only the `goal` and `context` the parent agent passes when calling `delegate_task`
 - **Default 50 iterations** — set `max_iterations` lower for simple tasks to save cost
-- **Not durable** — `delegate_task` is synchronous and runs inside the parent turn. If the parent is interrupted (new user message, `/stop`, `/new`), all active children are cancelled (`status="interrupted"`) and their work is discarded. For work that must outlive the current turn, use `cronjob` or `terminal(background=True, notify_on_complete=True)`.
+- **Background by default** — top-level `delegate_task` calls return immediately and re-enter the conversation when the consolidated result is ready. Set `wait=true` when the current answer depends on the workers; batch workers still run concurrently, but their result returns inline before the parent finalizes.
+- **Not durable** — background and waiting delegations are process-local. Closing/resetting the owning session or stopping Hermes cancels active children. For work that must survive session or process shutdown, use `cronjob` or `terminal(background=True, notify_on_complete=True)`.
 
 ---
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -27,8 +27,14 @@ delegate_task(tasks=[
     {"goal": "Research topic A", "toolsets": ["web"]},
     {"goal": "Research topic B", "toolsets": ["web"]},
     {"goal": "Fix the build", "toolsets": ["terminal", "file"]}
-])
+], wait=True)
 ```
+
+Top-level delegation runs in the background by default and returns a handle
+immediately. Use `wait=True` when the parent needs the worker result before it
+can finalize the current answer. Batch workers still execute concurrently; the
+tool waits at the join and returns one consolidated result inline. Nested
+orchestrator delegations wait automatically.
 
 ## How Subagent Context Works
 
@@ -241,10 +247,10 @@ delegate_task(
 ## Lifetime and Durability
 
 :::warning Background completion durability is not durable execution
-By default, `delegate_task` runs **inside the parent's current turn** and blocks until every child finishes. With `background=true`, the child may continue after that turn returns while the owning session and Hermes process remain alive:
+By default, a top-level `delegate_task` runs in the background and may continue after the current turn returns while the owning session and Hermes process remain alive. Set `wait=true` when its result is required in the current turn; this changes result delivery, not execution durability:
 
-- If the parent is interrupted (user sends a new message, `/stop`, `/new`), all active children are cancelled and return `status="interrupted"`. Their in-progress work is discarded.
-- Explicit session close/reset interrupts that session's background children. Closing a TUI viewer of a gateway-owned session does not kill the gateway's work.
+- Waiting workers are attached to the current parent turn. Interrupting that turn interrupts its active children.
+- Background workers are attached to the owning session. Explicit session close/reset or `/stop` cancels them. Closing a TUI viewer of a gateway-owned session does not kill the gateway's work.
 - A Hermes process restart does **not** resume a running child. Its attempt becomes `unknown` because Hermes cannot prove which side effects happened.
 - A child that completed before restart but whose result was not delivered is restored and routed back through the owning session's normal checks.
 - Cancelled children return a structured result (`status="interrupted"`, `exit_reason="interrupted"`), but because the parent was interrupted too, that result often never makes it into a user-visible reply.


### PR DESCRIPTION
## Summary

- add a model-facing `wait=true` option to `delegate_task`
- preserve background execution as the top-level default
- reuse the existing synchronous aggregate path for required current-turn workers
- keep nested orchestrator delegation synchronous and deprecated `background` ignored
- align internal and public delegation documentation with the actual lifecycle

## Why

Background workers are useful for optional work, but material worker results need a coordinator barrier: workers can execute concurrently while the parent waits for their consolidated result and gives the final user-facing verdict.

## Compatibility

- omitted or `wait=false`: unchanged top-level background behavior
- `wait=true`: workers run concurrently and return one consolidated result inline
- nested orchestrators: unchanged synchronous behavior
- direct Python callers: unchanged synchronous default
- deprecated `background`: still ignored on model-facing calls

## TDD evidence

RED:

```text
4 failed, 1 passed
- schema lacked wait
- live dispatch ignored wait=true
- registry fallback ignored wait=true
```

GREEN / regression:

```text
189 passed in 11.48s
```

Commands:

```bash
/Users/Amos/.hermes/hermes-agent/venv/bin/python -m pytest -q \
  tests/tools/test_delegate.py \
  tests/tools/test_async_delegation.py \
  tests/cli/test_cli_delegate_background_notice.py

/Users/Amos/.hermes/hermes-agent/venv/bin/python -m ruff check \
  run_agent.py tools/delegate_tool.py \
  tests/tools/test_delegate.py tests/tools/test_async_delegation.py

/Users/Amos/.hermes/hermes-agent/venv/bin/python -m py_compile \
  run_agent.py tools/delegate_tool.py \
  tests/tools/test_delegate.py tests/tools/test_async_delegation.py

git diff --check
```

## Review

A separate synchronous GPT-5.4-mini profile worker reviewed the seven-file diff read-only and found no blockers. The parent independently inspected the complete diff and reran all checks after addressing its one non-blocking nested-wait coverage suggestion.
