### PR TITLE
fix: allow only the current macOS user temp root

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -182,7 +185,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()), "foo", "bar", False
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -195,7 +200,9 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()), "x", "y", True
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -288,6 +288,39 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/db/something") is not None
 
+    def test_current_user_temp_root_allowed(self, monkeypatch):
+        """macOS pytest/tempfile paths under the current user's temp root are writable."""
+        from tools import file_tools
+
+        temp_root = "/private/var/folders/ab/current-user/T"
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: temp_root)
+        assert file_tools._check_sensitive_path(f"{temp_root}/workspace/result.txt") is None
+
+    def test_other_private_var_folder_remains_blocked(self, monkeypatch):
+        """The exception is exact to this process's temp root, not all /private/var/folders."""
+        from tools import file_tools
+
+        monkeypatch.setattr(
+            file_tools.tempfile,
+            "gettempdir",
+            lambda: "/private/var/folders/ab/current-user/T",
+        )
+        assert file_tools._check_sensitive_path(
+            "/private/var/folders/zz/other-user/T/result.txt"
+        ) is not None
+
+    def test_hermes_config_inside_temp_root_remains_blocked(self, monkeypatch):
+        from tools import file_tools
+
+        config_path = "/private/var/folders/ab/current-user/T/hermes/config.yaml"
+        monkeypatch.setattr(
+            file_tools.tempfile,
+            "gettempdir",
+            lambda: "/private/var/folders/ab/current-user/T",
+        )
+        monkeypatch.setattr(file_tools, "_get_hermes_config_resolved", lambda: config_path)
+        assert file_tools._check_sensitive_path(config_path) is not None
+
     def test_boot_still_blocked(self):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/boot/grub/grub.cfg") is not None

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -293,13 +293,26 @@ class TestCheckSensitivePathMacOSBypass:
         from tools import file_tools
 
         temp_root = "/private/var/folders/ab/current-user/T"
+        monkeypatch.setattr(file_tools.sys, "platform", "darwin")
         monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: temp_root)
         assert file_tools._check_sensitive_path(f"{temp_root}/workspace/result.txt") is None
+
+    def test_non_macos_never_uses_private_var_temp_exception(self, monkeypatch):
+        """The macOS-only exception must stay closed on other platforms."""
+        from tools import file_tools
+
+        temp_root = "/private/var/folders/ab/current-user/T"
+        monkeypatch.setattr(file_tools.sys, "platform", "linux")
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: temp_root)
+        assert file_tools._check_sensitive_path(
+            f"{temp_root}/workspace/result.txt"
+        ) is not None
 
     def test_other_private_var_folder_remains_blocked(self, monkeypatch):
         """The exception is exact to this process's temp root, not all /private/var/folders."""
         from tools import file_tools
 
+        monkeypatch.setattr(file_tools.sys, "platform", "darwin")
         monkeypatch.setattr(
             file_tools.tempfile,
             "gettempdir",
@@ -309,10 +322,62 @@ class TestCheckSensitivePathMacOSBypass:
             "/private/var/folders/zz/other-user/T/result.txt"
         ) is not None
 
+    @pytest.mark.parametrize(
+        ("temp_root", "target"),
+        [
+            (
+                "/private/var/folders/ab",
+                "/private/var/folders/ab/other-user/T/result.txt",
+            ),
+            (
+                "/private/var/folders/ab/current-user",
+                "/private/var/folders/ab/current-user/T/result.txt",
+            ),
+            (
+                "/private/var/folders/ab/current-user/C",
+                "/private/var/folders/ab/current-user/C/result.txt",
+            ),
+        ],
+    )
+    def test_malformed_macos_temp_roots_remain_blocked(
+        self, monkeypatch, temp_root, target
+    ):
+        """Only the exact /private/var/folders/<shard>/<user>/T shape qualifies."""
+        from tools import file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "darwin")
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: temp_root)
+        assert file_tools._check_sensitive_path(target) is not None
+
+    def test_private_etc_temp_root_remains_blocked(self, monkeypatch):
+        """A manipulated temp root must never relax the /private/etc guard."""
+        from tools import file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            file_tools.tempfile,
+            "gettempdir",
+            lambda: "/private/etc/hermes-temp",
+        )
+        assert file_tools._check_sensitive_path(
+            "/private/etc/hermes-temp/result.txt"
+        ) is not None
+
+    def test_broad_private_var_temp_root_remains_blocked(self, monkeypatch):
+        """Only a per-user /private/var/folders root can qualify for the exception."""
+        from tools import file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "darwin")
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: "/private/var")
+        assert file_tools._check_sensitive_path(
+            "/private/var/db/hermes-temp/result.txt"
+        ) is not None
+
     def test_hermes_config_inside_temp_root_remains_blocked(self, monkeypatch):
         from tools import file_tools
 
         config_path = "/private/var/folders/ab/current-user/T/hermes/config.yaml"
