### PR TITLE
fix(gateway): respect externally managed systemd units

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2820,6 +2820,8 @@ _SYSTEMD_OPTIONAL_DIRECTIVES = (
     "RestartSteps",
 )
 
+_SYSTEMD_EXTERNAL_MANAGEMENT_DIRECTIVE = "X-Hermes-Managed-Externally"
+
 
 def _strip_optional_systemd_directives(text: str) -> str:
     """Remove systemd directives that older hosts silently drop."""
@@ -2833,6 +2835,28 @@ def _strip_optional_systemd_directives(text: str) -> str:
                 continue
         filtered.append(line)
     return "\n".join(filtered)
+
+
+def _systemd_unit_is_externally_managed(text: str) -> bool:
+    """Return whether another declarative manager owns this unit.
+
+    Nix, Home Manager, and similar systems intentionally install immutable
+    service definitions.  Their units may differ from Hermes' generated unit
+    while still being authoritative, so Hermes must neither report drift nor
+    attempt to rewrite them.
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, separator, value = stripped.partition("=")
+        if (
+            separator
+            and key.strip() == _SYSTEMD_EXTERNAL_MANAGEMENT_DIRECTIVE
+            and value.strip().lower() in {"1", "yes", "true", "on"}
+        ):
+            return True
+    return False
 
 
 def _normalize_launchd_plist_for_comparison(text: str) -> str:
@@ -2878,6 +2902,9 @@ def systemd_unit_is_current(system: bool = False) -> bool:
         return False
 
     installed = unit_path.read_text(encoding="utf-8")
+    if _systemd_unit_is_externally_managed(installed):
+        return True
+
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
     expected = generate_systemd_unit(system=system, run_as_user=expected_user)
     # Normalize out directives that older systemd versions silently drop

--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -139,6 +139,51 @@ WantedBy=default.target
 
 
 class TestSystemdUnitIsCurrent:
+    def test_externally_managed_unit_is_authoritative(self, tmp_path, monkeypatch):
+        """A declarative manager's marker suppresses comparison and rewrites."""
+        from hermes_cli import gateway as gw
+
+        installed = """[Unit]
+Description=Declaratively managed Hermes Gateway
+X-Hermes-Managed-Externally=true
+
+[Service]
+ExecStart=/nix/store/example/bin/hermes gateway run
+"""
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+
+        def unexpected_generate(**_kwargs):
+            raise AssertionError("externally managed units must not be regenerated")
+
+        monkeypatch.setattr(gw, "generate_systemd_unit", unexpected_generate)
+
+        assert gw.systemd_unit_is_current(system=False) is True
+        assert gw.refresh_systemd_unit_if_needed(system=False) is False
+        assert unit_file.read_text() == installed
+
+    def test_false_external_management_marker_does_not_hide_drift(self, tmp_path, monkeypatch):
+        """Only a true marker transfers service-definition authority."""
+        from hermes_cli import gateway as gw
+
+        installed = """[Unit]
+Description=Hermes Gateway
+X-Hermes-Managed-Externally=false
+"""
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: "[Unit]\nDescription=Different\n",
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is False
+
     def test_unit_without_optional_directives_is_current(self, tmp_path, monkeypatch):
         """Installed unit missing RestartMaxDelaySec/RestartSteps should be
         considered current when the generated unit includes them."""

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -459,6 +459,11 @@ Use the user service on laptops and dev boxes. Use the system service on VPS or 
 The unit Hermes installs already shuts the gateway down cleanly with `KillMode=mixed` + `KillSignal=SIGTERM`, and uses `Restart=always` with `RestartForceExitStatus` so updates and `/restart` respawn correctly. Do **not** add a systemd drop-in such as `ExecStopPost=/bin/kill -9 $MAINPID` — `ExecStopPost` fires on *every* stop, including clean restarts, so it `SIGKILL`s the freshly spawned instance before it stabilizes and `Restart=always` immediately respawns it. The result is an infinite restart loop (and, on Telegram, a flood of restart messages). If you've added such a drop-in, remove it: `systemctl --user edit hermes-gateway` (or `sudo systemctl edit hermes-gateway` for a system service) and delete the `ExecStopPost` line, then `systemctl --user daemon-reload`.
 :::
 
+If Nix, Home Manager, or another declarative service manager owns the complete
+unit, add `X-Hermes-Managed-Externally=true` to its `[Unit]` section. Hermes
+will treat that definition as authoritative: `gateway status` will not report
+it as outdated, and gateway lifecycle commands will not try to rewrite it.
+
 :::tip Headless VMs: user service + linger avoids root prompts
 A system service needs root for every restart — including the automatic gateway restart at the end of `hermes update`. When `hermes update` runs as a non-root user, it tries passwordless `sudo systemctl`; if that's unavailable, it skips the restart and prints the manual `sudo systemctl restart hermes-gateway` command (it never blocks on an interactive password prompt).
 


### PR DESCRIPTION
## Summary

- recognize `X-Hermes-Managed-Externally=true` in systemd units
- treat marked declarative units as authoritative during status and restart
- skip drift rewrites while preserving the existing lifecycle path
- document the marker for Nix/Home Manager and other service managers

This fixes `hermes gateway status` reporting a deliberately different Nix-managed unit as outdated, followed by `hermes gateway restart` trying to rewrite an immutable store symlink.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_systemd_optional_directives.py -q` (13 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -q` (188 passed)
- `.venv/bin/ruff check hermes_cli/gateway.py tests/hermes_cli/test_systemd_optional_directives.py`