### PR TITLE
feat(gateway): show reasoning effort in runtime footer

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -58,6 +58,10 @@ class ResponsesApiTransport(ProviderTransport):
     # response are stamped with the endpoint that minted them. Plain class
     # attribute default; mutated on the instance, not the class.
     _last_issuer_kind: Optional[str] = None
+    # Wire-effective effort from the most recent request payload.  Keep this
+    # next to ``_last_issuer_kind``: both are per-call metadata consumed after
+    # ``build_kwargs`` by later response/finalization paths.
+    _last_reasoning_effort: Optional[str] = None
 
     @property
     def api_mode(self) -> str:
@@ -381,6 +385,21 @@ class ResponsesApiTransport(ProviderTransport):
                 merged_extra_body.update(existing_extra_body)
             merged_extra_body.setdefault("prompt_cache_key", cache_key)
             kwargs["extra_body"] = merged_extra_body
+
+        # Capture the final payload value after provider capability resolution
+        # and request overrides.  Consumers such as the gateway footer must not
+        # reconstruct routing/clamp rules from agent config: xAI may omit the
+        # dial, GitHub Models may select a supported fallback, and overrides can
+        # replace the value immediately before the request is sent.
+        wire_reasoning = kwargs.get("reasoning")
+        wire_effort = (
+            wire_reasoning.get("effort")
+            if isinstance(wire_reasoning, dict)
+            else None
+        )
+        self._last_reasoning_effort = (
+            str(wire_effort).strip().lower() if wire_effort is not None else None
+        ) or None
 
         return kwargs
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,63 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.model_metadata import grok_supports_reasoning_effort
+from hermes_constants import VALID_REASONING_EFFORTS
+
+
+def _effective_reasoning_effort(
+    reasoning_config,
+    *,
+    api_mode: str = "",
+    model: str = "",
+    provider: str = "",
+) -> str | None:
+    """Return the user-visible reasoning effort applied to this agent.
+
+    Gateway session overrides and the global ``agent.reasoning_effort`` setting
+    are both resolved before ``AIAgent`` is constructed, so
+    ``agent.reasoning_config`` is the canonical per-turn value here.  Hermes's
+    Codex Responses defaults to ``medium`` when that config is absent.  Other
+    transports may delegate the default to the provider, so return ``None``
+    rather than inventing a level for those routes.
+    """
+    normalized_api_mode = str(api_mode or "").strip().lower()
+    normalized_provider = str(provider or "").strip().lower()
+    if normalized_api_mode == "codex_responses" and normalized_provider == "xai-oauth":
+        # The xAI transport omits the effort parameter for models outside its
+        # conservative allowlist, and cannot explicitly disable native Grok
+        # reasoning.  Do not claim an effective level in either case.
+        if not grok_supports_reasoning_effort(model):
+            return None
+        if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
+            return None
+
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            return "none"
+        raw = reasoning_config.get("effort")
+        if raw is not None:
+            effort = str(raw).strip().lower()
+            if effort not in VALID_REASONING_EFFORTS:
+                effort = ""
+        else:
+            effort = ""
+    else:
+        effort = ""
+
+    if normalized_api_mode == "codex_responses":
+        effort = effort or "medium"
+        if effort == "minimal":
+            effort = "low"
+        if "gpt-5.6" in str(model or "").lower() and effort == "ultra":
+            effort = "max"
+        if normalized_provider == "xai-oauth" and effort in {
+            "xhigh", "max", "ultra",
+        }:
+            effort = "high"
+        return effort
+
+    return effort or None
 
 
 def finalize_turn(
@@ -451,6 +508,12 @@ def finalize_turn(
         "cache_read_tokens": agent.session_cache_read_tokens,
         "cache_write_tokens": agent.session_cache_write_tokens,
         "reasoning_tokens": agent.session_reasoning_tokens,
+        "reasoning_effort": _effective_reasoning_effort(
+            getattr(agent, "reasoning_config", None),
+            api_mode=getattr(agent, "api_mode", ""),
+            model=getattr(agent, "model", ""),
+            provider=getattr(agent, "provider", ""),
+        ),
         "prompt_tokens": agent.session_prompt_tokens,
         "completion_tokens": agent.session_completion_tokens,
         "total_tokens": agent.session_total_tokens,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
-from agent.model_metadata import grok_supports_reasoning_effort
 from hermes_constants import VALID_REASONING_EFFORTS
 
 
@@ -33,28 +32,23 @@ def _effective_reasoning_effort(
     reasoning_config,
     *,
     api_mode: str = "",
-    model: str = "",
-    provider: str = "",
+    transport=None,
 ) -> str | None:
     """Return the user-visible reasoning effort applied to this agent.
 
     Gateway session overrides and the global ``agent.reasoning_effort`` setting
     are both resolved before ``AIAgent`` is constructed, so
     ``agent.reasoning_config`` is the canonical per-turn value here.  Hermes's
-    Codex Responses defaults to ``medium`` when that config is absent.  Other
+    Codex Responses can normalize or omit that value based on its actual route,
+    model capabilities, and request overrides.  Read the final payload value
+    captured by the transport instead of duplicating those rules here.  Other
     transports may delegate the default to the provider, so return ``None``
     rather than inventing a level for those routes.
     """
     normalized_api_mode = str(api_mode or "").strip().lower()
-    normalized_provider = str(provider or "").strip().lower()
-    if normalized_api_mode == "codex_responses" and normalized_provider == "xai-oauth":
-        # The xAI transport omits the effort parameter for models outside its
-        # conservative allowlist, and cannot explicitly disable native Grok
-        # reasoning.  Do not claim an effective level in either case.
-        if not grok_supports_reasoning_effort(model):
-            return None
-        if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
-            return None
+    if normalized_api_mode == "codex_responses":
+        wire_effort = getattr(transport, "_last_reasoning_effort", None)
+        return (str(wire_effort).strip().lower() if wire_effort is not None else "") or None
 
     if isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is False:
@@ -68,18 +62,6 @@ def _effective_reasoning_effort(
             effort = ""
     else:
         effort = ""
-
-    if normalized_api_mode == "codex_responses":
-        effort = effort or "medium"
-        if effort == "minimal":
-            effort = "low"
-        if "gpt-5.6" in str(model or "").lower() and effort == "ultra":
-            effort = "max"
-        if normalized_provider == "xai-oauth" and effort in {
-            "xhigh", "max", "ultra",
-        }:
-            effort = "high"
-        return effort
 
     return effort or None
 
@@ -511,8 +493,12 @@ def finalize_turn(
         "reasoning_effort": _effective_reasoning_effort(
             getattr(agent, "reasoning_config", None),
             api_mode=getattr(agent, "api_mode", ""),
-            model=getattr(agent, "model", ""),
-            provider=getattr(agent, "provider", ""),
+            transport=(
+                agent._get_transport()
+                if getattr(agent, "api_mode", "") == "codex_responses"
+                and callable(getattr(agent, "_get_transport", None))
+                else None
+            ),
         ),
         "prompt_tokens": agent.session_prompt_tokens,
         "completion_tokens": agent.session_completion_tokens,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11930,6 +11930,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
+                    reasoning_effort=agent_result.get("reasoning_effort"),
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
             except Exception as _footer_err:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,6 +1,7 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
+Renders a compact footer showing runtime state (model, reasoning effort,
+context %, cwd) and
 appends it to the FINAL message of an agent turn when enabled.  Off by default
 to keep replies minimal.
 
@@ -9,7 +10,7 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, reasoning_effort, context_pct, cwd]  # order shown
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -28,8 +29,12 @@ from __future__ import annotations
 import os
 from typing import Any, Iterable, Optional
 
+from hermes_constants import VALID_REASONING_EFFORTS
+
+
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
+_REASONING_EFFORTS = frozenset((*VALID_REASONING_EFFORTS, "none"))
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -93,6 +98,7 @@ def format_runtime_footer(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    reasoning_effort: Optional[str] = None,
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
@@ -107,6 +113,10 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "reasoning_effort":
+            effort = str(reasoning_effort or "").strip().lower()
+            if effort in _REASONING_EFFORTS:
+                parts.append(effort)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -129,6 +139,7 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    reasoning_effort: Optional[str] = None,
     cwd: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
@@ -144,6 +155,7 @@ def build_footer_line(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
+        reasoning_effort=reasoning_effort,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1917,7 +1917,8 @@ DEFAULT_CONFIG = {
         },
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders
-        # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under
+        # e.g. `model · 68% · ~/projects/hermes`. Optional fields include
+        # `reasoning_effort`; per-platform overrides go under
         # display.platforms.<platform>.runtime_footer.
         "runtime_footer": {
             "enabled": False,

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -33,6 +33,8 @@ class _StubAgent:
         self.context_compressor = _StubCompressor()
         self.model = "stub/model"
         self.provider = "stub"
+        self.api_mode = "codex_responses"
+        self.reasoning_config = None
         self.base_url = "http://stub"
         self.session_id = "sess-1"
         self.quiet_mode = True
@@ -170,6 +172,13 @@ def test_clean_turn_has_no_cleanup_errors_key():
     assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
     assert result["completed"] is False
     assert "cleanup_errors" not in result
+
+
+def test_turn_result_exposes_effective_reasoning_effort():
+    agent = _StubAgent(raise_in=())
+    agent.reasoning_config = {"enabled": True, "effort": "high"}
+    result = _run(agent)
+    assert result["reasoning_effort"] == "high"
 
 
 def test_text_response_on_last_allowed_call_is_completed():

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -8,6 +8,8 @@ for must still be returned.  Previously any of those raised straight out of
 traceback and lost the whole turn.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from agent.turn_finalizer import finalize_turn
@@ -35,6 +37,7 @@ class _StubAgent:
         self.provider = "stub"
         self.api_mode = "codex_responses"
         self.reasoning_config = None
+        self._transport = SimpleNamespace(_last_reasoning_effort=None)
         self.base_url = "http://stub"
         self.session_id = "sess-1"
         self.quiet_mode = True
@@ -100,6 +103,9 @@ class _StubAgent:
 
     def _sync_external_memory_for_turn(self, **k):
         pass
+
+    def _get_transport(self):
+        return self._transport
 
 
 def _run(
@@ -177,6 +183,7 @@ def test_clean_turn_has_no_cleanup_errors_key():
 def test_turn_result_exposes_effective_reasoning_effort():
     agent = _StubAgent(raise_in=())
     agent.reasoning_config = {"enabled": True, "effort": "high"}
+    agent._transport._last_reasoning_effort = "high"
     result = _run(agent)
     assert result["reasoning_effort"] == "high"
 

--- a/tests/agent/test_turn_finalizer_reasoning_effort.py
+++ b/tests/agent/test_turn_finalizer_reasoning_effort.py
@@ -1,0 +1,46 @@
+"""Reasoning-effort metadata emitted by the turn finalizer."""
+
+import pytest
+
+from agent.turn_finalizer import _effective_reasoning_effort
+
+
+@pytest.mark.parametrize(
+    "reasoning_config,kwargs,expected",
+    [
+        (None, {}, None),
+        (None, {"api_mode": "codex_responses"}, "medium"),
+        ({"enabled": False}, {}, "none"),
+        ({"enabled": True, "effort": "low"}, {}, "low"),
+        (
+            {"enabled": True, "effort": "minimal"},
+            {"api_mode": "codex_responses"},
+            "low",
+        ),
+        (
+            {"enabled": True, "effort": "ULTRA"},
+            {"api_mode": "codex_responses", "model": "gpt-5.6-sol"},
+            "max",
+        ),
+        (
+            {"enabled": True, "effort": "xhigh"},
+            {
+                "api_mode": "codex_responses",
+                "provider": "xai-oauth",
+                "model": "grok-4.5",
+            },
+            "high",
+        ),
+        (
+            {"enabled": True, "effort": "high"},
+            {
+                "api_mode": "codex_responses",
+                "provider": "xai-oauth",
+                "model": "grok-4",
+            },
+            None,
+        ),
+    ],
+)
+def test_effective_reasoning_effort(reasoning_config, kwargs, expected):
+    assert _effective_reasoning_effort(reasoning_config, **kwargs) == expected

--- a/tests/agent/test_turn_finalizer_reasoning_effort.py
+++ b/tests/agent/test_turn_finalizer_reasoning_effort.py
@@ -1,5 +1,7 @@
 """Reasoning-effort metadata emitted by the turn finalizer."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from agent.turn_finalizer import _effective_reasoning_effort
@@ -9,36 +11,29 @@ from agent.turn_finalizer import _effective_reasoning_effort
     "reasoning_config,kwargs,expected",
     [
         (None, {}, None),
-        (None, {"api_mode": "codex_responses"}, "medium"),
+        (None, {"api_mode": "codex_responses"}, None),
         ({"enabled": False}, {}, "none"),
         ({"enabled": True, "effort": "low"}, {}, "low"),
         (
-            {"enabled": True, "effort": "minimal"},
-            {"api_mode": "codex_responses"},
-            "low",
-        ),
-        (
-            {"enabled": True, "effort": "ULTRA"},
-            {"api_mode": "codex_responses", "model": "gpt-5.6-sol"},
-            "max",
-        ),
-        (
-            {"enabled": True, "effort": "xhigh"},
+            {"enabled": True, "effort": "ultra"},
             {
                 "api_mode": "codex_responses",
-                "provider": "xai-oauth",
-                "model": "grok-4.5",
+                "transport": SimpleNamespace(_last_reasoning_effort="MAX"),
             },
-            "high",
+            "max",
         ),
         (
             {"enabled": True, "effort": "high"},
             {
                 "api_mode": "codex_responses",
-                "provider": "xai-oauth",
-                "model": "grok-4",
+                "transport": SimpleNamespace(_last_reasoning_effort=None),
             },
             None,
+        ),
+        (
+            {"enabled": True, "effort": "minimal"},
+            {},
+            "minimal",
         ),
     ],
 )

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -74,6 +74,7 @@ class TestCodexBuildKwargs:
             reasoning_config={"effort": "high"},
         )
         assert kw.get("reasoning", {}).get("effort") == "high"
+        assert transport._last_reasoning_effort == "high"
 
     @pytest.mark.parametrize("effort, wire_effort", [("max", "max"), ("ultra", "max")])
     def test_extended_reasoning_efforts_use_api_wire_value(self, transport, effort, wire_effort):
@@ -92,6 +93,33 @@ class TestCodexBuildKwargs:
             reasoning_config={"enabled": False},
         )
         assert "reasoning" not in kw or kw.get("include") == []
+        assert transport._last_reasoning_effort is None
+
+    def test_wire_effort_tracks_github_capability_resolution(self, transport):
+        kw = transport.build_kwargs(
+            model="github-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_github_responses=True,
+            reasoning_config={"enabled": True, "effort": "ultra"},
+            # AIAgent resolves this through the GitHub model capability list.
+            github_reasoning_extra={"effort": "medium"},
+        )
+
+        assert kw["reasoning"] == {"effort": "medium"}
+        assert transport._last_reasoning_effort == "medium"
+
+    def test_wire_effort_is_none_when_xai_omits_unsupported_dial(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_xai_responses=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+
+        assert "reasoning" not in kw
+        assert transport._last_reasoning_effort is None
 
     def test_cache_key_is_content_addressed_not_session_id(self, transport):
         """prompt_cache_key is content-addressed from the static prefix

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -70,6 +70,42 @@ def test_format_footer_all_fields(monkeypatch, tmp_path):
     assert out == "gpt-5.4 · 68% · ~/projects/hermes"
 
 
+def test_format_footer_includes_reasoning_effort():
+    out = format_runtime_footer(
+        model="openai/gpt-5.6-sol",
+        reasoning_effort="low",
+        context_tokens=12_000,
+        context_length=100_000,
+        cwd="",
+        fields=("model", "reasoning_effort", "context_pct"),
+    )
+    assert out == "gpt-5.6-sol · low · 12%"
+
+
+def test_format_footer_skips_missing_reasoning_effort():
+    out = format_runtime_footer(
+        model="openai/gpt-5.6-sol",
+        reasoning_effort=None,
+        context_tokens=12_000,
+        context_length=100_000,
+        cwd="",
+        fields=("model", "reasoning_effort", "context_pct"),
+    )
+    assert out == "gpt-5.6-sol · 12%"
+
+
+def test_format_footer_skips_unknown_reasoning_effort():
+    out = format_runtime_footer(
+        model="openai/gpt-5.6-sol",
+        reasoning_effort="turbo",
+        context_tokens=12_000,
+        context_length=100_000,
+        cwd="",
+        fields=("model", "reasoning_effort", "context_pct"),
+    )
+    assert out == "gpt-5.6-sol · 12%"
+
+
 def test_format_footer_skips_missing_context_length():
     out = format_runtime_footer(
         model="openai/gpt-5.4",
@@ -229,6 +265,26 @@ def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):
     (tmp_path / "proj").mkdir(exist_ok=True)
     assert "gpt-5.4" in out
     assert "25%" in out
+
+
+def test_build_footer_passes_reasoning_effort():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["model", "reasoning_effort"],
+                }
+            }
+        },
+        platform_key="telegram",
+        model="openai/gpt-5.6-sol",
+        reasoning_effort="medium",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+    )
+    assert out == "gpt-5.6-sol · medium"
 
 
 def test_build_footer_per_platform_off_suppresses():

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -437,6 +437,9 @@ def test_build_api_kwargs_copilot_responses_omits_openai_only_fields(monkeypatch
     assert kwargs["tool_choice"] == "auto"
     assert kwargs["parallel_tool_calls"] is True
     assert kwargs["reasoning"] == {"effort": "medium"}
+    transport = agent._get_transport()
+    assert transport is not None
+    assert transport._last_reasoning_effort == "medium"
     assert "prompt_cache_key" not in kwargs
     assert "include" not in kwargs
 
@@ -446,8 +449,41 @@ def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_mo
     kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
 
     assert "reasoning" not in kwargs
+    transport = agent._get_transport()
+    assert transport is not None
+    assert transport._last_reasoning_effort is None
     assert "include" not in kwargs
     assert "prompt_cache_key" not in kwargs
+
+
+@pytest.mark.parametrize(
+    "provider,base_url",
+    [
+        ("xai", "https://example.invalid/v1"),
+        ("custom", "https://api.x.ai/v1"),
+    ],
+)
+def test_xai_routes_capture_clamped_wire_effort(monkeypatch, provider, base_url):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="grok-4.3",
+        provider=provider,
+        api_mode="codex_responses",
+        base_url=base_url,
+        api_key="test-token",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+    )
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+    assert kwargs["reasoning"] == {"effort": "high"}
+    transport = agent._get_transport()
+    assert transport is not None
+    assert transport._last_reasoning_effort == "high"
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1489,13 +1489,14 @@ Tool progress requires a gateway adapter that can display progress updates safel
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, effective reasoning effort, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # supported fields: model, context_pct, cwd
+    fields: ["model", "reasoning_effort", "context_pct", "cwd"]
+    # supported fields: model, reasoning_effort, context_pct, cwd
 ```
 
 The `/footer` slash command toggles this at runtime in any session.
@@ -1503,7 +1504,7 @@ The `/footer` slash command toggles this at runtime in any session.
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+gpt-5.6-sol · low · 12% · ~/projects/hermes
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.


### PR DESCRIPTION
## Summary

Adds an opt-in `reasoning_effort` field to the gateway runtime footer so users can see the effort actually applied to the turn alongside model/context metadata.

Example:

```text
gpt-5.6-sol · low · 12% · ~/projects/hermes
```

## Behavior

- exports `reasoning_effort` in the agent turn result
- passes it through the gateway's final-message footer path
- supports `reasoning_effort` in `display.runtime_footer.fields`
- normalizes Codex Responses wire behavior:
  - unset -> `medium`
  - `minimal` -> `low`
  - GPT-5.6 `ultra` -> `max`
  - xAI values above `high` -> `high` when the model supports the effort dial
- omits the field when the provider's effective default cannot be determined reliably
- leaves the existing default footer fields unchanged (the new field is opt-in)

## Configuration

```yaml
display:
  runtime_footer:
    enabled: true
    fields: ["model", "reasoning_effort", "context_pct", "cwd"]
```

## Verification

```text
135 passed in 1.79s
Ruff: All checks passed
py_compile: passed
git diff --check: passed
```

Targeted suites covered the runtime footer, turn finalizer metadata, finalizer regressions, and Codex transport normalization.
