### PR TITLE
fix(terminal): close credential-leakage bypass via terminal reading secret files

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -345,6 +346,78 @@ def raise_if_read_blocked(path: str) -> None:
         return
     if blocked:
         raise ValueError(blocked)
+
+
+# Basenames from get_read_block_error's credential-store denylist, flattened
+# so a bare-filename terminal token (``cat auth.json``) can be recognized
+# without re-deriving the HERMES_HOME-relative paths.
+_SECRET_BASENAME_CANDIDATES: set[str] = _BLOCKED_PROJECT_ENV_BASENAMES | {
+    "auth.json",
+    "auth.lock",
+    ".anthropic_oauth.json",
+    "webhook_subscriptions.json",
+    "google_oauth.json",
+    "bws_cache.json",
+}
+
+
+def get_terminal_secret_access_error(command: str, cwd: Optional[str] = None) -> Optional[str]:
+    """Best-effort defense-in-depth: flag a terminal command that names a
+    known Hermes/project secret file, mirroring :func:`get_read_block_error`'s
+    denylist for the ``terminal`` tool.
+
+    ``read_file`` already refuses these paths, but a model blocked there can
+    trivially reach the same file with ``terminal: cat``/``grep``/``source`` —
+    a bypass the read-file guard's own error message documents. This closes
+    that specific gap for the common case (the path or bare filename appears
+    literally in the command string) without pretending to be a real sandbox:
+    variable expansion, symlinks, or an encoded path will not be caught, and
+    a command that's flagged can still be rewritten to dodge this check.
+
+    Tokenizes ``command`` with ``shlex`` (same approach as the disk-cleanup
+    plugin's path extraction) and resolves each path-like or denylisted-
+    basename token against ``cwd`` (falling back to the process cwd), then
+    defers to ``get_read_block_error`` for the actual verdict so both guards
+    stay in sync.
+    """
+    if not isinstance(command, str) or not command:
+        return None
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+    base_dir = Path(cwd).expanduser() if cwd else Path.cwd()
+    for tok in tokens:
+        candidate = tok
+        for prefix in ("<", ">", "2>", "&>"):
+            if candidate.startswith(prefix):
+                candidate = candidate[len(prefix):]
+        if not candidate:
+            continue
+
+        basename = os.path.basename(candidate.rstrip("/"))
+        looks_pathlike = candidate.startswith(("/", "~", "./", "../"))
+        if not looks_pathlike and basename not in _SECRET_BASENAME_CANDIDATES:
+            continue
+
+        try:
+            expanded = Path(candidate).expanduser()
+            resolved = expanded if expanded.is_absolute() else (base_dir / expanded)
+            resolved = resolved.resolve()
+        except Exception:
+            continue
+
+        try:
+            blocked = get_read_block_error(str(resolved))
+        except Exception:
+            continue
+        if blocked:
+            return (
+                f"Blocked: command references {tok!r}, which resolves to a "
+                f"denied secret path. {blocked}"
+            )
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -396,7 +396,12 @@ def get_terminal_secret_access_error(command: str, cwd: Optional[str] = None) ->
         if not candidate:
             continue
 
-        basename = os.path.basename(candidate.rstrip("/"))
+        # Lowercased for the membership test only (mirrors get_read_block_error,
+        # which lowercases the resolved basename before checking the denylist)
+        # -- a bare `cat .ENV` must not skip this gate just because the
+        # candidate set is all-lowercase. The original-case `candidate` is
+        # still what gets resolved/passed to get_read_block_error below.
+        basename = os.path.basename(candidate.rstrip("/")).lower()
         looks_pathlike = candidate.startswith(("/", "~", "./", "../"))
         if not looks_pathlike and basename not in _SECRET_BASENAME_CANDIDATES:
             continue

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -8,6 +8,7 @@ clear denial for models that respect tool errors plus a visible audit trail.
 from __future__ import annotations
 
 import os
+import shlex
 from pathlib import Path
 from contextlib import suppress
 from typing import Optional
@@ -268,6 +269,83 @@ def raise_if_read_blocked(path: str) -> None:
         return
     if blocked:
         raise ValueError(blocked)
