### PR TITLE
feat(slack): resolve channel name + topic into session context

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -441,6 +441,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        self._channel_info_cache: Dict[str, tuple] = {}  # channel_id → (name, topic)
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
@@ -2106,6 +2107,36 @@ class SlackAdapter(BasePlatformAdapter):
             self._user_name_cache[user_id] = user_id
             return user_id
 
+    async def _resolve_channel_info(self, channel_id: str):
+        """Resolve a channel ID to (name, topic), cached.
+
+        Fail-open: any API error caches (None, None) so a dead lookup never
+        retries per message and callers keep today's raw-ID behaviour.
+        Topic falls back to purpose — most channels only fill one of the two.
+        """
+        if not channel_id:
+            return (None, None)
+        if channel_id in self._channel_info_cache:
+            return self._channel_info_cache[channel_id]
+        if not self._app:
+            return (None, None)
+        try:
+            client = self._get_client(channel_id)
+            result = await client.conversations_info(channel=channel_id)
+            channel = result.get("channel", {}) or {}
+            name = channel.get("name") or None
+            topic = (
+                (channel.get("topic") or {}).get("value")
+                or (channel.get("purpose") or {}).get("value")
+                or None
+            )
+            self._channel_info_cache[channel_id] = (name, topic)
+            return (name, topic)
+        except Exception as e:
+            logger.debug("[Slack] conversations.info failed for %s: %s", channel_id, e)
+            self._channel_info_cache[channel_id] = (None, None)
+            return (None, None)
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -3160,11 +3191,19 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
 
+        # Resolve channel identity (name + topic) so the model knows WHERE
+        # this message came from instead of a raw channel ID. DMs skip the
+        # lookup — conversations.info has no useful name for an IM.
+        chan_name, chan_topic = (None, None)
+        if not is_dm:
+            chan_name, chan_topic = await self._resolve_channel_info(channel_id)
+
         # Build source
         source = self.build_source(
             chat_id=channel_id,
-            chat_name=channel_id,  # Will be resolved later if needed
+            chat_name=f"#{chan_name}" if chan_name else channel_id,
             chat_type="dm" if is_dm else "group",
+            chat_topic=chan_topic,
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
@@ -3957,9 +3996,14 @@ class SlackAdapter(BasePlatformAdapter):
         # keep group semantics so different users do not collide into one
         # session key.
         is_dm = str(channel_id).startswith("D")
+        chan_name, chan_topic = (None, None)
+        if not is_dm:
+            chan_name, chan_topic = await self._resolve_channel_info(channel_id)
         source = self.build_source(
             chat_id=channel_id,
+            chat_name=f"#{chan_name}" if chan_name else channel_id,
             chat_type="dm" if is_dm else "group",
+            chat_topic=chan_topic,
             user_id=user_id,
         )
 

--- a/tests/gateway/test_slack_channel_identity.py
+++ b/tests/gateway/test_slack_channel_identity.py
@@ -1,0 +1,110 @@
+"""Slack sources must carry the channel NAME and topic.
+
+Before: build_source stamped chat_name=channel_id ('Will be resolved later
+if needed' — nothing ever did), so the model's Source line read a raw
+channel ID (e.g. 'group: C0A094J5RAP') instead of the channel name, and
+the bot had no way to tell which channel it was actually posting in."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app.client = AsyncMock()
+    a._bot_user_id = "U_BOT"
+    a._running = True
+    a.handle_message = AsyncMock()
+    return a
+
+
+@pytest.fixture(autouse=True)
+def _redirect_cache(tmp_path, monkeypatch):
+    """Point document cache to tmp_path so tests don't touch ~/.hermes."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+    )
+
+
+def _channel_event(text: str, ts: str, thread_ts: str = None) -> dict:
+    """Build a minimal ``message`` event for the Slack Events API
+    resembling what ``handle_message_event`` would pass through."""
+    event = {
+        "channel": "C_CHAN",
+        "channel_type": "channel",
+        "user": "U_USER",
+        "text": text,
+        "ts": ts,
+    }
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    return event
+
+
+def _conv_info(name, topic="", purpose=""):
+    return {"ok": True, "channel": {
+        "name": name,
+        "topic": {"value": topic},
+        "purpose": {"value": purpose},
+    }}
+
+
+@pytest.mark.asyncio
+async def test_channel_message_carries_name_topic_and_group_type(adapter):
+    adapter._app.client.conversations_info = AsyncMock(
+        return_value=_conv_info("project-hermes", topic="Project Hermes planning"))
+    captured = []
+    adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+    event = _channel_event("<@U_BOT> which project?", ts="1700000000.000001")
+    with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="alice")):
+        await adapter._handle_slack_message(event)
+    source = captured[0].source
+    assert source.chat_name == "#project-hermes"
+    assert source.chat_topic == "Project Hermes planning"
+    # session keys embed chat_type — MUST stay 'group' (session.py:893)
+    assert source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_purpose_falls_back_when_topic_empty(adapter):
+    adapter._app.client.conversations_info = AsyncMock(
+        return_value=_conv_info("leads", topic="", purpose="Inbound seller leads"))
+    captured = []
+    adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+    with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="alice")):
+        await adapter._handle_slack_message(
+            _channel_event("<@U_BOT> hi", ts="1700000000.000002"))
+    assert captured[0].source.chat_topic == "Inbound seller leads"
+
+
+@pytest.mark.asyncio
+async def test_api_failure_falls_back_to_raw_id_and_caches(adapter):
+    adapter._app.client.conversations_info = AsyncMock(side_effect=RuntimeError("boom"))
+    captured = []
+    adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+    with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="alice")):
+        await adapter._handle_slack_message(
+            _channel_event("<@U_BOT> a", ts="1700000000.000003"))
+        await adapter._handle_slack_message(
+            _channel_event("<@U_BOT> b", ts="1700000000.000004"))
+    assert captured[0].source.chat_name == "C_CHAN"       # today's behaviour
+    assert captured[0].source.chat_topic is None
+    # failure is cached: the dead lookup must not retry per message
+    assert adapter._app.client.conversations_info.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_success_is_cached_one_api_call(adapter):
+    adapter._app.client.conversations_info = AsyncMock(
+        return_value=_conv_info("leads"))
+    adapter.handle_message = AsyncMock()
+    with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="alice")):
+        await adapter._handle_slack_message(_channel_event("<@U_BOT> a", ts="1700000000.000005"))
+        await adapter._handle_slack_message(_channel_event("<@U_BOT> b", ts="1700000000.000006"))
+    assert adapter._app.client.conversations_info.await_count == 1


