### PR TITLE
fix(agent): evict old tool-result screenshots on the OpenAI-compatible path

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1120,6 +1120,72 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+_MAX_KEEP_TOOL_RESULT_IMAGES = 3
+
+
+def _evict_old_screenshots_openai(
+    api_messages: list,
+    max_keep: int = _MAX_KEEP_TOOL_RESULT_IMAGES,
+) -> list:
+    """Keep only the most recent ``max_keep`` tool-result screenshots in a
+    chat.completions payload.
+
+    OpenAI-format counterpart of the Anthropic adapter's
+    ``_evict_old_screenshots`` (agent/anthropic_adapter.py): base64 images
+    cost ~1,465 tokens each and accumulate across computer-use tool calls.
+    Walk backward, keep the most recent N image-bearing tool results, and
+    replace image parts in older ones with a text placeholder.
+
+    Shared request-preparation helper: applied by the main conversation
+    loop's payload assembly AND by ``handle_max_iterations``'s summary
+    request below — the summary path hand-builds its own ``api_messages``
+    and calls ``chat.completions.create()`` directly, so without the shared
+    transform it would re-send every historical tool-result image.
+
+    On this wire format tool-result images are inline content parts on
+    ``role: "tool"`` messages (``image_url`` / ``input_image``), not nested
+    ``tool_result`` blocks — detection is shared with the compressor via
+    :func:`agent.context_compressor._is_image_part`.  Counting matches the
+    Anthropic adapter: each tool message containing at least one image
+    counts once, regardless of how many image parts it carries.
+
+    Scope also matches the Anthropic adapter: only tool results are
+    evicted.  Image parts on ``role: "user"`` messages (user uploads) are
+    left untouched.
+
+    Never mutates its input.  ``api_messages`` entries are shallow copies
+    whose ``content`` lists are shared with the stored conversation
+    history, so affected messages are replaced with new dicts holding new
+    content lists — the per-call payload shrinks while stored history
+    keeps its images (prompt-caching invariant: never mutate past context).
+    """
+    from agent.context_compressor import _is_image_part
+
+    result = list(api_messages)
+    image_result_count = 0
+    for idx in range(len(result) - 1, -1, -1):
+        msg = result[idx]
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        if not any(_is_image_part(part) for part in content):
+            continue
+        image_result_count += 1
+        if image_result_count <= max_keep:
+            continue
+        result[idx] = {
+            **msg,
+            "content": [
+                part if not _is_image_part(part)
+                else {"type": "text", "text": "[screenshot removed to save context]"}
+                for part in content
+            ],
+        }
+    return result
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     if tools_for_api is None:
@@ -2168,6 +2234,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # Same safety net as the main loop: drop thinking-only assistant
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # Same eviction as the main loop's payload assembly: this request
+        # re-sends the whole transcript, and without it every historical
+        # tool-result screenshot rides along one last time.
+        if agent.api_mode == "chat_completions":
+            api_messages = _evict_old_screenshots_openai(api_messages)
 
         summary_extra_body = {}
         try:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1749,6 +1749,23 @@ def run_conversation(
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
 
+        # Evict old tool-result screenshots from the outbound payload.
+        # Mirrors the Anthropic adapter's request-build-time
+        # _evict_old_screenshots: keep the most recent 3 image-bearing tool
+        # results, placeholder the rest.  chat_completions only — the
+        # anthropic_messages path already evicts inside
+        # convert_messages_to_anthropic during format conversion, and other
+        # modes are out of scope here.  Operates on the per-call copy
+        # (returns new dicts for affected messages); the stored conversation
+        # history keeps its images.  Runs before cache-control marking below
+        # (marking is last-after-every-mutation) and before MoA prep so both
+        # see the payload actually sent.  The helper is shared with
+        # handle_max_iterations' summary request, which builds its own
+        # payload outside this loop.
+        if agent.api_mode == "chat_completions":
+            from agent.chat_completion_helpers import _evict_old_screenshots_openai
+            api_messages = _evict_old_screenshots_openai(api_messages)
+
         # NOTE (empty-content class fix): no send-time pad loop here.  The
         # single owner for "never send a turn strict wire validation rejects
         # as empty" is ``repair_empty_non_final_messages``, which runs inside

--- a/tests/agent/test_openai_screenshot_eviction.py
+++ b/tests/agent/test_openai_screenshot_eviction.py
@@ -1,0 +1,440 @@
+"""Request-build-time screenshot eviction for the chat.completions path.
+
+Mirrors the Anthropic adapter's ``_evict_old_screenshots``
+(agent/anthropic_adapter.py) for OpenAI-format payloads: keep only the
+most recent N image-bearing tool results in the outbound request,
+placeholder the rest, and never touch the stored conversation history
+(prompt-caching invariant — only the per-call payload copy changes).
+
+See the Anthropic-side coverage in
+tests/tools/test_computer_use.py::TestAnthropicAdapterMultimodal.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List
+
+from unittest.mock import MagicMock
+
+from agent.chat_completion_helpers import (
+    _evict_old_screenshots_openai,
+    handle_max_iterations,
+)
+
+
+def _image_tool_msg(call_id: str) -> Dict[str, Any]:
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": [
+            {"type": "text", "text": f"screenshot {call_id}"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{call_id}"}},
+        ],
+    }
+
+
+class TestMaxIterationSummaryEviction:
+    """The max-iteration summary request builds its own api_messages and
+    calls chat.completions.create() directly, bypassing the main loop's
+    payload assembly — it must apply the same eviction or every historical
+    tool-result image rides along one last time."""
+
+    def test_summary_request_payload_is_evicted(self):
+        agent = MagicMock()
+        agent.api_mode = "chat_completions"
+        agent.max_iterations = 60
+        agent.model = "test-model"
+        agent.provider = "lmstudio"
+        agent._base_url_lower = "http://localhost:1234/v1"
+        agent._cached_system_prompt = "system"
+        agent.ephemeral_system_prompt = None
+        agent.prefill_messages = []
+        agent.max_tokens = None
+        agent.reasoning_config = None
+        agent._should_sanitize_tool_calls.return_value = False
+        agent._supports_reasoning_extra_body.return_value = False
+        agent._copy_reasoning_content_for_api.side_effect = lambda src, dst: None
+        agent._sanitize_api_messages.side_effect = lambda msgs: msgs
+        agent._drop_thinking_only_and_merge_users.side_effect = lambda msgs: msgs
+
+        captured: Dict[str, Any] = {}
+
+        def _create(**kwargs):
+            captured.update(kwargs)
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = "summary text"
+            return response
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        agent._ensure_primary_openai_client.return_value = client
+        # The chat path normalizes the raw response through the transport.
+        _normalized = MagicMock()
+        _normalized.content = "summary text"
+        agent._get_transport.return_value.normalize_response.return_value = _normalized
+
+        messages = [{"role": "user", "content": "start"}]
+        for i in range(5):
+            messages.append({
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": f"c{i}", "type": "function",
+                    "function": {"name": "browser_vision", "arguments": "{}"},
+                }],
+            })
+            messages.append(_image_tool_msg(f"c{i}"))
+
+        result = handle_max_iterations(agent, messages, api_call_count=60)
+
+        assert result == "summary text"
+        sent = captured["messages"]
+        tool_msgs = [
+            m for m in sent
+            if m.get("role") == "tool" and isinstance(m.get("content"), list)
+        ]
+        assert len(tool_msgs) == 5
+        with_images = [
+            m for m in tool_msgs
+            if any(p.get("type") in ("image_url", "input_image") for p in m["content"])
+        ]
+        placeholdered = [
+            m for m in tool_msgs
+            if any(
+                p.get("type") == "text" and "screenshot removed" in p.get("text", "")
+                for p in m["content"]
+            )
+        ]
+        # Anthropic-parity keep window: newest 3 keep their images, the
+        # 2 oldest are placeholdered.
+        assert len(with_images) == 3
+        assert len(placeholdered) == 2
+        # The two evicted messages are the OLDEST ones.
+        assert placeholdered == tool_msgs[:2]
+
+
+FAKE_PNG = "iVBORw0KGgo="
+
+
+def _image_part(tag: str = "") -> Dict[str, Any]:
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,{FAKE_PNG}{tag}"},
+    }
+
+
+def _tool_msg(call_id: str, parts: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "role": "tool",
+        "name": "computer_use",
+        "tool_call_id": call_id,
+        "content": parts,
+    }
+
+
+def _assistant_call(call_id: str) -> Dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{
+            "id": call_id,
+            "type": "function",
+            "function": {"name": "computer_use", "arguments": "{}"},
+        }],
+    }
+
+
+def _screenshot_conversation(n_screenshots: int) -> List[Dict[str, Any]]:
+    """User turn followed by ``n_screenshots`` assistant/tool pairs."""
+    messages: List[Dict[str, Any]] = [{"role": "user", "content": "start"}]
+    for i in range(n_screenshots):
+        messages.append(_assistant_call(f"call_{i}"))
+        messages.append(_tool_msg(
+            f"call_{i}",
+            [{"type": "text", "text": f"cap {i}"}, _image_part(str(i))],
+        ))
+    messages.append({"role": "assistant", "content": "done"})
+    return messages
+
+
+def _image_bearing_tool_msgs(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [
+        m for m in messages
+        if m.get("role") == "tool"
+        and isinstance(m.get("content"), list)
+        and any(
+            isinstance(p, dict) and p.get("type") == "image_url"
+            for p in m["content"]
+        )
+    ]
+
+
+def _placeholder_tool_msgs(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [
+        m for m in messages
+        if m.get("role") == "tool"
+        and isinstance(m.get("content"), list)
+        and any(
+            isinstance(p, dict)
+            and p.get("type") == "text"
+            and "screenshot removed" in p.get("text", "")
+            for p in m["content"]
+        )
+    ]
+
+
+class TestEviction:
+    def test_keeps_most_recent_three_placeholders_older(self):
+        messages = _screenshot_conversation(5)
+        out = _evict_old_screenshots_openai(messages)
+
+        assert len(_image_bearing_tool_msgs(out)) == 3
+        assert len(_placeholder_tool_msgs(out)) == 2
+
+        # It is specifically the OLDEST two that were evicted.
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert _placeholder_tool_msgs(tool_msgs[:2]) == tool_msgs[:2]
+        assert _image_bearing_tool_msgs(tool_msgs[2:]) == tool_msgs[2:]
+
+    def test_at_or_below_keep_window_is_a_passthrough(self):
+        messages = _screenshot_conversation(3)
+        out = _evict_old_screenshots_openai(messages)
+        # Same message objects, by identity — nothing was rebuilt.
+        assert all(a is b for a, b in zip(out, messages))
+        assert len(out) == len(messages)
+
+    def test_text_parts_survive_eviction(self):
+        messages = _screenshot_conversation(5)
+        out = _evict_old_screenshots_openai(messages)
+        evicted = _placeholder_tool_msgs(out)
+        assert len(evicted) == 2
+        for msg in evicted:
+            texts = [p["text"] for p in msg["content"] if p.get("type") == "text"]
+            # Original caption preserved alongside the placeholder.
+            assert any(t.startswith("cap ") for t in texts)
+            # No image parts remain.
+            assert all(p.get("type") == "text" for p in msg["content"])
+
+    def test_counts_per_tool_message_not_per_image_part(self):
+        # One tool result carrying two images counts once — same semantics
+        # as the Anthropic adapter, which counts image-bearing tool_result
+        # blocks, not individual image blocks.
+        messages: List[Dict[str, Any]] = [{"role": "user", "content": "go"}]
+        messages.append(_assistant_call("call_multi"))
+        messages.append(_tool_msg(
+            "call_multi",
+            [_image_part("a"), _image_part("b")],
+        ))
+        for i in range(2):
+            messages.append(_assistant_call(f"call_{i}"))
+            messages.append(_tool_msg(f"call_{i}", [_image_part(str(i))]))
+
+        out = _evict_old_screenshots_openai(messages)
+        # 3 image-bearing tool messages total — all within the keep window.
+        assert len(_image_bearing_tool_msgs(out)) == 3
+        assert not _placeholder_tool_msgs(out)
+
+    def test_every_image_part_in_an_evicted_message_is_replaced(self):
+        messages: List[Dict[str, Any]] = [{"role": "user", "content": "go"}]
+        messages.append(_assistant_call("call_old"))
+        messages.append(_tool_msg("call_old", [_image_part("a"), _image_part("b")]))
+        for i in range(3):
+            messages.append(_assistant_call(f"call_{i}"))
+            messages.append(_tool_msg(f"call_{i}", [_image_part(str(i))]))
+
+        out = _evict_old_screenshots_openai(messages)
+        evicted = _placeholder_tool_msgs(out)
+        assert len(evicted) == 1
+        assert [p["text"] for p in evicted[0]["content"]] == [
+            "[screenshot removed to save context]",
+            "[screenshot removed to save context]",
+        ]
+
+    def test_input_image_shape_is_also_evicted(self):
+        # OpenAI Responses-style parts stored on tool messages count too —
+        # detection is shared with the compressor's _is_image_part.
+        input_image = {"type": "input_image", "image_url": f"data:image/png;base64,{FAKE_PNG}"}
+        messages: List[Dict[str, Any]] = [{"role": "user", "content": "go"}]
+        messages.append(_assistant_call("call_old"))
+        messages.append(_tool_msg("call_old", [dict(input_image)]))
+        for i in range(3):
+            messages.append(_assistant_call(f"call_{i}"))
+            messages.append(_tool_msg(f"call_{i}", [_image_part(str(i))]))
+
+        out = _evict_old_screenshots_openai(messages)
+        evicted = _placeholder_tool_msgs(out)
+        assert len(evicted) == 1
+        assert evicted[0]["tool_call_id"] == "call_old"
+
+
+class TestScope:
+    def test_user_uploaded_images_are_untouched(self):
+        # A user-role image older than every screenshot must survive —
+        # scope matches the Anthropic adapter (tool results only).
+        user_upload = {
+            "role": "user",
+            "content": [{"type": "text", "text": "look at this"}, _image_part("upload")],
+        }
+        messages = [user_upload] + _screenshot_conversation(5)[1:]
+        out = _evict_old_screenshots_openai(messages)
+
+        assert out[0] is user_upload
+        assert any(p.get("type") == "image_url" for p in out[0]["content"])
+        # Tool-side eviction still happened.
+        assert len(_placeholder_tool_msgs(out)) == 2
+
+    def test_string_tool_content_is_ignored(self):
+        messages: List[Dict[str, Any]] = [{"role": "user", "content": "go"}]
+        messages.append(_assistant_call("call_s"))
+        messages.append(_tool_msg("call_s", []))
+        messages[-1]["content"] = "plain text result"
+        for i in range(4):
+            messages.append(_assistant_call(f"call_{i}"))
+            messages.append(_tool_msg(f"call_{i}", [_image_part(str(i))]))
+
+        out = _evict_old_screenshots_openai(messages)
+        assert len(_image_bearing_tool_msgs(out)) == 3
+        assert len(_placeholder_tool_msgs(out)) == 1
+        # The string tool message passed through by identity.
+        assert any(m.get("content") == "plain text result" for m in out)
+
+    def test_text_only_tool_results_do_not_consume_the_window(self):
+        messages: List[Dict[str, Any]] = [{"role": "user", "content": "go"}]
+        for i in range(4):
+            messages.append(_assistant_call(f"img_{i}"))
+            messages.append(_tool_msg(f"img_{i}", [_image_part(str(i))]))
+            messages.append(_assistant_call(f"txt_{i}"))
+            messages.append(_tool_msg(f"txt_{i}", [{"type": "text", "text": "ok"}]))
+
+        out = _evict_old_screenshots_openai(messages)
+        # 4 image results: newest 3 kept, oldest placeholdered; the text-only
+        # results neither count against the window nor get rewritten.
+        assert len(_image_bearing_tool_msgs(out)) == 3
+        assert len(_placeholder_tool_msgs(out)) == 1
+        for a, b in zip(messages, out):
+            if a.get("tool_call_id", "").startswith("txt_"):
+                assert a is b
+
+
+class TestHistoryNotMutated:
+    def test_input_messages_and_content_lists_are_untouched(self):
+        messages = _screenshot_conversation(6)
+        snapshot = copy.deepcopy(messages)
+
+        out = _evict_old_screenshots_openai(messages)
+
+        # Stored history is byte-identical to what it was before the call.
+        assert messages == snapshot
+        assert out is not messages
+
+        # Evicted slots hold NEW dicts with NEW content lists; the original
+        # dicts still carry their images for compression/UI use.
+        original_by_id = {m.get("tool_call_id"): m for m in messages if m.get("role") == "tool"}
+        for msg in _placeholder_tool_msgs(out):
+            original = original_by_id[msg["tool_call_id"]]
+            assert msg is not original
+            assert msg["content"] is not original["content"]
+            assert any(p.get("type") == "image_url" for p in original["content"])
+
+    def test_unaffected_messages_pass_through_by_reference(self):
+        messages = _screenshot_conversation(6)
+        out = _evict_old_screenshots_openai(messages)
+        rebuilt = 0
+        for a, b in zip(messages, out):
+            if a is not b:
+                rebuilt += 1
+        # Exactly the evicted tool messages were rebuilt (6 - 3 kept).
+        assert rebuilt == 3
+
+
+class TestParityWithAnthropicAdapter:
+    def test_placeholder_text_matches_anthropic_adapter(self):
+        """Both request-build-time evictors must speak the same placeholder.
+
+        The wording is shared context the model sees across providers;
+        drifting apart would make cross-provider session handoff
+        inconsistent. Derive the expected text from the Anthropic adapter
+        instead of hardcoding it twice.
+        """
+        from agent.anthropic_adapter import _evict_old_screenshots
+
+        # Anthropic-format: 4 tool_result blocks with image blocks — the
+        # oldest gets placeholdered by the adapter's evictor.
+        anthropic_msgs = [
+            {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": f"call_{i}",
+                    "content": [
+                        {"type": "image", "source": {"type": "base64", "data": FAKE_PNG}},
+                    ],
+                }],
+            }
+            for i in range(4)
+        ]
+        _evict_old_screenshots(anthropic_msgs)
+        anthropic_placeholders = [
+            part["text"]
+            for msg in anthropic_msgs
+            for block in msg["content"]
+            for part in block["content"]
+            if part.get("type") == "text"
+        ]
+        assert len(anthropic_placeholders) == 1
+
+        openai_msgs: List[Dict[str, Any]] = [{"role": "user", "content": "go"}]
+        for i in range(4):
+            openai_msgs.append(_assistant_call(f"call_{i}"))
+            openai_msgs.append(_tool_msg(f"call_{i}", [_image_part(str(i))]))
+        out = _evict_old_screenshots_openai(openai_msgs)
+        openai_placeholders = [
+            p["text"]
+            for m in _placeholder_tool_msgs(out)
+            for p in m["content"]
+            if p.get("type") == "text"
+        ]
+        assert len(openai_placeholders) == 1
+
+        assert openai_placeholders == anthropic_placeholders
+
+    def test_keep_window_matches_anthropic_adapter(self):
+        """Both paths keep the same number of recent screenshots.
+
+        Relationship invariant, not a literal: run both evictors over
+        equivalently sized conversations and compare survivor counts.
+        """
+        from agent.anthropic_adapter import _evict_old_screenshots
+
+        n = 7
+        anthropic_msgs = [
+            {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": f"call_{i}",
+                    "content": [
+                        {"type": "image", "source": {"type": "base64", "data": FAKE_PNG}},
+                    ],
+                }],
+            }
+            for i in range(n)
+        ]
+        _evict_old_screenshots(anthropic_msgs)
+        anthropic_survivors = sum(
+            1
+            for msg in anthropic_msgs
+            for block in msg["content"]
+            if any(p.get("type") == "image" for p in block["content"])
+        )
+
+        openai_msgs: List[Dict[str, Any]] = [{"role": "user", "content": "go"}]
+        for i in range(n):
+            openai_msgs.append(_assistant_call(f"call_{i}"))
+            openai_msgs.append(_tool_msg(f"call_{i}", [_image_part(str(i))]))
+        out = _evict_old_screenshots_openai(openai_msgs)
+        openai_survivors = len(_image_bearing_tool_msgs(out))
+
+        assert openai_survivors == anthropic_survivors

--- a/tests/run_agent/test_openai_screenshot_eviction_integration.py
+++ b/tests/run_agent/test_openai_screenshot_eviction_integration.py
@@ -1,0 +1,168 @@
+"""Integration: request-build-time screenshot eviction on chat_completions.
+
+Drives ``run_conversation`` with a screenshot-heavy history and captures the
+outbound API payload. Asserts the wiring in ``agent/conversation_loop.py``:
+
+  * the payload sent to the provider keeps only the most recent 3
+    image-bearing tool results (older ones placeholdered), and
+  * the stored conversation history keeps every image — eviction operates
+    on the per-call copy only (prompt-caching invariant: never mutate past
+    context).
+
+Unit-level semantics of ``_evict_old_screenshots_openai`` are covered in
+tests/agent/test_openai_screenshot_eviction.py; the Anthropic-side
+equivalent lives in tests/tools/test_computer_use.py.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+
+
+FAKE_PNG = "iVBORw0KGgo="
+
+
+def _patch_bootstrap(monkeypatch):
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: [{
+        "type": "function",
+        "function": {"name": "t", "description": "t", "parameters": {"type": "object", "properties": {}}},
+    }])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+
+def _final_text_response():
+    return SimpleNamespace(
+        choices=[SimpleNamespace(index=0, message=SimpleNamespace(
+            role="assistant", content="ok", tool_calls=None, reasoning_content=None,
+        ), finish_reason="stop")],
+        usage=SimpleNamespace(prompt_tokens=100, completion_tokens=10, total_tokens=110),
+        model="test-model",
+    )
+
+
+def _make_agent(monkeypatch, captured_kwargs: List[Dict[str, Any]]):
+    _patch_bootstrap(monkeypatch)
+
+    class _A(run_agent.AIAgent):
+        def __init__(self, *a, **kw):
+            kw.update(skip_context_files=True, skip_memory=True, max_iterations=4)
+            super().__init__(*a, **kw)
+            self._cleanup_task_resources = self._persist_session = lambda *a, **k: None
+            self._save_trajectory = lambda *a, **k: None
+
+        def _model_supports_vision(self):
+            # Keep the non-vision image-strip fallback out of the way so the
+            # captured payload reflects the eviction transform alone.
+            return True
+
+        def run_conversation(self, msg, conversation_history=None, task_id=None):
+            def _capture(kw):
+                captured_kwargs.append(kw)
+                return _final_text_response()
+
+            self._interruptible_api_call = _capture
+            self._disable_streaming = True
+            return super().run_conversation(
+                msg, conversation_history=conversation_history, task_id=task_id,
+            )
+
+    return _A(
+        model="test-model",
+        api_key="test-key",
+        base_url="http://localhost:1234/v1",
+        provider="openrouter",
+        api_mode="chat_completions",
+    )
+
+
+def _image_part(tag: str) -> Dict[str, Any]:
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,{FAKE_PNG}{tag}"},
+    }
+
+
+def _screenshot_history(n: int) -> List[Dict[str, Any]]:
+    history: List[Dict[str, Any]] = [{"role": "user", "content": "start"}]
+    for i in range(n):
+        history.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": f"call_{i}",
+                "type": "function",
+                "function": {"name": "computer_use", "arguments": "{}"},
+            }],
+        })
+        history.append({
+            "role": "tool",
+            "name": "computer_use",
+            "tool_call_id": f"call_{i}",
+            "content": [
+                {"type": "text", "text": f"cap {i}"},
+                _image_part(str(i)),
+            ],
+        })
+    history.append({"role": "assistant", "content": "done"})
+    return history
+
+
+def _tool_messages(payload_messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [m for m in payload_messages if m.get("role") == "tool"]
+
+
+def _has_image(msg: Dict[str, Any]) -> bool:
+    content = msg.get("content")
+    return isinstance(content, list) and any(
+        isinstance(p, dict) and p.get("type") == "image_url" for p in content
+    )
+
+
+def _has_placeholder(msg: Dict[str, Any]) -> bool:
+    content = msg.get("content")
+    return isinstance(content, list) and any(
+        isinstance(p, dict)
+        and p.get("type") == "text"
+        and "screenshot removed" in p.get("text", "")
+        for p in content
+    )
+
+
+def test_outbound_payload_evicts_old_screenshots_history_keeps_them(monkeypatch):
+    captured: List[Dict[str, Any]] = []
+    agent = _make_agent(monkeypatch, captured)
+
+    history = _screenshot_history(5)
+    agent.run_conversation("continue", conversation_history=history)
+
+    assert captured, "expected at least one API call"
+    sent = _tool_messages(captured[0]["messages"])
+    assert len(sent) == 5
+
+    with_images = [m for m in sent if _has_image(m)]
+    placeholdered = [m for m in sent if _has_placeholder(m)]
+    assert len(with_images) == 3
+    assert len(placeholdered) == 2
+    # The oldest two were the ones evicted.
+    assert {m["tool_call_id"] for m in placeholdered} == {"call_0", "call_1"}
+    # Captions survive next to the placeholder.
+    for m in placeholdered:
+        assert any(
+            p.get("type") == "text" and p.get("text", "").startswith("cap ")
+            for p in m["content"]
+        )
+
+    # The stored history the caller handed in still carries every image.
+    stored_tool_msgs = [m for m in history if m.get("role") == "tool"]
+    assert len(stored_tool_msgs) == 5
+    assert all(_has_image(m) for m in stored_tool_msgs)
+    assert not any(_has_placeholder(m) for m in stored_tool_msgs)


### PR DESCRIPTION
## What does this PR do?

Ports the Anthropic adapter's request-build-time screenshot eviction to the chat_completions path. Tool-result images (browser_vision / vision_analyze native embeds, computer-use screenshots) currently accumulate **unbounded** on OpenAI-compatible providers — every screenshot is re-sent on every subsequent turn for the life of the session. The three mechanisms that might catch this each miss it (verified in #63849): `_evict_old_screenshots` runs only inside `convert_messages_to_anthropic`; the compressor's media stripper anchors on user-role images so tool-role screenshots survive; and the 4xx image-strip recovery explicitly excludes the 5xx/timeout/crash failures local servers actually produce.

Real-world impact: repeated Metal `kIOGPUCommandBufferCallbackErrorOutOfMemory` crashes on a 36 GB Apple Silicon box running an MLX VLM via LM Studio, as retries re-sent the same image-laden context. Follows the fix direction endorsed in the issue thread.

## Related Issue

Fixes #63849. Companion to #63850 (which caps each embed's size; this bounds how many embeds ride along).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — `_evict_old_screenshots_openai(api_messages, max_keep=3)` as a shared request-preparation helper, applied at BOTH chat_completions payload-assembly sites: the main loop (`agent/conversation_loop.py`, `run_conversation`) and `handle_max_iterations`'s summary request (which hand-builds its own payload and calls `create()` directly), gated to `api_mode == "chat_completions"` (the anthropic_messages path already evicts during format conversion). Placed immediately after `_sanitize_messages_surrogates` and **before** the token-pressure estimation, so request-size/compression-pressure checks see the payload actually sent. Detection reuses `_is_image_part` from `agent/context_compressor.py` — no duplicated format knowledge.
- Semantics mirror the Anthropic adapter exactly: walk backward, count each image-bearing tool message once (regardless of image-part count), keep the newest 3, replace older image parts with the identical `[screenshot removed to save context]` placeholder; text captions survive; `role: "user"` images (user uploads) untouched.
- **No history mutation**: the transform is pure — affected messages become new dicts with new content lists; unaffected messages pass through by reference. The stored conversation history keeps all images (prompt-caching invariant: never mutate past context; only the outbound payload changes).
- `tests/agent/test_openai_screenshot_eviction.py` (13 tests) — keep-window, per-message counting, `input_image` shape, user-upload scope, input-purity, pass-through-by-reference, and a runtime parity test deriving the placeholder and semantics from the Anthropic implementation (no hardcoded twins to drift).
- `tests/run_agent/test_openai_screenshot_eviction_integration.py` — drives `run_conversation` end-to-end with the fake-client harness, asserts the outbound payload is evicted while the caller's history still carries every image.

## How to Test

1. On an OpenAI-compatible provider with a vision model, run a browser session that takes 5+ `browser_vision` screenshots.
2. Before: every request carries all screenshots (payload grows monotonically). After: outbound requests carry the newest 3; older tool results show the placeholder text; session history (e.g. `/resume`) still has all images.
3. `scripts/run_tests.sh tests/agent/test_openai_screenshot_eviction.py tests/run_agent/test_openai_screenshot_eviction_integration.py` → 14 passed.
4. Adjacent suites: context tracking, compressor historical media, 413 compression, multimodal tool-content recovery, surrogate sanitization → 449 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all pass (via `scripts/run_tests.sh`, the CI-parity wrapper)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 / Darwin 25.4 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal request-assembly behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (mirrors the Anthropic adapter's fixed keep-window; making it configurable is a separate decision)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure payload transform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Iteration During Review

- `fda85968d` — addressed the sweeper review: the max-iteration summary request (`handle_max_iterations`) builds its own `api_messages` and calls `chat.completions.create()` directly, bypassing the main-loop eviction. The transform now lives in `agent/chat_completion_helpers.py` as a shared request-preparation helper applied on both paths, with a regression test driving `handle_max_iterations` with five image-bearing tool messages and asserting the newest-3 keep window on the captured outbound payload.
- Validation rerun: eviction suites 35/35, adjacent compression suites 177/177, computer-use eviction parity 30/30 — all via `scripts/run_tests.sh`.

## Screenshots / Logs

```text
scripts/run_tests.sh tests/agent/test_openai_screenshot_eviction.py tests/run_agent/test_openai_screenshot_eviction_integration.py tests/run_agent/test_context_token_tracking.py tests/agent/test_context_compressor.py
=== Summary: 4 files, 170 tests passed, 0 failed (100% complete) in 18.0s (20 workers) ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

