### PR TITLE
fix(tools): support explicit kanban profile opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -974,9 +974,12 @@ Current toolset keys: `browser`, `clarify`, `code_execution`, `cronjob`,
 `messaging`, `moa`, `rl`, `safe`, `search`, `session_search`, `skills`,
 `spotify`, `terminal`, `todo`, `tts`, `video`, `vision`, `web`, `yuanbao`.
 
-Enable/disable per platform via `hermes tools` (the curses UI) or the
-`tools.<platform>.enabled` / `tools.<platform>.disabled` lists in
-`config.yaml`.
+Enable/disable configurable toolsets per platform via `hermes tools`; the
+selection is stored under `platform_toolsets.<platform>` in `config.yaml`.
+Profile-gated toolsets intentionally omitted from the curses checklist use the
+explicit non-interactive command instead. For example,
+`hermes tools enable kanban --platform slack` keeps Kanban's top-level runtime
+gate and Slack platform selection in sync.
 
 ---
 

--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -17,6 +17,7 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
         description=(
             "Enable, disable, or list tools for CLI, Telegram, Discord, etc.\n\n"
             "Built-in toolsets use plain names (e.g. web, memory).\n"
+            "Profile-gated toolsets (e.g. kanban) are explicit opt-ins.\n"
             "MCP tools use server:tool notation (e.g. github:create_issue).\n\n"
             "Run 'hermes tools' with no subcommand for the interactive configuration UI."
         ),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -85,6 +85,14 @@ CONFIGURABLE_TOOLSETS = [
     ("computer_use",     "🖱️  Computer Use (macOS/Windows/Linux)", "background desktop control via cua-driver"),
 ]
 
