### PR TITLE
fix(acp): cancelled turn with final_response=None permanently bricks the session (every prompt queued forever)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1567,85 +1567,100 @@ class HermesACPAgent(acp.Agent):
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
-        if result.get("messages"):
-            state.history = result["messages"]
-            # Persist updated history so sessions survive process restarts.
-            self.session_manager.save_session(session_id)
+        # The whole post-turn tail below runs BEFORE ``state.is_running`` is
+        # reset. If anything in it raises, the exception escapes ``prompt()``
+        # with the session still marked running — permanently bricking it:
+        # every subsequent user message hits the ``state.is_running`` guard
+        # and is appended to ``queued_prompts`` ("Queued for the next turn.
+        # (N queued)") with no turn ever draining the queue. Seen live when
+        # a /stop-style cancel landed mid tool call: the interrupted turn
+        # returned ``final_response=None`` and ``None.startswith(...)`` blew
+        # up here. Guarantee the idle reset with try/finally.
+        try:
+            if result.get("messages"):
+                state.history = result["messages"]
+                # Persist updated history so sessions survive process restarts.
+                self.session_manager.save_session(session_id)
 
-        # Detect a compression-driven internal session rotation. If the agent's
-        # DB head moved during the turn, emit a session_info_update carrying
-        # _meta.hermes.sessionProvenance so ACP clients can render the boundary
-        # and keep old/new ids in lineage. The ACP session_id is unchanged.
-        post_turn_hermes_id = getattr(state.agent, "session_id", None)
-        if (
-            conn
-            and post_turn_hermes_id
-            and pre_turn_hermes_id
-            and post_turn_hermes_id != pre_turn_hermes_id
-        ):
-            try:
-                await self._send_session_info_update(
-                    session_id,
-                    current_hermes_session_id=post_turn_hermes_id,
-                    previous_hermes_session_id=pre_turn_hermes_id,
-                )
-            except Exception:
-                logger.debug(
-                    "Could not emit ACP provenance update after rotation for %s",
-                    session_id,
-                    exc_info=True,
-                )
+            # Detect a compression-driven internal session rotation. If the agent's
+            # DB head moved during the turn, emit a session_info_update carrying
+            # _meta.hermes.sessionProvenance so ACP clients can render the boundary
+            # and keep old/new ids in lineage. The ACP session_id is unchanged.
+            post_turn_hermes_id = getattr(state.agent, "session_id", None)
+            if (
+                conn
+                and post_turn_hermes_id
+                and pre_turn_hermes_id
+                and post_turn_hermes_id != pre_turn_hermes_id
+            ):
+                try:
+                    await self._send_session_info_update(
+                        session_id,
+                        current_hermes_session_id=post_turn_hermes_id,
+                        previous_hermes_session_id=pre_turn_hermes_id,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not emit ACP provenance update after rotation for %s",
+                        session_id,
+                        exc_info=True,
+                    )
 
-        final_response = result.get("final_response", "")
-        cancelled = bool(state.cancel_event and state.cancel_event.is_set())
-        interrupted = bool(result.get("interrupted")) or cancelled
-        # Hermes' local "waiting for model response" interrupt status is metadata,
-        # not assistant prose — clients get cancellation from stop_reason instead.
-        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+            # ``final_response`` is ``None`` (key present) for interrupted /
+            # recovery turns — ``.get()``'s default doesn't apply, so coerce.
+            final_response = result.get("final_response") or ""
+            cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+            interrupted = bool(result.get("interrupted")) or cancelled
+            # Hermes' local "waiting for model response" interrupt status is metadata,
+            # not assistant prose — clients get cancellation from stop_reason instead.
+            from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 
-        suppress_interrupt_response = interrupted and final_response.startswith(
-            INTERRUPT_WAITING_FOR_MODEL_PREFIX
-        )
-        if final_response and not suppress_interrupt_response:
-            try:
-                from agent.title_generator import maybe_auto_title
+            suppress_interrupt_response = interrupted and final_response.startswith(
+                INTERRUPT_WAITING_FOR_MODEL_PREFIX
+            )
+            if final_response and not suppress_interrupt_response:
+                try:
+                    from agent.title_generator import maybe_auto_title
 
-                def _notify_title_update(_title: str) -> None:
-                    if conn:
-                        loop.call_soon_threadsafe(
-                            asyncio.create_task,
-                            self._send_session_info_update(session_id),
-                        )
+                    def _notify_title_update(_title: str) -> None:
+                        if conn:
+                            loop.call_soon_threadsafe(
+                                asyncio.create_task,
+                                self._send_session_info_update(session_id),
+                            )
 
