### PR TITLE
feat: add privacy-preserving runtime telemetry

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -116,6 +116,75 @@ def estimate_request_context_tokens(api_payload: Any) -> int:
     return _chars(api_payload) // 4
 
 
+def _usage_token_value(usage: Any, *names: str) -> int | None:
+    for name in names:
+        try:
+            value = getattr(usage, name)
+        except Exception:
+            value = None
+        if value is None and isinstance(usage, dict):
+            value = usage.get(name)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _response_usage(response: Any) -> dict[str, int | None]:
+    usage = getattr(response, "usage", None)
+    if usage is None and isinstance(response, dict):
+        usage = response.get("usage")
+    return {
+        "context_units": _usage_token_value(usage, "prompt_tokens", "input_tokens"),
+        "output_units": _usage_token_value(usage, "completion_tokens", "output_tokens"),
+        "total_units": _usage_token_value(usage, "total_tokens"),
+    }
+
+
+def _emit_model_call_event(
+    agent,
+    api_kwargs: dict,
+    *,
+    response: Any = None,
+    error: Any = None,
+    duration_ms: int = 0,
+    streaming: bool = False,
+    partial_response: bool = False,
+) -> None:
+    """Emit best-effort privacy-preserving telemetry for provider calls."""
+    try:
+        from hermes_telemetry import error_fingerprint, safe_emit_event, stable_hash
+
+        usage = _response_usage(response)
+        payload = {
+            "provider_hash": stable_hash(getattr(agent, "provider", None)),
+            "model_hash": stable_hash(api_kwargs.get("model") or getattr(agent, "model", None)),
+            "api_mode": str(getattr(agent, "api_mode", "unknown") or "unknown"),
+            "streaming": bool(streaming),
+            "partial_response": bool(partial_response),
+            "duration_ms": max(0, int(duration_ms)),
+            "estimated_context_tokens": estimate_request_context_tokens(api_kwargs),
+            "message_count": len(api_kwargs.get("messages") or []) if isinstance(api_kwargs.get("messages"), list) else None,
+            "input_count": len(api_kwargs.get("input") or []) if isinstance(api_kwargs.get("input"), list) else None,
+            "tool_count": len(api_kwargs.get("tools") or []) if isinstance(api_kwargs.get("tools"), list) else None,
+            "response_id_hash": stable_hash(getattr(response, "id", None) or (response.get("id") if isinstance(response, dict) else None)),
+            "error_type": type(error).__name__ if error is not None else None,
+            "error_fingerprint": error_fingerprint(error),
+            **usage,
+        }
+        safe_emit_event(
+            "model_call",
+            payload,
+            status="error" if error is not None else "ok",
+            source="agent.chat_completion_helpers",
+        )
+    except Exception as exc:  # pragma: no cover - telemetry must never break model calls
+        logger.debug("Failed to emit model telemetry: %s", exc)
+
+
 def _is_openai_codex_backend(agent) -> bool:
     base_url_lower = str(getattr(agent, "_base_url_lower", "") or "")
     base_url_hostname = str(getattr(agent, "_base_url_hostname", "") or "")
@@ -568,6 +637,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         agent._codex_stream_last_progress_ts = None
 
     _call_start = time.time()
+    _model_call_start = time.monotonic()
     agent._touch_activity("waiting for non-streaming API response")
 
     t = threading.Thread(target=_call, daemon=True)
@@ -765,11 +835,25 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 pass
             raise InterruptedError("Agent interrupted during API call")
     if result["error"] is not None:
+        _emit_model_call_event(
+            agent,
+            api_kwargs,
+            error=result["error"],
+            duration_ms=int((time.monotonic() - _model_call_start) * 1000),
+            streaming=False,
+        )
         raise result["error"]
     # Success — clear the circuit breaker (#58962): the provider proved
     # responsive.  See the canonical comment block above ``_stale_streak()``.
     if result["response"] is not None:
         _reset_stale_streak(agent)
+    _emit_model_call_event(
+        agent,
+        api_kwargs,
+        response=result["response"],
+        duration_ms=int((time.monotonic() - _model_call_start) * 1000),
+        streaming=False,
+    )
     return result["response"]
 
 
@@ -1974,6 +2058,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if should_use_direct_api_call(agent):
         return agent._interruptible_api_call(api_kwargs)
 
+    _model_call_start = time.monotonic()
+
     if agent.api_mode == "codex_responses":
         # Codex streams internally via _run_codex_stream. The main dispatch
         # in _interruptible_api_call already calls it; we just need to
@@ -2085,7 +2171,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted during Bedrock API call (post-worker)")
         if result["error"] is not None:
+            _emit_model_call_event(
+                agent,
+                api_kwargs,
+                error=result["error"],
+                duration_ms=int((time.monotonic() - _model_call_start) * 1000),
+                streaming=True,
+            )
             raise result["error"]
+        _emit_model_call_event(
+            agent,
+            api_kwargs,
+            response=result["response"],
+            duration_ms=int((time.monotonic() - _model_call_start) * 1000),
+            streaming=True,
+        )
         return result["response"]
 
     result = {"response": None, "error": None, "partial_tool_names": []}
@@ -3208,12 +3308,35 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # the provider is demonstrably responsive — clear the circuit
             # breaker (#58962) just like the full-success return below.
             _reset_stale_streak(agent)
