### PR TITLE
fix(telegram): instrument getUpdates request via subclass re-tag, not slotted attr (#64482)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1969,34 +1969,62 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_conflict_count = 0
         self._send_path_degraded = False
 
+    def _observe_polling_request_result(self, request, generation, result):
+        """Record getUpdates progress from an observed do_request result.
+
+        Purely observational: PTB still parses the untouched payload and owns
+        any resulting exception. Kept as its own method so the observation
+        logic is shared and independently testable.
+        """
+        status_code, payload = result
+        if generation is None or not (200 <= status_code < 300):
+            return
+        try:
+            # Use the request's own parser so health observation agrees
+            # exactly with PTB's authoritative response handling (e.g.
+            # UTF-8 replacement decoding and BOM rejection).
+            envelope = request.parse_json_payload(payload)
+        except Exception:
+            return
+        if (
+            isinstance(envelope, dict)
+            and envelope.get("ok") is True
+            and "result" in envelope
+        ):
+            self._record_polling_progress(generation)
+
     def _instrument_polling_request(self, request):
-        """Wrap one dedicated PTB getUpdates request with progress tracking."""
-        do_request = request.do_request
+        """Instrument one dedicated PTB getUpdates request with progress tracking.
 
-        async def _do_request(*args, **kwargs):
-            generation = _POLLING_GENERATION_CONTEXT.get()
-            result = await do_request(*args, **kwargs)
-            status_code, payload = result
-            if generation is not None and 200 <= status_code < 300:
-                try:
-                    # Use the request's own parser so health observation agrees
-                    # exactly with PTB's authoritative response handling (e.g.
-                    # UTF-8 replacement decoding and BOM rejection).
-                    envelope = request.parse_json_payload(payload)
-                except Exception:
-                    # Instrumentation is observational: PTB still parses the
-                    # untouched payload and owns the resulting exception.
-                    pass
-                else:
-                    if (
-                        isinstance(envelope, dict)
-                        and envelope.get("ok") is True
-                        and "result" in envelope
-                    ):
-                        self._record_polling_progress(generation)
-            return result
+        PTB's request classes (``BaseRequest`` / ``HTTPXRequest``) use
+        ``__slots__``. On Python 3.13 their instances no longer carry a
+        ``__dict__`` (the ``AbstractAsyncContextManager`` MRO stopped yielding
+        one), so ``request.do_request = wrapper`` raises
+        ``AttributeError: 'HTTPXRequest' object attribute 'do_request' is
+        read-only`` and the whole Telegram connect fails (#64482). It only
+        appeared to work on Python 3.12, where those instances still had a
+        ``__dict__``.
 
-        request.do_request = _do_request
+        Instead of monkey-patching the instance, re-tag it to a thin subclass
+        that overrides ``do_request``. This is portable across Python versions
+        and works for both the real request and the test doubles. The subclass
+        declares ``__slots__ = ()`` so its instance layout stays identical to
+        the base, which is what makes the ``__class__`` swap legal on a slotted
+        instance.
+        """
+        adapter = self
+        base_cls = type(request)
+
+        class _InstrumentedPollingRequest(base_cls):
+            __slots__ = ()
+
+            async def do_request(self, *args, **kwargs):
+                generation = _POLLING_GENERATION_CONTEXT.get()
+                result = await super().do_request(*args, **kwargs)
+                adapter._observe_polling_request_result(self, generation, result)
+                return result
+
+        request.__class__ = _InstrumentedPollingRequest
         return request
 
     async def _start_polling_once(

--- a/tests/test_telegram_polling_progress_ptb.py
+++ b/tests/test_telegram_polling_progress_ptb.py
@@ -92,6 +92,34 @@ class _EnvelopeRequest(BaseRequest):
         return 200, self.payload
 
 
+class _SlottedEnvelopeRequest(BaseRequest):
+    """A getUpdates request with no instance ``__dict__``.
+
+    Reproduces PTB's real HTTPXRequest shape on Python 3.13, where every
+    class in the MRO defines ``__slots__`` and instances therefore reject an
+    instance-attribute ``do_request`` monkey-patch as "read-only" (#64482).
+    ``__slots__`` names the payload so the double needs no ``__dict__``.
+    """
+
+    __slots__ = ("_payload",)
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    @property
+    def read_timeout(self):
+        return 10
+
+    async def initialize(self):
+        return None
+
+    async def shutdown(self):
+        return None
+
+    async def do_request(self, url, method, request_data=None, **_kwargs):
+        return 200, self._payload
+
+
 async def _cancel_task(task):
     if task is None or task.done():
         return
@@ -214,6 +242,43 @@ async def test_real_base_request_valid_success_envelope_records_progress():
 
     try:
         result = await request.post(
+            "https://api.telegram.org/bot-token/getUpdates"
+        )
+    finally:
+        tg_adapter._POLLING_GENERATION_CONTEXT.reset(context_token)
+
+    assert result == []
+    assert progress.is_set()
+    assert adapter._polling_network_error_count == 0
+    assert adapter._polling_conflict_count == 0
+    assert adapter._send_path_degraded is False
+
+
+@pytest.mark.asyncio
+async def test_slotted_request_instrumented_without_read_only_error():
+    """Instrumenting a __slots__ request must not raise, and must still record.
+
+    Regression for #64482: PTB's HTTPXRequest carries no instance ``__dict__``
+    on Python 3.13, so the old ``request.do_request = wrapper`` monkey-patch
+    raised ``AttributeError: ... 'do_request' is read-only`` and broke every
+    Telegram connect. The subclass re-tag must instrument such an instance and
+    still observe getUpdates progress.
+    """
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="123456:test-token"))
+    generation, progress = adapter._begin_polling_generation()
+    adapter._polling_network_error_count = 4
+    adapter._polling_conflict_count = 3
+
+    request = _SlottedEnvelopeRequest(b'{"ok":true,"result":[]}')
+    # Guard the premise: the slotted instance rejects the old monkey-patch,
+    # exactly as PTB's HTTPXRequest does on Python 3.13.
+    with pytest.raises(AttributeError, match="read-only"):
+        request.do_request = lambda *a, **k: None
+
+    instrumented = adapter._instrument_polling_request(request)
+    context_token = tg_adapter._POLLING_GENERATION_CONTEXT.set(generation)
+    try:
+        result = await instrumented.post(
             "https://api.telegram.org/bot-token/getUpdates"
         )
     finally:


