### PR TITLE
fix(cli): keep borderless table rows out of the streaming spinner preview

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6653,8 +6653,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if (
             self._stream_buf
             and not self._in_stream_table
-            and not self._stream_buf.lstrip().startswith("|")
             and len(self._stream_buf) >= 80
+            and not looks_like_table_row(self._stream_buf)
         ):
             preview = self._stream_buf[-int(_STREAM_PARTIAL_PREVIEW_LEN):]
             cut = preview.find(" ")

--- a/tests/cli/test_stream_partial_line_flush.py
+++ b/tests/cli/test_stream_partial_line_flush.py
@@ -99,6 +99,21 @@ class TestLogicalLineStreaming:
         assert "cell19" not in plain
         assert cli._spinner_text == ""
 
+    def test_borderless_table_row_not_previewed_in_spinner(self, cli_stub):
+        cli, emitted = cli_stub
+        # Same invariant as above for a row WITHOUT a leading pipe. Models
+        # frequently omit it, and the rest of _emit_stream_text already treats
+        # a borderless `>= 2`-pipe row as a table via looks_like_table_row.
+        # The spinner-preview guard tested only for a leading pipe, so an
+        # in-flight borderless row leaked a half-row of pipe-separated cells
+        # into the status line instead of staying silent until its newline.
+        row = " | ".join(f"cell{i}" for i in range(20))  # no leading pipe
+        assert len(row) >= 80, "row must cross the preview threshold"
+        cli._stream_delta(row)  # no newline
+        plain = _strip_ansi("\n".join(emitted))
+        assert "cell19" not in plain
+        assert cli._spinner_text == "", "borderless row leaked into the spinner"
+
     def test_newline_lines_still_emit_normally(self, cli_stub):
         cli, emitted = cli_stub
         cli._stream_delta("line one\nline two\n")


### PR DESCRIPTION
> **Rebased onto current `main` (2026-07-29).** The original version of this PR
> targeted the partial-line **force-flush** from #59389. That force-flush was
> since removed by `64beb25a3` ("stop hard-wrapping streamed paragraphs"), which
> replaced it with the spinner-tail preview — but carried the narrow leading-pipe
> guard over verbatim. The inconsistency this PR fixes survived the rewrite; the
> description, the fix and the test below are re-stated against `main` as it is
> today.

## What does this PR do?

`_emit_stream_text` mirrors an in-flight line's tail into the status-bar spinner
so the user sees tokens arriving before the first newline lands. It deliberately
exempts table rows, so a half-built row never flashes in the status line — but
the exemption only recognises rows with a **leading pipe**
(`self._stream_buf.lstrip().startswith("|")`).

Everywhere else in the same method — the newline handler (`cli.py:6625`/`6631`)
and the end-of-stream flush (`cli.py:6692`) — uses `looks_like_table_row()`,
which deliberately also accepts **borderless** rows (`>= 2` pipes, no leading
pipe). Its docstring states exactly why: the permissiveness exists *"so models
that omit the leading pipe don't slip past us"*.

Because the preview guard is narrower than the rest of the method, a borderless
row (`Col1 | Col2 | … | ColN`) that crosses the 80-char preview threshold before
its trailing newline arrives slips past and leaks a half-row of pipe-separated
cells into the spinner:

```
… | cell14 | cell15 | cell16 | cell17 | cell18 | cell19
```

LLMs very commonly emit markdown tables without a leading pipe, so this is a
common input. Upstream already treats "table rows must not be previewed in the
spinner" as an invariant worth a dedicated test
(`test_table_rows_not_previewed_in_spinner`); this PR extends that invariant to
the borderless rows the repo's own predicate already recognises.

## Related Issue

None — code-originated inconsistency. Follow-up to the guard introduced in
#59389 (`0800af0b8`) and carried forward by `64beb25a3`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` (spinner-preview guard, ~line 6653): replace the narrow leading-pipe
  test with the module's real predicate `looks_like_table_row(self._stream_buf)`,
  matching the newline path and the flush path. `looks_like_table_row` is already
  in scope (thin re-export at `cli.py:196`); no new import.
- Same hunk: move the cheap `len(self._stream_buf) >= 80` check **ahead** of the
  predicate, so the lazy-import wrapper is not invoked on every stream delta.
  Both operands are pure, so ordering is semantically neutral.
- `tests/cli/test_stream_partial_line_flush.py`: add
  `test_borderless_table_row_not_previewed_in_spinner`, mirroring the existing
  leading-pipe `test_table_rows_not_previewed_in_spinner` with a borderless row.

Single-site fix: `grep -rn 'lstrip().startswith("|")' --include='*.py'` returns
this one guard and nothing else, so there is no sibling site to widen to.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/cli/test_stream_partial_line_flush.py -v` — 9 passed.
2. Regression guard (verified in both directions on this rebase):
   - With the test in place and the prod hunk reverted to `main`, the new test
     **fails**:
     `AssertionError: borderless row leaked into the spinner` /
     `assert '… | cell14 | … | cell19' == ''`.
   - With the one-line fix applied it **passes** — the borderless row stays as
     quiet as a leading-pipe row.
3. Adjacent coverage green on the rebased branch: `test_stream_partial_line_flush.py`,
   `test_cli_markdown_rendering.py`, `test_stream_delta_think_tag.py`,
   `tests/agent/test_markdown_tables.py`, `test_cli_status_bar.py` — **97 passed**.
4. Pipe-free prose is unaffected (no pipes → `looks_like_table_row` False →
   preview still runs), so the TTFT behaviour of #59389 is preserved;
   `test_partial_tail_mirrored_into_spinner` still passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the touched-area suites (see How to Test); did not run the whole suite locally -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
