### PR TITLE
fix(line): preserve postback answers after progress updates

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -604,6 +604,7 @@ _SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = (
     "⚡ Interrupting",
     "⏳ Queued",
     "⏩ Steered",
+    "⏳ Working",
     "💾",  # background-review summary
 )
 
@@ -1092,12 +1093,17 @@ class LineAdapter(BasePlatformAdapter):
         if _is_system_bypass(content):
             return await self._send_text_chunks(chat_id, content, force_push=False)
 
-        # If the chat has a PENDING postback button outstanding, route the
-        # response into the cache for the user to fetch via tap.
+        # If the chat has a genuinely PENDING postback button outstanding,
+        # route this response into the cache for the user to fetch via tap.
+        # A READY/DELIVERED/expired entry is stale and must not swallow the
+        # answer to a later inbound message.
         pending_rid = self._pending_buttons.get(chat_id)
         if pending_rid:
-            self._cache.set_ready(pending_rid, content)
-            return SendResult(success=True, message_id=pending_rid)
+            entry = self._cache.get(pending_rid)
+            if entry and entry.state is State.PENDING:
+                self._cache.set_ready(pending_rid, content)
+                return SendResult(success=True, message_id=pending_rid)
+            self._pending_buttons.pop(chat_id, None)
 
         return await self._send_text_chunks(chat_id, content, force_push=False)
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -378,6 +378,31 @@ class TestSendRouting:
         # And the cache entry is unchanged (still PENDING for the eventual answer)
         assert adapter._cache.get(rid).state is State.PENDING
 
+    def test_ready_postback_does_not_swallow_next_answer(self, adapter):
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._cache.set_ready(rid, "previous answer")
+        adapter._pending_buttons["Uchat"] = rid
+
+        result = asyncio.run(adapter.send("Uchat", "new answer"))
+
+        assert result.success
+        adapter._client.push.assert_called_once()
+        assert adapter._cache.get(rid).payload == "previous answer"
+        assert "Uchat" not in adapter._pending_buttons
+
+    def test_working_heartbeat_does_not_replace_pending_final_answer(self, adapter):
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._pending_buttons["Uchat"] = rid
+
+        result = asyncio.run(
+            adapter.send("Uchat", "⏳ Working — 3 min — iteration 1/60, terminal")
+        )
+
+        assert result.success
+        adapter._client.push.assert_called_once()
+        assert adapter._cache.get(rid).state is State.PENDING
+        assert adapter._cache.get(rid).payload is None
+
     def test_send_caps_messages_per_call_at_five(self, adapter):
         # Build a payload that would naturally split into more than 5 LINE
         # bubbles; the chunker should cap at 5 + truncate.


### PR DESCRIPTION
## Summary
- Bypass `⏳ Working` heartbeats while a LINE postback response is pending, so progress updates do not replace the eventual answer.
- Only cache an outbound response for a genuinely `PENDING` postback entry; discard stale `READY`, `DELIVERED`, or expired references so later answers are delivered normally.
- Add regression coverage for both flows.

## Test plan
- [x] `uv run --with pytest python -m pytest tests/gateway/test_line_plugin.py -q` (78 passed)