### PR TITLE
feat(desktop): /reasoning command + /clear and /models aliases in the slash palette

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/reasoning-parity.integration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/reasoning-parity.integration.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { type MutableRefObject, useEffect } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import { en } from '@/i18n/en'
+import { formatModelStatusLabel } from '@/lib/model-status-label'
+import { REASONING_COMMAND_HELP } from '@/lib/reasoning-effort'
+import { $modelPresets, getModelPreset, setModelPreset } from '@/store/model-presets'
+import { $activeSessionId, $currentReasoningEffort, setCurrentReasoningEffort } from '@/store/session'
+
+import { ModelEditSubmenu } from '../../../shell/model-edit-submenu'
+
+import { useSlashCommand } from './slash'
+
+const SESSION_ID = 'rt-reasoning'
+const PROVIDER = 'nous'
+const MODEL = 'hermes-4'
+const appendSessionTextMessage = vi.fn()
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $activeSessionId.set(SESSION_ID)
+  $currentReasoningEffort.set('medium')
+  $modelPresets.set({})
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function renderPicker(requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>) {
+  return render(
+    <DropdownMenu open>
+      <DropdownMenuContent>
+        <DropdownMenuSub open>
+          <DropdownMenuSubTrigger>edit</DropdownMenuSubTrigger>
+          <ModelEditSubmenu
+            effort={$currentReasoningEffort.get()}
+            fastControl={{ kind: 'none' }}
+            isActive
+            model={MODEL}
+            onSelectModel={vi.fn()}
+            provider={PROVIDER}
+            reasoning
+            requestGateway={requestGateway}
+          />
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function SlashHarness({
+  onReady,
+  requestGateway
+}: {
+  onReady: (runSlash: (command: string) => Promise<void>) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}) {
+  const activeSessionIdRef: MutableRefObject<string | null> = { current: SESSION_ID }
+
+  const runSlash = useSlashCommand({
+    activeSessionIdRef,
+    appendSessionTextMessage,
+    branchCurrentSession: async () => true,
+    busyRef: { current: false },
+    copy: en.desktop,
+    createBackendSessionForSend: async () => SESSION_ID,
+    handleSkinCommand: () => '',
+    handoffSession: async () => ({ ok: true }),
+    openMemoryGraph: vi.fn(),
+    refreshSessions: async () => undefined,
+    requestGateway,
+    resumeStoredSession: vi.fn(),
+    startFreshSessionDraft: vi.fn(),
+    submitPromptText: async () => true
+  })
+
+  useEffect(() => {
+    onReady(runSlash)
+  }, [onReady, runSlash])
+
+  return null
+}
+
+function gatewayHarness() {
+  let value = 'medium'
+
+  const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === 'config.set') {
+      value = String(params?.value ?? '')
+
+      return { value } as never
+    }
+
+    if (method === 'config.get') {
+      return { display: 'show', value } as never
+    }
+
+    return {} as never
+  })
+
+  return requestGateway
+}
+
+describe('desktop reasoning picker and slash parity', () => {
+  it.each([
+    ['Extra High', 'xhigh', 'XHigh'],
+    ['Max', 'max', 'Max'],
+    ['Ultra', 'ultra', 'Ultra']
+  ])('%s and /reasoning %s converge on live state while preserving preset scope', async (label, effort, compact) => {
+    const pickerGateway = gatewayHarness()
+    renderPicker(pickerGateway)
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: label }))
+
+    await waitFor(() => expect($currentReasoningEffort.get()).toBe(effort))
+    expect(pickerGateway).toHaveBeenCalledWith('config.set', {
+      key: 'reasoning',
+      session_id: SESSION_ID,
+      value: effort
+    })
+    expect(formatModelStatusLabel(MODEL, { reasoningEffort: $currentReasoningEffort.get() })).toContain(compact)
+    expect(getModelPreset(PROVIDER, MODEL).effort).toBe(effort)
+
+    setCurrentReasoningEffort('medium')
+    setModelPreset(PROVIDER, MODEL, { effort: 'medium' })
+
+    const slashGateway = gatewayHarness()
+    let runSlash: ((command: string) => Promise<void>) | null = null
+    render(<SlashHarness onReady={fn => (runSlash = fn)} requestGateway={slashGateway} />)
+
+    await waitFor(() => expect(runSlash).not.toBeNull())
+    await runSlash!(`/reasoning ${effort}`)
+
+    expect(slashGateway).toHaveBeenCalledWith('config.set', {
+      key: 'reasoning',
+      session_id: SESSION_ID,
+      value: effort
+    })
+    expect($currentReasoningEffort.get()).toBe(effort)
+    expect(formatModelStatusLabel(MODEL, { reasoningEffort: $currentReasoningEffort.get() })).toContain(compact)
+    expect(getModelPreset(PROVIDER, MODEL).effort).toBe('medium')
+  })
+
+  it('keeps display commands separate from the live effort', async () => {
+    setCurrentReasoningEffort('ultra')
+
+    const requestGateway = vi.fn(async () => ({ value: 'hide' }) as never)
+    let runSlash: ((command: string) => Promise<void>) | null = null
+    render(<SlashHarness onReady={fn => (runSlash = fn)} requestGateway={requestGateway} />)
+
+    await waitFor(() => expect(runSlash).not.toBeNull())
+    await runSlash!('/reasoning hide')
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      key: 'reasoning',
+      session_id: SESSION_ID,
+      value: 'hide'
+    })
+    expect($currentReasoningEffort.get()).toBe('ultra')
+    expect(appendSessionTextMessage.mock.calls.at(-1)?.[2]).toContain('Reasoning display: hide')
+  })
+
+  it('renders current status with the shared command vocabulary', async () => {
+    const requestGateway = vi.fn(async () => ({ display: 'full', value: 'max' }) as never)
+    let runSlash: ((command: string) => Promise<void>) | null = null
+    render(<SlashHarness onReady={fn => (runSlash = fn)} requestGateway={requestGateway} />)
+
+    await waitFor(() => expect(runSlash).not.toBeNull())
+    await runSlash!('/reasoning')
+
+    expect(requestGateway).toHaveBeenCalledWith('config.get', {
+      key: 'reasoning',
+      session_id: SESSION_ID
+    })
+    expect(appendSessionTextMessage.mock.calls.at(-1)?.[2]).toContain(REASONING_COMMAND_HELP)
+  })
+
+  it('preserves the live effort and renders a failure when the gateway rejects the change', async () => {
+    setCurrentReasoningEffort('high')
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error('unsupported')
+    })
+
+    let runSlash: ((command: string) => Promise<void>) | null = null
+    render(<SlashHarness onReady={fn => (runSlash = fn)} requestGateway={requestGateway} />)
+
+    await waitFor(() => expect(runSlash).not.toBeNull())
+    await runSlash!('/reasoning ultra')
+
+    expect($currentReasoningEffort.get()).toBe('high')
+    expect(appendSessionTextMessage.mock.calls.at(-1)?.[2]).toContain('Could not update reasoning: unsupported')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -12,6 +12,7 @@ import {
   isDesktopSlashCommand,
   resolveDesktopCommand
 } from '@/lib/desktop-slash-commands'
