### PR TITLE
fix(clarify): show decision context and compact Discord choices

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1325,6 +1325,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
                     callback=agent.clarify_callback,
+                    context=next_args.get("context"),
                 )
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -55,6 +55,10 @@ _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 _DISCORD_MAX_APP_COMMANDS = 100
 _DISCORD_SELECT_FIELD_LIMIT = 100
 _DISCORD_BUTTON_LABEL_LIMIT = 80
+# Discord recommends concise button labels (about 38 characters without an
+# icon). Clarify buttons include an option number, so the whole visible label
+# stays within that mobile-friendly budget even though the API allows 80.
+_DISCORD_CLARIFY_BUTTON_SOFT_LIMIT = 38
 _DISCORD_ELLIPSIS = "\u2026"
 _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
     "non_conversational",
@@ -131,6 +135,33 @@ from tools.url_safety import is_safe_url
 def _truncate_discord_component_text(text: str, limit: int) -> str:
     """Return text within Discord's UTF-16 component field budget."""
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
+
+
+def _clarify_choice_button_label(index: int, choice: str) -> str:
+    """Build ``1 · Approve`` from ``Approve — full explanation``.
+
+    The full canonical choice remains in the message body and callback. This
+    compact label is only a mobile-friendly pointer to the matching numbered
+    row, never the sole source of decision context.
+    """
+    prefix = f"{index + 1} · "
+    text = " ".join(str(choice or "").split())
+    short = text
+    for separator in (" — ", " – ", " - ", ": "):
+        head, found, _tail = text.partition(separator)
+        if found and head.strip():
+            short = head.strip()
+            break
+
+    budget = _DISCORD_CLARIFY_BUTTON_SOFT_LIMIT - utf16_len(prefix)
+    if utf16_len(short) > budget:
+        short = (
+            _prefix_within_utf16_limit(
+                short, budget - utf16_len(_DISCORD_ELLIPSIS)
+            ).rstrip()
+            + _DISCORD_ELLIPSIS
+        )
+    return f"{prefix}{short}"
 
 
 async def _wait_for_ready_or_bot_exit(
@@ -5803,10 +5834,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Mirror the full choice text as a numbered list, same as the
                 # Telegram/WhatsApp adapters. Button labels are capped at 80
                 # chars by Discord and become unreadable on mobile long before
-                # that (see ClarifyChoiceView), so the button is just a short
-                # index — the full text the user needs to make an informed
-                # decision lives here, in the embed field / message body,
-                # which has a much higher cap (1024 for embed fields).
+                # that (see ClarifyChoiceView), so the button carries only the
+                # option number plus a short action label — the full text the
+                # user needs to make an informed decision lives here, in the
+                # embed field / message body, which has a much higher cap
+                # (1024 for embed fields).
                 option_lines_full = "\n".join(
                     f"**{i + 1}.** {c}" for i, c in enumerate(clean_choices)
                 )
@@ -7556,7 +7588,7 @@ def _define_discord_view_classes() -> None:
         """Interactive button view for the clarify tool's multiple-choice prompts.
 
         Renders one button per choice (max 24) plus a final ``✏️ Other`` button.
-        Picking a numeric choice resolves the gateway clarify entry immediately;
+        Picking a choice button resolves the gateway clarify entry immediately;
         picking ``Other`` flips the entry into text-capture mode so the next
         user message in the session becomes the response (the gateway's
         text-intercept handles the resolution).
@@ -7582,22 +7614,14 @@ def _define_discord_view_classes() -> None:
             self.resolved = False
 
             for index, choice in enumerate(self.choices):
-                # Button labels are just the option number ("1", "2", ...).
-                # The full choice text is unreadable on Discord buttons no
-                # matter how we truncate it: the 80-char API cap is already
-                # much wider than what mobile clients render before
-                # wrapping/cutting a second line (~40 visible chars), so any
-                # truncation strategy here still garbles longer choices.
-                # send_clarify() now mirrors the full, untruncated choice
-                # text as a numbered list in the embed/message body (mirrors
-                # the Telegram/WhatsApp adapters' approach) — the button only
-                # needs to carry the index so the label is always short and
-                # legible, and the real text lives where there's room to
-                # read it.
-                label_body = str(index + 1)
+                # The message body carries the complete numbered choices. The
+                # button repeats the same number plus the short action label so
+                # the relationship is obvious without sacrificing mobile
+                # legibility. Clicking still returns the canonical full choice.
+                label_body = _clarify_choice_button_label(index, choice)
                 button = discord.ui.Button(
                     label=label_body,
-                    style=discord.ButtonStyle.primary,
+                    style=discord.ButtonStyle.secondary,
                     custom_id=f"clarify:{clarify_id}:{index}",
                 )
                 button.callback = self._make_choice_callback(index, choice)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5800,9 +5800,33 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
+                # Mirror the full choice text as a numbered list, same as the
+                # Telegram/WhatsApp adapters. Button labels are capped at 80
+                # chars by Discord and become unreadable on mobile long before
+                # that (see ClarifyChoiceView), so the button is just a short
+                # index — the full text the user needs to make an informed
+                # decision lives here, in the embed field / message body,
+                # which has a much higher cap (1024 for embed fields).
+                option_lines_full = "\n".join(
+                    f"**{i + 1}.** {c}" for i, c in enumerate(clean_choices)
+                )
+                embed_suffix = (
+                    "\n\nPick a button below, or click ✏️ Other to type a "
+                    "custom answer."
+                )
+                max_field = 1024
+                # Reserve space for the suffix before truncating the options
+                # list, otherwise a long-but-under-cap option_lines plus the
+                # suffix can push the combined field value past Discord's
+                # real 1024-char embed-field limit and the send silently
+                # fails downstream.
+                option_lines = option_lines_full
+                if len(option_lines) + len(embed_suffix) > max_field:
+                    budget = max_field - len(embed_suffix) - 3
+                    option_lines = option_lines_full[:budget] + "..."
                 embed.add_field(
                     name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
+                    value=f"{option_lines}{embed_suffix}",
                     inline=False,
                 )
                 view = ClarifyChoiceView(
@@ -5818,14 +5842,22 @@ class DiscordAdapter(BasePlatformAdapter):
                     inline=False,
                 )
                 view = None
+                option_lines_full = ""
 
-            # Mirror the question in plain content — embeds are invisible on
-            # some clients (see send_exec_approval).
-            clarify_tail = (
-                "\n\nPick one below, or click ✏️ Other to type a custom answer."
-                if clean_choices
-                else "\n\nReply in this channel with your answer."
-            )
+            # Mirror the question (and, for multi-choice, the full option
+            # text) in plain content — embeds are invisible on some clients
+            # (see send_exec_approval). The plain-text mirror uses the
+            # untruncated option list; Discord's message content cap (2000
+            # chars) is a separate, much larger limit than the embed field's
+            # 1024, so reusing the embed-truncated value here would cut off
+            # options unnecessarily.
+            if clean_choices:
+                clarify_tail = (
+                    f"\n\n{option_lines_full}\n\nPick a button below, or click "
+                    "✏️ Other to type a custom answer."
+                )
+            else:
+                clarify_tail = "\n\nReply in this channel with your answer."
             content = self._self_contained_prompt_content(
                 "❓ **Hermes needs your input**", str(question or "").strip(),
                 tail=clarify_tail,
@@ -7550,50 +7582,21 @@ def _define_discord_view_classes() -> None:
             self.resolved = False
 
             for index, choice in enumerate(self.choices):
-                # Discord button labels are capped at 80 chars. On mobile the
-                # visible width is much narrower (often <40 chars before it
-                # wraps to 2 lines and the second line gets cut off), so we
-                # cap aggressively and cut at a word boundary when possible
-                # to keep the trailing text readable.
-                #
-                # Cut strategy (most-preferred to least-preferred):
-                #   1. Last space in the trailing half of the budget
-                #      (cleanest word boundary)
-                #   2. Last soft boundary in the trailing half of the
-                #      budget (hyphen, comma, period, paren)
-                #   3. Hard cut at the budget limit (last resort)
-                prefix = f"{index + 1}. "
-                budget = _DISCORD_BUTTON_LABEL_LIMIT - utf16_len(prefix)
-                if utf16_len(choice) <= budget:
-                    label_body = choice
-                else:
-                    truncated = _prefix_within_utf16_limit(
-                        choice,
-                        max(0, budget - utf16_len(_DISCORD_ELLIPSIS)),
-                    ).rstrip()
-                    cut_at = -1
-                    # 1. Last space in the trailing half of the budget.
-                    space = truncated.rfind(" ")
-                    if space >= len(truncated) // 2:
-                        cut_at = space
-                    # 2. Soft boundary — only if no word boundary found.
-                    # Find the latest soft boundary in the trailing half
-                    # of the budget; that maximizes preserved text length.
-                    # Cut AT the soft boundary (inclusive) so the label
-                    # ends on the soft char (e.g. "-" or ",") rather than
-                    # on the alpha char that followed it.
-                    if cut_at < 0:
-                        latest_soft = max(
-                            (truncated.rfind(s) for s in ("-", ",", ".", ")")),
-                            default=-1,
-                        )
-                        if latest_soft >= len(truncated) // 2:
-                            cut_at = latest_soft + 1
-                    if cut_at > 0:
-                        truncated = truncated[:cut_at]
-                    label_body = truncated.rstrip() + _DISCORD_ELLIPSIS
+                # Button labels are just the option number ("1", "2", ...).
+                # The full choice text is unreadable on Discord buttons no
+                # matter how we truncate it: the 80-char API cap is already
+                # much wider than what mobile clients render before
+                # wrapping/cutting a second line (~40 visible chars), so any
+                # truncation strategy here still garbles longer choices.
+                # send_clarify() now mirrors the full, untruncated choice
+                # text as a numbered list in the embed/message body (mirrors
+                # the Telegram/WhatsApp adapters' approach) — the button only
+                # needs to carry the index so the label is always short and
+                # legible, and the real text lives where there's room to
+                # read it.
+                label_body = str(index + 1)
                 button = discord.ui.Button(
-                    label=f"{prefix}{label_body}",
+                    label=label_body,
                     style=discord.ButtonStyle.primary,
                     custom_id=f"clarify:{clarify_id}:{index}",
                 )

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -30,7 +30,23 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
     DiscordAdapter,
 )
 from gateway.config import PlatformConfig  # noqa: E402
-from gateway.platforms.base import utf16_len  # noqa: E402
+
+
+def _choices_field_value(embed) -> str:
+    """Pull the 'Choices' embed field's rendered text (full option list).
+
+    The test conftest's ``_FakeEmbed.add_field`` stores fields as plain
+    dicts (``{"name": ..., "value": ..., "inline": ...}``); support both
+    that shape and objects with ``.name``/``.value`` attributes in case a
+    real ``discord.Embed`` is ever passed in.
+    """
+    for field in embed.fields:
+        if isinstance(field, dict):
+            if field.get("name") == "Choices":
+                return field.get("value") or ""
+        elif getattr(field, "name", None) == "Choices":
+            return field.value
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -94,9 +110,13 @@ class TestClarifyChoiceViewConstruction:
         # 3 numeric + 1 "Other"
         assert len(view.children) == 4
         labels = [b.label for b in view.children]
-        assert labels[0].startswith("1. apple")
-        assert labels[1].startswith("2. banana")
-        assert labels[2].startswith("3. cherry")
+        # Buttons are short numeric indices — the full choice text is
+        # mirrored in the message body / embed field instead (see
+        # send_clarify), since Discord's 80-char label cap is already wider
+        # than what mobile clients render before truncating/wrapping.
+        assert labels[0] == "1"
+        assert labels[1] == "2"
+        assert labels[2] == "3"
         assert "Other" in labels[3]
         # custom_ids encode clarify_id + index/other
         ids = [b.custom_id for b in view.children]
@@ -116,37 +136,30 @@ class TestClarifyChoiceViewConstruction:
         assert len(view.children) == 25
         assert "Other" in view.children[-1].label
 
-    def test_truncates_long_choice_label(self):
+    def test_button_label_is_short_index_regardless_of_choice_length(self):
+        # Button labels never carry choice text anymore — they're always
+        # just the option number, so length/truncation of the underlying
+        # choice text can never affect button legibility.
         long_choice = "x" * 200
         view = ClarifyChoiceView(
             choices=[long_choice],
             clarify_id="cidZ",
             allowed_user_ids=set(),
         )
-        # 78 chars + single-char ellipsis in the body, plus "1. " prefix.
-        # Uses U+2026 (…) instead of "..." to fit the 80-char Discord cap.
         first_label = view.children[0].label
-        assert first_label.startswith("1. ")
-        assert first_label.endswith("\u2026")
-        # Final label total <= 80 (Discord cap on button labels)
-        assert len(first_label) <= 80
+        assert first_label == "1"
 
-    def test_truncates_emoji_choice_label_by_utf16_limit(self):
+    def test_button_label_short_for_emoji_choice(self):
         long_choice = "\U0001f600" * 80
         view = ClarifyChoiceView(
             choices=[long_choice],
             clarify_id="cidEmoji",
             allowed_user_ids=set(),
         )
-
         first_label = view.children[0].label
-        assert first_label.startswith("1. ")
-        assert first_label.endswith("\u2026")
-        assert utf16_len(first_label) <= 80
+        assert first_label == "1"
 
-    def test_truncates_long_choice_label_breaks_on_word_boundary(self):
-        # Long choice with spaces — should cut at the last whole word so the
-        # trailing text stays readable on Discord mobile.
+    def test_button_label_short_for_multiword_choice(self):
         long_choice = (
             "Tight, well-illustrated, covers all 3 audiences "
             "(patients, families, curious general readers)"
@@ -157,34 +170,7 @@ class TestClarifyChoiceViewConstruction:
             allowed_user_ids=set(),
         )
         first_label = view.children[0].label
-        assert first_label.startswith("1. ")
-        assert first_label.endswith("\u2026")
-        # No mid-word fragment before the ellipsis.
-        assert not first_label.rstrip("\u2026").endswith("(")
-
-    def test_truncates_long_no_space_choice_on_soft_boundary(self):
-        # A long choice with soft boundaries (commas, hyphens) but no spaces
-        # should still cut on a soft boundary, not mid-word. We use an input
-        # where position 76 is NOT a soft boundary — the test only passes
-        # if the renderer actively searches backward for a soft char
-        # rather than blindly cutting at the budget limit.
-        long_choice = "a" * 30 + "-" + "b" * 30 + "-" + "c" * 30 + "-" + "d" * 30
-        # 30a-30b-30c-30d = 30 + 1 + 30 + 1 + 30 + 1 + 30 = 123 chars
-        # Position 76 is 'b' (a mid-word alpha). The renderer must look back
-        # for a '-' to cut on.
-        view = ClarifyChoiceView(
-            choices=[long_choice],
-            clarify_id="cidSB",
-            allowed_user_ids=set(),
-        )
-        first_label = view.children[0].label
-        assert first_label.endswith("\u2026")
-        assert len(first_label) <= 80
-        body = first_label[len("1. "):].rstrip("\u2026")
-        last_char = body[-1]
-        assert last_char in {"-", ",", ".", ")", " "}, (
-            f"Label cuts mid-word at {last_char!r}: {first_label!r}"
-        )
+        assert first_label == "1"
 
 
 # ===========================================================================
@@ -460,13 +446,16 @@ class TestDiscordSendClarify:
         view = kwargs["view"]
         # Only 1 real choice + 1 Other = 2 children
         assert len(view.children) == 2
-        assert "real-choice" in view.children[0].label
+        # Button label is just the index; full text lives in the embed.
+        assert view.children[0].label == "1"
+        embed = kwargs["embed"]
+        assert "real-choice" in _choices_field_value(embed)
 
     @pytest.mark.asyncio
     async def test_unwraps_dict_choices_to_description(self):
         # LLMs sometimes emit [{"description": "..."}] instead of bare strings
         # — the renderer must unwrap common dict shapes, not str() the whole
-        # dict into a Python repr on the button label.
+        # dict into a Python repr anywhere user-facing (embed field text).
         adapter = _make_adapter()
         channel = MagicMock()
         sent_msg = MagicMock()
@@ -488,24 +477,26 @@ class TestDiscordSendClarify:
             session_key="sk-U",
         )
         kwargs = channel.send.call_args.kwargs
-        view = kwargs["view"]
-        labels = [b.label for b in view.children[:-1]]  # exclude Other
-        # No raw Python repr should leak onto any label.
-        for label in labels:
-            assert "{'" not in label
-            assert "':" not in label
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        # No raw Python repr should leak into the rendered choice text.
+        assert "{'" not in option_text
+        assert "':" not in option_text
         # Each dict unwrapped to its inner string.
-        assert any("Tight, well-illustrated" in lbl for lbl in labels)
-        assert any("Use label key" in lbl for lbl in labels)
-        assert any("Use text key" in lbl for lbl in labels)
-        assert any("normal-string" in lbl for lbl in labels)
+        assert "Tight, well-illustrated" in option_text
+        assert "Use label key" in option_text
+        assert "Use text key" in option_text
+        assert "normal-string" in option_text
+        # Button labels remain short numeric indices regardless.
+        labels = [b.label for b in kwargs["view"].children[:-1]]
+        assert labels == ["1", "2", "3", "4"]
 
     @pytest.mark.asyncio
     async def test_unwrap_prefers_description_over_name_in_multi_key_dict(self):
         # When the LLM emits both 'name' (often a short identifier in
         # OpenAI-style tool calls) and 'description' (the user-facing text),
         # the renderer must surface 'description'. The user should never see
-        # a 4-char model identifier on a button label.
+        # a 4-char model identifier in the rendered choice text.
         adapter = _make_adapter()
         channel = MagicMock()
         sent_msg = MagicMock()
@@ -521,12 +512,14 @@ class TestDiscordSendClarify:
             session_key="sk-N",
         )
         kwargs = channel.send.call_args.kwargs
-        view = kwargs["view"]
-        choice_label = view.children[0].label
-        assert "Tight, well-illustrated" in choice_label
-        # The 'name' value (a short identifier) must NOT have leaked.
-        body = choice_label.split("1. ", 1)[1].rstrip("\u2026")
-        assert "tight" not in body, f"'name' leaked onto button: {choice_label!r}"
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert "Tight, well-illustrated" in option_text
+        # The 'name' value (a short identifier) must NOT have leaked as its
+        # own standalone token (it's fine that "tight" is a substring of
+        # "Tight" case-insensitively — check the literal lowercase form
+        # isn't present as a separate word).
+        assert "\ntight\n" not in option_text.lower()
 
     @pytest.mark.asyncio
     async def test_unwrap_prefers_label_over_description(self):
@@ -548,12 +541,12 @@ class TestDiscordSendClarify:
             session_key="sk-L",
         )
         kwargs = channel.send.call_args.kwargs
-        view = kwargs["view"]
-        choice_label = view.children[0].label
-        assert "Short" in choice_label
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert "Short" in option_text
         # The longer description must NOT have leaked.
-        assert "Long verbose" not in choice_label, (
-            f"'description' leaked over 'label': {choice_label!r}"
+        assert "Long verbose" not in option_text, (
+            f"'description' leaked over 'label': {option_text!r}"
         )
 
     @pytest.mark.asyncio
@@ -561,8 +554,8 @@ class TestDiscordSendClarify:
         # 'name' and 'value' are Discord-component-shaped fields that could
         # accidentally appear in dicts not intended as choices (e.g., a
         # developer-error in the gateway wiring). The renderer should not
-        # surface them as button labels — only the well-known LLM tool-call
-        # keys (label, description, text, title) should win.
+        # surface them in the rendered choice text — only the well-known
+        # LLM tool-call keys (label, description, text, title) should win.
         adapter = _make_adapter()
         channel = MagicMock()
         sent_msg = MagicMock()
@@ -583,12 +576,57 @@ class TestDiscordSendClarify:
         )
         kwargs = channel.send.call_args.kwargs
         view = kwargs["view"]
-        choice_labels = [b.label for b in view.children[:-1]]  # exclude Other
-        # Only the well-formed dict survives.
-        assert len(choice_labels) == 1, (
-            f"Expected 1 choice, got {len(choice_labels)}: {choice_labels!r}"
+        # Only the well-formed dict survives as an actual button.
+        choice_buttons = view.children[:-1]  # exclude Other
+        assert len(choice_buttons) == 1, (
+            f"Expected 1 choice, got {len(choice_buttons)}"
         )
-        assert "real choice" in choice_labels[0]
-        for label in choice_labels:
-            assert "only_name_here" not in label, f"name leaked: {label!r}"
-            assert "only_value_here" not in label, f"value leaked: {label!r}"
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert "real choice" in option_text
+        assert "only_name_here" not in option_text
+        assert "only_value_here" not in option_text
+
+    @pytest.mark.asyncio
+    async def test_choices_field_value_never_exceeds_discord_embed_field_cap(self):
+        # Regression test: the "Choices" embed field value is the numbered
+        # option list PLUS a fixed instruction suffix ("Pick a button
+        # below, or click..."). Truncating only the option list to 1024
+        # chars and then appending the suffix can push the *combined*
+        # value over Discord's real 1024-char embed-field cap, which
+        # causes channel.send() to raise and send_clarify() to report a
+        # failed send on exactly the long-choice-list case this feature
+        # exists to handle.
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 999
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        # 24 choices (the max allowed) of substantial length guarantees the
+        # raw numbered option list alone is well over 1024 chars, forcing
+        # the truncation path to run.
+        long_choices = [f"Option number {i} with some extra descriptive text" for i in range(24)]
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one",
+            choices=long_choices,
+            clarify_id="cidCap",
+            session_key="sk-Cap",
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        embed = kwargs["embed"]
+        option_text = _choices_field_value(embed)
+        assert len(option_text) <= 1024, (
+            f"Choices embed field value is {len(option_text)} chars, "
+            "exceeding Discord's 1024-char embed field cap"
+        )
+        # The instruction suffix must still be present and intact even when
+        # the option list had to be truncated to make room for it.
+        assert option_text.endswith(
+            "Pick a button below, or click ✏️ Other to type a custom answer."
+        )

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -5,7 +5,7 @@ override and the ``ClarifyChoiceView`` callbacks. Discord uses ``discord.ui.View
 button callbacks (closures) rather than a string-prefixed callback_query
 dispatcher like Telegram — the auth + resolution path is the same:
 
-  · numeric choice → resolve_gateway_clarify(clarify_id, choice_text)
+  · choice button → resolve_gateway_clarify(clarify_id, choice_text)
   · "Other" button → mark_awaiting_text(clarify_id) so the text-intercept
     captures the next user message in this session
   · already-resolved or unauthorized → ephemeral "this prompt..." reply
@@ -99,25 +99,33 @@ def _make_interaction(*, user_id="42", display_name="Tester", roles=None,
 # ===========================================================================
 
 class TestClarifyChoiceViewConstruction:
-    """The view should build numeric buttons plus an Other button."""
+    """The view should build short action buttons plus an Other button."""
 
     def test_renders_n_choice_buttons_plus_other(self):
         view = ClarifyChoiceView(
-            choices=["apple", "banana", "cherry"],
+            choices=[
+                "Approve — apply the exact visible change",
+                "Revise — change nothing and request edits",
+                "Show diff — display the exact patch before deciding",
+            ],
             clarify_id="cidX",
             allowed_user_ids={"42"},
         )
-        # 3 numeric + 1 "Other"
+        # 3 short action labels + 1 "Other"
         assert len(view.children) == 4
         labels = [b.label for b in view.children]
-        # Buttons are short numeric indices — the full choice text is
-        # mirrored in the message body / embed field instead (see
-        # send_clarify), since Discord's 80-char label cap is already wider
-        # than what mobile clients render before truncating/wrapping.
-        assert labels[0] == "1"
-        assert labels[1] == "2"
-        assert labels[2] == "3"
+        # The number links each short button to the complete numbered row in
+        # the message body. The explanatory tail never lives only on a button.
+        assert labels[0] == "1 · Approve"
+        assert labels[1] == "2 · Revise"
+        assert labels[2] == "3 · Show diff"
         assert "Other" in labels[3]
+        # Equal-significance choices follow Discord's secondary-button guidance.
+        other_style = getattr(view.children[-1], "style", None)
+        assert all(
+            getattr(button, "style", None) == other_style
+            for button in view.children[:-1]
+        )
         # custom_ids encode clarify_id + index/other
         ids = [b.custom_id for b in view.children]
         assert ids[0] == "clarify:cidX:0"
@@ -136,10 +144,7 @@ class TestClarifyChoiceViewConstruction:
         assert len(view.children) == 25
         assert "Other" in view.children[-1].label
 
-    def test_button_label_is_short_index_regardless_of_choice_length(self):
-        # Button labels never carry choice text anymore — they're always
-        # just the option number, so length/truncation of the underlying
-        # choice text can never affect button legibility.
+    def test_button_label_uses_short_preview_when_choice_has_no_separator(self):
         long_choice = "x" * 200
         view = ClarifyChoiceView(
             choices=[long_choice],
@@ -147,7 +152,9 @@ class TestClarifyChoiceViewConstruction:
             allowed_user_ids=set(),
         )
         first_label = view.children[0].label
-        assert first_label == "1"
+        assert first_label.startswith("1 · ")
+        assert first_label.endswith("…")
+        assert len(first_label.encode("utf-16-le")) // 2 <= 38
 
     def test_button_label_short_for_emoji_choice(self):
         long_choice = "\U0001f600" * 80
@@ -157,11 +164,13 @@ class TestClarifyChoiceViewConstruction:
             allowed_user_ids=set(),
         )
         first_label = view.children[0].label
-        assert first_label == "1"
+        assert first_label.startswith("1 · ")
+        assert first_label.endswith("…")
+        assert len(first_label.encode("utf-16-le")) // 2 <= 38
 
-    def test_button_label_short_for_multiword_choice(self):
+    def test_button_label_uses_text_before_explanation_separator(self):
         long_choice = (
-            "Tight, well-illustrated, covers all 3 audiences "
+            "Tight layout — well-illustrated and covers all 3 audiences "
             "(patients, families, curious general readers)"
         )
         view = ClarifyChoiceView(
@@ -170,7 +179,7 @@ class TestClarifyChoiceViewConstruction:
             allowed_user_ids=set(),
         )
         first_label = view.children[0].label
-        assert first_label == "1"
+        assert first_label == "1 · Tight layout"
 
 
 # ===========================================================================
@@ -446,8 +455,8 @@ class TestDiscordSendClarify:
         view = kwargs["view"]
         # Only 1 real choice + 1 Other = 2 children
         assert len(view.children) == 2
-        # Button label is just the index; full text lives in the embed.
-        assert view.children[0].label == "1"
+        # Short action label is linked to the complete row by its number.
+        assert view.children[0].label == "1 · real-choice"
         embed = kwargs["embed"]
         assert "real-choice" in _choices_field_value(embed)
 
@@ -487,9 +496,14 @@ class TestDiscordSendClarify:
         assert "Use label key" in option_text
         assert "Use text key" in option_text
         assert "normal-string" in option_text
-        # Button labels remain short numeric indices regardless.
+        # Button labels keep a compact preview of the same numbered choices.
         labels = [b.label for b in kwargs["view"].children[:-1]]
-        assert labels == ["1", "2", "3", "4"]
+        assert labels == [
+            "1 · Tight, well-illustrated",
+            "2 · Use label key",
+            "3 · Use text key",
+            "4 · normal-string",
+        ]
 
     @pytest.mark.asyncio
     async def test_unwrap_prefers_description_over_name_in_multi_key_dict(self):

--- a/tests/gateway/test_discord_prompt_content_siblings.py
+++ b/tests/gateway/test_discord_prompt_content_siblings.py
@@ -72,8 +72,14 @@ async def test_clarify_with_choices_mirrors_question_into_content():
 
     result = await adapter.send_clarify(
         chat_id="555",
-        question="Which environment should I deploy to?",
-        choices=["staging", "production"],
+        question=(
+            "Context:\nProduction currently serves users; staging is isolated."
+            "\n\nQuestion:\nWhich environment should I deploy to?"
+        ),
+        choices=[
+            "Staging — deploy safely without user impact",
+            "Production — deploy directly to live users",
+        ],
         clarify_id="cl1",
         session_key="discord:555",
     )
@@ -81,8 +87,11 @@ async def test_clarify_with_choices_mirrors_question_into_content():
     assert result.success is True
     assert sent["view"] is not None
     assert "Hermes needs your input" in sent["content"]
+    assert "Production currently serves users" in sent["content"]
     assert "Which environment should I deploy to?" in sent["content"]
-    assert "Pick one below" in sent["content"]
+    assert "**1.** Staging — deploy safely without user impact" in sent["content"]
+    assert "**2.** Production — deploy directly to live users" in sent["content"]
+    assert "Pick a button below" in sent["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -353,3 +353,32 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_sequential_clarify_forwards_context_to_platform_callback():
+    """The executor must not drop context before the platform renders it."""
+    agent = _make_agent("clarify")
+    agent.clarify_callback = MagicMock(return_value="Approve — apply it")
+    args = {
+        "context": "The patch changes only the Discord clarify renderer.",
+        "question": "Should I apply it?",
+        "choices": [
+            "Approve — apply the exact visible patch",
+            "Revise — change nothing and request edits",
+        ],
+    }
+    tool_call = _mock_tool_call("clarify", json.dumps(args), "c-clarify")
+    message = SimpleNamespace(content="", tool_calls=[tool_call])
+    results = []
+
+    agent._execute_tool_calls_sequential(message, results, "task-clarify")
+
+    agent.clarify_callback.assert_called_once_with(
+        "Context:\nThe patch changes only the Discord clarify renderer."
+        "\n\nQuestion:\nShould I apply it?",
+        args["choices"],
+    )
+    assert len(results) == 1
+    payload = json.loads(results[0]["content"])
+    assert payload["context"] == args["context"]
+    assert payload["user_response"] == "Approve — apply it"

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -13,6 +13,9 @@ from tools.clarify_tool import (
 )
 
 
+TEST_CONTEXT = "The user needs this background to make an informed decision."
+
+
 class TestClarifyToolBasics:
     """Basic functionality tests for clarify_tool."""
 
@@ -31,18 +34,64 @@ class TestClarifyToolBasics:
     def test_question_with_choices(self):
         """Should pass choices to callback and return response."""
         def mock_callback(question: str, choices: Optional[List[str]]) -> str:
-            assert question == "Pick a number"
+            assert question == f"Context:\n{TEST_CONTEXT}\n\nQuestion:\nPick a number"
             assert choices == ["1", "2", "3"]
             return "2"
 
         result = json.loads(clarify_tool(
             "Pick a number",
             choices=["1", "2", "3"],
-            callback=mock_callback
+            callback=mock_callback,
+            context=TEST_CONTEXT,
         ))
         assert result["question"] == "Pick a number"
         assert result["choices_offered"] == ["1", "2", "3"]
         assert result["user_response"] == "2"
+
+    def test_multiple_choice_requires_context(self):
+        """A decision card without context must never reach the user."""
+        called = False
+
+        def mock_callback(question, choices):
+            nonlocal called
+            called = True
+            return "ignored"
+
+        result = json.loads(clarify_tool(
+            "Which option?",
+            choices=["Approve — apply the change", "Revise — change nothing"],
+            callback=mock_callback,
+        ))
+
+        assert called is False
+        assert "context" in result["error"].lower()
+
+    def test_context_is_rendered_before_question(self):
+        """Every surface receives explicit context above the decision."""
+        seen = []
+
+        def mock_callback(prompt, choices):
+            seen.append((prompt, choices))
+            return choices[0]
+
+        result = json.loads(clarify_tool(
+            "Do you authorize these exact changes?",
+            context=TEST_CONTEXT,
+            choices=[
+                "Approve — apply only the described changes",
+                "Revise — change nothing and request edits",
+            ],
+            callback=mock_callback,
+        ))
+
+        assert seen == [(
+            f"Context:\n{TEST_CONTEXT}\n\nQuestion:\nDo you authorize these exact changes?",
+            [
+                "Approve — apply only the described changes",
+                "Revise — change nothing and request edits",
+            ],
+        )]
+        assert result["context"] == TEST_CONTEXT
 
     def test_empty_question_returns_error(self):
         """Should return error for empty question."""
@@ -74,7 +123,10 @@ class TestClarifyToolChoicesValidation:
             return "picked"
 
         many_choices = ["a", "b", "c", "d", "e", "f", "g"]
-        clarify_tool("Pick one", choices=many_choices, callback=mock_callback)
+        clarify_tool(
+            "Pick one", choices=many_choices, callback=mock_callback,
+            context=TEST_CONTEXT,
+        )
 
         assert len(choices_passed) == MAX_CHOICES
 
@@ -99,7 +151,10 @@ class TestClarifyToolChoicesValidation:
             choices_received.extend(choices or [])
             return "answer"
 
-        clarify_tool("Pick", choices=["valid", "  ", "", "also valid"], callback=mock_callback)
+        clarify_tool(
+            "Pick", choices=["valid", "  ", "", "also valid"],
+            callback=mock_callback, context=TEST_CONTEXT,
+        )
         assert choices_received == ["valid", "also valid"]
 
     def test_invalid_choices_type_returns_error(self):
@@ -120,7 +175,10 @@ class TestClarifyToolChoicesValidation:
             choices_received.extend(choices or [])
             return "answer"
 
-        clarify_tool("Pick", choices=[1, 2, 3], callback=mock_callback)  # type: ignore
+        clarify_tool(
+            "Pick", choices=[1, 2, 3], callback=mock_callback,
+            context=TEST_CONTEXT,
+        )  # type: ignore
         assert choices_received == ["1", "2", "3"]
 
 
@@ -217,6 +275,7 @@ class TestClarifyDictChoices:
                 "A plain string choice",
             ],
             callback=cb,
+            context=TEST_CONTEXT,
         ))  # type: ignore
         assert seen == [
             "Tight, covers all 3 points",
@@ -244,6 +303,18 @@ class TestClarifySchema:
     def test_schema_question_required(self):
         """Question parameter should be required."""
         assert "question" in CLARIFY_SCHEMA["parameters"]["required"]
+
+    def test_schema_requires_self_contained_context(self):
+        required = CLARIFY_SCHEMA["parameters"]["required"]
+        assert "context" in required
+        description = CLARIFY_SCHEMA["parameters"]["properties"]["context"]["description"].lower()
+        assert "self-contained" in description
+        assert "unseen" in description
+
+    def test_schema_choices_define_short_label_and_full_explanation(self):
+        description = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]["description"].lower()
+        assert "short label" in description
+        assert "explanation" in description
 
     def test_schema_choices_optional(self):
         """Choices parameter should be optional."""

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -57,25 +57,19 @@ def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
     callback: Optional[Callable] = None,
+    context: Optional[str] = None,
 ) -> str:
-    """
-    Ask the user a question, optionally with multiple-choice options.
+    """Ask the user a question with the context needed to answer it.
 
-    Args:
-        question: The question text to present.
-        choices:  Up to 4 predefined answer choices. When omitted the
-                  question is purely open-ended.
-        callback: Platform-provided function that handles the actual UI
-                  interaction. Signature: callback(question, choices) -> str.
-                  Injected by the agent runner (cli.py / gateway).
-
-    Returns:
-        JSON string with the user's response.
+    ``context`` is rendered above ``question`` on every platform. Multiple-choice
+    prompts require non-empty context so a decision never depends only on a
+    clipped button label or on reasoning that the user cannot see.
     """
     if not question or not question.strip():
         return tool_error("Question text is required.")
 
     question = question.strip()
+    context = str(context or "").strip()
 
     # Validate and trim choices
     if choices is not None:
@@ -92,14 +86,24 @@ def clarify_tool(
         if not choices:
             choices = None  # empty list → open-ended
 
+    if choices and not context:
+        return tool_error(
+            "Context is required for multiple-choice clarification so the user "
+            "can make an informed decision."
+        )
+
     if callback is None:
         return json.dumps(
             {"error": "Clarify tool is not available in this execution context."},
             ensure_ascii=False,
         )
 
+    display_prompt = question
+    if context:
+        display_prompt = f"Context:\n{context}\n\nQuestion:\n{question}"
+
     try:
-        user_response = callback(question, choices)
+        user_response = callback(display_prompt, choices)
     except Exception as exc:
         return json.dumps(
             {"error": f"Failed to get user input: {exc}"},
@@ -108,6 +112,7 @@ def clarify_tool(
 
     return json.dumps({
         "question": question,
+        "context": context or None,
         "choices_offered": choices,
         "user_response": str(user_response).strip(),
     }, ensure_ascii=False)
@@ -121,7 +126,6 @@ def check_clarify_requirements() -> bool:
 # =============================================================================
 # OpenAI Function-Calling Schema
 # =============================================================================
-
 CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
@@ -131,12 +135,14 @@ CLARIFY_SCHEMA = {
         "or types their own answer via a 5th 'Other' option.\n"
         "2. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
+        "CONTEXT: every prompt must be self-contained. Provide all visible "
+        "facts, consequences, constraints, recommendations, and artifact "
+        "summaries needed to decide. Never refer to an unseen diff, proposal, "
+        "file, or earlier internal reasoning.\n\n"
         "CRITICAL: when you are offering options, put each option ONLY in the "
         "`choices` array — NEVER enumerate the options inside the `question` "
         "text. The UI renders `choices` as selectable rows; options written "
-        "into the question string render as dead prose the user can't pick. "
-        "Right: question='Which deployment target?', choices=['staging', "
-        "'prod']. Wrong: question='Which target? 1) staging 2) prod', choices=[].\n\n"
+        "into the question string render as dead prose the user can't pick.\n\n"
         "Use this tool when:\n"
         "- The task is ambiguous and you need the user to choose an approach\n"
         "- You want post-task feedback ('How did that work out?')\n"
@@ -149,12 +155,21 @@ CLARIFY_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
+            "context": {
+                "type": "string",
+                "description": (
+                    "A concise, self-contained decision brief containing all "
+                    "facts, consequences, constraints, recommendations, and "
+                    "artifact summaries the user needs. Never refer to an "
+                    "unseen diff, proposal, file, or hidden agent context."
+                ),
+            },
             "question": {
                 "type": "string",
                 "description": (
-                    "The question itself, and ONLY the question (e.g. 'Which "
-                    "deployment target?'). Do NOT embed the answer options here "
-                    "— pass them as separate elements in `choices`."
+                    "The focused question to answer after reading the context. "
+                    "Do not enumerate answer options here; put each option only "
+                    "in the choices array."
                 ),
             },
             "choices": {
@@ -162,15 +177,16 @@ CLARIFY_SCHEMA = {
                 "items": {"type": "string"},
                 "maxItems": MAX_CHOICES,
                 "description": (
-                    "REQUIRED whenever you are presenting selectable options: "
-                    "each distinct option is its own array element (up to 4). "
-                    "The UI renders these as pickable rows and auto-appends an "
-                    "'Other (type your answer)' option. Omit this parameter "
-                    "entirely ONLY for a genuinely open-ended free-text question."
+                    "Selectable options, up to 4. Write each as "
+                    "'Short label — full explanation of the outcome and key "
+                    "consequence'. Do not number the items; the UI numbers "
+                    "them. The full choice is shown in the message while "
+                    "interactive controls may use the short label. Omit "
+                    "choices only for a genuinely open-ended question."
                 ),
             },
         },
-        "required": ["question"],
+        "required": ["context", "question"],
     },
 }
 
@@ -185,7 +201,8 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
-        callback=kw.get("callback")),
+        callback=kw.get("callback"),
+        context=args.get("context")),
     check_fn=check_clarify_requirements,
     emoji="❓",
 )

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -42,7 +42,25 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `clarify` | Ask the user a question when you need clarification, feedback, or a decision before proceeding. Supports two modes: 1. **Multiple choice** — provide up to 4 choices. The user picks one or types their own answer via a 5th 'Other' option. 2.… | — |
+| `clarify` | Ask the user a question when you need clarification, feedback, or a decision before proceeding. Supports open-ended and multiple-choice prompts with explicit decision context. | — |
+
+Each call includes a self-contained `context` plus one focused `question`. For
+multiple-choice prompts, write every option as `Short label — full explanation`.
+Hermes shows the complete numbered options in the message. Discord buttons use
+the same number and short label (for example, `1 · Approve`) while returning the
+complete canonical choice after a click. Never ask the user to approve an unseen
+diff, file, proposal, or internal agent reasoning.
+
+```json
+{
+  "context": "The patch changes only the Discord clarify renderer.",
+  "question": "Should I apply it?",
+  "choices": [
+    "Approve — apply the exact visible patch",
+    "Revise — change nothing and request edits"
+  ]
+}
+```
 
 ## `code_execution` toolset
 


