### PR TITLE
fix(delegation): route async_delegation's state.db connections through apply_wal_with_fallback

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -8,6 +8,7 @@ formatting, capacity rejection, and crash handling.
 import json
 import os
 import queue
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -304,6 +305,66 @@ def test_submit_failure_removes_durable_running_record(tmp_path, monkeypatch):
     assert result["status"] == "rejected"
     with ad._DB_LOCK, ad._connect() as conn:
         assert conn.execute("SELECT COUNT(*) FROM async_delegations").fetchone()[0] == 0
+
+
+def test_connect_routes_through_shared_wal_fallback_helper(tmp_path, monkeypatch):
+    """_connect() must delegate to hermes_state.apply_wal_with_fallback(), not a
+    bare PRAGMA — this module opens its own connections to the SAME state.db
+    that SessionDB owns, so a bare PRAGMA would skip the macOS
+    synchronous=FULL hardening (btreeInitPage corruption on a WAL
+    checkpoint/termination race) and the NFS/SMB WAL-fallback safety net that
+    every other consumer of state.db already gets.
+    """
+    import hermes_state
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = []
+    real_apply = hermes_state.apply_wal_with_fallback
+
+    def _spy(conn, *, db_label="state.db"):
+        calls.append((conn, db_label))
+        return real_apply(conn, db_label=db_label)
+
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", _spy)
+
+    with ad._DB_LOCK, ad._connect() as conn:
+        pass
+
+    assert len(calls) == 1, "_connect() must call apply_wal_with_fallback exactly once"
+    # Same db_label SessionDB itself uses for state.db, so the shared
+    # once-per-process fallback-warning dedup treats both consumers of the
+    # same physical file as one database, not two.
+    assert calls[0][1] == "state.db"
+
+
+def test_connect_falls_back_gracefully_on_wal_incompatible_filesystem(tmp_path, monkeypatch):
+    """On NFS/SMB (or any filesystem SQLite rejects WAL locking on), _connect()
+    must fall back to journal_mode=DELETE instead of raising — a bare
+    ``PRAGMA journal_mode=WAL`` propagates OperationalError uncaught, which
+    would crash every dispatch/persist call in this module on such a mount.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _WalIncompatibleConn(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            if isinstance(sql, str) and sql.strip().upper() == "PRAGMA JOURNAL_MODE=WAL":
+                raise sqlite3.OperationalError("database is locked (locking protocol)")
+            return super().execute(sql, *args, **kwargs)
+
+    real_connect = ad.sqlite3.connect
+    monkeypatch.setattr(
+        ad.sqlite3,
+        "connect",
+        lambda path, timeout=10: real_connect(path, timeout=timeout, factory=_WalIncompatibleConn),
+    )
+
+    with ad._DB_LOCK, ad._connect() as conn:
+        journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        # Proves the connection is still fully usable post-fallback.
+        row_count = conn.execute("SELECT COUNT(*) FROM async_delegations").fetchone()[0]
+
+    assert journal_mode == "delete"
+    assert row_count == 0
 
 
 def test_pending_retention_prunes_delivered_before_undelivered(tmp_path, monkeypatch):

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -88,7 +88,16 @@ def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path, timeout=10)
-    conn.execute("PRAGMA journal_mode=WAL")
+    # This module opens its own connections to the SAME state.db that
+    # SessionDB owns, so it must go through the shared helper rather than
+    # a bare PRAGMA: apply_wal_with_fallback() also sets synchronous=FULL
+    # on macOS (prevents btree corruption on a WAL-checkpoint/termination
+    # race) and falls back to DELETE mode on WAL-incompatible filesystems
+    # (NFS/SMB) instead of raising. db_label matches SessionDB's own
+    # "state.db" label so the fallback warning is deduped as one file.
+    from hermes_state import apply_wal_with_fallback
+
+    apply_wal_with_fallback(conn, db_label="state.db")
     conn.execute(
         """CREATE TABLE IF NOT EXISTS async_delegations (
             delegation_id TEXT PRIMARY KEY,


### PR DESCRIPTION
## What does this PR do?

`tools/async_delegation.py::_connect()` opens its own `sqlite3` connections to the **same `state.db`** file that `hermes_state.SessionDB` owns (`get_hermes_home() / "state.db"` — identical path to `hermes_state.DEFAULT_DB_PATH`), then sets `journal_mode=WAL` with a bare `PRAGMA` instead of the shared `apply_wal_with_fallback()` helper that every other consumer of this file goes through.

Two consequences:
1. **macOS durability gap.** `apply_wal_with_fallback()` also applies `PRAGMA synchronous=FULL` on Darwin (`hermes_state.py::_enforce_macos_synchronous_full`) — WAL mode's own default, `synchronous=NORMAL`, only calls `fsync()`, which Apple's `fsync(2)` man page explicitly does not guarantee flushes to the platter. A WAL-checkpoint race with process termination (e.g. launchd shutdown) can leave `state.db` with half-written btree pages (`btreeInitPage error 11`). PR #64355 (merged today) gave this hardening to `SessionDB`, `kanban_db.py`, `projects_db.py`, `api_server.py`'s response_store, and `holographic/store.py`'s memory_store — five call sites, but `async_delegation.py`'s own connections to the exact same file were missed. Because the file is shared, a corruption event here isn't scoped to delegation records — it can take down normal session storage.
2. **Unhandled crash on WAL-incompatible filesystems.** `apply_wal_with_fallback()` catches `OperationalError` on NFS/SMB/some-FUSE mounts and falls back to `journal_mode=DELETE` (logging one warning). The bare `PRAGMA journal_mode=WAL` in `_connect()` has no such handling — it raises uncaught, crashing every `dispatch_async_delegation`/`_persist_dispatch`/etc. call on such a mount.

Fix: call `apply_wal_with_fallback(conn, db_label="state.db")` instead of the bare PRAGMA. Same `db_label` string `SessionDB` itself uses (`hermes_state.py:1057`), so the shared once-per-process fallback-warning dedup correctly treats both consumers of the same physical file as one database rather than logging twice.

No behavior change on WAL-capable filesystems beyond the macOS `synchronous=FULL` upgrade (matching what `SessionDB` already does to the same file); on WAL-incompatible filesystems this fixes an existing crash.

Same file class and fix shape as open PR #54101, which routes `verification_evidence.py` through the same shared helper for the same reason.

## Related Issue

None filed — found via code review of today's #64355 while auditing its five stated call sites against the actual `state.db` consumers in the repo.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `tools/async_delegation.py`: `_connect()` now calls `apply_wal_with_fallback(conn, db_label="state.db")` instead of a bare `PRAGMA journal_mode=WAL` (+9/-1 lines)
- `tests/tools/test_async_delegation.py`: two new regression tests — `test_connect_routes_through_shared_wal_fallback_helper` (spies on `hermes_state.apply_wal_with_fallback` to prove `_connect()` routes through it, once, with the correct `db_label`) and `test_connect_falls_back_gracefully_on_wal_incompatible_filesystem` (simulates a WAL-incompatible filesystem via a `sqlite3.Connection` subclass and asserts `_connect()` falls back to `journal_mode=DELETE` instead of raising)

## How to Test
```
python3.11 -m pytest tests/tools/test_async_delegation.py tests/gateway/test_async_delegation_session_binding.py tests/test_hermes_state.py -v --override-ini="addopts="
```
400 passed. Both new tests independently mutation-verified (stashed the fix, confirmed both fail against pre-fix code with the exact expected error — one via the missing spy call, one via the uncaught `OperationalError`).

## Checklist
- [x] Contributing Guide read | Conventional Commits | Duplicate PR checked (`gh pr list --search "async_delegation"` / `"state.db WAL synchronous"` — #51310 also touches this file but adds an unrelated on-disk roster-snapshot writer, no overlap with `_connect()`)
- [x] Only this fix | Tests added | Platform: macOS (behavior also verified on the WAL-incompatible-filesystem path, which is platform-independent)
- [x] Docs — N/A | Cross-platform — the macOS branch is a no-op on other platforms (`sys.platform != "darwin"` guard inside `apply_wal_with_fallback`), the WAL-fallback branch benefits Linux/NFS and Windows/SMB equally