+import { isReasoningEffort, REASONING_COMMAND_HELP } from '@/lib/reasoning-effort'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { type ComposerAttachment, setComposerDraft } from '@/store/composer'
@@ -23,6 +24,7 @@ import {
   $connection,
   $sessions,
   $yoloActive,
+  setCurrentReasoningEffort,
   setModelPickerOpen,
   setSessionPickerOpen,
   setSessions,
@@ -317,6 +319,50 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             notify({ kind: 'success', message: copy.newChatsProfile(match.name) })
           } catch (err) {
             notifyError(err, copy.setProfileFailed)
+          }
+        },
+        // /reasoning shows or sets the session's reasoning effort / thinking
+        // display via the gateway's session-scoped `config.get/set reasoning`
+        // (the same RPC the model-edit submenu uses). Levels update the
+        // composer's effort store so the pill reflects the change immediately.
+        reasoning: async ctx => {
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render, sessionId } = resolved
+          const arg = ctx.arg.trim().toLowerCase()
+
+          try {
+            if (!arg) {
+              const current = await requestGateway<{ display?: string; value?: string }>('config.get', {
+                key: 'reasoning',
+                session_id: sessionId
+              })
+
+              render(copy.reasoning.status(current.value || 'medium', current.display || 'show', REASONING_COMMAND_HELP))
+
+              return
+            }
+
+            const applied = await requestGateway<{ value?: string }>('config.set', {
+              key: 'reasoning',
+              session_id: sessionId,
+              value: arg
+            })
+
+            const value = applied.value || arg
+
+            if (isReasoningEffort(value)) {
+              setCurrentReasoningEffort(value)
+              render(copy.reasoning.effortSet(value))
+            } else {
+              render(copy.reasoning.displaySet(value))
+            }
+          } catch (err) {
+            render(`${copy.reasoning.failed}: ${err instanceof Error ? err.message : String(err)}`)
           }
         },
         skin: async ({ arg, command, recordInput, sessionHint }) => {

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -11,6 +11,7 @@ import {
   Sun,
   Wrench
 } from '@/lib/icons'
+import { ENABLED_REASONING_EFFORTS } from '@/lib/reasoning-effort'
 import type { ThemeMode } from '@/themes/context'
 
 import { defineFieldCopy } from './field-copy'
@@ -237,7 +238,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'approvals.mode': ['manual', 'smart', 'off'],
   'code_execution.mode': ['project', 'strict'],
   'context.engine': ['compressor', 'default', 'custom'],
-  'delegation.reasoning_effort': ['', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+  'delegation.reasoning_effort': ['', ...ENABLED_REASONING_EFFORTS],
   'memory.provider': ['', 'builtin', 'hindsight', 'honcho'],
   // Terminal execution backends — kept in sync with the dispatch ladder in
   // tools/terminal_tool.py::_create_environment (local/docker/singularity/

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -25,6 +25,7 @@ import type {
 } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
+import { REASONING_EFFORTS } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
 import { startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
@@ -80,10 +81,6 @@ export function ModelSettingsSkeleton() {
   )
 }
 
-// Hermes' reasoning levels (VALID_REASONING_EFFORTS); `none` = thinking off.
-// Empty config = Hermes default (medium), shown as Medium.
-const EFFORT_VALUES = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const
-
 // agent.service_tier stores "fast"/"priority"/"on" for fast; anything else is
 // normal (mirrors tui_gateway _load_service_tier).
 const isFastTier = (tier: unknown): boolean =>
@@ -92,9 +89,6 @@ const isFastTier = (tier: unknown): boolean =>
       .trim()
       .toLowerCase()
   )
-
-// Reuse the composer's effort labels.
-const effortLabelKey = (v: string) => v as 'high' | 'low' | 'max' | 'medium' | 'minimal' | 'ultra' | 'xhigh'
 
 // A provider row is "ready" to pick a model from when it reports models. The
 // backend now surfaces the full `hermes model` universe (every canonical
@@ -783,9 +777,9 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {EFFORT_VALUES.map(value => (
+                    {REASONING_EFFORTS.map(value => (
                       <SelectItem key={value} value={value}>
-                        {value === 'none' ? m.reasoningOff : t.shell.modelOptions[effortLabelKey(value)]}
+                        {value === 'none' ? m.reasoningOff : t.shell.modelOptions[value]}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
+import { ENABLED_REASONING_EFFORTS, normalizeEnabledReasoningEffort } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
 import { setModelPreset } from '@/store/model-presets'
 import { notifyError } from '@/store/notifications'
@@ -19,15 +20,7 @@ import { $activeSessionId, setCurrentFastMode, setCurrentReasoningEffort } from 
 
 // Hermes' real reasoning levels (see VALID_REASONING_EFFORTS); `none` is owned
 // by the Thinking toggle, not the radio.
-const EFFORT_OPTIONS = [
-  { value: 'minimal', labelKey: 'minimal' },
-  { value: 'low', labelKey: 'low' },
-  { value: 'medium', labelKey: 'medium' },
-  { value: 'high', labelKey: 'high' },
-  { value: 'xhigh', labelKey: 'xhigh' },
-  { value: 'max', labelKey: 'max' },
-  { value: 'ultra', labelKey: 'ultra' }
-] as const
+const EFFORT_OPTIONS = ENABLED_REASONING_EFFORTS.map(value => ({ labelKey: value, value }))
 
 /** How "fast" is achieved for a given model — two different mechanisms:
  *  - `param`: the Anthropic/OpenAI `speed=fast` request parameter.
@@ -247,5 +240,5 @@ function normalizeEffort(effort: string): string {
     return ''
   }
 
-  return EFFORT_OPTIONS.some(option => option.value === value) ? value : 'medium'
+  return normalizeEnabledReasoningEffort(value)
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2530,6 +2530,12 @@ export const en: Translations = {
     yoloSystem: active => `YOLO ${active ? 'on' : 'off'} for this session`,
     yoloTitle: 'YOLO',
     yoloToggleFailed: 'Could not toggle YOLO',
+    reasoning: {
+      status: (level, display, values) => `Reasoning effort: ${level} · display: ${display}. Use /reasoning <${values}>.`,
+      effortSet: level => `Reasoning effort set to ${level} for this session`,
+      displaySet: value => `Reasoning display: ${value}`,
+      failed: 'Could not update reasoning'
+    },
     profileStatus: current =>
       `Profile: ${current}. Use /profile <name> or the "New session" picker to start a chat in another profile.`,
     unknownProfile: 'Unknown profile',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2461,6 +2461,12 @@ export const ja = defineLocale({
     yoloSystem: active => `このセッションの YOLO ${active ? 'オン' : 'オフ'}`,
     yoloTitle: 'YOLO',
     yoloToggleFailed: 'YOLO を切り替えられませんでした',
+    reasoning: {
+      status: (level, display, values) => `推論エフォート: ${level} · 表示: ${display}。/reasoning <${values}> で変更できます。`,
+      effortSet: level => `このセッションの推論エフォートを ${level} に設定しました`,
+      displaySet: value => `推論の表示: ${value}`,
+      failed: '推論設定を更新できませんでした'
+    },
     profileStatus: current =>
       `プロファイル: ${current}。/profile <name> または「新しいセッション」ピッカーを使って別のプロファイルでチャットを始めてください。`,
     unknownProfile: '不明なプロファイル',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2115,6 +2115,12 @@ export interface Translations {
     yoloSystem: (active: boolean) => string
     yoloTitle: string
     yoloToggleFailed: string
+    reasoning: {
+      status: (level: string, display: string, values: string) => string
+      effortSet: (level: string) => string
+      displaySet: (value: string) => string
+      failed: string
+    }
     profileStatus: (current: string) => string
     unknownProfile: string
     noProfileNamed: (target: string, available: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2366,6 +2366,12 @@ export const zhHant = defineLocale({
     yoloSystem: active => `此工作階段 YOLO ${active ? '已開啟' : '已關閉'}`,
     yoloTitle: 'YOLO',
     yoloToggleFailed: '無法切換 YOLO',
+    reasoning: {
+      status: (level, display, values) => `推理強度: ${level} · 顯示: ${display}。使用 /reasoning <${values}> 變更。`,
+      effortSet: level => `本工作階段的推理強度已設為 ${level}`,
+      displaySet: value => `推理顯示: ${value}`,
+      failed: '無法更新推理設定'
+    },
     profileStatus: current => `設定檔：${current}。使用 /profile <name> 或「新工作階段」選擇器在其他設定檔中開始聊天。`,
     unknownProfile: '未知設定檔',
     noProfileNamed: (target, available) => `沒有名為「${target}」的設定檔。可用的：${available}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2677,6 +2677,12 @@ export const zh: Translations = {
     yoloSystem: active => `此会话 YOLO ${active ? '已开启' : '已关闭'}`,
     yoloTitle: 'YOLO',
     yoloToggleFailed: '无法切换 YOLO',
+    reasoning: {
+      status: (level, display, values) => `推理强度: ${level} · 显示: ${display}。使用 /reasoning <${values}> 更改。`,
+      effortSet: level => `本会话的推理强度已设为 ${level}`,
+      displaySet: value => `推理显示: ${value}`,
+      failed: '无法更新推理设置'
+    },
     profileStatus: current => `配置档案：${current}。使用 /profile <name> 或“新建会话”选择器在其他配置档案中开始对话。`,
     unknownProfile: '未知配置档案',
     noProfileNamed: (target, available) => `没有名为“${target}”的配置档案。可用：${available}`,

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -34,7 +34,6 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/compact')).toBe(false)
     expect(isDesktopSlashSuggestion('/redraw')).toBe(false)
     expect(isDesktopSlashSuggestion('/approve')).toBe(false)
-    expect(isDesktopSlashSuggestion('/model')).toBe(false)
     expect(isDesktopSlashSuggestion('/skills')).toBe(false)
     expect(isDesktopSlashSuggestion('/voice')).toBe(false)
     expect(isDesktopSlashSuggestion('/curator')).toBe(false)
@@ -119,6 +118,7 @@ describe('desktop slash command curation', () => {
     ])
     expect(filtered.pairs).toEqual([
       ['/new', 'Start a new desktop chat'],
+      ['/model', 'Switch the model for this session'],
       ['/ship-it', 'Run release checklist']
     ])
     // skill_count is recomputed from the filtered output (only /ship-it is an
@@ -179,7 +179,26 @@ describe('desktop slash command curation', () => {
   it('explains known commands that desktop owns elsewhere', () => {
     expect(desktopSlashUnavailableMessage('/model sonnet')).toContain('model picker')
     expect(desktopSlashUnavailableMessage('/skills')).toContain('desktop sidebar')
-    expect(desktopSlashUnavailableMessage('/clear')).toContain('terminal interface')
+    expect(desktopSlashUnavailableMessage('/verbose')).toContain('terminal interface')
+  })
+
+  it('routes /reasoning (and /effort) to the reasoning action with every upstream effort', () => {
+    const command = resolveDesktopCommand('/reasoning')
+
+    expect(command?.surface).toEqual({ kind: 'action', action: 'reasoning' })
+    expect(resolveDesktopCommand('/effort')?.surface).toEqual({ kind: 'action', action: 'reasoning' })
+    expect(command?.description).toContain('xhigh|max|ultra|show|hide|full|clamp')
+    expect(command?.args).toBe(true)
+    expect(isDesktopSlashSuggestion('/reasoning')).toBe(true)
+    expect(isDesktopSlashSuggestion('/effort')).toBe(false) // alias: executes, stays out of the popover
+    expect(desktopSlashUnavailableMessage('/reasoning')).toBeNull()
+  })
+
+  it('treats /clear and /models as aliases of /new and /model', () => {
+    expect(resolveDesktopCommand('/clear')?.name).toBe('/new')
+    expect(resolveDesktopCommand('/models')?.name).toBe('/model')
+    expect(isDesktopSlashCommand('/clear')).toBe(true)
+    expect(isDesktopSlashCommand('/models')).toBe(true)
   })
 
   it('flags /model as a picker-owned command so the desktop opens the overlay', () => {
@@ -206,7 +225,8 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/reset')?.surface).toEqual({ kind: 'action', action: 'new' })
     expect(resolveDesktopCommand('/resume')?.surface).toEqual({ kind: 'picker', picker: 'session' })
     expect(resolveDesktopCommand('/usage')?.surface).toEqual({ kind: 'exec' })
-    expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'unavailable', reason: 'terminal' })
+    expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'action', action: 'new' })
+    expect(resolveDesktopCommand('/verbose')?.surface).toEqual({ kind: 'unavailable', reason: 'terminal' })
     // Skill / quick commands aren't in the registry.
     expect(resolveDesktopCommand('/gif-search')).toBeNull()
   })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -1,3 +1,5 @@
+import { REASONING_COMMAND_HELP } from './reasoning-effort'
+
 export interface CommandsCatalogSection {
   name: string
   pairs: [string, string][]
@@ -38,6 +40,7 @@ export type DesktopActionId =
   | 'new'
   | 'pet'
   | 'profile'
+  | 'reasoning'
   | 'skin'
   | 'title'
   | 'yolo'
@@ -99,7 +102,7 @@ const unavailable = (reason: DesktopUnavailableReason): DesktopCommandSurface =>
  */
 const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   // Local client actions
-  { name: '/new', description: 'Start a new desktop chat', aliases: ['/reset'], surface: action('new') },
+  { name: '/new', description: 'Start a new desktop chat', aliases: ['/reset', '/clear'], surface: action('new') },
   {
     name: '/branch',
     description: 'Branch the latest message into a new chat',
@@ -118,6 +121,13 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/title', description: 'Rename the current session', surface: action('title') },
   { name: '/help', description: 'Show desktop slash commands', aliases: ['/commands'], surface: action('help') },
   {
+    name: '/reasoning',
+    description: `Show or set reasoning effort (${REASONING_COMMAND_HELP})`,
+    aliases: ['/effort'],
+    surface: action('reasoning'),
+    args: true
+  },
+  {
     name: '/browser',
     description: 'Manage browser CDP connection [connect|disconnect|status] (local gateway only)',
     surface: action('browser'),
@@ -131,7 +141,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   },
 
   // Overlay pickers
-  { name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
+  { name: '/model', description: 'Switch the model for this session', aliases: ['/models'], surface: picker('model') },
   {
     name: '/resume',
     description: 'Resume a saved session',
@@ -186,7 +196,6 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
 const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = {
   terminal: [
     '/busy',
-    '/clear',
     '/compact',
     '/config',
     '/copy',
@@ -219,7 +228,7 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
   ],
   messaging: ['/approve', '/deny'],
   settings: ['/skills', '/pets'],
-  advanced: ['/curator', '/fast', '/insights', '/kanban', '/reasoning', '/voice']
+  advanced: ['/curator', '/fast', '/insights', '/kanban', '/voice']
 }
 
 const ALL_SPECS: readonly DesktopCommandSpec[] = [

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -26,6 +26,7 @@ describe('model-status-label', () => {
     expect(reasoningEffortLabel('max')).toBe('Max')
     expect(reasoningEffortLabel('ultra')).toBe('Ultra')
     expect(reasoningEffortLabel('')).toBe('')
+    expect(reasoningEffortLabel('  ')).toBe('')
   })
 
   it('appends fast + effort session state to the status label', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -1,6 +1,7 @@
+import { isReasoningEffort, type ReasoningEffort } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
 
-const REASONING_LABELS: Record<string, string> = {
+const REASONING_LABELS: Record<ReasoningEffort, string> = {
   none: 'Off',
   minimal: 'Min',
   low: 'Low',
@@ -18,7 +19,7 @@ export function reasoningEffortLabel(effort: string): string {
     return ''
   }
 
-  return REASONING_LABELS[key] ?? effort
+  return isReasoningEffort(key) ? REASONING_LABELS[key] : effort
 }
 
 /** Which model/provider a picker should mark "current". With a live session the

--- a/apps/desktop/src/lib/reasoning-effort.test.ts
+++ b/apps/desktop/src/lib/reasoning-effort.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ENABLED_REASONING_EFFORTS,
+  isReasoningEffort,
+  normalizeEnabledReasoningEffort,
+  REASONING_COMMAND_HELP,
+  REASONING_DISPLAY_VALUES,
+  REASONING_EFFORTS
+} from './reasoning-effort'
+
+describe('desktop reasoning effort contract', () => {
+  it('keeps the enabled and off-inclusive Hermes effort ladders ordered', () => {
+    expect(ENABLED_REASONING_EFFORTS).toEqual(['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'])
+    expect(REASONING_EFFORTS).toEqual(['none', ...ENABLED_REASONING_EFFORTS])
+  })
+
+  it('keeps display commands separate from effort values', () => {
+    expect(REASONING_DISPLAY_VALUES).toEqual(['show', 'hide', 'full', 'clamp'])
+    expect(REASONING_COMMAND_HELP).toBe([...REASONING_EFFORTS, ...REASONING_DISPLAY_VALUES].join('|'))
+    expect(REASONING_DISPLAY_VALUES.every(value => !isReasoningEffort(value))).toBe(true)
+  })
+
+  it('recognizes exact effort values and normalizes user-facing enabled values', () => {
+    expect(REASONING_EFFORTS.every(isReasoningEffort)).toBe(true)
+    expect(isReasoningEffort(' ULTRA ')).toBe(false)
+    expect(normalizeEnabledReasoningEffort(' ULTRA ')).toBe('ultra')
+    expect(normalizeEnabledReasoningEffort('unknown')).toBe('medium')
+  })
+})

--- a/apps/desktop/src/lib/reasoning-effort.test.ts
+++ b/apps/desktop/src/lib/reasoning-effort.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   ENABLED_REASONING_EFFORTS,
+  isEnabledReasoningEffort,
   isReasoningEffort,
   normalizeEnabledReasoningEffort,
   REASONING_COMMAND_HELP,
@@ -9,22 +10,77 @@ import {
   REASONING_EFFORTS
 } from './reasoning-effort'
 
+/**
+ * These tests assert INVARIANTS between the exported ladders and their
+ * predicates, not a frozen catalog of tier names.
+ *
+ * The previous version asserted `ENABLED_REASONING_EFFORTS` equals an exact
+ * literal list. That is a change-detector: adding or reordering a valid
+ * backend tier breaks the test even though the Desktop contract is still
+ * correct, so the failure carries no information about the thing under test.
+ *
+ * The relationships below are what Desktop actually depends on, and they hold
+ * for any tier ladder the backend chooses. They still fail on a real contract
+ * break (e.g. a display value leaking into the effort ladder).
+ */
 describe('desktop reasoning effort contract', () => {
-  it('keeps the enabled and off-inclusive Hermes effort ladders ordered', () => {
-    expect(ENABLED_REASONING_EFFORTS).toEqual(['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'])
+  it('derives the off-inclusive ladder from the enabled ladder', () => {
     expect(REASONING_EFFORTS).toEqual(['none', ...ENABLED_REASONING_EFFORTS])
+    expect(ENABLED_REASONING_EFFORTS).toEqual(REASONING_EFFORTS.filter(value => value !== 'none'))
+    // Order is a contract (the ladder is ranked), so relative order must survive.
+    expect(REASONING_EFFORTS.indexOf('none')).toBe(0)
   })
 
-  it('keeps display commands separate from effort values', () => {
-    expect(REASONING_DISPLAY_VALUES).toEqual(['show', 'hide', 'full', 'clamp'])
-    expect(REASONING_COMMAND_HELP).toBe([...REASONING_EFFORTS, ...REASONING_DISPLAY_VALUES].join('|'))
-    expect(REASONING_DISPLAY_VALUES.every(value => !isReasoningEffort(value))).toBe(true)
+  it('keeps both ladders non-empty and duplicate-free', () => {
+    expect(ENABLED_REASONING_EFFORTS.length).toBeGreaterThan(0)
+    expect(new Set(REASONING_EFFORTS).size).toBe(REASONING_EFFORTS.length)
+    expect(new Set(REASONING_DISPLAY_VALUES).size).toBe(REASONING_DISPLAY_VALUES.length)
   })
 
-  it('recognizes exact effort values and normalizes user-facing enabled values', () => {
+  it('keeps the predicates consistent with the ladders they guard', () => {
     expect(REASONING_EFFORTS.every(isReasoningEffort)).toBe(true)
+    expect(ENABLED_REASONING_EFFORTS.every(isEnabledReasoningEffort)).toBe(true)
+    // Every enabled tier is also a valid effort; the reverse holds for all but 'none'.
+    expect(ENABLED_REASONING_EFFORTS.every(isReasoningEffort)).toBe(true)
+    expect(isReasoningEffort('none')).toBe(true)
+    expect(isEnabledReasoningEffort('none')).toBe(false)
+  })
+
+  it('keeps display commands disjoint from effort values', () => {
+    expect(REASONING_DISPLAY_VALUES.every(value => !isReasoningEffort(value))).toBe(true)
+    expect(REASONING_EFFORTS.every(value => !REASONING_DISPLAY_VALUES.includes(value as never))).toBe(true)
+  })
+
+  it('derives the help string from both ladders rather than hand-writing it', () => {
+    expect(REASONING_COMMAND_HELP).toBe([...REASONING_EFFORTS, ...REASONING_DISPLAY_VALUES].join('|'))
+    expect(REASONING_COMMAND_HELP.split('|')).toHaveLength(
+      REASONING_EFFORTS.length + REASONING_DISPLAY_VALUES.length
+    )
+  })
+
+  // Behavioral coverage the review asked to KEEP: these tiers are the reason
+  // the Desktop ladder was extended, so they are asserted by behavior
+  // (accepted by the predicate) rather than by position in a frozen list.
+  it('accepts the extended xhigh/max/ultra tiers', () => {
+    for (const tier of ['xhigh', 'max', 'ultra']) {
+      expect(isEnabledReasoningEffort(tier)).toBe(true)
+      expect(isReasoningEffort(tier)).toBe(true)
+    }
+  })
+
+  it('normalizes user input while keeping the strict predicate strict', () => {
     expect(isReasoningEffort(' ULTRA ')).toBe(false)
     expect(normalizeEnabledReasoningEffort(' ULTRA ')).toBe('ultra')
     expect(normalizeEnabledReasoningEffort('unknown')).toBe('medium')
+    // Normalization must land inside the enabled ladder for every enabled tier,
+    // including any future one, in both padded and upper-cased forms.
+    for (const tier of ENABLED_REASONING_EFFORTS) {
+      expect(normalizeEnabledReasoningEffort(` ${tier.toUpperCase()} `)).toBe(tier)
+    }
+  })
+
+  it('falls back to a tier that is itself enabled', () => {
+    const fallback = normalizeEnabledReasoningEffort('definitely-not-a-tier')
+    expect(isEnabledReasoningEffort(fallback)).toBe(true)
   })
 })

--- a/apps/desktop/src/lib/reasoning-effort.ts
+++ b/apps/desktop/src/lib/reasoning-effort.ts
@@ -1,0 +1,29 @@
+import { normalize } from '@/lib/text'
+
+export const ENABLED_REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const
+
+export const REASONING_EFFORTS = ['none', ...ENABLED_REASONING_EFFORTS] as const
+
+export const REASONING_DISPLAY_VALUES = ['show', 'hide', 'full', 'clamp'] as const
+
+export const REASONING_COMMAND_HELP = [...REASONING_EFFORTS, ...REASONING_DISPLAY_VALUES].join('|')
+
+export type EnabledReasoningEffort = (typeof ENABLED_REASONING_EFFORTS)[number]
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number]
+
+export function isEnabledReasoningEffort(value: unknown): value is EnabledReasoningEffort {
+  return typeof value === 'string' && (ENABLED_REASONING_EFFORTS as readonly string[]).includes(value)
+}
+
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+  return typeof value === 'string' && (REASONING_EFFORTS as readonly string[]).includes(value)
+}
+
+export function normalizeEnabledReasoningEffort(
+  value: unknown,
+  fallback: EnabledReasoningEffort = 'medium'
+): EnabledReasoningEffort {
+  const normalized = normalize(String(value ?? ''))
+
+  return isEnabledReasoningEffort(normalized) ? normalized : fallback
+}


### PR DESCRIPTION
Follow-up to #64464 (surfacing `/model`), refreshed onto current `main` after #62650 added the `max` and `ultra` reasoning tiers.

## What this PR does

### `/reasoning` (alias: `/effort`) becomes a first-class Desktop action

Previously Desktop classified `/reasoning` as unavailable. This PR routes it through the same session-scoped gateway contract used by the model editor:

- bare `/reasoning` reads the current effort/display state with `config.get reasoning`
- `/reasoning <none|minimal|low|medium|high|xhigh|max|ultra>` writes the exact session effort with `config.set reasoning`
- `/reasoning <show|hide|full|clamp>` updates reasoning display without changing the live effort
- successful effort changes update the renderer store immediately so the compact model pill stays accurate (`XHigh`, `Max`, and `Ultra` remain distinct)
- gateway rejection leaves the live renderer state unchanged and renders the backend error

Persistence is intentionally scoped:

- the picker updates the current session **and** that model's Desktop preset
- `/reasoning` updates the current session only and does **not** rewrite the model preset

The refresh also consolidates Desktop's reasoning vocabulary into one typed contract consumed by the picker, agent Settings, delegation Settings, compact labels, slash routing, and help text. This prevents another hand-maintained-list drift when reasoning tiers change.

Status/help copy is localized in English, Japanese, Simplified Chinese, and Traditional Chinese.

### `/clear` aliases `/new`

Desktop previously classified `/clear` as terminal-only. The Desktop equivalent is a fresh chat, so `/clear` now resolves to the existing `/new` action (matching `/reset`).

### `/models` aliases `/model`

The common plural form opens the model picker. The branch also carries the one-property `/model` palette un-hide from #64464; if this PR merges first, #64464 is redundant.

## Why this refresh was needed

The original PR branch recognized effort values only through `xhigh`. Current upstream already exposes distinct `xhigh`, `max`, and `ultra` picker/status/settings behavior, so the old slash whitelist would have accepted the backend RPC but misclassified `max` and `ultra` as display changes. The refreshed integration contract proves all three tiers converge on the same live session state and remain label-distinct.

## Verification

- TDD reproduction: `xhigh` passed while `max` and `ultra` failed against the stale slash classifier; the command-help assertion also failed at `xhigh`
- focused reasoning/registry/settings/picker/status tests: PASS
- full Desktop UI suite: **169 files / 1,314 tests passed**
- Desktop typecheck (renderer + Electron): PASS
- changed-file ESLint: **0 errors** (one pre-existing `react-hooks/exhaustive-deps` warning outside changed lines)
- deterministic pre-scan: **0 findings**
- current-upstream gateway contract test: `tests/test_tui_gateway_server.py::test_config_set_reasoning_updates_live_session_and_agent` → **1 passed**
- direct real-handler probe: `none`, `xhigh`, `max`, and `ultra` each round-tripped byte-for-byte; `none` produced `{enabled:false}`, while enabled tiers produced the matching effort config

## How to test

1. Open a Desktop session and run `/reasoning`; confirm the status includes all effort levels plus `show|hide|full|clamp`.
2. Run `/reasoning xhigh`, `/reasoning max`, and `/reasoning ultra`; confirm the model pill shows `XHigh`, `Max`, and `Ultra` respectively.
3. Save a model preset, run one of the slash commands, and confirm the current session changes while the preset remains unchanged.
4. Run `/reasoning hide` and confirm the reasoning display changes without changing the effort pill.
5. Run `/models` and confirm the model picker opens; run `/clear` and confirm Desktop starts a fresh chat.