### PR DESCRIPTION
## Problem

`SlackAdapter` builds a `MessageSource` for every incoming message and
slash command, and stamps `chat_name=channel_id` with a comment saying
"Will be resolved later if needed." Nothing ever resolves it. The
model-facing Source line ends up reading something like
`group: C0A094J5RAP` instead of a human-readable channel name — the
model has no idea what channel it's actually posting in, even though
Slack's `conversations.info` API happily returns the channel's name
and topic/purpose.

This is easy to reproduce: ask a Slack bot built on this adapter "what
channel are we in?" from inside a channel whose name is meaningful
context (e.g. a project or team channel) — the model can't answer,
because all it ever saw was the raw ID.

## Fix

- Add `SlackAdapter._resolve_channel_info(channel_id)`, mirroring the
  existing `_resolve_user_name` cache pattern: a per-adapter
  `_channel_info_cache` dict, one `conversations.info` call per
  channel (cached after success), and **fail-open** on any API error
  — a failure caches `(None, None)` so a dead lookup is retried at
  most once total, never per message.
- Topic falls back to purpose when the topic field is empty (many
  channels only set one of the two).
- Wire the resolved `(name, topic)` into both places that build a
  channel `MessageSource`: the incoming-message path
  (`_handle_slack_message`) and the slash-command path
  (`_handle_slash_command`). `chat_name` becomes `f"#{name}"` when
  resolved, else falls back to today's raw `channel_id` behavior.
  `chat_type` is untouched (`"dm"`/`"group"`) — it's embedded in
  session keys and this change must not alter session scoping.
- DMs skip the lookup entirely — `conversations.info` has no useful
  "name" for an IM.

## Tests

`tests/gateway/test_slack_channel_identity.py` (new, 4 tests):

- a channel message carries the resolved `#name` and topic, with
  `chat_type` still `"group"`
- purpose is used as the topic when topic is empty
- a `conversations.info` failure falls back to the raw channel ID and
  `chat_topic=None`, and the failure is cached (the dead lookup is not
  retried per message — asserted via mock call count)
- a successful lookup is cached to exactly one API call across
  multiple messages

Verified no regression in the adjacent
`tests/gateway/test_slack_channel_session_scope.py` (channel-session
scoping, pre-existing upstream suite) and across the full Slack
adapter test surface: `543 passed, 7 skipped` (`pytest tests -k slack`).

Local dev install: `uv venv .venv --python 3.11 && uv pip install -e ".[all,dev]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