-                maybe_auto_title(
-                    self.session_manager._get_db(),
-                    session_id,
-                    user_text,
-                    final_response,
-                    state.history,
-                    title_callback=_notify_title_update,
-                )
-            except Exception:
-                logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
-        if (
-            final_response
-            and conn
-            and not suppress_interrupt_response
-            and (not streamed_message or result.get("response_transformed"))
-        ):
-            # Deliver the final response when streaming did not already send it,
-            # or when a plugin hook transformed the response after streaming
-            # finished (e.g. transform_llm_output) — otherwise the appended /
-            # rewritten text never reaches the client.
-            update = acp.update_agent_message_text(final_response)
-            await conn.session_update(session_id, update)
+                    maybe_auto_title(
+                        self.session_manager._get_db(),
+                        session_id,
+                        user_text,
+                        final_response,
+                        state.history,
+                        title_callback=_notify_title_update,
+                    )
+                except Exception:
+                    logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
+            if (
+                final_response
+                and conn
+                and not suppress_interrupt_response
+                and (not streamed_message or result.get("response_transformed"))
+            ):
+                # Deliver the final response when streaming did not already send it,
+                # or when a plugin hook transformed the response after streaming
+                # finished (e.g. transform_llm_output) — otherwise the appended /
+                # rewritten text never reaches the client.
+                update = acp.update_agent_message_text(final_response)
+                await conn.session_update(session_id, update)
 
-        # Mark this turn idle before draining queued work so recursive prompt()
-        # calls can acquire the session. Queued turns are intentionally run as
-        # normal follow-up user prompts, preserving role alternation and history.
-        with state.runtime_lock:
-            state.is_running = False
-            state.current_prompt_text = ""
+        finally:
+            # Mark this turn idle before draining queued work so recursive
+            # prompt() calls can acquire the session — and so an exception in
+            # the tail above can never leave the session stuck busy. Queued
+            # turns are intentionally run as normal follow-up user prompts,
+            # preserving role alternation and history.
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
 
         while True:
             with state.runtime_lock:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2129,64 +2129,65 @@ class HermesACPAgent(acp.Agent):
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
-        if result.get("messages"):
-            state.history = result["messages"]
-            # Persist updated history so sessions survive process restarts.
-            self.session_manager.save_session(session_id)
+        try:
+            if result.get("messages"):
+                state.history = result["messages"]
+                # Persist updated history so sessions survive process restarts.
+                self.session_manager.save_session(session_id)
 
-        # Detect a compression-driven internal session rotation. If the agent's
-        # DB head moved during the turn, emit a session_info_update carrying
-        # _meta.hermes.sessionProvenance so ACP clients can render the boundary
-        # and keep old/new ids in lineage. The ACP session_id is unchanged.
-        post_turn_hermes_id = getattr(state.agent, "session_id", None)
-        if (
-            conn
-            and post_turn_hermes_id
-            and pre_turn_hermes_id
-            and post_turn_hermes_id != pre_turn_hermes_id
-        ):
-            try:
-                await self._send_session_info_update(
-                    session_id,
-                    current_hermes_session_id=post_turn_hermes_id,
-                    previous_hermes_session_id=pre_turn_hermes_id,
-                )
-            except Exception:
-                logger.debug(
-                    "Could not emit ACP provenance update after rotation for %s",
-                    session_id,
-                    exc_info=True,
-                )
+            # Detect a compression-driven internal session rotation. If the agent's
+            # DB head moved during the turn, emit a session_info_update carrying
+            # _meta.hermes.sessionProvenance so ACP clients can render the boundary
+            # and keep old/new ids in lineage. The ACP session_id is unchanged.
+            post_turn_hermes_id = getattr(state.agent, "session_id", None)
+            if (
+                conn
+                and post_turn_hermes_id
+                and pre_turn_hermes_id
+                and post_turn_hermes_id != pre_turn_hermes_id
+            ):
+                try:
+                    await self._send_session_info_update(
+                        session_id,
+                        current_hermes_session_id=post_turn_hermes_id,
+                        previous_hermes_session_id=pre_turn_hermes_id,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not emit ACP provenance update after rotation for %s",
+                        session_id,
+                        exc_info=True,
+                    )
 
