### PR TITLE
fix(desktop): make shallow update status presence-only

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -105,7 +105,7 @@ import {
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
-import { resolveBehindCount, shouldCountCommits } from './update-count'
+import { resolveBehindCount, resolveCommitLogSelection, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
@@ -2103,37 +2103,36 @@ async function checkUpdates() {
 
   const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
 
-  const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr, mergeBaseStr] = await Promise.all([
+  const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr] = await Promise.all([
     git(['rev-parse', 'HEAD']),
     git(['rev-parse', `origin/${branch}`]),
     git(['status', '--porcelain']),
     git(['rev-parse', '--abbrev-ref', 'HEAD']),
-    git(['rev-parse', '--is-shallow-repository']),
-    // merge-base exits non-zero with empty stdout when HEAD shares no common
-    // ancestor with the freshly fetched tip — exactly the shallow-clone case.
-    git(['merge-base', 'HEAD', `origin/${branch}`])
+    git(['rev-parse', '--is-shallow-repository'])
   ])
 
   const isShallow = shallowStr === 'true'
-  const hasMergeBase = Boolean(mergeBaseStr)
 
-  // Only enumerate the commit count when it is meaningful. On a shallow checkout
-  // with no merge-base, `rev-list --count` walks the entire remote ancestry
-  // (thousands of commits, see #51922) and resolveBehindCount discards the
-  // result anyway in favour of a SHA compare — so skip the expensive query.
-  const countStr = shouldCountCommits({ isShallow, hasMergeBase })
-    ? await git(['rev-list', `HEAD..origin/${branch}`, '--count'])
-    : ''
+  // A shallow graph cannot provide a trustworthy exact count, even when it has
+  // a visible merge-base. Skip the ancestry walk and use the SHA fallback.
+  const countStr = shouldCountCommits({ isShallow }) ? await git(['rev-list', `HEAD..origin/${branch}`, '--count']) : ''
+
+  // A positive directional ancestry result remains trustworthy in a shallow
+  // graph and prevents a local commit on top of origin from looking outdated.
+  const targetIsAncestorOfHead =
+    isShallow &&
+    currentSha !== targetSha &&
+    (await runGit(['merge-base', '--is-ancestor', `origin/${branch}`, 'HEAD'], { cwd: updateRoot })).code === 0
 
   const behind = resolveBehindCount({
     countStr,
     currentSha,
     targetSha,
     isShallow,
-    hasMergeBase
+    targetIsAncestorOfHead
   })
 
-  const commits = behind > 0 ? await readCommitLog(updateRoot, branch) : []
+  const commits = behind > 0 ? await readCommitLog(updateRoot, branch, isShallow) : []
 
   return {
     supported: true,
@@ -2149,12 +2148,13 @@ async function checkUpdates() {
   }
 }
 
-async function readCommitLog(cwd, branch) {
+async function readCommitLog(cwd, branch, isShallow) {
   const SEP = '\x1f'
   const REC = '\x1e'
+  const { limit, revision } = resolveCommitLogSelection({ branch, isShallow })
 
   const { stdout } = await runGit(
-    ['log', `HEAD..origin/${branch}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', '40'],
+    ['log', revision, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', String(limit)],
     { cwd }
   )
 

--- a/apps/desktop/electron/update-count.test.ts
+++ b/apps/desktop/electron/update-count.test.ts
@@ -1,20 +1,41 @@
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 import { test } from 'vitest'
 
-import { resolveBehindCount, shouldCountCommits } from './update-count'
+import { resolveBehindCount, resolveCommitLogSelection, shouldCountCommits } from './update-count'
+
+function createTempGitRepo() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-update-count-'))
+  const git = (...args: string[]) => execFileSync('git', args, { cwd, encoding: 'utf8', timeout: 10_000 }).trim()
+
+  try {
+    git('init', '--quiet')
+    git('config', 'commit.gpgSign', 'false')
+    git('config', 'core.hooksPath', '.git/no-hooks')
+    git('config', 'user.name', 'Hermes Test')
+    git('config', 'user.email', 'hermes@example.invalid')
+
+    return { cwd, git }
+  } catch (error) {
+    fs.rmSync(cwd, { recursive: true, force: true })
+    throw error
+  }
+}
 
 // FAIL-BEFORE: pre-fix the function did `Number.parseInt(countStr) || 0`
 // unconditionally, so a shallow checkout with no merge-base surfaced the bogus
-// rev-list count (e.g. 12104). This asserts the new shallow/no-merge-base branch.
+// rev-list count (e.g. 12104). This asserts the original #51922 regression.
 test('shallow checkout with no merge-base does NOT trust the bogus rev-list count', () => {
   assert.equal(
     resolveBehindCount({
       countStr: '12104',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     1
   )
@@ -26,23 +47,114 @@ test('shallow checkout with no merge-base but identical SHA reports up-to-date',
       countStr: '12104',
       currentSha: 'abc',
       targetSha: 'abc',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     0
   )
 })
 
-test('shallow checkout WITH a merge-base keeps the exact count (reliable)', () => {
+test('shallow local-ahead checkout reports up-to-date when origin is a known ancestor', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '',
+      currentSha: 'local-child',
+      targetSha: 'origin-parent',
+      isShallow: true,
+      targetIsAncestorOfHead: true
+    }),
+    0
+  )
+})
+
+test('shallow Git graph proves the remote tip is an ancestor of a local commit', () => {
+  const { cwd, git } = createTempGitRepo()
+
+  try {
+    git('commit', '--allow-empty', '-m', 'origin tip')
+
+    const targetSha = git('rev-parse', 'HEAD')
+
+    git('update-ref', 'refs/remotes/origin/main', targetSha)
+    fs.writeFileSync(path.join(cwd, '.git', 'shallow'), `${targetSha}\n`)
+    git('commit', '--allow-empty', '-m', 'local child')
+
+    const currentSha = git('rev-parse', 'HEAD')
+
+    git('merge-base', '--is-ancestor', 'origin/main', 'HEAD')
+    assert.notEqual(currentSha, targetSha)
+    assert.equal(
+      resolveBehindCount({
+        countStr: '',
+        currentSha,
+        targetSha,
+        isShallow: true,
+        targetIsAncestorOfHead: true
+      }),
+      0
+    )
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true })
+  }
+}, 30_000)
+
+test('shallow checkout with a merge-base does not trust an inflated rev-list count', () => {
+  const { cwd, git } = createTempGitRepo()
+
+  try {
+    git('commit', '--allow-empty', '-m', 'root')
+    git('commit', '--allow-empty', '-m', 'ancestor')
+
+    const redundantParent = git('rev-parse', 'HEAD')
+
+    git('commit', '--allow-empty', '-m', 'installed head')
+
+    const currentSha = git('rev-parse', 'HEAD')
+    const tree = git('rev-parse', 'HEAD^{tree}')
+
+    const targetSha = execFileSync('git', ['commit-tree', tree, '-p', currentSha, '-p', redundantParent], {
+      cwd,
+      encoding: 'utf8',
+      input: 'remote merge\n',
+      timeout: 10_000
+    }).trim()
+
+    git('update-ref', 'refs/remotes/origin/main', targetSha)
+
+    const completeCount = git('rev-list', 'HEAD..origin/main', '--count')
+
+    assert.equal(completeCount, '1')
+
+    fs.writeFileSync(path.join(cwd, '.git', 'shallow'), `${currentSha}\n`)
+
+    assert.equal(git('rev-parse', '--is-shallow-repository'), 'true')
+    assert.equal(git('merge-base', 'HEAD', 'origin/main'), currentSha)
+
+    const shallowCount = git('rev-list', 'HEAD..origin/main', '--count')
+
+    assert.ok(Number.parseInt(shallowCount, 10) > Number.parseInt(completeCount, 10))
+    assert.equal(
+      resolveBehindCount({
+        countStr: shallowCount,
+        currentSha,
+        targetSha,
+        isShallow: true
+      }),
+      1
+    )
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true })
+  }
+}, 30_000)
+
+test('shallow checkout with a merge-base still uses presence-only status', () => {
   assert.equal(
     resolveBehindCount({
       countStr: '3',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: true,
-      hasMergeBase: true
+      isShallow: true
     }),
-    3
+    1
   )
 })
 
@@ -52,8 +164,7 @@ test('full (non-shallow) clone keeps the exact count path unchanged', () => {
       countStr: '7',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: false,
-      hasMergeBase: true
+      isShallow: false
     }),
     7
   )
@@ -65,8 +176,7 @@ test('up-to-date full clone reports 0', () => {
       countStr: '0',
       currentSha: 'x',
       targetSha: 'x',
-      isShallow: false,
-      hasMergeBase: true
+      isShallow: false
     }),
     0
   )
@@ -78,28 +188,35 @@ test('non-numeric count falls back to 0 (defensive, unchanged behaviour)', () =>
       countStr: '',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: false,
-      hasMergeBase: true
+      isShallow: false
     }),
     0
   )
 })
 
 // shouldCountCommits gates the expensive `rev-list --count` in checkUpdates().
-// FAIL-BEFORE: in the shallow + no-merge-base case the caller ran rev-list
-// unconditionally and discarded the bogus result; this predicate lets the
-// caller SKIP the whole-ancestry enumeration in exactly that case (#51922).
-test('shallow checkout with no merge-base SKIPS the rev-list count', () => {
-  assert.equal(shouldCountCommits({ isShallow: true, hasMergeBase: false }), false)
+// Every shallow graph is incomplete, so a visible merge-base is not enough to
+// prove that the count is exact.
+test('shallow checkouts skip the rev-list count', () => {
+  assert.equal(shouldCountCommits({ isShallow: true }), false)
 })
 
-test('shallow checkout WITH a merge-base still runs the count', () => {
-  assert.equal(shouldCountCommits({ isShallow: true, hasMergeBase: true }), true)
+test('full (non-shallow) clones run the rev-list count', () => {
+  assert.equal(shouldCountCommits({ isShallow: false }), true)
 })
 
-test('full (non-shallow) clone always runs the count', () => {
-  assert.equal(shouldCountCommits({ isShallow: false, hasMergeBase: true }), true)
-  assert.equal(shouldCountCommits({ isShallow: false, hasMergeBase: false }), true)
+test('shallow commit logs select only the fetched remote tip', () => {
+  assert.deepEqual(resolveCommitLogSelection({ branch: 'main', isShallow: true }), {
+    limit: 1,
+    revision: 'origin/main'
+  })
+})
+
+test('full-clone commit logs keep the complete behind range', () => {
+  assert.deepEqual(resolveCommitLogSelection({ branch: 'release', isShallow: false }), {
+    limit: 40,
+    revision: 'HEAD..origin/release'
+  })
 })
 
 // The skip path produces an empty countStr; resolveBehindCount must NOT trust
@@ -110,8 +227,7 @@ test('skipped-count path resolves via SHA compare, never via empty countStr', ()
       countStr: '',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     1
   )
@@ -120,8 +236,7 @@ test('skipped-count path resolves via SHA compare, never via empty countStr', ()
       countStr: '',
       currentSha: 'same',
       targetSha: 'same',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     0
   )

--- a/apps/desktop/electron/update-count.ts
+++ b/apps/desktop/electron/update-count.ts
@@ -1,23 +1,20 @@
 // Whether `git rev-list HEAD..origin/<branch> --count` produces a meaningful
-// number worth computing. On a SHALLOW checkout (installer clones with
-// --depth 1) the local history often shares no merge-base with the freshly
-// fetched origin tip, so the count enumerates the entire remote ancestry and
-// returns a bogus huge number (e.g. 12104) — see #51922. resolveBehindCount
-// discards that bogus count in favour of a SHA compare, so the caller should
-// SKIP the expensive rev-list entirely in that case rather than run it and
-// throw the result away.
-function shouldCountCommits({ isShallow, hasMergeBase }) {
-  return !(isShallow && !hasMergeBase)
+// number worth computing. Installer checkouts are shallow (`--depth 1`), so
+// their visible graph is incomplete even when `merge-base` happens to find a
+// common commit. A merge can expose ancestry that the local shallow boundary
+// hides from HEAD, inflating the count with old commits. Exact counts are only
+// trustworthy in full clones; shallow checkouts use presence-only status plus
+// any positively proven local-ahead ancestry.
+function shouldCountCommits({ isShallow }) {
+  return !isShallow
 }
 
 // Resolve how many commits the local checkout is behind origin for the desktop
-// update indicator. When the count isn't meaningful (shallow + no merge-base)
-// fall back to a binary up-to-date check by SHA, exactly like the official-SSH
-// path in checkUpdates() and the CLI guard in hermes_cli/banner.py. Full clones
-// (developers / Docker dev images) keep the exact count path unchanged.
-function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMergeBase }) {
-  if (!shouldCountCommits({ isShallow, hasMergeBase })) {
-    if (currentSha && targetSha && currentSha === targetSha) {
+// update indicator. Shallow checkouts use SHA equality plus any positively
+// proven local-ahead ancestry; exact counts remain exclusive to full clones.
+function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, targetIsAncestorOfHead = false }) {
+  if (!shouldCountCommits({ isShallow })) {
+    if (currentSha && targetSha && (currentSha === targetSha || targetIsAncestorOfHead)) {
       return 0
     }
 
@@ -27,4 +24,13 @@ function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMer
   return Number.parseInt(countStr, 10) || 0
 }
 
-export { resolveBehindCount, shouldCountCommits }
+// Shallow history can also contaminate the changelog range. Trust the fetched
+// remote tip itself, but do not walk its ancestry. Full clones retain the
+// detailed range used by the existing update overlay.
+function resolveCommitLogSelection({ branch, isShallow }) {
+  const remote = `origin/${branch}`
+
+  return isShallow ? { limit: 1, revision: remote } : { limit: 40, revision: `HEAD..${remote}` }
+}
+
+export { resolveBehindCount, resolveCommitLogSelection, shouldCountCommits }


### PR DESCRIPTION
## What does this PR do?

This is a focused follow-up to #51922 / #52201. The existing Desktop guard treats a shallow checkout as unsafe only when `merge-base` is absent, and explicitly assumes that a shallow checkout *with* a visible merge-base has a reliable `rev-list` count.

That assumption does not always hold. A clean Windows installer checkout briefly reported **6,588** commits behind while the complete object graph between the same tips contained **49** commits. In a shallow graph, HEAD can hide ancestry that a remote merge path exposes, so `merge-base` can still succeed while `git rev-list HEAD..origin/main --count` includes old commits.

This change treats exact counts as trustworthy only in full clones. Shallow installs report `0` when the tips are equal or when Git positively proves that the remote tip is an ancestor of local HEAD; every other SHA mismatch remains the presence-only `1` sentinel. The changelog shows only the fetched remote tip instead of walking the contaminated ancestry range.

## Related Issue

Follow-up to #51922 and the merged fix #52201.

Related but intentionally non-overlapping: #53479 / #53494 cover the **CLI updater** path; this PR only fixes the Desktop `checkUpdates()` path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/update-count.ts`
  - trust exact commit counts only for full clones;
  - preserve shallow local-ahead checkouts by accepting only a positive remote-tip-is-ancestor result, while treating other SHA mismatches as presence-only updates;
  - select only `origin/<branch>` tip metadata for shallow changelogs while preserving the existing 40-commit range for full clones.
- `apps/desktop/electron/main.ts`
  - replace the count-oriented merge-base assumption with a directional `merge-base --is-ancestor` proof for shallow local-ahead checkouts;
  - apply the shallow-safe count and changelog selection.
- `apps/desktop/electron/update-count.test.ts`
  - add a real temporary-Git regression where a merge-base exists but shallow `rev-list` overcounts;
  - add a real shallow local-ahead graph so a local commit on top of `origin/main` remains up to date;
  - isolate Git signing/hooks, bound subprocess time, and cover shallow tip-only changelogs plus unchanged full-clone behavior.

## How to Test

1. `cd apps/desktop && npm run test:desktop:platforms -- electron/update-count.test.ts electron/update-remote.test.ts`
   - **20 passed** (14 update-count + 6 update-remote).
   - The regression creates a complete graph where the real behind count is 1, marks the installed HEAD shallow, confirms `merge-base` still succeeds, and proves the visible shallow count is inflated before asserting the presence-only result.
   - A second real Git graph creates a local child on top of the shallow remote tip and verifies the directional ancestry check keeps `behind` at 0.
2. `cd apps/desktop && npm run typecheck`
   - passed.
3. `cd apps/desktop && npx eslint electron/update-count.ts electron/update-count.test.ts`
   - passed.
4. `cd apps/desktop && npx prettier --check electron/update-count.ts electron/update-count.test.ts`
   - passed.
5. `cd apps/desktop && npm run build`
   - passed, including Electron main/preload bundles and `assert-dist-built`.
6. `npm run test:desktop:platforms` was also exercised on Windows. The changed `update-count.test.ts` passed under the full parallel suite (including the Git regression); the run retained unrelated existing Windows/POSIX baseline failures in `windows-hermes-path.test.ts`, `update-relaunch.test.ts`, `git-worktree-ops.test.ts`, and two `.mjs` test-loading suites.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] N/A — no Python files changed; targeted Desktop tests, typecheck, lint, formatting, and build were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] N/A — no user-facing documentation changes needed
- [x] N/A — no config keys changed
- [x] N/A — no architecture or contributor workflow changes
- [x] I've considered cross-platform impact; the regression uses Git commands already required by Desktop update checks and cleans its temporary repository in `finally`
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Observed real installer state before the fix:

```text
is_shallow=true
merge-base present
Desktop behind count=6588
complete object-graph behind count=49
```

After the shallow boundary was refreshed, the same checkout switched to the existing presence-only `1` display without moving HEAD. The regression test captures the underlying graph condition directly so the fix does not depend on a screenshot or a particular upstream commit count.
