### PR TITLE
fix(providers): resolve custom:<name> slug to custom profile for wire path (#39281)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -949,7 +949,11 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # found, delegate fully; otherwise fall through to the legacy flag path.
     try:
         from providers import get_provider_profile
-        _profile = get_provider_profile(agent.provider)
+        # resolve_custom_slug=True: a user-config `custom:<name>` slug takes the
+        # same profile path as bare `custom`, so the wire sends the custom
+        # profile's max_tokens default (matching the compressor's reservation,
+        # #43547) instead of silently dropping to the legacy no-default branch.
+        _profile = get_provider_profile(agent.provider, resolve_custom_slug=True)
     except Exception:
         _profile = None
 
@@ -1795,7 +1799,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             try:
                 from providers import get_provider_profile
 
-                provider_profile = get_provider_profile(agent.provider)
+                provider_profile = get_provider_profile(
+                    agent.provider, resolve_custom_slug=True
+                )
                 if provider_profile is not None:
                     profile_extra_body = provider_profile.build_extra_body(
                         session_id=getattr(agent, "session_id", None),

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -62,13 +62,30 @@ def register_provider(profile: ProviderProfile) -> None:
         _ALIASES[alias] = profile.name
 
 
-def get_provider_profile(name: str) -> ProviderProfile | None:
+def get_provider_profile(
+    name: str, *, resolve_custom_slug: bool = False,
+) -> ProviderProfile | None:
     """Look up a provider profile by name or alias.
 
     Returns None if the provider has no profile (falls back to generic).
+
+    ``resolve_custom_slug`` (opt-in): when True, a user-config custom-provider
+    slug of the form ``custom:<name>`` (e.g. ``custom:vllm-5090``) resolves to
+    the bundled ``custom`` ProviderProfile -- the ``<name>`` suffix is a user
+    label, not a registry key. The agent stores the provider string verbatim
+    (``agent.provider == "custom:vllm-5090"``), and only the paths that resolve
+    an output-token reservation need this mapping so the wire and the context
+    compressor agree with the bare-``custom`` case. It is OFF by default so the
+    other callers (CLI model-picker dispatch, aux-model lookup, vision flags)
+    keep their existing behavior -- a ``custom:`` slug is NOT a real
+    ``api_key`` provider for those flows. A BARE user-config name with no
+    ``custom:`` prefix (``vllm-5090``) is intentionally NOT mapped here: nothing
+    syntactic marks it as custom, so config normalization handles that case.
     """
     if not _discovered:
         _discover_providers()
+    if resolve_custom_slug and isinstance(name, str) and name.startswith("custom:"):
+        name = "custom"
     canonical = _ALIASES.get(name, name)
     return _REGISTRY.get(canonical)
 

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -116,3 +116,63 @@ class TestCustomReasoningWithNumCtx:
         )
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {"reasoning_effort": "high"}
+
+
+class TestCustomSlugResolution:
+    """get_provider_profile(resolve_custom_slug=True) maps a `custom:<name>`
+    slug to the bundled `custom` ProviderProfile.
+
+    Rationale: `agent.provider` stores the slug verbatim (e.g. `custom:vllm-5090`)
+    but the registry only knows `custom` (+ aliases). Without stripping, the
+    wire path takes its legacy branch and sends NO provider default, while the
+    trading profile (bare `custom`) sends 65536 -- divergent behavior for the
+    same backend. This is opt-in so the six other get_provider_profile callers
+    (CLI model-picker dispatch in particular) keep their current behavior.
+    """
+
+    def test_default_off_slug_returns_none(self):
+        """Backward-compat: without the flag, a slug still returns None."""
+        import providers
+        assert providers.get_provider_profile("custom:vllm-5090") is None
+
+    def test_opt_in_slug_resolves_to_custom(self):
+        import providers
+        p = providers.get_provider_profile(
+            "custom:vllm-5090", resolve_custom_slug=True
+        )
+        assert p is not None
+        assert p.name == "custom"
+        assert p.get_max_tokens("Qwen3.6-27B") == 65536
+
+    def test_opt_in_bare_custom_unchanged(self):
+        """Bare `custom` resolves with or without the flag."""
+        import providers
+        assert providers.get_provider_profile(
+            "custom", resolve_custom_slug=True
+        ).name == "custom"
+
+    def test_opt_in_bare_user_name_still_none(self):
+        """A bare user-config name (no `custom:` prefix) is NOT a slug -- the
+        flag must not turn it into the custom profile. (Handled by config
+        normalization, not code.)"""
+        import providers
+        assert providers.get_provider_profile(
+            "vllm-5090", resolve_custom_slug=True
+        ) is None
+
+    def test_opt_in_non_custom_provider_unchanged(self):
+        """The flag only affects the `custom:` prefix; a real provider still
+        resolves to its own profile, and a `custom:` slug never shadows it."""
+        import providers
+        assert providers.get_provider_profile(
+            "nvidia", resolve_custom_slug=True
+        ).name == "nvidia"
+
+    def test_opt_in_unknown_slug_body_resolves_to_custom(self):
+        """Any `custom:<anything>` maps to the custom profile -- the suffix is a
+        user label, not a registry key."""
+        import providers
+        p = providers.get_provider_profile(
+            "custom:some-random-proxy", resolve_custom_slug=True
+        )
+        assert p is not None and p.name == "custom"


### PR DESCRIPTION
# fix(providers): resolve custom:<name> slug to custom profile for wire path (#39281)

**Issue:** When `hermes setup` writes a *named* custom endpoint, it stores the provider as `custom:<name>` (e.g. `custom:vllm-5090`). The registry only knows `custom`, so `get_provider_profile("custom:vllm-5090")` returns `None`. The wire path takes its legacy branch and sends **no** `max_tokens` default -- while a bare `custom` provider sends the profile default (65536). Same backend, divergent behavior.

For Ollama backends this means responses truncate at `num_predict=128` (the Ollama server default), which is the exact bug #39281 tracks.

## Changes

| File | Change |
|---|---|
| `providers/__init__.py` | Add opt-in `resolve_custom_slug` keyword to `get_provider_profile()`. When `True`, strips the `custom:` prefix and resolves to the bundled `custom` profile. |
| `agent/chat_completion_helpers.py` | Enable `resolve_custom_slug=True` at both wire-path call sites (`build_api_kwargs` + `handle_max_iterations`). |
| `tests/plugins/model_providers/test_custom_profile.py` | 6 new tests in `TestCustomSlugResolution` class. |

## Design

- **Opt-in flag** -- `resolve_custom_slug` defaults to `False`. The other ~6 callers of `get_provider_profile()` (CLI model-picker dispatch, aux-model lookup, vision flags) keep their existing behavior.
- **`custom:<name>` only** -- bare user-config names with no `custom:` prefix (e.g. `vllm-5090`) are intentionally NOT mapped here. Nothing syntactic marks them as custom; that is handled by config normalization, not code.
- **Full profile inheritance** -- enabling slug resolution makes `custom:<name>` take the full custom profile branch, so it also inherits other behaviors (Qwen3 `think=false` reasoning control, Ollama `num_ctx`). That is arguably more correct (a named Ollama endpoint should get Ollama handling) and is identical to what bare `custom` already does -- not new risk, just consistency.

## Tests

```
pytest tests/plugins/model_providers/test_custom_profile.py -q  # 19 passed (13 existing + 6 new)
pytest tests/providers/ -q                                       # 120 passed
pytest tests/plugins/model_providers/ -q                          # 178 passed
```

## Related

- Fixes #39281
- Partial fix for #43547 (compressor-side resolution deferred until #63839 merges)