### PR TITLE
fix(skills): make duplicate identifiers consistently loadable

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1263,7 +1263,7 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1352,13 +1352,10 @@ def _build_snapshot_entry(
 ) -> dict:
     """Build a serialisable metadata dict for one skill."""
     rel_path = skill_file.relative_to(skills_dir)
-    parts = rel_path.parts
-    if len(parts) >= 2:
-        skill_name = parts[-2]
-        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
-    else:
-        category = "general"
-        skill_name = skill_file.parent.name
+    skill_relative_path = rel_path.parent
+    parts = skill_relative_path.parts
+    skill_name = parts[-1] if parts else skill_file.parent.name
+    category = "/".join(parts[:-1]) or "general"
 
     platforms = frontmatter.get("platforms") or []
     if isinstance(platforms, str):
@@ -1367,6 +1364,7 @@ def _build_snapshot_entry(
     return {
         "skill_name": skill_name,
         "category": category,
+        "relative_path": skill_relative_path.as_posix(),
         "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
@@ -1466,15 +1464,17 @@ def build_skills_system_prompt(
     Falls back to a full filesystem scan when both layers miss.
 
     External skill directories (``skills.external_dirs`` in config.yaml) are
-    scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
+    scanned alongside the local ``~/.hermes/skills/`` directory. External dirs
     are read-only — they appear in the index but new skills are always created
-    in the local dir.  Local skills take precedence when names collide.
+    in the local dir. Colliding names are rendered with exact relative paths
+    when those paths are unambiguous to ``skill_view``.
 
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in
-    the rendered index. Nothing is ever hidden: every skill name stays
-    visible and loadable via ``skill_view`` / ``skills_list``; only the
-    descriptions are dropped, and a footer note explains the demotion.
+    the rendered index. Every resolvable skill stays visible; only descriptions
+    are dropped. The sole exception is a collision with no unique declared name
+    or relative path, which is omitted with a diagnostic instead of publishing
+    an identifier that ``skill_view`` must reject.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
@@ -1506,6 +1506,7 @@ def build_skills_system_prompt(
     snapshot = _load_skills_snapshot(skills_dir)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
+    identifier_candidates: list[dict] = []
     category_descriptions: dict[str, str] = {}
 
     if snapshot is not None:
@@ -1517,19 +1518,24 @@ def build_skills_system_prompt(
             category = entry.get("category") or "general"
             frontmatter_name = entry.get("frontmatter_name") or skill_name
             platforms = entry.get("platforms") or []
-            if not skill_matches_platform_list(platforms):
-                continue
-            if frontmatter_name in disabled or skill_name in disabled:
-                continue
-            if not _skill_should_show(
-                entry.get("conditions") or {},
-                available_tools,
-                available_toolsets,
-            ):
-                continue
-            skills_by_category.setdefault(category, []).append(
-                (frontmatter_name, entry.get("description", ""))
+            visible = (
+                skill_matches_platform_list(platforms)
+                and frontmatter_name not in disabled
+                and skill_name not in disabled
+                and _skill_should_show(
+                    entry.get("conditions") or {},
+                    available_tools,
+                    available_toolsets,
+                )
             )
+            identifier_candidates.append({
+                "name": frontmatter_name,
+                "directory_name": skill_name,
+                "relative_path": entry.get("relative_path") or skill_name,
+                "category": category,
+                "description": entry.get("description", ""),
+                "visible": visible,
+            })
         category_descriptions = {
             str(k): str(v)
             for k, v in (snapshot.get("category_descriptions") or {}).items()
@@ -1541,20 +1547,26 @@ def build_skills_system_prompt(
             is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
             entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
             skill_entries.append(entry)
-            if not is_compatible:
-                continue
             skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
-                continue
-            if not _skill_should_show(
-                extract_skill_conditions(frontmatter),
-                available_tools,
-                available_toolsets,
-            ):
-                continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
+            frontmatter_name = entry["frontmatter_name"]
+            visible = (
+                is_compatible
+                and frontmatter_name not in disabled
+                and skill_name not in disabled
+                and _skill_should_show(
+                    extract_skill_conditions(frontmatter),
+                    available_tools,
+                    available_toolsets,
+                )
             )
+            identifier_candidates.append({
+                "name": frontmatter_name,
+                "directory_name": skill_name,
+                "relative_path": entry["relative_path"],
+                "category": entry["category"],
+                "description": entry["description"],
+                "visible": visible,
+            })
 
         # Read category-level DESCRIPTION.md files
         for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
@@ -1579,38 +1591,35 @@ def build_skills_system_prompt(
 
     # ── External skill directories ─────────────────────────────────────
     # Scan external dirs directly (no snapshot caching — they're read-only
-    # and typically small).  Local skills already in skills_by_category take
-    # precedence: we track seen names and skip duplicates from external dirs.
-    seen_skill_names: set[str] = set()
-    for cat_skills in skills_by_category.values():
-        for name, _desc in cat_skills:
-            seen_skill_names.add(name)
-
+    # and typically small). Keep every candidate so collisions can be resolved
+    # with the same lookup aliases accepted by skill_view.
     for ext_dir in external_dirs:
         if not ext_dir.exists():
             continue
         for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):
             try:
                 is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-                if not is_compatible:
-                    continue
                 entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
                 skill_name = entry["skill_name"]
                 frontmatter_name = entry["frontmatter_name"]
-                if frontmatter_name in seen_skill_names:
-                    continue
-                if frontmatter_name in disabled or skill_name in disabled:
-                    continue
-                if not _skill_should_show(
-                    extract_skill_conditions(frontmatter),
-                    available_tools,
-                    available_toolsets,
-                ):
-                    continue
-                seen_skill_names.add(frontmatter_name)
-                skills_by_category.setdefault(entry["category"], []).append(
-                    (frontmatter_name, entry["description"])
+                visible = (
+                    is_compatible
+                    and frontmatter_name not in disabled
+                    and skill_name not in disabled
+                    and _skill_should_show(
+                        extract_skill_conditions(frontmatter),
+                        available_tools,
+                        available_toolsets,
+                    )
                 )
+                identifier_candidates.append({
+                    "name": frontmatter_name,
+                    "directory_name": skill_name,
+                    "relative_path": entry["relative_path"],
+                    "category": entry["category"],
+                    "description": entry["description"],
+                    "visible": visible,
+                })
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)
 
@@ -1628,15 +1637,29 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
+    from agent.skill_utils import resolve_skill_identifiers
+
+    omitted_ambiguous_names: set[str] = set()
+    for entry in resolve_skill_identifiers(identifier_candidates):
+        if not entry["visible"]:
+            continue
+        load_name = entry["load_name"]
+        if not load_name:
+            omitted_ambiguous_names.add(entry["name"])
+            continue
+        skills_by_category.setdefault(entry["category"], []).append(
+            (load_name, entry["description"])
+        )
+
     # Posture-driven category demotion (e.g. non-coding skills while pairing
     # on code). Demoted categories stay in the index as a single names-only
     # line — descriptions are dropped to cut noise, but every skill name
     # remains visible so memory-anchored recall ("load <name>") keeps working.
-    # NEVER remove entries entirely: agent-created skills are the model's
-    # project memory, and models don't reach for skills_list to rediscover
-    # what the index stops showing them. Match on the top-level category
-    # segment so nested categories ("social-media/twitter") are demoted with
-    # their parent.
+    # Do not remove resolvable entries: agent-created skills are the model's
+    # project memory, and models don't reach for skills_list to rediscover what
+    # the index stops showing them. Unresolvable collision groups were already
+    # diagnosed and omitted above. Match on the top-level category segment so
+    # nested categories ("social-media/twitter") are demoted with their parent.
     demoted = frozenset(
         cat for cat in skills_by_category
         if cat.split("/", 1)[0] in (compact_categories or frozenset())
@@ -1650,8 +1673,17 @@ def build_skills_system_prompt(
             "normally and load with skill_view(name) as usual.)"
         )
 
+    collision_note = ""
+    if omitted_ambiguous_names:
+        collision_note = (
+            "\n(Ambiguous skills omitted because neither their declared names nor "
+            "relative paths resolve uniquely: "
+            + ", ".join(sorted(omitted_ambiguous_names))
+            + ". Use skills_list for candidate paths and sources.)"
+        )
+
     if not skills_by_category:
-        result = ""
+        result = collision_note.strip()
     else:
         index_lines = []
         for category in sorted(skills_by_category.keys()):
@@ -1703,6 +1735,7 @@ def build_skills_system_prompt(
             "\n"
             "Only proceed without loading a skill if genuinely none are relevant to the task."
             + hidden_note
+            + collision_note
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -511,6 +511,53 @@ def get_all_skills_dirs() -> List[Path]:
     return dirs
 
 
+def resolve_skill_identifiers(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Annotate discovered skills with identifiers that ``skill_view`` can load.
+
+    ``skill_view`` resolves a local skill by its declared frontmatter name, its
+    directory name, or its path relative to a configured skills root. A name is
+    therefore safe to advertise only when exactly one candidate owns that
+    lookup alias. When a declared name collides, prefer the relative path if it
+    is unique; otherwise leave ``load_name`` unset so callers can diagnose or
+    omit the unresolvable candidate instead of advertising a broken identifier.
+
+    Each input entry must contain ``name``, ``directory_name``, and
+    ``relative_path``. The returned dictionaries are copies with ``load_name``,
+    ``collision``, and ``collision_indices`` added.
+    """
+    normalized = [dict(entry) for entry in entries]
+    alias_owners: Dict[str, Set[int]] = {}
+
+    for index, entry in enumerate(normalized):
+        aliases = {
+            str(entry.get("name") or "").strip(),
+            str(entry.get("directory_name") or "").strip(),
+            str(entry.get("relative_path") or "").strip(),
+        }
+        for alias in aliases:
+            if alias:
+                alias_owners.setdefault(alias, set()).add(index)
+
+    for index, entry in enumerate(normalized):
+        declared_name = str(entry.get("name") or "").strip()
+        relative_path = str(entry.get("relative_path") or "").strip()
+        collision_indices = sorted(alias_owners.get(declared_name, set()))
+        collision = len(collision_indices) > 1
+
+        if not collision and declared_name:
+            load_name: Optional[str] = declared_name
+        elif relative_path and len(alias_owners.get(relative_path, set())) == 1:
+            load_name = relative_path
+        else:
+            load_name = None
+
+        entry["load_name"] = load_name
+        entry["collision"] = collision
+        entry["collision_indices"] = collision_indices if collision else []
+
+    return normalized
+
+
 def normalize_skill_lookup_name(identifier: str) -> str:
     """Normalize a skill identifier to a ``skill_view()``-safe relative path.
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -104,8 +104,13 @@ def get_available_skills() -> Dict[str, List[str]]:
 
     skills_by_category: Dict[str, List[str]] = {}
     for skill in all_skills:
+        load_name = skill.get("load_name") or (
+            skill["name"] if not skill.get("collision") else None
+        )
+        if not load_name:
+            continue
         category = skill.get("category") or "general"
-        skills_by_category.setdefault(category, []).append(skill["name"])
+        skills_by_category.setdefault(category, []).append(load_name)
     return skills_by_category
 
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -969,6 +969,7 @@ def do_list(source_filter: str = "all",
 
     for skill in sorted(all_skills, key=lambda s: (s.get("category") or "", s["name"])):
         name = skill["name"]
+        display_name = skill.get("load_name") or name
         category = skill.get("category", "")
         hub_entry = hub_installed.get(name)
 
@@ -984,6 +985,9 @@ def do_list(source_filter: str = "all",
             source_type = "local"
             source_display = "local"
             trust = "local"
+
+        if skill.get("collision") and skill.get("source"):
+            source_display = skill["source"]
 
         if source_filter != "all" and source_filter != source_type:
             continue
@@ -1006,9 +1010,21 @@ def do_list(source_filter: str = "all",
             disabled_count += 1
             status_cell = "[dim red]disabled[/]"
 
+        if skill.get("collision"):
+            if skill.get("load_name"):
+                status_cell += " [yellow](qualified)[/]"
+            else:
+                status_cell += " [bold red](ambiguous)[/]"
+
         trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow", "local": "dim"}.get(trust, "dim")
         trust_label = "official" if source_display == "official" else trust
-        table.add_row(name, category, source_display, f"[{trust_style}]{trust_label}[/]", status_cell)
+        table.add_row(
+            display_name,
+            category,
+            source_display,
+            f"[{trust_style}]{trust_label}[/]",
+            status_cell,
+        )
 
     c.print(table)
     summary = f"[dim]{hub_count} hub-installed, {builtin_count} builtin, {local_count} local"

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -118,8 +118,10 @@ class TestExternalSkillsInFindAll:
         names = [s["name"] for s in skills]
         assert "my-external-skill" in names
 
-    def test_local_takes_precedence(self, hermes_home, external_skills_dir):
-        """If the same skill name exists locally and externally, local wins."""
+    def test_same_relative_path_collision_preserves_both_sources(
+        self, hermes_home, external_skills_dir
+    ):
+        """Identical local/external paths are visible but not loadable by alias."""
         local_skills = hermes_home / "skills"
         local_skill = local_skills / "my-external-skill"
         local_skill.mkdir(parents=True)
@@ -136,8 +138,17 @@ class TestExternalSkillsInFindAll:
             from tools.skills_tool import _find_all_skills
             skills = _find_all_skills()
         matching = [s for s in skills if s["name"] == "my-external-skill"]
-        assert len(matching) == 1
-        assert matching[0]["description"] == "Local version"
+        assert len(matching) == 2
+        assert {skill["description"] for skill in matching} == {
+            "Local version",
+            "A skill from an external directory",
+        }
+        assert all(skill["collision"] for skill in matching)
+        assert all(skill["load_name"] is None for skill in matching)
+        assert {skill["source"] for skill in matching} == {
+            str(local_skills),
+            str(external_skills_dir.resolve()),
+        }
 
 
 class TestExternalSkillView:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -425,6 +426,75 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         # "search" should appear only once per category
         assert result.count("- search") == 1
+
+    def test_cross_category_collisions_use_loadable_identifiers(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for category, directory in (("alpha", "one"), ("beta", "two")):
+            skill_dir = tmp_path / "skills" / category / directory
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: duplicate-demo\ndescription: Duplicate demo.\n---\n"
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "- alpha/one: Duplicate demo." in result
+        assert "- beta/two: Duplicate demo." in result
+        assert "- duplicate-demo:" not in result
+
+        from tools.skills_tool import skill_view
+
+        assert json.loads(skill_view("alpha/one"))["success"] is True
+        assert json.loads(skill_view("beta/two"))["success"] is True
+
+    def test_same_category_collisions_keep_both_qualified_entries(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for directory in ("one", "two"):
+            skill_dir = tmp_path / "skills" / "alpha" / directory
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: duplicate-demo\ndescription: Duplicate demo.\n---\n"
+            )
+
+        result = build_skills_system_prompt()
+
+        assert result.count("duplicate-demo") == 0
+        assert "- alpha/one: Duplicate demo." in result
+        assert "- alpha/two: Duplicate demo." in result
+
+    def test_omits_collision_without_unique_relative_path(
+        self, monkeypatch, tmp_path
+    ):
+        local_dir = tmp_path / "skills"
+        external_dir = tmp_path / "external"
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        prompt_globals = build_skills_system_prompt.__globals__
+        prompt_globals["_SKILLS_PROMPT_CACHE"].clear()
+        monkeypatch.setitem(prompt_globals, "get_skills_dir", lambda: local_dir)
+        monkeypatch.setitem(
+            prompt_globals, "_load_skills_snapshot", lambda _root: None
+        )
+        monkeypatch.setitem(
+            prompt_globals,
+            "get_all_skills_dirs",
+            lambda: [local_dir, external_dir],
+        )
+        for root in (local_dir, external_dir):
+            skill_dir = root / "same-path"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: duplicate-demo\ndescription: Duplicate demo.\n---\n"
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "- duplicate-demo:" not in result
+        assert "Ambiguous skills omitted" in result
+        assert "duplicate-demo" in result
 
     def test_compact_categories_demoted_to_names_only(self, monkeypatch, tmp_path):
         """Posture-driven demotion keeps every skill NAME visible.
@@ -1651,5 +1721,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -10,10 +10,48 @@ from agent.skill_utils import (
     is_external_skill_path,
     is_skill_support_path,
     iter_skill_index_files,
+    resolve_skill_identifiers,
     resolve_skill_config_values,
     skill_matches_platform,
     skill_matches_platform_list,
 )
+
+
+def test_resolve_skill_identifiers_accounts_for_directory_aliases():
+    resolved = resolve_skill_identifiers([
+        {
+            "name": "alpha",
+            "directory_name": "duplicate-demo",
+            "relative_path": "tools/alpha",
+        },
+        {
+            "name": "duplicate-demo",
+            "directory_name": "beta",
+            "relative_path": "tools/beta",
+        },
+    ])
+
+    assert resolved[0]["load_name"] == "alpha"
+    assert resolved[0]["collision"] is False
+    assert resolved[1]["load_name"] == "tools/beta"
+    assert resolved[1]["collision"] is True
+
+
+def test_resolve_skill_identifiers_rejects_duplicate_relative_paths():
+    entries = [
+        {
+            "name": "duplicate-demo",
+            "directory_name": "same-path",
+            "relative_path": "same-path",
+            "source": source,
+        }
+        for source in ("local", "external")
+    ]
+
+    resolved = resolve_skill_identifiers(entries)
+
+    assert all(entry["collision"] for entry in resolved)
+    assert all(entry["load_name"] is None for entry in resolved)
 
 
 def test_metadata_as_dict_with_hermes():

--- a/tests/hermes_cli/test_banner_skills.py
+++ b/tests/hermes_cli/test_banner_skills.py
@@ -65,3 +65,26 @@ def test_get_available_skills_null_category_becomes_general():
 
     assert "general" in result
     assert result["general"] == ["orphan-skill"]
+
+
+def test_get_available_skills_uses_only_loadable_collision_names():
+    skills = [
+        {
+            "name": "duplicate-demo",
+            "load_name": "alpha/one",
+            "collision": True,
+            "category": "alpha",
+        },
+        {
+            "name": "duplicate-demo",
+            "load_name": None,
+            "collision": True,
+            "category": "external",
+        },
+    ]
+    with patch("tools.skills_tool._find_all_skills", return_value=skills):
+        from hermes_cli.banner import get_available_skills
+
+        result = get_available_skills()
+
+    assert result == {"alpha": ["alpha/one"]}

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -130,6 +130,45 @@ def test_do_list_distinguishes_hub_builtin_and_local(three_source_env):
     assert "1 hub-installed, 1 builtin, 1 local" in output
 
 
+def test_do_list_surfaces_collision_identifier_and_source(monkeypatch, hub_env):
+    import tools.skills_hub as hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile([]))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {})
+    monkeypatch.setattr(
+        skills_tool,
+        "_find_all_skills",
+        lambda **_kwargs: [
+            {
+                "name": "duplicate-demo",
+                "load_name": "alpha/one",
+                "category": "alpha",
+                "description": "first",
+                "collision": True,
+                "source": "/skills/local",
+            },
+            {
+                "name": "duplicate-demo",
+                "load_name": None,
+                "category": "external",
+                "description": "second",
+                "collision": True,
+                "source": "/skills/external",
+            },
+        ],
+    )
+
+    output = _capture()
+
+    assert "alpha/one" in output
+    assert "/skills/local" in output
+    assert "/skills/external" in output
+    assert "qualified" in output
+    assert "ambiguous" in output
+
+
 def test_do_list_filter_local(three_source_env):
     output = _capture(source_filter="local")
 
@@ -780,4 +819,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -307,6 +307,23 @@ class TestFindAllSkills:
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
 
+    def test_preserves_collisions_with_exact_load_names(self, tmp_path):
+        for category, directory in (("alpha", "one"), ("beta", "two")):
+            skill_dir = tmp_path / category / directory
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: duplicate-demo\ndescription: Duplicate demo.\n---\n"
+            )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skills = _find_all_skills()
+
+        assert len(skills) == 2
+        assert {skill["name"] for skill in skills} == {"duplicate-demo"}
+        assert {skill["load_name"] for skill in skills} == {"alpha/one", "beta/two"}
+        assert all(skill["collision"] for skill in skills)
+        assert all(len(skill["matches"]) == 2 for skill in skills)
+
 
 # ---------------------------------------------------------------------------
 # skills_list
@@ -1224,6 +1241,31 @@ class TestSkillViewCollisionDetection:
         result = json.loads(raw)
         assert result["success"] is True
         assert "LOCAL VERSION" in result["content"]
+
+    def test_cross_category_collision_reports_loadable_identifiers(self, tmp_path):
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+        for category, directory, body in (
+            ("alpha", "one", "FIRST VERSION"),
+            ("beta", "two", "SECOND VERSION"),
+        ):
+            skill_dir = local_dir / category / directory
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: duplicate-demo\ndescription: Duplicate demo.\n---\n\n"
+                + body
+            )
+
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            ambiguous = json.loads(skill_view("duplicate-demo"))
+            first = json.loads(skill_view("alpha/one"))
+            second = json.loads(skill_view("beta/two"))
+
+        assert ambiguous["success"] is False
+        assert ambiguous["load_names"] == ["alpha/one", "beta/two"]
+        assert first["success"] is True and "FIRST VERSION" in first["content"]
+        assert second["success"] is True and "SECOND VERSION" in second["content"]
 
     def test_support_markdown_does_not_collide_with_real_skill(self, tmp_path):
         """Supporting reference docs named <skill>.md are not skills.

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -675,7 +675,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             filters out disabled skills.
 
     Returns:
-        List of skill metadata dicts (name, description, category).
+        List of skill metadata dicts. Every entry includes ``name``,
+        ``load_name``, ``description``, ``category``, and ``collision``.
+        Collision entries also expose their candidate ``path``, ``source``,
+        and complete ``matches`` list.
 
     Results are cached per-session; the cache is invalidated when the scan
     signature changes (dir/category mtimes or the disabled-set) and expires
@@ -712,11 +715,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         # out the cached objects would poison the cache for everyone else.
         return [dict(s) for s in cached[2]]
 
-    skills = []
-    seen_names: set = set()
+    discovered = []
 
-    # Scan local dir first, then external dirs (local takes precedence) —
-    # dirs_to_scan already resolved above for the signature.
+    # Scan local first for stable output ordering, then external dirs. Collision
+    # resolution below decides whether a declared name or relative path is safe.
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
@@ -728,18 +730,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 content = skill_md.read_text(encoding="utf-8")[:4000]
                 frontmatter, body = _parse_frontmatter(content)
 
-                if not skill_matches_platform(frontmatter):
-                    continue
-
-                if not skill_matches_environment(frontmatter):
-                    continue
-
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
-                if name in seen_names:
-                    continue
-                if name in disabled:
-                    continue
-
                 description = frontmatter.get("description", "")
                 if not description:
                     for line in body.strip().split("\n"):
@@ -752,12 +743,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
 
                 category = _get_category_from_path(skill_md)
-
-                seen_names.add(name)
-                skills.append({
+                relative_path = skill_dir.relative_to(scan_dir).as_posix()
+                discovered.append({
                     "name": name,
+                    "directory_name": skill_dir.name,
+                    "relative_path": relative_path,
                     "description": description,
                     "category": category,
+                    "source": str(scan_dir),
+                    "path": str(skill_md),
+                    "platform_compatible": skill_matches_platform(frontmatter),
+                    "environment_compatible": skill_matches_environment(frontmatter),
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -768,6 +764,31 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     "Skipping skill at %s: failed to parse: %s", skill_md, e, exc_info=True
                 )
                 continue
+
+    from agent.skill_utils import resolve_skill_identifiers
+
+    resolved = resolve_skill_identifiers(discovered)
+    skills = []
+    for entry in resolved:
+        if not entry["platform_compatible"]:
+            continue
+        if not entry["environment_compatible"]:
+            continue
+        if entry["name"] in disabled:
+            continue
+
+        skill = dict(entry)
+        collision_indices = skill.pop("collision_indices")
+        if skill["collision"]:
+            skill["matches"] = [resolved[i]["path"] for i in collision_indices]
+        else:
+            skill.pop("source")
+            skill.pop("path")
+        skill.pop("directory_name")
+        skill.pop("relative_path")
+        skill.pop("platform_compatible")
+        skill.pop("environment_compatible")
+        skills.append(skill)
 
     # Store in cache keyed by the scan signature computed BEFORE the scan
     # (a write racing the scan changes the signature, so the next call
@@ -786,15 +807,16 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
-    Returns only name + description to minimize token usage. Use skill_view() to
-    load full content, tags, related files, etc.
+    Returns compact metadata plus the exact ``load_name`` accepted by
+    skill_view(). Collision entries include candidate paths and sources.
 
     Args:
         category: Optional category filter (e.g., "mlops")
         task_id: Optional task identifier used to probe the active backend
 
     Returns:
-        JSON string with minimal skill info: name, description, category
+        JSON string with skill identifiers, descriptions, categories, and
+        collision diagnostics
     """
     try:
         active_skills_dir = _skills_dir()
@@ -842,7 +864,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 "skills": all_skills,
                 "categories": categories,
                 "count": len(all_skills),
-                "hint": "Use skill_view(name) to see full content, tags, and linked files",
+                "hint": "Use skill_view(load_name) to see full content, tags, and linked files",
             },
             ensure_ascii=False,
         )
@@ -1106,10 +1128,10 @@ def skill_view(
         # loaded the other) so we surface it loudly instead of guessing.
         from agent.skill_utils import iter_skill_index_files
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
+        candidates: List[Tuple[Optional[Path], Path, Path]] = []
         seen_md: set = set()
 
-        def _record(sd: Optional[Path], smd: Path) -> None:
+        def _record(sd: Optional[Path], smd: Path, root: Path) -> None:
             try:
                 key = smd.resolve()
             except Exception:
@@ -1117,7 +1139,7 @@ def skill_view(
             if key in seen_md:
                 return
             seen_md.add(key)
-            candidates.append((sd, smd))
+            candidates.append((sd, smd, root))
 
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
@@ -1128,11 +1150,11 @@ def skill_view(
                 and direct_path.is_dir()
                 and (direct_path / "SKILL.md").exists()
             ):
-                _record(direct_path, direct_path / "SKILL.md")
+                _record(direct_path, direct_path / "SKILL.md", search_dir)
             elif direct_path.with_suffix(".md").exists() and not _is_skill_support_path(
                 direct_path.with_suffix(".md")
             ):
-                _record(None, direct_path.with_suffix(".md"))
+                _record(None, direct_path.with_suffix(".md"), search_dir)
 
             # Strategy 1b: categorized form for plugin namespace fall-through
             # (e.g., a "myplugin:explore" name with no plugin registered also
@@ -1144,13 +1166,13 @@ def skill_view(
                     and categorized_path.is_dir()
                     and (categorized_path / "SKILL.md").exists()
                 ):
-                    _record(categorized_path, categorized_path / "SKILL.md")
+                    _record(categorized_path, categorized_path / "SKILL.md", search_dir)
                 elif categorized_path.with_suffix(
                     ".md"
                 ).exists() and not _is_skill_support_path(
                     categorized_path.with_suffix(".md")
                 ):
-                    _record(None, categorized_path.with_suffix(".md"))
+                    _record(None, categorized_path.with_suffix(".md"), search_dir)
 
             # Strategy 2: recursive by directory name (catches nested skills
             # like "foundations/runtime/explore-codebase" called by bare name),
@@ -1159,7 +1181,7 @@ def skill_view(
             # when the on-disk directory is a shorter category/alias.
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
+                    _record(found_skill_md.parent, found_skill_md, search_dir)
                     continue
                 try:
                     fm_content = found_skill_md.read_text(encoding="utf-8")
@@ -1167,7 +1189,7 @@ def skill_view(
                 except Exception:
                     fm = {}
                 if fm.get("name") == name:
-                    _record(found_skill_md.parent, found_skill_md)
+                    _record(found_skill_md.parent, found_skill_md, search_dir)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             # Exclude skill support docs: references/templates/assets/scripts
@@ -1177,10 +1199,34 @@ def skill_view(
                 if found_md.name != "SKILL.md" and not _is_skill_support_path(
                     found_md
                 ):
-                    _record(None, found_md)
+                    _record(None, found_md, search_dir)
 
         if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
+            paths = [str(smd) for _, smd, _ in candidates]
+            from agent.skill_utils import resolve_skill_identifiers
+
+            identifier_entries = []
+            for candidate_dir, candidate_md, root in candidates:
+                try:
+                    candidate_content = candidate_md.read_text(encoding="utf-8")
+                    candidate_frontmatter, _ = _parse_frontmatter(candidate_content)
+                except Exception:
+                    candidate_frontmatter = {}
+                if candidate_dir is not None:
+                    relative_path = candidate_dir.relative_to(root).as_posix()
+                    directory_name = candidate_dir.name
+                else:
+                    relative_path = candidate_md.relative_to(root).with_suffix("").as_posix()
+                    directory_name = candidate_md.stem
+                identifier_entries.append({
+                    "name": candidate_frontmatter.get("name", directory_name),
+                    "directory_name": directory_name,
+                    "relative_path": relative_path,
+                })
+            resolved_identifiers = resolve_skill_identifiers(identifier_entries)
+            load_names = sorted({
+                entry["load_name"] for entry in resolved_identifiers if entry["load_name"]
+            })
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
@@ -1194,20 +1240,28 @@ def skill_view(
                         "Refusing to guess — load one explicitly by its categorized path."
                     ),
                     "matches": paths,
+                    "load_names": load_names,
                     "hint": (
-                        "Pass the full relative path instead of the bare name "
-                        "(e.g., 'category/skill-name'), or rename one of the "
-                        "colliding skills so each name is unique."
+                        f"Load an unambiguous candidate with one of: {load_names}. "
+                        if load_names else
+                        "No unique relative path exists for these candidates. "
+                    ) + (
+                        "Otherwise rename one of the colliding skills so each "
+                        "name or relative path is unique."
                     ),
                 },
                 ensure_ascii=False,
             )
 
         if candidates:
-            skill_dir, skill_md = candidates[0]
+            skill_dir, skill_md, _ = candidates[0]
 
         if not skill_md or not skill_md.exists():
-            available = [s["name"] for s in _sort_skills(_find_all_skills())[:20]]
+            available = [
+                s["load_name"]
+                for s in _sort_skills(_find_all_skills())
+                if s.get("load_name")
+            ][:20]
             return json.dumps(
                 {
                     "success": False,


### PR DESCRIPTION
## Summary

- centralize local/external skill identifier resolution across declared names, directory aliases, and relative paths
- preserve every collision candidate in `skills_list`, including exact `load_name`, source, path, and collision diagnostics
- advertise only identifiers that `skill_view` can actually resolve; use real on-disk relative paths for resolvable collisions and omit irreducibly ambiguous candidates with one diagnostic
- surface qualified/ambiguous status in `hermes skills list` and keep banner/not-found suggestions free of unloadable bare names

## Root cause

Discovery silently first-won by frontmatter name, prompt rendering deduplicated only inside each category, and `skill_view` correctly rejected every matching bare name. Those independent policies allowed Hermes to advertise names its loader could not use.

The shared resolver now models the loader's three aliases: declared frontmatter name, directory name, and path relative to a configured skills root. A declared name is used only when unique. Otherwise Hermes uses the relative directory path if that path is unique across roots; candidates with no unique alias remain visible in list diagnostics but are not advertised as loadable.

## Relation to #64453

This is an alternative implementation. #64453 qualifies cross-category entries as `category/<frontmatter-name>`, which is not loadable when the directory name differs from the declared name (the issue's `a/one` and `b/two` reproduction), and it keeps first-win list behavior. This PR derives identifiers from actual relative directories and also covers same-category duplicates, directory-name aliases, and identical relative paths across sources.

## Validation

- `scripts/run_tests.sh tests/agent/test_external_skills.py tests/agent/test_skill_utils.py tests/tools/test_skills_tool.py tests/agent/test_prompt_builder.py tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_banner_skills.py -q` (326 passed)
- `ruff check .`
- `git diff --check`

Fixes #64392