+            _emit_model_call_event(
+                agent,
+                api_kwargs,
+                response=_stub,
+                error=result["error"],
+                duration_ms=int((time.monotonic() - _model_call_start) * 1000),
+                streaming=True,
+                partial_response=True,
+            )
             return _stub
+        _emit_model_call_event(
+            agent,
+            api_kwargs,
+            error=result["error"],
+            duration_ms=int((time.monotonic() - _model_call_start) * 1000),
+            streaming=True,
+        )
         raise result["error"]
     # Success — clear the circuit breaker (#58962): the provider proved
     # responsive.  See the canonical comment block above ``_stale_streak()``.
     if result["response"] is not None:
         _reset_stale_streak(agent)
+    _emit_model_call_event(
+        agent,
+        api_kwargs,
+        response=result["response"],
+        duration_ms=int((time.monotonic() - _model_call_start) * 1000),
+        streaming=True,
+    )
     return result["response"]
 
 # ── Provider fallback ──────────────────────────────────────────────────

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+from contextlib import contextmanager
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -557,6 +558,127 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+def _cron_job_mode(job: dict) -> str:
+    """Return the coarse cron execution mode for telemetry."""
+    if job.get("no_agent"):
+        return "no_agent"
+    if job.get("script"):
+        return "agent_with_script_gate"
+    return "agent"
+
+
+def _emit_cron_run_event(
+    job: dict,
+    *,
+    success: bool,
+    final_response: str = "",
+    error: str | None = None,
+    duration_ms: int = 0,
+) -> None:
+    """Best-effort privacy-preserving cron completion telemetry."""
+    try:
+        from hermes_telemetry import error_fingerprint, safe_emit_event, stable_hash
+
+        final_text = final_response or ""
+        if final_text.startswith(SILENT_MARKER):
+            delivery_state = "silent"
+        elif final_text.strip():
+            delivery_state = "non_empty"
+        else:
+            delivery_state = "empty"
+
+        payload = {
+            "job_id_hash": stable_hash(job.get("id")),
+            "schedule_hash": stable_hash(job.get("schedule") or job.get("schedule_display")),
+            "mode": _cron_job_mode(job),
+            "has_script": bool(job.get("script")),
+            "has_workdir": bool(job.get("workdir")),
+            "profile_hash": stable_hash(job.get("profile")),
+            "enabled_toolsets_count": len(job.get("enabled_toolsets") or []),
+            "skills_count": len(job.get("skills") or []),
+            "context_from_count": len(job.get("context_from") or []),
+            "delivery_state": delivery_state,
+            "final_response_chars": len(final_text),
+            "duration_ms": max(0, int(duration_ms)),
+            "error_fingerprint": error_fingerprint(error),
+            "error_type": (str(error).split(":", 1)[0] if error else None),
+        }
+        safe_emit_event(
+            "cron_run",
+            payload,
+            status="ok" if success else "error",
+            source="cron.scheduler",
+            hermes_home=_get_hermes_home(),
+        )
+    except Exception as exc:  # pragma: no cover - telemetry must never break cron
+        logger.debug("Job '%s': failed to emit cron telemetry: %s", job.get("id", "?"), exc)
+
+
+@contextmanager
+def _job_profile_context(job_id: str, profile: Optional[str]):
+    """Temporarily run a job under a specific Hermes profile.
+
+    Cron jobs are stored and scheduled by the profile running the scheduler, but
+    an individual job can opt into a different runtime profile. While active,
+    the scheduler's test/override hook and a context-local Hermes home override
+    both point at the resolved profile directory so _get_hermes_home(),
+    .env/config loading, script resolution, AIAgent construction, and downstream
+    get_hermes_home() callers agree on the same home.
+
+    Some existing provider/config paths still load profile .env values through
+    os.environ, so profile jobs also snapshot and restore the process
+    environment on exit. tick() runs profile jobs sequentially to keep that
+    temporary mutation isolated from other scheduled jobs.
+    """
+    raw_profile = str(profile or "").strip()
+    if not raw_profile:
+        yield None
+        return
+
+    global _hermes_home
+    prior_override = _hermes_home
+    env_snapshot = os.environ.copy()
+
+    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    normalized_profile = normalize_profile_name(raw_profile)
+    try:
+        profile_home = Path(resolve_profile_env(normalized_profile)).resolve()
+    except (FileNotFoundError, ValueError) as exc:
+        logger.warning(
+            "Job '%s': configured profile %r no longer valid (%s) — "
+            "falling back to scheduler default",
+            job_id, raw_profile, exc,
+        )
+        yield None
+        return
+
+    override_token = None
+    try:
+        override_token = set_hermes_home_override(profile_home)
+        _hermes_home = profile_home
+        logger.info(
+            "Job '%s': using Hermes profile '%s' (%s)",
+            job_id,
+            normalized_profile,
+            profile_home,
+        )
+        yield normalized_profile
+    finally:
+        _hermes_home = prior_override
+        if override_token is not None:
+            reset_hermes_home_override(override_token)
+        # Delta-based restore: remove added keys, restore changed keys.
+        # Avoids a brief window where other threads see an empty env.
+        added = set(os.environ.keys()) - set(env_snapshot.keys())
+        for k in added:
+            os.environ.pop(k, None)
+        for k, v in env_snapshot.items():
+            if os.environ.get(k) != v:
+                os.environ[k] = v
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -2547,8 +2669,41 @@ def _guard_job_credential_exfil(job: dict) -> None:
         )
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
-
 def run_job(
+    job: dict, *, defer_agent_teardown: Optional[list] = None
+) -> tuple[bool, str, str, Optional[str]]:
+    """Execute a single cron job, applying profile context and telemetry."""
+    job_id = job["id"]
+    started = time.perf_counter()
+    with _job_profile_context(job_id, job.get("profile")):
+        try:
+            success, output, final_response, error = _run_job_impl(
+                job, defer_agent_teardown=defer_agent_teardown
+            )
+        except Exception as exc:
+            duration_ms = int((time.perf_counter() - started) * 1000)
+            _emit_cron_run_event(
+                job,
+                success=False,
+                final_response="",
+                error=f"{type(exc).__name__}: {exc}",
+                duration_ms=duration_ms,
+            )
+            raise
+
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        _emit_cron_run_event(
+            job,
+            success=success,
+            final_response=final_response,
+            error=error,
+            duration_ms=duration_ms,
+        )
+        return success, output, final_response, error
+
+
+
+def _run_job_impl(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
     """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,7 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
+from hermes_telemetry import error_fingerprint, safe_emit_event, stable_hash
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -140,6 +141,115 @@ _GATEWAY_AUTH_ERROR_RE = re.compile(
     r"(provider\s+authentication\s+failed|incorrect\s+api\s+key|invalid\s+api\s+key|\b401\b)",
     re.IGNORECASE,
 )
+
+
+def _result_response_chars(result: Any) -> int:
+    """Return final-response length without exposing response content."""
+    if isinstance(result, dict):
+        return len(str(result.get("final_response") or ""))
+    if isinstance(result, str):
+        return len(result)
+    return 0
+
+
+def _gateway_action_status(result: Any, error: BaseException | None = None) -> str:
+    """Classify a gateway action outcome for privacy-preserving telemetry."""
+    if error is not None:
+        return "error"
+    if isinstance(result, dict):
+        if result.get("interrupted"):
+            return "interrupted"
+        if result.get("failed") or result.get("error"):
+            return "error"
+        if result.get("partial"):
+            return "partial"
+    return "ok"
+
+
+def _build_gateway_action_telemetry_payload(
+    *,
+    source: Any,
+    event: Any,
+    session_key: str | None,
+    result: Any = None,
+    duration_ms: int = 0,
+    error: BaseException | None = None,
+) -> dict[str, Any]:
+    """Build a privacy-safe gateway action payload.
+
+    Raw message text, response text, user names, chat names, and platform IDs are
+    intentionally excluded.  IDs are represented only by stable hashes so local
+    summaries can group events without storing PII.
+    """
+    platform = getattr(source, "platform", None)
+    platform_name = getattr(platform, "value", platform) or "unknown"
+    message_type = getattr(event, "message_type", None)
+    message_type_name = getattr(message_type, "value", message_type) or "unknown"
+    command_name = None
+    try:
+        command_name = event.get_command()
+    except Exception:
+        command_name = None
+
+    payload: dict[str, Any] = {
+        "platform": str(platform_name),
+        "chat_type": str(getattr(source, "chat_type", "unknown") or "unknown"),
+        "message_type": str(message_type_name),
+        "is_internal": bool(getattr(event, "internal", False)),
+        "is_command": bool(command_name),
+        "command_hash": stable_hash(command_name),
+        "has_media": bool(getattr(event, "media_urls", None)),
+        "media_count": len(getattr(event, "media_urls", None) or []),
+        "session_key_hash": stable_hash(session_key),
+        "user_id_hash": stable_hash(getattr(source, "user_id", None)),
+        "chat_id_hash": stable_hash(getattr(source, "chat_id", None)),
+        "thread_id_hash": stable_hash(getattr(source, "thread_id", None)),
+        "response_chars": _result_response_chars(result),
+        "duration_ms": int(duration_ms),
+    }
+    if isinstance(result, dict):
+        payload.update(
+            {
+                "api_calls": int(result.get("api_calls") or 0),
+                "tools_count": len(result.get("tools") or []),
+                "model_hash": stable_hash(result.get("model")),
+                "input_tokens": int(result.get("input_tokens") or 0),
+                "output_tokens": int(result.get("output_tokens") or 0),
+            }
+        )
+        if result.get("error"):
+            payload["error_fingerprint"] = error_fingerprint(result.get("error"))
+    if error is not None:
+        payload["error_type"] = type(error).__name__
+        payload["error_fingerprint"] = error_fingerprint(error)
+    return payload
+
+
+def _emit_gateway_action_telemetry(
+    *,
+    source: Any,
+    event: Any,
+    session_key: str | None,
+    result: Any = None,
+    started_at: float,
+    error: BaseException | None = None,
+) -> None:
+    """Best-effort gateway telemetry; never break message handling."""
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    status = _gateway_action_status(result, error)
+    safe_emit_event(
+        "gateway_action",
+        _build_gateway_action_telemetry_payload(
+            source=source,
+            event=event,
+            session_key=session_key,
+            result=result,
+            duration_ms=duration_ms,
+            error=error,
+        ),
+        status=status,
+        source="gateway",
+    )
 
 _GATEWAY_RATE_LIMIT_RE = re.compile(
     r"(rate\s+limit|rate-limited|\b429\b|quota|usage\s+limit)",
@@ -10376,8 +10486,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
+        _gateway_action_started_at = time.perf_counter()
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            _emit_gateway_action_telemetry(
+                source=source,
+                event=event,
+                session_key=_quick_key,
+                result=_agent_result,
+                started_at=_gateway_action_started_at,
+            )
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -10407,6 +10525,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _goal_exc:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
+        except Exception as _gateway_action_exc:
+            _emit_gateway_action_telemetry(
+                source=source,
+                event=event,
+                session_key=_quick_key,
+                started_at=_gateway_action_started_at,
+                error=_gateway_action_exc,
+            )
+            raise
         finally:
             # MoA one-shot restore must run on EVERY exit path, not just
             # success. The restore data lives on the per-turn event object

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -178,6 +178,9 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
+        # `--all` means show all status sections, not raw secret values. Keep
+        # API credentials redacted in every status mode so diagnostics can be
+        # safely copied into chats, tickets, and logs.
         display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 

--- a/hermes_telemetry.py
+++ b/hermes_telemetry.py
@@ -1,0 +1,157 @@
+"""Minimal local telemetry/event sink for Hermes Agent.
+
+This module intentionally starts small: privacy-preserving JSONL events under
+``$HERMES_HOME/ops/events/YYYY-MM-DD.jsonl``.  It is designed so future OTLP
+exporters can tail or translate the same schema without requiring a collector
+for local installs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+_MAX_STRING_LEN = 240
+_SENSITIVE_KEY_FRAGMENTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "completion",
+    "content",
+    "cookie",
+    "password",
+    "prompt",
+    "secret",
+    "token",
+)
+
+
+def stable_hash(value: Any) -> str | None:
+    """Return a stable short SHA-256 hash for IDs without storing raw values."""
+    if value is None:
+        return None
+    text = str(value)
+    if not text:
+        return None
+    digest = hashlib.sha256(f"hermes-telemetry-v1:{text}".encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def error_fingerprint(error: Any) -> str | None:
+    """Hash an error string/object so telemetry can group failures safely."""
+    if error is None:
+        return None
+    return stable_hash(f"{type(error).__name__}:{str(error)}")
+
+
+def events_dir(hermes_home: str | Path | None = None) -> Path:
+    """Resolve the JSONL event directory for the active Hermes profile."""
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    return home / "ops" / "events"
+
+
+def event_path(ts: datetime | None = None, hermes_home: str | Path | None = None) -> Path:
+    """Return the daily JSONL path for ``ts`` in the active Hermes profile."""
+    when = ts or datetime.now(UTC)
+    return events_dir(hermes_home) / f"{when.date().isoformat()}.jsonl"
+
+
+def _safe_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return value if len(value) <= _MAX_STRING_LEN else value[:_MAX_STRING_LEN] + "…"
+    if isinstance(value, dict):
+        safe: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            key_lc = key_text.lower()
+            if any(fragment in key_lc for fragment in _SENSITIVE_KEY_FRAGMENTS):
+                safe[key_text] = "[REDACTED]"
+            else:
+                safe[key_text] = _safe_value(item)
+        return safe
+    if isinstance(value, (list, tuple, set)):
+        return [_safe_value(item) for item in list(value)[:50]]
+    return str(value)[:_MAX_STRING_LEN]
+
+
+def build_event(
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    status: str = "ok",
+    source: str = "hermes",
+    ts: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a privacy-preserving telemetry event dictionary."""
+    when = ts or datetime.now(UTC)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": str(uuid4()),
+        "timestamp": when.isoformat().replace("+00:00", "Z"),
+        "event_type": str(event_type),
+        "source": str(source),
+        "status": str(status),
+        "payload": _safe_value(payload or {}),
+    }
+
+
+def emit_event(
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    status: str = "ok",
+    source: str = "hermes",
+    ts: datetime | None = None,
+    hermes_home: str | Path | None = None,
+) -> Path:
+    """Append one JSONL event and return the file path.
+
+    This function may raise filesystem/serialization errors. Runtime callers
+    that must never fail because of telemetry should use ``safe_emit_event``.
+    """
+    event = build_event(event_type, payload, status=status, source=source, ts=ts)
+    path = event_path(ts, hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n")
+    return path
+
+
+def safe_emit_event(
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    status: str = "ok",
+    source: str = "hermes",
+    ts: datetime | None = None,
+    hermes_home: str | Path | None = None,
+) -> Path | None:
+    """Best-effort event emission for hot paths.
+
+    Telemetry must never break cron, gateway, tools, or model calls.  Failures
+    are logged at debug level and otherwise ignored.
+    """
+    try:
+        return emit_event(
+            event_type,
+            payload,
+            status=status,
+            source=source,
+            ts=ts,
+            hermes_home=hermes_home,
+        )
+    except Exception as exc:  # pragma: no cover - defensive by design
+        logger.debug("Failed to emit Hermes telemetry event %s: %s", event_type, exc)
+        return None

--- a/model_tools.py
+++ b/model_tools.py
@@ -971,6 +971,54 @@ def _tool_result_observer_fields(result: Any) -> tuple[str, Optional[str], Optio
     return "ok", None, None
 
 
+def _emit_tool_call_event(
+    *,
+    function_name: str,
+    function_args: Dict[str, Any],
+    result: Any = None,
+    duration_ms: int = 0,
+    status: Optional[str] = None,
+    error_type: Optional[str] = None,
+    error_message: Optional[str] = None,
+    task_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
+    api_request_id: Optional[str] = None,
+    middleware_trace: Optional[List[Dict[str, Any]]] = None,
+) -> None:
+    """Emit best-effort privacy-preserving telemetry for tool execution."""
+    try:
+        from hermes_telemetry import error_fingerprint, safe_emit_event, stable_hash
+
+        if status is None:
+            status, error_type, error_message = _tool_result_observer_fields(result)
+        result_text = "" if result is None else str(result)
+        payload = {
+            "tool_name_hash": stable_hash(function_name),
+            "toolset": registry.get_toolset_for_tool(function_name) or "unknown",
+            "duration_ms": max(0, int(duration_ms)),
+            "arg_count": len(function_args or {}),
+            "result_chars": len(result_text),
+            "has_task_id": bool(task_id),
+            "session_id_hash": stable_hash(session_id),
+            "tool_call_id_hash": stable_hash(tool_call_id),
+            "turn_id_hash": stable_hash(turn_id),
+            "api_request_id_hash": stable_hash(api_request_id),
+            "middleware_trace_count": len(middleware_trace or []),
+            "error_type": error_type,
+            "error_fingerprint": error_fingerprint(error_message),
+        }
+        safe_emit_event(
+            "tool_call",
+            payload,
+            status="ok" if status == "ok" else "error",
+            source="model_tools.handle_function_call",
+        )
+    except Exception as exc:  # pragma: no cover - telemetry must never break tools
+        logger.debug("Failed to emit tool telemetry for %s: %s", function_name, exc)
+
+
 def _emit_post_tool_call_hook(
     *,
     function_name: str,
@@ -1197,6 +1245,20 @@ def handle_function_call(
 
             if block_message is not None:
                 result = json.dumps({"error": block_message}, ensure_ascii=False)
+                _emit_tool_call_event(
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=result,
+                    task_id=task_id,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    status="blocked",
+                    error_type="plugin_block",
+                    error_message=block_message,
+                    middleware_trace=list(_tool_middleware_trace),
+                )
                 _emit_post_tool_call_hook(
                     function_name=function_name,
                     function_args=function_args,
@@ -1221,11 +1283,40 @@ def handle_function_call(
 
             edit_block_message = maybe_require_edit_approval(function_name, function_args)
             if edit_block_message is not None:
+                _emit_tool_call_event(
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=edit_block_message,
+                    task_id=task_id,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    status="blocked",
+                    error_type="edit_approval_denied",
+                    error_message=edit_block_message,
+                    middleware_trace=list(_tool_middleware_trace),
+                )
                 return edit_block_message
         except Exception as _edit_approval_err:
             logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
             if function_name in {"write_file", "patch"}:
-                return json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
+                result = json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
+                _emit_tool_call_event(
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=result,
+                    task_id=task_id,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    status="error",
+                    error_type="edit_approval_guard_failed",
+                    error_message=str(_edit_approval_err),
+                    middleware_trace=list(_tool_middleware_trace),
+                )
+                return result
 
         # Notify the read-loop tracker when a non-read/search tool runs,
         # so the *consecutive* counter resets (reads after other work are fine).
@@ -1297,6 +1388,19 @@ def handle_function_call(
                     pass
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 
+        _emit_tool_call_event(
+            function_name=function_name,
+            function_args=function_args,
+            result=result,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+            duration_ms=duration_ms,
+            middleware_trace=list(_tool_middleware_trace),
+        )
+
         _emit_post_tool_call_hook(
             function_name=function_name,
             function_args=function_args,
@@ -1349,7 +1453,22 @@ def handle_function_call(
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.exception(error_msg)
-        return json.dumps({"error": _sanitize_tool_error(error_msg)}, ensure_ascii=False)
+        result = json.dumps({"error": _sanitize_tool_error(error_msg)}, ensure_ascii=False)
+        _emit_tool_call_event(
+            function_name=function_name,
+            function_args=function_args if isinstance(function_args, dict) else {},
+            result=result,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+            status="error",
+            error_type=type(e).__name__,
+            error_message=str(e),
+            middleware_trace=list(_tool_middleware_trace) if "_tool_middleware_trace" in locals() else [],
+        )
+        return result
 
 
 # =============================================================================

--- a/tests/cron/test_cron_telemetry.py
+++ b/tests/cron/test_cron_telemetry.py
@@ -1,0 +1,86 @@
+import json
+import os
+
+import cron.scheduler as scheduler
+
+
+def test_no_agent_cron_run_emits_completion_event(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    scripts_dir = hermes_home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    script = scripts_dir / "ok.sh"
+    script.write_text("printf 'hello from watchdog'\n", encoding="utf-8")
+    script.chmod(0o700)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(scheduler, "_hermes_home", hermes_home)
+    monkeypatch.setattr(scheduler, "_SCRIPT_TIMEOUT", 5)
+
+    job = {
+        "id": "raw-job-id-123",
+        "name": "Sensitive prompt-like job name",
+        "no_agent": True,
+        "script": "ok.sh",
+        "schedule": "every 1h",
+    }
+
+    success, _doc, final_response, error = scheduler.run_job(job)
+
+    assert success is True
+    assert final_response == "hello from watchdog"
+    assert error is None
+
+    event_files = list((hermes_home / "ops" / "events").glob("*.jsonl"))
+    assert len(event_files) == 1
+    lines = event_files[0].read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    event = json.loads(lines[0])
+
+    assert event["event_type"] == "cron_run"
+    assert event["source"] == "cron.scheduler"
+    assert event["status"] == "ok"
+    assert event["payload"]["mode"] == "no_agent"
+    assert event["payload"]["has_script"] is True
+    assert event["payload"]["delivery_state"] == "non_empty"
+    assert event["payload"]["final_response_chars"] == len(final_response)
+    assert event["payload"]["error_fingerprint"] is None
+    assert event["payload"]["job_id_hash"]
+
+    raw_line = lines[0]
+    assert "raw-job-id-123" not in raw_line
+    assert "Sensitive prompt-like job name" not in raw_line
+    assert "hello from watchdog" not in raw_line
+
+
+def test_no_agent_cron_failure_emits_error_event(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    scripts_dir = hermes_home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    script = scripts_dir / "fail.sh"
+    script.write_text("echo 'boom' >&2\nexit 7\n", encoding="utf-8")
+    script.chmod(0o700)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(scheduler, "_hermes_home", hermes_home)
+    monkeypatch.setattr(scheduler, "_SCRIPT_TIMEOUT", 5)
+
+    success, _doc, _final_response, error = scheduler.run_job(
+        {
+            "id": "failing-job-id",
+            "no_agent": True,
+            "script": "fail.sh",
+            "schedule": "every 1h",
+        }
+    )
+
+    assert success is False
+    assert error
+
+    event_file = next((hermes_home / "ops" / "events").glob("*.jsonl"))
+    event = json.loads(event_file.read_text(encoding="utf-8").strip())
+
+    assert event["event_type"] == "cron_run"
+    assert event["status"] == "error"
+    assert event["payload"]["mode"] == "no_agent"
+    assert event["payload"]["error_fingerprint"]
+    assert "boom" not in json.dumps(event, ensure_ascii=False)

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -15,6 +15,19 @@ def test_show_status_all_does_not_print_tavily_key_value(monkeypatch, capsys, tm
     assert sentinel not in output
 
 
+def test_show_status_all_never_prints_raw_api_keys(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw_key = "tvly-dev-1234567890abcdefghijklmnopqrstuvwxyz"
+    monkeypatch.setenv("TAVILY_API_KEY", raw_key)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Tavily" in output
+    assert raw_key not in output
+    assert "tvly" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod

--- a/tests/test_gateway_telemetry.py
+++ b/tests/test_gateway_telemetry.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import (
+    _build_gateway_action_telemetry_payload,
+    _gateway_action_status,
+    _result_response_chars,
+)
+from gateway.session import SessionSource
+from hermes_telemetry import safe_emit_event
+
+
+def test_gateway_action_payload_hashes_identifiers_and_omits_text():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-123",
+        chat_type="dm",
+        user_id="user-456",
+        user_name="Alice Example",
+        thread_id="thread-789",
+    )
+    event = MessageEvent(
+        text="/deploy production with secret details",
+        message_type=MessageType.TEXT,
+        source=source,
+        media_urls=["/tmp/private-image.png"],
+        media_types=["image/png"],
+    )
+    result = {
+        "final_response": "Deployment completed with sensitive prose",
+        "api_calls": 2,
+        "tools": ["terminal", "read_file"],
+        "model": "provider/private-model-name",
+        "input_tokens": 100,
+        "output_tokens": 20,
+    }
+
+    payload = _build_gateway_action_telemetry_payload(
+        source=source,
+        event=event,
+        session_key="telegram:chat-123:user-456",
+        result=result,
+        duration_ms=42,
+    )
+
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert payload["platform"] == "telegram"
+    assert payload["chat_type"] == "dm"
+    assert payload["message_type"] == "text"
+    assert payload["is_command"] is True
+    assert payload["media_count"] == 1
+    assert payload["response_chars"] == len(result["final_response"])
+    assert payload["api_calls"] == 2
+    assert payload["tools_count"] == 2
+    assert payload["duration_ms"] == 42
+
+    # No raw text, names, IDs, paths, command names, or model names in telemetry.
+    assert "deploy" not in serialized
+    assert "secret details" not in serialized
+    assert "Deployment completed" not in serialized
+    assert "Alice" not in serialized
+    assert "chat-123" not in serialized
+    assert "user-456" not in serialized
+    assert "thread-789" not in serialized
+    assert "private-image" not in serialized
+    assert "private-model-name" not in serialized
+
+    assert payload["chat_id_hash"]
+    assert payload["user_id_hash"]
+    assert payload["thread_id_hash"]
+    assert payload["session_key_hash"]
+    assert payload["command_hash"]
+    assert payload["model_hash"]
+
+
+def test_gateway_action_status_classification():
+    assert _gateway_action_status("plain response") == "ok"
+    assert _gateway_action_status({"final_response": "ok"}) == "ok"
+    assert _gateway_action_status({"interrupted": True}) == "interrupted"
+    assert _gateway_action_status({"partial": True}) == "partial"
+    assert _gateway_action_status({"failed": True}) == "error"
+    assert _gateway_action_status({"error": "raw provider failure"}) == "error"
+    assert _gateway_action_status(None, RuntimeError("boom")) == "error"
+
+
+def test_result_response_chars_never_returns_content():
+    assert _result_response_chars("hello") == 5
+    assert _result_response_chars({"final_response": "hello world"}) == 11
+    assert _result_response_chars(SimpleNamespace(final_response="ignored")) == 0
+
+
+def test_safe_emit_gateway_action_redacts_sensitive_payload_keys(tmp_path):
+    path = safe_emit_event(
+        "gateway_action",
+        {
+            "platform": "telegram",
+            "prompt_text": "do not store me",
+            "completion_text": "do not store me either",
+            "user_id_hash": "abc123",
+        },
+        source="gateway",
+        hermes_home=tmp_path,
+    )
+
+    assert path is not None
+    event = json.loads(path.read_text(encoding="utf-8").strip())
+    assert event["event_type"] == "gateway_action"
+    assert event["source"] == "gateway"
+    assert event["payload"]["prompt_text"] == "[REDACTED]"
+    assert event["payload"]["completion_text"] == "[REDACTED]"
+    assert event["payload"]["user_id_hash"] == "abc123"

--- a/tests/test_hermes_telemetry.py
+++ b/tests/test_hermes_telemetry.py
@@ -1,0 +1,46 @@
+import json
+from datetime import UTC, datetime
+
+from hermes_telemetry import emit_event, error_fingerprint, stable_hash
+
+
+def test_emit_event_writes_privacy_preserving_jsonl(tmp_path):
+    ts = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)
+
+    path = emit_event(
+        "cron_run",
+        {
+            "job_id_hash": stable_hash("raw-job-id"),
+            "prompt": "do not store this",
+            "api_key": "sk-secret",
+            "safe_count": 3,
+        },
+        status="ok",
+        source="test",
+        ts=ts,
+        hermes_home=tmp_path,
+    )
+
+    assert path == tmp_path / "ops" / "events" / "2026-07-08.jsonl"
+    line = path.read_text(encoding="utf-8").strip()
+    event = json.loads(line)
+
+    assert event["schema_version"] == 1
+    assert event["event_type"] == "cron_run"
+    assert event["source"] == "test"
+    assert event["status"] == "ok"
+    assert event["payload"]["safe_count"] == 3
+    assert event["payload"]["prompt"] == "[REDACTED]"
+    assert event["payload"]["api_key"] == "[REDACTED]"
+    assert "raw-job-id" not in line
+    assert "sk-secret" not in line
+    assert "do not store this" not in line
+
+
+def test_error_fingerprint_groups_without_storing_error_text():
+    fp1 = error_fingerprint("RuntimeError: provider key failed")
+    fp2 = error_fingerprint("RuntimeError: provider key failed")
+
+    assert fp1 == fp2
+    assert fp1
+    assert "provider" not in fp1

--- a/tests/test_model_call_telemetry.py
+++ b/tests/test_model_call_telemetry.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import _emit_model_call_event
+
+
+def _last_event(tmp_path: Path) -> dict:
+    event_files = sorted((tmp_path / "ops" / "events").glob("*.jsonl"))
+    assert event_files
+    lines = event_files[-1].read_text(encoding="utf-8").splitlines()
+    assert lines
+    return json.loads(lines[-1])
+
+
+def test_model_call_event_hashes_provider_model_and_keeps_usage_counts(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    agent = SimpleNamespace(provider="RAW_PROVIDER_DO_NOT_STORE", model="RAW_MODEL_DO_NOT_STORE", api_mode="chat_completions")
+    api_kwargs = {
+        "model": "RAW_MODEL_DO_NOT_STORE",
+        "messages": [{"role": "user", "content": "RAW_PROMPT_DO_NOT_STORE"}],
+        "tools": [{"name": "RAW_TOOL_SCHEMA_DO_NOT_STORE"}],
+    }
+    response = SimpleNamespace(
+        id="RAW_RESPONSE_ID_DO_NOT_STORE",
+        usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+    )
+
+    _emit_model_call_event(agent, api_kwargs, response=response, duration_ms=123, streaming=True)
+
+    event = _last_event(tmp_path)
+    assert event["event_type"] == "model_call"
+    assert event["source"] == "agent.chat_completion_helpers"
+    assert event["status"] == "ok"
+    payload = event["payload"]
+    assert payload["provider_hash"]
+    assert payload["model_hash"]
+    assert payload["api_mode"] == "chat_completions"
+    assert payload["streaming"] is True
+    assert payload["partial_response"] is False
+    assert payload["duration_ms"] == 123
+    assert payload["message_count"] == 1
+    assert payload["tool_count"] == 1
+    assert payload["context_units"] == 11
+    assert payload["output_units"] == 7
+    assert payload["total_units"] == 18
+    assert payload["response_id_hash"]
+    assert payload["error_fingerprint"] is None
+
+    raw_file = next((tmp_path / "ops" / "events").glob("*.jsonl")).read_text(encoding="utf-8")
+    assert "RAW_PROVIDER_DO_NOT_STORE" not in raw_file
+    assert "RAW_MODEL_DO_NOT_STORE" not in raw_file
+    assert "RAW_PROMPT_DO_NOT_STORE" not in raw_file
+    assert "RAW_TOOL_SCHEMA_DO_NOT_STORE" not in raw_file
+    assert "RAW_RESPONSE_ID_DO_NOT_STORE" not in raw_file
+
+
+def test_model_call_event_groups_errors_without_raw_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    agent = SimpleNamespace(provider="RAW_PROVIDER_DO_NOT_STORE", model="RAW_MODEL_DO_NOT_STORE", api_mode="anthropic_messages")
+    api_kwargs = {"model": "RAW_MODEL_DO_NOT_STORE", "messages": []}
+    error = RuntimeError("RAW_ERROR_DO_NOT_STORE")
+
+    _emit_model_call_event(agent, api_kwargs, error=error, duration_ms=5, streaming=False)
+
+    event = _last_event(tmp_path)
+    assert event["event_type"] == "model_call"
+    assert event["status"] == "error"
+    payload = event["payload"]
+    assert payload["error_type"] == "RuntimeError"
+    assert payload["error_fingerprint"]
+    assert payload["streaming"] is False
+    raw_file = next((tmp_path / "ops" / "events").glob("*.jsonl")).read_text(encoding="utf-8")
+    assert "RAW_ERROR_DO_NOT_STORE" not in raw_file
+    assert "RAW_PROVIDER_DO_NOT_STORE" not in raw_file
+    assert "RAW_MODEL_DO_NOT_STORE" not in raw_file

--- a/tests/test_tool_call_telemetry.py
+++ b/tests/test_tool_call_telemetry.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+import model_tools
+
+
+def _events_for(tmp_path: Path) -> list[dict]:
+    event_files = sorted((tmp_path / "ops" / "events").glob("*.jsonl"))
+    assert event_files
+    return [json.loads(line) for line in event_files[-1].read_text(encoding="utf-8").splitlines()]
+
+
+def test_handle_function_call_emits_privacy_preserving_tool_call_event(monkeypatch, tmp_path):
+    from tools.registry import registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        registry,
+        "dispatch",
+        lambda name, args, **kw: json.dumps({"output": "safe result"}),
+    )
+    monkeypatch.setattr(registry, "get_toolset_for_tool", lambda name: "safe_toolset")
+    monkeypatch.setattr(model_tools, "_READ_SEARCH_TOOLS", frozenset())
+
+    tool_name = "RAW_TOOL_NAME_DO_NOT_STORE"
+    raw_secret_arg = "ARG_VALUE_DO_NOT_STORE_123"
+    result = model_tools.handle_function_call(
+        tool_name,
+        {"secret_arg": raw_secret_arg, "count": 2},
+        task_id="task-raw-id",
+        session_id="session-raw-id",
+        tool_call_id="tool-call-raw-id",
+        turn_id="turn-raw-id",
+        api_request_id="api-request-raw-id",
+        skip_pre_tool_call_hook=True,
+    )
+
+    assert result == '{"output": "safe result"}'
+    events = _events_for(tmp_path)
+    event = events[-1]
+    assert event["event_type"] == "tool_call"
+    assert event["source"] == "model_tools.handle_function_call"
+    assert event["status"] == "ok"
+    payload = event["payload"]
+    assert payload["tool_name_hash"]
+    assert payload["toolset"] == "safe_toolset"
+    assert payload["arg_count"] == 2
+    assert payload["result_chars"] == len(result)
+    assert payload["duration_ms"] >= 0
+    assert payload["session_id_hash"]
+    assert payload["tool_call_id_hash"]
+    assert payload["turn_id_hash"]
+    assert payload["api_request_id_hash"]
+    assert payload["error_fingerprint"] is None
+
+    raw_file = next((tmp_path / "ops" / "events").glob("*.jsonl")).read_text(encoding="utf-8")
+    assert tool_name not in raw_file
+    assert raw_secret_arg not in raw_file
+    assert "task-raw-id" not in raw_file
+    assert "session-raw-id" not in raw_file
+    assert "tool-call-raw-id" not in raw_file
+    assert "turn-raw-id" not in raw_file
+    assert "api-request-raw-id" not in raw_file
+
+
+def test_handle_function_call_tool_call_event_groups_errors_without_raw_error(monkeypatch, tmp_path):
+    from tools.registry import registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        registry,
+        "dispatch",
+        lambda name, args, **kw: json.dumps({"error": "SECRET_ERROR_VALUE_DO_NOT_STORE"}),
+    )
+    monkeypatch.setattr(registry, "get_toolset_for_tool", lambda name: "dummy_toolset")
+    monkeypatch.setattr(model_tools, "_READ_SEARCH_TOOLS", frozenset())
+
+    model_tools.handle_function_call(
+        "dummy_error_tool",
+        {"path": "/private/path/should/not/store"},
+        skip_pre_tool_call_hook=True,
+    )
+
+    event = _events_for(tmp_path)[-1]
+    assert event["event_type"] == "tool_call"
+    assert event["status"] == "error"
+    payload = event["payload"]
+    assert payload["error_type"] == "tool_error"
+    assert payload["error_fingerprint"]
+    raw_file = next((tmp_path / "ops" / "events").glob("*.jsonl")).read_text(encoding="utf-8")
+    assert "SECRET_ERROR_VALUE_DO_NOT_STORE" not in raw_file
+    assert "/private/path/should/not/store" not in raw_file
+    assert "dummy_error_tool" not in raw_file


### PR DESCRIPTION
## Summary
- add privacy-preserving local telemetry primitives
- instrument cron, gateway, tool, and model calls without recording prompts, responses, secrets, or raw identifiers
- redact secret values from the expanded status output
- add focused telemetry and redaction regression tests

## Privacy properties
- no prompt or response bodies
- no API keys, tokens, or credential values
- bounded categorical metadata and hashed identifiers only
- local telemetry storage remains optional and failure-isolated

## Test plan
- `python -m pytest tests/test_hermes_telemetry.py tests/cron/test_cron_telemetry.py tests/test_gateway_telemetry.py tests/test_tool_call_telemetry.py tests/test_model_call_telemetry.py tests/hermes_cli/test_status.py -q -o 'addopts='`
- `ruff check hermes_telemetry.py cron/scheduler.py gateway/run.py model_tools.py agent/chat_completion_helpers.py hermes_cli/status.py`

This is the telemetry-only replacement for #50894; delegation and Telegram changes are submitted separately.
