### PR TITLE
feat(plugins): add on_session_pre_switch and on_session_post_switch hooks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10497,19 +10497,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 self.agent._invalidate_system_prompt()
 
-            # Plugin hook: session_switched — fires after session rotation completes.
-            try:
-                from hermes_cli.plugins import has_hook, invoke_hook
-                if has_hook("session_switched"):
-                    invoke_hook(
-                        "session_switched",
-                        old_session_id=old_session_id,
-                        new_session_id=self.session_id,
-                        cli=self,
-                    )
-            except Exception:
-                pass
-
             if self._session_db:
                 try:
                     self.agent._session_db_created = False
@@ -10525,29 +10512,44 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self.agent._session_db_created = True
                 except Exception:
                     pass
-                if title and self._session_db:
-                    from hermes_state import SessionDB
+            # Plugin hook: session_switched — fires after session rotation
+            # and fresh SessionDB row have completed, so callbacks can
+            # observe the new session state.
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("session_switched"):
+                    invoke_hook(
+                        "session_switched",
+                        old_session_id=old_session_id,
+                        new_session_id=self.session_id,
+                        cli=self,
+                    )
+            except Exception:
+                pass
+
+            if title and self._session_db:
+                from hermes_state import SessionDB
+                try:
+                    sanitized = SessionDB.sanitize_title(title)
+                except ValueError as e:
+                    _cprint(f"  Title rejected: {e}")
+                    sanitized = None
+                    title = None
+                if sanitized:
                     try:
-                        sanitized = SessionDB.sanitize_title(title)
+                        self._session_db.set_session_title(self.session_id, sanitized)
+                        self._pending_title = None
+                        self._status_bar_title_checked_at = 0.0
+                        title = sanitized
                     except ValueError as e:
-                        _cprint(f"  Title rejected: {e}")
-                        sanitized = None
+                        _cprint(f"  {e} — session started untitled.")
                         title = None
-                    if sanitized:
-                        try:
-                            self._session_db.set_session_title(self.session_id, sanitized)
-                            self._pending_title = None
-                            self._status_bar_title_checked_at = 0.0
-                            title = sanitized
-                        except ValueError as e:
-                            _cprint(f"  {e} — session started untitled.")
-                            title = None
-                        except Exception:
-                            title = None
-                    elif title is not None:
-                        # sanitize_title returned empty (whitespace-only / unprintable)
-                        _cprint("  Title is empty after cleanup — session started untitled.")
+                    except Exception:
                         title = None
+                elif title is not None:
+                    # sanitize_title returned empty (whitespace-only / unprintable)
+                    _cprint("  Title is empty after cleanup — session started untitled.")
+                    title = None
             # Notify memory providers that session_id rotated to a fresh
             # conversation. reset=True signals providers to flush accumulated
             # per-session state (_session_turns, _turn_counter, _document_id).

--- a/cli.py
+++ b/cli.py
@@ -10356,12 +10356,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         old_session_id = self.session_id
         # Plugin hook: on_session_pre_switch — fires before session rotation.
         try:
-            from hermes_cli.plugins import invoke_hook as _pre_switch
-            _pre_switch(
-                "on_session_pre_switch",
-                old_session_id=old_session_id,
-                cli=self,
-            )
+            from hermes_cli.plugins import has_hook, invoke_hook
+            if has_hook("on_session_pre_switch"):
+                invoke_hook(
+                    "on_session_pre_switch",
+                    old_session_id=old_session_id,
+                    cli=self,
+                )
         except Exception:
             pass
         _boundary_snapshot = None
@@ -10498,13 +10499,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             # Plugin hook: on_session_post_switch — fires after session rotation completes.
             try:
-                from hermes_cli.plugins import invoke_hook as _post_switch
-                _post_switch(
-                    "on_session_post_switch",
-                    old_session_id=old_session_id,
-                    new_session_id=self.session_id,
-                    cli=self,
-                )
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("on_session_post_switch"):
+                    invoke_hook(
+                        "on_session_post_switch",
+                        old_session_id=old_session_id,
+                        new_session_id=self.session_id,
+                        cli=self,
+                    )
             except Exception:
                 pass
 

--- a/cli.py
+++ b/cli.py
@@ -10354,6 +10354,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
         old_session_id = self.session_id
