### PR TITLE
fix(telegram): accept scalar allowlist configuration

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -928,7 +928,14 @@ class TelegramAdapter(BasePlatformAdapter):
         # Adapter-level allow_from: when set, it is the sole authority.
         adapter_allow_from = self.config.extra.get("allow_from")
         if adapter_allow_from is not None:
-            allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
+            if isinstance(adapter_allow_from, list):
+                allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
+            else:
+                allowed = {
+                    part.strip()
+                    for part in str(adapter_allow_from).split(",")
+                    if part.strip()
+                }
             return user_id in allowed or "*" in allowed
 
         # Test/custom injection only. The class method named

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -19,7 +19,11 @@ def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None,
     except ModuleNotFoundError:  # PR branch before Telegram plugin extraction
         from gateway.platforms.telegram import TelegramAdapter
 
-    extra = {}
+    # Keep these unit tests independent from the developer's live Telegram
+    # gateway config/env. In Micha's Hermes profile, TELEGRAM_ALLOWED_CHATS is
+    # set for production hardening; if the helper leaves allowed_chats unset,
+    # generic group-message tests are silently gated by that live value.
+    extra = {"allowed_chats": ""}
     if allow_from is not None:
         extra["allow_from"] = allow_from
     if allowed_chats is not None:

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -216,6 +216,28 @@ def test_is_user_authorized_from_message_allow_from():
     assert adapter._is_user_authorized_from_message(msg) is False
 
 
+def test_is_user_authorized_from_message_allow_from_scalar_int():
+    """allow_from can be a YAML scalar when set via `hermes config set`."""
+    adapter = _make_adapter(allow_from=111)
+
+    msg = _make_message(from_user_id=111)
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=222)
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_is_user_authorized_from_message_allow_from_csv_string():
+    """allow_from should accept comma-separated config/env style values."""
+    adapter = _make_adapter(allow_from="111,222")
+
+    msg = _make_message(from_user_id=222)
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=333)
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
 def test_is_user_authorized_from_message_wildcard():
     """_is_user_authorized_from_message should accept wildcard '*'."""
     adapter = _make_adapter(allow_from=["*"])


### PR DESCRIPTION
## Summary
- accept scalar `allow_from` / allowlist values in Telegram configuration
- normalize scalar and sequence forms consistently
- isolate authorization tests from live environment allowlists

## Test plan
- `python -m pytest tests/gateway/test_telegram_auth_check.py tests/gateway/test_telegram_rich_messages.py -q -o 'addopts='`
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_auth_check.py`

Split from and supersedes the Telegram portion of #50894.
