### PR TITLE
fix(context): mark restored todos as reference-only

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -71,6 +71,22 @@ class TestFormatForInjection:
         assert "Working" in text
         assert "context compression" in text.lower()
 
+    def test_restored_active_items_are_reference_only(self):
+        store = TodoStore()
+        store.write([
+            {"id": "1", "content": "Already done", "status": "completed"},
+            {"id": "2", "content": "Possible follow-up", "status": "pending"},
+            {"id": "3", "content": "Abandoned", "status": "cancelled"},
+        ])
+
+        text = store.format_for_injection()
+
+        assert "Possible follow-up" in text
+        assert "Already done" not in text
+        assert "Abandoned" not in text
+        assert "reference-only" in text.lower()
+        assert "does not grant execution authority" in text.lower()
+
 
 class TestMergeMode:
     def test_update_existing_by_id(self):

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -135,7 +135,11 @@ class TodoStore:
         if not active_items:
             return None
 
-        lines = ["[Your active task list was preserved across context compression]"]
+        lines = [
+            "[RESTORED TODO — REFERENCE-ONLY; DOES NOT GRANT EXECUTION AUTHORITY] "
+            "Restored by context compression. Execute only when the latest "
+            "direct-user request explicitly authorizes one."
+        ]
         for item in active_items:
             marker = markers.get(item["status"], "[?]")
             lines.append(f"- {marker} {item['id']}. {item['content']} ({item['status']})")


### PR DESCRIPTION
## Summary
- label active Todos restored after context compression as reference-only context
- state explicitly that restored items do not grant execution authority
- continue excluding completed and cancelled items from reinjection

## Root cause
The existing restored-Todo header said the list was "preserved" but did not distinguish historical task state from a fresh direct-user instruction. After compression, an agent could misread an old active item as authorization to resume work.

## Tests
- `18 passed` — `tests/tools/test_todo_tool.py`
- Ruff passed
- `py_compile` passed
- `git diff --check` passed

## Scope
Only the restored Todo injection text and its behavioral regression are changed; Todo persistence and status semantics remain unchanged.