+        # Plugin hook: on_session_pre_switch — fires before session rotation.
+        try:
+            from hermes_cli.plugins import invoke_hook as _pre_switch
+            _pre_switch(
+                "on_session_pre_switch",
+                old_session_id=old_session_id,
+                cli=self,
+            )
+        except Exception:
+            pass
         _boundary_snapshot = None
         if self.agent and self.conversation_history:
             # Deliver the context-engine boundary synchronously and get back
@@ -10485,6 +10495,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     pass
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 self.agent._invalidate_system_prompt()
+
+            # Plugin hook: on_session_post_switch — fires after session rotation completes.
+            try:
+                from hermes_cli.plugins import invoke_hook as _post_switch
+                _post_switch(
+                    "on_session_post_switch",
+                    old_session_id=old_session_id,
+                    new_session_id=self.session_id,
+                    cli=self,
+                )
+            except Exception:
+                pass
 
             if self._session_db:
                 try:

--- a/cli.py
+++ b/cli.py
@@ -10354,12 +10354,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
         old_session_id = self.session_id
-        # Plugin hook: on_session_pre_switch — fires before session rotation.
+        # Plugin hook: session_switch_starting — fires before session rotation.
         try:
             from hermes_cli.plugins import has_hook, invoke_hook
-            if has_hook("on_session_pre_switch"):
+            if has_hook("session_switch_starting"):
                 invoke_hook(
-                    "on_session_pre_switch",
+                    "session_switch_starting",
                     old_session_id=old_session_id,
                     cli=self,
                 )
@@ -10497,12 +10497,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 self.agent._invalidate_system_prompt()
 
-            # Plugin hook: on_session_post_switch — fires after session rotation completes.
+            # Plugin hook: session_switched — fires after session rotation completes.
             try:
                 from hermes_cli.plugins import has_hook, invoke_hook
