### PR TITLE
feat(workspace-docs): inert workspace documents — backend CRUD + desktop panel

### DIFF
--- a/agent/workspace_docs.py
+++ b/agent/workspace_docs.py
@@ -1,0 +1,466 @@
+"""Pure-Python foundation for workspace documents.
+
+Workspace documents are inert safekeeping artifacts: drafted skill templates,
+memory notes, workspace instructions, prompt templates, runbooks, and generic
+Markdown notes that live under ``<workspace>/.hermes/docs/``. This module only
+covers schema validation and safe path resolution. It deliberately does not
+render MDX, expose tools/endpoints, or hook documents into skills, memory, or
+prompt construction.
+
+Workspace identity decision
+---------------------------
+For this first slice, a workspace identity is the resolved absolute workspace
+root path. That is deterministic, stable within a checkout/worktree, and avoids
+string-prefix mistakes around ``~/.hermes``. A normal repository may itself live
+under ``~/.hermes`` (Hermes local development commonly does); only the existing
+``agent.file_safety`` classifiers decide whether a path is profile state or a
+sandbox/container mirror.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from agent.file_safety import (
+    classify_container_mirror_target,
+    classify_cross_profile_target,
+    classify_sandbox_mirror_target,
+    get_container_mirror_warning,
+    get_cross_profile_warning,
+    get_sandbox_mirror_warning,
+)
+from agent.skill_utils import parse_frontmatter
+from hermes_constants import get_hermes_home
+
+StrPath = Union[str, "os.PathLike[str]"]
+
+WORKSPACE_DOCS_RELPATH = Path(".hermes") / "docs"
+WORKSPACE_DOC_FRONTMATTER_TYPE = "hermes-workspace-document"
+
+
+class WorkspaceDocError(Exception):
+    """Base class for workspace document validation/safety failures."""
+
+
+class WorkspaceDocValidationError(WorkspaceDocError):
+    """Frontmatter is missing or fails schema validation."""
+
+
+class WorkspaceDocPathError(WorkspaceDocError):
+    """Requested document path escapes the workspace/docs boundary."""
+
+
+class WorkspaceDocSafetyError(WorkspaceDocError):
+    """Resolved path collides with a Hermes profile/sandbox safety guard."""
+
+    def __init__(self, message: str, *, classifier: str):
+        super().__init__(message)
+        self.classifier = classifier
+
+
+class WorkspaceDocType(str, Enum):
+    SKILL_TEMPLATE = "skill-template"
+    MEMORY_NOTE = "memory-note"
+    WORKSPACE_INSTRUCTIONS = "workspace-instructions"
+    PROMPT_TEMPLATE = "prompt-template"
+    RUNBOOK = "runbook"
+    GENERIC_MD = "generic-md"
+
+
+class WorkspaceDocStatus(str, Enum):
+    DRAFT = "draft"
+    READY = "ready"
+    ARCHIVED = "archived"
+
+
+class WorkspaceDocApplyState(str, Enum):
+    UNAPPLIED = "unapplied"
+    EXPORTED = "exported"
+    IMPORTED = "imported"
+
+
+@dataclass(frozen=True)
+class WorkspaceDocFrontmatter:
+    """Validated frontmatter for an inert workspace document."""
+
+    doc_type: WorkspaceDocType
+    title: str
+    workspace_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    status: WorkspaceDocStatus = WorkspaceDocStatus.DRAFT
+    apply_state: WorkspaceDocApplyState = WorkspaceDocApplyState.UNAPPLIED
+    description: Optional[str] = None
+    tags: tuple[str, ...] = ()
+
+
+def _require_string(frontmatter: dict[str, Any], field: str) -> str:
+    value = frontmatter.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise WorkspaceDocValidationError(f"missing required field: {field}")
+    return value.strip()
+
+
+def _optional_string(frontmatter: dict[str, Any], field: str) -> Optional[str]:
+    value = frontmatter.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise WorkspaceDocValidationError(f"{field} must be a string")
+    return value.strip() or None
+
+
+def _enum_value(enum_cls: type[Enum], raw: Any, field: str, default: Any = None) -> Any:
+    if raw is None:
+        return default
+    try:
+        return enum_cls(str(raw))
+    except ValueError as exc:
+        valid = ", ".join(member.value for member in enum_cls)  # type: ignore[attr-defined]
+        raise WorkspaceDocValidationError(
+            f"invalid {field} {raw!r}; must be one of: {valid}"
+        ) from exc
+
+
+def validate_workspace_doc_frontmatter(frontmatter: dict[str, Any]) -> WorkspaceDocFrontmatter:
+    """Validate workspace-document YAML frontmatter.
+
+    Required fields are ``type: hermes-workspace-document``, ``doc_type``, and
+    ``title``. ``status`` defaults to ``draft`` and ``apply_state`` defaults to
+    ``unapplied`` so newly-created documents are explicitly inert until a later
+    import/export flow changes them.
+    """
+
+    if not isinstance(frontmatter, dict):
+        raise WorkspaceDocValidationError("frontmatter must be a mapping")
+
+    document_type = frontmatter.get("type")
+    if document_type != WORKSPACE_DOC_FRONTMATTER_TYPE:
+        raise WorkspaceDocValidationError(
+            f"type must be {WORKSPACE_DOC_FRONTMATTER_TYPE!r}"
+        )
+
+    doc_type = _enum_value(
+        WorkspaceDocType,
+        frontmatter.get("doc_type"),
+        "doc_type",
+    )
+    if doc_type is None:
+        raise WorkspaceDocValidationError("missing required field: doc_type")
+
+    tags_raw = frontmatter.get("tags") or []
+    if not isinstance(tags_raw, list) or not all(isinstance(tag, str) for tag in tags_raw):
+        raise WorkspaceDocValidationError("tags must be a list of strings")
+
+    return WorkspaceDocFrontmatter(
+        doc_type=doc_type,
+        title=_require_string(frontmatter, "title"),
+        workspace_id=_optional_string(frontmatter, "workspace_id"),
+        created_at=_optional_string(frontmatter, "created_at"),
+        updated_at=_optional_string(frontmatter, "updated_at"),
+        status=_enum_value(
+            WorkspaceDocStatus,
+            frontmatter.get("status"),
+            "status",
+            WorkspaceDocStatus.DRAFT,
+        ),
+        apply_state=_enum_value(
+            WorkspaceDocApplyState,
+            frontmatter.get("apply_state"),
+            "apply_state",
+            WorkspaceDocApplyState.UNAPPLIED,
+        ),
+        description=_optional_string(frontmatter, "description"),
+        tags=tuple(tags_raw),
+    )
+
+
+def parse_workspace_doc(content: str) -> tuple[WorkspaceDocFrontmatter, str]:
+    """Parse and validate a workspace document from Markdown text."""
+
+    raw_frontmatter, body = parse_frontmatter(content)
+    if not raw_frontmatter:
+        raise WorkspaceDocValidationError("workspace document is missing YAML frontmatter")
+    return validate_workspace_doc_frontmatter(raw_frontmatter), body
+
+
+@dataclass(frozen=True)
+class WorkspaceIdentity:
+    """A deterministic identity for a workspace or profile fallback."""
+
+    kind: str
+    identity: str
+    root: Path
+
+
+def resolve_workspace_identity(workspace_root: Optional[StrPath] = None) -> WorkspaceIdentity:
+    """Resolve the current workspace identity.
+
+    The identity is a resolved absolute root path. When no workspace root is
+    available, the active profile's resolved ``HERMES_HOME`` is used as an
+    explicit ``profile-fallback`` identity.
+    """
+
+    if workspace_root is not None:
+        root = Path(os.path.expanduser(str(workspace_root))).resolve()
+        return WorkspaceIdentity(kind="workspace", identity=str(root), root=root)
+    home = get_hermes_home().resolve()
+    return WorkspaceIdentity(kind="profile-fallback", identity=str(home), root=home)
+
+
+def workspace_doc_frontmatter_defaults(workspace_root: StrPath) -> dict[str, str]:
+    """Return default inert frontmatter values for a new workspace document."""
+
+    return {
+        "type": WORKSPACE_DOC_FRONTMATTER_TYPE,
+        "workspace_id": resolve_workspace_identity(workspace_root).identity,
+        "status": WorkspaceDocStatus.DRAFT.value,
+        "apply_state": WorkspaceDocApplyState.UNAPPLIED.value,
+    }
+
+
+def _resolve_workspace_root(workspace_root: StrPath) -> Path:
+    return Path(os.path.expanduser(str(workspace_root))).resolve()
+
+
+def get_workspace_docs_root(workspace_root: StrPath) -> Path:
+    """Return the resolved ``<workspace_root>/.hermes/docs`` root.
+
+    If ``.hermes`` or ``docs`` is a symlink escaping the workspace, this raises
+    ``WorkspaceDocPathError`` instead of silently storing safekeeping data
+    elsewhere.
+    """
+
+    root = _resolve_workspace_root(workspace_root)
+    docs_root = (root / WORKSPACE_DOCS_RELPATH).resolve()
+    try:
+        docs_root.relative_to(root)
+    except ValueError as exc:
+        raise WorkspaceDocPathError(
+            f"workspace docs root {docs_root} escapes workspace root {root}"
+        ) from exc
+    return docs_root
+
+
+def _raise_if_file_safety_guarded(resolved: Path, *, mirror_prefix: Optional[str]) -> None:
+    resolved_str = str(resolved)
+
+    if classify_cross_profile_target(resolved_str) is not None:
+        raise WorkspaceDocSafetyError(
+            get_cross_profile_warning(resolved_str) or "cross-profile target",
+            classifier="cross_profile",
+        )
+    if classify_sandbox_mirror_target(resolved_str) is not None:
+        raise WorkspaceDocSafetyError(
+            get_sandbox_mirror_warning(resolved_str) or "sandbox-mirror target",
+            classifier="sandbox_mirror",
+        )
+    if mirror_prefix and classify_container_mirror_target(resolved_str, mirror_prefix) is not None:
+        raise WorkspaceDocSafetyError(
+            get_container_mirror_warning(resolved_str, mirror_prefix) or "container-mirror target",
+            classifier="container_mirror",
+        )
+
+
+def resolve_workspace_doc_path(
+    workspace_root: StrPath,
+    relative_path: str = "",
+    *,
+    mirror_prefix: Optional[str] = None,
+) -> Path:
+    """Resolve a document path under ``<workspace_root>/.hermes/docs`` safely."""
+
+    if relative_path and os.path.isabs(relative_path):
+        raise WorkspaceDocPathError(f"absolute path not allowed: {relative_path!r}")
+
+    docs_root = get_workspace_docs_root(workspace_root)
+    _raise_if_file_safety_guarded(docs_root, mirror_prefix=mirror_prefix)
+
+    resolved = (docs_root / relative_path).resolve() if relative_path else docs_root
+    try:
+        resolved.relative_to(docs_root)
+    except ValueError as exc:
+        raise WorkspaceDocPathError(
+            f"{relative_path!r} escapes the workspace docs root {docs_root}"
+        ) from exc
+
+    _raise_if_file_safety_guarded(resolved, mirror_prefix=mirror_prefix)
+    return resolved
+
+
+def is_workspace_docs_path(path: StrPath) -> bool:
+    """Return True when *path* is under a ``.hermes/docs`` segment."""
+
+    resolved = Path(os.path.expanduser(str(path))).resolve()
+    parts = resolved.parts
+    return any(
+        parts[index] == ".hermes" and parts[index + 1] == "docs"
+        for index in range(len(parts) - 1)
+    )
+
+
+def workspace_docs_are_inert() -> bool:
+    """Document the slice-1 invariant that workspace docs are safekeeping data."""
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Slice 2: backend CRUD (list/read/write/archive). Still no MDX rendering,
+# import/export, model tool, or profile index — callers (e.g. the REST layer
+# in hermes_cli.web_server) own transport concerns; this module keeps owning
+# schema validation, path safety, and atomic writes.
+# ---------------------------------------------------------------------------
+
+WORKSPACE_DOC_MAX_BYTES = 2 * 1024 * 1024
+
+
+def frontmatter_to_mapping(frontmatter: WorkspaceDocFrontmatter) -> dict[str, Any]:
+    """Convert validated frontmatter back into a plain YAML-serializable mapping."""
+
+    mapping: dict[str, Any] = {
+        "type": WORKSPACE_DOC_FRONTMATTER_TYPE,
+        "doc_type": frontmatter.doc_type.value,
+        "title": frontmatter.title,
+        "status": frontmatter.status.value,
+        "apply_state": frontmatter.apply_state.value,
+    }
+    if frontmatter.workspace_id is not None:
+        mapping["workspace_id"] = frontmatter.workspace_id
+    if frontmatter.created_at is not None:
+        mapping["created_at"] = frontmatter.created_at
+    if frontmatter.updated_at is not None:
+        mapping["updated_at"] = frontmatter.updated_at
+    if frontmatter.description is not None:
+        mapping["description"] = frontmatter.description
+    if frontmatter.tags:
+        mapping["tags"] = list(frontmatter.tags)
+    return mapping
+
+
+def render_workspace_doc(frontmatter: dict[str, Any], body: str) -> str:
+    """Serialize frontmatter + Markdown body back into workspace-document text."""
+
+    import yaml
+
+    fm_yaml = yaml.safe_dump(dict(frontmatter), sort_keys=False, allow_unicode=True).strip()
+    body_text = (body or "").strip("\n")
+    if body_text:
+        return f"---\n{fm_yaml}\n---\n\n{body_text}\n"
+    return f"---\n{fm_yaml}\n---\n"
+
+
+def _atomic_write_workspace_doc(target: Path, text: str) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f".{target.name}.hermes-tmp-{os.getpid()}")
+    renamed = False
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, target)
+        renamed = True
+    finally:
+        if not renamed:
+            tmp.unlink(missing_ok=True)
+
+
+def write_workspace_doc(
+    workspace_root: StrPath,
+    relative_path: str,
+    *,
+    frontmatter: dict[str, Any],
+    body: str,
+    mirror_prefix: Optional[str] = None,
+) -> tuple[Path, WorkspaceDocFrontmatter]:
+    """Validate and atomically create/update a workspace document.
+
+    Callers own merge-with-existing-frontmatter and timestamp policy; this
+    validates the final frontmatter mapping, resolves+guards the path, and
+    performs the atomic write. Directories under ``.hermes/docs`` are created
+    as needed; nothing outside that root is ever touched.
+    """
+
+    if not relative_path or not relative_path.lower().endswith(".md"):
+        raise WorkspaceDocPathError(f"document path must end with .md: {relative_path!r}")
+
+    encoded_body = (body or "").encode("utf-8")
+    if len(encoded_body) > WORKSPACE_DOC_MAX_BYTES:
+        raise WorkspaceDocValidationError("document body exceeds the maximum allowed size")
+    if b"\0" in encoded_body:
+        raise WorkspaceDocValidationError("document body must be text, not binary")
+
+    validated = validate_workspace_doc_frontmatter(frontmatter)
+    target = resolve_workspace_doc_path(workspace_root, relative_path, mirror_prefix=mirror_prefix)
+
+    text = render_workspace_doc(frontmatter_to_mapping(validated), body)
+    _atomic_write_workspace_doc(target, text)
+    return target, validated
+
+
+def archive_workspace_doc(
+    workspace_root: StrPath,
+    relative_path: str,
+    *,
+    mirror_prefix: Optional[str] = None,
+) -> tuple[Path, WorkspaceDocFrontmatter]:
+    """Mark an existing workspace document archived in place, idempotently.
+
+    Reversible and explicit: this only flips ``status`` to ``archived`` in the
+    document's own frontmatter. The file stays at the same path so a later
+    un-archive is just another status update.
+    """
+
+    target = resolve_workspace_doc_path(workspace_root, relative_path, mirror_prefix=mirror_prefix)
+    if not target.is_file():
+        raise FileNotFoundError(str(target))
+
+    frontmatter, body = parse_workspace_doc(target.read_text(encoding="utf-8"))
+    if frontmatter.status is WorkspaceDocStatus.ARCHIVED:
+        return target, frontmatter
+
+    archived = replace(frontmatter, status=WorkspaceDocStatus.ARCHIVED)
+    text = render_workspace_doc(frontmatter_to_mapping(archived), body)
+    _atomic_write_workspace_doc(target, text)
+    return target, archived
+
+
+@dataclass(frozen=True)
+class WorkspaceDocSummary:
+    """One entry in a workspace-docs listing."""
+
+    relative_path: str
+    valid: bool
+    frontmatter: Optional[WorkspaceDocFrontmatter] = None
+    error: Optional[str] = None
+
+
+def list_workspace_docs(
+    workspace_root: StrPath,
+    *,
+    mirror_prefix: Optional[str] = None,
+) -> list[WorkspaceDocSummary]:
+    """List Markdown documents under ``<workspace_root>/.hermes/docs``, sorted by path."""
+
+    docs_root = resolve_workspace_doc_path(workspace_root, mirror_prefix=mirror_prefix)
+    if not docs_root.is_dir():
+        return []
+
+    paths = sorted(
+        (path for path in docs_root.rglob("*.md") if path.is_file()),
+        key=lambda path: path.relative_to(docs_root).as_posix(),
+    )
+
+    summaries: list[WorkspaceDocSummary] = []
+    for path in paths:
+        relative_path = path.relative_to(docs_root).as_posix()
+        try:
+            content = path.read_text(encoding="utf-8")
+            frontmatter, _body = parse_workspace_doc(content)
+        except (WorkspaceDocValidationError, OSError, UnicodeDecodeError) as exc:
+            summaries.append(WorkspaceDocSummary(relative_path=relative_path, valid=False, error=str(exc)))
+            continue
+        summaries.append(WorkspaceDocSummary(relative_path=relative_path, valid=True, frontmatter=frontmatter))
+    return summaries

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -27,6 +27,7 @@ import {
   updateProject
 } from '@/store/projects'
 
+import { WorkspaceDocumentsPanel } from './workspace-documents-panel'
 import type { SidebarProjectTree } from './workspace-groups'
 
 // Curated codicons for the project glyph (tinted by the chosen color).
@@ -90,6 +91,7 @@ export function ProjectMenu({
   const target = { id: project.id, name: project.label }
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
   const [appearanceOpen, setAppearanceOpen] = useState(false)
+  const [docsOpen, setDocsOpen] = useState(false)
   // Open toward the content area: right when the sidebar is on the left, left
   // when the panes are flipped (sidebar on the right).
   const panesFlipped = useStore($panesFlipped)
@@ -173,6 +175,10 @@ export function ProjectMenu({
             <Codicon name="copy" size="0.875rem" />
             <span>{p.copyPath}</span>
           </DropdownMenuItem>
+          <DropdownMenuItem disabled={!project.path} onSelect={() => setDocsOpen(true)}>
+            <Codicon name="book" size="0.875rem" />
+            <span>{p.menuDocuments}</span>
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           {project.isAuto ? (
             <DropdownMenuItem onSelect={removeAuto} variant="destructive">
@@ -230,6 +236,14 @@ export function ProjectMenu({
         open={confirmDeleteOpen}
         title={`${p.menuDelete} "${project.label}"?`}
       />
+      {project.path && (
+        <WorkspaceDocumentsPanel
+          label={project.label}
+          onOpenChange={setDocsOpen}
+          open={docsOpen}
+          workspaceRoot={project.path}
+        />
+      )}
     </Popover>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-documents-panel.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-documents-panel.tsx
@@ -1,0 +1,509 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { useI18n } from '@/i18n'
+import { AlertTriangle, Loader2, Plus } from '@/lib/icons'
+import {
+  archiveWorkspaceDoc,
+  listWorkspaceDocs,
+  readWorkspaceDoc,
+  writeWorkspaceDoc,
+  type WorkspaceDocDetail,
+  type WorkspaceDocStatus,
+  type WorkspaceDocSummary,
+  type WorkspaceDocType
+} from '@/lib/workspace-docs'
+
+// Templates offered from "New document" — a fixed subset of WorkspaceDocType
+// (skill/memory/prompt authoring belongs to other surfaces; this panel only
+// covers the doc types explicitly scoped for this slice).
+const CREATE_TEMPLATES: { docType: WorkspaceDocType; body: string }[] = [
+  { docType: 'generic-md', body: '' },
+  { docType: 'runbook', body: '## Steps\n\n1. \n' },
+  { docType: 'skill-template', body: '## When to use\n\n## Steps\n' },
+  { docType: 'memory-note', body: '## Context\n\n## Notes\n' }
+]
+
+const STATUS_OPTIONS: WorkspaceDocStatus[] = ['draft', 'ready', 'archived']
+
+function slugify(title: string): string {
+  const slug = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return slug || 'document'
+}
+
+function uniqueDocPath(title: string, existing: WorkspaceDocSummary[]): string {
+  const base = slugify(title)
+  const taken = new Set(existing.map(doc => doc.path))
+  let candidate = `${base}.md`
+  let suffix = 2
+
+  while (taken.has(candidate)) {
+    candidate = `${base}-${suffix}.md`
+    suffix += 1
+  }
+
+  return candidate
+}
+
+function tagsToInput(tags?: string[]): string {
+  return (tags ?? []).join(', ')
+}
+
+function inputToTags(value: string): string[] {
+  return value
+    .split(',')
+    .map(tag => tag.trim())
+    .filter(Boolean)
+}
+
+function statusBadgeVariant(status?: WorkspaceDocStatus): 'default' | 'muted' | 'outline' {
+  if (status === 'ready') {
+    return 'default'
+  }
+
+  if (status === 'archived') {
+    return 'outline'
+  }
+
+  return 'muted'
+}
+
+type View = 'list' | 'create' | 'detail'
+
+// Minimal library UI for the inert workspace documents under
+// `<project.path>/.hermes/docs` — list, create-from-template, edit, and
+// archive. No MDX rendering, no import/export/promote actions; saves and
+// archives go straight through `@/lib/workspace-docs`.
+export function WorkspaceDocumentsPanel({
+  open,
+  onOpenChange,
+  workspaceRoot,
+  label
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceRoot: string
+  label: string
+}) {
+  const { t } = useI18n()
+  const d = t.workspaceDocs
+
+  const [view, setView] = useState<View>('list')
+  const [docs, setDocs] = useState<WorkspaceDocSummary[]>([])
+  const [listState, setListState] = useState<'error' | 'idle' | 'loading'>('loading')
+  const [listError, setListError] = useState<null | string>(null)
+
+  const [createDocType, setCreateDocType] = useState<WorkspaceDocType>('generic-md')
+  const [createTitle, setCreateTitle] = useState('')
+  const [createState, setCreateState] = useState<'error' | 'idle' | 'saving'>('idle')
+  const [createError, setCreateError] = useState<null | string>(null)
+
+  const [selected, setSelected] = useState<null | WorkspaceDocDetail>(null)
+  const [readError, setReadError] = useState<null | string>(null)
+  const [titleInput, setTitleInput] = useState('')
+  const [statusInput, setStatusInput] = useState<WorkspaceDocStatus>('draft')
+  const [descriptionInput, setDescriptionInput] = useState('')
+  const [tagsInput, setTagsInput] = useState('')
+  const [bodyInput, setBodyInput] = useState('')
+  const [saveState, setSaveState] = useState<'error' | 'idle' | 'saving'>('idle')
+  const [saveError, setSaveError] = useState<null | string>(null)
+  const [archiveState, setArchiveState] = useState<'error' | 'idle' | 'saving'>('idle')
+  const [archiveError, setArchiveError] = useState<null | string>(null)
+
+  const dirty = useMemo(() => {
+    if (!selected) {
+      return false
+    }
+
+    return (
+      titleInput !== selected.frontmatter.title ||
+      statusInput !== selected.frontmatter.status ||
+      descriptionInput !== (selected.frontmatter.description ?? '') ||
+      tagsInput !== tagsToInput(selected.frontmatter.tags) ||
+      bodyInput !== selected.body
+    )
+  }, [selected, titleInput, statusInput, descriptionInput, tagsInput, bodyInput])
+
+  async function loadDocs() {
+    setListState('loading')
+    setListError(null)
+
+    try {
+      const result = await listWorkspaceDocs(workspaceRoot)
+      setDocs(result)
+      setListState('idle')
+    } catch (err) {
+      setListState('error')
+      setListError(err instanceof Error ? err.message : d.loadFailed)
+    }
+  }
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    setView('list')
+    setSelected(null)
+    void loadDocs()
+    // Only reload when the panel opens for a (possibly different) project —
+    // in-panel navigation manages its own refreshes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, workspaceRoot])
+
+  function openCreate() {
+    setCreateDocType('generic-md')
+    setCreateTitle('')
+    setCreateError(null)
+    setCreateState('idle')
+    setView('create')
+  }
+
+  function loadDetail(detail: WorkspaceDocDetail) {
+    setSelected(detail)
+    setTitleInput(detail.frontmatter.title)
+    setStatusInput(detail.frontmatter.status)
+    setDescriptionInput(detail.frontmatter.description ?? '')
+    setTagsInput(tagsToInput(detail.frontmatter.tags))
+    setBodyInput(detail.body)
+    setSaveState('idle')
+    setSaveError(null)
+    setArchiveState('idle')
+    setArchiveError(null)
+    setView('detail')
+  }
+
+  async function openDoc(doc: WorkspaceDocSummary) {
+    setReadError(null)
+
+    try {
+      const detail = await readWorkspaceDoc(workspaceRoot, doc.path)
+      loadDetail(detail)
+    } catch (err) {
+      setReadError(err instanceof Error ? err.message : d.readFailed)
+    }
+  }
+
+  async function handleCreate() {
+    setCreateState('saving')
+    setCreateError(null)
+
+    const title = createTitle.trim() || d.titlePlaceholder
+    const path = uniqueDocPath(title, docs)
+    const template = CREATE_TEMPLATES.find(entry => entry.docType === createDocType) ?? CREATE_TEMPLATES[0]
+
+    try {
+      await writeWorkspaceDoc(workspaceRoot, path, { docType: createDocType, title, status: 'draft', tags: [] }, template.body)
+      const detail = await readWorkspaceDoc(workspaceRoot, path)
+      await loadDocs()
+      loadDetail(detail)
+    } catch (err) {
+      setCreateState('error')
+      setCreateError(err instanceof Error ? err.message : d.saveFailed)
+    }
+  }
+
+  async function handleSave() {
+    if (!selected) {
+      return
+    }
+
+    setSaveState('saving')
+    setSaveError(null)
+
+    try {
+      const result = await writeWorkspaceDoc(
+        workspaceRoot,
+        selected.path,
+        {
+          docType: selected.frontmatter.docType,
+          title: titleInput.trim() || selected.frontmatter.title,
+          status: statusInput,
+          applyState: selected.frontmatter.applyState,
+          description: descriptionInput.trim() || null,
+          tags: inputToTags(tagsInput),
+          workspaceId: selected.frontmatter.workspaceId,
+          createdAt: selected.frontmatter.createdAt
+        },
+        bodyInput
+      )
+
+      setSelected({ ...selected, frontmatter: result.frontmatter, body: bodyInput })
+      setSaveState('idle')
+      await loadDocs()
+    } catch (err) {
+      setSaveState('error')
+      setSaveError(err instanceof Error ? err.message : d.saveFailed)
+    }
+  }
+
+  async function handleArchive() {
+    if (!selected) {
+      return
+    }
+
+    setArchiveState('saving')
+    setArchiveError(null)
+
+    try {
+      const result = await archiveWorkspaceDoc(workspaceRoot, selected.path)
+      setSelected({ ...selected, frontmatter: result.frontmatter })
+      setStatusInput(result.frontmatter.status)
+      setArchiveState('idle')
+      await loadDocs()
+    } catch (err) {
+      setArchiveState('error')
+      setArchiveError(err instanceof Error ? err.message : d.archiveFailed)
+    }
+  }
+
+  const isArchived = selected?.frontmatter.status === 'archived'
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-lg" onClick={event => event.stopPropagation()}>
+        {view === 'list' && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{d.title}</DialogTitle>
+              <DialogDescription>{d.description(label)}</DialogDescription>
+            </DialogHeader>
+
+            {listState === 'loading' && (
+              <div className="flex items-center gap-2 py-6 text-xs text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" />
+                {d.loading}
+              </div>
+            )}
+
+            {listState === 'error' && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>{listError ?? d.loadFailed}</span>
+              </div>
+            )}
+
+            {listState === 'idle' && docs.length === 0 && (
+              <div className="flex flex-col items-center gap-1 py-6 text-center text-xs text-muted-foreground">
+                <span>{d.empty}</span>
+                <span>{d.emptyHint}</span>
+              </div>
+            )}
+
+            {listState === 'idle' && docs.length > 0 && (
+              <div className="flex max-h-80 flex-col gap-1 overflow-y-auto">
+                {docs.map(doc => (
+                  <button
+                    className="flex w-full items-center justify-between gap-2 rounded-md border border-transparent px-2.5 py-1.5 text-left text-xs hover:border-(--ui-stroke-secondary) hover:bg-(--chrome-action-hover) disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={!doc.valid}
+                    key={doc.path}
+                    onClick={() => void openDoc(doc)}
+                    type="button"
+                  >
+                    <span className="flex min-w-0 flex-col gap-0.5">
+                      <span className="truncate font-medium text-foreground">{doc.title ?? doc.path}</span>
+                      <span className="truncate text-(--ui-text-tertiary)">
+                        {doc.docType ? d.docType[doc.docType] : doc.path}
+                        {doc.error ? ` — ${doc.error}` : ''}
+                      </span>
+                    </span>
+                    <span className="flex shrink-0 items-center gap-1.5">
+                      {!doc.valid && (
+                        <Badge variant="destructive">
+                          <AlertTriangle className="size-3" />
+                          {d.invalid}
+                        </Badge>
+                      )}
+                      {doc.status && <Badge variant={statusBadgeVariant(doc.status)}>{d.status[doc.status]}</Badge>}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {readError && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>{readError}</span>
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button onClick={openCreate} variant="secondary">
+                <Plus className="size-3.5" />
+                {d.newButton}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {view === 'create' && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{d.createTitle}</DialogTitle>
+              <DialogDescription>{d.createDesc}</DialogDescription>
+            </DialogHeader>
+
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-(--ui-text-secondary)">{d.fieldTitle}</label>
+                <Input
+                  onChange={event => setCreateTitle(event.target.value)}
+                  placeholder={d.titlePlaceholder}
+                  value={createTitle}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                {CREATE_TEMPLATES.map(template => (
+                  <button
+                    className={`rounded-md border px-2.5 py-2 text-left text-xs transition ${
+                      createDocType === template.docType
+                        ? 'border-primary bg-primary/10 text-foreground'
+                        : 'border-(--ui-stroke-secondary) text-(--ui-text-secondary) hover:bg-(--chrome-action-hover)'
+                    }`}
+                    key={template.docType}
+                    onClick={() => setCreateDocType(template.docType)}
+                    type="button"
+                  >
+                    {d.docType[template.docType]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {createState === 'error' && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>{createError ?? d.saveFailed}</span>
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button disabled={createState === 'saving'} onClick={() => setView('list')} variant="ghost">
+                {d.back}
+              </Button>
+              <Button disabled={createState === 'saving'} onClick={() => void handleCreate()}>
+                {createState === 'saving' ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                {d.newButton}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {view === 'detail' && selected && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{titleInput || d.titlePlaceholder}</DialogTitle>
+              <DialogDescription>
+                {d.docType[selected.frontmatter.docType]}
+                {dirty ? ` · ${d.dirtyHint}` : ''}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex max-h-[60vh] flex-col gap-3 overflow-y-auto pr-1">
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-(--ui-text-secondary)">{d.fieldTitle}</label>
+                <Input onChange={event => setTitleInput(event.target.value)} value={titleInput} />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-(--ui-text-secondary)">{d.fieldStatus}</label>
+                <Select
+                  onValueChange={value => setStatusInput(value as WorkspaceDocStatus)}
+                  value={statusInput}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STATUS_OPTIONS.map(status => (
+                      <SelectItem key={status} value={status}>
+                        {d.status[status]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-(--ui-text-secondary)">{d.fieldDescription}</label>
+                <Input onChange={event => setDescriptionInput(event.target.value)} value={descriptionInput} />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-(--ui-text-secondary)">{d.fieldTags}</label>
+                <Input
+                  onChange={event => setTagsInput(event.target.value)}
+                  placeholder={d.tagsPlaceholder}
+                  value={tagsInput}
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-(--ui-text-secondary)">{d.fieldBody}</label>
+                <Textarea
+                  className="min-h-40"
+                  onChange={event => setBodyInput(event.target.value)}
+                  value={bodyInput}
+                />
+              </div>
+            </div>
+
+            {saveState === 'error' && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>{saveError ?? d.saveFailed}</span>
+              </div>
+            )}
+
+            {archiveState === 'error' && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>{archiveError ?? d.archiveFailed}</span>
+              </div>
+            )}
+
+            <DialogFooter className="sm:justify-between">
+              <Button onClick={() => setView('list')} variant="ghost">
+                {d.back}
+              </Button>
+              <div className="flex gap-2">
+                <Button
+                  disabled={isArchived || archiveState === 'saving'}
+                  onClick={() => void handleArchive()}
+                  variant="secondary"
+                >
+                  {archiveState === 'saving' ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                  {d.archive}
+                </Button>
+                <Button disabled={!dirty || saveState === 'saving'} onClick={() => void handleSave()}>
+                  {saveState === 'saving' ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                  {d.save}
+                </Button>
+              </div>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1609,7 +1609,8 @@ export const en: Translations = {
       enter: label => `Open ${label}`,
       reorder: label => `Reorder ${label}`,
       toggle: label => `Toggle ${label} sessions`,
-      back: 'All projects'
+      back: 'All projects',
+      menuDocuments: 'Documents'
     },
     newSessionIn: label => `New session in ${label}`,
     showMoreIn: (count, label) => `Show ${count} more in ${label}`,
@@ -1641,6 +1642,48 @@ export const en: Translations = {
       ageDay: 'd',
       ageHour: 'h',
       ageMin: 'm'
+    }
+  },
+
+  workspaceDocs: {
+    title: 'Workspace documents',
+    description: label => `Safekeeping notes for ${label}. Inert until you promote them elsewhere.`,
+    newButton: 'New document',
+    createTitle: 'New document',
+    createDesc: 'Choose a document type to start from a template.',
+    loading: 'Loading documents…',
+    loadFailed: 'Could not load workspace documents',
+    empty: 'No workspace documents yet.',
+    emptyHint: 'Create a runbook, memory note, skill template, or generic note to get started.',
+    invalid: 'Invalid',
+    back: 'Back',
+    fieldTitle: 'Title',
+    fieldStatus: 'Status',
+    fieldDescription: 'Description',
+    fieldTags: 'Tags',
+    tagsPlaceholder: 'comma, separated, tags',
+    fieldBody: 'Body',
+    save: 'Save',
+    saveFailed: 'Could not save document',
+    saved: 'Saved',
+    archive: 'Archive',
+    archiveFailed: 'Could not archive document',
+    archived: 'Archived',
+    readFailed: 'Could not open document',
+    dirtyHint: 'Unsaved changes',
+    titlePlaceholder: 'Untitled document',
+    docType: {
+      'skill-template': 'Skill template',
+      'memory-note': 'Memory note',
+      'workspace-instructions': 'Workspace instructions',
+      'prompt-template': 'Prompt template',
+      runbook: 'Runbook',
+      'generic-md': 'Note'
+    },
+    status: {
+      draft: 'Draft',
+      ready: 'Ready',
+      archived: 'Archived'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1335,6 +1335,7 @@ export interface Translations {
       reorder: (label: string) => string
       toggle: (label: string) => string
       back: string
+      menuDocuments: string
     }
     newSessionIn: (label: string) => string
     showMoreIn: (count: number, label: string) => string
@@ -1366,6 +1367,48 @@ export interface Translations {
       ageDay: string
       ageHour: string
       ageMin: string
+    }
+  }
+
+  workspaceDocs: {
+    title: string
+    description: (label: string) => string
+    newButton: string
+    createTitle: string
+    createDesc: string
+    loading: string
+    loadFailed: string
+    empty: string
+    emptyHint: string
+    invalid: string
+    back: string
+    fieldTitle: string
+    fieldStatus: string
+    fieldDescription: string
+    fieldTags: string
+    tagsPlaceholder: string
+    fieldBody: string
+    save: string
+    saveFailed: string
+    saved: string
+    archive: string
+    archiveFailed: string
+    archived: string
+    readFailed: string
+    dirtyHint: string
+    titlePlaceholder: string
+    docType: {
+      'skill-template': string
+      'memory-note': string
+      'workspace-instructions': string
+      'prompt-template': string
+      runbook: string
+      'generic-md': string
+    }
+    status: {
+      draft: string
+      ready: string
+      archived: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1784,7 +1784,8 @@ export const zh: Translations = {
       enter: label => `打开 ${label}`,
       reorder: label => `重新排序 ${label}`,
       toggle: label => `展开/收起 ${label} 会话`,
-      back: '全部项目'
+      back: '全部项目',
+      menuDocuments: '工作区文档'
     },
     newSessionIn: label => `在 ${label} 中新建会话`,
     showMoreIn: (count, label) => `在 ${label} 中再显示 ${count} 个`,
@@ -1816,6 +1817,48 @@ export const zh: Translations = {
       ageDay: '天',
       ageHour: '时',
       ageMin: '分'
+    }
+  },
+
+  workspaceDocs: {
+    title: '工作区文档',
+    description: label => `${label} 的安全保存笔记。只有明确提升后才会生效。`,
+    newButton: '新建文档',
+    createTitle: '新建文档',
+    createDesc: '选择文档类型并从模板开始。',
+    loading: '正在加载文档…',
+    loadFailed: '无法加载工作区文档',
+    empty: '还没有工作区文档。',
+    emptyHint: '创建运行手册、记忆笔记、技能模板或普通笔记来开始。',
+    invalid: '无效',
+    back: '返回',
+    fieldTitle: '标题',
+    fieldStatus: '状态',
+    fieldDescription: '描述',
+    fieldTags: '标签',
+    tagsPlaceholder: '逗号分隔的标签',
+    fieldBody: '正文',
+    save: '保存',
+    saveFailed: '无法保存文档',
+    saved: '已保存',
+    archive: '归档',
+    archiveFailed: '无法归档文档',
+    archived: '已归档',
+    readFailed: '无法打开文档',
+    dirtyHint: '有未保存的更改',
+    titlePlaceholder: '未命名文档',
+    docType: {
+      'skill-template': '技能模板',
+      'memory-note': '记忆笔记',
+      'workspace-instructions': '工作区说明',
+      'prompt-template': '提示模板',
+      runbook: '运行手册',
+      'generic-md': '笔记'
+    },
+    status: {
+      draft: '草稿',
+      ready: '就绪',
+      archived: '已归档'
     }
   },
 

--- a/apps/desktop/src/lib/workspace-docs.test.ts
+++ b/apps/desktop/src/lib/workspace-docs.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $connection } from '@/store/session'
+
+import { archiveWorkspaceDoc, listWorkspaceDocs, readWorkspaceDoc, writeWorkspaceDoc } from './workspace-docs'
+
+const api = vi.fn(async ({ path }: { path: string }): Promise<unknown> => {
+  if (path.startsWith('/api/workspace-docs/list?')) {
+    return { documents: [{ docType: 'runbook', path: 'runbook.md', status: 'draft', title: 'A runbook', valid: true }] }
+  }
+
+  if (path.startsWith('/api/workspace-docs/read?')) {
+    return {
+      body: 'Body text',
+      content: '---\n---\nBody text',
+      frontmatter: {
+        applyState: 'unapplied',
+        docType: 'runbook',
+        status: 'draft',
+        tags: [],
+        title: 'A runbook'
+      },
+      path: 'runbook.md'
+    }
+  }
+
+  throw new Error(`unexpected GET path ${path}`)
+})
+
+function stubBridge() {
+  vi.stubGlobal('window', { hermesDesktop: { api } })
+}
+
+describe('workspace docs client', () => {
+  beforeEach(() => {
+    stubBridge()
+    $connection.set(null)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    $connection.set(null)
+  })
+
+  it('lists documents for a workspace root', async () => {
+    await expect(listWorkspaceDocs('/work/project')).resolves.toEqual([
+      { docType: 'runbook', path: 'runbook.md', status: 'draft', title: 'A runbook', valid: true }
+    ])
+
+    expect(api).toHaveBeenCalledWith({ path: '/api/workspace-docs/list?workspaceRoot=%2Fwork%2Fproject' })
+  })
+
+  it('reads a document by relative path', async () => {
+    await expect(readWorkspaceDoc('/work/project', 'runbook.md')).resolves.toMatchObject({
+      body: 'Body text',
+      path: 'runbook.md'
+    })
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/workspace-docs/read?path=runbook.md&workspaceRoot=%2Fwork%2Fproject'
+    })
+  })
+
+  it('routes reads/lists to the active profile backend', async () => {
+    $connection.set({ mode: 'remote', profile: 'remote-docker' } as never)
+
+    await listWorkspaceDocs('/work/project')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/workspace-docs/list?workspaceRoot=%2Fwork%2Fproject',
+      profile: 'remote-docker'
+    })
+  })
+
+  it('writes a document with a snake_case frontmatter payload', async () => {
+    api.mockResolvedValueOnce({
+      frontmatter: { applyState: 'unapplied', docType: 'generic-md', status: 'draft', tags: ['x'], title: 'Note' },
+      ok: true,
+      path: 'note.md'
+    })
+
+    await expect(
+      writeWorkspaceDoc(
+        '/work/project',
+        'note.md',
+        { description: 'A note', docType: 'generic-md', status: 'draft', tags: ['x'], title: 'Note' },
+        '# Note\n'
+      )
+    ).resolves.toMatchObject({ ok: true, path: 'note.md' })
+
+    expect(api).toHaveBeenCalledWith({
+      body: {
+        body: '# Note\n',
+        frontmatter: { description: 'A note', doc_type: 'generic-md', status: 'draft', tags: ['x'], title: 'Note' },
+        path: 'note.md',
+        workspaceRoot: '/work/project'
+      },
+      method: 'POST',
+      path: '/api/workspace-docs',
+      profile: undefined
+    })
+  })
+
+  it('archives a document', async () => {
+    api.mockResolvedValueOnce({
+      frontmatter: { applyState: 'unapplied', docType: 'generic-md', status: 'archived', tags: [], title: 'Note' },
+      ok: true,
+      path: 'note.md'
+    })
+
+    await expect(archiveWorkspaceDoc('/work/project', 'note.md')).resolves.toMatchObject({
+      frontmatter: { status: 'archived' },
+      ok: true
+    })
+
+    expect(api).toHaveBeenCalledWith({
+      body: { path: 'note.md', workspaceRoot: '/work/project' },
+      method: 'POST',
+      path: '/api/workspace-docs/archive',
+      profile: undefined
+    })
+  })
+})

--- a/apps/desktop/src/lib/workspace-docs.ts
+++ b/apps/desktop/src/lib/workspace-docs.ts
@@ -1,0 +1,145 @@
+// Typed client for the workspace-documents REST endpoints
+// (`hermes_cli/web_server.py`'s `/api/workspace-docs/*`). Documents are inert
+// safekeeping Markdown files under `<workspaceRoot>/.hermes/docs`; this client
+// only does list/read/write/archive transport — no MDX rendering, import,
+// export, or promotion. Always goes through `window.hermesDesktop.api` (there
+// is no local Electron IPC counterpart), routed to the active profile like
+// `desktop-fs.ts` does so a remote profile never reads the wrong backend.
+
+import { desktopFsProfile } from './desktop-fs'
+
+export type WorkspaceDocType =
+  | 'skill-template'
+  | 'memory-note'
+  | 'workspace-instructions'
+  | 'prompt-template'
+  | 'runbook'
+  | 'generic-md'
+
+export type WorkspaceDocStatus = 'draft' | 'ready' | 'archived'
+
+export type WorkspaceDocApplyState = 'unapplied' | 'exported' | 'imported'
+
+export interface WorkspaceDocFrontmatterJson {
+  docType: WorkspaceDocType
+  title: string
+  workspaceId?: string | null
+  createdAt?: string | null
+  updatedAt?: string | null
+  status: WorkspaceDocStatus
+  applyState: WorkspaceDocApplyState
+  description?: string | null
+  tags: string[]
+}
+
+export interface WorkspaceDocSummary extends Partial<WorkspaceDocFrontmatterJson> {
+  path: string
+  valid: boolean
+  error?: string
+}
+
+export interface WorkspaceDocDetail {
+  path: string
+  content: string
+  body: string
+  frontmatter: WorkspaceDocFrontmatterJson
+}
+
+export interface WorkspaceDocWriteFrontmatter {
+  docType: WorkspaceDocType
+  title: string
+  status?: WorkspaceDocStatus
+  applyState?: WorkspaceDocApplyState
+  description?: string | null
+  tags?: string[]
+  workspaceId?: string | null
+  createdAt?: string | null
+}
+
+export interface WorkspaceDocWriteResult {
+  ok: boolean
+  path: string
+  frontmatter: WorkspaceDocFrontmatterJson
+}
+
+function bridge() {
+  const desktop = window.hermesDesktop
+
+  if (!desktop) {
+    throw new Error('Hermes Desktop bridge is unavailable')
+  }
+
+  return desktop
+}
+
+function docsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
+  return bridge().api<T>(
+    body
+      ? { body, method: 'POST', path, profile: desktopFsProfile() }
+      : { path, profile: desktopFsProfile() }
+  )
+}
+
+function docsQuery(params: Record<string, string>): string {
+  return Object.entries(params)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join('&')
+}
+
+function frontmatterToPayload(frontmatter: WorkspaceDocWriteFrontmatter): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    doc_type: frontmatter.docType,
+    title: frontmatter.title
+  }
+
+  if (frontmatter.status !== undefined) {
+    payload.status = frontmatter.status
+  }
+  if (frontmatter.applyState !== undefined) {
+    payload.apply_state = frontmatter.applyState
+  }
+  if (frontmatter.description !== undefined) {
+    payload.description = frontmatter.description
+  }
+  if (frontmatter.tags !== undefined) {
+    payload.tags = frontmatter.tags
+  }
+  if (frontmatter.workspaceId !== undefined) {
+    payload.workspace_id = frontmatter.workspaceId
+  }
+  if (frontmatter.createdAt !== undefined) {
+    payload.created_at = frontmatter.createdAt
+  }
+
+  return payload
+}
+
+export async function listWorkspaceDocs(workspaceRoot: string): Promise<WorkspaceDocSummary[]> {
+  const result = await docsApi<{ documents: WorkspaceDocSummary[] }>(
+    `/api/workspace-docs/list?${docsQuery({ workspaceRoot })}`
+  )
+
+  return result.documents ?? []
+}
+
+export async function readWorkspaceDoc(workspaceRoot: string, path: string): Promise<WorkspaceDocDetail> {
+  return docsApi<WorkspaceDocDetail>(`/api/workspace-docs/read?${docsQuery({ path, workspaceRoot })}`)
+}
+
+export async function writeWorkspaceDoc(
+  workspaceRoot: string,
+  path: string,
+  frontmatter: WorkspaceDocWriteFrontmatter,
+  body = ''
+): Promise<WorkspaceDocWriteResult> {
+  return docsApi<WorkspaceDocWriteResult>('/api/workspace-docs', {
+    body,
+    frontmatter: frontmatterToPayload(frontmatter),
+    path,
+    workspaceRoot
+  })
+}
+
+export async function archiveWorkspaceDoc(workspaceRoot: string, path: string): Promise<WorkspaceDocWriteResult> {
+  return docsApi<WorkspaceDocWriteResult>('/api/workspace-docs/archive', { path, workspaceRoot })
+}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2289,6 +2289,155 @@ async def fs_default_cwd():
 
 
 # ---------------------------------------------------------------------------
+# Workspace documents — REST CRUD over ``agent.workspace_docs``'s schema and
+# path safety. Documents are inert safekeeping Markdown files under
+# ``<workspaceRoot>/.hermes/docs``; this slice is backend-only (list/read/
+# write/archive) — no MDX rendering, import/export, or model tool here. All
+# path resolution, traversal checks, and profile/sandbox/container-mirror
+# safety guards are owned by ``agent.workspace_docs``, not reimplemented here.
+# ---------------------------------------------------------------------------
+
+from agent import workspace_docs as _workspace_docs  # noqa: E402
+
+
+def _workspace_doc_error_response(exc: Exception) -> HTTPException:
+    if isinstance(exc, _workspace_docs.WorkspaceDocSafetyError):
+        return HTTPException(status_code=403, detail=str(exc))
+    if isinstance(exc, _workspace_docs.WorkspaceDocPathError):
+        return HTTPException(status_code=400, detail=str(exc))
+    if isinstance(exc, _workspace_docs.WorkspaceDocValidationError):
+        return HTTPException(status_code=422, detail=str(exc))
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+def _workspace_doc_frontmatter_json(frontmatter) -> Dict[str, Any]:
+    return {
+        "docType": frontmatter.doc_type.value,
+        "title": frontmatter.title,
+        "workspaceId": frontmatter.workspace_id,
+        "createdAt": frontmatter.created_at,
+        "updatedAt": frontmatter.updated_at,
+        "status": frontmatter.status.value,
+        "applyState": frontmatter.apply_state.value,
+        "description": frontmatter.description,
+        "tags": list(frontmatter.tags),
+    }
+
+
+def _workspace_doc_summary_json(summary) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {"path": summary.relative_path, "valid": summary.valid}
+    if summary.error is not None:
+        entry["error"] = summary.error
+    if summary.frontmatter is not None:
+        entry.update(_workspace_doc_frontmatter_json(summary.frontmatter))
+    return entry
+
+
+@app.get("/api/workspace-docs/list")
+async def workspace_docs_list(workspaceRoot: str):
+    try:
+        summaries = _workspace_docs.list_workspace_docs(workspaceRoot)
+    except _workspace_docs.WorkspaceDocError as exc:
+        raise _workspace_doc_error_response(exc)
+    return {"documents": [_workspace_doc_summary_json(summary) for summary in summaries]}
+
+
+@app.get("/api/workspace-docs/read")
+async def workspace_docs_read(workspaceRoot: str, path: str):
+    try:
+        target = _workspace_docs.resolve_workspace_doc_path(workspaceRoot, path)
+    except _workspace_docs.WorkspaceDocError as exc:
+        raise _workspace_doc_error_response(exc)
+
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    try:
+        content = target.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=422, detail="Document is not valid UTF-8 text")
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Document is not readable")
+    except OSError as exc:
+        raise HTTPException(status_code=400, detail=str(exc) or "Could not read document")
+
+    try:
+        frontmatter, body = _workspace_docs.parse_workspace_doc(content)
+    except _workspace_docs.WorkspaceDocValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return {
+        "path": path,
+        "content": content,
+        "body": body,
+        "frontmatter": _workspace_doc_frontmatter_json(frontmatter),
+    }
+
+
+class WorkspaceDocWrite(BaseModel):
+    workspaceRoot: str
+    path: str
+    frontmatter: Dict[str, Any]
+    body: str = ""
+
+
+@app.post("/api/workspace-docs")
+async def workspace_docs_write(payload: WorkspaceDocWrite):
+    frontmatter = dict(payload.frontmatter or {})
+    frontmatter["type"] = _workspace_docs.WORKSPACE_DOC_FRONTMATTER_TYPE
+    if not frontmatter.get("workspace_id"):
+        frontmatter["workspace_id"] = _workspace_docs.resolve_workspace_identity(payload.workspaceRoot).identity
+    now = datetime.now(timezone.utc).isoformat()
+    frontmatter.setdefault("created_at", now)
+    frontmatter["updated_at"] = now
+
+    try:
+        _target, validated = _workspace_docs.write_workspace_doc(
+            payload.workspaceRoot,
+            payload.path,
+            frontmatter=frontmatter,
+            body=payload.body,
+        )
+    except _workspace_docs.WorkspaceDocError as exc:
+        raise _workspace_doc_error_response(exc)
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Document is not writable")
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not write document: {exc}")
+
+    return {
+        "ok": True,
+        "path": payload.path,
+        "frontmatter": _workspace_doc_frontmatter_json(validated),
+    }
+
+
+class WorkspaceDocArchive(BaseModel):
+    workspaceRoot: str
+    path: str
+
+
+@app.post("/api/workspace-docs/archive")
+async def workspace_docs_archive(payload: WorkspaceDocArchive):
+    try:
+        _target, archived = _workspace_docs.archive_workspace_doc(payload.workspaceRoot, payload.path)
+    except _workspace_docs.WorkspaceDocError as exc:
+        raise _workspace_doc_error_response(exc)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Document not found")
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Document is not writable")
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not archive document: {exc}")
+
+    return {
+        "ok": True,
+        "path": payload.path,
+        "frontmatter": _workspace_doc_frontmatter_json(archived),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Git ops — the remote half of the desktop coding rail + review pane.
 #
 # The desktop runs these as Electron-local git on the user's machine; over a

--- a/tests/agent/test_workspace_docs.py
+++ b/tests/agent/test_workspace_docs.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _with_hermes_home(path: Path):
+    path.mkdir(parents=True, exist_ok=True)
+    return set_hermes_home_override(path)
+
+
+VALID_DOC = """---
+type: hermes-workspace-document
+doc_type: skill-template
+title: Draft import workflow
+workspace_id: /tmp/project
+created_at: '2026-07-14T00:00:00Z'
+updated_at: '2026-07-14T00:00:00Z'
+status: draft
+apply_state: unapplied
+description: Reusable draft
+tags:
+  - skills
+---
+# Body
+"""
+
+
+class TestWorkspaceDocFrontmatter:
+    def test_parse_valid_document(self):
+        from agent.workspace_docs import (
+            WorkspaceDocApplyState,
+            WorkspaceDocStatus,
+            WorkspaceDocType,
+            parse_workspace_doc,
+        )
+
+        frontmatter, body = parse_workspace_doc(VALID_DOC)
+
+        assert frontmatter.doc_type is WorkspaceDocType.SKILL_TEMPLATE
+        assert frontmatter.title == "Draft import workflow"
+        assert frontmatter.workspace_id == "/tmp/project"
+        assert frontmatter.status is WorkspaceDocStatus.DRAFT
+        assert frontmatter.apply_state is WorkspaceDocApplyState.UNAPPLIED
+        assert frontmatter.tags == ("skills",)
+        assert body.strip() == "# Body"
+
+    @pytest.mark.parametrize(
+        "doc_type",
+        [
+            "skill-template",
+            "memory-note",
+            "workspace-instructions",
+            "prompt-template",
+            "runbook",
+            "generic-md",
+        ],
+    )
+    def test_all_initial_doc_types_are_valid(self, doc_type):
+        from agent.workspace_docs import validate_workspace_doc_frontmatter
+
+        parsed = validate_workspace_doc_frontmatter(
+            {
+                "type": "hermes-workspace-document",
+                "doc_type": doc_type,
+                "title": "Title",
+            }
+        )
+
+        assert parsed.doc_type.value == doc_type
+        assert parsed.status.value == "draft"
+        assert parsed.apply_state.value == "unapplied"
+
+    @pytest.mark.parametrize(
+        "frontmatter,error",
+        [
+            ({"doc_type": "runbook", "title": "T"}, "type must be"),
+            ({"type": "hermes-workspace-document", "title": "T"}, "doc_type"),
+            ({"type": "hermes-workspace-document", "doc_type": "bogus", "title": "T"}, "invalid doc_type"),
+            ({"type": "hermes-workspace-document", "doc_type": "runbook", "title": ""}, "title"),
+            ({"type": "hermes-workspace-document", "doc_type": "runbook", "title": "T", "tags": "x"}, "tags"),
+            ({"type": "hermes-workspace-document", "doc_type": "runbook", "title": "T", "status": "live"}, "status"),
+            ({"type": "hermes-workspace-document", "doc_type": "runbook", "title": "T", "apply_state": "active"}, "apply_state"),
+        ],
+    )
+    def test_invalid_frontmatter_rejected(self, frontmatter, error):
+        from agent.workspace_docs import WorkspaceDocValidationError, validate_workspace_doc_frontmatter
+
+        with pytest.raises(WorkspaceDocValidationError, match=error):
+            validate_workspace_doc_frontmatter(frontmatter)
+
+    def test_missing_frontmatter_rejected(self):
+        from agent.workspace_docs import WorkspaceDocValidationError, parse_workspace_doc
+
+        with pytest.raises(WorkspaceDocValidationError, match="missing YAML frontmatter"):
+            parse_workspace_doc("# plain markdown")
+
+
+class TestWorkspaceDocPaths:
+    def test_workspace_identity_uses_resolved_root(self, tmp_path):
+        from agent.workspace_docs import resolve_workspace_identity
+
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+
+        identity = resolve_workspace_identity(workspace)
+
+        assert identity.kind == "workspace"
+        assert identity.identity == str(workspace.resolve())
+        assert identity.root == workspace.resolve()
+
+    def test_profile_fallback_identity_uses_active_hermes_home(self, tmp_path):
+        from agent.workspace_docs import resolve_workspace_identity
+
+        hermes_home = tmp_path / ".hermes"
+        token = _with_hermes_home(hermes_home)
+        try:
+            identity = resolve_workspace_identity()
+        finally:
+            reset_hermes_home_override(token)
+
+        assert identity.kind == "profile-fallback"
+        assert identity.identity == str(hermes_home.resolve())
+
+    def test_defaults_include_workspace_identity_and_inert_state(self, tmp_path):
+        from agent.workspace_docs import workspace_doc_frontmatter_defaults
+
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        defaults = workspace_doc_frontmatter_defaults(workspace)
+
+        assert defaults == {
+            "type": "hermes-workspace-document",
+            "workspace_id": str(workspace.resolve()),
+            "status": "draft",
+            "apply_state": "unapplied",
+        }
+
+    def test_resolves_safe_relative_path_under_workspace_docs(self, tmp_path):
+        from agent.workspace_docs import resolve_workspace_doc_path
+
+        workspace = tmp_path / "repo"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        resolved = resolve_workspace_doc_path(workspace, "runbooks/oncall.md")
+
+        assert resolved == (workspace / ".hermes" / "docs" / "runbooks" / "oncall.md").resolve()
+
+    @pytest.mark.parametrize("relative_path", ["../skills/SKILL.md", "../../outside.md", "/abs/path.md"])
+    def test_path_traversal_and_absolute_paths_rejected(self, tmp_path, relative_path):
+        from agent.workspace_docs import WorkspaceDocPathError, resolve_workspace_doc_path
+
+        workspace = tmp_path / "repo"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        with pytest.raises(WorkspaceDocPathError):
+            resolve_workspace_doc_path(workspace, relative_path)
+
+    def test_docs_root_symlink_escape_rejected(self, tmp_path):
+        from agent.workspace_docs import WorkspaceDocPathError, get_workspace_docs_root
+
+        workspace = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        (workspace / ".hermes").mkdir(parents=True)
+        outside.mkdir()
+        (workspace / ".hermes" / "docs").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(WorkspaceDocPathError, match="escapes workspace root"):
+            get_workspace_docs_root(workspace)
+
+    def test_workspace_inside_hermes_home_is_not_misclassified_as_profile_state(self, tmp_path):
+        from agent.workspace_docs import resolve_workspace_doc_path
+
+        hermes_home = tmp_path / ".hermes"
+        workspace = hermes_home / "hermes-agent"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+        token = _with_hermes_home(hermes_home)
+        try:
+            resolved = resolve_workspace_doc_path(workspace, "notes/plan.md")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert resolved == (workspace / ".hermes" / "docs" / "notes" / "plan.md").resolve()
+
+    def test_workspace_root_inside_other_profile_scoped_area_is_rejected(self, tmp_path, monkeypatch):
+        from agent.workspace_docs import WorkspaceDocSafetyError, resolve_workspace_doc_path
+
+        hermes_home = tmp_path / ".hermes"
+        other_profile_workspace = hermes_home / "profiles" / "other" / "skills" / "draft-repo"
+        (other_profile_workspace / ".hermes" / "docs").mkdir(parents=True)
+        # file_safety's root resolver follows HERMES_HOME, while get_hermes_home
+        # can also be context-overridden. Set both so this mirrors a real profile
+        # process without relying on the developer's ambient ~/.hermes.
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        token = _with_hermes_home(hermes_home)
+        try:
+            with pytest.raises(WorkspaceDocSafetyError) as exc:
+                resolve_workspace_doc_path(other_profile_workspace, "x.md")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert exc.value.classifier == "cross_profile"
+
+    def test_sandbox_mirror_workspace_root_is_rejected(self, tmp_path):
+        from agent.workspace_docs import WorkspaceDocSafetyError, resolve_workspace_doc_path
+
+        workspace = tmp_path / "profiles" / "group1" / "sandboxes" / "docker" / "default" / "home"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        with pytest.raises(WorkspaceDocSafetyError) as exc:
+            resolve_workspace_doc_path(workspace, "x.md")
+
+        assert exc.value.classifier == "sandbox_mirror"
+
+    def test_container_mirror_workspace_root_is_rejected_when_prefix_supplied(self, tmp_path):
+        from agent.workspace_docs import WorkspaceDocSafetyError, resolve_workspace_doc_path
+
+        mirror_root = tmp_path / "container-home" / ".hermes"
+        workspace = mirror_root.parent
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        with pytest.raises(WorkspaceDocSafetyError) as exc:
+            resolve_workspace_doc_path(workspace, "x.md", mirror_prefix=str(mirror_root))
+
+        assert exc.value.classifier == "container_mirror"
+
+
+class TestWorkspaceDocsInertness:
+    def test_workspace_docs_path_shape_detected(self, tmp_path):
+        from agent.workspace_docs import is_workspace_docs_path
+
+        assert is_workspace_docs_path(tmp_path / "repo" / ".hermes" / "docs" / "runbook.md")
+        assert not is_workspace_docs_path(tmp_path / "repo" / ".hermes" / "skills" / "SKILL.md")
+
+    def test_workspace_docs_are_not_a_skill_discovery_root(self, tmp_path):
+        from agent.skill_utils import get_all_skills_dirs
+        from agent.workspace_docs import workspace_docs_are_inert
+
+        hermes_home = tmp_path / ".hermes"
+        workspace = tmp_path / "repo"
+        docs_skill = workspace / ".hermes" / "docs" / "skill-template" / "SKILL.md"
+        docs_skill.parent.mkdir(parents=True)
+        docs_skill.write_text("---\nname: draft\ndescription: inert\n---\n# Draft\n")
+
+        token = _with_hermes_home(hermes_home)
+        try:
+            skill_roots = [path.resolve() for path in get_all_skills_dirs()]
+        finally:
+            reset_hermes_home_override(token)
+
+        assert workspace_docs_are_inert() is True
+        assert (workspace / ".hermes" / "docs").resolve() not in skill_roots
+        assert hermes_home.joinpath("skills").resolve() in skill_roots

--- a/tests/hermes_cli/test_web_server_workspace_docs.py
+++ b/tests/hermes_cli/test_web_server_workspace_docs.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import web_server
+
+pytest.importorskip("starlette.testclient")
+from starlette.testclient import TestClient
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def client(monkeypatch):
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        if previous_auth_required is None:
+            try:
+                delattr(web_server.app.state, "auth_required")
+            except AttributeError:
+                pass
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+def _with_hermes_home(path: Path):
+    path.mkdir(parents=True, exist_ok=True)
+    return set_hermes_home_override(path)
+
+
+VALID_DOC = """---
+type: hermes-workspace-document
+doc_type: runbook
+title: Oncall runbook
+workspace_id: /tmp/project
+created_at: '2026-07-14T00:00:00+00:00'
+updated_at: '2026-07-14T00:00:00+00:00'
+status: draft
+apply_state: unapplied
+description: Reusable draft
+tags:
+  - ops
+---
+# Body
+
+Some notes.
+"""
+
+INVALID_DOC = "# no frontmatter here\n"
+
+
+def _write_doc(workspace: Path, relative: str, text: str = VALID_DOC) -> Path:
+    target = workspace / ".hermes" / "docs" / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text)
+    return target
+
+
+class TestWorkspaceDocsList:
+    def test_list_returns_only_markdown_sorted_with_metadata(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        _write_doc(workspace, "a.md")
+        _write_doc(workspace, "z.md")
+        _write_doc(workspace, "subdir/b.md")
+        _write_doc(workspace, "invalid.md", INVALID_DOC)
+        (workspace / ".hermes" / "docs" / "note.txt").write_text("not markdown")
+
+        response = client.get("/api/workspace-docs/list", params={"workspaceRoot": str(workspace)})
+
+        assert response.status_code == 200
+        documents = response.json()["documents"]
+        paths = [doc["path"] for doc in documents]
+        assert paths == ["a.md", "invalid.md", "subdir/b.md", "z.md"]
+
+        valid_doc = next(doc for doc in documents if doc["path"] == "a.md")
+        assert valid_doc["valid"] is True
+        assert valid_doc["title"] == "Oncall runbook"
+        assert valid_doc["docType"] == "runbook"
+        assert valid_doc["status"] == "draft"
+        assert valid_doc["tags"] == ["ops"]
+
+        invalid_doc = next(doc for doc in documents if doc["path"] == "invalid.md")
+        assert invalid_doc["valid"] is False
+        assert "error" in invalid_doc
+
+    def test_list_missing_docs_root_returns_empty(self, client, tmp_path):
+        workspace = tmp_path / "empty-project"
+        workspace.mkdir()
+
+        response = client.get("/api/workspace-docs/list", params={"workspaceRoot": str(workspace)})
+
+        assert response.status_code == 200
+        assert response.json() == {"documents": []}
+
+
+class TestWorkspaceDocsRead:
+    def test_read_returns_content_metadata_and_path(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        _write_doc(workspace, "runbooks/oncall.md")
+
+        response = client.get(
+            "/api/workspace-docs/read",
+            params={"workspaceRoot": str(workspace), "path": "runbooks/oncall.md"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["path"] == "runbooks/oncall.md"
+        assert body["frontmatter"]["title"] == "Oncall runbook"
+        assert body["frontmatter"]["docType"] == "runbook"
+        assert body["frontmatter"]["tags"] == ["ops"]
+        assert "# Body" in body["body"]
+        assert body["content"] == VALID_DOC
+
+    def test_read_missing_document_returns_404(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        response = client.get(
+            "/api/workspace-docs/read",
+            params={"workspaceRoot": str(workspace), "path": "missing.md"},
+        )
+
+        assert response.status_code == 404
+
+    def test_read_invalid_frontmatter_rejected(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        _write_doc(workspace, "broken.md", INVALID_DOC)
+
+        response = client.get(
+            "/api/workspace-docs/read",
+            params={"workspaceRoot": str(workspace), "path": "broken.md"},
+        )
+
+        assert response.status_code == 422
+
+
+class TestWorkspaceDocsWrite:
+    def test_create_writes_atomically_and_validates_frontmatter(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+
+        response = client.post(
+            "/api/workspace-docs",
+            json={
+                "workspaceRoot": str(workspace),
+                "path": "notes/new.md",
+                "frontmatter": {"doc_type": "generic-md", "title": "New note"},
+                "body": "# New note\n\nHello.",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["frontmatter"]["title"] == "New note"
+        assert body["frontmatter"]["docType"] == "generic-md"
+        assert body["frontmatter"]["status"] == "draft"
+
+        on_disk = workspace / ".hermes" / "docs" / "notes" / "new.md"
+        assert on_disk.is_file()
+        content = on_disk.read_text()
+        assert "type: hermes-workspace-document" in content
+        assert "# New note" in content
+
+    def test_update_existing_document_overwrites_content(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        _write_doc(workspace, "notes/existing.md")
+
+        response = client.post(
+            "/api/workspace-docs",
+            json={
+                "workspaceRoot": str(workspace),
+                "path": "notes/existing.md",
+                "frontmatter": {"doc_type": "runbook", "title": "Updated title"},
+                "body": "# Updated body",
+            },
+        )
+
+        assert response.status_code == 200
+        on_disk = workspace / ".hermes" / "docs" / "notes" / "existing.md"
+        content = on_disk.read_text()
+        assert "Updated title" in content
+        assert "# Updated body" in content
+        assert "Some notes." not in content
+
+    def test_create_rejects_invalid_frontmatter(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+
+        response = client.post(
+            "/api/workspace-docs",
+            json={
+                "workspaceRoot": str(workspace),
+                "path": "notes/bad.md",
+                "frontmatter": {"title": "Missing doc_type"},
+                "body": "content",
+            },
+        )
+
+        assert response.status_code == 422
+
+    def test_create_rejects_path_traversal(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        response = client.post(
+            "/api/workspace-docs",
+            json={
+                "workspaceRoot": str(workspace),
+                "path": "../outside.md",
+                "frontmatter": {"doc_type": "generic-md", "title": "Escape"},
+                "body": "content",
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_create_rejects_oversized_body(self, client, tmp_path, monkeypatch):
+        from agent import workspace_docs as workspace_docs_module
+
+        monkeypatch.setattr(workspace_docs_module, "WORKSPACE_DOC_MAX_BYTES", 8)
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+
+        response = client.post(
+            "/api/workspace-docs",
+            json={
+                "workspaceRoot": str(workspace),
+                "path": "notes/huge.md",
+                "frontmatter": {"doc_type": "generic-md", "title": "Huge"},
+                "body": "way more than eight bytes of body content",
+            },
+        )
+
+        assert response.status_code == 422
+
+
+class TestWorkspaceDocsReadPathTraversal:
+    def test_read_rejects_path_traversal(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        response = client.get(
+            "/api/workspace-docs/read",
+            params={"workspaceRoot": str(workspace), "path": "../../etc/passwd"},
+        )
+
+        assert response.status_code == 400
+
+
+class TestWorkspaceDocsArchive:
+    def test_archive_marks_doc_archived_and_list_read_reflect_state(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        _write_doc(workspace, "runbooks/oncall.md")
+
+        archive_response = client.post(
+            "/api/workspace-docs/archive",
+            json={"workspaceRoot": str(workspace), "path": "runbooks/oncall.md"},
+        )
+
+        assert archive_response.status_code == 200
+        assert archive_response.json()["frontmatter"]["status"] == "archived"
+
+        read_response = client.get(
+            "/api/workspace-docs/read",
+            params={"workspaceRoot": str(workspace), "path": "runbooks/oncall.md"},
+        )
+        assert read_response.json()["frontmatter"]["status"] == "archived"
+
+        list_response = client.get("/api/workspace-docs/list", params={"workspaceRoot": str(workspace)})
+        listed = next(doc for doc in list_response.json()["documents"] if doc["path"] == "runbooks/oncall.md")
+        assert listed["status"] == "archived"
+
+    def test_archive_is_idempotent(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        _write_doc(workspace, "runbooks/oncall.md")
+
+        first = client.post(
+            "/api/workspace-docs/archive",
+            json={"workspaceRoot": str(workspace), "path": "runbooks/oncall.md"},
+        )
+        second = client.post(
+            "/api/workspace-docs/archive",
+            json={"workspaceRoot": str(workspace), "path": "runbooks/oncall.md"},
+        )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.json()["frontmatter"]["status"] == "archived"
+
+    def test_archive_missing_document_returns_404(self, client, tmp_path):
+        workspace = tmp_path / "project"
+        (workspace / ".hermes" / "docs").mkdir(parents=True)
+
+        response = client.post(
+            "/api/workspace-docs/archive",
+            json={"workspaceRoot": str(workspace), "path": "missing.md"},
+        )
+
+        assert response.status_code == 404
+
+
+class TestWorkspaceDocsSafety:
+    def test_workspace_inside_hermes_home_is_accepted(self, client, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        workspace = hermes_home / "hermes-agent"
+        _write_doc(workspace, "notes/plan.md")
+
+        token = _with_hermes_home(hermes_home)
+        try:
+            response = client.get("/api/workspace-docs/list", params={"workspaceRoot": str(workspace)})
+        finally:
+            reset_hermes_home_override(token)
+
+        assert response.status_code == 200
+        assert response.json()["documents"][0]["path"] == "notes/plan.md"
+
+    def test_cross_profile_workspace_rejected(self, client, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        other_profile_workspace = hermes_home / "profiles" / "other" / "skills" / "draft-repo"
+        _write_doc(other_profile_workspace, "x.md")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        token = _with_hermes_home(hermes_home)
+        try:
+            response = client.get(
+                "/api/workspace-docs/list",
+                params={"workspaceRoot": str(other_profile_workspace)},
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert response.status_code == 403
+
+    def test_sandbox_mirror_workspace_rejected(self, client, tmp_path):
+        workspace = tmp_path / "profiles" / "group1" / "sandboxes" / "docker" / "default" / "home"
+        _write_doc(workspace, "x.md")
+
+        response = client.get("/api/workspace-docs/list", params={"workspaceRoot": str(workspace)})
+
+        assert response.status_code == 403
+
+    def test_container_mirror_safety_error_maps_to_403(self, client, tmp_path, monkeypatch):
+        # The REST layer has no active container/sandbox task context to derive
+        # a mirror prefix from (unlike the in-process file-editing tool), so
+        # this slice never triggers classify_container_mirror_target end-to-end.
+        # Verify the endpoint's error-mapping still turns that classifier into a
+        # 403 by simulating the safety error directly.
+        from agent import workspace_docs as workspace_docs_module
+
+        def _raise_container_mirror(*args, **kwargs):
+            raise workspace_docs_module.WorkspaceDocSafetyError(
+                "container-mirror target", classifier="container_mirror"
+            )
+
+        monkeypatch.setattr(workspace_docs_module, "list_workspace_docs", _raise_container_mirror)
+        monkeypatch.setattr(web_server._workspace_docs, "list_workspace_docs", _raise_container_mirror)
+
+        response = client.get("/api/workspace-docs/list", params={"workspaceRoot": str(tmp_path)})
+
+        assert response.status_code == 403
+
+
+class TestWorkspaceDocsEndpointsRequireAuth:
+    def test_workspace_docs_endpoints_require_auth(self, tmp_path):
+        test_client = TestClient(web_server.app)
+        workspace = tmp_path / "project"
+        _write_doc(workspace, "a.md")
+
+        list_response = test_client.get(
+            "/api/workspace-docs/list", params={"workspaceRoot": str(workspace)}
+        )
+        read_response = test_client.get(
+            "/api/workspace-docs/read",
+            params={"workspaceRoot": str(workspace), "path": "a.md"},
+        )
+        write_response = test_client.post(
+            "/api/workspace-docs",
+            json={
+                "workspaceRoot": str(workspace),
+                "path": "a.md",
+                "frontmatter": {"doc_type": "generic-md", "title": "X"},
+                "body": "x",
+            },
+        )
+        archive_response = test_client.post(
+            "/api/workspace-docs/archive",
+            json={"workspaceRoot": str(workspace), "path": "a.md"},
+        )
+
+        assert list_response.status_code == 401
+        assert read_response.status_code == 401
+        assert write_response.status_code == 401
+        assert archive_response.status_code == 401


### PR DESCRIPTION
## Summary
- add a pure-Python workspace-documents foundation with safe inert markdown storage under `.hermes/docs`
- add backend REST CRUD endpoints for list/read/write/archive at `/api/workspace-docs/*`
- add a desktop typed client and a minimal project-menu dialog to list, create, edit, save, and archive workspace documents
- keep scope intentionally inert only: no MDX renderer, import/export, or promote actions yet

## Verification
- `python -m pytest tests/agent/test_workspace_docs.py tests/hermes_cli/test_web_server_workspace_docs.py tests/hermes_cli/test_web_server_fs.py -q` → `61 passed`
- `npm --prefix apps/desktop test -- workspace-docs --run` → `5 passed`
- `npm --prefix apps/desktop run typecheck` → passed
- `git diff --check` → clean

## Follow-ups
- API callers that omit `created_at` on update reset it; the desktop client preserves it today
- `workspaceDocs.saved` / `workspaceDocs.archived` i18n keys are present but currently unused
- saves are last-write-wins; no optimistic concurrency yet
