### PR TITLE
fix(browser): discover fnm installs on Windows

### DIFF
--- a/tests/tools/test_browser_fnm_paths.py
+++ b/tests/tools/test_browser_fnm_paths.py
@@ -1,0 +1,145 @@
+"""Tests for fnm-managed Node discovery in browser_tool.py."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+import tools.browser_tool as _bt
+from tools.browser_tool import (
+    _discover_fnm_node_dirs,
+    _find_agent_browser,
+    _run_browser_command,
+    cleanup_all_browsers,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_browser_caches():
+    _discover_fnm_node_dirs.cache_clear()
+    _bt._cached_agent_browser = None
+    _bt._agent_browser_resolved = False
+    yield
+    _discover_fnm_node_dirs.cache_clear()
+    _bt._cached_agent_browser = None
+    _bt._agent_browser_resolved = False
+
+
+def _installation(root: Path, version: str) -> Path:
+    path = root / "node-versions" / version / "installation"
+    path.mkdir(parents=True)
+    return path
+
+
+def test_discovers_configured_fnm_versions_newest_first(tmp_path, monkeypatch):
+    fnm_root = tmp_path / "fnm"
+    node20 = _installation(fnm_root, "v20.19.0")
+    node24 = _installation(fnm_root, "v24.12.0")
+    monkeypatch.setenv("FNM_DIR", str(fnm_root))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    assert _discover_fnm_node_dirs() == (str(node24), str(node20))
+
+
+def test_discovers_windows_appdata_fnm_root(tmp_path, monkeypatch):
+    appdata = tmp_path / "Roaming"
+    installation = _installation(appdata / "fnm", "v24.12.0")
+    monkeypatch.delenv("FNM_DIR", raising=False)
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    assert _discover_fnm_node_dirs() == (str(installation),)
+
+
+def test_find_agent_browser_uses_windows_appdata_fnm_installation(tmp_path, monkeypatch):
+    appdata = tmp_path / "Roaming"
+    installation = _installation(appdata / "fnm", "v24.12.0")
+    expected = str(installation / "agent-browser.cmd")
+    monkeypatch.delenv("FNM_DIR", raising=False)
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    def fake_which(command, path=None):
+        if command == "agent-browser" and path and str(installation) in path:
+            return expected
+        return None
+
+    with patch("shutil.which", side_effect=fake_which), patch(
+        "tools.browser_tool.agent_browser_runnable", return_value=True
+    ):
+        assert _find_agent_browser() == expected
+
+
+def test_cleanup_all_browsers_refreshes_cached_fnm_dirs(tmp_path, monkeypatch):
+    fnm_root = tmp_path / "fnm"
+    monkeypatch.setenv("FNM_DIR", str(fnm_root))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    assert _discover_fnm_node_dirs() == ()
+    installation = _installation(fnm_root, "v24.12.0")
+    assert _discover_fnm_node_dirs() == ()
+
+    cleanup_all_browsers()
+
+    assert _discover_fnm_node_dirs() == (str(installation),)
+
+
+def test_run_browser_command_includes_fnm_installation_in_path(tmp_path):
+    installation = _installation(tmp_path / "fnm", "v24.12.0")
+    captured_env = {}
+    mock_proc = MagicMock(returncode=0)
+    mock_proc.wait.return_value = 0
+
+    def capture_popen(_cmd, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return mock_proc
+
+    fake_session = {
+        "session_name": "test-session",
+        "session_id": "test-id",
+        "cdp_url": None,
+    }
+    fake_json = json.dumps({"success": True})
+
+    with patch(
+        "tools.browser_tool._find_agent_browser",
+        return_value=str(installation / "agent-browser.cmd"),
+    ), patch("tools.browser_tool._chromium_installed", return_value=True), patch(
+        "tools.browser_tool._get_session_info", return_value=fake_session
+    ), patch(
+        "tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)
+    ), patch(
+        "tools.browser_tool._discover_fnm_node_dirs", return_value=[str(installation)]
+    ), patch(
+        "tools.browser_tool._discover_homebrew_node_dirs", return_value=[]
+    ), patch(
+        "subprocess.Popen", side_effect=capture_popen
+    ), patch(
+        "os.open", return_value=99
+    ), patch(
+        "os.close"
+    ), patch(
+        "tools.interrupt.is_interrupted", return_value=False
+    ), patch.dict(
+        os.environ,
+        {
+            "PATH": os.defpath,
+            "HOME": str(tmp_path),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+        },
+        clear=True,
+    ), patch(
+        "builtins.open", mock_open(read_data=fake_json)
+    ):
+        result = _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+    assert result["success"] is True
+    assert str(installation) in captured_env["PATH"].split(os.pathsep)
+
+
+def test_missing_or_unreadable_fnm_root_is_ignored(monkeypatch):
+    monkeypatch.setenv("FNM_DIR", os.path.join("missing", "fnm"))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    with patch("os.listdir", side_effect=OSError("permission denied")):
+        assert _discover_fnm_node_dirs() == ()

--- a/tests/tools/test_browser_fnm_paths.py
+++ b/tests/tools/test_browser_fnm_paths.py
@@ -1,0 +1,143 @@
+"""Tests for fnm-managed Node discovery in browser_tool.py."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+import tools.browser_tool as _bt
+from tools import browser_tool_install as bt_install
+from tools import browser_tool_lifecycle as bt_lifecycle
+from tools import browser_tool_session as bt_session
+from tools.browser_tool_install import _discover_fnm_node_dirs, _find_agent_browser
+
+
+@pytest.fixture(autouse=True)
+def _clear_browser_caches():
+    bt_install._discover_fnm_node_dirs.cache_clear()
+    _bt._cached_agent_browser = None
+    _bt._agent_browser_resolved = False
+    yield
+    bt_install._discover_fnm_node_dirs.cache_clear()
+    _bt._cached_agent_browser = None
+    _bt._agent_browser_resolved = False
+
+
+def _installation(root: Path, version: str) -> Path:
+    path = root / "node-versions" / version / "installation"
+    path.mkdir(parents=True)
+    return path
+
+
+def test_discovers_configured_fnm_versions_newest_first(tmp_path, monkeypatch):
+    fnm_root = tmp_path / "fnm"
+    node20 = _installation(fnm_root, "v20.19.0")
+    node24 = _installation(fnm_root, "v24.12.0")
+    monkeypatch.setenv("FNM_DIR", str(fnm_root))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    assert _discover_fnm_node_dirs() == (str(node24), str(node20))
+
+
+def test_discovers_windows_appdata_fnm_root(tmp_path, monkeypatch):
+    appdata = tmp_path / "Roaming"
+    installation = _installation(appdata / "fnm", "v24.12.0")
+    monkeypatch.delenv("FNM_DIR", raising=False)
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    assert _discover_fnm_node_dirs() == (str(installation),)
+
+
+def test_find_agent_browser_uses_windows_appdata_fnm_installation(tmp_path, monkeypatch):
+    appdata = tmp_path / "Roaming"
+    installation = _installation(appdata / "fnm", "v24.12.0")
+    expected = str(installation / "agent-browser.cmd")
+    monkeypatch.delenv("FNM_DIR", raising=False)
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    def fake_which(command, path=None):
+        if command == "agent-browser" and path and str(installation) in path:
+            return expected
+        return None
+
+    with patch("shutil.which", side_effect=fake_which), patch(
+        "tools.browser_tool_install.agent_browser_runnable", return_value=True
+    ):
+        assert _find_agent_browser() == expected
+
+
+def test_cleanup_all_browsers_refreshes_cached_fnm_dirs(tmp_path, monkeypatch):
+    fnm_root = tmp_path / "fnm"
+    monkeypatch.setenv("FNM_DIR", str(fnm_root))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    assert _discover_fnm_node_dirs() == ()
+    installation = _installation(fnm_root, "v24.12.0")
+    assert _discover_fnm_node_dirs() == ()
+
+    bt_lifecycle.cleanup_all_browsers()
+
+    assert _discover_fnm_node_dirs() == (str(installation),)
+
+
+def test_run_browser_command_includes_fnm_installation_in_path(tmp_path):
+    installation = _installation(tmp_path / "fnm", "v24.12.0")
+    captured_env = {}
+    mock_proc = MagicMock(returncode=0)
+    mock_proc.wait.return_value = 0
+
+    def capture_popen(_cmd, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return mock_proc
+
+    fake_session = {
+        "session_name": "test-session",
+        "session_id": "test-id",
+        "cdp_url": None,
+    }
+    fake_json = json.dumps({"success": True})
+
+    with patch(
+        "tools.browser_tool_install._find_agent_browser",
+        return_value=str(installation / "agent-browser.cmd"),
+    ), patch("tools.browser_tool_install._chromium_installed", return_value=True), patch(
+        "tools.browser_tool_session._get_session_info", return_value=fake_session
+    ), patch(
+        "tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)
+    ), patch(
+        "tools.browser_tool_install._discover_fnm_node_dirs", return_value=[str(installation)]
+    ), patch(
+        "tools.browser_tool_install._discover_homebrew_node_dirs", return_value=[]
+    ), patch(
+        "subprocess.Popen", side_effect=capture_popen
+    ), patch(
+        "os.open", return_value=99
+    ), patch(
+        "os.close"
+    ), patch(
+        "tools.interrupt.is_interrupted", return_value=False
+    ), patch.dict(
+        os.environ,
+        {
+            "PATH": os.defpath,
+            "HOME": str(tmp_path),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+        },
+        clear=True,
+    ), patch(
+        "builtins.open", mock_open(read_data=fake_json)
+    ):
+        result = bt_session._run_browser_command("test-task", "navigate", ["https://example.com"])
+
+    assert result["success"] is True
+    assert str(installation) in captured_env["PATH"].split(os.pathsep)
+
+
+def test_missing_or_unreadable_fnm_root_is_ignored(monkeypatch):
+    monkeypatch.setenv("FNM_DIR", os.path.join("missing", "fnm"))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    with patch("os.listdir", side_effect=OSError("permission denied")):
+        assert _discover_fnm_node_dirs() == ()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -191,13 +191,65 @@ def _discover_homebrew_node_dirs() -> tuple[str, ...]:
     return tuple(dirs)
 
 
+@functools.lru_cache(maxsize=1)
+def _discover_fnm_node_dirs() -> tuple[str, ...]:
+    """Find stable Node installation directories managed by fnm.
+
+    fnm exposes its selected Node version through a per-shell multishell PATH.
+    Desktop applications launched outside that shell do not inherit it, but the
+    global npm shims remain under ``node-versions/<version>/installation``.
+    """
+    roots: list[Path] = []
+    configured_root = os.environ.get("FNM_DIR", "").strip()
+    if configured_root:
+        roots.append(Path(configured_root).expanduser())
+
+    appdata = os.environ.get("APPDATA", "").strip()
+    if appdata:
+        roots.append(Path(appdata) / "fnm")
+
+    dirs: list[str] = []
+    seen_roots: set[str] = set()
+    for root in roots:
+        root_key = os.path.normcase(os.path.abspath(str(root)))
+        if root_key in seen_roots:
+            continue
+        seen_roots.add(root_key)
+
+        versions_root = root / "node-versions"
+        try:
+            entries = os.listdir(versions_root)
+        except OSError:
+            continue
+
+        # Prefer newer Node installations when more than one contains a global
+        # agent-browser shim. Validation still happens in _find_agent_browser().
+        def version_key(value: str) -> tuple[int, ...]:
+            return tuple(int(part) for part in re.findall(r"\d+", value))
+
+        entries.sort(key=version_key, reverse=True)
+        for entry in entries:
+            installation = versions_root / entry / "installation"
+            if installation.is_dir():
+                dirs.append(str(installation))
+
+    return tuple(dirs)
+
+
 def _browser_candidate_path_dirs() -> list[str]:
     """Return ordered browser CLI PATH candidates shared by discovery and execution."""
     hermes_home = get_hermes_home()
     hermes_node_bin = str(hermes_home / "node" / "bin")
     hermes_node_root = str(hermes_home / "node")
     hermes_nm_bin = str(hermes_home / "node_modules" / ".bin")
-    return [hermes_node_bin, hermes_node_root, hermes_nm_bin, *list(_discover_homebrew_node_dirs()), *_SANE_PATH_DIRS]
+    return [
+        hermes_node_bin,
+        hermes_node_root,
+        hermes_nm_bin,
+        *list(_discover_fnm_node_dirs()),
+        *list(_discover_homebrew_node_dirs()),
+        *_SANE_PATH_DIRS,
+    ]
 
 
 def _merge_browser_path(existing_path: str = "") -> str:
@@ -4384,6 +4436,7 @@ def cleanup_all_browsers() -> None:
     global _cached_browser_engine, _browser_engine_resolved
     _cached_agent_browser = None
     _agent_browser_resolved = False
+    _discover_fnm_node_dirs.cache_clear()
     _discover_homebrew_node_dirs.cache_clear()
     # Flip the resolved flag BEFORE nulling the cache so a concurrent
     # reader never sees ``resolved=True`` with ``cache=None`` (#14331).

--- a/tools/browser_tool_install.py
+++ b/tools/browser_tool_install.py
@@ -5,6 +5,7 @@ Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt
 import contextlib
 import functools
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -36,12 +37,43 @@ def _discover_homebrew_node_dirs() -> tuple[str, ...]:
     )
 
 
