### PR TITLE
fix(acp): honor --yolo for ACP edit approval

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -522,6 +522,10 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        # Freeze --yolo / HERMES_YOLO_MODE at server start so a mid-process
+        # skill cannot flip it to bypass ACP edit approval (same security
+        # rationale as tools/approval._YOLO_MODE_FROZEN).
+        self._yolo_mode: bool = os.environ.get("HERMES_YOLO_MODE") == "1"
 
     # ---- Connection lifecycle -----------------------------------------------
 
@@ -567,6 +571,11 @@ class HermesACPAgent(acp.Agent):
     def _edit_approval_policy_for_state(self, state: SessionState) -> tuple[str, str | None]:
         mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
+        # --yolo / HERMES_YOLO_MODE: auto-approve edits (except sensitive
+        # paths, which should_auto_approve_edit still guards).  Mirrors the
+        # _YOLO_MODE_FROZEN bypass in tools/approval.check_dangerous_command.
+        if policy == "ask" and self._yolo_mode:
+            policy = "session"
         return policy, state.cwd
 
     @staticmethod

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -74,6 +74,7 @@ from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
 from acp_adapter.tools import build_tool_complete, build_tool_start
+from utils import is_truthy_value
 from tools.approval import (
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
@@ -525,7 +526,7 @@ class HermesACPAgent(acp.Agent):
         # Freeze --yolo / HERMES_YOLO_MODE at server start so a mid-process
         # skill cannot flip it to bypass ACP edit approval (same security
         # rationale as tools/approval._YOLO_MODE_FROZEN).
-        self._yolo_mode: bool = os.environ.get("HERMES_YOLO_MODE") == "1"
+        self._yolo_mode: bool = is_truthy_value(os.getenv("HERMES_YOLO_MODE", ""))
 
     # ---- Connection lifecycle -----------------------------------------------
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "lemonwan@users.noreply.github.com": "lemonwan",  # PR #59430 sibling salvage (adapter reconnect contract guard)
     "luxuguangno1@163.com": "luxuguang-leo",  # PR #52966 + #52908 salvage (QQBot reconnect + Feishu Channel signaling)
     "grace@weeb.onl": "evelynburger",  # PR #57544 salvage (gateway: webhook payload filters + route scripts; commit under unlinked identity)
+    "hubin-ll@foxmail.com": "LLQWQ",  # PR #64429 (acp: honor --yolo for ACP edit approval)
     "contato@siteup.com.br": "SiteupAgencia",  # PR #57435 salvage (tui_gateway: back off notification poller when session is busy; #55578)
     "164521089+rainbowgits@users.noreply.github.com": "rainbowgore",  # PR #59405 salvage (mcp: bound stdio initialize handshake to stop subprocess/FD leak; #59349)
     "sage@Sages-Mac-mini.local": "thestudionorth",  # PR #60015 salvage (mcp: parent-death watchdog for stdio children; commit under unlinked local identity)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1860,3 +1860,70 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+class TestEditApprovalPolicyYolo:
+    """Verify --yolo / HERMES_YOLO_MODE overrides ACP edit approval policy."""
+
+    def test_yolo_mode_overrides_ask_policy(self, monkeypatch):
+        """With HERMES_YOLO_MODE=1, default 'ask' policy becomes 'session'."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(
+            session_manager=SessionManager(agent_factory=lambda: MagicMock())
+        )
+        state = SimpleNamespace(mode="default", cwd="/workspace")
+        policy, cwd = agent._edit_approval_policy_for_state(state)
+        assert policy == "session"
+        assert cwd == "/workspace"
+
+    def test_without_yolo_mode_keeps_ask_policy(self, monkeypatch):
+        """Without HERMES_YOLO_MODE, default mode stays 'ask'."""
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(
+            session_manager=SessionManager(agent_factory=lambda: MagicMock())
+        )
+        state = SimpleNamespace(mode="default", cwd="/workspace")
+        policy, cwd = agent._edit_approval_policy_for_state(state)
+        assert policy == "ask"
+
+    def test_yolo_does_not_override_explicit_accept_edits(self, monkeypatch):
+        """HERMES_YOLO_MODE doesn't change a non-ask policy."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(
+            session_manager=SessionManager(agent_factory=lambda: MagicMock())
+        )
+        state = SimpleNamespace(mode="accept_edits", cwd="/workspace")
+        policy, cwd = agent._edit_approval_policy_for_state(state)
+        assert policy == "workspace_session"
+
+    def test_yolo_does_not_override_explicit_dont_ask(self, monkeypatch):
+        """HERMES_YOLO_MODE doesn't change an already autonomous policy."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(
+            session_manager=SessionManager(agent_factory=lambda: MagicMock())
+        )
+        state = SimpleNamespace(mode="dont_ask", cwd="/workspace")
+        policy, cwd = agent._edit_approval_policy_for_state(state)
+        assert policy == "session"
+
+    def test_yolo_frozen_at_init_time(self, monkeypatch):
+        """HERMES_YOLO_MODE is frozen at server init, not read per-call."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(
+            session_manager=SessionManager(agent_factory=lambda: MagicMock())
+        )
+        # Remove env var after init — frozen value should still be True
+        monkeypatch.delenv("HERMES_YOLO_MODE")
+        state = SimpleNamespace(mode="default", cwd="/workspace")
+        policy, _ = agent._edit_approval_policy_for_state(state)
+        assert policy == "session"

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1927,3 +1927,29 @@ class TestEditApprovalPolicyYolo:
         state = SimpleNamespace(mode="default", cwd="/workspace")
         policy, _ = agent._edit_approval_policy_for_state(state)
         assert policy == "session"
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "True", "YES", "ON"])
+    def test_yolo_accepts_all_truthy_strings(self, monkeypatch, value):
+        """is_truthy_value accepts all TRUTHY_STRINGS, not just '1'."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", value)
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(
+            session_manager=SessionManager(agent_factory=lambda: MagicMock())
+        )
+        state = SimpleNamespace(mode="default", cwd="/workspace")
+        policy, _ = agent._edit_approval_policy_for_state(state)
+        assert policy == "session"
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_yolo_rejects_falsy_strings(self, monkeypatch, value):
+        """Falsy or empty HERMES_YOLO_MODE keeps default 'ask' policy."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", value)
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(
+            session_manager=SessionManager(agent_factory=lambda: MagicMock())
+        )
+        state = SimpleNamespace(mode="default", cwd="/workspace")
+        policy, _ = agent._edit_approval_policy_for_state(state)
+        assert policy == "ask"


