### PR TITLE
feat(chat): add single-query usage receipts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15932,6 +15932,7 @@ def main(
     api_key: str = None,
     base_url: str = None,
     max_turns: int = None,
+    usage_file: str = None,
     verbose: Optional[bool] = None,
     quiet: bool = False,
     compact: bool = False,
@@ -16399,6 +16400,10 @@ def main(
                                     _exit_code = _RL_CODE
                                 except Exception:
                                     _exit_code = 1
+                        if usage_file:
+                            from hermes_cli.usage_report import write_usage_file
+
+                            write_usage_file(usage_file, result if isinstance(result, dict) else {})
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -384,6 +384,15 @@ def build_top_level_parser():
         metavar="N",
         help="Maximum tool-calling iterations per conversation turn (default: 90, or agent.max_turns in config)",
     )
+    chat_parser.add_argument(
+        "--usage-file",
+        metavar="PATH",
+        default=argparse.SUPPRESS,
+        help=(
+            "After a single-query run, write a JSON usage report (estimated cost, "
+            "token counts, model, api_calls) to PATH."
+        ),
+    )
     _inherited_flag(
         chat_parser,
         "--yolo",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2444,6 +2444,7 @@ def cmd_chat(args):
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
         "max_turns": getattr(args, "max_turns", None),
+        "usage_file": getattr(args, "usage_file", None),
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
         "compact": getattr(args, "compact", False),

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -25,10 +25,10 @@ import logging
 import os
 import sys
 from contextlib import redirect_stderr, redirect_stdout
-from pathlib import Path
 from typing import Optional
 
 from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.usage_report import write_usage_file as _write_usage_file
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -121,49 +121,6 @@ def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | No
         return None, "hermes -z: --toolsets did not contain any valid toolsets.\n"
 
     return valid, None
-
-
-def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] = None) -> None:
-    """Best-effort JSON usage report for pipelines (``-z --usage-file``).
-
-    Written even on failure so callers can always account for spend. Never
-    raises — a broken usage write must not mask the run's own outcome.
-    """
-    if not path:
-        return
-    try:
-        import json
-
-        report = {
-            "estimated_cost_usd": result.get("estimated_cost_usd"),
-            "cost_status": result.get("cost_status"),
-            "cost_source": result.get("cost_source"),
-            "input_tokens": result.get("input_tokens"),
-            "output_tokens": result.get("output_tokens"),
-            "cache_read_tokens": result.get("cache_read_tokens"),
-            "cache_write_tokens": result.get("cache_write_tokens"),
-            "reasoning_tokens": result.get("reasoning_tokens"),
-            "total_tokens": result.get("total_tokens"),
-            "api_calls": result.get("api_calls"),
-            "model": result.get("model"),
-            "provider": result.get("provider"),
-            "session_id": result.get("session_id"),
-            "completed": result.get("completed"),
-            "failed": bool(result.get("failed")) or failure is not None,
-            # Billing-audit field: the service tier this run REQUESTED via
-            # request_overrides.extra_body (e.g. OpenAI "flex"). None when
-            # unset. Lets batch pipelines verify the tier they think they're
-            # paying for actually went out on the wire (July 2026 incident:
-            # a config-matching bug silently dropped flex -> 2.3x billing).
-            "service_tier": result.get("service_tier"),
-        }
-        if failure is not None:
-            report["failure"] = failure
-        out = Path(path).expanduser()
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
-    except Exception:
-        pass
 
 
 def run_oneshot(

--- a/hermes_cli/usage_report.py
+++ b/hermes_cli/usage_report.py
@@ -1,0 +1,39 @@
+"""Best-effort JSON usage reports for non-interactive Hermes runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+
+def write_usage_file(path: Optional[str], result: dict, failure: Optional[str] = None) -> None:
+    """Write a pipeline usage report without masking the run outcome."""
+    if not path:
+        return
+    try:
+        report = {
+            "estimated_cost_usd": result.get("estimated_cost_usd"),
+            "cost_status": result.get("cost_status"),
+            "cost_source": result.get("cost_source"),
+            "input_tokens": result.get("input_tokens"),
+            "output_tokens": result.get("output_tokens"),
+            "cache_read_tokens": result.get("cache_read_tokens"),
+            "cache_write_tokens": result.get("cache_write_tokens"),
+            "reasoning_tokens": result.get("reasoning_tokens"),
+            "total_tokens": result.get("total_tokens"),
+            "api_calls": result.get("api_calls"),
+            "model": result.get("model"),
+            "provider": result.get("provider"),
+            "session_id": result.get("session_id"),
+            "completed": result.get("completed"),
+            "failed": bool(result.get("failed")) or failure is not None,
+            "service_tier": result.get("service_tier"),
+        }
+        if failure is not None:
+            report["failure"] = failure
+        output = Path(path).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    except Exception:
+        pass

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -268,3 +268,69 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")
+
+
+def test_quiet_single_query_writes_usage_report(monkeypatch, tmp_path):
+    import cli as cli_mod
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self.session_id = "usage-session"
+            self.conversation_history = []
+            self._active_agent_route_signature = "same-route"
+            self.agent = SimpleNamespace(
+                session_id="usage-session",
+                quiet_mode=False,
+                suppress_status_output=False,
+                stream_delta_callback=object(),
+                tool_gen_callback=object(),
+                run_conversation=lambda **_kwargs: {
+                    "final_response": "done",
+                    "estimated_cost_usd": 0.01,
+                    "input_tokens": 5,
+                    "output_tokens": 2,
+                    "api_calls": 1,
+                    "model": "test-model",
+                    "provider": "test-provider",
+                    "session_id": "usage-session",
+                    "completed": True,
+                    "failed": False,
+                },
+            )
+
+        def _claim_active_session(self, _surface, *, stderr=False):
+            return True
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, _effective_query):
+            return {
+                "signature": "same-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            return True
+
+    usage_path = tmp_path / "usage.json"
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(
+            query="hello",
+            quiet=True,
+            toolsets="safe",
+            usage_file=str(usage_path),
+        )
+
+    assert exc_info.value.code == 0
+    assert usage_path.exists()

--- a/tests/hermes_cli/test_chat_usage_file.py
+++ b/tests/hermes_cli/test_chat_usage_file.py
@@ -1,0 +1,15 @@
+"""Regression tests for chat -q usage-report output."""
+
+from hermes_cli._parser import build_top_level_parser
+
+
+def test_chat_query_accepts_usage_file_after_subcommand():
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    args = parser.parse_args(
+        ["chat", "--usage-file", "/tmp/chat-usage.json", "-Q", "-q", "inspect"]
+    )
+
+    assert args.command == "chat"
+    assert args.query == "inspect"
+    assert args.usage_file == "/tmp/chat-usage.json"


### PR DESCRIPTION
## Summary
- add `--usage-file` to `hermes chat` single-query mode
- reuse one best-effort JSON receipt writer for chat and one-shot execution
- preserve top-level/subcommand argument propagation with `argparse.SUPPRESS`

## Why
Foreground worker adapters must preserve normal chat approvals and CWD semantics while returning structured runtime usage/accounting evidence. One-shot (`-z`) is intentionally not used for that path.

## Verification
- 90 focused parser, forwarding, chat-query, one-shot, and session-finalization tests passed
- `ruff check hermes_cli/_parser.py hermes_cli/main.py hermes_cli/oneshot.py hermes_cli/usage_report.py cli.py tests/hermes_cli/test_chat_usage_file.py tests/cli/test_single_query_session_finalize.py`
- `git diff --check`

## Companion
`rabadaki/hermes-harness#3` consumes this capability through a bounded, parent-verified worker adapter. It is independently reviewable, but its cloud usage receipt requires this core change to be installed.