### PR TITLE
fix(tools): bound results before incremental session flush

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -42,10 +42,7 @@ from tools.terminal_tool import (
     get_active_env,
 )
 from tools.thread_context import propagate_context_to_thread
-from tools.tool_result_storage import (
-    maybe_persist_tool_result,
-    enforce_turn_budget,
-)
+from tools.tool_result_storage import maybe_persist_tool_result
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
@@ -65,6 +62,37 @@ def _budget_for_agent(agent) -> BudgetConfig:
         return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
     except Exception:
         return DEFAULT_BUDGET
+
+
+def _allocated_tool_result_budget(
+    tool_messages: list[dict],
+    pending_tool_names: list[str],
+    config: BudgetConfig,
+) -> int | None:
+    """Fairly allocate remaining turn room across eligible pending calls.
+
+    ``None`` preserves a tool's infinite/pinned threshold (notably read_file).
+    Previously flushed messages are treated as immutable: each new result is
+    bounded before it is appended and incrementally persisted.
+    """
+    used = 0
+    for message in tool_messages:
+        tool_name = str(message.get("tool_name") or message.get("name") or "")
+        if config.resolve_threshold(tool_name) == float("inf"):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            used += len(content)
+
+    eligible_pending = [
+        str(name)
+        for name in pending_tool_names
+        if config.resolve_threshold(str(name)) != float("inf")
+    ]
+    if not eligible_pending:
+        return None
+    remaining = max(0, config.turn_budget - used)
+    return remaining // len(eligible_pending)
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
@@ -334,6 +362,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
     _tool_budget = _budget_for_agent(agent)
+    _turn_tool_messages: list[dict] = []
 
     # ── Pre-flight: interrupt check ──────────────────────────────────
     if agent._interrupt_requested:
@@ -943,14 +972,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=name,
-            tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
-
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
@@ -959,6 +980,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _append_subdir_hint_to_multimodal(function_result, subdir_hints)
             else:
                 function_result += subdir_hints
+
+        _allocated_budget = _allocated_tool_result_budget(
+            _turn_tool_messages,
+            [pending[1] for pending in parsed_calls[i:]],
+            _tool_budget,
+        )
+        function_result = maybe_persist_tool_result(
+            content=function_result,
+            tool_name=name,
+            tool_use_id=tc.id,
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            threshold=_allocated_budget,
+        ) if (
+            not _is_multimodal_tool_result(function_result)
+            and _allocated_budget is not None
+        ) else function_result
 
         # Unwrap _multimodal dicts to an OpenAI-style content list so any
         # vision-capable provider receives [{type:text},{type:image_url}]
@@ -976,6 +1014,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             effect_disposition=effect_disposition,
         )
         messages.append(tool_message)
