### PR TITLE
fix(checkpoints): remove files added after restore target

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -353,6 +353,46 @@ class TestRestore:
         assert result["success"] is True
         assert (work_dir / "main.py").read_text() == "original\n"
 
+    def test_restore_removes_file_created_after_checkpoint(self, mgr, work_dir):
+        mgr.ensure_checkpoint(str(work_dir), "before create")
+        mgr.new_turn()
+
+        created = work_dir / "created-after-checkpoint.txt"
+        created.write_text("new\n")
+
+        checkpoint = mgr.list_checkpoints(str(work_dir))[0]
+        result = mgr.restore(str(work_dir), checkpoint["hash"])
+
+        assert result["success"] is True
+        assert not created.exists()
+
+    def test_restore_removes_nested_added_file_and_empty_directory(self, mgr, work_dir):
+        mgr.ensure_checkpoint(str(work_dir), "before nested create")
+        mgr.new_turn()
+
+        nested_dir = work_dir / "generated" / "nested"
+        nested_dir.mkdir(parents=True)
+        (nested_dir / "result.txt").write_text("new\n")
+
+        checkpoint = mgr.list_checkpoints(str(work_dir))[0]
+        result = mgr.restore(str(work_dir), checkpoint["hash"])
+
+        assert result["success"] is True
+        assert not (work_dir / "generated").exists()
+
+    def test_restore_preserves_excluded_file_created_after_checkpoint(self, mgr, work_dir):
+        mgr.ensure_checkpoint(str(work_dir), "before excluded create")
+        mgr.new_turn()
+
+        excluded = work_dir / ".env"
+        excluded.write_text("LOCAL_ONLY=value\n")
+
+        checkpoint = mgr.list_checkpoints(str(work_dir))[0]
+        result = mgr.restore(str(work_dir), checkpoint["hash"])
+
+        assert result["success"] is True
+        assert excluded.read_text() == "LOCAL_ONLY=value\n"
+
     def test_restore_invalid_hash(self, mgr, work_dir):
         mgr.ensure_checkpoint(str(work_dir), "initial")
         result = mgr.restore(str(work_dir), "deadbeef1234")

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -821,8 +821,32 @@ class CheckpointManager:
 
         dir_hash = _project_hash(abs_dir)
         index_file = _index_path(store, dir_hash)
+        ref = _ref_name(dir_hash)
 
         restore_target = file_path if file_path else "."
+        # ``git checkout <commit> -- .`` restores paths present in the target
+        # tree, but it does not remove paths created after that commit. Compare
+        # the target checkpoint with the pre-rollback snapshot and remove only
+        # files that Hermes actually captured as additions. This deliberately
+        # avoids ``git clean`` so ignored, excluded, and oversized files that
+        # were never checkpointed remain untouched.
+        added_paths: List[str] = []
+        ok_current, current_commit, _ = _run_git(
+            ["rev-parse", "--verify", ref + "^{commit}"],
+            store, abs_dir,
+            allowed_returncodes={128},
+        )
+        if ok_current and current_commit and current_commit != commit_hash:
+            ok_added, added_out, _ = _run_git(
+                [
+                    "diff", "--name-only", "--diff-filter=A", "-z",
+                    commit_hash, current_commit, "--", restore_target,
+                ],
+                store, abs_dir,
+            )
+            if ok_added and added_out:
+                added_paths = [path for path in added_out.split("\x00") if path]
+
         ok, stdout, err = _run_git(
             ["checkout", commit_hash, "--", restore_target],
             store, abs_dir, timeout=_GIT_TIMEOUT * 2,
@@ -832,6 +856,37 @@ class CheckpointManager:
         if not ok:
             return {"success": False, "error": f"Restore failed: {err}",
                     "debug": err or None}
+
+        abs_workdir = _normalize_path(abs_dir)
+        parent_dirs: Set[Path] = set()
+        for rel_path in added_paths:
+            target = abs_workdir / rel_path
+            try:
+                target.parent.resolve().relative_to(abs_workdir)
+                if target.is_symlink() or target.is_file():
+                    target.unlink()
+                    parent_dirs.add(target.parent)
+                elif target.exists():
+                    return {
+                        "success": False,
+                        "error": f"Restore could not safely remove added path: {rel_path}",
+                    }
+            except (OSError, ValueError) as exc:
+                return {
+                    "success": False,
+                    "error": f"Restore could not remove added path: {rel_path}",
+                    "debug": str(exc),
+                }
+
+        # Remove empty directories left behind by deleted added files, but
+        # never recurse or cross the checkpoint working-directory boundary.
+        for parent in sorted(parent_dirs, key=lambda path: len(path.parts), reverse=True):
+            while parent != abs_workdir:
+                try:
+                    parent.rmdir()
+                except OSError:
+                    break
+                parent = parent.parent
 
         ok2, reason_out, _ = _run_git(
             ["log", "--format=%s", "-1", commit_hash], store, abs_dir,


### PR DESCRIPTION
## Summary
- remove files added after the selected checkpoint when restoring
- derive removals from Hermes' pre-rollback snapshot instead of using destructive `git clean`
- preserve ignored, excluded, oversized, and pre-existing untracked user files
- prune only empty directories created by removed checkpoint additions

## Test plan
- `python -m pytest tests/tools/test_checkpoint_manager.py tests/test_batch_runner_checkpoint.py tests/integration/test_checkpoint_resumption.py -q -o 'addopts='`
- `ruff check tools/checkpoint_manager.py tests/tools/test_checkpoint_manager.py`

## Safety
The restore path never recursively cleans the repository. It only removes paths recorded as additions between the target checkpoint and Hermes' pre-rollback snapshot.
