### PR TITLE
fix(agent): bound the connect phase of auxiliary HTTP calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1049,7 +1049,14 @@ class _CodexCompletionsAdapter:
         text_parts: List[str] = []
         tool_calls_raw: List[Any] = []
         usage = None
-        total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
+        # ``timeout`` may be a connect-bounded ``httpx.Timeout`` built by
+        # ``_build_call_kwargs`` — its ``read`` phase carries the configured
+        # total budget. Plain numeric timeouts pass through unchanged.
+        _timeout_secs = (
+            timeout if isinstance(timeout, (int, float))
+            else getattr(timeout, "read", None)
+        )
+        total_timeout = _timeout_secs if isinstance(_timeout_secs, (int, float)) and _timeout_secs > 0 else None
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
         timed_out = threading.Event()
         timeout_timer: Optional[threading.Timer] = None
@@ -6064,6 +6071,37 @@ _DEFAULT_AUX_TIMEOUT = 30.0
 # is kept unchanged.
 _COMPRESSION_TIMEOUT_FLOOR_SECONDS = 300.0
 
+# Cap for the TCP-connect phase of auxiliary HTTP calls. A bare float passed
+# as a per-request ``timeout`` becomes ``httpx.Timeout(float)`` on the wire,
+# giving every phase (connect/read/write/pool) the full value. When an
+# endpoint is unreachable but silently drops SYNs (e.g. a sleeping LAN
+# server), each connection attempt then blocks until the OS gives up
+# (~75 s on macOS, ``net.inet.tcp.keepinit``; the configured httpx connect
+# timeout of e.g. 120 s never fires), and the OpenAI SDK's default
+# ``max_retries=2`` turns one call into three attempts — ~226 s wall clock
+# for a configured timeout of 120. Bounding only the connect phase keeps the
+# configured value as the read/write budget (local models legitimately take
+# long to generate) while a dead endpoint fails within seconds.
+_AUX_CONNECT_TIMEOUT = env_float("HERMES_AUX_CONNECT_TIMEOUT", 10.0)
+
+
+def _connect_bounded_timeout(timeout: Any) -> Any:
+    """Convert a numeric timeout into an ``httpx.Timeout`` with capped connect.
+
+    Non-numeric or non-positive values (and environments without httpx) are
+    returned unchanged, so callers can pass the result anywhere a plain
+    ``timeout`` value was accepted before.
+    """
+    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or timeout <= 0:
+        return timeout
+    try:
+        import httpx
+    except ImportError:
+        return timeout
+    return httpx.Timeout(
+        float(timeout), connect=min(float(timeout), _AUX_CONNECT_TIMEOUT)
+    )
+
 
 def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     """Return the config dict for auxiliary.<task>, or {} when unavailable.
@@ -6270,7 +6308,9 @@ def _build_call_kwargs(
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,
-        "timeout": timeout,
+        # Bound the connect phase so a dead endpoint fails fast instead of
+        # holding each SDK connection attempt for the OS SYN timeout (F055).
+        "timeout": _connect_bounded_timeout(timeout),
     }
 
     fixed_temperature = _fixed_temperature_for_model(model, base_url)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -343,6 +343,81 @@ class TestBuildCallKwargsMaxTokens:
         assert kwargs["max_tokens"] == 4096
 
 
+class TestConnectBoundedTimeout:
+    """A bare numeric ``timeout`` becomes ``httpx.Timeout(timeout)`` on the
+    wire, giving every phase (connect/read/write/pool) the full value. When
+    an endpoint is unreachable but silently drops SYNs, each connection
+    attempt then blocks until the OS gives up (tens of seconds), turning one
+    dead-endpoint call into minutes once SDK retries are layered on top.
+    ``_build_call_kwargs`` bounds only the connect phase so a dead endpoint
+    fails fast while read/write keep the full configured budget."""
+
+    def test_build_call_kwargs_bounds_connect_phase(self):
+        import httpx
+
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="local-model",
+            messages=[{"role": "user", "content": "hi"}],
+            timeout=120.0,
+            base_url="http://localhost:8080/v1",
+        )
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.read == 120.0
+        assert timeout.connect == 10.0
+
+    def test_connect_cap_never_exceeds_total_timeout(self):
+        """A total timeout shorter than the default connect cap must not
+        make the connect phase longer than the whole call budget."""
+        import httpx
+
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="local-model",
+            messages=[{"role": "user", "content": "hi"}],
+            timeout=5.0,
+            base_url="http://localhost:8080/v1",
+        )
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.read == 5.0
+        assert timeout.connect == 5.0
+
+    def test_connect_cap_overridable_via_env(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("HERMES_AUX_CONNECT_TIMEOUT", "2.5")
+        # The module-level constant is read at import time; patch it directly
+        # rather than reimporting the module.
+        with patch("agent.auxiliary_client._AUX_CONNECT_TIMEOUT", 2.5):
+            kwargs = _build_call_kwargs(
+                provider="custom",
+                model="local-model",
+                messages=[{"role": "user", "content": "hi"}],
+                timeout=120.0,
+                base_url="http://localhost:8080/v1",
+            )
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 2.5
+
+    def test_non_numeric_timeout_passes_through_unchanged(self):
+        """An already-built httpx.Timeout (or any non-numeric value) must
+        not be re-wrapped."""
+        import httpx
+
+        explicit = httpx.Timeout(60.0, connect=3.0)
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="local-model",
+            messages=[{"role": "user", "content": "hi"}],
+            timeout=explicit,
+            base_url="http://localhost:8080/v1",
+        )
+        assert kwargs["timeout"] is explicit
+
+
 class TestNousTagsScoping:
     def test_tags_injected_when_provider_is_nous(self, monkeypatch):
         import agent.auxiliary_client as aux

--- a/tests/agent/test_auxiliary_compression_timeout_floor.py
+++ b/tests/agent/test_auxiliary_compression_timeout_floor.py
@@ -23,6 +23,7 @@ paths with a mocked LLM client and assert the timeout that actually reaches
 
 from unittest.mock import patch, MagicMock, AsyncMock
 
+import httpx
 import pytest
 
 from agent.auxiliary_client import call_llm, async_call_llm
@@ -36,6 +37,21 @@ COMPRESSION_TIMEOUT_FLOOR = 300.0
 # The default ``auxiliary.compression.timeout`` shipped in the config schema
 # (hermes_cli/config.py).  Simulated here as the config-derived value.
 COMPRESSION_CONFIG_TIMEOUT = 120.0
+
+
+def _total_budget(timeout):
+    """The read/write/pool budget a timeout value carries.
+
+    ``_build_call_kwargs`` wraps a bare numeric timeout in an
+    ``httpx.Timeout`` with a capped connect phase (see
+    ``_connect_bounded_timeout``); the overall call budget these tests care
+    about lives on ``.read``. A plain number (already-explicit
+    ``httpx.Timeout`` passed by a caller, or an environment without httpx)
+    passes through unchanged.
+    """
+    if isinstance(timeout, httpx.Timeout):
+        return timeout.read
+    return timeout
 
 
 def _ok_response():
@@ -84,7 +100,7 @@ class TestCompressionTimeoutFloorSync:
                 task="compression",
                 messages=[{"role": "user", "content": "summarise this"}],
             )
-        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        timeout = _total_budget(client.chat.completions.create.call_args.kwargs["timeout"])
         assert timeout >= COMPRESSION_TIMEOUT_FLOOR, (
             f"compression timeout {timeout} should be >= floor "
             f"{COMPRESSION_TIMEOUT_FLOOR}"
@@ -105,7 +121,7 @@ class TestCompressionTimeoutFloorSync:
                 messages=[{"role": "user", "content": "x"}],
                 timeout=explicit,
             )
-        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        timeout = _total_budget(client.chat.completions.create.call_args.kwargs["timeout"])
         assert timeout == explicit, (
             f"explicit per-call timeout {explicit} must not be floored, got {timeout}"
         )
@@ -121,7 +137,7 @@ class TestCompressionTimeoutFloorSync:
                 task="title_generation",
                 messages=[{"role": "user", "content": "x"}],
             )
-        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        timeout = _total_budget(client.chat.completions.create.call_args.kwargs["timeout"])
         assert timeout == low, (
             f"non-compression task timeout must stay {low}, got {timeout}"
         )
@@ -137,7 +153,7 @@ class TestCompressionTimeoutFloorSync:
                 task="compression",
                 messages=[{"role": "user", "content": "x"}],
             )
-        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        timeout = _total_budget(client.chat.completions.create.call_args.kwargs["timeout"])
         assert timeout == high, (
             f"config timeout {high} above the floor must be unchanged, got {timeout}"
         )
@@ -155,7 +171,7 @@ class TestCompressionTimeoutFloorAsync:
                 task="compression",
                 messages=[{"role": "user", "content": "summarise this"}],
             )
-        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        timeout = _total_budget(client.chat.completions.create.call_args.kwargs["timeout"])
         assert timeout >= COMPRESSION_TIMEOUT_FLOOR, (
             f"async compression timeout {timeout} should be >= floor "
             f"{COMPRESSION_TIMEOUT_FLOOR}"
@@ -172,7 +188,7 @@ class TestCompressionTimeoutFloorAsync:
                 messages=[{"role": "user", "content": "x"}],
                 timeout=explicit,
             )
-        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        timeout = _total_budget(client.chat.completions.create.call_args.kwargs["timeout"])
         assert timeout == explicit
 
     @pytest.mark.asyncio
@@ -185,5 +201,5 @@ class TestCompressionTimeoutFloorAsync:
                 task="session_search",
                 messages=[{"role": "user", "content": "x"}],
             )
-        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        timeout = _total_budget(client.chat.completions.create.call_args.kwargs["timeout"])
         assert timeout == low


### PR DESCRIPTION
## Problem

Auxiliary LLM calls (compression, title generation, vision, etc.) take
a numeric `timeout` and pass it straight through to the HTTP client.
When that bare float reaches httpx as `httpx.Timeout(timeout)`, *every*
phase — connect, read, write, pool — gets the full value.

That's fine when the endpoint is up. It's a problem when the endpoint
is unreachable but silently drops SYN packets (a sleeping LAN box, a
firewalled/blackholed host): each connection attempt then blocks until
the OS gives up on the SYN — commonly tens of seconds — rather than
hitting the configured httpx connect timeout, which never gets a
chance to fire before the OS does. Layer the SDK's default retry count
on top and a single dead-endpoint call can take several times the
configured timeout to actually fail. A configured timeout of 120s can
mean minutes of wall-clock stall before the caller sees an error and
falls back.

## Fix

- Add `_connect_bounded_timeout(timeout)`: converts a bare numeric
  timeout into `httpx.Timeout(timeout, connect=min(timeout,
  _AUX_CONNECT_TIMEOUT))`, where `_AUX_CONNECT_TIMEOUT` defaults to
  10s and is overridable via `HERMES_AUX_CONNECT_TIMEOUT`. Non-numeric
  values (e.g. an already-built `httpx.Timeout`, `None`) and
  environments without `httpx` pass through unchanged, so every
  existing caller of `_build_call_kwargs` keeps working without
  changes.
- `_build_call_kwargs` now runs the resolved timeout through this
  helper before handing it to the SDK. The read/write/pool budget
  stays exactly what the caller configured (so a legitimately slow
  local model is unaffected) — only the connect phase gets capped, so
  a dead endpoint fails within seconds instead of minutes.
- The Codex Responses streaming path's total-timeout watchdog
  previously assumed `timeout` was always a bare float; it now reads
  the `.read` phase off an `httpx.Timeout` when that's what it
  receives, falling back to the plain numeric value otherwise.

## Interaction with the existing compression timeout floor (#54915)

This branch was rebased on top of the compression-timeout-floor fix
that already landed on `main`. That fix's regression tests
(`tests/agent/test_auxiliary_compression_timeout_floor.py`) asserted
numeric equality directly against `client.chat.completions.create`'s
`timeout` kwarg — which now arrives as an `httpx.Timeout` rather than
a bare float. Updated those assertions to unwrap `.read` off an
`httpx.Timeout` (added a small `_total_budget()` test helper) so the
floor's behavior contract keeps being exercised precisely; the floor
semantics themselves are untouched by this change.

## Tests

- `tests/agent/test_auxiliary_client.py`: new `TestConnectBoundedTimeout`
  class (4 tests) — the connect phase is bounded to the default cap; the
  connect cap never exceeds a shorter total timeout; the cap is
  overridable via `HERMES_AUX_CONNECT_TIMEOUT`; non-numeric timeouts
  pass through unchanged.
- `tests/agent/test_auxiliary_compression_timeout_floor.py`: updated to
  unwrap `httpx.Timeout` before asserting — all 7 pre-existing cases
  (sync + async, floor applied / explicit override / non-compression
  task / higher-config-not-lowered) still pass.
- `tests/agent/test_auxiliary_transient_retry.py`: unaffected, still
  passing (confirms the retry-skip-on-timeout logic doesn't care about
  the timeout kwarg's concrete type).

Full run: `pytest tests/agent/test_auxiliary_client.py
tests/agent/test_auxiliary_transient_retry.py
tests/agent/test_auxiliary_compression_timeout_floor.py -q` →
**315 passed**.

Local dev install: `uv venv .venv --python 3.11 && uv pip install -e ".[dev]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