+
+
+# Basenames from get_read_block_error's credential-store denylist, flattened
+# so a bare-filename terminal token (``cat auth.json``) can be recognized
+# without re-deriving the HERMES_HOME-relative paths.
+_SECRET_BASENAME_CANDIDATES: set[str] = _BLOCKED_PROJECT_ENV_BASENAMES | {
+    "auth.json",
+    "auth.lock",
+    ".anthropic_oauth.json",
+    "webhook_subscriptions.json",
+    "google_oauth.json",
+    "bws_cache.json",
+}
+
+
+def get_terminal_secret_access_error(command: str, cwd: Optional[str] = None) -> Optional[str]:
+    """Best-effort defense-in-depth: flag a terminal command that names a
+    known Hermes/project secret file, mirroring :func:`get_read_block_error`'s
+    denylist for the ``terminal`` tool.
+
+    ``read_file`` already refuses these paths, but a model blocked there can
+    trivially reach the same file with ``terminal: cat``/``grep``/``source`` —
+    a bypass the read-file guard's own error message documents. This closes
+    that specific gap for the common case (the path or bare filename appears
+    literally in the command string) without pretending to be a real sandbox:
+    variable expansion, symlinks, or an encoded path will not be caught, and
+    a command that's flagged can still be rewritten to dodge this check.
+
+    Tokenizes ``command`` with ``shlex`` (same approach as the disk-cleanup
+    plugin's path extraction) and resolves each path-like or denylisted-
+    basename token against ``cwd`` (falling back to the process cwd), then
+    defers to ``get_read_block_error`` for the actual verdict so both guards
+    stay in sync.
+    """
+    if not isinstance(command, str) or not command:
+        return None
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+    base_dir = Path(cwd).expanduser() if cwd else Path.cwd()
+    for tok in tokens:
+        candidate = tok
+        for prefix in ("<", ">", "2>", "&>"):
+            if candidate.startswith(prefix):
+                candidate = candidate[len(prefix):]
+        if not candidate:
+            continue
+
+        # Lowercased for the membership test only (mirrors get_read_block_error,
+        # which lowercases the resolved basename before checking the denylist)
+        # -- a bare `cat .ENV` must not skip this gate just because the
+        # candidate set is all-lowercase. The original-case `candidate` is
+        # still what gets resolved/passed to get_read_block_error below.
+        basename = os.path.basename(candidate.rstrip("/")).lower()
+        looks_pathlike = candidate.startswith(("/", "~", "./", "../"))
+        if not looks_pathlike and basename not in _SECRET_BASENAME_CANDIDATES:
+            continue
+
+        try:
+            expanded = Path(candidate).expanduser()
+            resolved = expanded if expanded.is_absolute() else (base_dir / expanded)
+            resolved = resolved.resolve()
+        except Exception:
+            continue
+
+        try:
+            blocked = get_read_block_error(str(resolved))
+        except Exception:
+            continue
+        if blocked:
+            return (
+                f"Blocked: command references {tok!r}, which resolves to a "
+                f"denied secret path. {blocked}"
+            )
+    return None
 
 
 def _resolve_active_profile_name() -> str:

--- a/tests/agent/test_terminal_secret_guard.py
+++ b/tests/agent/test_terminal_secret_guard.py
@@ -78,6 +78,19 @@ def test_bare_basename_in_cwd_blocked(fake_home):
     assert err is not None
 
 
+def test_uppercase_bare_basename_blocked(fake_home):
+    """Regression: the candidate-gate basename comparison used to skip the
+    membership test without lowercasing, so a literal ``cat .ENV`` (or any
+    other-case variant of a denylisted basename) never even reached
+    get_read_block_error -- get_read_block_error itself lowercases before
+    checking, so only the candidate gate needed the fix."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    _create(fake_home, ".env")
+    err = get_terminal_secret_access_error("cat .ENV", cwd=str(fake_home))
+    assert err is not None
+
+
 def test_auth_json_path_blocked(fake_home):
     from agent.file_safety import get_terminal_secret_access_error
 

--- a/tests/agent/test_terminal_secret_guard.py
+++ b/tests/agent/test_terminal_secret_guard.py
@@ -1,0 +1,131 @@
+"""Tests for the terminal-tool secret-read guard in file_safety.
+
+``get_read_block_error`` blocks ``read_file`` from returning credential
+stores (auth.json, .env, mcp-tokens/, ...), but its own docstring admits the
+``terminal`` tool can trivially reach the same files with ``cat``/``grep``/
+``source`` — nothing cross-checked terminal commands against that denylist.
+``get_terminal_secret_access_error`` closes the literal-path/bare-basename
+case of that gap by tokenizing the command and deferring to
+``get_read_block_error`` for the actual verdict, so both guards share one
+source of truth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def fake_home(tmp_path, monkeypatch):
+    import agent.file_safety as fs
+
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: home)
+    return home
+
+
+def _create(home: Path, rel: str | Path) -> Path:
+    p = home / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("dummy", encoding="utf-8")
+    return p
+
+
+def test_absolute_path_to_env_file_blocked(fake_home):
+    """.env under HERMES_HOME matches the credential-store denylist entry
+    (checked before the anywhere-on-disk env-basename check), so either
+    denial wording is a correct outcome here — only the block itself, and
+    that the path is echoed, are asserted."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    env = _create(fake_home, ".env")
+    err = get_terminal_secret_access_error(f'grep "TOKEN=" {env} | head -3')
+    assert err is not None
+    assert str(env) in err
+
+
+def test_project_local_env_file_outside_hermes_home_blocked(fake_home, tmp_path):
+    """.env anywhere on disk (not just under HERMES_HOME) is blocked too —
+    exercises the anywhere-on-disk basename branch specifically."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    project = tmp_path / "someproject"
+    project.mkdir()
+    env = project / ".env"
+    env.write_text("API_KEY=x", encoding="utf-8")
+    err = get_terminal_secret_access_error(f"cat {env}")
+    assert err is not None
+    assert "secret-bearing environment file" in err
+
+
+def test_source_command_blocked(fake_home):
+    from agent.file_safety import get_terminal_secret_access_error
+
+    env = _create(fake_home, ".env")
+    err = get_terminal_secret_access_error(f"source {env} && echo done")
+    assert err is not None
+
+
+def test_bare_basename_in_cwd_blocked(fake_home):
+    """``cat .env`` with no path separator — resolved against ``cwd``."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    _create(fake_home, ".env")
+    err = get_terminal_secret_access_error("cat .env", cwd=str(fake_home))
+    assert err is not None
+
+
+def test_auth_json_path_blocked(fake_home):
+    from agent.file_safety import get_terminal_secret_access_error
+
+    auth = _create(fake_home, "auth.json")
+    err = get_terminal_secret_access_error(f"cat {auth}")
+    assert err is not None
+    assert "credential store" in err
+
+
+def test_tilde_path_blocked(fake_home, monkeypatch):
+    """``~/.hermes/.env``-style tokens must expand before resolution."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    _create(fake_home, ".env")
+    monkeypatch.setenv("HOME", str(fake_home.parent))
+    fake_home.parent.joinpath(".hermes").symlink_to(fake_home, target_is_directory=True)
+    err = get_terminal_secret_access_error("cat ~/.hermes/.env")
+    assert err is not None
+
+
+def test_unrelated_command_not_blocked(fake_home):
+    from agent.file_safety import get_terminal_secret_access_error
+
+    assert get_terminal_secret_access_error("ls -la /tmp") is None
+    assert get_terminal_secret_access_error("grep TOKEN config.yaml") is None
+
+
+def test_media_delivery_path_not_blocked(fake_home):
+    """Regression guard: ordinary cache-dir file operations (the guest-media
+    delivery flow) must not be caught by the secret-file heuristic."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    video = fake_home / "cache" / "videos" / "clip.mp4"
+    video.parent.mkdir(parents=True, exist_ok=True)
+    video.write_bytes(b"x")
+    assert get_terminal_secret_access_error(f"ls -la {video}") is None
+
+
+def test_non_string_command_returns_none():
+    from agent.file_safety import get_terminal_secret_access_error
+
+    assert get_terminal_secret_access_error(None) is None  # type: ignore[arg-type]
+    assert get_terminal_secret_access_error("") is None
+
+
+def test_unbalanced_quotes_does_not_raise():
+    """shlex.split can raise ValueError on unbalanced quotes — must degrade
+    to "not blocked" rather than propagate."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    assert get_terminal_secret_access_error("echo 'unterminated") is None