### PR DESCRIPTION
## Summary

Fixes #64482 — Telegram fails to connect on the latest image with
`ERROR ... [Telegram] Failed to connect to Telegram: 'HTTPXRequest' object attribute 'do_request' is read-only`.

The getUpdates polling-progress instrumentation added in `b8295cf6f`
("fix(telegram): gate polling health on getUpdates progress") monkey-patches
the request instance: `request.do_request = wrapper` in
`_instrument_polling_request()`.

PTB's `HTTPXRequest`/`BaseRequest` use `__slots__`. On **Python 3.13** (which
the Docker image ships — `uv:...python3.13-trixie`) those instances no longer
carry an instance `__dict__` (the `AbstractAsyncContextManager` MRO stopped
yielding one), so assigning `request.do_request` raises
`AttributeError: 'HTTPXRequest' object attribute 'do_request' is read-only`
and every Telegram connect attempt fails in a retry loop. It only *appeared*
to work on Python 3.12, where the instance still had a `__dict__` — which is
also why the existing tests (using `BaseRequest` doubles that carry a
`__dict__`) stayed green while the real path broke.

### Fix

Instead of mutating the instance, re-tag it to a thin `__slots__ = ()`
subclass that overrides `do_request`. Declaring `__slots__ = ()` keeps the
instance layout identical to the base, which makes the `__class__` swap legal
on a slotted instance. This is portable across Python 3.12/3.13 and works for
both the real request and the test doubles. The progress-observation logic is
factored into `_observe_polling_request_result()` and its semantics
(generation gating, `parse_json_payload` reuse, `ok`/`result` checks) are
unchanged.

## Test plan

- [x] New regression test `test_slotted_request_instrumented_without_read_only_error`
      uses a `__slots__` request double (no instance `__dict__`, mirroring PTB's
      3.13 shape). It asserts the old monkey-patch is rejected as read-only and
      that `_instrument_polling_request` re-tags the class and still records
      progress. **Fails on pre-fix `main` with the exact reported AttributeError;
      passes with the fix.**
- [x] `scripts/run_tests.sh tests/test_telegram_polling_progress_ptb.py tests/gateway/test_telegram_polling_progress.py` → 30 passed on Python 3.13.