### PR TITLE
fix(process): reap local children before pipe EOF

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -316,6 +316,40 @@ class TestOrphanedPipeReconciliation:
         except (ProcessLookupError, PermissionError):
             pass
 
+    @pytest.mark.live_system_guard_bypass
+    def test_direct_child_is_reaped_and_notified_without_polling(self, registry):
+        """A descendant-held pipe must not gate direct-child completion."""
+        marker = "hermes_process_reaper_regression_child"
+        command = (
+            f"{sys.executable} -c 'import subprocess; "
+            f"subprocess.Popen([\"{sys.executable}\", \"-c\", "
+            "\"import time; time.sleep(30)\", "
+            f"\"{marker}\"]); print(\"parent done\")'"
+        )
+        session = registry.spawn_local(
+            command, cwd="/tmp", notify_on_complete=True,
+        )
+
+        try:
+            assert session._completion_event.wait(5.0), (
+                "direct child completion remained gated on stdout EOF"
+            )
+            event = registry.completion_queue.get(timeout=1.0)
+            assert event["session_id"] == session.id
+            assert event["exit_code"] == 0
+            assert session.process.wait(timeout=0) == 0
+            with pytest.raises(ChildProcessError):
+                os.waitpid(session.pid, os.WNOHANG)
+            assert session.id in registry._finished
+            assert session.id not in registry._running
+            assert registry.completion_queue.empty()
+        finally:
+            subprocess.run(
+                ["pkill", "-9", "-f", marker],
+                capture_output=True,
+                check=False,
+            )
+
     def test_reconcile_noop_when_child_still_running(self, registry):
         """Reconcile must NOT flip exited when the direct child is alive."""
         proc = _spawn_python_sleep(5.0)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -136,6 +136,7 @@ class ProcessSession:
     _completion_event: threading.Event = field(default_factory=threading.Event, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
+    _reaper_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
 
 
@@ -694,6 +695,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        notify_on_complete: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -712,6 +714,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            notify_on_complete=notify_on_complete,
         )
 
         if use_pty:
@@ -787,7 +790,8 @@ class ProcessRegistry:
         session.host_start_time = self._safe_host_start_time(session.pid)
 
         try:
-            # Start output reader thread
+            # Register before either worker can finish. Fast commands must
+            # still move from running exactly once and enqueue completion.
             reader = threading.Thread(
                 target=self._reader_loop,
                 args=(session,),
@@ -795,12 +799,20 @@ class ProcessRegistry:
                 name=f"proc-reader-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
+            reaper = threading.Thread(
+                target=self._local_reaper_loop,
+                args=(session,),
+                daemon=True,
+                name=f"proc-reaper-{session.id}",
+            )
+            session._reaper_thread = reaper
 
             with self._lock:
                 self._prune_if_needed()
                 self._running[session.id] = session
 
+            reader.start()
+            reaper.start()
             self._write_checkpoint()
         except Exception:
             # Post-Popen setup failed — kill the orphaned subprocess (and any
@@ -967,16 +979,41 @@ class ProcessRegistry:
         except Exception as e:
             logger.debug("Process stdout reader ended: %s", e)
         finally:
-            # Always reap the child to prevent zombie processes.
-            try:
-                session.process.wait(timeout=5)
-            except Exception as e:
-                logger.debug("Process wait timed out or failed: %s", e)
+            # Spawned sessions have a dedicated waiter because descendants can
+            # hold stdout open after the direct child exits. Retain ownership
+            # here for tests/legacy callers that invoke the reader directly.
+            if session._reaper_thread is None:
+                try:
+                    rc = session.process.wait(timeout=5)
+                except Exception as e:
+                    logger.debug("Process wait timed out or failed: %s", e)
+                    rc = session.process.returncode
+                if rc is not None:
+                    self._complete_local_exit(session, rc)
+
+    def _local_reaper_loop(self, session: ProcessSession) -> None:
+        """Own the direct local child lifecycle independently of stdout EOF."""
+        try:
+            rc = session.process.wait()
+        except Exception as e:
+            logger.debug("Process wait failed for %s: %s", session.id, e)
+            return
+
+        reader = session._reader_thread
+        if reader is not None and reader is not threading.current_thread():
+            reader.join(timeout=0.1)
+        self._complete_local_exit(session, rc)
+
+    def _complete_local_exit(self, session: ProcessSession, rc: int) -> None:
+        """Publish a reaped local exit once across waiter/poll/reader races."""
+        with session._lock:
+            if session.exited:
+                return
             session.exited = True
             if session.completion_reason != "killed":
-                session.exit_code = session.process.returncode
+                session.exit_code = rc
                 session.completion_reason = "exited"
-            self._move_to_finished(session)
+        self._move_to_finished(session)
 
     def _env_poller_loop(
         self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str
@@ -1227,8 +1264,9 @@ class ProcessRegistry:
     def _reconcile_local_exit(self, session: "ProcessSession") -> None:
         """Reconcile session.exited against the real child process state.
 
-        The reader thread (`_reader_loop`) sets `session.exited = True` only
-        in its `finally` block, which runs when `stdout.read()` returns EOF.
+        The dedicated local reaper normally sets ``session.exited`` as soon as
+        the direct child terminates, independently of stdout EOF. This helper
+        remains the synchronous fallback for callers racing that reaper.
         If the direct `Popen` child has exited but a descendant process (e.g.
         a daemon spawned by `hermes update` restarting the gateway) is still
         holding the stdout pipe open, the reader blocks forever and poll()
@@ -1283,20 +1321,18 @@ class ProcessRegistry:
                 logger.debug("Non-blocking drain failed for %s: %s", session.id, e)
 
         with session._lock:
+            if session.exited:
+                return
             if drained:
                 session.output_buffer += drained
                 if len(session.output_buffer) > session.max_output_chars:
                     session.output_buffer = session.output_buffer[-session.max_output_chars:]
-            session.exited = True
-            if session.completion_reason != "killed":
-                session.exit_code = rc
-                session.completion_reason = "exited"
         logger.info(
             "Reconciled session %s: direct child exited with code %s but reader "
             "was still blocked (orphaned pipe). Flipped to exited.",
             session.id, rc,
         )
-        self._move_to_finished(session)
+        self._complete_local_exit(session, rc)
 
     def poll(self, session_id: str) -> dict:
         """Check status and get new output for a background process."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2379,6 +2379,7 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        notify_on_complete=bool(notify_on_complete),
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(


### PR DESCRIPTION
## Summary
- add a dedicated local child reaper that waits on the direct `Popen` independently of stdout EOF
- keep reader output collection, PTY handling, kill semantics, completion deduplication, checkpoints, and notifications unchanged
- prevent descendant processes that inherit stdout from keeping an already-exited direct child reported as running

## Root cause
Local completion was finalized from the stdout reader's `finally` block. If a descendant inherited the pipe, the reader could remain blocked after the direct child exited, delaying reap/completion indefinitely.

## Tests
- `138 passed` — `tests/tools/test_process_registry.py` + `tests/tools/test_terminal_compound_background.py`
- Ruff passed
- `py_compile` passed
- `git diff --check` passed

## Scope
Only local background process lifecycle code and its regression coverage are changed. Remote backends and public process-tool behavior are unchanged.