-        final_response = result.get("final_response", "")
-        cancelled = bool(state.cancel_event and state.cancel_event.is_set())
-        interrupted = bool(result.get("interrupted")) or cancelled
-        # Hermes' local "waiting for model response" interrupt status is metadata,
-        # not assistant prose — clients get cancellation from stop_reason instead.
-        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+            final_response = result.get("final_response") or ""
+            cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+            interrupted = bool(result.get("interrupted")) or cancelled
+            # Hermes' local "waiting for model response" interrupt status is metadata,
+            # not assistant prose — clients get cancellation from stop_reason instead.
+            from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 
-        suppress_interrupt_response = interrupted and final_response.startswith(
-            INTERRUPT_WAITING_FOR_MODEL_PREFIX
-        )
-        if (
-            final_response
-            and conn
-            and not suppress_interrupt_response
-            and (not streamed_message or result.get("response_transformed"))
-        ):
-            # Deliver the final response when streaming did not already send it,
-            # or when a plugin hook transformed the response after streaming
-            # finished (e.g. transform_llm_output) — otherwise the appended /
-            # rewritten text never reaches the client.
-            update = acp.update_agent_message_text(final_response)
-            await conn.session_update(session_id, update)
-
-        # Mark this turn idle before draining queued work so recursive prompt()
-        # calls can acquire the session. Queued turns are intentionally run as
-        # normal follow-up user prompts, preserving role alternation and history.
-        with state.runtime_lock:
-            state.is_running = False
-            state.current_prompt_text = ""
+            suppress_interrupt_response = interrupted and final_response.startswith(
+                INTERRUPT_WAITING_FOR_MODEL_PREFIX
+            )
+            if (
+                final_response
+                and conn
+                and not suppress_interrupt_response
+                and (not streamed_message or result.get("response_transformed"))
+            ):
+                # Deliver the final response when streaming did not already send it,
+                # or when a plugin hook transformed the response after streaming
+                # finished (e.g. transform_llm_output) — otherwise the appended /
+                # rewritten text never reaches the client.
+                update = acp.update_agent_message_text(final_response)
+                await conn.session_update(session_id, update)
+        finally:
+            # Mark this turn idle before draining queued work so recursive prompt()
+            # calls can acquire the session. Queued turns are intentionally run as
+            # normal follow-up user prompts, preserving role alternation and history.
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
 
         while True:
             with state.runtime_lock:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1177,6 +1177,83 @@ class TestPrompt:
         assert final_text in agent_texts
 
     @pytest.mark.asyncio
