### PR TITLE
fix(config): merge duplicate kanban DEFAULT_CONFIG key (auto_subscribe_on_create was dropped)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1479,20 +1479,6 @@ DEFAULT_CONFIG = {
     },
 
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).
-    # See tools/kanban_tools.py and hermes_cli/kanban_db.py for the actual
-    # implementations. Per-platform notification opt-out is handled by the
-    # kanban dashboard (see ``hermes dashboard`` -> Notifications).
-    "kanban": {
-        # Auto-subscribe the originating gateway/TUI session to task
-        # completion + block events when ``kanban_create`` is called from
-        # inside a session that has a persistent delivery channel. The
-        # agent that dispatched the task will get notified automatically
-        # instead of having to poll. Disable to mirror pre-feature
-        # behaviour — e.g. for a profile that prefers explicit
-        # ``kanban_notify-subscribe`` calls per task.
-        "auto_subscribe_on_create": True,
-    },
-
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
@@ -2720,6 +2706,10 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Auto-subscribe the originating gateway/TUI session to task
+        # completion + block events on kanban_create (persistent-channel
+        # sessions only). Set false to require explicit notify-subscribe.
+        "auto_subscribe_on_create": True,
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false


### PR DESCRIPTION
## Summary

`DEFAULT_CONFIG` in `hermes_cli/config.py` declares the top-level key `"kanban"` **twice**:

- The first block (around line 1485) contains a single key: `"auto_subscribe_on_create": True`.
- A second block (around line 2722) contains the dispatcher settings (`dispatch_in_gateway`, `dispatch_interval_seconds`, `failure_limit`, …).

Because Python resolves duplicate dict-literal keys as **last-wins**, the second `"kanban"` block silently replaces the first, so `kanban.auto_subscribe_on_create` never actually lands in `DEFAULT_CONFIG`.

## Impact

Behavior is currently unaffected only because the sole consumer defaults it in code:

```python
# tools/kanban_tools.py
if not cfg_get(cfg, "kanban", "auto_subscribe_on_create", default=True):
```

So the effective default stays `True` (matching `features/kanban.md`, which documents `true`). But the config schema silently drops a documented key, and any future reader/consumer relying on `DEFAULT_CONFIG["kanban"]["auto_subscribe_on_create"]` would miss it.

## Fix

Merge the two blocks: move `auto_subscribe_on_create` into the surviving `"kanban"` block and delete the dead first block. No behavior change — the effective default is unchanged (`True`), and the schema now matches the docs.

## Validation

- Provable by reading the source: two `"kanban":` keys at the same nesting level in one dict literal; after the fix there is exactly one, containing all keys.
- Behavior-neutral: the consumer already falls back to `True`.
- `config.py` not touched by any open PR.
