### PR TITLE
fix: forward webhook approvals to delivery platform

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -142,7 +142,7 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_order: Deque[tuple[float, str]] = deque()
 
         # Reference to gateway runner for cross-platform delivery (set externally)
-        self.gateway_runner = None
+        self.gateway_runner: Optional[Any] = None
 
         # Idempotency: TTL cache of recently processed delivery IDs.
         # Prevents duplicate agent runs when webhook providers retry.
@@ -301,6 +301,51 @@ class WebhookAdapter(BasePlatformAdapter):
         logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
         return SendResult(
             success=False, error=f"Unknown deliver type: {deliver_type}"
+        )
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Forward an approval prompt to the webhook route's delivery adapter.
+
+        Webhook-triggered agents keep a webhook session key even when their
+        responses are delivered to Discord, Telegram, or another interactive
+        platform. Forwarding that key lets destination buttons resolve the
+        command that is actually blocked. A failed result preserves the
+        gateway's plain-text fallback for non-interactive destinations.
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        deliver_type = delivery.get("deliver", "log")
+        target, target_chat_id, target_metadata, error = self._resolve_cross_platform_target(
+            deliver_type, delivery
+        )
+        if error or target is None:
+            return SendResult(
+                success=False,
+                error=error or f"Platform {deliver_type} not connected",
+            )
+
+        if getattr(type(target), "send_exec_approval", None) is None:
+            return SendResult(
+                success=False,
+                error=f"Platform {deliver_type} does not support approval buttons",
+            )
+
+        return await target.send_exec_approval(
+            chat_id=target_chat_id,
+            command=command,
+            session_key=session_key,
+            description=description,
+            metadata=target_metadata,
+            allow_permanent=allow_permanent,
+            smart_denied=smart_denied,
         )
 
     def _prune_delivery_info(self, now: float) -> None:
@@ -1224,25 +1269,32 @@ class WebhookAdapter(BasePlatformAdapter):
         self, platform_name: str, content: str, delivery: dict
     ) -> SendResult:
         """Route response to another platform (telegram, discord, etc.)."""
-        if not self.gateway_runner:
+        adapter, chat_id, metadata, error = self._resolve_cross_platform_target(
+            platform_name, delivery
+        )
+        if error or adapter is None:
             return SendResult(
                 success=False,
-                error="No gateway runner for cross-platform delivery",
+                error=error or f"Platform {platform_name} not connected",
             )
+
+        return await adapter.send(chat_id, content, metadata=metadata)
+
+    def _resolve_cross_platform_target(
+        self, platform_name: str, delivery: dict
+    ) -> tuple[Optional[Any], str, Optional[Dict[str, Any]], Optional[str]]:
+        """Resolve a delivery platform into its adapter, chat, and thread."""
+        if not self.gateway_runner:
+            return None, "", None, "No gateway runner for cross-platform delivery"
 
         try:
             target_platform = Platform(platform_name)
         except ValueError:
-            return SendResult(
-                success=False, error=f"Unknown platform: {platform_name}"
-            )
+            return None, "", None, f"Unknown platform: {platform_name}"
 
         adapter = self.gateway_runner.adapters.get(target_platform)
         if not adapter:
-            return SendResult(
-                success=False,
-                error=f"Platform {platform_name} not connected",
-            )
+            return None, "", None, f"Platform {platform_name} not connected"
 
         # Use home channel if no specific chat_id in deliver_extra
         extra = delivery.get("deliver_extra", {})
@@ -1252,15 +1304,13 @@ class WebhookAdapter(BasePlatformAdapter):
             if home:
                 chat_id = home.chat_id
             else:
-                return SendResult(
-                    success=False,
-                    error=f"No chat_id or home channel for {platform_name}",
-                )
+                return None, "", None, f"No chat_id or home channel for {platform_name}"
 
-        # Pass thread_id from deliver_extra so Telegram forum topics work
+        # Pass thread_id from deliver_extra so interactive prompts and regular
+        # messages land in the same Discord/Telegram thread.
         metadata = None
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
             metadata = {"thread_id": thread_id}
 
-        return await adapter.send(chat_id, content, metadata=metadata)
+        return adapter, chat_id, metadata, None

