### PR TITLE
fix(cli): report update and OAuth status accurately

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -170,25 +170,59 @@ def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str
     return (result.stdout or "").strip()
 
 
-def _check_via_rev(local_rev: str) -> Optional[int]:
-    """Compare an embedded git revision to upstream main via ls-remote.
+def _git_network_env() -> dict[str, str]:
+    """Return a git environment that cannot open credential prompts."""
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GCM_INTERACTIVE"] = "Never"
+    return env
 
-    Returns 0 if up-to-date, ``UPDATE_AVAILABLE_NO_COUNT`` if behind,
-    or ``None`` on failure.
-    """
+
+def _upstream_main_rev() -> Optional[str]:
+    """Return the current upstream-main revision without using SSH auth."""
     try:
         result = subprocess.run(
             ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
             capture_output=True, text=True, timeout=10,
+            env=_git_network_env(),
         )
     except Exception:
         return None
     if result.returncode != 0 or not result.stdout:
         return None
     upstream_rev = result.stdout.split()[0]
+    return upstream_rev or None
+
+
+def _check_via_rev(local_rev: str) -> Optional[int]:
+    """Compare an embedded git revision to upstream main via ls-remote.
+
+    Returns 0 if up-to-date, ``UPDATE_AVAILABLE_NO_COUNT`` if behind,
+    or ``None`` on failure.
+    """
+    upstream_rev = _upstream_main_rev()
     if not upstream_rev:
         return None
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
+
+
+def _git_is_ancestor(ancestor: str, descendant: str, *, cwd: Path) -> Optional[bool]:
+    """Return whether ``ancestor`` is contained in ``descendant`` history."""
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(cwd),
+        )
+    except Exception:
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
 
 
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
@@ -196,10 +230,36 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
-        return checked
+        upstream_rev = _upstream_main_rev()
+        if not head_rev or not upstream_rev:
+            return None
+        if head_rev == upstream_rev:
+            return 0
+        # Fetch over HTTPS so passive checks never trigger an SSH key prompt,
+        # then count the actual graph distance instead of treating every
+        # differing developer-branch tip as exactly one commit behind.
+        try:
+            fetched = subprocess.run(
+                ["git", "fetch", _UPSTREAM_REPO_URL, "main", "--quiet"],
+                capture_output=True,
+                timeout=10,
+                cwd=str(repo_dir),
+                env=_git_network_env(),
+            )
+            if fetched.returncode == 0:
+                count = _git_stdout(
+                    ["rev-list", "--count", "HEAD..FETCH_HEAD"], cwd=repo_dir
+                )
+                if count is not None:
+                    return int(count)
+        except Exception:
+            pass
+        # Developer/fork branches legitimately sit ahead of upstream main.
+        # A differing tip is not evidence of being behind when the upstream
+        # revision is already an ancestor of the local branch.
+        if _git_is_ancestor(upstream_rev, "HEAD", cwd=repo_dir):
+            return 0
+        return 1
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would
@@ -221,6 +281,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
             fetch_args,
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
+            env=_git_network_env(),
         )
     except Exception:
         pass  # Offline or timeout — use stale refs, that's fine

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -257,9 +257,12 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         # Developer/fork branches legitimately sit ahead of upstream main.
         # A differing tip is not evidence of being behind when the upstream
         # revision is already an ancestor of the local branch.
-        if _git_is_ancestor(upstream_rev, "HEAD", cwd=repo_dir):
+        is_ancestor = _git_is_ancestor(upstream_rev, "HEAD", cwd=repo_dir)
+        if is_ancestor is True:
             return 0
-        return 1
+        if is_ancestor is False:
+            return UPDATE_AVAILABLE_NO_COUNT
+        return None
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -105,6 +105,31 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _has_provider_auth_config(content: str) -> bool:
+    """Return True when API-key, endpoint, or OAuth provider auth is usable."""
+    if _has_provider_env_config(content):
+        return True
+    try:
+        import hermes_cli.auth as auth
+    except Exception:
+        return False
+
+    for status_name in (
+        "get_nous_auth_status",
+        "get_codex_auth_status",
+        "get_minimax_oauth_auth_status",
+        "get_xai_oauth_auth_status",
+        "get_qwen_auth_status",
+    ):
+        try:
+            status = getattr(auth, status_name)() or {}
+        except Exception:
+            continue
+        if status.get("logged_in"):
+            return True
+    return False
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -704,6 +729,8 @@ def run_doctor(args):
         content = env_path.read_text(encoding="utf-8")
         if _has_provider_env_config(content):
             check_ok("API key or custom endpoint configured")
+        elif _has_provider_auth_config(content):
+            check_ok("OAuth provider authentication configured")
         else:
             check_warn(f"No API key found in {_DHH}/.env")
             issues.append("Run 'hermes setup' to configure API keys")
@@ -712,6 +739,8 @@ def run_doctor(args):
         fallback_env = PROJECT_ROOT / '.env'
         if fallback_env.exists():
             check_ok(".env file exists (in project directory)")
+        elif _has_provider_auth_config(""):
+            check_ok("OAuth provider authentication configured")
         else:
             check_fail(f"{_DHH}/.env file missing")
             if should_fix:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -50,6 +50,64 @@ class TestProviderEnvDetection:
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
 