+@functools.lru_cache(maxsize=1)
+def _discover_fnm_node_dirs() -> tuple[str, ...]:
+    """Find stable Node installation directories managed by fnm."""
+    roots: list[Path] = []
+    configured_root = os.environ.get("FNM_DIR", "").strip()
+    if configured_root:
+        roots.append(Path(configured_root).expanduser())
+    appdata = os.environ.get("APPDATA", "").strip()
+    if appdata:
+        roots.append(Path(appdata) / "fnm")
+
+    dirs: list[str] = []
+    seen_roots: set[str] = set()
+    for root in roots:
+        root_key = os.path.normcase(os.path.abspath(str(root)))
+        if root_key in seen_roots:
+            continue
+        seen_roots.add(root_key)
+        versions_root = root / "node-versions"
+        try:
+            entries = os.listdir(versions_root)
+        except OSError:
+            continue
+        entries.sort(key=lambda value: tuple(int(part) for part in re.findall(r"\d+", value)), reverse=True)
+        for entry in entries:
+            installation = versions_root / entry / "installation"
+            if installation.is_dir():
+                dirs.append(str(installation))
+    return tuple(dirs)
+
+
 def _browser_candidate_path_dirs() -> list[str]:
     """Return ordered browser CLI PATH candidates shared by discovery and execution."""
     _bt = _origin()
     home = get_hermes_home()
     managed = (home / "node" / "bin", home / "node", home / "node_modules" / ".bin")
