### PR TITLE
fix(kanban): expose durable handoff semantics

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -931,6 +931,10 @@ def test_comment_happy_path(worker_env):
     d = json.loads(out)
     assert d["ok"] is True
     assert d["comment_id"]
+    assert d["delivery"] == "durable_not_pushed"
+    assert d["active_worker_notified"] is False
+    assert "explicit kanban_show reads" in d["guidance"]
+    assert "not injected" in d["guidance"]
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
@@ -941,6 +945,34 @@ def test_comment_happy_path(worker_env):
         assert comments[0].body == "hello thread"
     finally:
         conn.close()
+
+
+def test_comment_delivery_contract_does_not_depend_on_task_status(worker_env):
+    """Task status is not evidence that an active prompt saw the comment."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET status = 'ready' WHERE id = ?",
+            (worker_env,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_comment({
+        "task_id": worker_env,
+        "body": "add this to the queued brief",
+    })
+    d = json.loads(out)
+
+    assert d["ok"] is True
+    assert d["delivery"] == "durable_not_pushed"
+    assert d["active_worker_notified"] is False
+    assert "explicit kanban_show reads" in d["guidance"]
+    assert "may be running" in d["guidance"]
 
 
 def test_comment_rejects_empty_body(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -828,7 +828,20 @@ def _handle_comment(args: dict, **kw) -> str:
         kb, conn = _connect(board=board)
         try:
             cid = kb.add_comment(conn, tid, author=author, body=str(body))
-            return _ok(task_id=tid, comment_id=cid)
+            return _ok(
+                task_id=tid,
+                comment_id=cid,
+                delivery="durable_not_pushed",
+                active_worker_notified=False,
+                guidance=(
+                    "The comment is persisted for future worker context and "
+                    "explicit kanban_show reads, but is not injected into an "
+                    "already-constructed worker prompt. For a material scope "
+                    "change to a task that may be running, create a follow-up "
+                    "task that depends on it instead of claiming its live brief "
+                    "was updated."
+                ),
+            )
         finally:
             conn.close()
     except ValueError as e:
@@ -1371,10 +1384,14 @@ KANBAN_HEARTBEAT_SCHEMA = {
 KANBAN_COMMENT_SCHEMA = {
     "name": "kanban_comment",
     "description": (
-        "Append a comment to a task's thread. Use for durable notes "
-        "that should outlive this run (questions for the next worker, "
-        "partial findings, rationale). Ephemeral reasoning doesn't "
-        "belong here — use your normal response instead."
+        "Append a durable comment to a task's thread. The comment is available "
+        "to future worker context and explicit kanban_show reads, but is not "
+        "pushed or injected into an already-constructed worker prompt. For a "
+        "material scope change to a task that may be running, create a "
+        "follow-up task that depends on it instead of claiming its live brief "
+        "was updated. Use comments for questions for the next worker, partial "
+        "findings, and rationale. Ephemeral reasoning doesn't belong here — "
+        "use your normal response instead."
     ),
     "parameters": {
         "type": "object",
@@ -1403,8 +1420,14 @@ KANBAN_CREATE_SCHEMA = {
         "one (pass the current task id in ``parents``). Used by "
         "orchestrator workers to fan out — decompose work into child "
         "tasks with specific assignees, link them into a pipeline, "
-        "then complete your own task. The dispatcher picks up the new "
-        "tasks on its next tick and spawns the assigned profiles."
+        "then complete your own task. From a gateway or TUI session, call "
+        "this native tool directly rather than shelling out to the CLI: the "
+        "native call preserves the originating delivery context and can "
+        "auto-subscribe that conversation to completion/block events. Check "
+        "the returned ``subscribed`` field; if false, do not promise an "
+        "automatic handoff until notification routing is established. The "
+        "dispatcher picks up the new tasks on its next tick and spawns the "
+        "assigned profiles."
     ),
     "parameters": {
         "type": "object",
@@ -1459,9 +1482,15 @@ KANBAN_CREATE_SCHEMA = {
                 "type": "string",
                 "enum": ["scratch", "dir", "worktree"],
                 "description": (
-                    "Workspace flavor: 'scratch' (fresh tmp dir, "
-                    "default), 'dir' (shared directory, requires "
-                    "absolute workspace_path), 'worktree' (git worktree)."
+                    "Workspace flavor: 'scratch' (fresh ephemeral tmp dir, "
+                    "default; deleted after completion), 'dir' (shared durable "
+                    "directory, requires absolute workspace_path), 'worktree' "
+                    "(git worktree). Declared scratch deliverables from "
+                    "kanban_complete(artifacts=[...]) are copied to durable "
+                    "task attachments before cleanup; each must be no larger "
+                    "than 25 MiB. Use 'dir' when multiple tasks must "
+                    "collaborate through the same files or produce larger "
+                    "artifacts."
                 ),
             },
             "workspace_path": {

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -468,6 +468,12 @@ kanban_complete(
 
 The orchestrator guidance ships in the worker's system prompt automatically — there is nothing to install or sync per profile.
 
+Comments are a durable handoff channel, not a live control channel. They are
+available to future worker context and explicit `kanban_show` reads, but
+`kanban_comment` does not push or inject text into an already-constructed worker
+prompt. For a material scope change to a task that may be running, create a
+follow-up task that depends on it instead of claiming the live brief was updated.
+
 For best results, pair it with a profile whose toolsets are restricted to board operations (`kanban`, `gateway`, `memory`) so the orchestrator literally cannot execute implementation tasks even if it tries.
 
 ## Dashboard (GUI)


### PR DESCRIPTION
## What does this PR do?

Orchestrators can no longer mistake a persisted Kanban comment for a live worker-prompt update. `kanban_comment` now reports the enforceable delivery contract: the comment is durable and available to future context or an explicit `kanban_show`, but it is not proactively pushed into an already-constructed prompt.

The contract is deliberately independent of task status, avoiding a race between comment persistence and worker lifecycle changes. Native tool guidance also preserves gateway notification context, requires callers to verify `subscribed`, and makes scratch cleanup, the 25 MiB attachment boundary, and durable shared workspaces explicit.

## Related Issue

Fixes #64447

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/kanban_tools.py`: return explicit comment-delivery metadata and teach native creation, subscription verification, dependent revision cards, and durable artifact routing at tool-selection time.
- `tests/tools/test_kanban_tools.py`: prove the delivery contract is invariant across task status and does not claim active-worker notification.
- `website/docs/user-guide/features/kanban.md`: document comments as durable handoffs rather than a live control channel.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_kanban_tools.py -q` and confirm all 99 focused tests pass.
2. Run `ruff check .` and confirm the project is lint-clean.
3. Call `kanban_comment` and confirm the response contains `delivery: durable_not_pushed`, `active_worker_notified: false`, and guidance that distinguishes explicit reads from prompt injection.

## Post-Deploy Monitoring & Validation

- Watch `kanban_comment` tool errors and orchestration reports during the first release after merge.
- Healthy behavior: comments persist, the new response fields are present, and callers create dependent revision cards instead of claiming a running brief changed.
- Failure signal: missing response metadata, comment-write errors, or orchestration that still treats write success as active-worker notification.
- Rollback: revert this commit; the runtime change is additive response metadata plus tool/schema guidance.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (99 focused Kanban tool tests pass; full suite is left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, neither changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — response metadata and descriptions are platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a non-visual tool-contract change. The focused test and lint results are listed above.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
