### PR TITLE
feat(cli): add kimi-k.3.0 to kimi-coding and related model catalogs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -318,6 +318,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
     "kimi": 262144,
+    "kimi-k.3.0": 262144,
     # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
     # OpenRouter live metadata reports 262144 (256 × 1024); align the
     # static fallback so cache and offline both agree (issue #22268).

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -69,6 +69,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("qwen/qwen3.7-plus",                      ""),
     ("qwen/qwen3.6-35b-a3b",                   ""),
     # MoonshotAI
+    ("moonshotai/kimi-k.3.0",                  ""),
     ("moonshotai/kimi-k2.6",                   "recommended"),
     ("moonshotai/kimi-k2.7-code",              ""),
     # MiniMax
@@ -220,6 +221,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen/qwen3.7-plus",
         "qwen/qwen3.6-35b-a3b",
         # MoonshotAI
+        "moonshotai/kimi-k.3.0",
         "moonshotai/kimi-k2.6",
         "moonshotai/kimi-k2.7-code",
         # MiniMax
@@ -316,10 +318,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # Third-party agentic models hosted on build.nvidia.com
         # (map to OpenRouter defaults — users get familiar picks on NIM)
         "z-ai/glm-5.2",
+        "moonshotai/kimi-k.3.0",
         "moonshotai/kimi-k2.6",
         "minimaxai/minimax-m3",
     ],
     "kimi-coding": [
+        "kimi-k.3.0",
         "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
@@ -330,6 +334,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "kimi-coding-cn": [
+        "kimi-k.3.0",
         "kimi-k2.6",
         "kimi-k2.5",
         "kimi-k2-thinking",
@@ -341,6 +346,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "step-3.5-flash-2603",
     ],
     "moonshot": [
+        "kimi-k.3.0",
         "kimi-k2.6",
         "kimi-k2.5",
         "kimi-k2-thinking",
@@ -408,6 +414,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4",
     ],
     "opencode-zen": [
+        "kimi-k.3.0",
         "kimi-k2.5",
         "kimi-k2.6",
         "gpt-5.5",
@@ -460,6 +467,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free",
     ],
     "opencode-go": [
+        "kimi-k.3.0",
         "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
@@ -495,6 +503,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "alibaba": [
         "qwen3.7-max",
         "qwen3.6-plus",
+        "kimi-k.3.0",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",
@@ -549,6 +558,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Empty list because models depend on the endpoint configuration.
     "azure-foundry": [],
     "novita": [
+        "moonshotai/kimi-k.3.0",
         "moonshotai/kimi-k2.5",
         "minimax/minimax-m2.7",
         "zai-org/glm-5",

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -62,7 +62,7 @@ kimi = KimiProfile(
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
     default_headers={"User-Agent": "hermes-agent/1.0"},
-    default_aux_model="kimi-k2-turbo-preview",
+    default_aux_model="kimi-k.3.0",
 )
 
 kimi_cn = KimiProfile(
@@ -73,7 +73,7 @@ kimi_cn = KimiProfile(
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
     default_headers={"User-Agent": "hermes-agent/1.0"},
-    default_aux_model="kimi-k2-turbo-preview",
+    default_aux_model="kimi-k.3.0",
 )
 
 register_provider(kimi)

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -45,6 +45,20 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
+    def test_k3_model_id_present_in_provider_catalog(self):
+        """The pre-release K3.0 model id is available for selection."""
+        from hermes_cli.models import provider_model_ids
+
+        assert "kimi-k.3.0" in provider_model_ids("kimi-coding")
+
+    def test_k3_model_validation_accepts(self):
+        """``validate_requested_model`` recognizes the pre-release K3.0 id."""
+        from hermes_cli.models import validate_requested_model
+
+        result = validate_requested_model("kimi-k.3.0", "kimi-coding")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
     @pytest.mark.parametrize("effort", ["low", "medium", "high"])
     def test_explicit_effort_sends_effort_only(self, kimi_profile, effort):
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -228,11 +228,11 @@ hermes chat --provider zai --model glm-5
 # Requires: GLM_API_KEY in ~/.hermes/.env
 
 # Kimi / Moonshot AI (international: api.moonshot.ai)
-hermes chat --provider kimi-coding --model kimi-for-coding
+hermes chat --provider kimi-coding --model kimi-k.3.0
 # Requires: KIMI_API_KEY in ~/.hermes/.env
 
 # Kimi / Moonshot AI (China: api.moonshot.cn)
-hermes chat --provider kimi-coding-cn --model kimi-k2.5
+hermes chat --provider kimi-coding-cn --model kimi-k.3.0
 # Requires: KIMI_CN_API_KEY in ~/.hermes/.env
 
 # MiniMax (global endpoint)

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -210,11 +210,11 @@ hermes chat --provider zai --model glm-5
 # 需要：~/.hermes/.env 中的 GLM_API_KEY
 
 # Kimi / Moonshot AI（国际版：api.moonshot.ai）
-hermes chat --provider kimi-coding --model kimi-for-coding
+hermes chat --provider kimi-coding --model kimi-k.3.0
 # 需要：~/.hermes/.env 中的 KIMI_API_KEY
 
 # Kimi / Moonshot AI（中国版：api.moonshot.cn）
-hermes chat --provider kimi-coding-cn --model kimi-k2.5
+hermes chat --provider kimi-coding-cn --model kimi-k.3.0
 # 需要：~/.hermes/.env 中的 KIMI_CN_API_KEY
 
 # MiniMax（全球端点）

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-09T18:38:59Z",
+  "updated_at": "2026-07-14T18:18:22Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -102,6 +102,10 @@
         },
         {
           "id": "qwen/qwen3.6-35b-a3b",
+          "description": ""
+        },
+        {
+          "id": "moonshotai/kimi-k.3.0",
           "description": ""
         },
         {
@@ -245,6 +249,9 @@
         },
         {
           "id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "id": "moonshotai/kimi-k.3.0"
         },
         {
           "id": "moonshotai/kimi-k2.6"


### PR DESCRIPTION
## Summary

Adds the pre-release **Kimi K3.0** model id (`kimi-k.3.0`) to the Hermes model menus and provider catalogs ahead of its public release.

## What changed

- `hermes_cli/models.py`
  - Added `moonshotai/kimi-k.3.0` to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]` so it appears in the Nous portal/OpenRouter curated lists.
  - Added `kimi-k.3.0` to `_PROVIDER_MODELS` for `kimi-coding`, `kimi-coding-cn`, `moonshot`, `opencode-zen`, `opencode-go`, `alibaba`.
  - Added `moonshotai/kimi-k.3.0` to `_PROVIDER_MODELS` for `nvidia` and `novita`.
- `agent/model_metadata.py`
  - Added explicit `kimi-k.3.0` context length fallback of `262144`.
- `plugins/model-providers/kimi-coding/__init__.py`
  - Updated `default_aux_model` from `kimi-k2-turbo-preview` to `kimi-k.3.0` for both the international and China profiles.
- `website/static/api/model-catalog.json`
  - Regenerated with `python3 scripts/build_model_catalog.py` so the online manifest matches the in-repo curated lists.
- `website/docs/integrations/providers.md` and its Chinese translation
  - Updated the quick-start examples to use `kimi-k.3.0`.
- `tests/plugins/model_providers/test_kimi_profile.py`
  - Added drift-guard tests asserting `kimi-k.3.0` is present in the `kimi-coding` catalog and accepted by `validate_requested_model`.

## Testing

```bash
python3 -m pytest tests/hermes_cli/test_model_validation.py \
                 tests/hermes_cli/test_model_catalog.py \
                 tests/plugins/model_providers/test_kimi_profile.py \
                 tests/agent/test_model_metadata.py -q
```

Result: **260 passed**.

## Notes

- OpenRouter has not publicly listed `kimi-k.3.0` yet, so the OpenRouter/Nous/Novita/NVIDIA entries are staged for the slug `moonshotai/kimi-k.3.0` and can be corrected via the live manifest once the model is released.
- No new provider plugin was needed; this is purely a model catalog update.

## Checklist

- [x] Branch cut from latest `origin/main`.
- [x] Conventional Commits message used.
- [x] In-repo manifest regenerated and matches `models.py`.
- [x] Targeted tests added and passing.
- [x] Provider docs and i18n docs updated.