### PR TITLE
feat(skills): journal mutating skill writes + rate-limit autonomous re-patches

### DIFF
--- a/tests/tools/test_skill_patch_journal.py
+++ b/tests/tools/test_skill_patch_journal.py
@@ -1,0 +1,176 @@
+"""Tests for the skill write journal + background-review cooldown (local patch 10, F008).
+
+Every successful mutating skill_manage action must land in the per-profile
+.patch-journal.jsonl with enough content to revert it, and autonomous
+background-review content writes are rate-limited per skill.
+"""
+
+import json
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from tools.skill_manager_tool import (
+    _background_review_cooldown_guard,
+    _background_review_write_guard,
+    skill_manage,
+)
+
+
+@contextmanager
+def _skill_env(tmp_path):
+    """Sandbox the skills dir AND the journal path to tmp_path."""
+    journal = tmp_path / ".patch-journal.jsonl"
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         patch("tools.skill_manager_tool._skill_journal_path", return_value=journal):
+        yield journal
+
+
+VALID_SKILL_CONTENT = """\
+---
+name: journal-test-skill
+description: A test skill for journal testing.
+---
+
+# Journal Test Skill
+
+Step 1: Do the thing.
+"""
+
+REWRITTEN_CONTENT = """\
+---
+name: journal-test-skill
+description: Updated description.
+---
+
+# Journal Test Skill v2
+
+Step 1: Do the new thing.
+"""
+
+
+def _journal_entries(journal):
+    if not journal.exists():
+        return []
+    return [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
+
+
+def _write_journal_entry(journal, skill, action="patch", origin="background_review", hours_ago=0.0):
+    ts = (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat(timespec="seconds")
+    entry = {"ts": ts, "origin": origin, "action": action, "skill": skill, "file": "SKILL.md"}
+    with open(journal, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+class TestJournalWrites:
+    def test_patch_journals_old_and_new_strings(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            skill_manage("create", "journal-test-skill", content=VALID_SKILL_CONTENT)
+            skill_manage(
+                "patch", "journal-test-skill",
+                old_string="Do the thing.", new_string="Do the better thing.",
+            )
+            entries = _journal_entries(journal)
+            actions = [e["action"] for e in entries]
+            assert "create" in actions and "patch" in actions
+            patch_entry = [e for e in entries if e["action"] == "patch"][0]
+            assert patch_entry["skill"] == "journal-test-skill"
+            assert patch_entry["old_string"] == "Do the thing."
+            assert patch_entry["new_string"] == "Do the better thing."
+            assert patch_entry["origin"] == "foreground"
+            assert patch_entry["file"] == "SKILL.md"
+            assert patch_entry["ts"]
+
+    def test_edit_journals_prior_content(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            skill_manage("create", "journal-test-skill", content=VALID_SKILL_CONTENT)
+            skill_manage("edit", "journal-test-skill", content=REWRITTEN_CONTENT)
+            edit_entry = [e for e in _journal_entries(journal) if e["action"] == "edit"][0]
+            assert edit_entry["prior_content"] == VALID_SKILL_CONTENT
+
+    def test_failed_patch_not_journaled(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            skill_manage("create", "journal-test-skill", content=VALID_SKILL_CONTENT)
+            skill_manage(
+                "patch", "journal-test-skill",
+                old_string="text that does not exist anywhere", new_string="x",
+            )
+            assert all(e["action"] != "patch" for e in _journal_entries(journal))
+
+    def test_journal_failure_never_breaks_the_write(self, tmp_path):
+        bad_journal = tmp_path / "no-such-dir-parent-is-a-file" / "j.jsonl"
+        (tmp_path / "no-such-dir-parent-is-a-file").write_text("a file, not a dir")
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+             patch("tools.skill_manager_tool._skill_journal_path", return_value=bad_journal):
+            result = json.loads(skill_manage("create", "journal-test-skill", content=VALID_SKILL_CONTENT))
+            assert result["success"] is True
+            result = json.loads(skill_manage(
+                "patch", "journal-test-skill",
+                old_string="Do the thing.", new_string="Do the better thing.",
+            ))
+            assert result["success"] is True
+
+
+class TestBackgroundCooldown:
+    def test_recent_bg_write_blocks(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            _write_journal_entry(journal, "journal-test-skill", hours_ago=1)
+            with patch("tools.skill_provenance.is_background_review", return_value=True):
+                guard = _background_review_cooldown_guard("journal-test-skill", "patch")
+            assert guard is not None
+            assert guard["success"] is False
+            assert "cooldown" in guard["error"]
+
+    def test_old_bg_write_allows(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            _write_journal_entry(journal, "journal-test-skill", hours_ago=48)
+            guard = _background_review_cooldown_guard("journal-test-skill", "patch")
+            assert guard is None
+
+    def test_foreground_entries_do_not_count(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            _write_journal_entry(journal, "journal-test-skill", origin="foreground", hours_ago=1)
+            guard = _background_review_cooldown_guard("journal-test-skill", "patch")
+            assert guard is None
+
+    def test_other_skill_entries_do_not_count(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            _write_journal_entry(journal, "some-other-skill", hours_ago=1)
+            guard = _background_review_cooldown_guard("journal-test-skill", "patch")
+            assert guard is None
+
+    def test_delete_not_cooldown_limited(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            _write_journal_entry(journal, "journal-test-skill", hours_ago=1)
+            guard = _background_review_cooldown_guard("journal-test-skill", "delete")
+            assert guard is None
+
+    def test_env_zero_disables(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_BG_SKILL_WRITE_COOLDOWN_HOURS", "0")
+        with _skill_env(tmp_path) as journal:
+            _write_journal_entry(journal, "journal-test-skill", hours_ago=1)
+            guard = _background_review_cooldown_guard("journal-test-skill", "patch")
+            assert guard is None
+
+    def test_write_guard_end_to_end_blocks_bg_repatch(self, tmp_path):
+        """Full guard path: an unpinned local skill, fresh bg journal entry -> refusal."""
+        with _skill_env(tmp_path) as journal:
+            skill_manage("create", "journal-test-skill", content=VALID_SKILL_CONTENT)
+            _write_journal_entry(journal, "journal-test-skill", hours_ago=1)
+            skill_dir = tmp_path / "journal-test-skill"
+            with patch("tools.skill_provenance.is_background_review", return_value=True):
+                guard = _background_review_write_guard("journal-test-skill", skill_dir, "patch")
+            assert guard is not None
+            assert "cooldown" in guard["error"]
+
+    def test_write_guard_foreground_unaffected(self, tmp_path):
+        with _skill_env(tmp_path) as journal:
+            skill_manage("create", "journal-test-skill", content=VALID_SKILL_CONTENT)
+            _write_journal_entry(journal, "journal-test-skill", hours_ago=1)
+            skill_dir = tmp_path / "journal-test-skill"
+            guard = _background_review_write_guard("journal-test-skill", skill_dir, "patch")
+            assert guard is None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -90,6 +90,142 @@ def _reset_background_review_read_marks() -> None:
     """Test helper: clear read-before-write marks for the current context."""
     _background_review_read_paths.set(frozenset())
 
+
+# ---------------------------------------------------------------------------
+# Skill write journal + autonomous-write cooldown (local patch 10, F008)
+# ---------------------------------------------------------------------------
+# Every successful mutating skill_manage action is appended to a per-profile
+# JSONL journal next to .usage.json, with enough content to revert it
+# (old/new strings for patches, prior file content for full rewrites).
+# Autonomous background-review content writes are additionally rate-limited
+# per skill via HERMES_BG_SKILL_WRITE_COOLDOWN_HOURS (default 24; 0 disables).
+
+_JOURNAL_MAX_BYTES = 5 * 1024 * 1024
+_JOURNALED_ACTIONS = {"create", "edit", "patch", "write_file", "remove_file", "delete"}
+_COOLDOWN_ACTIONS = {"edit", "patch", "write_file"}
+
+
+def _skill_journal_path() -> Path:
+    return get_hermes_home() / "skills" / ".patch-journal.jsonl"
+
+
+def _journal_write_origin() -> str:
+    try:
+        from tools.skill_provenance import is_background_review
+        return "background_review" if is_background_review() else "foreground"
+    except Exception:
+        return "unknown"
+
+
+def _journal_skill_write(entry: Dict[str, Any]) -> None:
+    """Append one entry to the skill write journal. Best-effort: never raises."""
+    try:
+        import fcntl as _fcntl
+    except ImportError:  # pragma: no cover - platform-specific
+        _fcntl = None
+    try:
+        from datetime import datetime, timezone
+        path = _skill_journal_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "origin": _journal_write_origin(),
+        }
+        record.update(entry)
+        line = json.dumps(record, ensure_ascii=False)
+        try:
+            if path.exists() and path.stat().st_size > _JOURNAL_MAX_BYTES:
+                os.replace(path, path.with_suffix(".jsonl.1"))
+        except OSError:
+            pass
+        with open(path, "a", encoding="utf-8") as fh:
+            if _fcntl is not None:
+                _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX)
+            try:
+                fh.write(line + "\n")
+            finally:
+                if _fcntl is not None:
+                    _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+    except Exception:
+        logger.debug("skill write journal append failed", exc_info=True)
+
+
+def _last_background_write_ts(name: str) -> Optional[str]:
+    """Most recent background-review journal ts for content writes to a skill."""
+    try:
+        path = _skill_journal_path()
+        if not path.exists():
+            return None
+        last = None
+        with open(path, "r", encoding="utf-8") as fh:
+            for raw in fh:
+                try:
+                    rec = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if (
+                    rec.get("skill") == name
+                    and rec.get("origin") == "background_review"
+                    and rec.get("action") in _COOLDOWN_ACTIONS
+                ):
+                    last = rec.get("ts") or last
+        return last
+    except Exception:
+        return None
+
+
+def _read_prior_for_journal(action: str, name: str, file_path: Optional[str]) -> Optional[str]:
+    """Current content of the file a full-rewrite action is about to replace."""
+    try:
+        existing = _find_skill(name)
+        if not existing:
+            return None
+        skill_dir = existing["path"]
+        if action == "edit" or not file_path:
+            target = skill_dir / "SKILL.md"
+        else:
+            target, err = _resolve_skill_target(skill_dir, file_path)
+            if err or target is None:
+                return None
+        return target.read_text(encoding="utf-8") if target.exists() else None
+    except Exception:
+        return None
+
+
+def _background_review_cooldown_guard(name: str, action: str) -> Optional[Dict[str, Any]]:
+    """Rate-limit autonomous content writes per skill (journal + trim, F008)."""
+    if action not in _COOLDOWN_ACTIONS:
+        return None
+    try:
+        hours = float(os.environ.get("HERMES_BG_SKILL_WRITE_COOLDOWN_HOURS", "24"))
+    except ValueError:
+        hours = 24.0
+    if hours <= 0:
+        return None
+    last = _last_background_write_ts(name)
+    if not last:
+        return None
+    try:
+        from datetime import datetime, timezone
+        age_h = (
+            datetime.now(timezone.utc) - datetime.fromisoformat(last)
+        ).total_seconds() / 3600.0
+    except Exception:
+        return None
+    if age_h >= hours:
+        return None
+    return {
+        "success": False,
+        "error": (
+            f"Refusing background curator {action} for skill '{name}': it was "
+            f"already patched autonomously {age_h:.1f}h ago (cooldown "
+            f"{hours:g}h, HERMES_BG_SKILL_WRITE_COOLDOWN_HOURS). Note the "
+            "improvement in your review summary instead; it can be applied "
+            "after the cooldown or by the user."
+        ),
+    }
+
+
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.
 try:
@@ -376,6 +512,14 @@ def _background_review_write_guard(
             }
     except Exception:
         logger.debug("owned skill guard lookup failed for %s", name, exc_info=True)
+
+    # Journal + trim (F008): autonomous content writes to any one skill are
+    # rate-limited so the review fork cannot re-patch the same skill every
+    # conversation (scheduled-agent-jobs accrued 168 unaudited patches in 11
+    # days before this guard existed).
+    cooldown = _background_review_cooldown_guard(name, action)
+    if cooldown:
+        return cooldown
     return None
 
 
@@ -1351,6 +1495,13 @@ def skill_manage(
     if gate_result is not None:
         return gate_result
 
+    # Journal support (local patch 10): full-rewrite actions need the prior
+    # content captured up front to be revertible; patch carries its own
+    # old/new strings.
+    _journal_prior = None
+    if action in {"edit", "write_file"}:
+        _journal_prior = _read_prior_for_journal(action, name, file_path)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -1392,6 +1543,20 @@ def skill_manage(
             clear_skills_system_prompt_cache(clear_snapshot=True)
         except Exception:
             pass
+        # Journal every mutating write with revert data (local patch 10, F008).
+        if action in _JOURNALED_ACTIONS:
+            rec: Dict[str, Any] = {
+                "action": action,
+                "skill": name,
+                "file": file_path or "SKILL.md",
+            }
+            if action == "patch":
+                rec["old_string"] = old_string
+                rec["new_string"] = new_string
+                rec["replace_all"] = bool(replace_all)
+            elif action in {"edit", "write_file"}:
+                rec["prior_content"] = _journal_prior
+            _journal_skill_write(rec)
         # Curator telemetry: bump patch_count on edit/patch/write_file (the actions
         # that mutate an existing skill's guidance), drop the record on delete.
         # Only mark a skill as agent-created when the background self-improvement


### PR DESCRIPTION
## Problem

`skill_manage` can create/edit/patch/rewrite/delete a skill's on-disk
files, and any of those actions can be invoked autonomously by a
background self-improvement/review loop, not just by a foreground
user request. Today none of those writes leave a durable, revertible
record, and there's no limit on how often the same skill can be
autonomously re-patched. In practice a background review job that
keeps finding the "same" improvement opportunity can re-patch one
skill's content on every run, silently accruing a large number of
unaudited changes to a single skill in a short window with nothing to
show what changed or how to undo it.

## Fix

- Journal every successful mutating `skill_manage` action
  (`create`/`edit`/`patch`/`write_file`/`remove_file`/`delete`) to a
  per-profile JSONL file (`skills/.patch-journal.jsonl`), with enough
  content to revert it: `old_string`/`new_string` for a `patch`, the
  prior file content for a full `edit`/`write_file` rewrite. Each
  entry also records a timestamp and an `origin` (`"foreground"` vs.
  `"background_review"`, via `tools.skill_provenance.is_background_review`).
  The journal write is best-effort — file-lock protected
  (`fcntl.flock` where available) and wrapped so a journal failure
  (e.g. an unwritable directory) never blocks the underlying skill
  write itself. The journal file is also size-capped with a simple
  rotate-on-overflow.
- Rate-limit autonomous content writes: `_background_review_cooldown_guard`
  refuses a `background_review`-origin `edit`/`patch`/`write_file` on a
  skill that already received a `background_review` content write
  within `HERMES_BG_SKILL_WRITE_COOLDOWN_HOURS` (default 24h; `0`
  disables the cooldown). Foreground writes and `delete` are never
  rate-limited — only same-skill, same-origin, content-mutating writes
  from the background path count toward the window. The refusal
  message tells the caller to note the improvement in its review
  summary instead of retrying immediately.

## Tests

`tests/tools/test_skill_patch_journal.py` (new, 12 tests):

- `TestJournalWrites`: a `patch` journals old/new strings and
  `origin="foreground"`; an `edit` journals the prior file content; a
  failed patch (old_string not found) is not journaled; a journal
  write failure (unwritable parent path) never breaks the underlying
  skill write.
- `TestBackgroundCooldown`: a recent background-review write blocks a
  further background patch; an old (past-cooldown) write allows it;
  foreground-origin entries don't count toward the cooldown;
  entries for a *different* skill don't count; `delete` is never
  cooldown-limited; `HERMES_BG_SKILL_WRITE_COOLDOWN_HOURS=0` disables
  the guard entirely; and an end-to-end check that the full write-guard
  path blocks a background re-patch (and doesn't affect a foreground one).

Also ran the full existing `tests/tools/test_skill_manager_tool.py`
suite to check for regressions in `skill_manage` itself:
`pytest tests/tools/test_skill_patch_journal.py
tests/tools/test_skill_manager_tool.py -q` → **119 passed** (12 + 107).

Local dev install: `uv venv .venv --python 3.11 && uv pip install -e ".[dev]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