+        monkeypatch.setattr(file_tools.sys, "platform", "darwin")
         monkeypatch.setattr(
             file_tools.tempfile,
             "gettempdir",

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import posixpath
 import sys
+import tempfile
 import threading
 from pathlib import Path, PurePosixPath
 
@@ -659,6 +660,22 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _is_current_user_temp_path(path: str) -> bool:
+    """Return whether *path* is inside this process's resolved temp root.
+
+    On macOS, ``tempfile`` and pytest use ``/var/folders/...`` which resolves
+    beneath ``/private/var/folders/...``.  File tools should work in that
+    per-user workspace without opening the rest of ``/private/var``.
+    """
+    try:
+        temp_root = Path(tempfile.gettempdir()).expanduser().resolve(strict=False)
+        target = Path(path).expanduser().resolve(strict=False)
+        target.relative_to(temp_root)
+        return True
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -670,11 +687,6 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
@@ -686,6 +698,13 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            if _is_current_user_temp_path(resolved) or _is_current_user_temp_path(normalized):
+                return None
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -661,14 +661,21 @@ def _get_hermes_config_resolved() -> str | None:
 
 
 def _is_current_user_temp_path(path: str) -> bool:
-    """Return whether *path* is inside this process's resolved temp root.
+    """Return whether *path* is inside this process's macOS per-user temp root.
 
     On macOS, ``tempfile`` and pytest use ``/var/folders/...`` which resolves
-    beneath ``/private/var/folders/...``.  File tools should work in that
-    per-user workspace without opening the rest of ``/private/var``.
+    beneath ``/private/var/folders/...``.  Require that resolved root before
+    granting the narrow exception so a manipulated broad or sensitive temp
+    root cannot relax another system-path guard.
     """
+    if sys.platform != "darwin":
+        return False
     try:
         temp_root = Path(tempfile.gettempdir()).expanduser().resolve(strict=False)
+        macos_temp_parent = Path("/private/var/folders")
+        temp_relative = temp_root.relative_to(macos_temp_parent)
+        if len(temp_relative.parts) != 3 or temp_relative.parts[-1] != "T":
+            return False
         target = Path(path).expanduser().resolve(strict=False)
         target.relative_to(temp_root)
         return True
@@ -700,7 +707,10 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         )
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
-            if _is_current_user_temp_path(resolved) or _is_current_user_temp_path(normalized):
+            if prefix == "/private/var/" and (
+                _is_current_user_temp_path(resolved)
+                or _is_current_user_temp_path(normalized)
+            ):
                 return None
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:


### PR DESCRIPTION
## Problem

On macOS, `tempfile` and pytest workspaces live under `/var/folders/...`, which resolves to `/private/var/folders/...`. The file-tool sensitive-path guard blocks all of `/private/var`, so legitimate writes inside the current process's own temporary workspace are denied.

A broad exception for all of `/private/var/folders` would be unsafe because it would also relax protection for other users' temporary trees.

## Fix

- Allow a target only when it resolves inside `tempfile.gettempdir()` for the current process.
- Keep all other `/private/var` paths blocked.
- Check the Hermes configuration path before applying the temp-root exception, so security configuration remains protected even in a temporary test profile.
- Make existing `/tmp` test assertions compare canonical resolved paths, which handles macOS `/tmp` -> `/private/tmp` resolution without weakening runtime checks.

## Verification

- `101 passed` across `tests/tools/test_file_write_safety.py` and `tests/tools/test_file_tools.py`.
- Ruff and `git diff --check` passed.
- Regression coverage proves:
  - the current user's temp root is allowed;
  - another `/private/var/folders` tree remains denied;
  - Hermes configuration remains denied inside the allowed temp root.
