### PR TITLE
fix(model-normalize): drop duplicate 'trinity' key in _VENDOR_PREFIXES

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -60,7 +60,6 @@ _VENDOR_PREFIXES: dict[str, str] = {
     "nemotron": "nvidia",
     "llama": "meta-llama",
     "step": "stepfun",
-    "trinity": "arcee-ai",
 }
 
 # Providers whose APIs consume vendor/model slugs.


### PR DESCRIPTION
## Summary

`_VENDOR_PREFIXES` in `hermes_cli/model_normalize.py` lists the key `"trinity"` **twice**, both mapping to the same value:

```python
"trinity": "arcee-ai",
...
"step": "stepfun",
"trinity": "arcee-ai",   # duplicate — silently overwrites the first
```

Python resolves duplicate dict-literal keys as last-wins. Since both entries map to `"arcee-ai"`, this is harmless at runtime, but the second entry is a redundant duplicate (also flagged by ruff/flake8 `F601`).

## Fix

Remove the redundant second `"trinity": "arcee-ai"` entry. The first occurrence (grouped with the other vendor prefixes) is kept.

## Validation

- Provable by reading the dict: `"trinity"` appears twice with identical values; after the fix it appears once.
- Zero behavior change (both entries were identical).
- `model_normalize.py` not touched by any open PR.
