### PR TITLE
fix(providers): support authoritative live catalog metadata

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -150,8 +150,8 @@ _MODEL_CACHE_TTL = 3600
 _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
-_profile_model_metadata_cache: Dict[tuple[str, str], list[dict[str, Any]]] = {}
-_profile_model_metadata_cache_time: Dict[tuple[str, str], float] = {}
+_profile_model_metadata_cache: Dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+_profile_model_metadata_cache_time: Dict[tuple[str, str, str], float] = {}
 _PROFILE_MODEL_METADATA_CACHE_TTL = 300
 # Bounded-lifetime cache: after the first successful probe we remember the
 # server type so subsequent refreshes skip the full waterfall (no more 404
@@ -1548,12 +1548,17 @@ def _resolve_profile_context_length(
 ) -> Optional[int]:
     """Resolve context length through a provider profile's catalog hook."""
     profile_name = str(getattr(profile, "name", "unknown"))
-    effective_base_url = (
-        base_url
-        or str(getattr(profile, "models_url", "") or "")
+    catalog_url = (
+        str(getattr(profile, "models_url", "") or "")
+        or base_url
         or str(getattr(profile, "base_url", "") or "")
     )
-    cache_key = (profile_name, effective_base_url.rstrip("/"))
+    credential_fingerprint = (
+        hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+        if api_key
+        else ""
+    )
+    cache_key = (profile_name, catalog_url.rstrip("/"), credential_fingerprint)
     now = time.time()
     cached = _profile_model_metadata_cache.get(cache_key)
     cached_at = _profile_model_metadata_cache_time.get(cache_key, 0)
@@ -1606,19 +1611,15 @@ def _resolve_profile_context_length(
         None,
     )
     if matched is None:
-        valid_entries = entries
-        if len(valid_entries) == 1:
-            matched = valid_entries[0]
-        else:
-            matched = next(
-                (
-                    entry
-                    for entry in valid_entries
-                    if isinstance(entry.get("id"), str)
-                    and (model in entry["id"] or entry["id"] in model)
-                ),
-                None,
-            )
+        matched = next(
+            (
+                entry
+                for entry in entries
+                if isinstance(entry.get("id"), str)
+                and (model in entry["id"] or entry["id"] in model)
+            ),
+            None,
+        )
     return _extract_context_length(matched) if matched else None
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1537,6 +1537,53 @@ def _resolve_endpoint_context_length(
     return None
 
 
+def _resolve_profile_context_length(
+    profile: Any,
+    model: str,
+    base_url: str,
+    api_key: str = "",
+) -> Optional[int]:
+    """Resolve context length through a provider profile's catalog hook."""
+    try:
+        entries = profile.fetch_model_metadata(
+            api_key=api_key,
+            base_url=base_url or None,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Provider %s live metadata lookup failed: %s",
+            getattr(profile, "name", "unknown"),
+            exc,
+        )
+        return None
+    if not entries:
+        return None
+
+    matched = next(
+        (
+            entry
+            for entry in entries
+            if isinstance(entry, dict) and entry.get("id") == model
+        ),
+        None,
+    )
+    if matched is None:
+        valid_entries = [entry for entry in entries if isinstance(entry, dict)]
+        if len(valid_entries) == 1:
+            matched = valid_entries[0]
+        else:
+            matched = next(
+                (
+                    entry
+                    for entry in valid_entries
+                    if isinstance(entry.get("id"), str)
+                    and (model in entry["id"] or entry["id"] in model)
+                ),
+                None,
+            )
+    return _extract_context_length(matched) if matched else None
+
+
 def _get_context_cache_path() -> Path:
     """Return path to the persistent context length cache file."""
     from hermes_constants import get_hermes_home
@@ -2928,9 +2975,10 @@ def get_model_context_length(
     0. Explicit config override (model.context_length or custom_providers per-model)
     0b. model_overrides config (per-provider+model context_window override)
     0c. Endpoint-scoped metadata for models validated on one multiplexed endpoint
-    1. Persistent cache (previously discovered via probing).  Nous URLs,
-       LM Studio, and Codex OAuth bypass the cache here so their provider
-       metadata can be reconciled against the authoritative live source.
+    1. Persistent cache (previously discovered via probing). Nous URLs,
+       LM Studio, Codex OAuth, and provider profiles that opt into live
+       metadata bypass the cache so their authoritative source can be
+       reconciled.
     1b. AWS Bedrock static table (must precede custom-endpoint probe)
     2. Active endpoint metadata (/models for explicit custom endpoints)
     3. Local server query (for local endpoints)
@@ -3063,13 +3111,39 @@ def get_model_context_length(
         and base_url_host_matches(base_url, "amazonaws.com")
     )
 
+    # Resolve the effective provider before cache lookup so out-of-tree profiles
+    # can opt into authoritative live metadata by provider name or endpoint URL.
+    effective_provider = provider
+    if not effective_provider or effective_provider in {"openrouter", "custom"}:
+        if base_url:
+            inferred = _infer_provider_from_url(base_url)
+            if inferred:
+                effective_provider = inferred
+
+    provider_profile = None
+    use_live_model_metadata = False
+    if effective_provider:
+        try:
+            from providers import get_provider_profile
+
+            provider_profile = get_provider_profile(effective_provider)
+            use_live_model_metadata = (
+                getattr(provider_profile, "use_live_model_metadata", False) is True
+            )
+        except Exception:
+            pass
+
     # 1. Check persistent cache (model+provider)
     # LM Studio is excluded — its loaded context length is transient (the
     # user can reload the model with a different context_length at any time
     # via /api/v1/models/load), so a stale cached value would mask reloads.
     # Codex OAuth is excluded because the authenticated /models catalogue is
     # account-specific and a fallback must never suppress later revalidation.
-    if base_url and not _skip_persistent_context_cache(base_url, provider):
+    if (
+        base_url
+        and not use_live_model_metadata
+        and not _skip_persistent_context_cache(base_url, provider)
+    ):
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
             # Reject non-positive cached values — a 0 or negative value
@@ -3204,12 +3278,27 @@ def get_model_context_length(
                 save_context_length(model, base_url, ctx)
             return ctx
 
-    # 2. Active endpoint metadata for truly custom/unknown endpoints.
+    # 2. Active endpoint metadata for truly custom/unknown endpoints and
+    # provider profiles that explicitly declare their /models response
+    # authoritative for provider-enforced context limits.
     # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their
     # /models endpoint may report a provider-imposed limit (e.g. Copilot
     # returns 128k) instead of the model's full context (400k).  models.dev
     # has the correct per-provider values and is checked at step 5+.
-    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
+    if use_live_model_metadata and provider_profile is not None:
+        context_length = _resolve_profile_context_length(
+            provider_profile,
+            model,
+            base_url,
+            api_key=api_key,
+        )
+        if context_length is not None:
+            return context_length
+
+    unknown_endpoint = (
+        _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url)
+    )
+    if base_url and unknown_endpoint and not use_live_model_metadata:
         context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if context_length is not None:
             return context_length
@@ -3280,13 +3369,8 @@ def get_model_context_length(
     # These are provider-specific and take priority over the generic OR cache,
     # since the same model can have different context limits per provider
     # (e.g. claude-opus-4.6 is 1M on Anthropic but 128K on GitHub Copilot).
-    # If provider is generic (openrouter/custom/empty), try to infer from URL.
-    effective_provider = provider
-    if not effective_provider or effective_provider in {"openrouter", "custom"}:
-        if base_url:
-            inferred = _infer_provider_from_url(base_url)
-            if inferred:
-                effective_provider = inferred
+    # If provider was generic (openrouter/custom/empty), it was inferred from
+    # the URL before cache resolution above.
 
     # 5a. Copilot live /models API — max_prompt_tokens from the user's account.
     # This catches account-specific models (e.g. claude-opus-4.6-1m) that

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -150,6 +150,9 @@ _MODEL_CACHE_TTL = 3600
 _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
+_profile_model_metadata_cache: Dict[tuple[str, str], list[dict[str, Any]]] = {}
+_profile_model_metadata_cache_time: Dict[tuple[str, str], float] = {}
+_PROFILE_MODEL_METADATA_CACHE_TTL = 300
 # Bounded-lifetime cache: after the first successful probe we remember the
 # server type so subsequent refreshes skip the full waterfall (no more 404
 # spam every 5 minutes on non-matching endpoints like /api/v1/models on vllm).
@@ -1544,18 +1547,53 @@ def _resolve_profile_context_length(
     api_key: str = "",
 ) -> Optional[int]:
     """Resolve context length through a provider profile's catalog hook."""
-    try:
-        entries = profile.fetch_model_metadata(
-            api_key=api_key,
-            base_url=base_url or None,
+    profile_name = str(getattr(profile, "name", "unknown"))
+    effective_base_url = (
+        base_url
+        or str(getattr(profile, "models_url", "") or "")
+        or str(getattr(profile, "base_url", "") or "")
+    )
+    cache_key = (profile_name, effective_base_url.rstrip("/"))
+    now = time.time()
+    cached = _profile_model_metadata_cache.get(cache_key)
+    cached_at = _profile_model_metadata_cache_time.get(cache_key, 0)
+    if cached is not None and (now - cached_at) < _PROFILE_MODEL_METADATA_CACHE_TTL:
+        entries = cached
+    else:
+        try:
+            fetched = profile.fetch_model_metadata(
+                api_key=api_key,
+                base_url=base_url or None,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Provider %s live metadata lookup failed: %s",
+                profile_name,
+                exc,
+            )
+            fetched = None
+
+        valid_fetched = (
+            [entry for entry in fetched if isinstance(entry, dict)]
+            if fetched
+            else []
         )
-    except Exception as exc:
-        logger.debug(
-            "Provider %s live metadata lookup failed: %s",
-            getattr(profile, "name", "unknown"),
-            exc,
-        )
-        return None
+        if valid_fetched:
+            entries = valid_fetched
+            _profile_model_metadata_cache[cache_key] = entries
+        elif cached:
+            logger.debug(
+                "Provider %s live metadata refresh failed; using stale in-memory catalog",
+                profile_name,
+            )
+            entries = cached
+        else:
+            entries = []
+            _profile_model_metadata_cache[cache_key] = entries
+        # Cache both successful and failed refreshes. This prevents an unavailable
+        # catalog from turning every context lookup into blocking remote I/O.
+        _profile_model_metadata_cache_time[cache_key] = now
+
     if not entries:
         return None
 
@@ -1568,7 +1606,7 @@ def _resolve_profile_context_length(
         None,
     )
     if matched is None:
-        valid_entries = [entry for entry in entries if isinstance(entry, dict)]
+        valid_entries = entries
         if len(valid_entries) == 1:
             matched = valid_entries[0]
         else:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1570,6 +1570,18 @@ def _resolve_profile_context_length(
                 api_key=api_key,
                 base_url=base_url or None,
             )
+            if fetched is not None and not isinstance(fetched, list):
+                logger.debug(
+                    "Provider %s live metadata returned unsupported type %s",
+                    profile_name,
+                    type(fetched).__name__,
+                )
+                fetched = None
+            valid_fetched = (
+                [entry for entry in fetched if isinstance(entry, dict)]
+                if fetched
+                else []
+            )
         except Exception as exc:
             logger.debug(
                 "Provider %s live metadata lookup failed: %s",
@@ -1577,12 +1589,7 @@ def _resolve_profile_context_length(
                 exc,
             )
             fetched = None
-
-        valid_fetched = (
-            [entry for entry in fetched if isinstance(entry, dict)]
-            if fetched
-            else []
-        )
+            valid_fetched = []
         if valid_fetched:
             entries = valid_fetched
             _profile_model_metadata_cache[cache_key] = entries

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1446,6 +1446,18 @@ def _resolve_profile_context_length(
                 api_key=api_key,
                 base_url=base_url or None,
             )
+            if fetched is not None and not isinstance(fetched, list):
+                logger.debug(
+                    "Provider %s live metadata returned unsupported type %s",
+                    profile_name,
+                    type(fetched).__name__,
+                )
+                fetched = None
+            valid_fetched = (
+                [entry for entry in fetched if isinstance(entry, dict)]
+                if fetched
+                else []
+            )
         except Exception as exc:
             logger.debug(
                 "Provider %s live metadata lookup failed: %s",
@@ -1453,12 +1465,7 @@ def _resolve_profile_context_length(
                 exc,
             )
             fetched = None
-
-        valid_fetched = (
-            [entry for entry in fetched if isinstance(entry, dict)]
-            if fetched
-            else []
-        )
+            valid_fetched = []
         if valid_fetched:
             entries = valid_fetched
             _profile_model_metadata_cache[cache_key] = entries

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -135,6 +135,9 @@ _MODEL_CACHE_TTL = 3600
 _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
+_profile_model_metadata_cache: Dict[tuple[str, str], list[dict[str, Any]]] = {}
+_profile_model_metadata_cache_time: Dict[tuple[str, str], float] = {}
+_PROFILE_MODEL_METADATA_CACHE_TTL = 300
 # Bounded-lifetime cache: after the first successful probe we remember the
 # server type so subsequent refreshes skip the full waterfall (no more 404
 # spam every 5 minutes on non-matching endpoints like /api/v1/models on vllm).
@@ -1420,18 +1423,53 @@ def _resolve_profile_context_length(
     api_key: str = "",
 ) -> Optional[int]:
     """Resolve context length through a provider profile's catalog hook."""
-    try:
-        entries = profile.fetch_model_metadata(
-            api_key=api_key,
-            base_url=base_url or None,
+    profile_name = str(getattr(profile, "name", "unknown"))
+    effective_base_url = (
+        base_url
+        or str(getattr(profile, "models_url", "") or "")
+        or str(getattr(profile, "base_url", "") or "")
+    )
+    cache_key = (profile_name, effective_base_url.rstrip("/"))
+    now = time.time()
+    cached = _profile_model_metadata_cache.get(cache_key)
+    cached_at = _profile_model_metadata_cache_time.get(cache_key, 0)
+    if cached is not None and (now - cached_at) < _PROFILE_MODEL_METADATA_CACHE_TTL:
+        entries = cached
+    else:
+        try:
+            fetched = profile.fetch_model_metadata(
+                api_key=api_key,
+                base_url=base_url or None,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Provider %s live metadata lookup failed: %s",
+                profile_name,
+                exc,
+            )
+            fetched = None
+
+        valid_fetched = (
+            [entry for entry in fetched if isinstance(entry, dict)]
+            if fetched
+            else []
         )
-    except Exception as exc:
-        logger.debug(
-            "Provider %s live metadata lookup failed: %s",
-            getattr(profile, "name", "unknown"),
-            exc,
-        )
-        return None
+        if valid_fetched:
+            entries = valid_fetched
+            _profile_model_metadata_cache[cache_key] = entries
+        elif cached:
+            logger.debug(
+                "Provider %s live metadata refresh failed; using stale in-memory catalog",
+                profile_name,
+            )
+            entries = cached
+        else:
+            entries = []
+            _profile_model_metadata_cache[cache_key] = entries
+        # Cache both successful and failed refreshes. This prevents an unavailable
+        # catalog from turning every context lookup into blocking remote I/O.
+        _profile_model_metadata_cache_time[cache_key] = now
+
     if not entries:
         return None
 
@@ -1444,7 +1482,7 @@ def _resolve_profile_context_length(
         None,
     )
     if matched is None:
-        valid_entries = [entry for entry in entries if isinstance(entry, dict)]
+        valid_entries = entries
         if len(valid_entries) == 1:
             matched = valid_entries[0]
         else:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1413,6 +1413,53 @@ def _resolve_endpoint_context_length(
     return None
 
 
+def _resolve_profile_context_length(
+    profile: Any,
+    model: str,
+    base_url: str,
+    api_key: str = "",
+) -> Optional[int]:
+    """Resolve context length through a provider profile's catalog hook."""
+    try:
+        entries = profile.fetch_model_metadata(
+            api_key=api_key,
+            base_url=base_url or None,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Provider %s live metadata lookup failed: %s",
+            getattr(profile, "name", "unknown"),
+            exc,
+        )
+        return None
+    if not entries:
+        return None
+
+    matched = next(
+        (
+            entry
+            for entry in entries
+            if isinstance(entry, dict) and entry.get("id") == model
+        ),
+        None,
+    )
+    if matched is None:
+        valid_entries = [entry for entry in entries if isinstance(entry, dict)]
+        if len(valid_entries) == 1:
+            matched = valid_entries[0]
+        else:
+            matched = next(
+                (
+                    entry
+                    for entry in valid_entries
+                    if isinstance(entry.get("id"), str)
+                    and (model in entry["id"] or entry["id"] in model)
+                ),
+                None,
+            )
+    return _extract_context_length(matched) if matched else None
+
+
 def _get_context_cache_path() -> Path:
     """Return path to the persistent context length cache file."""
     from hermes_constants import get_hermes_home
@@ -2468,9 +2515,10 @@ def get_model_context_length(
     Resolution order:
     0. Explicit config override (model.context_length or custom_providers per-model)
     0c. Endpoint-scoped metadata for models validated on one multiplexed endpoint
-    1. Persistent cache (previously discovered via probing).  Nous URLs,
-       LM Studio, and Codex OAuth bypass the cache here so their provider
-       metadata can be reconciled against the authoritative live source.
+    1. Persistent cache (previously discovered via probing). Nous URLs,
+       LM Studio, Codex OAuth, and provider profiles that opt into live
+       metadata bypass the cache so their authoritative source can be
+       reconciled.
     1b. AWS Bedrock static table (must precede custom-endpoint probe)
     2. Active endpoint metadata (/models for explicit custom endpoints)
     3. Local server query (for local endpoints)
@@ -2574,13 +2622,39 @@ def get_model_context_length(
         and base_url_host_matches(base_url, "amazonaws.com")
     )
 
+    # Resolve the effective provider before cache lookup so out-of-tree profiles
+    # can opt into authoritative live metadata by provider name or endpoint URL.
+    effective_provider = provider
+    if not effective_provider or effective_provider in {"openrouter", "custom"}:
+        if base_url:
+            inferred = _infer_provider_from_url(base_url)
+            if inferred:
+                effective_provider = inferred
+
+    provider_profile = None
+    use_live_model_metadata = False
+    if effective_provider:
+        try:
+            from providers import get_provider_profile
+
+            provider_profile = get_provider_profile(effective_provider)
+            use_live_model_metadata = (
+                getattr(provider_profile, "use_live_model_metadata", False) is True
+            )
+        except Exception:
+            pass
+
     # 1. Check persistent cache (model+provider)
     # LM Studio is excluded — its loaded context length is transient (the
     # user can reload the model with a different context_length at any time
     # via /api/v1/models/load), so a stale cached value would mask reloads.
     # Codex OAuth is excluded because the authenticated /models catalogue is
     # account-specific and a fallback must never suppress later revalidation.
-    if base_url and not _skip_persistent_context_cache(base_url, provider):
+    if (
+        base_url
+        and not use_live_model_metadata
+        and not _skip_persistent_context_cache(base_url, provider)
+    ):
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
             # Invalidate stale 32k cache entries for Kimi-family models.
@@ -2717,12 +2791,27 @@ def get_model_context_length(
                 save_context_length(model, base_url, ctx)
             return ctx
 
-    # 2. Active endpoint metadata for truly custom/unknown endpoints.
+    # 2. Active endpoint metadata for truly custom/unknown endpoints and
+    # provider profiles that explicitly declare their /models response
+    # authoritative for provider-enforced context limits.
     # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their
     # /models endpoint may report a provider-imposed limit (e.g. Copilot
     # returns 128k) instead of the model's full context (400k).  models.dev
     # has the correct per-provider values and is checked at step 5+.
-    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
+    if use_live_model_metadata and provider_profile is not None:
+        context_length = _resolve_profile_context_length(
+            provider_profile,
+            model,
+            base_url,
+            api_key=api_key,
+        )
+        if context_length is not None:
+            return context_length
+
+    unknown_endpoint = (
+        _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url)
+    )
+    if base_url and unknown_endpoint and not use_live_model_metadata:
         context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if context_length is not None:
             return context_length
@@ -2793,13 +2882,8 @@ def get_model_context_length(
     # These are provider-specific and take priority over the generic OR cache,
     # since the same model can have different context limits per provider
     # (e.g. claude-opus-4.6 is 1M on Anthropic but 128K on GitHub Copilot).
-    # If provider is generic (openrouter/custom/empty), try to infer from URL.
-    effective_provider = provider
-    if not effective_provider or effective_provider in {"openrouter", "custom"}:
-        if base_url:
-            inferred = _infer_provider_from_url(base_url)
-            if inferred:
-                effective_provider = inferred
+    # If provider was generic (openrouter/custom/empty), it was inferred from
+    # the URL before cache resolution above.
 
     # 5a. Copilot live /models API — max_prompt_tokens from the user's account.
     # This catches account-specific models (e.g. claude-opus-4.6-1m) that

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -135,8 +135,8 @@ _MODEL_CACHE_TTL = 3600
 _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
-_profile_model_metadata_cache: Dict[tuple[str, str], list[dict[str, Any]]] = {}
-_profile_model_metadata_cache_time: Dict[tuple[str, str], float] = {}
+_profile_model_metadata_cache: Dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+_profile_model_metadata_cache_time: Dict[tuple[str, str, str], float] = {}
 _PROFILE_MODEL_METADATA_CACHE_TTL = 300
 # Bounded-lifetime cache: after the first successful probe we remember the
 # server type so subsequent refreshes skip the full waterfall (no more 404
@@ -1424,12 +1424,17 @@ def _resolve_profile_context_length(
 ) -> Optional[int]:
     """Resolve context length through a provider profile's catalog hook."""
     profile_name = str(getattr(profile, "name", "unknown"))
-    effective_base_url = (
-        base_url
-        or str(getattr(profile, "models_url", "") or "")
+    catalog_url = (
+        str(getattr(profile, "models_url", "") or "")
+        or base_url
         or str(getattr(profile, "base_url", "") or "")
     )
-    cache_key = (profile_name, effective_base_url.rstrip("/"))
+    credential_fingerprint = (
+        hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+        if api_key
+        else ""
+    )
+    cache_key = (profile_name, catalog_url.rstrip("/"), credential_fingerprint)
     now = time.time()
     cached = _profile_model_metadata_cache.get(cache_key)
     cached_at = _profile_model_metadata_cache_time.get(cache_key, 0)
@@ -1482,19 +1487,15 @@ def _resolve_profile_context_length(
         None,
     )
     if matched is None:
-        valid_entries = entries
-        if len(valid_entries) == 1:
-            matched = valid_entries[0]
-        else:
-            matched = next(
-                (
-                    entry
-                    for entry in valid_entries
-                    if isinstance(entry.get("id"), str)
-                    and (model in entry["id"] or entry["id"] in model)
-                ),
-                None,
-            )
+        matched = next(
+            (
+                entry
+                for entry in entries
+                if isinstance(entry.get("id"), str)
+                and (model in entry["id"] or entry["id"] in model)
+            ),
+            None,
+        )
     return _extract_context_length(matched) if matched else None
 
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,11 @@ def _profile_user_agent() -> str:
 @dataclass
 class ProviderProfile:
     """Base provider profile — subclass or instantiate with overrides."""
+
+    # Opt in only when this provider's live /models response is authoritative
+    # for provider-enforced context limits. ClassVar preserves the constructor
+    # contract for existing profiles and out-of-tree plugins.
+    use_live_model_metadata: ClassVar[bool] = False
 
     # ── Identity ─────────────────────────────────────────────
     name: str
@@ -194,17 +199,17 @@ class ProviderProfile:
         """
         return self.default_max_tokens
 
-    def fetch_models(
+    def fetch_model_metadata(
         self,
         *,
         api_key: str | None = None,
         base_url: str | None = None,
         timeout: float = 8.0,
-    ) -> list[str] | None:
-        """Fetch the live model list from the provider's models endpoint.
+    ) -> list[dict[str, Any]] | None:
+        """Fetch raw entries from the provider's models endpoint.
 
-        Returns a list of model ID strings, or None if the fetch failed or
-        the provider does not support live model listing.
+        Returns model dictionaries without discarding provider metadata, or
+        None if the fetch failed or the provider has no live catalog.
 
         Resolution order for the endpoint URL:
           1. base_url + "/models", but ONLY when the caller passed a base_url
@@ -224,8 +229,8 @@ class ProviderProfile:
         and forwards self.default_headers. Override to customise auth, path,
         response shape, or to return None for providers with no REST catalog.
 
-        Callers must always fall back to the static _PROVIDER_MODELS list
-        when this returns None.
+        Override this hook when a provider needs custom catalog auth, response
+        parsing, or filtering. ``fetch_models`` derives its IDs from this hook.
         """
         caller_base = (base_url or "").strip()
         effective_base = caller_base or self.base_url
@@ -261,7 +266,28 @@ class ProviderProfile:
             with open_credentialed_url(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             items = data if isinstance(data, list) else data.get("data", [])
-            return [m["id"] for m in items if isinstance(m, dict) and "id" in m]
+            return [item for item in items if isinstance(item, dict)]
         except Exception as exc:
-            logger.debug("fetch_models(%s): %s", self.name, exc)
+            logger.debug("fetch_model_metadata(%s): %s", self.name, exc)
             return None
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch live model IDs, preserving the existing picker contract."""
+        items = self.fetch_model_metadata(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        if items is None:
+            return None
+        return [
+            model_id
+            for item in items
+            if isinstance(model_id := item.get("id"), str) and model_id
+        ]

--- a/providers/base.py
+++ b/providers/base.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,11 @@ def _profile_user_agent() -> str:
 @dataclass
 class ProviderProfile:
     """Base provider profile — subclass or instantiate with overrides."""
+
+    # Opt in only when this provider's live /models response is authoritative
+    # for provider-enforced context limits. ClassVar preserves the constructor
+    # contract for existing profiles and out-of-tree plugins.
+    use_live_model_metadata: ClassVar[bool] = False
 
     # ── Identity ─────────────────────────────────────────────
     name: str
@@ -178,17 +183,17 @@ class ProviderProfile:
         """
         return self.default_max_tokens
 
-    def fetch_models(
+    def fetch_model_metadata(
         self,
         *,
         api_key: str | None = None,
         base_url: str | None = None,
         timeout: float = 8.0,
-    ) -> list[str] | None:
-        """Fetch the live model list from the provider's models endpoint.
+    ) -> list[dict[str, Any]] | None:
+        """Fetch raw entries from the provider's models endpoint.
 
-        Returns a list of model ID strings, or None if the fetch failed or
-        the provider does not support live model listing.
+        Returns model dictionaries without discarding provider metadata, or
+        None if the fetch failed or the provider has no live catalog.
 
         Resolution order for the endpoint URL:
           1. self.models_url  (explicit override — use when the models
@@ -202,8 +207,8 @@ class ProviderProfile:
         and forwards self.default_headers. Override to customise auth, path,
         response shape, or to return None for providers with no REST catalog.
 
-        Callers must always fall back to the static _PROVIDER_MODELS list
-        when this returns None.
+        Override this hook when a provider needs custom catalog auth, response
+        parsing, or filtering. ``fetch_models`` derives its IDs from this hook.
         """
         effective_base = base_url or self.base_url
         url = (self.models_url or "").strip()
@@ -232,7 +237,28 @@ class ProviderProfile:
             with open_credentialed_url(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             items = data if isinstance(data, list) else data.get("data", [])
-            return [m["id"] for m in items if isinstance(m, dict) and "id" in m]
+            return [item for item in items if isinstance(item, dict)]
         except Exception as exc:
-            logger.debug("fetch_models(%s): %s", self.name, exc)
+            logger.debug("fetch_model_metadata(%s): %s", self.name, exc)
             return None
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch live model IDs, preserving the existing picker contract."""
+        items = self.fetch_model_metadata(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        if items is None:
+            return None
+        return [
+            model_id
+            for item in items
+            if isinstance(model_id := item.get("id"), str) and model_id
+        ]

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -939,6 +939,12 @@ class TestNousPortalContextResolution:
 # =========================================================================
 
 class TestProviderProfileLiveMetadataContextResolution:
+    def setup_method(self):
+        import agent.model_metadata as mm
+
+        mm._profile_model_metadata_cache.clear()
+        mm._profile_model_metadata_cache_time.clear()
+
     def test_opted_in_profile_uses_its_catalog_when_base_url_is_omitted(self):
         profile = MagicMock(use_live_model_metadata=True)
         profile.fetch_model_metadata.return_value = [
@@ -1036,8 +1042,9 @@ class TestProviderProfileLiveMetadataContextResolution:
         assert context_length == 262_144
         mock_metadata.assert_not_called()
 
-    def test_live_probe_failure_preserves_provider_fallback_chain(self):
+    def test_live_probe_failure_is_cached_and_preserves_provider_fallback_chain(self):
         profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "fallback-vendor"
         profile.fetch_model_metadata.return_value = None
 
         with (
@@ -1052,8 +1059,72 @@ class TestProviderProfileLiveMetadataContextResolution:
                 base_url="https://api.vendor.test/v1",
                 provider="vendor",
             )
+            repeated_context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="vendor",
+            )
 
-        assert context_length == 202_752
+        assert context_length == repeated_context_length == 202_752
+        profile.fetch_model_metadata.assert_called_once()
+
+    def test_repeated_resolution_reuses_profile_metadata_within_ttl(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "cached-vendor"
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "context_length": 65_536},
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            first = get_model_context_length("vendor/model", provider="cached-vendor")
+            second = get_model_context_length("vendor/model", provider="cached-vendor")
+
+        assert first == second == 65_536
+        profile.fetch_model_metadata.assert_called_once()
+
+    def test_expired_profile_metadata_refreshes(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "refreshing-vendor"
+        profile.fetch_model_metadata.side_effect = [
+            [{"id": "vendor/model", "context_length": 65_536}],
+            [{"id": "vendor/model", "context_length": 131_072}],
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch("agent.model_metadata.time.time", side_effect=[1_000, 1_301]),
+        ):
+            first = get_model_context_length("vendor/model", provider="refreshing-vendor")
+            refreshed = get_model_context_length("vendor/model", provider="refreshing-vendor")
+
+        assert first == 65_536
+        assert refreshed == 131_072
+        assert profile.fetch_model_metadata.call_count == 2
+
+    def test_failed_refresh_reuses_stale_metadata_and_negative_caches_failure(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "stale-vendor"
+        profile.fetch_model_metadata.side_effect = [
+            [{"id": "vendor/model", "context_length": 65_536}],
+            None,
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.model_metadata.time.time",
+                side_effect=[1_000, 1_301, 1_302],
+            ),
+        ):
+            first = get_model_context_length("vendor/model", provider="stale-vendor")
+            stale = get_model_context_length("vendor/model", provider="stale-vendor")
+            cached_stale = get_model_context_length(
+                "vendor/model",
+                provider="stale-vendor",
+            )
+
+        assert first == stale == cached_stale == 65_536
+        assert profile.fetch_model_metadata.call_count == 2
 
 
 class TestGetModelContextLength:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -938,6 +938,124 @@ class TestNousPortalContextResolution:
 # get_model_context_length — resolution order
 # =========================================================================
 
+class TestProviderProfileLiveMetadataContextResolution:
+    def test_opted_in_profile_uses_its_catalog_when_base_url_is_omitted(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "context_length": 65_536},
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                provider="vendor",
+            )
+
+        assert context_length == 65_536
+        profile.fetch_model_metadata.assert_called_once_with(
+            api_key="",
+            base_url=None,
+        )
+
+    def test_opted_in_known_provider_uses_live_context_before_persistent_cache(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/small-model", "context_length": 40_960},
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.model_metadata.get_cached_context_length",
+                return_value=999_999,
+            ) as mock_cache,
+        ):
+            context_length = get_model_context_length(
+                model="vendor/small-model",
+                base_url="https://api.vendor.test/v1",
+                api_key="test-key",
+                provider="vendor",
+            )
+
+        assert context_length == 40_960
+        mock_cache.assert_not_called()
+        profile.fetch_model_metadata.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://api.vendor.test/v1",
+        )
+
+    def test_url_inferred_opt_in_uses_live_context(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "max_model_len": 131_072},
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile) as mock_profile,
+            patch(
+                "agent.model_metadata._infer_provider_from_url",
+                return_value="vendor",
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="custom",
+            )
+
+        assert context_length == 131_072
+        mock_profile.assert_called_with("vendor")
+
+    def test_default_profile_does_not_probe_known_provider_endpoint(self):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="vendor")
+        with (
+            patch(
+                "providers.get_provider_profile",
+                return_value=profile,
+            ),
+            patch(
+                "providers.base.ProviderProfile.fetch_model_metadata"
+            ) as mock_metadata,
+            patch(
+                "agent.model_metadata._is_known_provider_base_url",
+                return_value=True,
+            ),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=262_144,
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="vendor",
+            )
+
+        assert context_length == 262_144
+        mock_metadata.assert_not_called()
+
+    def test_live_probe_failure_preserves_provider_fallback_chain(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = None
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=202_752,
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="vendor",
+            )
+
+        assert context_length == 202_752
+
+
 class TestGetModelContextLength:
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_known_model_from_api(self, mock_fetch):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1068,6 +1068,31 @@ class TestProviderProfileLiveMetadataContextResolution:
         assert context_length == repeated_context_length == 202_752
         profile.fetch_model_metadata.assert_called_once()
 
+    def test_malformed_live_metadata_is_cached_and_preserves_fallback_chain(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "malformed-vendor"
+        profile.models_url = ""
+        profile.fetch_model_metadata.return_value = 42
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=202_752,
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                provider="malformed-vendor",
+            )
+            repeated_context_length = get_model_context_length(
+                model="vendor/model",
+                provider="malformed-vendor",
+            )
+
+        assert context_length == repeated_context_length == 202_752
+        profile.fetch_model_metadata.assert_called_once()
+
     def test_repeated_resolution_reuses_profile_metadata_within_ttl(self):
         profile = MagicMock(use_live_model_metadata=True)
         profile.name = "cached-vendor"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1082,6 +1082,82 @@ class TestProviderProfileLiveMetadataContextResolution:
         assert first == second == 65_536
         profile.fetch_model_metadata.assert_called_once()
 
+    def test_profile_metadata_cache_is_scoped_by_credential(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "credential-vendor"
+        profile.models_url = ""
+        profile.fetch_model_metadata.side_effect = lambda **kwargs: [
+            {
+                "id": "vendor/model",
+                "context_length": (
+                    65_536 if kwargs["api_key"] == "key-a" else 131_072
+                ),
+            },
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            first = get_model_context_length(
+                "vendor/model",
+                base_url="https://api.vendor.test/v1",
+                api_key="key-a",
+                provider="credential-vendor",
+            )
+            second = get_model_context_length(
+                "vendor/model",
+                base_url="https://api.vendor.test/v1",
+                api_key="key-b",
+                provider="credential-vendor",
+            )
+
+        assert first == 65_536
+        assert second == 131_072
+        assert profile.fetch_model_metadata.call_count == 2
+
+    def test_explicit_models_url_defines_profile_metadata_cache_scope(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "split-endpoint-vendor"
+        profile.models_url = "https://catalog.vendor.test/models"
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "context_length": 65_536},
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            first = get_model_context_length(
+                "vendor/model",
+                base_url="https://inference-a.vendor.test/v1",
+                provider="split-endpoint-vendor",
+            )
+            second = get_model_context_length(
+                "vendor/model",
+                base_url="https://inference-b.vendor.test/v1",
+                provider="split-endpoint-vendor",
+            )
+
+        assert first == second == 65_536
+        profile.fetch_model_metadata.assert_called_once()
+
+    def test_unmatched_routing_alias_does_not_inherit_sole_catalog_entry(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "routing-vendor"
+        profile.models_url = ""
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/concrete-model", "context_length": 40_960},
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=262_144,
+            ),
+        ):
+            context_length = get_model_context_length(
+                "default:latency",
+                provider="routing-vendor",
+            )
+
+        assert context_length == 262_144
+
     def test_expired_profile_metadata_refreshes(self):
         profile = MagicMock(use_live_model_metadata=True)
         profile.name = "refreshing-vendor"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -674,6 +674,124 @@ class TestNousPortalContextResolution:
 # get_model_context_length — resolution order
 # =========================================================================
 
+class TestProviderProfileLiveMetadataContextResolution:
+    def test_opted_in_profile_uses_its_catalog_when_base_url_is_omitted(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "context_length": 65_536},
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                provider="vendor",
+            )
+
+        assert context_length == 65_536
+        profile.fetch_model_metadata.assert_called_once_with(
+            api_key="",
+            base_url=None,
+        )
+
+    def test_opted_in_known_provider_uses_live_context_before_persistent_cache(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/small-model", "context_length": 40_960},
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.model_metadata.get_cached_context_length",
+                return_value=999_999,
+            ) as mock_cache,
+        ):
+            context_length = get_model_context_length(
+                model="vendor/small-model",
+                base_url="https://api.vendor.test/v1",
+                api_key="test-key",
+                provider="vendor",
+            )
+
+        assert context_length == 40_960
+        mock_cache.assert_not_called()
+        profile.fetch_model_metadata.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://api.vendor.test/v1",
+        )
+
+    def test_url_inferred_opt_in_uses_live_context(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "max_model_len": 131_072},
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile) as mock_profile,
+            patch(
+                "agent.model_metadata._infer_provider_from_url",
+                return_value="vendor",
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="custom",
+            )
+
+        assert context_length == 131_072
+        mock_profile.assert_called_with("vendor")
+
+    def test_default_profile_does_not_probe_known_provider_endpoint(self):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="vendor")
+        with (
+            patch(
+                "providers.get_provider_profile",
+                return_value=profile,
+            ),
+            patch(
+                "providers.base.ProviderProfile.fetch_model_metadata"
+            ) as mock_metadata,
+            patch(
+                "agent.model_metadata._is_known_provider_base_url",
+                return_value=True,
+            ),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=262_144,
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="vendor",
+            )
+
+        assert context_length == 262_144
+        mock_metadata.assert_not_called()
+
+    def test_live_probe_failure_preserves_provider_fallback_chain(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.fetch_model_metadata.return_value = None
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=202_752,
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="vendor",
+            )
+
+        assert context_length == 202_752
+
+
 class TestGetModelContextLength:
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_known_model_from_api(self, mock_fetch):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -818,6 +818,82 @@ class TestProviderProfileLiveMetadataContextResolution:
         assert first == second == 65_536
         profile.fetch_model_metadata.assert_called_once()
 
+    def test_profile_metadata_cache_is_scoped_by_credential(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "credential-vendor"
+        profile.models_url = ""
+        profile.fetch_model_metadata.side_effect = lambda **kwargs: [
+            {
+                "id": "vendor/model",
+                "context_length": (
+                    65_536 if kwargs["api_key"] == "key-a" else 131_072
+                ),
+            },
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            first = get_model_context_length(
+                "vendor/model",
+                base_url="https://api.vendor.test/v1",
+                api_key="key-a",
+                provider="credential-vendor",
+            )
+            second = get_model_context_length(
+                "vendor/model",
+                base_url="https://api.vendor.test/v1",
+                api_key="key-b",
+                provider="credential-vendor",
+            )
+
+        assert first == 65_536
+        assert second == 131_072
+        assert profile.fetch_model_metadata.call_count == 2
+
+    def test_explicit_models_url_defines_profile_metadata_cache_scope(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "split-endpoint-vendor"
+        profile.models_url = "https://catalog.vendor.test/models"
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "context_length": 65_536},
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            first = get_model_context_length(
+                "vendor/model",
+                base_url="https://inference-a.vendor.test/v1",
+                provider="split-endpoint-vendor",
+            )
+            second = get_model_context_length(
+                "vendor/model",
+                base_url="https://inference-b.vendor.test/v1",
+                provider="split-endpoint-vendor",
+            )
+
+        assert first == second == 65_536
+        profile.fetch_model_metadata.assert_called_once()
+
+    def test_unmatched_routing_alias_does_not_inherit_sole_catalog_entry(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "routing-vendor"
+        profile.models_url = ""
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/concrete-model", "context_length": 40_960},
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=262_144,
+            ),
+        ):
+            context_length = get_model_context_length(
+                "default:latency",
+                provider="routing-vendor",
+            )
+
+        assert context_length == 262_144
+
     def test_expired_profile_metadata_refreshes(self):
         profile = MagicMock(use_live_model_metadata=True)
         profile.name = "refreshing-vendor"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -675,6 +675,12 @@ class TestNousPortalContextResolution:
 # =========================================================================
 
 class TestProviderProfileLiveMetadataContextResolution:
+    def setup_method(self):
+        import agent.model_metadata as mm
+
+        mm._profile_model_metadata_cache.clear()
+        mm._profile_model_metadata_cache_time.clear()
+
     def test_opted_in_profile_uses_its_catalog_when_base_url_is_omitted(self):
         profile = MagicMock(use_live_model_metadata=True)
         profile.fetch_model_metadata.return_value = [
@@ -772,8 +778,9 @@ class TestProviderProfileLiveMetadataContextResolution:
         assert context_length == 262_144
         mock_metadata.assert_not_called()
 
-    def test_live_probe_failure_preserves_provider_fallback_chain(self):
+    def test_live_probe_failure_is_cached_and_preserves_provider_fallback_chain(self):
         profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "fallback-vendor"
         profile.fetch_model_metadata.return_value = None
 
         with (
@@ -788,8 +795,72 @@ class TestProviderProfileLiveMetadataContextResolution:
                 base_url="https://api.vendor.test/v1",
                 provider="vendor",
             )
+            repeated_context_length = get_model_context_length(
+                model="vendor/model",
+                base_url="https://api.vendor.test/v1",
+                provider="vendor",
+            )
 
-        assert context_length == 202_752
+        assert context_length == repeated_context_length == 202_752
+        profile.fetch_model_metadata.assert_called_once()
+
+    def test_repeated_resolution_reuses_profile_metadata_within_ttl(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "cached-vendor"
+        profile.fetch_model_metadata.return_value = [
+            {"id": "vendor/model", "context_length": 65_536},
+        ]
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            first = get_model_context_length("vendor/model", provider="cached-vendor")
+            second = get_model_context_length("vendor/model", provider="cached-vendor")
+
+        assert first == second == 65_536
+        profile.fetch_model_metadata.assert_called_once()
+
+    def test_expired_profile_metadata_refreshes(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "refreshing-vendor"
+        profile.fetch_model_metadata.side_effect = [
+            [{"id": "vendor/model", "context_length": 65_536}],
+            [{"id": "vendor/model", "context_length": 131_072}],
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch("agent.model_metadata.time.time", side_effect=[1_000, 1_301]),
+        ):
+            first = get_model_context_length("vendor/model", provider="refreshing-vendor")
+            refreshed = get_model_context_length("vendor/model", provider="refreshing-vendor")
+
+        assert first == 65_536
+        assert refreshed == 131_072
+        assert profile.fetch_model_metadata.call_count == 2
+
+    def test_failed_refresh_reuses_stale_metadata_and_negative_caches_failure(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "stale-vendor"
+        profile.fetch_model_metadata.side_effect = [
+            [{"id": "vendor/model", "context_length": 65_536}],
+            None,
+        ]
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.model_metadata.time.time",
+                side_effect=[1_000, 1_301, 1_302],
+            ),
+        ):
+            first = get_model_context_length("vendor/model", provider="stale-vendor")
+            stale = get_model_context_length("vendor/model", provider="stale-vendor")
+            cached_stale = get_model_context_length(
+                "vendor/model",
+                provider="stale-vendor",
+            )
+
+        assert first == stale == cached_stale == 65_536
+        assert profile.fetch_model_metadata.call_count == 2
 
 
 class TestGetModelContextLength:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -804,6 +804,31 @@ class TestProviderProfileLiveMetadataContextResolution:
         assert context_length == repeated_context_length == 202_752
         profile.fetch_model_metadata.assert_called_once()
 
+    def test_malformed_live_metadata_is_cached_and_preserves_fallback_chain(self):
+        profile = MagicMock(use_live_model_metadata=True)
+        profile.name = "malformed-vendor"
+        profile.models_url = ""
+        profile.fetch_model_metadata.return_value = 42
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "agent.models_dev.lookup_models_dev_context",
+                return_value=202_752,
+            ),
+        ):
+            context_length = get_model_context_length(
+                model="vendor/model",
+                provider="malformed-vendor",
+            )
+            repeated_context_length = get_model_context_length(
+                model="vendor/model",
+                provider="malformed-vendor",
+            )
+
+        assert context_length == repeated_context_length == 202_752
+        profile.fetch_model_metadata.assert_called_once()
+
     def test_repeated_resolution_reuses_profile_metadata_within_ttl(self):
         profile = MagicMock(use_live_model_metadata=True)
         profile.name = "cached-vendor"

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -42,6 +42,21 @@ def _start_server(models=None):
 class TestFetchModelsBaseUrlOverride:
     """fetch_models() should use caller-provided base_url when given."""
 
+    def test_fetch_model_metadata_preserves_catalog_fields(self):
+        models = [{"id": "model-a", "context_length": 40_960, "custom": True}]
+        server, port = _start_server(models)
+        try:
+            profile = ProviderProfile(
+                name="test",
+                models_url=f"http://127.0.0.1:{port}/models",
+            )
+
+            result = profile.fetch_model_metadata(api_key="test-key")
+
+            assert result == models
+        finally:
+            server.shutdown()
+
     def test_base_url_override_used(self):
         """When base_url is passed, it overrides self.base_url."""
         server, port = _start_server([{"id": "proxy-model-a"}])

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -120,6 +120,74 @@ def test_user_plugin_overrides_bundled(tmp_path, monkeypatch):
     _clear_provider_caches()
 
 
+def test_user_plugin_live_metadata_resolves_context(tmp_path, monkeypatch):
+    """A discovered out-of-tree profile can supply authoritative metadata."""
+    hermes_home = tmp_path / ".hermes"
+    plugin_dir = hermes_home / "plugins" / "model-providers" / "live-metadata"
+    plugin_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (plugin_dir / "__init__.py").write_text(
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        "\n"
+        "class LiveMetadataProfile(ProviderProfile):\n"
+        "    use_live_model_metadata = True\n"
+        "\n"
+        "    def fetch_model_metadata(self, **_kwargs):\n"
+        "        return [{\"id\": \"live/model\", \"context_length\": 40960}]\n"
+        "\n"
+        "profile = LiveMetadataProfile(\n"
+        "    name=\"live-metadata\",\n"
+        "    aliases=(\"live-alias\",),\n"
+        "    base_url=\"https://live.example.com/v1\",\n"
+        ")\n"
+        "register_provider(profile)\n",
+        encoding="utf-8",
+    )
+
+    _clear_provider_caches()
+    from agent.model_metadata import get_model_context_length
+
+    context_length = get_model_context_length(
+        "live/model",
+        provider="live-alias",
+    )
+
+    assert context_length == 40_960
+    _clear_provider_caches()
+
+
+def test_general_plugin_manager_skips_model_provider_kind(tmp_path, monkeypatch):
+    """The general PluginManager must NOT import model-provider plugins
+    (providers/__init__.py handles them). It records the manifest only."""
+    from hermes_cli import plugins as plugin_mod
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Create a user-installed plugin with an explicit kind: model-provider.
+    user_plugin = hermes_home / "plugins" / "test-model-provider"
+    user_plugin.mkdir(parents=True)
+    (user_plugin / "plugin.yaml").write_text(
+        "name: test-model-provider\n"
+        "kind: model-provider\n"
+        "version: 0.0.1\n"
+    )
+    (user_plugin / "__init__.py").write_text(
+        # Intentionally broken import — if the general loader tries to
+        # import this module, the test will fail with ImportError.
+        "raise AssertionError('model-provider plugins must not be imported by PluginManager')\n"
+    )
+
+    # Fresh manager
+    manager = plugin_mod.PluginManager()
+    manager.discover_and_load(force=True)
+
+    # The manifest should be recorded but not loaded
+    loaded = manager._plugins.get("test-model-provider")
+    assert loaded is not None
+    assert loaded.manifest.kind == "model-provider"
     # No import means the module must NOT be in the plugins list as a loaded one.
     # We check that the general loader didn't crash and didn't raise from the
     # broken __init__.py.

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -1,5 +1,7 @@
 """Tests for the provider module registry and profiles."""
 
+from dataclasses import fields
+
 from providers import get_provider_profile, _REGISTRY
 from providers.base import ProviderProfile, OMIT_TEMPERATURE
 
@@ -260,5 +262,20 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestBaseProfile:
+    def test_live_model_metadata_opt_in_is_class_only(self):
+        class LiveMetadataProfile(ProviderProfile):
+            use_live_model_metadata = True
+
+        assert ProviderProfile(name="default").use_live_model_metadata is False
+        assert LiveMetadataProfile(name="live").use_live_model_metadata is True
+        assert "use_live_model_metadata" not in {
+            profile_field.name for profile_field in fields(ProviderProfile)
+        }
+
+    def test_prepare_messages_passthrough(self):
+        p = ProviderProfile(name="test")
+        msgs = [{"role": "user", "content": "hi"}]
+        assert p.prepare_messages(msgs) is msgs
 
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -1,5 +1,7 @@
 """Tests for the provider module registry and profiles."""
 
+from dataclasses import fields
+
 from providers import get_provider_profile, _REGISTRY
 from providers.base import ProviderProfile, OMIT_TEMPERATURE
 
@@ -187,5 +189,20 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestBaseProfile:
+    def test_live_model_metadata_opt_in_is_class_only(self):
+        class LiveMetadataProfile(ProviderProfile):
+            use_live_model_metadata = True
+
+        assert ProviderProfile(name="default").use_live_model_metadata is False
+        assert LiveMetadataProfile(name="live").use_live_model_metadata is True
+        assert "use_live_model_metadata" not in {
+            profile_field.name for profile_field in fields(ProviderProfile)
+        }
+
+    def test_prepare_messages_passthrough(self):
+        p = ProviderProfile(name="test")
+        msgs = [{"role": "user", "content": "hi"}]
+        assert p.prepare_messages(msgs) is msgs
 
 

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -161,7 +161,8 @@ when `fetch_model_metadata()` returns an accurate `context_length`,
 `max_model_len`, or equivalent supported field. The default hook honors
 `models_url`, Bearer authentication, and `default_headers`; override it for
 other catalog contracts. Results and initial failures are cached in memory for
-five minutes. If a refresh fails after a successful lookup, Hermes retains the
+five minutes, scoped by provider, catalog URL, and a non-secret credential
+fingerprint. If a refresh fails after a successful lookup, Hermes retains the
 last valid catalog; an initial failure falls through to the normal
 provider-aware resolution chain. Providers that leave the flag disabled are
 not affected.

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -160,9 +160,11 @@ class AcmeProfile(ProviderProfile):
 when `fetch_model_metadata()` returns an accurate `context_length`,
 `max_model_len`, or equivalent supported field. The default hook honors
 `models_url`, Bearer authentication, and `default_headers`; override it for
-other catalog contracts. A failed live probe falls through to the normal
-provider-aware resolution chain and does not affect providers that leave the
-flag disabled.
+other catalog contracts. Results and initial failures are cached in memory for
+five minutes. If a refresh fails after a successful lookup, Hermes retains the
+last valid catalog; an initial failure falls through to the normal
+provider-aware resolution chain. Providers that leave the flag disabled are
+not affected.
 
 ## Hook reference examples
 

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -114,6 +114,11 @@ from typing import Any
 from providers.base import ProviderProfile
 
 class AcmeProfile(ProviderProfile):
+    # Opt in only when /models reports the provider-enforced context limit.
+    # Hermes bypasses its persistent context cache and checks the live endpoint
+    # before models.dev or hardcoded family defaults.
+    use_live_model_metadata = True
+
     def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Provider-specific message preprocessing. Runs after codex
         sanitization, before developer-role swap. Default: pass-through."""
@@ -141,7 +146,23 @@ class AcmeProfile(ProviderProfile):
         Bearer auth. Override for: custom auth (Anthropic), no REST endpoint
         (Bedrock → None), or public/unauthenticated catalogs (OpenRouter)."""
         return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
+
+    def fetch_model_metadata(self, *, api_key=None, base_url=None, timeout=8.0):
+        """Raw live catalog entries used by fetch_models and, when opted in,
+        context-length resolution. Override this instead of fetch_models when
+        custom auth or response parsing must preserve model metadata."""
+        return super().fetch_model_metadata(
+            api_key=api_key, base_url=base_url, timeout=timeout
+        )
 ```
+
+`use_live_model_metadata` is a class-only, default-off opt-in. Enable it only
+when `fetch_model_metadata()` returns an accurate `context_length`,
+`max_model_len`, or equivalent supported field. The default hook honors
+`models_url`, Bearer authentication, and `default_headers`; override it for
+other catalog contracts. A failed live probe falls through to the normal
+provider-aware resolution chain and does not affect providers that leave the
+flag disabled.
 
 ## Hook reference examples
 


### PR DESCRIPTION
## What does this PR do?

Adds a generic, default-off contract for model-provider plugins whose live catalog is authoritative for provider-enforced context limits.

`ProviderProfile.fetch_models()` currently reduces `/models` responses to model IDs. Out-of-tree providers can therefore participate in model discovery but cannot expose provider-specific context windows to `get_model_context_length()`. Known provider URLs also skip the custom-endpoint metadata probe, so affected models can fall through to an incorrect family or 256K default.

This change adds a raw `fetch_model_metadata()` hook, derives the existing ID-only picker contract from it, and lets a profile subclass opt in with `use_live_model_metadata = True`. Opted-in profiles bypass stale persistent context values. Their live metadata is cached in memory for 300 seconds, scoped by provider, catalog URL, and a non-secret credential fingerprint, including initial failures; an expired successful entry is retained if refresh fails. Initial failures continue through the existing provider-aware fallback chain. Existing providers remain opted out and unchanged.

## Related Issue

Related to #44766 and #64277.

This PR is generic infrastructure only. It does not add Chutes or another third-party provider to Hermes. It also leaves `_extract_pricing` untouched; #42854 remains the separate owner of that fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `ProviderProfile.fetch_model_metadata()` while preserving the existing `fetch_models()` signature and return contract.
- Preserve `models_url`, Bearer authentication, `default_headers`, and the credential-safe redirect policy for metadata fetches.
- Add the class-only, default-off `use_live_model_metadata` opt-in without changing the profile constructor.
- Resolve opted-in context metadata before persistent cache values, including calls that omit `base_url` and rely on the profile endpoint.
- Cache profile metadata in memory for 300 seconds with provider, catalog URL, and non-secret credential scoping; negative-cache initial failures and retain the last valid catalog when a refresh fails.
- Fall through to the existing provider-aware resolution chain when the initial live lookup is unavailable, malformed, or lacks a matching context value.
- Keep unmatched routing aliases from inheriting metadata from an unrelated sole catalog entry.
- Document the opt-in and metadata hook in the model-provider authoring guide.
- Add unit and user-plugin discovery coverage for metadata preservation, cache precedence and credential isolation, URL inference, aliases, no-URL calls, default-off behavior, TTL reuse/expiry, negative caching, stale-on-error refresh, malformed hook output, and unmatched routing aliases.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/providers/test_fetch_models_base_url.py tests/providers/test_plugin_discovery.py tests/providers/test_provider_profiles.py -q`.
2. Run `ruff check providers/base.py agent/model_metadata.py tests/providers/test_provider_profiles.py tests/providers/test_fetch_models_base_url.py tests/providers/test_plugin_discovery.py tests/agent/test_model_metadata.py`.
3. Install an out-of-tree provider subclass that defines `use_live_model_metadata = True`, then verify its catalog context limit wins over a stale persistent value and family fallback.

Focused result: 101 tests passed with the canonical per-file runner. The standalone provider contract and Hermes integration suite also passed all 7 tests. A standalone provider canary against a public OpenAI-compatible catalog filtered 12 tool-capable models and resolved `Qwen/Qwen3-32B-TEE` to the endpoint-reported 40,960-token context instead of the 131,072-token family fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused 101-test canonical-runner suite is green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; the provider authoring guide documents the extension point
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific paths or process APIs changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Backend provider-resolution change; no visual surface changed.