+        _turn_tool_messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if (
             risk_metadata is not None
@@ -1004,11 +1043,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # result so the steer lands as early as possible.
         agent._apply_pending_steer_to_tool_results(messages, 1)
 
-    # ── Per-turn aggregate budget enforcement ─────────────────────────
+    # Results were bounded against the evolving turn budget before each
+    # incremental flush. Never mutate a flushed tool message afterward.
     num_tools = len(parsed_calls)
-    if num_tools > 0:
-        turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -1023,6 +1060,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    _turn_tool_messages: list[dict] = []
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
@@ -1634,14 +1672,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=function_name,
-            tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
-
         # Discover subdirectory context files from tool arguments
         subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
         if subdir_hints:
@@ -1650,11 +1680,30 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             else:
                 function_result += subdir_hints
 
+        _allocated_budget = _allocated_tool_result_budget(
+            _turn_tool_messages,
+            [function_name]
+            + [pending.function.name for pending in assistant_message.tool_calls[i:]],
+            _tool_budget,
+        )
+        function_result = maybe_persist_tool_result(
+            content=function_result,
+            tool_name=function_name,
+            tool_use_id=tool_call.id,
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            threshold=_allocated_budget,
+        ) if (
+            not _is_multimodal_tool_result(function_result)
+            and _allocated_budget is not None
+        ) else function_result
+
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
         tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
         messages.append(tool_message)
+        _turn_tool_messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if (
             risk_metadata is not None
@@ -1714,10 +1763,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         if agent.tool_delay > 0 and i < len(assistant_message.tool_calls):
             time.sleep(agent.tool_delay)
 
-    # ── Per-turn aggregate budget enforcement ─────────────────────────
+    # Results were bounded against the evolving turn budget before each
+    # incremental flush. Never mutate a flushed tool message afterward.
     num_tools_seq = len(assistant_message.tool_calls)
-    if num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -30,6 +30,7 @@ from unittest.mock import MagicMock, patch
 
 from agent.tool_dispatch_helpers import make_tool_result_message
 from run_agent import AIAgent
+from tools.budget_config import BudgetConfig
 
 
 def _make_tool_defs(*names: str) -> list:
@@ -250,3 +251,77 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     # production flush call breaks one of these assertions.
     assert flushed_tool_ids == ["c1", "c2"]
     assert flush_lengths == [1, 2]
+
+
+def _assert_aggregate_tool_results_bounded_before_each_flush(
+    agent, assistant_message, messages, execute,
+):
+    """Every incremental snapshot must already satisfy the turn budget."""
+    snapshots: list[list] = []
+
+    def _record_flush(flush_messages, conversation_history=None):
+        snapshots.append(copy.deepcopy(flush_messages))
+
+    agent._flush_messages_to_session_db = MagicMock(side_effect=_record_flush)
+    budget = BudgetConfig(
+        default_result_size=150_000,
+        turn_budget=200_000,
+        preview_size=64,
+        tool_overrides={"web_search": 150_000},
+    )
+    sandbox = MagicMock()
+    sandbox.execute.return_value = {"output": "", "returncode": 0}
+
+    with (
+        patch("agent.tool_executor._budget_for_agent", return_value=budget),
+        patch("agent.tool_executor.get_active_env", return_value=sandbox),
+    ):
+        execute(assistant_message, messages, "task-1")
+
+    assert len(snapshots) == 2
+    for snapshot in snapshots:
+        tool_chars = sum(
+            len(message.get("content", ""))
+            for message in snapshot
+            if message.get("role") == "tool"
+        )
+        assert tool_chars <= budget.turn_budget
+
+    # Bounding mutates content only; current-main safety metadata survives.
+    assert all("_tool_output_risk" in message for message in messages)
+
+
+def test_sequential_bounds_aggregate_tool_results_before_incremental_flush():
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(name="web_search", call_id="c1"),
+        _mock_tool_call(name="web_search", call_id="c2"),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+
+    with patch("run_agent.handle_function_call", return_value="x" * 120_000):
+        _assert_aggregate_tool_results_bounded_before_each_flush(
+            agent,
+            assistant_message,
+            messages,
+            agent._execute_tool_calls_sequential,
+        )
+
+
+def test_concurrent_bounds_aggregate_tool_results_before_incremental_flush():
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(name="web_search", call_id="c1"),
+        _mock_tool_call(name="web_search", call_id="c2"),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+
+    with patch.object(agent, "_invoke_tool", return_value="x" * 120_000):
+        _assert_aggregate_tool_results_bounded_before_each_flush(
+            agent,
+            assistant_message,
+            messages,
+            agent._execute_tool_calls_concurrent,
+        )


### PR DESCRIPTION
## Summary
- allocate the remaining per-turn tool-result budget before each result is appended and incrementally persisted
- cover both sequential and concurrent tool execution paths
- preserve pinned/infinite thresholds, multimodal results, output-risk metadata, and effect disposition metadata

## Root cause
Tool results were incrementally flushed to SessionDB before the aggregate turn budget was enforced. A later in-memory truncation could not repair the already-persisted oversized transcript, so restart/resume could reload content that the live turn had already bounded.

## Tests
- `5 passed` — `tests/run_agent/test_tool_call_incremental_persistence.py`
- Ruff passed
- `py_compile` passed
- `git diff --check` passed

## Scope
The change is limited to pre-persistence budgeting in `agent/tool_executor.py` and focused incremental-persistence regressions.
