### PR TITLE
fix(gateway): multiplex secret_scope for authz, Slack, webhooks

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -28,6 +28,21 @@ from gateway.whatsapp_identity import (
 )
 
 
+def _auth_env(name: str, default: str = "") -> str:
+    """Read allowlist/auth env; prefer profile secret_scope under multiplex."""
+    if not name:
+        return default
+    try:
+        from agent.secret_scope import get_secret
+
+        val = get_secret(name)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    except Exception:
+        pass
+    return (os.getenv(name) or default).strip()
+
+
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
@@ -425,7 +440,7 @@ class GatewayAuthorizationMixin:
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
+        if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
             return True
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
@@ -456,13 +471,13 @@ class GatewayAuthorizationMixin:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
+        platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
-            group_user_allowlist = os.getenv(platform_group_user_env_map.get(source.platform, ""), "").strip()
-            group_chat_allowlist = os.getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
-        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+            group_user_allowlist = _auth_env(platform_group_user_env_map.get(source.platform, ""))
+            group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
+        global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
             # No env allowlist configured. Adapters that own their own
@@ -511,7 +526,7 @@ class GatewayAuthorizationMixin:
                 if effective_policy == "allowlist":
                     return True
             # No allowlists configured -- check global allow-all flag
-            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+            return _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
         # Telegram can optionally authorize group traffic by chat ID.
         # Keep this separate from TELEGRAM_GROUP_ALLOWED_USERS, which gates

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1089,6 +1089,8 @@ class WebhookAdapter(BasePlatformAdapter):
             # Special token: dump the entire payload as JSON
             if key == "__raw__":
                 return json.dumps(payload, indent=2)[:4000]
+            if key == "event_type":
+                return event_type
             value: Any = payload
             for part in key.split("."):
                 if isinstance(value, dict):
@@ -1237,7 +1239,18 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error=f"Unknown platform: {platform_name}"
             )
 
+        # Default adapters first; multiplex may park Slack/etc. only on a
+        # secondary profile (self._profile_adapters). Fall back so webhook
+        # deliver:slack still works when default has slack disabled.
         adapter = self.gateway_runner.adapters.get(target_platform)