-    return [*map(str, managed), *_discover_homebrew_node_dirs(), *_bt._SANE_PATH_DIRS]
+    return [*map(str, managed), *_discover_fnm_node_dirs(), *_discover_homebrew_node_dirs(), *_bt._SANE_PATH_DIRS]
 
 
 def _merge_browser_path(existing_path: str = "") -> str:

--- a/tools/browser_tool_lifecycle.py
+++ b/tools/browser_tool_lifecycle.py
@@ -687,6 +687,7 @@ def cleanup_all_browsers() -> None:
     except Exception:
         pass
 
+    _install._discover_fnm_node_dirs.cache_clear()
     _install._discover_homebrew_node_dirs.cache_clear()
     # Each resolved flag flips BEFORE its cache is nulled so a concurrent reader never
     # sees ``resolved=True`` with ``cache=None``.


### PR DESCRIPTION
## Summary

- Discover stable Node installation directories managed by fnm through `FNM_DIR` and Windows `%APPDATA%\fnm`.
- Add those directories to the existing validated browser CLI resolution and subprocess PATH paths.
- Clear cached fnm discovery during `cleanup_all_browsers()` so installs and upgrades are visible after cleanup.
- Add regression coverage for version ordering, Windows AppData discovery, cleanup refresh, subprocess PATH propagation, production resolver integration, and unreadable roots.

Fixes #64538

## Test Plan

- [x] `python -m pytest tests/tools/test_browser_fnm_paths.py -q` — 6 passed
- [x] `python -m pytest tests/tools/test_browser_fnm_paths.py tests/tools/test_browser_chromium_check.py tests/tools/test_browser_chromium_autoinstall.py -q` — 23 passed
- [x] `uv.exe run --with ruff ruff check tools/browser_tool.py tests/tools/test_browser_fnm_paths.py` — passed
- [x] `python scripts/check-windows-footguns.py --diff upstream/main` — no Windows footguns found
- [x] `git diff --check upstream/main...HEAD` — passed
- [x] Windows 10 manual probe: `agent-browser doctor --offline --quick` reported 0 failures and `agent-browser open https://example.com` succeeded from the fnm-managed installation.

## Notes

- Existing inherited PATH and Hermes-managed Node candidates keep their current precedence.
- Every fnm candidate still passes through `agent_browser_runnable()` before it can be cached.
- `tests/tools/test_browser_homebrew_paths.py` has the same four Windows-only baseline failures on this branch and current `upstream/main` because the POSIX-focused tests clear Windows home variables; the remaining 18 tests pass.
