### PR TITLE
fix: make shutdown diagnostics portable without coreutils timeout

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -254,8 +254,31 @@ def spawn_async_diagnostic(
         # would also reap us anyway, but defense in depth).  Without
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
+        # Run the diagnostic through Python so the timeout is portable. macOS
+        # does not ship GNU coreutils `timeout`; relying on that binary made
+        # every diagnostic silently fail on an otherwise supported platform.
+        wrapper = r'''
+import os, signal, subprocess, sys
+script, timeout_s = sys.argv[1], float(sys.argv[2])
+proc = subprocess.Popen(
+    ["bash", "-c", script],
+    stdin=subprocess.DEVNULL,
+    stdout=sys.stdout,
+    stderr=subprocess.STDOUT,
+    start_new_session=True,
+)
+try:
+    proc.wait(timeout=timeout_s)
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    proc.wait()
+    print(f"=== diagnostic timed out after {timeout_s:.1f}s ===", flush=True)
+'''
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            [sys.executable, "-c", wrapper, script, str(timeout_seconds)],
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -185,6 +185,30 @@ class TestSpawnAsyncDiagnostic:
         assert result is None
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only diagnostic")
+    def test_uses_python_timeout_wrapper_without_coreutils(self, tmp_path, monkeypatch):
+        """The launcher must not depend on GNU `timeout`, which macOS lacks."""
+        calls = []
+
+        class FakeProcess:
+            pid = 12345
+
+        def fake_popen(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return FakeProcess()
+
+        monkeypatch.setattr(sf.subprocess, "Popen", fake_popen)
+        pid = sf.spawn_async_diagnostic(
+            tmp_path / "diag.log", "SIGTERM", timeout_seconds=2.5
+        )
+
+        assert pid == 12345
+        argv = calls[0][0]
+        assert argv[0] == sys.executable
+        assert argv[1] == "-c"
+        assert "subprocess.TimeoutExpired" in argv[2]
+        assert argv[-1] == "2.5"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only diagnostic")
     def test_handles_unwritable_log_path_gracefully(self, tmp_path):
         # Point at a nonexistent parent that we can't create
         log_path = Path("/proc/cant-write-here/diag.log")


### PR DESCRIPTION
## Problem

`gateway.shutdown_forensics.spawn_async_diagnostic()` launches diagnostics through the GNU `timeout` executable. macOS does not ship `timeout` or `gtimeout`, so the supported macOS path catches `FileNotFoundError`, returns `None`, and silently produces no shutdown diagnostic.

## Fix

Run the detached diagnostic through the current Python interpreter. The wrapper:

- starts the Bash diagnostic in its own process group;
- enforces the configured timeout with `Popen.wait(timeout=...)`;
- kills the diagnostic process group on timeout;
- preserves the existing non-blocking caller behavior and output file contract;
- removes the GNU coreutils dependency.

## Verification

- Reproduced on macOS with neither `timeout` nor `gtimeout` installed.
- `31 passed` in `tests/gateway/test_shutdown_forensics.py`.
- Ruff passed for the changed source and tests.
- Added a regression test asserting the launcher uses `sys.executable` and carries an internal `TimeoutExpired` path instead of invoking coreutils.
