### PR TITLE
fix(desktop): surface /model in the slash palette

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -34,7 +34,6 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/compact')).toBe(false)
     expect(isDesktopSlashSuggestion('/redraw')).toBe(false)
     expect(isDesktopSlashSuggestion('/approve')).toBe(false)
-    expect(isDesktopSlashSuggestion('/model')).toBe(false)
     expect(isDesktopSlashSuggestion('/skills')).toBe(false)
     expect(isDesktopSlashSuggestion('/voice')).toBe(false)
     expect(isDesktopSlashSuggestion('/curator')).toBe(false)
@@ -119,6 +118,7 @@ describe('desktop slash command curation', () => {
     ])
     expect(filtered.pairs).toEqual([
       ['/new', 'Start a new desktop chat'],
+      ['/model', 'Switch the model for this session'],
       ['/ship-it', 'Run release checklist']
     ])
     // skill_count is recomputed from the filtered output (only /ship-it is an

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -131,7 +131,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   },
 
   // Overlay pickers
-  { name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
+  { name: '/model', description: 'Switch the model for this session', surface: picker('model') },
   {
     name: '/resume',
     description: 'Resume a saved session',


### PR DESCRIPTION
## Symptom

Typing `/model` in the desktop app's composer does nothing discoverable: it never appears in the slash popover or completions, so the command looks broken. (Reported live 2026-07-14 — user typed `/model` repeatedly expecting the model picker.)

## Root cause

`apps/desktop/src/lib/desktop-slash-commands.ts` registers `/model` with `hidden: true`:

```ts
{ name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
```

`hidden` suppresses it from `isDesktopSlashSuggestion` (popover/completions) and `filterDesktopCommandsCatalog` (/help). The original intent was "the model picker lives on the status bar, so don't clutter the popover" — but in practice users type `/model` (it works everywhere else: CLI, TUI, gateway platforms) and get zero feedback that the command exists.

## Fix

Drop `hidden: true`. The surface stays `picker('model')`, so behavior on selection is unchanged:
- picking bare `/model` (or typing it + Enter) opens the model-picker overlay
- `/model <name>` with a typed arg still executes on the backend as before

## Testing

- `desktop-slash-commands.test.ts` updated: `/model` now expected in suggestions + catalog pairs — 16/16 pass
- `use-prompt-actions/index.test.tsx` + `model-menu-panel.test.tsx` — 55/55 pass (jsdom)
- `tsc --noEmit` clean
- Live E2E on a real install: typed `/model` via CDP key events → popover shows the command → Enter opens the picker overlay with the provider/model list