+        if not adapter:
+            for _prof, amap in (getattr(self.gateway_runner, "_profile_adapters", None) or {}).items():
+                if not isinstance(amap, dict):
+                    continue
+                cand = amap.get(target_platform)
+                if cand is not None:
+                    adapter = cand
+                    break
         if not adapter:
             return SendResult(
                 success=False,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8727,14 +8727,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return connected
 
     def _make_profile_message_handler(self, profile_name: str):
-        """Return a message handler that stamps source.profile then delegates."""
+        """Return a message handler that stamps source.profile then delegates.
+
+        Auth runs inside ``_handle_message`` *before* the agent-turn scope is
+        installed. For secondary profiles under multiplex, wrap the whole
+        handler in ``_profile_runtime_scope`` so allowlists/tokens from that
+        profile's ``.env`` are visible to ``get_secret`` / authz.
+        """
+        from hermes_cli.profiles import get_profile_dir
+
+        try:
+            profile_home = get_profile_dir(profile_name)
+        except Exception:
+            profile_home = None
+
         async def _handler(event):
             try:
                 if getattr(event, "source", None) is not None and not event.source.profile:
                     event.source.profile = profile_name
             except Exception:
                 pass
+            if profile_home is not None:
+                with _profile_runtime_scope(profile_home):
+                    return await self._handle_message(event)
             return await self._handle_message(event)
+
         return _handler
 
     @staticmethod
@@ -11619,7 +11636,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
-            if not os.getenv(env_key):
+            # Multiplex: home channel may live only in the profile secret
+            # scope / PlatformConfig, not process os.environ.
+            home_env = ""
+            try:
+                from agent.secret_scope import get_secret
+
+                home_env = (get_secret(env_key) or "").strip() if env_key else ""
+            except Exception:
+                home_env = ""
+            if not home_env:
+                home_env = (os.getenv(env_key) or "").strip() if env_key else ""
+            # Also honor in-memory / yaml home_channel on this platform.
+            try:
+                if not home_env and self.config.get_home_channel(source.platform):
+                    home_env = "set"
+            except Exception:
+                pass
+            # Secondary-profile platforms (e.g. Slack on yolo) may only exist
+            # under that profile's loaded config — check after scope install.
+            if not home_env:
+                try:
+                    from hermes_cli.profiles import get_profile_dir
+                    from gateway.config import load_gateway_config as _lgc
+                    prof = (getattr(source, "profile", None) or "").strip()
+                    if prof and prof != "default":
+                        # Already inside profile scope for secondary handlers;
+                        # re-read live config for home_channel.
+                        _pcfg = _lgc()
+                        if _pcfg.get_home_channel(source.platform):
+                            home_env = "set"
+                except Exception:
+                    pass
+            if not home_env:
                 # Slack dispatches all Hermes commands through a single
                 # parent slash command `/hermes`; bare `/sethome` is not
                 # registered and would fail with "app did not respond".

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -960,7 +960,14 @@ class SlackAdapter(BasePlatformAdapter):
             return False
 
         raw_token = self.config.token
-        app_token = os.getenv("SLACK_APP_TOKEN")
+        # Multiplex: profile secrets live in secret_scope, not process os.environ.
+        # Prefer get_secret; fall back to os.getenv for single-profile / tests.
+        try:
+            from agent.secret_scope import get_secret
+
+            app_token = get_secret("SLACK_APP_TOKEN") or os.getenv("SLACK_APP_TOKEN")
+        except Exception:
+            app_token = os.getenv("SLACK_APP_TOKEN")
 
         if not raw_token:
             logger.error("[Slack] SLACK_BOT_TOKEN not set")
@@ -3443,18 +3450,32 @@ class SlackAdapter(BasePlatformAdapter):
         if os.getenv("SLACK_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
 
+        def _env(name: str) -> str:
+            # Multiplex: profile .env is in secret_scope, not process environ.
+            try:
+                from agent.secret_scope import get_secret
+
+                val = get_secret(name)
+                if val is not None and str(val).strip():
+                    return str(val).strip()
+            except Exception:
+                pass
+            return (os.getenv(name) or "").strip()
+
         allowed_ids = set()
-        platform_allowlist = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        platform_allowlist = _env("SLACK_ALLOWED_USERS")
         if platform_allowlist:
             allowed_ids.update(uid.strip() for uid in platform_allowlist.split(",") if uid.strip())
-        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+        global_allowlist = _env("GATEWAY_ALLOWED_USERS")
         if global_allowlist:
             allowed_ids.update(uid.strip() for uid in global_allowlist.split(",") if uid.strip())
 
         if allowed_ids:
             return "*" in allowed_ids or normalized_user_id in allowed_ids
 
-        return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        if _env("SLACK_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
+            return True
+        return _env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:
         """Handle a slash-confirm button click from Block Kit."""


### PR DESCRIPTION
## What does this PR do?

Under gateway **multiplex**, secondary profiles load platform tokens and allowlists into the per-profile **secret_scope**, not into process `os.environ`. Several auth and delivery paths still called `os.getenv` only, so:

1. **Slack on a secondary profile** could fail Socket Mode (`SLACK_APP_TOKEN`) and user allowlists (`SLACK_ALLOWED_USERS` / `GATEWAY_ALLOWED_*`) even when those values were correctly set in the profile `.env`.
2. **Authorization** ran *before* the agent-turn secret scope was installed for secondary-profile handlers, so allow-all / allowlist checks saw the wrong env.
3. **Webhook `deliver:<platform>`** only looked up adapters on the default `gateway_runner.adapters` map, so delivery to a platform that exists only on a secondary profile (e.g. Slack only on a secondary multiplex profile) failed with "adapter not connected".
4. Webhook prompt templates had no way to inject the Bitbucket/GitHub **event type** without stuffing it into the payload path.

This PR makes those paths **secret_scope-aware** with `os.getenv` fallback for single-profile installs and tests, wraps secondary profile message handlers in `_profile_runtime_scope` for the whole `_handle_message` (so auth sees the right secrets), and falls back to `_profile_adapters` when resolving webhook delivery targets.

**Why this approach:** Prefer `get_secret` → process env, matching existing multiplex credential isolation. No new config keys. No behavior change for single-profile gateways where secrets already live in `os.environ`.

## Related Issue

Fixes # (none filed — multiplex gateway where platforms are split across profiles, e.g. Telegram on default + Slack on secondary, with webhook deliver to the secondary platform)

Related open work (adjacent, not duplicate of this slice):
- #50094 — multiplex profile config env isolation (broader config load)
- #63256 — restore multiplex secondary adapters / validation split
- #57417 — multiplex routing isolation

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/authz_mixin.py` — `_auth_env()` prefers `get_secret` for platform allow-all, allowlists, and `GATEWAY_ALLOW_ALL_USERS`
- `plugins/platforms/slack/adapter.py` — Socket Mode app token + allowlist reads via secret_scope / `_env()` helper
- `gateway/run.py` — secondary profile message handler wraps full `_handle_message` in `_profile_runtime_scope`; home-channel detection uses secret_scope + in-memory/yaml home channel (not only process env)
- `gateway/platforms/webhook.py` — deliver path falls back to `_profile_adapters`; prompt template key `event_type`

## How to Test

1. Configure multiplex: default profile with Telegram only; secondary profile with Slack tokens + allowlist **only** in that profile's `.env` (not in process env of the gateway).
2. Start single gateway with multiplex secondary profile; confirm Slack connects (Socket Mode uses profile `SLACK_APP_TOKEN`).
3. Message the Slack bot from an allowlisted user → should authorize (not rejected as unauthorized).
4. Webhook subscription with `deliver: slack` while Slack adapter lives only on secondary profile → delivery succeeds.
5. Webhook prompt using `{{event_type}}` → renders Bitbucket/GitHub event name.
6. Single-profile gateway (no multiplex) — Slack/Telegram allowlists via process env still work (fallback path).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (VPS), Hermes gateway multiplex default+secondary profile

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (uses existing secret_scope APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Production-style multiplex (default profile: Telegram only; secondary profile: Slack only):

- Before: Slack secondary profile allowlist/token via process env only → unauthorized / missing app token; webhook deliver to Slack failed when adapter only on secondary profile.
- After: Slack connects and authorizes from profile `.env`; webhook deliver falls back to `_profile_adapters`.

**Follow-up welcome:** regression tests under `tests/gateway/` for secret_scope authz + webhook `_profile_adapters` fallback (not included in this PR to keep the live fix small).
