### PR TITLE
fix(desktop): enable local markdown checkbox toggles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-checkbox.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-checkbox.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Markdown task-list checkboxes', () => {
+  it('preserves the Markdown state and lets the user toggle it locally', () => {
+    const text = '- [ ] Open item\n- [x] Completed item'
+    const { rerender, unmount } = render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    const [openItem, completedItem] = screen.getAllByRole<HTMLInputElement>('checkbox')
+
+    expect(openItem.disabled).toBe(false)
+    expect(openItem.checked).toBe(false)
+    expect(completedItem.disabled).toBe(false)
+    expect(completedItem.checked).toBe(true)
+
+    fireEvent.click(openItem)
+    fireEvent.click(completedItem)
+    rerender(<MarkdownTextContent isRunning={false} text={`${text}\n\nMore text`} />)
+
+    const [updatedOpenItem, updatedCompletedItem] = screen.getAllByRole<HTMLInputElement>('checkbox')
+
+    expect(updatedOpenItem.checked).toBe(true)
+    expect(updatedCompletedItem.checked).toBe(false)
+
+    unmount()
+    render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    const [resetOpenItem, resetCompletedItem] = screen.getAllByRole<HTMLInputElement>('checkbox')
+
+    expect(resetOpenItem.checked).toBe(false)
+    expect(resetCompletedItem.checked).toBe(true)
+  })
+
+  it('keeps checkboxes outside GFM task-list items disabled', () => {
+    render(<MarkdownTextContent isRunning={false} text={'<input type="checkbox" checked disabled>'} />)
+
+    const checkbox = screen.getByRole<HTMLInputElement>('checkbox')
+
+    expect(checkbox.disabled).toBe(true)
+    expect(checkbox.checked).toBe(true)
+
+    fireEvent.click(checkbox)
+
+    expect(checkbox.checked).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,7 +8,15 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import { code } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import {
+  type ComponentProps,
+  createContext,
+  memo,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -301,6 +309,32 @@ function MarkdownImage({ className, src, alt, ...props }: ComponentProps<'img'>)
   )
 }
 
+const MarkdownTaskListItemContext = createContext(false)
+
+function MarkdownInput({ checked, disabled, type, ...props }: ComponentProps<'input'>) {
+  const isTaskListItem = useContext(MarkdownTaskListItemContext)
+
+  if (type !== 'checkbox' || !isTaskListItem) {
+    return <input checked={checked} disabled={disabled} type={type} {...props} />
+  }
+
+  // GFM marks task-list inputs as disabled. Keep the Markdown value as the
+  // initial state, then let the browser own local, ephemeral toggles.
+  return <input defaultChecked={checked} type="checkbox" {...props} />
+}
+
+function MarkdownListItem({ children, className, ...props }: ComponentProps<'li'>) {
+  const isTaskListItem = className?.split(/\s+/).includes('task-list-item') ?? false
+
+  return (
+    <li className={cn('leading-(--dt-line-height)', className)} {...props}>
+      <MarkdownTaskListItemContext.Provider value={isTaskListItem}>
+        {children}
+      </MarkdownTaskListItemContext.Provider>
+    </li>
+  )
+}
+
 interface MarkdownTextSurfaceProps {
   containerClassName?: string
   containerProps?: ComponentProps<'div'>
@@ -428,9 +462,8 @@ function MarkdownTextSurface({ containerClassName, containerProps, defer }: Mark
         ol: ({ className, ...props }: ComponentProps<'ol'>) => (
           <ol className={cn('my-1 gap-0', className)} dir="auto" {...props} />
         ),
-        li: ({ className, ...props }: ComponentProps<'li'>) => (
-          <li className={cn('leading-(--dt-line-height)', className)} {...props} />
-        ),
+        li: MarkdownListItem,
+        input: MarkdownInput,
         table: ({ className, ...props }: ComponentProps<'table'>) => (
           <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-border">
             <table


### PR DESCRIPTION
Closes #64489.

## Summary
- make GFM task-list checkboxes locally toggleable in Desktop chat
- preserve the checked state from the original Markdown on first render
- keep toggles ephemeral and entirely in the renderer

No transcript edits, backend calls, or persistence are added.

## Tests
- `npx vitest run --project ui --maxWorkers=1` (1,283 passed)
- `npm run typecheck`
- `npx eslint src/components/assistant-ui/markdown-text.tsx src/components/assistant-ui/markdown-checkbox.test.tsx`
- `npm run build`