+    async def test_prompt_cancelled_turn_with_none_response_does_not_brick_session(self, agent):
+        """A /stop mid tool call yields ``final_response=None`` (key present).
+
+        Regression: ``result.get("final_response", "")`` kept the ``None``,
+        ``None.startswith(...)`` raised, the exception escaped ``prompt()``
+        before ``state.is_running`` was reset, and every subsequent message
+        was queued forever ("Queued for the next turn. (N queued)")."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": None,
+                "messages": [],
+                "interrupted": True,
+                "completed": False,
+            }
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="do something slow")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert resp.stop_reason == "cancelled"
+        # The session must be released — not stuck busy queueing forever.
+        assert state.is_running is False
+        assert state.queued_prompts == []
+
+        # A follow-up prompt must run as a normal turn, not get queued.
+        state.cancel_event.clear()
+        follow_up_ran = []
+
+        def mock_run_ok(*args, **kwargs):
+            follow_up_ran.append(True)
+            return {"final_response": "done", "messages": [], "completed": True}
+
+        state.agent.run_conversation = mock_run_ok
+        resp2 = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="follow up")],
+            session_id=new_resp.session_id,
+        )
+        assert resp2.stop_reason == "end_turn"
+        assert follow_up_ran, "follow-up prompt was queued instead of running"
+
+    @pytest.mark.asyncio
+    async def test_prompt_tail_exception_still_releases_session(self, agent):
+        """Any exception in the post-turn tail must not leave is_running set."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def mock_run(*args, **kwargs):
+            return {"final_response": "ok", "messages": [{"role": "user", "content": "x"}], "completed": True}
+
+        state.agent.run_conversation = mock_run
+
+        # Force a failure inside the guarded tail (history persistence).
+        agent.session_manager.save_session = MagicMock(side_effect=RuntimeError("disk full"))
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with pytest.raises(RuntimeError):
+            await agent.prompt(
+                prompt=[TextContentBlock(type="text", text="hi")],
+                session_id=new_resp.session_id,
+            )
+
+        assert state.is_running is False
+        assert state.current_prompt_text == ""
+
+    @pytest.mark.asyncio
     async def test_prompt_propagates_hermes_session_id_env(self, agent, monkeypatch):
         """ACP must propagate the originating session id to the agent loop
         via ``HERMES_SESSION_ID`` so tools that want to stamp side-effects

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,6 +446,77 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_prompt_cancelled_turn_with_none_response_does_not_brick_session(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": None,
+                "messages": [],
+                "interrupted": True,
+                "completed": False,
+            }
+
+        state.agent.run_conversation = mock_run
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="do something slow")],
+            session_id=new_resp.session_id,
+        )
+
+        assert resp.stop_reason == "cancelled"
+        assert state.is_running is False
+        assert state.queued_prompts == []
+
+        state.cancel_event.clear()
+        follow_up_ran = []
+
+        def mock_run_ok(*args, **kwargs):
+            follow_up_ran.append(True)
+            return {"final_response": "done", "messages": [], "completed": True}
+
+        state.agent.run_conversation = mock_run_ok
+        resp2 = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="follow up")],
+            session_id=new_resp.session_id,
+        )
+
+        assert resp2.stop_reason == "end_turn"
+        assert follow_up_ran, "follow-up prompt was queued instead of running"
+
+    @pytest.mark.asyncio
+    async def test_prompt_tail_exception_still_releases_session(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def mock_run(*args, **kwargs):
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "user", "content": "x"}],
+                "completed": True,
+            }
+
+        state.agent.run_conversation = mock_run
+        agent.session_manager.save_session = MagicMock(side_effect=RuntimeError("disk full"))
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with pytest.raises(RuntimeError, match="disk full"):
+            await agent.prompt(
+                prompt=[TextContentBlock(type="text", text="hi")],
+                session_id=new_resp.session_id,
+            )
+
+        assert state.is_running is False
+        assert state.current_prompt_text == ""
+
 
 
 


### PR DESCRIPTION
## Problem

Cancelling an ACP turn (`session/cancel`, e.g. hitting Stop in Zed / a VS Code ACP client) while a tool call is in flight can permanently brick the session: every subsequent user prompt is answered only with `Queued for the next turn. (N queued)` and never runs. The only recovery is restarting the `hermes acp` process.

## Root cause

When a cancel lands mid tool call, `run_conversation` returns `{"final_response": None, "interrupted": True, ...}` — the key is **present with value `None`**, so in `acp_adapter/server.py::prompt`:

```python
final_response = result.get("final_response", "")   # keeps None — default doesn't apply
...
suppress_interrupt_response = interrupted and final_response.startswith(  # AttributeError
    INTERRUPT_WAITING_FOR_MODEL_PREFIX
)
```

The `AttributeError` escapes `prompt()` **before** the `state.is_running = False` reset at the end of the post-turn tail. The session is then stuck marked running forever:

- the client sees `prompt failed ...: Internal error` (`acp.exceptions.RequestError` via `acp/task/supervisor.py`);
- every later prompt hits the `if state.is_running:` guard and is appended to `state.queued_prompts` → `Queued for the next turn. (N queued)`;
- nothing ever drains the queue, because draining only happens at the end of a successful `prompt()` call that can never start.

Observed live (agent log excerpt):

```
acp_adapter.server: Cancelled session 145febe7-...
agent.tool_executor: Tool terminal returned error (89.92s): {"output": "[Command interrupted]", "exit_code": 130}
agent.conversation_loop: Turn ended: reason=interrupted_by_user ... response_len=0
prompt failed for 145febe7-...: Internal error
acp.exceptions.RequestError: Internal error
```

Trigger condition: the cancel must land while the turn has produced no partial response text yet (e.g. during a long-running `terminal` tool call), so `final_response` comes back `None` rather than `""` or partial text.

## Fix (two layers)

1. **Coerce the trigger:** `final_response = result.get("final_response") or ""` — `None` can no longer reach `.startswith()`.
2. **Fix the class, not just the instance:** wrap the whole post-turn tail (history persist, provenance update, auto-title, final-response delivery) in `try/finally` so the `state.is_running` / `state.current_prompt_text` reset is guaranteed. Any future exception in that tail can no longer leave the session stuck busy — it propagates to the client as a failed request, but the next prompt runs normally.

The diff is larger than the logic change because the tail block is re-indented under the `try:`; `git diff -w` shows the real delta.

## Tests

Two regression tests in `tests/acp/test_server.py`:

- `test_prompt_cancelled_turn_with_none_response_does_not_brick_session` — cancelled turn returning `final_response=None` completes with `stop_reason="cancelled"`, leaves `is_running=False` and an empty queue, and a follow-up prompt runs as a normal turn instead of being queued.
- `test_prompt_tail_exception_still_releases_session` — a forced exception inside the guarded tail (`save_session` raising) still resets `is_running`/`current_prompt_text`.

```
python -m pytest tests/acp/ -q
308 passed
```
