### PR TITLE
fix: propagate telegram.extra.base_url to platforms.telegram.extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1332,6 +1332,20 @@ def load_gateway_config() -> GatewayConfig:
             # plugin's apply_yaml_config_fn hook
             # (plugins/platforms/telegram/adapter.py). #41112 / #3823.
 
+            # Propagate telegram.extra.* keys (e.g. base_url for custom Bot API
+            # servers) into platforms.telegram.extra so the adapter can read
+            # them at runtime.  The apply_yaml_config_fn hook above handles
+            # many extras, but base_url must be bridged here because the hook
+            # may not run when plugin discovery is skipped or the platform
+            # isn't in the registry.  (#26359)
+            _tg_section = yaml_cfg.get("telegram") or {}
+            if isinstance(_tg_section, dict):
+                _tg_extra_src = _tg_section.get("extra")
+                if isinstance(_tg_extra_src, dict) and "base_url" in _tg_extra_src:
+                    _tg_plat = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    _tg_extra = _tg_plat.setdefault("extra", {})
+                    _tg_extra.setdefault("base_url", _tg_extra_src["base_url"])
+
             # WhatsApp settings → env vars: migrated to the whatsapp plugin's
             # apply_yaml_config_fn hook (plugins/platforms/whatsapp/adapter.py).
             # #41112 / #3823.


### PR DESCRIPTION
## Summary

Fixes #26359

The `apply_yaml_config_fn` hook in the telegram plugin handles many extra keys, but `base_url` was not being propagated when plugin discovery was skipped or the platform wasn't in the registry. This caused `telegram.extra.base_url` to be silently ignored at runtime, falling back to the default `api.telegram.org` endpoint.

## Changes

- Add explicit propagation of `base_url` from the top-level `telegram:` block to `platforms.telegram.extra` in `gateway/config.py`
- Uses `setdefault` to respect existing values and environment variable overrides

## Testing

Verified that when config.yaml contains:
```yaml
telegram:
  extra:
    base_url: "http://custom-api.example.com"
```

The `base_url` is now correctly propagated to `platforms.telegram.extra.base_url` and read by `TelegramAdapter._start()`.

## Additional Context

This fix was generated by Hermes Agent (model: deepseek/deepseek-v4-flash), tested end-to-end by the reporter, and confirmed working. The code was reviewed and manually verified by a human before submission.

The broader goal is to later migrate the agent into Docker and, by specifying the appropriate environment variables, obtain a fully working setup with Telegram base_url substitution — enabling Hermes to operate behind a custom Bot API endpoint in containerized environments.
