### PR TITLE
fix(aux): fall back when MoA preset resolution fails

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4249,6 +4249,16 @@ def _resolve_auto(
                 runtime_api_mode = ""
         except Exception:
             logger.debug("MoA aux resolution to aggregator failed", exc_info=True)
+        # A failed or recursive preset resolution must not let the virtual
+        # provider/model pair reach the HTTP resolver.  The preset name is not
+        # a real model ID on any provider; fall through to the configured
+        # fallback chain instead.
+        if str(main_provider).strip().lower() == "moa":
+            main_provider = ""
+            main_model = ""
+            runtime_base_url = ""
+            runtime_api_key = ""
+            runtime_api_mode = ""
 
     if (main_provider and main_model
             and main_provider not in {"auto", ""}):

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -111,6 +111,36 @@ class TestResolveAutoMainFirst:
         # aggregator's base_url.
         assert mock_resolve.call_args.kwargs.get("explicit_base_url") in (None, "")
 
+    def test_moa_resolution_failure_falls_through_without_virtual_provider(self):
+        """A broken MoA preset must not reach the HTTP resolver as ``moa``."""
+        fallback_client = MagicMock()
+        with patch(
+            "hermes_cli.config.load_config", return_value={"moa": {}}
+        ), patch(
+            "hermes_cli.moa_config.resolve_moa_preset",
+            side_effect=KeyError("missing preset"),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(fallback_client, "fallback-model", "configured"),
+        ):
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto(
+                main_runtime={
+                    "provider": "moa",
+                    "model": "missing-preset",
+                    "base_url": "moa://local",
+                    "api_key": "virtual-key",
+                },
+                task="title_generation",
+            )
+
+        assert client is fallback_client
+        assert model == "fallback-model"
+        mock_resolve.assert_not_called()
+
     def test_nous_main_uses_main_model_for_aux(self, monkeypatch):
         """Nous Portal main user → aux uses their picked Nous model, not free-tier MiMo."""
         # No OPENROUTER_API_KEY → ensures if main failed we'd fall to chain


### PR DESCRIPTION
## Summary
Preserve auxiliary-task execution by falling back when MoA preset resolution fails instead of turning a preset-resolution error into a hard failure.

## Validation
- `scripts/run_tests.sh tests/agent/test_auxiliary_main_first.py` (24 passed)