### PR TITLE
fix(#64428): ACP edit approval ignores --yolo / HERMES_YOLO_MODE

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -522,6 +522,12 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        # Freeze the process-scoped yolo flag at agent init time — same security
+        # rationale as _YOLO_MODE_FROZEN in tools/approval.py: a mid-process
+        # skill must not be able to flip this and bypass edit approval prompts.
+        from utils import is_truthy_value
+
+        self._yolo_mode_frozen = is_truthy_value(os.getenv("HERMES_YOLO_MODE", ""))
 
     # ---- Connection lifecycle -----------------------------------------------
 
@@ -567,6 +573,14 @@ class HermesACPAgent(acp.Agent):
     def _edit_approval_policy_for_state(self, state: SessionState) -> tuple[str, str | None]:
         mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
+        # When --yolo / HERMES_YOLO_MODE is active, auto-approve edits by
+        # promoting the policy from "ask" to "session" — same escape hatch
+        # that dangerous-command approval already has.  Sensitive paths
+        # (~/.hermes, ~/.ssh, ~/.aws) are still gated by the downstream
+        # sensitive-path check in edit_approval itself, so this never
+        # silently approves writes to auth/config files.
+        if self._yolo_mode_frozen and policy == "ask":
+            policy = "session"
         return policy, state.cwd
 
     @staticmethod


### PR DESCRIPTION
ACP edit approval and dangerous-command approval were two independent systems: dangerous-command approval checked the process-scoped HERMES_YOLO_MODE flag, but ACP's `_edit_approval_policy_for_state` only read the ACP session mode. This meant `hermes --yolo acp` still required human approval for every write_file/patch operation, causing timeouts in unattended scenarios (Multica workspaces, CI).

## Changes

1. **Freeze HERMES_YOLO_MODE at agent init** — Same security rationale as `_YOLO_MODE_FROZEN` in `tools/approval.py`: a mid-process skill must not be able to flip the env var and bypass edit approval checks (prompt-injection escalation path).

2. **Promote policy in `_edit_approval_policy_for_state`** — When yolo is active, promote the edit approval policy from `"ask"` to `"session"`, matching the escape hatch that dangerous-command approval already has.

3. **Sensitive paths remain gated** — The downstream sensitive-path check in edit_approval still blocks writes to `~/.hermes`, `~/.ssh`, `~/.aws`, etc., so this never silently approves writes to auth/config files.

Fixes #64428.

Closes #64428.