### PR TITLE
fix(systemd): set StartLimitIntervalSec=60 to enable burst protection

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2744,7 +2744,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=0
+StartLimitIntervalSec=60
 
 [Service]
 Type=simple
@@ -2783,7 +2783,7 @@ WantedBy=multi-user.target
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=0
+StartLimitIntervalSec=60
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Description

`StartLimitIntervalSec=0` disables systemd's start-limit burst protection entirely. When a service fails on startup — e.g. port conflict, missing dependency, transient environment issue — it retries forever every `RestartSec` seconds, generating endless log noise and wasted CPU cycles without anyone noticing.

Setting `StartLimitIntervalSec=60` makes the existing default `StartLimitBurst=5` actually take effect: after 5 failures within a 60-second window, systemd stops retrying. This matches the intuitive expectation that a repeatedly crashing service should eventually stay stopped.

Closes # — (no issue filed; discovered during production monitoring where a dashboard process occupying the same port caused the gateway service to accumulate 163K restart attempts in 13 days before being noticed)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

`hermes_cli/gateway.py`: Changed `StartLimitIntervalSec=0` → `StartLimitIntervalSec=60` in both systemd unit templates:
- System-level (`WantedBy=multi-user.target`) — line 2747
- User-level (`WantedBy=default.target`) — line 2786

Both templates already have `Restart=always` and `RestartSec=5`; with `IntervalSec=0` the burst limit was effectively disabled. A 60-second window aligns with the default `RestartSec=5` × `StartLimitBurst=5` = 25-second worst-case, providing 2× headroom.

## Testing

1. Generated a unit from the updated template and verified `StartLimitIntervalSec=60` appears in the output
2. Simulated a start failure by binding the gateway port manually before starting: service fails 5 times in 60s then stays stopped as expected
3. Normal startup (no port conflict) succeeds without any change in behavior

## Real Behavior Proof

- **Environment:** Linux (Ubuntu 22.04), Hermes v0.18.x, systemd 249
- **Exact command / steps:** `systemctl --user show hermes-gateway.service -p NRestarts` returned 163599 before fix; after fix the service stays stopped after 5 failures in 60s
- **Observed result:** With `IntervalSec=0`, one port-conflict scenario produced 163K restarts silently. With `IntervalSec=60`, the same scenario stops retrying after 5 failures and systemd marks the service as failed.
- **Not tested:** macOS launchd template (no equivalent — the fix is systemd-only)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review