--- a/tests/gateway/test_webhook_approval_delivery.py
+++ b/tests/gateway/test_webhook_approval_delivery.py
@@ -1,0 +1,109 @@
+"""Tests for webhook-triggered approvals delivered to interactive platforms."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter
+
+
+class _InteractiveTarget:
+    def __init__(self):
+        self.approval_mock = AsyncMock(return_value=SendResult(success=True))
+
+    async def send_exec_approval(self, **kwargs):
+        return await self.approval_mock(**kwargs)
+
+    async def send(self, chat_id, content, metadata=None):
+        return SendResult(success=True)
+
+
+def _make_adapter() -> WebhookAdapter:
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": {}},
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_forwards_approval_buttons_with_webhook_session_key():
+    adapter = _make_adapter()
+    target = _InteractiveTarget()
+    runner = MagicMock()
+    runner.adapters = {Platform.DISCORD: target}
+    runner.config.get_home_channel.return_value = None
+    adapter.gateway_runner = runner
+    webhook_chat_id = "webhook:pr-review:delivery-1"
+    adapter._delivery_info[webhook_chat_id] = {
+        "deliver": "discord",
+        "deliver_extra": {
+            "chat_id": "channel-1",
+            "thread_id": "thread-9",
+        },
+    }
+
+    result = await adapter.send_exec_approval(
+        chat_id=webhook_chat_id,
+        command="git status",
+        session_key="agent:main:webhook:pr-review:delivery-1",
+        description="test approval",
+        allow_permanent=False,
+        smart_denied=True,
+    )
+
+    assert result.success is True
+    target.approval_mock.assert_awaited_once_with(
+        chat_id="channel-1",
+        command="git status",
+        session_key="agent:main:webhook:pr-review:delivery-1",
+        description="test approval",
+        metadata={"thread_id": "thread-9"},
+        allow_permanent=False,
+        smart_denied=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_interactive_destination_returns_failure_for_text_fallback():
+    adapter = _make_adapter()
+    adapter._delivery_info["webhook:r:d"] = {"deliver": "log"}
+
+    result = await adapter.send_exec_approval(
+        chat_id="webhook:r:d",
+        command="git status",
+        session_key="agent:main:webhook:r:d",
+    )
+
+    assert result.success is False
+    assert result.error == "No gateway runner for cross-platform delivery"
+
+
+@pytest.mark.asyncio
+async def test_regular_cross_platform_delivery_still_uses_same_target_resolution():
+    adapter = _make_adapter()
+    target = _InteractiveTarget()
+    target.send = AsyncMock(return_value=SendResult(success=True))
+    runner = MagicMock()
+    runner.adapters = {Platform.DISCORD: target}
+    runner.config.get_home_channel.return_value = None
+    adapter.gateway_runner = runner
+
+    result = await adapter._deliver_cross_platform(
+        "discord",
+        "hello",
+        {
+            "deliver_extra": {
+                "chat_id": "channel-1",
+                "thread_id": "thread-9",
+            }
+        },
+    )
+
+    assert result.success is True
+    target.send.assert_awaited_once_with(
+        "channel-1", "hello", metadata={"thread_id": "thread-9"}
+    )


### PR DESCRIPTION
## Summary

- forward dangerous-command approval prompts from webhook-triggered agent sessions to the route's configured delivery adapter
- preserve the original webhook session key so Discord/Telegram buttons unblock the correct pending command
- share cross-platform target resolution between normal webhook delivery and interactive approvals
- retain the existing plain-text fallback when the destination is disconnected or does not support approval buttons

## Problem

A webhook route configured with `deliver: discord` currently renders a text-only `/approve` prompt. The gateway checks the source `WebhookAdapter` for `send_exec_approval`, not the actual Discord delivery adapter. Besides the degraded UX, typing `/approve` in Discord targets the Discord conversation session rather than the blocked webhook session.

## Verification

- `scripts/run_tests.sh tests/gateway/test_webhook_approval_delivery.py tests/gateway/test_webhook_deliver_only.py`
  - 17 passed
- related webhook suite
  - 20 passed
- `git diff --check`