### PR DESCRIPTION
## Summary

ACP edit approval ignores `--yolo` / `HERMES_YOLO_MODE`. This PR fixes it.

**Problem:** `tools/approval.py` already checks `_YOLO_MODE_FROZEN` to bypass dangerous-command prompts under `--yolo`, but `acp_adapter/server.py`'s `_edit_approval_policy_for_state` does not — so `hermes --yolo acp` still requires human approval for every `write_file`/patch, defeating unattended scenarios.

**Fix:** Freeze `HERMES_YOLO_MODE` at `HermesACPAgent.__init__` (same security rationale as `_YOLO_MODE_FROZEN`) and check it in `_edit_approval_policy_for_state` to promote `ask` → `session`.

Closes #64428

## Changes

- `acp_adapter/server.py`: Add `self._yolo_mode` in `__init__`, check it in `_edit_approval_policy_for_state`
- `tests/acp/test_server.py`: 5 test cases covering yolo override, no-yolo default, explicit modes unaffected, frozen-at-init

## Behavior

| Scenario | Result |
|---|---|
| `HERMES_YOLO_MODE=1` + edit `.env` | ❌ Still requires approval (sensitive path guard) |
| `HERMES_YOLO_MODE=1` + edit workspace file | ✅ Auto-approved |
| No yolo flag | Normal `ask` behavior |
| ACP client sends `set_session_mode` | Client choice takes precedence |