+# Toolsets that intentionally stay out of the interactive checklist but can be
+# enabled explicitly through ``hermes tools enable``. Their runtime check_fn
+# reads the profile-level ``toolsets`` list, while normal session filtering is
+# platform-scoped, so the non-interactive command keeps both layers in sync.
+_PROFILE_GATED_TOOLSETS = {
+    "kanban": ("📋 Kanban Orchestration", "durable multi-agent task routing"),
+}
+
 
 def gui_toolset_label(label: str) -> str:
     """Strip leading emoji/icons from toolset titles for GUI surfaces.
@@ -4378,6 +4386,42 @@ def _configure_mcp_tools_interactive(config: dict):
 
 def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
     """Add or remove built-in toolsets for a platform."""
+    profile_gated = set(toolset_names) & set(_PROFILE_GATED_TOOLSETS)
+    if profile_gated:
+        # The Kanban registry gate is profile-scoped (``toolsets``), while the
+        # model's requested tool definitions are platform-scoped
+        # (``platform_toolsets``). Keep the two explicit opt-ins atomic so a
+        # supported CLI command cannot produce the platform-only false positive
+        # that leaves native Kanban tools absent at runtime.
+        profile_toolsets = config.get("toolsets")
+        if isinstance(profile_toolsets, list):
+            profile_toolsets = [str(ts) for ts in profile_toolsets]
+        elif action == "enable":
+            profile_toolsets = []
+        else:
+            profile_toolsets = None
+
+        if profile_toolsets is not None:
+            if action == "disable":
+                profile_toolsets = [ts for ts in profile_toolsets if ts not in profile_gated]
+            else:
+                for ts in toolset_names:
+                    if ts in profile_gated and ts not in profile_toolsets:
+                        profile_toolsets.append(ts)
+            config["toolsets"] = profile_toolsets
+
+        if action == "disable":
+            # _save_platform_tools preserves non-configurable entries by
+            # design. Remove an explicitly disabled profile-gated entry before
+            # saving so it is not immediately restored from the old list.
+            platform_toolsets = config.get("platform_toolsets")
+            if isinstance(platform_toolsets, dict):
+                existing = platform_toolsets.get(platform)
+                if isinstance(existing, list):
+                    platform_toolsets[platform] = [
+                        ts for ts in existing if str(ts) not in profile_gated
+                    ]
+
     enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
     if action == "disable":
         updated = enabled - set(toolset_names)
@@ -4411,7 +4455,12 @@ def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]
     return failed_servers
 
 
-def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
+def _print_tools_list(
+    enabled_toolsets: set,
+    mcp_servers: dict,
+    platform: str = "cli",
+    profile_toolsets: Optional[Set[str]] = None,
+):
     """Print a summary of enabled/disabled toolsets and MCP tool filters."""
     effective_all = _get_effective_configurable_toolsets()
     effective = [
@@ -4437,6 +4486,20 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
             status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
                       else color("✗ disabled", Colors.RED))
             print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+
+    print()
+    print("Profile-gated toolsets:")
+    configured_profile_toolsets = profile_toolsets or set()
+    for ts_key, (label, _) in _PROFILE_GATED_TOOLSETS.items():
+        platform_enabled = ts_key in enabled_toolsets
+        profile_enabled = ts_key in configured_profile_toolsets
+        if platform_enabled and profile_enabled:
+            status = color("✓ enabled", Colors.GREEN)
+        elif platform_enabled:
+            status = color("✗ disabled (profile opt-in missing)", Colors.RED)
+        else:
+            status = color("✗ disabled", Colors.RED)
+        print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
 
     if mcp_servers:
         print()
@@ -4468,15 +4531,25 @@ def tools_disable_enable_command(args):
         return
 
     if action == "list":
+        raw_profile_toolsets = config.get("toolsets")
+        profile_toolsets = (
+            {str(ts) for ts in raw_profile_toolsets}
+            if isinstance(raw_profile_toolsets, list)
+            else set()
+        )
         _print_tools_list(_get_platform_tools(config, platform, include_default_mcp_servers=False),
-                          config.get("mcp_servers") or {}, platform)
+                          config.get("mcp_servers") or {}, platform, profile_toolsets)
         return
 
     targets: List[str] = args.names
     toolset_targets = [t for t in targets if ":" not in t]
     mcp_targets = [t for t in targets if ":" in t]
 
-    valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS} | _get_plugin_toolset_keys()
+    valid_toolsets = (
+        {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+        | _get_plugin_toolset_keys()
+        | set(_PROFILE_GATED_TOOLSETS)
+    )
     unknown_toolsets = [t for t in toolset_targets if t not in valid_toolsets]
     if unknown_toolsets:
         for name in unknown_toolsets:

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -60,6 +60,64 @@ class TestToolsEnableBuiltin:
         assert saved["platform_toolsets"]["cli"].count("web") == 1
 
 
+# ── Profile-gated toolsets ─────────────────────────────────────────────────
+
+
+class TestToolsProfileGated:
+
+    def test_enable_kanban_sets_profile_and_platform_opt_ins(self):
+        config = {
+            "toolsets": ["hermes-cli"],
+            "platform_toolsets": {"slack": ["web"]},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["kanban"], platform="slack")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["toolsets"] == ["hermes-cli", "kanban"]
+        assert "kanban" in saved["platform_toolsets"]["slack"]
+
+    def test_enable_kanban_is_idempotent(self):
+        config = {
+            "toolsets": ["kanban"],
+            "platform_toolsets": {"slack": ["web", "kanban"]},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["kanban"], platform="slack")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["toolsets"].count("kanban") == 1
+        assert saved["platform_toolsets"]["slack"].count("kanban") == 1
+
+    def test_disable_kanban_clears_profile_and_platform_opt_ins(self):
+        config = {
+            "toolsets": ["hermes-cli", "kanban"],
+            "platform_toolsets": {"slack": ["web", "kanban"]},
+        }
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["kanban"], platform="slack")
+            )
+        saved = mock_save.call_args[0][0]
+        assert saved["toolsets"] == ["hermes-cli"]
+        assert "kanban" not in saved["platform_toolsets"]["slack"]
+
+    def test_list_reports_missing_profile_opt_in(self, capsys):
+        config = {"platform_toolsets": {"slack": ["web", "kanban"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config):
+            tools_disable_enable_command(
+                Namespace(tools_action="list", platform="slack")
+            )
+        out = capsys.readouterr().out
+        assert "kanban" in out
+        assert "profile opt-in missing" in out
+
+
 # ── MCP tool disable ────────────────────────────────────────────────────────
 
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -29,16 +29,24 @@ hermes chat --toolsets all              # everything
 ### Per-platform (config.yaml)
 
 ```yaml
-toolsets:
-  - hermes-cli          # default for CLI
-  # - hermes-telegram   # override for Telegram gateway
+platform_toolsets:
+  cli:
+    - hermes-cli
+  telegram:
+    - hermes-telegram
 ```
 
 ### Interactive management
 
 ```bash
 hermes tools                            # curses UI to enable/disable per platform
+hermes tools enable kanban --platform slack  # explicit profile-gated opt-in
 ```
+
+Kanban intentionally stays out of the interactive picker and the `all`
+toolset. Its explicit command updates both the profile-level runtime gate and
+the selected platform, preventing a platform-only configuration that looks
+enabled but omits the native `kanban_*` tools at runtime.
 
 Or in-session:
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -629,6 +629,19 @@ The GUI is deliberately thin. Everything the plugin does is reachable from the C
 
 This is the surface **you** (or scripts, cron, the dashboard) use to drive the board. Workers running inside the dispatcher use the `kanban_*` [tool surface](#how-workers-interact-with-the-board) for the same operations — the CLI here and the tools there both route through `kanban_db`, so the two surfaces agree by construction.
 
+To let an orchestrator profile call the native `kanban_*` tools, explicitly
+enable the profile-gated toolset for the platform it serves:
+
+```bash
+hermes tools enable kanban --platform slack
+```
+
+The command updates both the profile-level runtime gate and the platform's
+toolset selection. Kanban intentionally stays out of the interactive tool
+picker and the `all` toolset, so normal sessions retain zero Kanban schema
+footprint. Start a fresh agent session after changing the setting. Disable the
+same opt-in with `hermes tools disable kanban --platform slack`.
+
 ```
 hermes kanban init                                     # create kanban.db + print daemon hint
 hermes kanban create "<title>" [--body ...] [--assignee <profile>]


### PR DESCRIPTION
## What does this PR do?

Makes the existing explicit Kanban opt-in deterministic through the canonical tools CLI.

Kanban intentionally stays out of the interactive picker and `all`, but `hermes tools enable kanban` previously rejected it even though the runtime gate requires top-level `toolsets: [kanban]`. The command now recognizes profile-gated toolsets, atomically syncs the profile runtime gate with the selected platform, and exposes the gate state in `hermes tools list`.

This preserves the zero-schema default for normal sessions and avoids the platform-only false positive where Kanban appears configured but native `kanban_*` tools are absent.

## Related Issue

Fixes #64494

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Teach the non-interactive tools command to accept profile-gated `kanban` without adding it to the interactive checklist.
- Keep top-level `toolsets` and `platform_toolsets.<platform>` synchronized on enable/disable.
- Show profile-gated toolsets and missing profile opt-ins in `hermes tools list`.
- Add enable, disable, idempotency, and partial-config regression tests.
- Document the canonical Kanban opt-in and correct stale per-platform config guidance.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_tools_disable_enable.py -q`
2. `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py -q -k kanban`
3. `scripts/run_tests.sh tests/hermes_cli/test_subcommands_followup.py tests/cli/test_cli_tools_command.py -q`
4. With a temporary `HERMES_HOME`, run `hermes tools enable kanban --platform slack`, confirm both config entries are present, and verify `kanban_create`, `kanban_list`, and `kanban_complete` pass runtime schema registration.
5. Run `hermes tools disable kanban --platform slack` and confirm both config entries are removed.

Focused result: 43 tests passed, Ruff passed, and both temporary-profile command/runtime smokes passed.

Environment note: running the entire `tests/hermes_cli/test_tools_config.py` file on this macOS host also reached 114 passing tests, with one unrelated existing failure in `test_computer_use_post_setup_missing_override_does_not_accept_default_binary` because `/Applications` is not writable and that test's mocked `curl` branch is skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — updated `AGENTS.md`
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — config-only Python path; no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, registration/configuration only

## Screenshots / Logs

```text
✓ Enabled: kanban
{'after_enable_profile': True, 'after_enable_slack': True}
{'runtime_gate': True, 'required': ['kanban_complete', 'kanban_create', 'kanban_list']}
✓ Disabled: kanban
{'after_disable_profile': False, 'after_disable_slack': False}
```