-                if has_hook("on_session_post_switch"):
+                if has_hook("session_switched"):
                     invoke_hook(
-                        "on_session_post_switch",
+                        "session_switched",
                         old_session_id=old_session_id,
                         new_session_id=self.session_id,
                         cli=self,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -223,6 +223,12 @@ VALID_HOOKS: Set[str] = {
     # Successful skill lifecycle facts. The local skill name is available to
     # plugins, while built-in shared metrics emit only bounded classifications.
     "on_skill_lifecycle",
+    # CLI session-switch hooks.
+    # on_session_pre_switch: fires in new_session() before session rotation.
+    # on_session_post_switch: fires after session rotation completes.
+    # Plugins receive old_session_id, new_session_id (post only), and CLI ref.
+    "on_session_pre_switch",
+    "on_session_post_switch",
     "subagent_start",
     "subagent_stop",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -223,12 +223,19 @@ VALID_HOOKS: Set[str] = {
     # Successful skill lifecycle facts. The local skill name is available to
     # plugins, while built-in shared metrics emit only bounded classifications.
     "on_skill_lifecycle",
-    # CLI session-switch hooks.
-    # on_session_pre_switch: fires in new_session() before session rotation.
-    # on_session_post_switch: fires after session rotation completes.
-    # Plugins receive old_session_id, new_session_id (post only), and CLI ref.
-    "on_session_pre_switch",
-    "on_session_post_switch",
+    # CLI session-switch hooks (observer, no mutation).
+    #
+    # session_switch_starting:
+    #   Fires in new_session() before session rotation.
+    #   Payload: old_session_id=str, cli=<CLI ref>
+    #   Privacy: carries old session ID only (no user content).
+    #
+    # session_switched:
+    #   Fires after session rotation completes.
+    #   Payload: old_session_id=str, new_session_id=str, cli=<CLI ref>
+    #   Privacy: carries session IDs only (no user content).
+    "session_switch_starting",
+    "session_switched",
     "subagent_start",
     "subagent_stop",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent

--- a/tests/hermes_cli/test_session_switch_hooks.py
+++ b/tests/hermes_cli/test_session_switch_hooks.py
@@ -20,10 +20,15 @@ class TestSessionSwitchHooks:
         cli.reasoning_config = None
         cli.agent = MagicMock()
         cli.conversation_history = []
-        cli._session_db = None
+        # Mock SessionDB so session_switched fires (lives after create_session)
+        mock_db = MagicMock()
+        mock_db.create_session = MagicMock()
+        cli._session_db = mock_db
         cli._pending_title = None
         cli._console_print = lambda text: None
         cli._active_session_lease = None
+        cli._discard_session_if_empty = MagicMock(return_value=False)
+        cli._notify_session_boundary = MagicMock()
         for k, v in overrides.items():
             setattr(cli, k, v)
         return cli
@@ -33,7 +38,7 @@ class TestSessionSwitchHooks:
         return [
             (c[0][0], c[1])
             for c in mock_invoke.call_args_list
-            if c[0][0].startswith("session_switch_")
+            if c[0][0].startswith("session_switch")
         ]
 
     # ── tests ──
@@ -43,8 +48,7 @@ class TestSessionSwitchHooks:
 
         with patch("hermes_cli.plugins.has_hook", return_value=True), \
              patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
-             patch("cli._sync_process_session_id"), \
-             patch.object(cli, "_notify_session_boundary"):
+             patch("cli._sync_process_session_id"):
             cli.new_session(silent=True)
 
         calls = self._switch_calls(mock_invoke)
@@ -63,12 +67,11 @@ class TestSessionSwitchHooks:
         cli = self._make_cli()
 
         def _has_hook(name):
-            return not name.startswith("session_switch_")
+            return not name.startswith("session_switch")
 
         with patch("hermes_cli.plugins.has_hook", side_effect=_has_hook), \
              patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
-             patch("cli._sync_process_session_id"), \
-             patch.object(cli, "_notify_session_boundary"):
+             patch("cli._sync_process_session_id"):
             cli.new_session(silent=True)
 
         assert self._switch_calls(mock_invoke) == []
@@ -79,8 +82,7 @@ class TestSessionSwitchHooks:
         with patch("hermes_cli.plugins.has_hook", return_value=True), \
              patch("hermes_cli.plugins.invoke_hook",
                    side_effect=RuntimeError("boom")), \
-             patch("cli._sync_process_session_id"), \
-             patch.object(cli, "_notify_session_boundary"):
+             patch("cli._sync_process_session_id"):
             cli.new_session(silent=True)
 
     def test_starting_hook_receives_old_session_id_only(self):
@@ -88,8 +90,7 @@ class TestSessionSwitchHooks:
 
         with patch("hermes_cli.plugins.has_hook", return_value=True), \
              patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
-             patch("cli._sync_process_session_id"), \
-             patch.object(cli, "_notify_session_boundary"):
+             patch("cli._sync_process_session_id"):
             cli.new_session(silent=True)
 
         kwargs = self._switch_calls(mock_invoke)[0][1]
@@ -101,8 +102,7 @@ class TestSessionSwitchHooks:
 
         with patch("hermes_cli.plugins.has_hook", return_value=True), \
              patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
-             patch("cli._sync_process_session_id"), \
-             patch.object(cli, "_notify_session_boundary"):
+             patch("cli._sync_process_session_id"):
             cli.new_session(silent=True)
 
         kwargs = self._switch_calls(mock_invoke)[1][1]

--- a/tests/hermes_cli/test_session_switch_hooks.py
+++ b/tests/hermes_cli/test_session_switch_hooks.py
@@ -1,0 +1,110 @@
+"""Tests for session-switch plugin hooks in CLI new_session()."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestSessionSwitchHooks:
+    """Verify session_switch_starting / session_switched fire correctly."""
+
+    @staticmethod
+    def _make_cli(**overrides):
+        from cli import HermesCLI
+
+        cli = object.__new__(HermesCLI)
+        cli.session_id = "old-session-id"
+        cli.config = {}
+        cli.model = "test-model"
+        cli.max_turns = 10
+        cli.reasoning_config = None
+        cli.agent = MagicMock()
+        cli.conversation_history = []
+        cli._session_db = None
+        cli._pending_title = None
+        cli._console_print = lambda text: None
+        cli._active_session_lease = None
+        for k, v in overrides.items():
+            setattr(cli, k, v)
+        return cli
+
+    @staticmethod
+    def _switch_calls(mock_invoke):
+        return [
+            (c[0][0], c[1])
+            for c in mock_invoke.call_args_list
+            if c[0][0].startswith("session_switch_")
+        ]
+
+    # ── tests ──
+
+    def test_hooks_fire_on_new_session(self):
+        cli = self._make_cli()
+
+        with patch("hermes_cli.plugins.has_hook", return_value=True), \
+             patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
+             patch("cli._sync_process_session_id"), \
+             patch.object(cli, "_notify_session_boundary"):
+            cli.new_session(silent=True)
+
+        calls = self._switch_calls(mock_invoke)
+        assert len(calls) == 2, f"expected 2, got {calls}"
+
+        assert calls[0][0] == "session_switch_starting"
+        assert calls[0][1]["old_session_id"] == "old-session-id"
+        assert calls[0][1]["cli"] is cli
+
+        assert calls[1][0] == "session_switched"
+        assert calls[1][1]["old_session_id"] == "old-session-id"
+        assert calls[1][1]["new_session_id"] != "old-session-id"
+        assert calls[1][1]["cli"] is cli
+
+    def test_has_hook_false_skips_switch_hooks(self):
+        cli = self._make_cli()
+
+        def _has_hook(name):
+            return not name.startswith("session_switch_")
+
+        with patch("hermes_cli.plugins.has_hook", side_effect=_has_hook), \
+             patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
+             patch("cli._sync_process_session_id"), \
+             patch.object(cli, "_notify_session_boundary"):
+            cli.new_session(silent=True)
+
+        assert self._switch_calls(mock_invoke) == []
+
+    def test_hook_exception_does_not_crash_new_session(self):
+        cli = self._make_cli()
+
+        with patch("hermes_cli.plugins.has_hook", return_value=True), \
+             patch("hermes_cli.plugins.invoke_hook",
+                   side_effect=RuntimeError("boom")), \
+             patch("cli._sync_process_session_id"), \
+             patch.object(cli, "_notify_session_boundary"):
+            cli.new_session(silent=True)
+
+    def test_starting_hook_receives_old_session_id_only(self):
+        cli = self._make_cli()
+
+        with patch("hermes_cli.plugins.has_hook", return_value=True), \
+             patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
+             patch("cli._sync_process_session_id"), \
+             patch.object(cli, "_notify_session_boundary"):
+            cli.new_session(silent=True)
+
+        kwargs = self._switch_calls(mock_invoke)[0][1]
+        assert "old_session_id" in kwargs
+        assert "new_session_id" not in kwargs
+
+    def test_switched_hook_receives_both_session_ids(self):
+        cli = self._make_cli()
+
+        with patch("hermes_cli.plugins.has_hook", return_value=True), \
+             patch("hermes_cli.plugins.invoke_hook") as mock_invoke, \
+             patch("cli._sync_process_session_id"), \
+             patch.object(cli, "_notify_session_boundary"):
+            cli.new_session(silent=True)
+
+        kwargs = self._switch_calls(mock_invoke)[1][1]
+        assert "old_session_id" in kwargs
+        assert "new_session_id" in kwargs

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -937,6 +937,8 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
 | [`gateway_platform_event`](/user-guide/features/hooks#gateway_platform_event) | An authorized platform-native event is normalized at the gateway boundary (Telegram reactions currently) | `platform: str, event_type: str, payload: dict` | ignored |
+| [`session_switch_starting`](#session_switch_starting) | Before session rotation begins (CLI only) | `old_session_id: str, new_session_id: str, cli: HermesCLI` | ignored |
+| [`session_switched`](#session_switched) | After session rotation + fresh SessionDB row created (CLI only) | `old_session_id: str, new_session_id: str, cli: HermesCLI` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |


### PR DESCRIPTION
## What does this PR do?

Adds two observer hooks for session-switch lifecycle in the CLI.

- `session_switch_starting` — fires in `new_session()` before rotation
- `session_switched` — fires after rotation completes

## Related Issue

#64231 (plugin lifecycle-event catalog & hook taxonomy)

## Type of Change

- [x] ✨ New feature

## Hook taxonomy (per #64231)

| Requirement | Detail |
|---|---|
| **Naming** | `<subsystem>_<noun>_<verb-past>` — `session_switch_starting` / `session_switched` |
| **Classification** | observer (no mutation, fire-and-forget) |
| **Payload** | keyword-only: `old_session_id=str`, `new_session_id=str` (post only), `cli=<CLI ref>` |
| **Privacy** | carries session IDs only — no user content |
| **Cost rule** | `has_hook()` short-circuit before `invoke_hook()` |
| **Bus mirroring** | not applicable (CLI-local event, no inter-plugin bus mirroring) |

## Scope

CLI-only. TUI/desktop session-switch tracking deferred to #64231.

## Checklist

- [x] VALID_HOOKS registered with docs
- [x] `has_hook()` short-circuit at call sites
- [x] Naming follows taxonomy grammar
- [x] Tests — `tests/hermes_cli/test_session_switch_hooks.py` (5 tests)