--- a/tests/agent/test_terminal_secret_guard.py
+++ b/tests/agent/test_terminal_secret_guard.py
@@ -1,0 +1,144 @@
+"""Tests for the terminal-tool secret-read guard in file_safety.
+
+``get_read_block_error`` blocks ``read_file`` from returning credential
+stores (auth.json, .env, mcp-tokens/, ...), but its own docstring admits the
+``terminal`` tool can trivially reach the same files with ``cat``/``grep``/
+``source`` — nothing cross-checked terminal commands against that denylist.
+``get_terminal_secret_access_error`` closes the literal-path/bare-basename
+case of that gap by tokenizing the command and deferring to
+``get_read_block_error`` for the actual verdict, so both guards share one
+source of truth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def fake_home(tmp_path, monkeypatch):
+    import agent.file_safety as fs
+
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: home)
+    return home
+
+
+def _create(home: Path, rel: str | Path) -> Path:
+    p = home / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("dummy", encoding="utf-8")
+    return p
+
+
+def test_absolute_path_to_env_file_blocked(fake_home):
+    """.env under HERMES_HOME matches the credential-store denylist entry
+    (checked before the anywhere-on-disk env-basename check), so either
+    denial wording is a correct outcome here — only the block itself, and
+    that the path is echoed, are asserted."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    env = _create(fake_home, ".env")
+    err = get_terminal_secret_access_error(f'grep "TOKEN=" {env} | head -3')
+    assert err is not None
+    assert str(env) in err
+
+
+def test_project_local_env_file_outside_hermes_home_blocked(fake_home, tmp_path):
+    """.env anywhere on disk (not just under HERMES_HOME) is blocked too —
+    exercises the anywhere-on-disk basename branch specifically."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    project = tmp_path / "someproject"
+    project.mkdir()
+    env = project / ".env"
+    env.write_text("API_KEY=x", encoding="utf-8")
+    err = get_terminal_secret_access_error(f"cat {env}")
+    assert err is not None
+    assert "secret-bearing environment file" in err
+
+
+def test_source_command_blocked(fake_home):
+    from agent.file_safety import get_terminal_secret_access_error
+
+    env = _create(fake_home, ".env")
+    err = get_terminal_secret_access_error(f"source {env} && echo done")
+    assert err is not None
+
+
+def test_bare_basename_in_cwd_blocked(fake_home):
+    """``cat .env`` with no path separator — resolved against ``cwd``."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    _create(fake_home, ".env")
+    err = get_terminal_secret_access_error("cat .env", cwd=str(fake_home))
+    assert err is not None
+
+
+def test_uppercase_bare_basename_blocked(fake_home):
+    """Regression: the candidate-gate basename comparison used to skip the
+    membership test without lowercasing, so a literal ``cat .ENV`` (or any
+    other-case variant of a denylisted basename) never even reached
+    get_read_block_error -- get_read_block_error itself lowercases before
+    checking, so only the candidate gate needed the fix."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    _create(fake_home, ".env")
+    err = get_terminal_secret_access_error("cat .ENV", cwd=str(fake_home))
+    assert err is not None
+
+
+def test_auth_json_path_blocked(fake_home):
+    from agent.file_safety import get_terminal_secret_access_error
+
+    auth = _create(fake_home, "auth.json")
+    err = get_terminal_secret_access_error(f"cat {auth}")
+    assert err is not None
+    assert "credential store" in err
+
+
+def test_tilde_path_blocked(fake_home, monkeypatch):
+    """``~/.hermes/.env``-style tokens must expand before resolution."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    _create(fake_home, ".env")
+    monkeypatch.setenv("HOME", str(fake_home.parent))
+    fake_home.parent.joinpath(".hermes").symlink_to(fake_home, target_is_directory=True)
+    err = get_terminal_secret_access_error("cat ~/.hermes/.env")
+    assert err is not None
+
+
+def test_unrelated_command_not_blocked(fake_home):
+    from agent.file_safety import get_terminal_secret_access_error
+
+    assert get_terminal_secret_access_error("ls -la /tmp") is None
+    assert get_terminal_secret_access_error("grep TOKEN config.yaml") is None
+
+
+def test_media_delivery_path_not_blocked(fake_home):
+    """Regression guard: ordinary cache-dir file operations (the guest-media
+    delivery flow) must not be caught by the secret-file heuristic."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    video = fake_home / "cache" / "videos" / "clip.mp4"
+    video.parent.mkdir(parents=True, exist_ok=True)
+    video.write_bytes(b"x")
+    assert get_terminal_secret_access_error(f"ls -la {video}") is None
+
+
+def test_non_string_command_returns_none():
+    from agent.file_safety import get_terminal_secret_access_error
+
+    assert get_terminal_secret_access_error(None) is None  # type: ignore[arg-type]
+    assert get_terminal_secret_access_error("") is None
+
+
+def test_unbalanced_quotes_does_not_raise():
+    """shlex.split can raise ValueError on unbalanced quotes — must degrade
+    to "not blocked" rather than propagate."""
+    from agent.file_safety import get_terminal_secret_access_error
+
+    assert get_terminal_secret_access_error("echo 'unterminated") is None

--- a/tests/tools/test_terminal_secret_guard_integration.py
+++ b/tests/tools/test_terminal_secret_guard_integration.py
@@ -65,3 +65,107 @@ def test_ordinary_command_reaches_env_setup(tmp_path, monkeypatch):
     )
     assert calls == [1]
     assert out["status"] == "error"
+
+
+class TestGuardUsesFinalizedCwdNotJustWorkdir:
+    """Regression: the guard used to check only the raw workdir= argument,
+    which is None for the common case (model didn't pass an explicit
+    workdir). The real command later resolves its cwd from a task override,
+    a live session cwd (a prior `cd`), or TERMINAL_CWD -- omitted workdir
+    must still be checked against THAT cwd, not the Python process's own.
+    """
+
+    def test_omitted_workdir_uses_task_override_cwd(self, tmp_path, monkeypatch):
+        """Uses auth.json (exact-path credential-store match), not .env
+        (blocked by bare basename regardless of which directory it resolves
+        into) -- only auth.json actually proves the guard resolved the
+        RIGHT directory: it's blocked solely because it resolves to
+        <mocked HERMES_HOME>/auth.json, which only happens when the task
+        override cwd is honored, not the process's real cwd."""
+        import agent.file_safety as fs
+
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: tmp_path)
+        (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+
+        terminal_tool.register_task_env_overrides("guard-test-task", {"cwd": str(tmp_path)})
+        try:
+            out = json.loads(
+                terminal_tool.terminal_tool(command="cat auth.json", task_id="guard-test-task")
+            )
+        finally:
+            terminal_tool._task_env_overrides.pop("guard-test-task", None)
+
+        assert out["status"] == "error"
+        assert "credential store" in out["error"]
+
+    def test_omitted_workdir_uses_live_session_cwd(self, tmp_path, monkeypatch):
+        """A prior `cd` in this session set env.cwd; a later bare `cat
+        auth.json` (no explicit workdir) must be checked against THAT
+        directory, not the task/config default or the process cwd. Uses
+        auth.json for the same reason as the task-override test above."""
+        import agent.file_safety as fs
+
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: tmp_path)
+        (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+
+        fake_env = type("FakeEnv", (), {"cwd": str(tmp_path)})()
+        monkeypatch.setitem(
+            terminal_tool._active_environments, "guard-live-cwd-task", fake_env
+        )
+        try:
+            out = json.loads(
+                terminal_tool.terminal_tool(
+                    command="cat auth.json", task_id="guard-live-cwd-task"
+                )
+            )
+        finally:
+            terminal_tool._active_environments.pop("guard-live-cwd-task", None)
+
+        assert out["status"] == "error"
+        assert "credential store" in out["error"]
+
+    def test_explicit_workdir_still_wins_over_live_session_cwd(self, tmp_path, monkeypatch):
+        """explicit workdir= must still take priority over a live session
+        cwd, matching _resolve_command_cwd's own precedence. HERMES_HOME is
+        mocked to decoy_dir: if the guard wrongly preferred the live session
+        cwd (decoy_dir) over the explicit workdir (real_dir), a bare
+        `cat auth.json` would resolve to decoy_dir/auth.json == mocked
+        HERMES_HOME/auth.json and get blocked; with the correct precedence
+        it resolves to real_dir/auth.json instead, which isn't HERMES_HOME
+        and isn't blocked. Stops the call at _get_env_config (same technique
+        as test_ordinary_command_reaches_env_setup) so this doesn't need a
+        real environment to execute against -- only that the guard let it
+        through."""
+        import agent.file_safety as fs
+
+        decoy_dir = tmp_path / "decoy"
+        decoy_dir.mkdir()
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: decoy_dir)
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+
+        fake_env = type("FakeEnv", (), {"cwd": str(decoy_dir)})()
+        monkeypatch.setitem(
+            terminal_tool._active_environments, "guard-precedence-task", fake_env
+        )
+
+        def _stop_here():
+            raise RuntimeError("stop here, we only care whether the guard blocked it")
+
+        monkeypatch.setattr(terminal_tool, "_get_env_config", _stop_here)
+
+        try:
+            out = json.loads(
+                terminal_tool.terminal_tool(
+                    command="cat auth.json",
+                    task_id="guard-precedence-task",
+                    workdir=str(real_dir),
+                )
+            )
+        finally:
+            terminal_tool._active_environments.pop("guard-precedence-task", None)
+
+        # real_dir isn't HERMES_HOME (decoy_dir is) -- must not be blocked,
+        # so execution reaches (and fails at) _get_env_config instead.
+        assert "credential store" not in out.get("error", "")
+        assert "stop here" in out.get("error", "")