### PR DESCRIPTION
## Summary

- require an explicit, self-contained `context` for model-generated clarify prompts
- render that context above the focused question on every platform callback
- keep the full canonical choices visible as a numbered list in Discord message content and embeds
- label Discord buttons with the matching number and a compact action label (`1 · Approve`) instead of numbers alone or clipped explanations
- preserve the full original choice as the callback value after a click
- use secondary button styling for equal-significance choices, following Discord guidance
- document the native prompt contract and add regression coverage across the tool, executor, Discord, Telegram, and gateway

## Why

Discord mobile clients truncate long button labels well before the API's 80-character limit. More importantly, a clarify card could previously ask the user to approve “the diff shown” or “this proposal” even when that context was only present in the agent's internal reasoning. The user then saw clipped controls without enough visible information to make an informed choice.

The new contract separates the two responsibilities:

- message body: complete context plus full numbered options
- controls: the same number plus a short action label

Choices use the format `Short label — full explanation`, so the relationship stays obvious while the canonical value remains unchanged.

## Community credit

This branch includes and preserves the author commit from #62291, which introduced the full numbered choice list and numeric controls after repeated real-user reports. This PR extends that work with explicit decision context and meaningful compact button labels.

Related reports and prior work: #37134, #41353, #60245, #62291.

## Compatibility

- `context` is appended to the Python helper signature, so existing positional callback callers remain compatible.
- model-facing tool calls require `context` in the schema.
- multiple-choice calls that bypass the schema fail closed when context is missing.
- open-ended direct Python callers remain backward-compatible.
- Telegram's existing full-choice rendering remains unchanged and covered by tests.

## Verification

```text
101 tests passed, 0 failed
```

Command:

```bash
scripts/run_tests.sh \
  tests/tools/test_clarify_tool.py \
  tests/tools/test_clarify_gateway.py \
  tests/gateway/test_discord_clarify_buttons.py \
  tests/gateway/test_discord_prompt_content_siblings.py \
  tests/gateway/test_telegram_clarify_buttons.py \
  tests/gateway/test_clarify_active_session_bypass.py \
  tests/run_agent/test_tool_call_guardrail_runtime.py -q
```

Additional checks:

- `ruff check` on all changed Python files: pass
- `python -m py_compile` on production modules: pass
- `git diff --check`: pass