+    def test_accepts_logged_in_codex_oauth_without_api_key(self, monkeypatch):
+        import hermes_cli.auth as auth
+
+        monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(auth, "get_codex_auth_status", lambda: {"logged_in": True})
+        monkeypatch.setattr(auth, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(auth, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(auth, "get_qwen_auth_status", lambda: {"logged_in": False})
+
+        assert doctor._has_provider_auth_config("TERMINAL_ENV=local\n")
+
+    def test_requires_env_or_logged_in_oauth_provider(self, monkeypatch):
+        import hermes_cli.auth as auth
+
+        for name in (
+            "get_nous_auth_status",
+            "get_codex_auth_status",
+            "get_minimax_oauth_auth_status",
+            "get_xai_oauth_auth_status",
+            "get_qwen_auth_status",
+        ):
+            monkeypatch.setattr(auth, name, lambda: {"logged_in": False})
+
+        assert not doctor._has_provider_auth_config("TERMINAL_ENV=local\n")
+
+    def test_doctor_accepts_oauth_when_env_file_is_missing(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        monkeypatch.setattr(doctor, "HERMES_HOME", hermes_home)
+        monkeypatch.setattr(doctor, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(doctor, "_DHH", str(hermes_home))
+
+        import hermes_cli.auth as auth
+
+        monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(auth, "get_codex_auth_status", lambda: {"logged_in": True})
+        monkeypatch.setattr(auth, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(auth, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(auth, "get_qwen_auth_status", lambda: {"logged_in": False})
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), pytest.raises(SystemExit):
+            doctor.run_doctor(Namespace(fix=False))
+
+        rendered = output.getvalue()
+        assert "OAuth provider authentication configured" in rendered
+        assert ".env file missing" not in rendered
+
 
 class TestDoctorToolAvailabilitySummary:
     def test_missing_api_key_summary_ignores_disabled_toolsets(self, monkeypatch):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -125,7 +125,7 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
     with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
         result = banner._check_via_local_git(repo_dir)
 
-    assert result == 1
+    assert result is None
     assert ["git", "fetch", "origin", "--quiet"] not in calls
 
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -129,6 +129,83 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
     assert ["git", "fetch", "origin", "--quiet"] not in calls
 
 
+def test_check_via_local_git_official_ssh_local_branch_ahead_is_up_to_date(tmp_path):
+    """A local branch containing upstream main must not be reported as behind."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="git@github.com:NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="local-ahead-sha\n")
+        if cmd == [
+            "git",
+            "ls-remote",
+            "https://github.com/NousResearch/hermes-agent.git",
+            "refs/heads/main",
+        ]:
+            return MagicMock(returncode=0, stdout="upstream-sha\trefs/heads/main\n")
+        if cmd == ["git", "merge-base", "--is-ancestor", "upstream-sha", "HEAD"]:
+            return MagicMock(returncode=0, stdout="")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 0
+
+
+def test_check_via_local_git_official_ssh_counts_via_https(tmp_path):
+    """Official SSH installs count behind commits without invoking SSH auth."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    calls = []
+    network_envs = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="git@github.com:NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="local-sha\n")
+        if cmd == [
+            "git",
+            "ls-remote",
+            "https://github.com/NousResearch/hermes-agent.git",
+            "refs/heads/main",
+        ]:
+            network_envs.append(kwargs.get("env"))
+            return MagicMock(returncode=0, stdout="upstream-sha\trefs/heads/main\n")
+        if cmd == [
+            "git",
+            "fetch",
+            "https://github.com/NousResearch/hermes-agent.git",
+            "main",
+            "--quiet",
+        ]:
+            network_envs.append(kwargs.get("env"))
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-list", "--count", "HEAD..FETCH_HEAD"]:
+            return MagicMock(returncode=0, stdout="7\n")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 7
+    assert ["git", "fetch", "origin", "--quiet"] not in calls
+    assert len(network_envs) == 2
+    assert all(env["GIT_TERMINAL_PROMPT"] == "0" for env in network_envs)
+    assert all(env["GCM_INTERACTIVE"] == "Never" for env in network_envs)
+
+
 def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
     """Shallow installer clones must report presence-only, never a bogus count.
 
@@ -204,13 +281,16 @@ def test_check_via_local_git_full_clone_keeps_exact_count(tmp_path):
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
+    fetch_env = None
 
     def fake_run(cmd, **kwargs):
+        nonlocal fetch_env
         if cmd == ["git", "remote", "get-url", "origin"]:
             return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
             return MagicMock(returncode=0, stdout="false\n")
         if cmd[:2] == ["git", "fetch"]:
+            fetch_env = kwargs.get("env")
             return MagicMock(returncode=0, stdout="")
         if cmd[:3] == ["git", "rev-list", "--count"]:
             return MagicMock(returncode=0, stdout="7\n")
@@ -220,6 +300,9 @@ def test_check_via_local_git_full_clone_keeps_exact_count(tmp_path):
         result = banner._check_via_local_git(repo_dir)
 
     assert result == 7
+    assert fetch_env is not None
+    assert fetch_env["GIT_TERMINAL_PROMPT"] == "0"
+    assert fetch_env["GCM_INTERACTIVE"] == "Never"
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- recognize healthy OAuth provider sessions as valid Hermes authentication, including OAuth-only installs without `~/.hermes/.env`
- report exact upstream divergence for source installs with official SSH remotes by fetching over HTTPS
- disable interactive Git credential prompts for all passive update probes
- treat branches containing upstream as current
- return an unknown result instead of fabricating a one-commit-behind count when Git evidence is incomplete

## Test plan
- `python -m pytest tests/hermes_cli/test_update_check.py tests/hermes_cli/test_doctor.py -q -o 'addopts='`
- `ruff check hermes_cli/banner.py hermes_cli/doctor.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_doctor.py`
- live `hermes doctor`: OAuth detected, no false missing-API-key warning
- live `hermes version`: exact Git behind count

## Review
An independent review identified and drove regression coverage for OAuth-only installs, noninteractive Git probes, and unknown-count fallbacks.