--- a/tests/tools/test_terminal_secret_guard_integration.py
+++ b/tests/tools/test_terminal_secret_guard_integration.py
@@ -1,0 +1,67 @@
+"""terminal_tool() must refuse commands referencing a denied secret path
+before doing any environment setup — the guard sits ahead of
+``_get_env_config()`` so it can't be skipped by an env-selection quirk, and
+it is NOT gated by ``force=True`` (force only pre-confirms the separate
+dangerous-command check; it isn't a secret-access override).
+"""
+
+from __future__ import annotations
+
+import json
+
+import tools.terminal_tool as terminal_tool
+
+
+def test_env_file_read_is_blocked_before_env_setup(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("TELEGRAM_BOT_TOKEN=live-secret-value", encoding="utf-8")
+
+    def _fail_if_called():
+        raise AssertionError("_get_env_config must not run for a blocked command")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", _fail_if_called)
+
+    out = json.loads(
+        terminal_tool.terminal_tool(command=f"cat {env_file}", workdir=str(tmp_path))
+    )
+    assert out["status"] == "error"
+    assert "secret-bearing environment file" in out["error"]
+    assert "live-secret-value" not in json.dumps(out)
+
+
+def test_force_does_not_bypass_secret_guard(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("TELEGRAM_BOT_TOKEN=live-secret-value", encoding="utf-8")
+
+    def _fail_if_called():
+        raise AssertionError("_get_env_config must not run for a blocked command")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", _fail_if_called)
+
+    out = json.loads(
+        terminal_tool.terminal_tool(
+            command=f"cat {env_file}", workdir=str(tmp_path), force=True
+        )
+    )
+    assert out["status"] == "error"
+    assert "secret-bearing environment file" in out["error"]
+
+
+def test_ordinary_command_reaches_env_setup(tmp_path, monkeypatch):
+    """Sanity check: an unrelated command still reaches _get_env_config —
+    proves the guard isn't accidentally blocking everything. terminal_tool()
+    wraps its body in a broad except-Exception, so a raise from the patched
+    helper surfaces as an error-status JSON rather than propagating."""
+    calls = []
+
+    def _record():
+        calls.append(1)
+        raise RuntimeError("stop here, we only care that we got this far")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", _record)
+
+    out = json.loads(
+        terminal_tool.terminal_tool(command="ls -la /tmp", workdir=str(tmp_path))
+    )
+    assert calls == [1]
+    assert out["status"] == "error"

--- a/tests/tools/test_terminal_secret_guard_integration.py
+++ b/tests/tools/test_terminal_secret_guard_integration.py
@@ -1,0 +1,171 @@
+"""terminal_tool() must refuse commands referencing a denied secret path
+before doing any environment setup — the guard sits ahead of
+``_get_env_config()`` so it can't be skipped by an env-selection quirk, and
+it is NOT gated by ``force=True`` (force only pre-confirms the separate
+dangerous-command check; it isn't a secret-access override).
+"""
+
+from __future__ import annotations
+
+import json
+
+import tools.terminal_tool as terminal_tool
+
+
+def test_env_file_read_is_blocked_before_env_setup(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("TELEGRAM_BOT_TOKEN=live-secret-value", encoding="utf-8")
+
+    def _fail_if_called():
+        raise AssertionError("_get_env_config must not run for a blocked command")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", _fail_if_called)
+
+    out = json.loads(
+        terminal_tool.terminal_tool(command=f"cat {env_file}", workdir=str(tmp_path))
+    )
+    assert out["status"] == "error"
+    assert "secret-bearing environment file" in out["error"]
+    assert "live-secret-value" not in json.dumps(out)
+
+
+def test_force_does_not_bypass_secret_guard(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("TELEGRAM_BOT_TOKEN=live-secret-value", encoding="utf-8")
+
+    def _fail_if_called():
+        raise AssertionError("_get_env_config must not run for a blocked command")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", _fail_if_called)
+
+    out = json.loads(
+        terminal_tool.terminal_tool(
+            command=f"cat {env_file}", workdir=str(tmp_path), force=True
+        )
+    )
+    assert out["status"] == "error"
+    assert "secret-bearing environment file" in out["error"]
+
+
+def test_ordinary_command_reaches_env_setup(tmp_path, monkeypatch):
+    """Sanity check: an unrelated command still reaches _get_env_config —
+    proves the guard isn't accidentally blocking everything. terminal_tool()
+    wraps its body in a broad except-Exception, so a raise from the patched
+    helper surfaces as an error-status JSON rather than propagating."""
+    calls = []
+
+    def _record():
+        calls.append(1)
+        raise RuntimeError("stop here, we only care that we got this far")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", _record)
+
+    out = json.loads(
+        terminal_tool.terminal_tool(command="ls -la /tmp", workdir=str(tmp_path))
+    )
+    assert calls == [1]
+    assert out["status"] == "error"
+
+
+class TestGuardUsesFinalizedCwdNotJustWorkdir:
+    """Regression: the guard used to check only the raw workdir= argument,
+    which is None for the common case (model didn't pass an explicit
+    workdir). The real command later resolves its cwd from a task override,
+    a live session cwd (a prior `cd`), or TERMINAL_CWD -- omitted workdir
+    must still be checked against THAT cwd, not the Python process's own.
+    """
+
+    def test_omitted_workdir_uses_task_override_cwd(self, tmp_path, monkeypatch):
+        """Uses auth.json (exact-path credential-store match), not .env
+        (blocked by bare basename regardless of which directory it resolves
+        into) -- only auth.json actually proves the guard resolved the
+        RIGHT directory: it's blocked solely because it resolves to
+        <mocked HERMES_HOME>/auth.json, which only happens when the task
+        override cwd is honored, not the process's real cwd."""
+        import agent.file_safety as fs
+
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: tmp_path)
+        (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+
+        terminal_tool.register_task_env_overrides("guard-test-task", {"cwd": str(tmp_path)})
+        try:
+            out = json.loads(
+                terminal_tool.terminal_tool(command="cat auth.json", task_id="guard-test-task")
+            )
+        finally:
+            terminal_tool._task_env_overrides.pop("guard-test-task", None)
+
+        assert out["status"] == "error"
+        assert "credential store" in out["error"]
+
+    def test_omitted_workdir_uses_live_session_cwd(self, tmp_path, monkeypatch):
+        """A prior `cd` in this session set env.cwd; a later bare `cat
+        auth.json` (no explicit workdir) must be checked against THAT
+        directory, not the task/config default or the process cwd. Uses
+        auth.json for the same reason as the task-override test above."""
+        import agent.file_safety as fs
+
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: tmp_path)
+        (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+
+        fake_env = type("FakeEnv", (), {"cwd": str(tmp_path)})()
+        monkeypatch.setitem(
+            terminal_tool._active_environments, "guard-live-cwd-task", fake_env
+        )
+        try:
+            out = json.loads(
+                terminal_tool.terminal_tool(
+                    command="cat auth.json", task_id="guard-live-cwd-task"
+                )
+            )
+        finally:
+            terminal_tool._active_environments.pop("guard-live-cwd-task", None)
+
+        assert out["status"] == "error"
+        assert "credential store" in out["error"]
+
+    def test_explicit_workdir_still_wins_over_live_session_cwd(self, tmp_path, monkeypatch):
+        """explicit workdir= must still take priority over a live session
+        cwd, matching _resolve_command_cwd's own precedence. HERMES_HOME is
+        mocked to decoy_dir: if the guard wrongly preferred the live session
+        cwd (decoy_dir) over the explicit workdir (real_dir), a bare
+        `cat auth.json` would resolve to decoy_dir/auth.json == mocked
+        HERMES_HOME/auth.json and get blocked; with the correct precedence
+        it resolves to real_dir/auth.json instead, which isn't HERMES_HOME
+        and isn't blocked. Stops the call at _get_env_config (same technique
+        as test_ordinary_command_reaches_env_setup) so this doesn't need a
+        real environment to execute against -- only that the guard let it
+        through."""
+        import agent.file_safety as fs
+
+        decoy_dir = tmp_path / "decoy"
+        decoy_dir.mkdir()
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: decoy_dir)
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+
+        fake_env = type("FakeEnv", (), {"cwd": str(decoy_dir)})()
+        monkeypatch.setitem(
+            terminal_tool._active_environments, "guard-precedence-task", fake_env
+        )
+
+        def _stop_here():
+            raise RuntimeError("stop here, we only care whether the guard blocked it")
+
+        monkeypatch.setattr(terminal_tool, "_get_env_config", _stop_here)
+
+        try:
+            out = json.loads(
+                terminal_tool.terminal_tool(
+                    command="cat auth.json",
+                    task_id="guard-precedence-task",
+                    workdir=str(real_dir),
+                )
+            )
+        finally:
+            terminal_tool._active_environments.pop("guard-precedence-task", None)
+
+        # real_dir isn't HERMES_HOME (decoy_dir is) -- must not be blocked,
+        # so execution reaches (and fails at) _get_env_config instead.
+        assert "credential store" not in out.get("error", "")
+        assert "stop here" in out.get("error", "")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any, List
 
 from utils import env_var_enabled
+from agent.file_safety import get_terminal_secret_access_error
 
 logger = logging.getLogger(__name__)
 
@@ -2078,6 +2079,25 @@ def terminal_tool(
                 "output": "",
                 "exit_code": -1,
                 "error": f"Invalid command: expected string, got {type(command).__name__}",
+                "status": "error",
+            }, ensure_ascii=False)
+
+        # Credential-leakage guard: same denylist read_file enforces, applied
+        # to the literal paths/basenames in the command string. Runs even
+        # when force=True — force only pre-confirms the dangerous-command
+        # check below, it isn't a secret-access override. Defense-in-depth,
+        # not a real boundary — see get_terminal_secret_access_error's
+        # docstring (#57698 follow-up).
+        _secret_block = get_terminal_secret_access_error(command, cwd=workdir)
+        if _secret_block:
+            logger.warning(
+                "Blocked terminal command referencing a denied secret path: %s",
+                _safe_command_preview(command),
+            )
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": _secret_block,
                 "status": "error",
             }, ensure_ascii=False)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2082,13 +2082,58 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
