### PR TITLE
fix(delegation): honor configured API mode

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1230,6 +1230,34 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("no API key", str(ctx.exception))
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolution_honors_explicit_api_mode(self, mock_resolve):
+        """delegation.api_mode must override provider runtime defaults too.
+
+        Regression: Copilot resolves claude-sonnet-4.6 with a runtime default
+        that routes through the Responses API, but that model is chat-only on
+        the Copilot endpoint. Users must be able to force chat_completions for
+        provider-based delegation, not only for direct base_url delegation.
+        """
+        mock_resolve.return_value = {
+            "provider": "copilot",
+            "model": "claude-sonnet-4.6",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-key",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "claude-sonnet-4.6",
+            "provider": "copilot",
+            "api_mode": "chat_completions",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        self.assertEqual(creds["provider"], "copilot")
+
     def test_missing_config_keys_inherit_parent(self):
         """When config dict has no model/provider keys at all, inherits parent."""
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3139,12 +3139,21 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Set the appropriate environment variable or run 'hermes auth'."
         )
 
+    api_mode = runtime.get("api_mode")
+    # Explicit delegation.api_mode must override provider runtime defaults for
+    # provider-based delegation too (not only direct base_url delegation). Some
+    # providers expose model-specific exceptions where the runtime default is
+    # too broad; e.g. Copilot's claude-sonnet-4.6 is chat-completions only and
+    # rejects the Responses API.
+    if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        api_mode = configured_api_mode
+
     return {
         "model": configured_model or runtime.get("model") or None,
         "provider": configured_provider if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM else runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
-        "api_mode": runtime.get("api_mode"),
+        "api_mode": api_mode,
         "request_overrides": dict(runtime.get("request_overrides") or {}),
         "max_output_tokens": runtime.get("max_output_tokens"),
         "command": runtime.get("command"),


### PR DESCRIPTION
## Summary
- honor the configured delegation API mode instead of resolving it from unrelated runtime state
- keep provider-specific delegation routing deterministic
- add regression coverage for the configured mode path

## Test plan
- `python -m pytest tests/tools/test_delegate.py -q -o 'addopts='`
- `ruff check tools/delegate_tool.py tests/tools/test_delegate.py`

Split from and supersedes the delegation portion of #50894.
