### PR TITLE
fix(#64391): skills list --enabled-only can include prompt-ineligible skills

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -921,6 +921,46 @@ def inspect_skill(identifier: str) -> Optional[dict]:
     return out
 
 
+def _resolve_session_capabilities() -> "tuple[set | None, set | None]":
+    """Resolve the effective tool names and toolsets for a fresh CLI session.
+
+    Mirrors the runtime path behind the system-prompt builder: the profile's
+    configured toolsets are expanded to concrete tool schemas exactly like
+    agent init does (``get_tool_definitions``), then toolset availability is
+    re-derived from those tool names via ``get_toolset_for_tool`` — the same
+    derivation ``agent/system_prompt.py`` feeds into ``_skill_should_show``.
+
+    Returns ``(None, None)`` when resolution fails so callers skip
+    conditional filtering entirely instead of mis-filtering against
+    empty sets.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+        from model_tools import get_tool_definitions, get_toolset_for_tool
+
+        cfg = load_config()
+        if not isinstance(cfg, dict):
+            cfg = {}
+        enabled_toolsets = sorted(_get_platform_tools(cfg, "cli"))
+        agent_cfg = cfg.get("agent") or {}
+        disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+        tool_defs = get_tool_definitions(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            quiet_mode=True,
+        )
+        available_tools = {t["function"]["name"] for t in tool_defs}
+        available_toolsets = {
+            ts
+            for ts in (get_toolset_for_tool(name) for name in available_tools)
+            if ts
+        }
+        return available_tools, available_toolsets
+    except Exception:
+        return None, None
+
+
 def do_list(source_filter: str = "all",
             enabled_only: bool = False,
             console: Optional[Console] = None) -> None:
@@ -953,19 +993,16 @@ def do_list(source_filter: str = "all",
     # When --enabled-only is set, also apply tool/toolset conditional activation
     # rules (the same _skill_should_show() check that the system-prompt builder
     # uses) so the list really matches which skills will load for the profile.
-    available_toolsets: set | None = None
+    # Both the effective tool names AND toolsets are resolved through the same
+    # runtime path a CLI session uses; passing only toolsets would make
+    # _skill_should_show() treat the tool set as empty and misclassify every
+    # requires_tools / fallback_for_tools skill.
+    available_tools: "set | None" = None
+    available_toolsets: "set | None" = None
     if enabled_only:
         from agent.prompt_builder import _skill_should_show
 
-        try:
-            from hermes_cli.config import load_config
-        except Exception:
-            load_config = None  # type: ignore[assignment]
-        if load_config is not None:
-            cfg = load_config()
-            ts_list = cfg.get("toolsets") if isinstance(cfg, dict) else None
-            if isinstance(ts_list, list):
-                available_toolsets = set(ts_list)
+        available_tools, available_toolsets = _resolve_session_capabilities()
 
     title = "Installed Skills"
     if enabled_only:
@@ -1011,9 +1048,11 @@ def do_list(source_filter: str = "all",
 
         # When --enabled-only, also filter by tool/toolset conditions so the
         # list matches what the system-prompt builder will actually load.
-        if enabled_only and available_toolsets is not None:
+        # (_skill_should_show() is a no-op when capability resolution failed
+        # and both sets are None — never mis-filter on missing info.)
+        if enabled_only:
             conditions = skill.get("conditions") or {}
-            if not _skill_should_show(conditions, None, available_toolsets):
+            if not _skill_should_show(conditions, available_tools, available_toolsets):
                 continue
 
         if source_type == "hub":

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -950,6 +950,23 @@ def do_list(source_filter: str = "all",
     all_skills = _find_all_skills(skip_disabled=True)
     disabled_names = get_disabled_skill_names()
 
+    # When --enabled-only is set, also apply tool/toolset conditional activation
+    # rules (the same _skill_should_show() check that the system-prompt builder
+    # uses) so the list really matches which skills will load for the profile.
+    available_toolsets: set | None = None
+    if enabled_only:
+        from agent.prompt_builder import _skill_should_show
+
+        try:
+            from hermes_cli.config import load_config
+        except Exception:
+            load_config = None  # type: ignore[assignment]
+        if load_config is not None:
+            cfg = load_config()
+            ts_list = cfg.get("toolsets") if isinstance(cfg, dict) else None
+            if isinstance(ts_list, list):
+                available_toolsets = set(ts_list)
+
     title = "Installed Skills"
     if enabled_only:
         title += " (enabled only)"
@@ -991,6 +1008,13 @@ def do_list(source_filter: str = "all",
         is_enabled = name not in disabled_names
         if enabled_only and not is_enabled:
             continue
+
+        # When --enabled-only, also filter by tool/toolset conditions so the
+        # list matches what the system-prompt builder will actually load.
+        if enabled_only and available_toolsets is not None:
+            conditions = skill.get("conditions") or {}
+            if not _skill_should_show(conditions, None, available_toolsets):
+                continue
 
         if source_type == "hub":
             hub_count += 1

--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     tags: [Research, Paper Writing, Experiments, ML, AI, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, LaTeX, Citations, Statistical Analysis]
     category: research
     related_skills: [arxiv, ml-paper-writing, subagent-driven-development, plan]
-    requires_toolsets: [terminal, files]
+    requires_toolsets: [terminal, file]
 
 ---
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -222,6 +222,209 @@ def test_do_list_platform_env_is_ignored(three_source_env, monkeypatch):
     assert seen["platform"] is None
 
 
+# ---------------------------------------------------------------------------
+# --enabled-only conditional activation filtering (#64391)
+# ---------------------------------------------------------------------------
+
+_EMPTY_CONDITIONS = {
+    "fallback_for_toolsets": [], "requires_toolsets": [],
+    "fallback_for_tools": [], "requires_tools": [],
+}
+
+
+def _conditional_skill(name, **overrides):
+    conditions = dict(_EMPTY_CONDITIONS)
+    conditions.update(overrides)
+    return {"name": name, "category": "x", "description": name,
+            "conditions": conditions}
+
+
+_CONDITIONAL_SKILLS = [
+    {"name": "plain-skill", "category": "x", "description": "no conditions"},
+    _conditional_skill("needs-term-ts", requires_toolsets=["terminal"]),
+    _conditional_skill("fb-web-ts", fallback_for_toolsets=["web"]),
+    _conditional_skill("needs-ws-tool", requires_tools=["web_search"]),
+    _conditional_skill("fb-ws-tool", fallback_for_tools=["web_search"]),
+]
+
+
+@pytest.fixture()
+def conditional_env(monkeypatch, hub_env):
+    """Skills carrying each of the four conditional activation fields."""
+    import tools.skills_hub as hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+    from agent import skill_utils
+
+    monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile([]))
+    monkeypatch.setattr(
+        skills_tool, "_find_all_skills",
+        lambda **_kwargs: [dict(s) for s in _CONDITIONAL_SKILLS],
+    )
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {})
+    monkeypatch.setattr(
+        skill_utils, "get_disabled_skill_names", lambda platform=None: set()
+    )
+    return hub_env
+
+
+def _capture_enabled_only(monkeypatch, tools, toolsets) -> str:
+    """Run do_list --enabled-only with pinned session capabilities."""
+    import hermes_cli.skills_hub as cli_hub
+
+    monkeypatch.setattr(
+        cli_hub, "_resolve_session_capabilities", lambda: (tools, toolsets)
+    )
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=200)
+    do_list(enabled_only=True, console=console)
+    return sink.getvalue()
+
+
+def test_enabled_only_requires_toolset_hidden_when_missing(conditional_env, monkeypatch):
+    output = _capture_enabled_only(monkeypatch, set(), set())
+    assert "needs-term-ts" not in output
+    assert "plain-skill" in output
+
+
+def test_enabled_only_requires_toolset_shown_when_available(conditional_env, monkeypatch):
+    output = _capture_enabled_only(monkeypatch, set(), {"terminal"})
+    assert "needs-term-ts" in output
+
+
+def test_enabled_only_fallback_toolset_hidden_when_primary_available(conditional_env, monkeypatch):
+    output = _capture_enabled_only(monkeypatch, set(), {"web"})
+    assert "fb-web-ts" not in output
+
+
+def test_enabled_only_fallback_toolset_shown_when_primary_missing(conditional_env, monkeypatch):
+    output = _capture_enabled_only(monkeypatch, set(), set())
+    assert "fb-web-ts" in output
+
+
+def test_enabled_only_requires_tool_hidden_when_missing(conditional_env, monkeypatch):
+    """Regression: requires_tools must be judged against the session's real
+    tool names — a None/empty tool set silently excluded every such skill."""
+    output = _capture_enabled_only(monkeypatch, set(), set())
+    assert "needs-ws-tool" not in output
+
+
+def test_enabled_only_requires_tool_shown_when_available(conditional_env, monkeypatch):
+    output = _capture_enabled_only(monkeypatch, {"web_search"}, set())
+    assert "needs-ws-tool" in output
+
+
+def test_enabled_only_fallback_tool_hidden_when_tool_available(conditional_env, monkeypatch):
+    """Regression: fallback_for_tools must hide the skill when the primary
+    tool IS in the session — a None/empty tool set never excluded these."""
+    output = _capture_enabled_only(monkeypatch, {"web_search"}, set())
+    assert "fb-ws-tool" not in output
+
+
+def test_enabled_only_fallback_tool_shown_when_tool_missing(conditional_env, monkeypatch):
+    output = _capture_enabled_only(monkeypatch, set(), set())
+    assert "fb-ws-tool" in output
+
+
+def test_enabled_only_shows_everything_when_resolution_fails(conditional_env, monkeypatch):
+    """(None, None) capabilities mean 'unknown' — never filter on them."""
+    output = _capture_enabled_only(monkeypatch, None, None)
+    for skill in _CONDITIONAL_SKILLS:
+        assert skill["name"] in output
+
+
+@pytest.mark.parametrize(
+    "tools_set,toolsets_set",
+    [
+        ({"web_search"}, {"terminal"}),
+        (set(), {"web"}),
+    ],
+)
+def test_enabled_only_listing_matches_prompt_eligibility(
+    conditional_env, monkeypatch, tools_set, toolsets_set
+):
+    """For every conditional field, --enabled-only must agree with the
+    system-prompt builder's predicate given the same capabilities."""
+    from agent.prompt_builder import _skill_should_show
+
+    output = _capture_enabled_only(monkeypatch, tools_set, toolsets_set)
+
+    for skill in _CONDITIONAL_SKILLS:
+        expected = _skill_should_show(
+            skill.get("conditions") or {}, tools_set, toolsets_set
+        )
+        assert (skill["name"] in output) is expected, skill["name"]
+
+
+@pytest.mark.parametrize(
+    "tools_set,toolsets_set",
+    [
+        ({"web_search"}, {"terminal"}),
+        (set(), {"web"}),
+    ],
+)
+def test_enabled_only_listing_matches_prompt_index_end_to_end(
+    monkeypatch, tmp_path, hub_env, tools_set, toolsets_set
+):
+    """End-to-end parity: real SKILL.md files with conditional frontmatter are
+    listed under --enabled-only iff the <available_skills> prompt index built
+    for the same tools/toolsets includes them. Exercises both frontmatter
+    parsing paths (listing scan vs prompt scan), not just the shared
+    predicate."""
+    import hermes_cli.skills_hub as cli_hub
+    import tools.skills_hub as hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+    from agent import skill_utils
+    from agent.prompt_builder import (
+        build_skills_system_prompt,
+        clear_skills_system_prompt_cache,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    skills_dir = tmp_path / "skills"
+    names = ["cond-req-ts", "cond-fb-ts", "cond-req-tool", "cond-fb-tool"]
+    for name, cond_line in zip(names, [
+        "requires_toolsets: [terminal]",
+        "fallback_for_toolsets: [web]",
+        "requires_tools: [web_search]",
+        "fallback_for_tools: [web_search]",
+    ]):
+        d = skills_dir / "test" / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {name}\n"
+            f"metadata:\n  hermes:\n    {cond_line}\n---\n"
+        )
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile([]))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {})
+    monkeypatch.setattr(
+        skill_utils, "get_disabled_skill_names", lambda platform=None: set()
+    )
+    monkeypatch.setattr(
+        cli_hub, "_resolve_session_capabilities",
+        lambda: (tools_set, toolsets_set),
+    )
+
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    try:
+        prompt = build_skills_system_prompt(
+            available_tools=tools_set, available_toolsets=toolsets_set
+        )
+    finally:
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=200)
+    do_list(enabled_only=True, console=console)
+    output = sink.getvalue()
+
+    for name in names:
+        assert (name in output) == (name in prompt), name
+
+
 def test_do_check_reports_available_updates(monkeypatch):
     output = _capture_check(monkeypatch, [
         {"name": "hub-skill", "source": "skills.sh", "status": "update_available"},

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -560,19 +560,14 @@ def _parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
 
 
 def _extract_conditions(frontmatter: Dict[str, Any]) -> Dict[str, list]:
-    """Extract conditional activation fields from parsed frontmatter."""
-    metadata = frontmatter.get("metadata")
-    if not isinstance(metadata, dict):
-        metadata = {}
-    hermes = metadata.get("hermes") or {}
-    if not isinstance(hermes, dict):
-        hermes = {}
-    return {
-        "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
-        "requires_toolsets": hermes.get("requires_toolsets", []),
-        "fallback_for_tools": hermes.get("fallback_for_tools", []),
-        "requires_tools": hermes.get("requires_tools", []),
-    }
+    """Extract conditional activation fields from parsed frontmatter.
+
+    Delegates to ``agent.skill_utils.extract_skill_conditions`` — the same
+    helper the system-prompt builder uses — so listing and prompt always
+    parse conditions identically.
+    """
+    from agent.skill_utils import extract_skill_conditions
+    return extract_skill_conditions(frontmatter)
 
 
 def _get_category_from_path(skill_path: Path) -> Optional[str]:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -559,6 +559,22 @@ def _parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     return parse_frontmatter(content)
 
 
+def _extract_conditions(frontmatter: Dict[str, Any]) -> Dict[str, list]:
+    """Extract conditional activation fields from parsed frontmatter."""
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    hermes = metadata.get("hermes") or {}
+    if not isinstance(hermes, dict):
+        hermes = {}
+    return {
+        "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
+        "requires_toolsets": hermes.get("requires_toolsets", []),
+        "fallback_for_tools": hermes.get("fallback_for_tools", []),
+        "requires_tools": hermes.get("requires_tools", []),
+    }
+
+
 def _get_category_from_path(skill_path: Path) -> Optional[str]:
     """
     Extract category from skill path based on directory structure.
@@ -753,11 +769,14 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
                 category = _get_category_from_path(skill_md)
 
+                conditions = _extract_conditions(frontmatter)
+
                 seen_names.add(name)
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
+                    "conditions": conditions,
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:


### PR DESCRIPTION
`hermes skills list --enabled-only` claimed to show "exactly which skills will load for that profile" but did not apply the same tool/toolset conditional activation rules as the system-prompt builder. This meant skills like `research-paper-writing` appeared as enabled in the listing even though they would be excluded from the actual session prompt because their `requires_toolsets` conditions were not satisfied.

## Changes

1. **Fix bundled skill** (`skills/research/research-paper-writing/SKILL.md`): Correct `requires_toolsets: [terminal, files]` to `requires_toolsets: [terminal, file]`. Hermes registers the file toolset as singular `file`, not `files`, so the skill was unconditionally excluded from every session prompt.

2. **Store conditions in find-all-skills** (`tools/skills_tool.py`): Store `requires_toolsets`, `requires_tools`, `fallback_for_toolsets`, `fallback_for_tools` in each skill dict returned by `_find_all_skills()`. Condition extraction delegates to `agent.skill_utils.extract_skill_conditions` — the exact helper the prompt builder uses — so listing and prompt can never drift in how they parse conditional frontmatter.

3. **Apply filtering in do_list** (`hermes_cli/skills_hub.py`): When `--enabled-only` is set, resolve the session's effective capabilities through the same runtime path the prompt builder sees: expand the profile's configured toolsets to concrete tool schemas exactly like agent init does (`get_tool_definitions` with the CLI platform toolsets and `agent.disabled_toolsets`), then re-derive toolset availability from those tool names via `get_toolset_for_tool` (mirroring `agent/system_prompt.py`). Both the effective **tool names** and **toolsets** are passed into `_skill_should_show()`, so `requires_tools` / `fallback_for_tools` conditions are evaluated against the session's real tool set. If capability resolution fails, `(None, None)` is passed and `_skill_should_show()` shows everything rather than mis-filtering against empty sets.

4. **Tests** (`tests/hermes_cli/test_skills_hub.py`): Listing tests for all four conditional fields (`requires_tools`, `fallback_for_tools`, `requires_toolsets`, `fallback_for_toolsets`), a resolution-failure no-filter test, a predicate-parity test, and an end-to-end parity test that builds the real `<available_skills>` prompt index from SKILL.md files on disk and asserts listing eligibility matches it for the same tools/toolsets.

Fixes #64391.