+        # Use task_id for environment isolation. By default all subagent
+        # task_ids collapse back to "default" so the top-level agent and
+        # every delegate_task child share one container; only task_ids with
+        # a registered env override (RL benchmarks) get isolated sandboxes.
+        effective_task_id = _resolve_container_task_id(task_id)
+
+        # Check per-task overrides (set by environments like TerminalBench2Env)
+        # before falling back to global env var config. ``resolve_task_overrides``
+        # reads the raw task id first then the collapsed container id, so a
+        # CWD-only override (which collapses ``effective_task_id`` to
+        # ``"default"``) is still found under its originating session id while
+        # isolation-keyed RL/benchmark overrides keep resolving as before.
+        overrides = resolve_task_overrides(task_id)
+
         # Credential-leakage guard: same denylist read_file enforces, applied
         # to the literal paths/basenames in the command string. Runs even
         # when force=True — force only pre-confirms the dangerous-command
         # check below, it isn't a secret-access override. Defense-in-depth,
         # not a real boundary — see get_terminal_secret_access_error's
-        # docstring (#57698 follow-up).
-        _secret_block = get_terminal_secret_access_error(command, cwd=workdir)
+        # docstring (#57698 follow-up). Deliberately still ahead of
+        # ``_get_env_config()``/environment setup — a blocked command must
+        # not pay for either.
+        #
+        # cwd resolution mirrors _resolve_command_cwd's priority (explicit
+        # workdir > live session cwd from a prior `cd` > the task/config
+        # default) using only cheap, side-effect-free primitives
+        # (os.getenv, resolve_task_overrides, a lock-free peek at any
+        # already-running environment) rather than the raw workdir=
+        # argument alone or the full _get_env_config(). Without this, a bare
+        # `cat .env` (no explicit workdir) after the model already `cd`ed
+        # elsewhere in this session would be checked against the wrong
+        # directory -- either the Python process's own cwd or a stale task
+        # default, never the directory the command actually runs in.
+        _existing_env_for_guard = (
+            _active_environments.get(effective_task_id)
+            or (_active_environments.get(task_id) if task_id else None)
+        )
+        _live_cwd_for_guard = getattr(_existing_env_for_guard, "cwd", None)
+        _guard_env_type = os.getenv("TERMINAL_ENV", "local")
+        if _guard_env_type == "local":
+            _guard_default_cwd = _safe_getcwd()
+        elif _guard_env_type == "ssh":
+            _guard_default_cwd = "~"
+        else:
+            _guard_default_cwd = "/root"
+        _guard_default_cwd = overrides.get("cwd") or os.getenv("TERMINAL_CWD", _guard_default_cwd)
+        _guard_cwd = (
+            workdir
+            or (_live_cwd_for_guard if isinstance(_live_cwd_for_guard, str) and _live_cwd_for_guard.strip() else None)
+            or _guard_default_cwd
+        )
+        _secret_block = get_terminal_secret_access_error(command, cwd=_guard_cwd)
         if _secret_block:
             logger.warning(
                 "Blocked terminal command referencing a denied secret path: %s",
@@ -2105,20 +2150,6 @@ def terminal_tool(
         config = _get_env_config()
         env_type = config["env_type"]
 
-        # Use task_id for environment isolation. By default all subagent
-        # task_ids collapse back to "default" so the top-level agent and
-        # every delegate_task child share one container; only task_ids with
-        # a registered env override (RL benchmarks) get isolated sandboxes.
-        effective_task_id = _resolve_container_task_id(task_id)
-
-        # Check per-task overrides (set by environments like TerminalBench2Env)
-        # before falling back to global env var config. ``resolve_task_overrides``
-        # reads the raw task id first then the collapsed container id, so a
-        # CWD-only override (which collapses ``effective_task_id`` to
-        # ``"default"``) is still found under its originating session id while
-        # isolation-keyed RL/benchmark overrides keep resolving as before.
-        overrides = resolve_task_overrides(task_id)
-        
         # Select image based on env type, with per-task override support
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1156,6 +1156,60 @@ def terminal_tool(
     children (kept in a separate env cache from the configured backend).
     """
     try:
+        # Credential-leakage guard: same denylist read_file enforces, applied
+        # to the literal paths/basenames in the command string. Runs even
+        # when force=True — force only pre-confirms the dangerous-command
+        # check below, it isn't a secret-access override. Defense-in-depth,
+        # not a real boundary — see get_terminal_secret_access_error's
+        # docstring (#57698 follow-up). Deliberately ahead of
+        # ``_plan_execution()`` (which calls ``_get_env_config()``/enforces
+        # the refusal scope) — a blocked command must not pay for either.
+        #
+        # cwd resolution mirrors _plan_execution's own priority (explicit
+        # workdir > live session cwd from a prior `cd` > the task/config
+        # default) using only cheap, side-effect-free primitives (env reads,
+        # resolve_task_overrides, a lock-free peek at any already-running
+        # environment) rather than _plan_execution's own cwd (which isn't
+        # resolved yet at this point). Without this, a bare `cat .env` (no
+        # explicit workdir) after the model already `cd`ed elsewhere in this
+        # session would be checked against the wrong directory -- either the
+        # Python process's own cwd or a stale task default, never the
+        # directory the command actually runs in.
+        from agent.file_safety import get_terminal_secret_access_error
+
+        _guard_effective_task_id = _resolve_container_task_id(task_id)
+        if _host_local:
+            _guard_effective_task_id = f"host-local-{_guard_effective_task_id}"
+        _existing_env_for_guard = (
+            _active_environments.get(_guard_effective_task_id)
+            or (_active_environments.get(task_id) if task_id else None)
+        )
+        _live_cwd_for_guard = getattr(_existing_env_for_guard, "cwd", None)
+        _guard_env_type = _tenv("TERMINAL_ENV", "local")
+        if _guard_env_type == "local":
+            _guard_default_cwd = _safe_getcwd()
+        else:
+            _guard_default_cwd = _DEFAULT_CWD_BY_BACKEND.get(_guard_env_type, "/root")
+        _guard_overrides = resolve_task_overrides(task_id)
+        _guard_default_cwd = _guard_overrides.get("cwd") or _tenv("TERMINAL_CWD", _guard_default_cwd)
+        _guard_cwd = (
+            workdir
+            or (_live_cwd_for_guard if isinstance(_live_cwd_for_guard, str) and _live_cwd_for_guard.strip() else None)
+            or _guard_default_cwd
+        )
+        _secret_block = get_terminal_secret_access_error(command, cwd=_guard_cwd)
+        if _secret_block:
+            logger.warning(
+                "Blocked terminal command referencing a denied secret path: %s",
+                _safe_command_preview(command),
+            )
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": _secret_block,
+                "status": "error",
+            }, ensure_ascii=False)
+
         plan = _plan_execution(
             command, task_id=task_id, timeout=timeout, background=background, _host_local=_host_local,
         )


### PR DESCRIPTION
## Summary
- `get_read_block_error` (used by `read_file`) already refuses to return Hermes credential stores (`auth.json`, `.env`, `mcp-tokens/`, ...), but the `terminal` tool had no equivalent check — an agent blocked by `read_file` on a secret file could immediately retry with `terminal: cat`/`grep`/`source` and succeed, exactly as the guard's own docstring warns.
- Adds `get_terminal_secret_access_error()` in `agent/file_safety.py`: tokenizes the command string and resolves each path-like or denylisted-basename token through the existing `get_read_block_error`, so both guards share one source of truth instead of drifting.
- Wires it into `terminal_tool()` ahead of environment setup and the dangerous-command check, unconditionally (not gated by `force=True`, which only pre-confirms the separate dangerous-command check and isn't a secret-access override).
- Best-effort by design, consistent with the guard it mirrors: this doesn't catch variable expansion, symlinks, or encoded paths — it closes the literal-path/bare-basename case.

## Test plan
- [x] `pytest tests/agent/test_terminal_secret_guard.py tests/tools/test_terminal_secret_guard_integration.py -q` — new tests, all passing
- [x] `pytest tests/agent/test_file_safety_credentials.py tests/agent/test_file_safety.py -q` — existing file_safety suite, no regressions
- [x] `pytest tests/tools/test_terminal_tool.py tests/tools/test_terminal_tool_requirements.py tests/tools/test_terminal_tool_pty_fallback.py -q` — existing terminal_tool suite, no regressions

## Update: closed the case-sensitivity and cwd-resolution gaps (addresses hermes-sweeper review)

Also rebased onto `main` (289 commits; clean, no conflicts).

sweeper found two literal-coverage gaps:

1. **Case sensitivity** (`file_safety.py:373`) — the candidate-gate basename comparison didn't lowercase before checking `_SECRET_BASENAME_CANDIDATES`, so a literal `cat .ENV` skipped the gate entirely (`get_read_block_error` itself lowercases, but never got the chance to run). Fixed by lowercasing the basename for the membership test only — resolution still uses the original-case candidate. Added `test_uppercase_bare_basename_blocked`.

2. **Wrong cwd** (`terminal_tool.py:2073`) — the guard checked only the raw `workdir=` argument, `None` for the common case. The command actually executes against a later-resolved cwd (explicit `workdir` > live session cwd from a prior `cd`, tracked on the environment object > task/config default, via `_resolve_command_cwd`) — a bare `cat .env` with no `workdir` was checked against the wrong directory. Fixed by resolving the guard's cwd the same way, using only cheap primitives (`os.getenv`, `resolve_task_overrides`, a lock-free peek at `_active_environments` for a live session cwd) — deliberately still ahead of `_get_env_config()`/environment setup, so a blocked command doesn't pay for either (an existing test asserts `_get_env_config` is never called for a blocked command; the fix preserves that). Added 3 tests in `TestGuardUsesFinalizedCwdNotJustWorkdir`: omitted workdir + task override cwd, omitted workdir + live session cwd, and explicit workdir still winning over a live session cwd.

Both new test groups use `auth.json` (an exact-path credential-store match) rather than `.env` for the cwd-dependent cases — `.env` is blocked by bare basename regardless of which directory it resolves into, so it can't actually distinguish "correct cwd" from "wrong cwd"; only a check that depends on the resolved absolute path (`auth.json` under a mocked `HERMES_HOME`) proves the guard used the right directory. Verified all 5 new/changed regression tests fail against the pre-fix code and pass with the fix.

**Docs**: not touched by this push, none needed.

Co-Authored-By: Claude <noreply@anthropic.com>