### PR TITLE
fix(macos): restart all launchd profile gateways after update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,9 +5,13 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import hashlib
 import json
 import logging
+import math
 import os
+import plistlib
+import re
 import shlex
 import shutil
 import signal
@@ -90,15 +94,71 @@ class ProfileGatewayProcess:
     pid: int
 
 
-def _get_service_pids() -> set:
-    """Return PIDs currently managed by systemd or launchd gateway services.
+@dataclass(frozen=True)
+class LaunchdGatewayJob:
+    """A running installed Hermes gateway and its owning bootstrap domain."""
+
+    domain: str
+    label: str
+    pid: int
+    hermes_home: Path
+
+
+@dataclass(frozen=True)
+class InstalledLaunchdGatewayPlistDiscovery:
+    """Validated installed plists plus whether every reserved label was valid."""
+
+    plists: tuple[tuple[str, Path, Path], ...]
+    complete: bool
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LaunchdGatewayDiscovery:
+    """Running launchd jobs plus whether every installed job was inspected."""
+
+    jobs: tuple[LaunchdGatewayJob, ...]
+    complete: bool
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ServicePidDiscovery:
+    """Service-owned PIDs and confidence that ownership discovery is complete."""
+
+    pids: frozenset[int]
+    complete: bool
+    errors: tuple[str, ...] = ()
+
+
+class IncompleteServiceDiscoveryError(RuntimeError):
+    """Raised when a destructive manual sweep cannot prove service ownership."""
+
+
+@dataclass
+class LaunchdGatewayRestartResult:
+    """State retained across the service restart and manual-process sweeps."""
+
+    restarted_labels: list[str]
+    service_pids: set[int]
+    deferred_current: list[LaunchdGatewayJob]
+    discovery_complete: bool = True
+    discovery_errors: tuple[str, ...] = ()
+
+
+def _get_service_pid_discovery(*, all_profiles: bool = False) -> ServicePidDiscovery:
+    """Return PIDs currently managed by gateway services.
 
     Used to avoid killing freshly-restarted service processes when sweeping
     for stale manual gateway processes after a service restart.  Relies on the
-    service manager having committed the new PID before the restart command
-    returns (true for both systemd and launchd in practice).
+    service manager having committed the new PID before this snapshot. Restart
+    helpers must establish that readiness before allowing a manual-process sweep.
+    ``all_profiles`` broadens launchd discovery only; existing systemd unit
+    discovery remains unchanged and includes every matching loaded unit.
     """
-    pids: set = set()
+    pids: set[int] = set()
+    complete = True
+    errors: list[str] = []
 
     # --- systemd (Linux): user and system scopes ---
     if supports_systemd_services():
@@ -139,35 +199,23 @@ def _get_service_pids() -> set:
 
     # --- launchd (macOS) ---
     if is_macos():
-        try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                # Try plist format first (macOS 26+): "PID" = <N>;
-                pid = _parse_launchd_pid_from_list_output(result.stdout)
-                if pid is not None and pid > 0:
-                    pids.add(pid)
-                else:
-                    # Fall back to legacy tab-separated format:
-                    # "PID\tStatus\tLabel"
-                    for line in result.stdout.strip().splitlines():
-                        parts = line.split()
-                        if len(parts) >= 3 and parts[2] == label:
-                            try:
-                                pid = int(parts[0])
-                                if pid > 0:
-                                    pids.add(pid)
-                            except ValueError:
-                                pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+        discovery = _discover_running_launchd_gateways(warn=False)
+        current_home = get_hermes_home().expanduser().resolve()
+        pids.update(
+            job.pid
+            for job in discovery.jobs
+            if all_profiles or job.hermes_home.expanduser().resolve() == current_home
+        )
+        complete = discovery.complete
+        errors.extend(discovery.errors)
 
-    return pids
+    return ServicePidDiscovery(frozenset(pids), complete, tuple(errors))
+
+
+def _get_service_pids(*, all_profiles: bool = False) -> set[int]:
+    """Return service-owned PIDs; launchd is profile-scoped unless requested."""
+
+    return set(_get_service_pid_discovery(all_profiles=all_profiles).pids)
 
 
 def _get_parent_pid(pid: int) -> int | None:
@@ -584,7 +632,10 @@ def _filter_venv_launcher_stubs(pids: list[int]) -> list[int]:
 
 
 def find_gateway_pids(
-    exclude_pids: set | None = None, all_profiles: bool = False
+    exclude_pids: set | None = None,
+    all_profiles: bool = False,
+    *,
+    exclude_service_pids: bool = False,
 ) -> list:
     """Find PIDs of running gateway processes.
 
@@ -596,6 +647,12 @@ def find_gateway_pids(
             needs this because a code update affects every profile.
             When ``False`` (default), only PIDs belonging to the current
             Hermes profile are returned.
+        exclude_service_pids: Explicitly return only manually managed gateways.
+            Service ownership is checked both before and after the process-table
+            scan. Incomplete launchd discovery raises
+            :class:`IncompleteServiceDiscoveryError` so destructive callers fail
+            closed. ``exclude_pids`` itself retains its historical exact-PID
+            meaning.
     """
     _exclude = set(exclude_pids or set())
     pids: list[int] = []
@@ -606,18 +663,41 @@ def find_gateway_pids(
             _append_unique_pid(pids, get_running_pid(), _exclude)
         except Exception:
             pass
-    for pid in _get_service_pids():
-        _append_unique_pid(pids, pid, _exclude)
+    if exclude_service_pids:
+        ownership_before = _get_service_pid_discovery(all_profiles=all_profiles)
+        if not ownership_before.complete:
+            detail = "; ".join(ownership_before.errors) or "unknown launchd discovery failure"
+            raise IncompleteServiceDiscoveryError(detail)
+        service_pids = set(ownership_before.pids)
+        scan_exclude = _exclude | service_pids
+    else:
+        if all_profiles:
+            service_pids = _get_service_pids(all_profiles=True)
+        else:
+            service_pids = _get_service_pids()
+        scan_exclude = _exclude
+        for pid in service_pids:
+            _append_unique_pid(pids, pid, _exclude)
     try:
         include_restart_managers = not supports_systemd_services()
     except Exception:
         include_restart_managers = False
     for pid in _scan_gateway_pids(
-        _exclude,
+        scan_exclude,
         all_profiles=all_profiles,
         include_restart_managers=include_restart_managers,
     ):
         _append_unique_pid(pids, pid, _exclude)
+    if exclude_service_pids:
+        # launchd registers ownership before the replacement process becomes
+        # visible. A second authoritative snapshot therefore closes the
+        # replacement-generation race between the first snapshot and the scan.
+        ownership_after = _get_service_pid_discovery(all_profiles=all_profiles)
+        if not ownership_after.complete:
+            detail = "; ".join(ownership_after.errors) or "unknown launchd discovery failure"
+            raise IncompleteServiceDiscoveryError(detail)
+        owned = service_pids | set(ownership_after.pids)
+        pids = [pid for pid in pids if pid not in owned]
     return pids
 
 
@@ -3514,6 +3594,452 @@ def get_launchd_label() -> str:
     """Return the launchd service label, scoped per profile."""
     suffix = _profile_suffix()
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
+
+
+def _is_launchd_gateway_label(label: str) -> bool:
+    """Return whether *label* is a Hermes gateway label we generate."""
+    prefix = "ai.hermes.gateway-"
+    if label == "ai.hermes.gateway":
+        return True
+    if not label.startswith(prefix):
+        return False
+    suffix = label[len(prefix) :]
+    allowed = "abcdefghijklmnopqrstuvwxyz0123456789_-"
+    return (
+        1 <= len(suffix) <= 64
+        and suffix[0] not in "_-"
+        and all(char in allowed for char in suffix)
+    )
+
+
+def _installed_launchd_gateway_plists() -> InstalledLaunchdGatewayPlistDiscovery:
+    """Validate Hermes-label gateway plists from the account home.
+
+    The filename, Label, and command must have the shape generated by
+    :func:`generate_launchd_plist`. Named/custom labels also require a matching
+    HERMES_HOME. Historical default-label plists predate HERMES_HOME and
+    unambiguously map to the real account's ``~/.hermes``. Invalid unrelated
+    filenames are ignored. A reserved Hermes-label filename that cannot be
+    validated makes discovery incomplete and is never queried or restarted.
+    """
+    launch_agents = _launchd_user_home() / "Library" / "LaunchAgents"
+    try:
+        candidates = sorted(launch_agents.glob("ai.hermes.gateway*.plist"))
+    except OSError as exc:
+        detail = f"{launch_agents}: could not enumerate launchd gateway plists: {exc}"
+        return InstalledLaunchdGatewayPlistDiscovery((), False, (detail,))
+
+    installed: list[tuple[str, Path, Path]] = []
+    errors: list[str] = []
+    for path in candidates:
+        label = path.name.removesuffix(".plist")
+        if not _is_launchd_gateway_label(label):
+            continue
+        try:
+            with path.open("rb") as handle:
+                data = plistlib.load(handle)
+        except (OSError, plistlib.InvalidFileException, ValueError, TypeError) as exc:
+            errors.append(f"{path}: could not read a valid plist: {exc}")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path}: plist root is not a dictionary")
+            continue
+        if data.get("Label") != label:
+            errors.append(f"{path}: Label does not match reserved filename {label!r}")
+            continue
+        environment = data.get("EnvironmentVariables")
+        hermes_home = environment.get("HERMES_HOME") if isinstance(environment, dict) else None
+        if not isinstance(hermes_home, str) or not hermes_home.strip():
+            if label != "ai.hermes.gateway":
+                errors.append(f"{path}: named/custom gateway is missing HERMES_HOME")
+                continue
+            hermes_home = str(_launchd_user_home() / ".hermes")
+        args = data.get("ProgramArguments")
+        if not (
+            isinstance(args, list)
+            and all(isinstance(arg, str) for arg in args)
+            and len(args) >= 5
+            and args[1:3] == ["-m", "hermes_cli.main"]
+        ):
+            errors.append(f"{path}: invalid Hermes gateway ProgramArguments")
+            continue
+        if args[-3:] == ["gateway", "run", "--replace"]:
+            command_profile_args = args[3:-3]
+        elif args[-2:] == ["gateway", "run"]:
+            command_profile_args = args[3:-2]
+        else:
+            errors.append(f"{path}: invalid Hermes gateway command suffix")
+            continue
+        resolved_home = Path(hermes_home).expanduser().resolve()
+        default_home = (_launchd_user_home() / ".hermes").resolve()
+        expected_label = "ai.hermes.gateway"
+        expected_profile_args: list[str] = []
+        if resolved_home != default_home:
+            try:
+                relative = resolved_home.relative_to((default_home / "profiles").resolve())
+                parts = relative.parts
+            except ValueError:
+                parts = ()
+            if (
+                len(parts) == 1
+                and _is_launchd_gateway_label(f"ai.hermes.gateway-{parts[0]}")
+            ):
+                expected_label = f"ai.hermes.gateway-{parts[0]}"
+                expected_profile_args = ["--profile", parts[0]]
+            else:
+                custom_suffix = hashlib.sha256(str(resolved_home).encode()).hexdigest()[:8]
+                expected_label = f"ai.hermes.gateway-{custom_suffix}"
+        if label != expected_label or command_profile_args != expected_profile_args:
+            errors.append(
+                f"{path}: HERMES_HOME/command does not match reserved label"
+            )
+            continue
+        installed.append((label, path, Path(hermes_home).expanduser()))
+    return InstalledLaunchdGatewayPlistDiscovery(
+        tuple(installed), not errors, tuple(errors)
+    )
+
+
+def _parse_launchd_print_pid(output: str) -> int | None:
+    """Safely parse the top-level positive ``pid`` field from launchctl print."""
+    for line in output.splitlines():
+        stripped = line.strip()
+        parts = stripped.split("=", 1)
+        if len(parts) != 2 or parts[0].strip().strip('"').lower() != "pid":
+            continue
+        raw_pid = parts[1].strip().rstrip(";").strip()
+        if not raw_pid.isascii() or not raw_pid.isdecimal():
+            return None
+        pid = int(raw_pid)
+        return pid if pid > 0 else None
+    return None
+
+
+def _launchd_print_state(output: str) -> tuple[str, int | None]:
+    """Classify launchctl output as running, expected stopped, or invalid."""
+    saw_pid = False
+    for line in output.splitlines():
+        parts = line.strip().split("=", 1)
+        if len(parts) == 2 and parts[0].strip().strip('"').lower() == "pid":
+            saw_pid = True
+            break
+    pid = _parse_launchd_print_pid(output)
+    if pid is not None:
+        return "running", pid
+    lowered = output.lower()
+    if any(
+        marker in lowered
+        for marker in ("state = not running", "state = stopped", "state = exited")
+    ):
+        return "stopped", None
+    if saw_pid:
+        return "invalid", None
+    return "invalid", None
+
+
+def _parse_launchd_domain_gateway_labels(output: str) -> tuple[set[str], bool]:
+    """Return reserved labels from a launchd domain's top-level service table.
+
+    Domain output contains labels in several nested sections. Only direct
+    entries in ``services = { ... }`` establish that a job is loaded. Refuse
+    structurally unexpected output rather than accidentally treating a nested
+    mention (or a truncated inventory) as a complete empty service table.
+    """
+    service_start = re.compile(r"^\s*services\s*=\s*\{\s*$")
+    table_entry = re.compile(
+        r"^\s*[0-9]+\s+(?:-?[0-9]+|-|\((?:pe|jt)\))\s+"
+        r"(?P<label>[^\s{}]+)\s*$"
+    )
+    dictionary_entry = re.compile(
+        r'^\s*(?:"(?P<quoted>[^"\r\n]+)"|(?P<bare>[^\s"{}]+))\s*=>\s*\{\s*$'
+    )
+    block_end = re.compile(r"^\s*}\s*$")
+    lines = output.splitlines()
+    start_index = None
+    domain_depth = 0
+    for index, line in enumerate(lines):
+        if service_start.fullmatch(line) and domain_depth == 1:
+            start_index = index
+            break
+        domain_depth += line.count("{") - line.count("}")
+        if domain_depth < 0:
+            return set(), False
+    if start_index is None:
+        return set(), False
+
+    labels: set[str] = set()
+    entry_format: str | None = None
+    depth = 1
+    for line in lines[start_index + 1 :]:
+        if depth == 1:
+            if block_end.fullmatch(line):
+                return labels, True
+            if not line.strip():
+                continue
+
+            table_match = table_entry.fullmatch(line)
+            dictionary_match = dictionary_entry.fullmatch(line)
+            if table_match:
+                if entry_format == "dictionary":
+                    return set(), False
+                entry_format = "table"
+                label = table_match.group("label")
+                if _is_launchd_gateway_label(label):
+                    labels.add(label)
+                continue
+            if dictionary_match:
+                if entry_format == "table":
+                    return set(), False
+                entry_format = "dictionary"
+                label = dictionary_match.group("quoted") or dictionary_match.group("bare")
+                if _is_launchd_gateway_label(label):
+                    labels.add(label)
+            else:
+                # An unknown direct entry means ownership cannot be safely
+                # ruled in or out. Dictionary values are ignored below only
+                # after an unambiguous ``label => {`` entry begins.
+                return set(), False
+
+        depth += line.count("{") - line.count("}")
+        if depth < 0:
+            return set(), False
+    return set(), False
+
+
+def _discover_running_launchd_gateways(*, warn: bool = True) -> LaunchdGatewayDiscovery:
+    """Discover jobs and report whether every launchd ownership probe was reliable."""
+    installed = _installed_launchd_gateway_plists()
+    uid = os.getuid()  # windows-footgun: ok — POSIX launchd (macOS) helper, called only from macOS paths
+    domains = (f"gui/{uid}", f"user/{uid}")
+    jobs: list[LaunchdGatewayJob] = []
+    errors: list[str] = list(installed.errors)
+
+    # A launchd job remains registered after its source plist is deleted.
+    # Inventory both possible bootstrap domains before probing any installed
+    # label so a detached loaded job cannot be mistaken for a manual process.
+    loaded_by_domain: dict[str, set[str]] = {}
+    for domain in domains:
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", domain],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            errors.append(f"{domain}: could not inventory launchd services: {exc}")
+            continue
+        if result.returncode != 0:
+            reason = (result.stderr or "").strip() or f"launchctl exited {result.returncode}"
+            errors.append(f"{domain}: could not inventory launchd services: {reason}")
+            continue
+        labels, parsed = _parse_launchd_domain_gateway_labels(result.stdout or "")
+        if not parsed:
+            errors.append(f"{domain}: launchctl returned an unparseable service inventory")
+            continue
+        loaded_by_domain[domain] = labels
+
+    installed_labels = {label for label, _path, _home in installed.plists}
+    detached_labels = {
+        label
+        for labels in loaded_by_domain.values()
+        for label in labels
+        if label not in installed_labels
+    }
+    for label in sorted(detached_labels):
+        owners = ", ".join(
+            domain for domain, labels in loaded_by_domain.items() if label in labels
+        )
+        errors.append(
+            f"{owners}/{label}: loaded reserved gateway label has no valid installed plist"
+        )
+
+    if errors:
+        if warn:
+            for detail in errors:
+                print(f"  ⚠ Could not inspect launchd gateway ownership: {detail}")
+        # Do not query or act on any individual label when domain-wide
+        # ownership cannot be proven complete.
+        return LaunchdGatewayDiscovery((), False, tuple(errors))
+
+    for label, _plist_path, hermes_home in installed.plists:
+        for domain in domains:
+            target = f"{domain}/{label}"
+            try:
+                result = subprocess.run(
+                    ["launchctl", "print", target],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                detail = f"{target}: {exc}"
+                errors.append(detail)
+                if warn:
+                    print(f"  ⚠ Could not inspect launchd gateway {detail}")
+                continue
+            if result.returncode != 0:
+                if result.returncode in {3, 113}:
+                    # Expected: this installed job is absent from this domain.
+                    continue
+                reason = (result.stderr or "").strip() or f"launchctl exited {result.returncode}"
+                detail = f"{target}: {reason}"
+                errors.append(detail)
+                if warn:
+                    print(f"  ⚠ Could not inspect launchd gateway {detail}")
+                continue
+            state, pid = _launchd_print_state(result.stdout or "")
+            if state == "running" and pid is not None:
+                jobs.append(LaunchdGatewayJob(domain, label, pid, hermes_home))
+            elif state == "invalid":
+                detail = f"{target}: launchctl returned unparseable PID/state output"
+                errors.append(detail)
+                if warn:
+                    print(f"  ⚠ Could not inspect launchd gateway {detail}")
+            # A recognized stopped state is complete discovery and intentionally
+            # contributes no ownership PID.
+    return LaunchdGatewayDiscovery(tuple(jobs), not errors, tuple(errors))
+
+
+def _wait_for_launchd_gateway_relaunch(
+    domain: str, label: str, previous_pid: int, timeout: float = 10.0
+) -> int | None:
+    """Wait until launchd reports a replacement PID for a named gateway job."""
+    deadline = time.monotonic() + max(timeout, 0.0)
+    while True:
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", f"{domain}/{label}"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if result.returncode == 0:
+                pid = _parse_launchd_print_pid(result.stdout or "")
+                if pid is not None and pid != previous_pid:
+                    return pid
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(0.2)
+
+
+def _launchd_gateway_drain_budget(job: LaunchdGatewayJob, fallback: float) -> float:
+    """Read one gateway's non-secret config without changing global profile state.
+
+    HERMES_HOME comes from the already-validated installed plist. Only
+    ``config.yaml`` is read; sibling ``.env`` files and credentials are never
+    opened. Failure is conservative: retain the caller's existing finite budget.
+    """
+    safe_fallback = fallback
+    if not math.isfinite(safe_fallback) or safe_fallback <= 0:
+        safe_fallback = max(float(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT), 30.0) + 15.0
+    try:
+        from hermes_cli.config import fast_safe_load
+
+        with (job.hermes_home / "config.yaml").open(encoding="utf-8") as handle:
+            config = fast_safe_load(handle) or {}
+        agent = config.get("agent") if isinstance(config, dict) else None
+        configured = agent.get("restart_drain_timeout") if isinstance(agent, dict) else None
+        if configured is None:
+            return safe_fallback
+        # Match update's existing safety margin. This avoids undercutting a
+        # sibling profile's drain and prematurely escalating to kickstart -k.
+        parsed = parse_restart_drain_timeout(configured)
+        if not math.isfinite(parsed):
+            return safe_fallback
+        return max(parsed, 30.0) + 15.0
+    except Exception:
+        # Config parsing is deliberately best-effort. Never shorten the known
+        # caller budget because one sibling config is missing or malformed.
+        return safe_fallback
+
+
+def restart_running_launchd_gateways(
+    drain_timeout: float,
+) -> LaunchdGatewayRestartResult:
+    """Best-effort restart of every running launchd-managed Hermes gateway.
+
+    Installed plists are probed in both bootstrap domains. The gateway containing
+    this updater is retained but not signalled here: the caller must complete its
+    manual-process sweep before calling
+    :func:`restart_deferred_current_launchd_gateways`.
+    """
+    discovery = _discover_running_launchd_gateways()
+    result = LaunchdGatewayRestartResult(
+        [],
+        {job.pid for job in discovery.jobs},
+        [],
+        discovery.complete,
+        discovery.errors,
+    )
+    for job in discovery.jobs:
+        if _is_pid_ancestor_of_current_process(job.pid):
+            result.deferred_current.append(job)
+            continue
+
+        budget = _launchd_gateway_drain_budget(job, drain_timeout)
+        try:
+            print(
+                f"  → {job.label}: draining gateway PID {job.pid} "
+                f"(up to {int(budget)}s)..."
+            )
+            if _graceful_restart_via_sigusr1(job.pid, drain_timeout=budget):
+                replacement = _wait_for_launchd_gateway_relaunch(
+                    job.domain, job.label, job.pid
+                )
+                if replacement is not None:
+                    result.service_pids.add(replacement)
+                    result.restarted_labels.append(job.label)
+                    continue
+                print(
+                    f"  ⚠ {job.label}: launchd did not report a replacement for "
+                    f"PID {job.pid} within 10s; using kickstart fallback"
+                )
+
+            subprocess.run(
+                ["launchctl", "kickstart", "-k", f"{job.domain}/{job.label}"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=90,
+            )
+            replacement = _wait_for_launchd_gateway_relaunch(
+                job.domain, job.label, job.pid
+            )
+            if replacement is None:
+                print(
+                    f"  ⚠ Failed to restart {job.label}: launchd kickstart succeeded "
+                    "but no replacement PID appeared"
+                )
+                continue
+            result.service_pids.add(replacement)
+            result.restarted_labels.append(job.label)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            detail = (getattr(exc, "stderr", "") or "").strip() or str(exc)
+            print(f"  ⚠ Failed to restart {job.label}: {detail}")
+    return result
+
+
+def restart_deferred_current_launchd_gateways(
+    result: LaunchdGatewayRestartResult,
+) -> list[str]:
+    """Request invoking-gateway restarts after all manual sweeps have finished."""
+    restarted = []
+    for job in result.deferred_current:
+        if _request_gateway_self_restart(job.pid):
+            restarted.append(job.label)
+        else:
+            # A direct kickstart would kill the updater before it can finish and
+            # can strand later jobs. Preserve the running service and make the
+            # required manual action explicit instead of introducing that race.
+            print(
+                f"  ⚠ Failed to request deferred restart for {job.label}; "
+                "restart it manually after this update"
+            )
+    return restarted
 
 
 # Cached launchd domain result — probing is cheap but should only run once per

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -272,6 +272,7 @@ if _try_termux_ultrafast_version():
 import argparse
 import hashlib
 import json
+import math
 import shlex
 import shutil
 import stat
@@ -10462,6 +10463,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
+        launchd_restart_result = None
+        restarted_services = []
         try:
             from hermes_cli.gateway import (
                 is_macos,
@@ -10473,6 +10476,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _get_service_pids,
                 _graceful_restart_via_sigusr1,
                 _wait_for_gateway_exit,
+                IncompleteServiceDiscoveryError,
             )
             import signal as _signal
 
@@ -10644,13 +10648,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 )
             except (TypeError, ValueError):
                 _drain_budget = float(_DEFAULT_DRAIN)
+            if not math.isfinite(_drain_budget):
+                _drain_budget = float(_DEFAULT_DRAIN)
+            if not math.isfinite(_drain_budget):
+                _drain_budget = 60.0
             # Add a 15s margin so the drain loop + final exit finish before
             # we escalate to ``systemctl restart`` / SIGTERM.
             _drain_budget = max(_drain_budget, 30.0) + 15.0
 
-            restarted_services = []
             killed_pids = set()
             relaunched_profiles = []
+            manual_sweeps_safe = True
 
             # --- Systemd services (Linux) ---
             # Discover all hermes-gateway* units (default + profiles)
@@ -10944,38 +10952,50 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # --- Launchd services (macOS) ---
             if is_macos():
                 try:
-                    from hermes_cli.gateway import (
-                        launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
-                    )
+                    from hermes_cli.gateway import restart_running_launchd_gateways
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
+                    launchd_restart_result = restart_running_launchd_gateways(
+                        _drain_budget
+                    )
+                    restarted_services.extend(
+                        launchd_restart_result.restarted_labels
+                    )
+                    if not launchd_restart_result.discovery_complete:
+                        manual_sweeps_safe = False
+                        detail = "; ".join(launchd_restart_result.discovery_errors)
+                        suffix = f": {detail}" if detail else ""
+                        print(
+                            "  ⚠ Skipping manual gateway sweeps because launchd "
+                            f"ownership discovery was incomplete{suffix}."
                         )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
-                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
-                    pass
+                        print("    No possibly launchd-supervised process will be signalled.")
+                except ImportError as exc:
+                    print(f"  ⚠ Could not load macOS gateway restart support: {exc}")
 
             # --- Manual (non-service) gateways ---
             # Kill any remaining gateway processes not managed by a service.
             # Exclude PIDs that belong to just-restarted services so we don't
             # immediately kill the process that systemd/launchd just spawned.
-            service_pids = _get_service_pids()
-            manual_pids = find_gateway_pids(
-                exclude_pids=service_pids, all_profiles=True
-            )
+            service_pids = _get_service_pids(all_profiles=True)
+            if launchd_restart_result is not None:
+                # Retain both old/current and verified replacement ownership
+                # across the next discovery inside find_gateway_pids().
+                service_pids.update(launchd_restart_result.service_pids)
+            manual_pids = []
+            if manual_sweeps_safe:
+                try:
+                    manual_pids = find_gateway_pids(
+                        exclude_pids=service_pids,
+                        all_profiles=True,
+                        exclude_service_pids=True,
+                    )
+                except IncompleteServiceDiscoveryError as discovery_exc:
+                    manual_sweeps_safe = False
+                    print(
+                        "  ⚠ Skipping manual gateway sweeps because service ownership "
+                        f"discovery was incomplete: {discovery_exc}"
+                    )
+                    print("    No possibly supervised process will be signalled.")
             profile_processes = {
                 proc.pid: proc
                 for proc in find_profile_gateway_processes(exclude_pids=service_pids)
@@ -11063,11 +11083,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # any remaining pre-update PIDs so the watcher / service
             # manager can relaunch with fresh code.
             try:
+                if not manual_sweeps_safe:
+                    raise IncompleteServiceDiscoveryError(
+                        "initial ownership discovery was incomplete"
+                    )
                 _time.sleep(3.0)
-                _service_pids_after = _get_service_pids()
+                _service_pids_after = _get_service_pids(all_profiles=True)
+                if launchd_restart_result is not None:
+                    _service_pids_after.update(launchd_restart_result.service_pids)
                 _surviving = find_gateway_pids(
                     exclude_pids=_service_pids_after,
                     all_profiles=True,
+                    exclude_service_pids=True,
                 )
                 # Scope to PIDs we already tried to kill during this
                 # update (killed_pids).  Anything new is a gateway that
@@ -11097,6 +11124,24 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         except Exception as e:
             logger.debug("Gateway restart during update failed: %s", e)
+        finally:
+            # The invoking launchd gateway must be the final restart action, even
+            # when discovery, watcher launch, or either manual sweep raises.
+            if launchd_restart_result is not None:
+                try:
+                    from hermes_cli.gateway import (
+                        restart_deferred_current_launchd_gateways,
+                    )
+
+                    deferred_restarted = restart_deferred_current_launchd_gateways(
+                        launchd_restart_result
+                    )
+                    restarted_services.extend(deferred_restarted)
+                    for svc in deferred_restarted:
+                        print(f"  ✓ Restart requested for {svc}")
+                except Exception as exc:
+                    logger.debug("Deferred launchd gateway restart failed: %s", exc)
+                    print(f"  ⚠ Could not request deferred gateway restart: {exc}")
 
         _resume_windows_gateways_after_update(_windows_gateway_resume)
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,13 +1,1060 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
 import hashlib
+import plistlib
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from hermes_cli.main import cmd_update, PROJECT_ROOT
+
+
+def _launchd_domain_inventory(*labels: str) -> str:
+    services = [
+        f"\t\t   {1000 + index}      - \t{label}"
+        for index, label in enumerate(labels)
+    ]
+    return "\n".join(
+        [
+            "gui/501 = {",
+            "\tservices = {",
+            *services,
+            "\t}",
+            "}",
+        ]
+    )
+
+
+REAL_LAUNCHD_DOMAIN_INVENTORY = """gui/501 = {
+\tservices = {
+\t\t   45254    -15 \tai.hermes.gateway
+\t\t       0      - \tai.hermes.gateway-stopped
+\t\t   21130   (pe) \tcom.apple.syncdefaultsd
+\t\t       0   (jt) \tcom.apple.knowledgeconstructiond
+\t\t    5392      0 \tai.hermes.gateway-coder
+\t\t     402      1 \tcom.apple.trustd.agent
+\t\t       0      - \tcom.example.ai.hermes.gateway-nested
+\t\t       0      - \t/tmp/ai.hermes.gateway-path
+\t}
+\tservice count = 8
+\tnested metadata = {
+\t\tpath = /tmp/ai.hermes.gateway-path
+\t\tlabel = ai.hermes.gateway-nested
+\t}
+}
+"""
+
+
+class TestMacOSMultiProfileGatewayRestart:
+    """Successful shared-source updates restart every running launchd gateway."""
+
+    def test_parses_real_launchd_services_table_rows_only(self):
+        from hermes_cli import gateway as gateway_cli
+
+        labels, parsed = gateway_cli._parse_launchd_domain_gateway_labels(
+            REAL_LAUNCHD_DOMAIN_INVENTORY
+        )
+
+        assert parsed is True
+        assert labels == {
+            "ai.hermes.gateway",
+            "ai.hermes.gateway-stopped",
+            "ai.hermes.gateway-coder",
+        }
+
+    def test_parses_unambiguous_dictionary_services_fixture(self):
+        from hermes_cli import gateway as gateway_cli
+
+        output = """gui/501 = {
+\tservices = {
+\t\t\"ai.hermes.gateway-coder\" => {
+\t\t\tpath = /tmp/ai.hermes.gateway-path
+\t\t\tnested label = ai.hermes.gateway-nested
+\t\t}
+\t\tcom.apple.unrelated => {
+\t\t\tlabel = ai.hermes.gateway-not-an-entry
+\t\t}
+\t}
+}
+"""
+
+        labels, parsed = gateway_cli._parse_launchd_domain_gateway_labels(output)
+
+        assert parsed is True
+        assert labels == {"ai.hermes.gateway-coder"}
+
+    def test_ignores_nested_services_blocks(self):
+        from hermes_cli import gateway as gateway_cli
+
+        output = """gui/501 = {
+\tmetadata = {
+\t\tservices = {
+\t\t\t 45254 -15 ai.hermes.gateway-nested
+\t\t}
+\t}
+\tservices = {
+\t\t 402 - com.apple.trustd.agent
+\t}
+}
+"""
+
+        labels, parsed = gateway_cli._parse_launchd_domain_gateway_labels(output)
+
+        assert parsed is True
+        assert labels == set()
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            "gui/501 = {\n}\n",
+            "gui/501 = {\n\tservices = {\n\t\t 45254 -15 ai.hermes.gateway\n",
+            "gui/501 = {\n\tservices = {\n\t\t 45254 running ai.hermes.gateway\n\t}\n}\n",
+            (
+                "gui/501 = {\n\tservices = {\n"
+                "\t\t 45254 -15 ai.hermes.gateway\n"
+                "\t\tcom.apple.mixed => {\n\t\t}\n\t}\n}\n"
+            ),
+            "gui/501 = {\n\tservices = {\n\t\t 45254 -15 ai.hermes.gateway\n\t};\n}\n",
+        ],
+    )
+    def test_rejects_malformed_or_truncated_service_inventories(self, output):
+        from hermes_cli import gateway as gateway_cli
+
+        labels, parsed = gateway_cli._parse_launchd_domain_gateway_labels(output)
+
+        assert parsed is False
+        assert labels == set()
+
+    @staticmethod
+    def _write_plist(
+        launch_agents: Path,
+        label: str,
+        hermes_home: Path,
+        *,
+        command: list[str] | None = None,
+        include_hermes_home: bool = True,
+    ) -> Path:
+        launch_agents.mkdir(parents=True, exist_ok=True)
+        path = launch_agents / f"{label}.plist"
+        payload = {
+            "Label": label,
+            "ProgramArguments": command
+            or [
+                "/usr/bin/python3",
+                "-m",
+                "hermes_cli.main",
+                "gateway",
+                "run",
+                "--replace",
+            ],
+        }
+        if include_hermes_home:
+            payload["EnvironmentVariables"] = {"HERMES_HOME": str(hermes_home)}
+        with path.open("wb") as handle:
+            plistlib.dump(payload, handle)
+        return path
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_defers_invoking_gateway_until_after_manual_sweeps(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import gateway as gateway_cli
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="1")
+        events = []
+        current = gateway_cli.LaunchdGatewayJob(
+            "gui/501", "ai.hermes.gateway-coder", 303, Path("/profiles/coder")
+        )
+        restart_result = gateway_cli.LaunchdGatewayRestartResult(
+            ["ai.hermes.gateway"], {101, 111, 303}, [current]
+        )
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "restart_running_launchd_gateways",
+            lambda timeout: events.append(("services", timeout)) or restart_result,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "restart_deferred_current_launchd_gateways",
+            lambda result: events.append(("deferred", result))
+            or ["ai.hermes.gateway-coder"],
+        )
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda **_kwargs: {111})
+        monkeypatch.setattr(
+            gateway_cli,
+            "find_gateway_pids",
+            lambda **kwargs: events.append(("manual-sweep", kwargs["exclude_pids"])) or [],
+        )
+        monkeypatch.setattr(
+            gateway_cli, "find_profile_gateway_processes", lambda **kwargs: []
+        )
+        monkeypatch.setattr(hm._time, "sleep", lambda _seconds: None)
+
+        cmd_update(mock_args)
+
+        assert events[0][0] == "services"
+        assert events[0][1] >= 45.0
+        assert [event[0] for event in events].count("manual-sweep") == 2
+        assert events[-1] == ("deferred", restart_result)
+        for event in events:
+            if event[0] == "manual-sweep":
+                assert event[1] >= {101, 111, 303}
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_incomplete_launchd_discovery_skips_both_manual_sweeps(
+        self, mock_run, _mock_which, mock_args, monkeypatch, capsys
+    ):
+        from hermes_cli import gateway as gateway_cli
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="1")
+        result = gateway_cli.LaunchdGatewayRestartResult(
+            [], set(), [], False, ("gui/501/ai.hermes.gateway: timed out",)
+        )
+        signals = []
+        watchers = []
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli, "restart_running_launchd_gateways", lambda _timeout: result
+        )
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda **_kwargs: set())
+        monkeypatch.setattr(
+            gateway_cli,
+            "find_gateway_pids",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("manual sweep must not run")
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "find_profile_gateway_processes", lambda **_kwargs: []
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "launch_detached_profile_gateway_restart",
+            lambda *args: watchers.append(args) or True,
+        )
+        monkeypatch.setattr(gateway_cli.os, "kill", lambda *args: signals.append(args))
+        monkeypatch.setattr(hm._time, "sleep", lambda _seconds: None)
+
+        cmd_update(mock_args)
+
+        assert signals == []
+        assert watchers == []
+        assert "Skipping manual gateway sweeps" in capsys.readouterr().out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_deferred_finalizer_runs_after_manual_discovery_exception(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="1")
+        current = gateway_cli.LaunchdGatewayJob(
+            "gui/501", "ai.hermes.gateway", 303, Path("/.hermes")
+        )
+        result = gateway_cli.LaunchdGatewayRestartResult([], {303}, [current])
+        finalized = []
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli, "restart_running_launchd_gateways", lambda _timeout: result
+        )
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda **_kwargs: {303})
+        monkeypatch.setattr(
+            gateway_cli,
+            "find_gateway_pids",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("injected sweep failure")),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "restart_deferred_current_launchd_gateways",
+            lambda value: finalized.append(value) or ["ai.hermes.gateway"],
+        )
+
+        cmd_update(mock_args)
+
+        assert finalized == [result]
+
+    def test_discovers_gui_and_user_jobs_from_installed_plists_only(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        self._write_plist(launch_agents, "ai.hermes.gateway", tmp_path / ".hermes")
+        self._write_plist(
+            launch_agents,
+            "ai.hermes.gateway-coder",
+            tmp_path / ".hermes/profiles/coder",
+            command=[
+                "/usr/bin/python3",
+                "-m",
+                "hermes_cli.main",
+                "--profile",
+                "coder",
+                "gateway",
+                "run",
+            ],
+        )
+        custom_home = tmp_path / "custom-hermes-home"
+        custom_suffix = hashlib.sha256(str(custom_home.resolve()).encode()).hexdigest()[:8]
+        custom_label = f"ai.hermes.gateway-{custom_suffix}"
+        self._write_plist(
+            launch_agents,
+            custom_label,
+            custom_home,
+            command=[
+                "/usr/bin/python3",
+                "-m",
+                "hermes_cli.main",
+                "gateway",
+                "run",
+            ],
+        )
+        self._write_plist(
+            launch_agents,
+            "ai.hermes.gateway-stopped",
+            tmp_path / ".hermes/profiles/stopped",
+            command=[
+                "/usr/bin/python3",
+                "-m",
+                "hermes_cli.main",
+                "--profile",
+                "stopped",
+                "gateway",
+                "run",
+                "--replace",
+            ],
+        )
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            if command == ["launchctl", "print", "gui/501"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=_launchd_domain_inventory(
+                        "ai.hermes.gateway", custom_label, "ai.hermes.gateway-stopped"
+                    ),
+                    stderr="",
+                )
+            if command == ["launchctl", "print", "user/501"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=_launchd_domain_inventory("ai.hermes.gateway-coder"),
+                    stderr="",
+                )
+            target = command[-1]
+            outputs = {
+                "gui/501/ai.hermes.gateway": "pid = 101\n",
+                "user/501/ai.hermes.gateway-coder": "pid = 202\n",
+                f"gui/501/{custom_label}": "pid = 303\n",
+                "gui/501/ai.hermes.gateway-stopped": "state = not running\n",
+            }
+            if target in outputs:
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=outputs[target], stderr=""
+                )
+            return subprocess.CompletedProcess(command, 113, stdout="", stderr="not found")
+
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        discovery = gateway_cli._discover_running_launchd_gateways()
+
+        assert discovery.complete is True
+        assert {(job.domain, job.label, job.pid) for job in discovery.jobs} == {
+            ("gui/501", "ai.hermes.gateway", 101),
+            ("user/501", "ai.hermes.gateway-coder", 202),
+            ("gui/501", custom_label, 303),
+        }
+        assert all(command[:2] == ["launchctl", "print"] for command in calls)
+        assert calls[:2] == [
+            ["launchctl", "print", "gui/501"],
+            ["launchctl", "print", "user/501"],
+        ]
+
+    @pytest.mark.parametrize("domain", ["gui/501", "user/501"])
+    def test_loaded_job_with_deleted_plist_fails_closed(
+        self, tmp_path, monkeypatch, domain
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        calls = []
+
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            assert command in (
+                ["launchctl", "print", "gui/501"],
+                ["launchctl", "print", "user/501"],
+            )
+            labels = ("ai.hermes.gateway-coder",) if command[-1] == domain else ()
+            return subprocess.CompletedProcess(
+                command, 0, stdout=_launchd_domain_inventory(*labels), stderr=""
+            )
+
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda _pid: pytest.fail("detached loaded job must not be signalled"),
+        )
+
+        discovery = gateway_cli._discover_running_launchd_gateways(warn=False)
+        restart = gateway_cli.restart_running_launchd_gateways(45.0)
+
+        assert discovery.complete is False
+        assert discovery.jobs == ()
+        assert "no valid installed plist" in discovery.errors[0]
+        assert restart.discovery_complete is False
+        assert restart.restarted_labels == []
+        assert calls == [
+            ["launchctl", "print", "gui/501"],
+            ["launchctl", "print", "user/501"],
+        ] * 2
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            subprocess.TimeoutExpired(["launchctl", "print", "gui/501"], 5),
+            OSError("launchctl unavailable"),
+            subprocess.CompletedProcess([], 5, stdout="", stderr="I/O error"),
+        ],
+    )
+    def test_domain_inventory_failure_prevents_per_label_probes(
+        self, tmp_path, monkeypatch, failure
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        self._write_plist(launch_agents, "ai.hermes.gateway", tmp_path / ".hermes")
+        calls = []
+
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            assert len(command) == 3, "per-label launchctl print must not run"
+            if command[-1] == "gui/501":
+                if isinstance(failure, BaseException):
+                    raise failure
+                return failure
+            return subprocess.CompletedProcess(
+                command, 0, stdout=_launchd_domain_inventory(), stderr=""
+            )
+
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        discovery = gateway_cli._discover_running_launchd_gateways(warn=False)
+
+        assert discovery.complete is False
+        assert discovery.jobs == ()
+        assert len(discovery.errors) == 1
+        assert calls == [
+            ["launchctl", "print", "gui/501"],
+            ["launchctl", "print", "user/501"],
+        ]
+
+    def test_valid_installed_unloaded_and_stopped_jobs_are_complete(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        self._write_plist(launch_agents, "ai.hermes.gateway", tmp_path / ".hermes")
+        self._write_plist(
+            launch_agents,
+            "ai.hermes.gateway-coder",
+            tmp_path / ".hermes/profiles/coder",
+            command=[
+                "/usr/bin/python3",
+                "-m",
+                "hermes_cli.main",
+                "--profile",
+                "coder",
+                "gateway",
+                "run",
+                "--replace",
+            ],
+        )
+
+        def fake_run(command, **_kwargs):
+            if command == ["launchctl", "print", "gui/501"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=_launchd_domain_inventory("ai.hermes.gateway-coder"),
+                    stderr="",
+                )
+            if command == ["launchctl", "print", "user/501"]:
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=_launchd_domain_inventory(), stderr=""
+                )
+            if command[-1] == "gui/501/ai.hermes.gateway-coder":
+                return subprocess.CompletedProcess(
+                    command, 0, stdout="state = stopped\n", stderr=""
+                )
+            return subprocess.CompletedProcess(command, 113, stdout="", stderr="not found")
+
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        discovery = gateway_cli._discover_running_launchd_gateways(warn=False)
+
+        assert discovery.complete is True
+        assert discovery.jobs == ()
+        assert discovery.errors == ()
+
+    @pytest.mark.parametrize(
+        ("payload", "expected_error"),
+        [
+            ({"Label": "ai.hermes.gateway-other"}, "Label does not match"),
+            (
+                {
+                    "Label": "ai.hermes.gateway-coder",
+                    "ProgramArguments": [
+                        "/usr/bin/python3",
+                        "-m",
+                        "hermes_cli.main",
+                        "--profile",
+                        "coder",
+                        "gateway",
+                        "run",
+                    ],
+                },
+                "missing HERMES_HOME",
+            ),
+            (
+                {
+                    "Label": "ai.hermes.gateway-coder",
+                    "EnvironmentVariables": {"HERMES_HOME": "/profiles/coder"},
+                    "ProgramArguments": ["/usr/bin/python3", "unrelated.py"],
+                },
+                "invalid Hermes gateway ProgramArguments",
+            ),
+            (
+                {
+                    "Label": "ai.hermes.gateway-coder",
+                    "EnvironmentVariables": {"HERMES_HOME": "/wrong/home"},
+                    "ProgramArguments": [
+                        "/usr/bin/python3",
+                        "-m",
+                        "hermes_cli.main",
+                        "--profile",
+                        "coder",
+                        "gateway",
+                        "run",
+                        "--replace",
+                    ],
+                },
+                "HERMES_HOME/command does not match",
+            ),
+        ],
+    )
+    def test_reserved_label_imposters_fail_closed_without_per_label_probe(
+        self, tmp_path, monkeypatch, payload, expected_error
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        path = launch_agents / "ai.hermes.gateway-coder.plist"
+        with path.open("wb") as handle:
+            plistlib.dump(payload, handle)
+        launchctl_calls = []
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda command, **_kwargs: launchctl_calls.append(command)
+            or subprocess.CompletedProcess(
+                command, 0, stdout=_launchd_domain_inventory(), stderr=""
+            ),
+        )
+
+        discovery = gateway_cli._discover_running_launchd_gateways(warn=False)
+        restart = gateway_cli.restart_running_launchd_gateways(45.0)
+
+        assert discovery.complete is False
+        assert expected_error in discovery.errors[0]
+        assert discovery.jobs == ()
+        assert restart.discovery_complete is False
+        assert restart.restarted_labels == []
+        assert launchctl_calls == [
+            ["launchctl", "print", "gui/501"],
+            ["launchctl", "print", "user/501"],
+        ] * 2
+
+    def test_invalid_non_hermes_filenames_are_ignored(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        (launch_agents / "com.example.valid.plist").write_bytes(b"not a plist")
+        # Matches the broad glob, but uppercase is outside generated label syntax.
+        (launch_agents / "ai.hermes.gateway-Bad.plist").write_bytes(b"not a plist")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+
+        installed = gateway_cli._installed_launchd_gateway_plists()
+
+        assert installed.complete is True
+        assert installed.plists == ()
+        assert installed.errors == ()
+
+    @pytest.mark.parametrize("failure", ["malformed", "unreadable"])
+    def test_invalid_reserved_plist_makes_update_skip_all_gateway_actions(
+        self,
+        tmp_path,
+        mock_args,
+        monkeypatch,
+        capsys,
+        failure,
+    ):
+        from hermes_cli import gateway as gateway_cli
+        from hermes_cli import main as hm
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        plist_path = launch_agents / "ai.hermes.gateway-coder.plist"
+        plist_path.write_bytes(b"not a plist")
+        real_path_open = Path.open
+        if failure == "unreadable":
+            def fake_path_open(path, *args, **kwargs):
+                if path == plist_path:
+                    raise PermissionError("injected unreadable plist")
+                return real_path_open(path, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "open", fake_path_open)
+
+        commands = []
+        git_side_effect = _make_run_side_effect(commit_count="1")
+
+        def fake_run(command, **kwargs):
+            commands.append(command)
+            if command and command[0] == "launchctl":
+                assert command in (
+                    ["launchctl", "print", "gui/501"],
+                    ["launchctl", "print", "user/501"],
+                )
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=_launchd_domain_inventory(), stderr=""
+                )
+            return git_side_effect(command, **kwargs)
+
+        signals = []
+        watchers = []
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "find_gateway_pids",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("manual sweep must not run")
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "find_profile_gateway_processes", lambda **_kwargs: []
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "launch_detached_profile_gateway_restart",
+            lambda *args: watchers.append(args) or True,
+        )
+        monkeypatch.setattr(gateway_cli.os, "kill", lambda *args: signals.append(args))
+        monkeypatch.setattr(hm._time, "sleep", lambda _seconds: None)
+
+        cmd_update(mock_args)
+
+        assert [
+            command for command in commands if command and command[0] == "launchctl"
+        ] == [
+            ["launchctl", "print", "gui/501"],
+            ["launchctl", "print", "user/501"],
+        ] * 2
+        assert signals == []
+        assert watchers == []
+        assert "Skipping manual gateway sweeps" in capsys.readouterr().out
+
+    @pytest.mark.parametrize(
+        ("gui_result", "expected_complete"),
+        [
+            (
+                subprocess.CompletedProcess(
+                    [],
+                    0,
+                    stdout="pid = 0\nstate = not running\n",
+                    stderr="",
+                ),
+                True,
+            ),
+            (subprocess.CompletedProcess([], 113, stdout="", stderr="not found"), True),
+            (subprocess.CompletedProcess([], 0, stdout="pid = garbage\n", stderr=""), False),
+            (subprocess.CompletedProcess([], 5, stdout="", stderr="I/O error"), False),
+            (subprocess.TimeoutExpired(["launchctl"], 5), False),
+            (OSError("launchctl unavailable"), False),
+        ],
+    )
+    def test_launchd_discovery_reports_completeness(
+        self, tmp_path, monkeypatch, gui_result, expected_complete
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        self._write_plist(launch_agents, "ai.hermes.gateway", tmp_path / ".hermes")
+
+        def fake_run(command, **_kwargs):
+            if command == ["launchctl", "print", "gui/501"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=_launchd_domain_inventory("ai.hermes.gateway"),
+                    stderr="",
+                )
+            if command == ["launchctl", "print", "user/501"]:
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=_launchd_domain_inventory(), stderr=""
+                )
+            if command[-1].startswith("gui/"):
+                if isinstance(gui_result, BaseException):
+                    raise gui_result
+                return gui_result
+            return subprocess.CompletedProcess(command, 113, stdout="", stderr="not found")
+
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        discovery = gateway_cli._discover_running_launchd_gateways(warn=False)
+
+        assert discovery.complete is expected_complete
+        assert bool(discovery.errors) is (not expected_complete)
+
+    def test_legacy_default_plist_without_hermes_home_uses_real_default(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        self._write_plist(
+            launch_agents,
+            "ai.hermes.gateway",
+            tmp_path / ".hermes",
+            include_hermes_home=False,
+        )
+        self._write_plist(
+            launch_agents,
+            "ai.hermes.gateway-coder",
+            tmp_path / ".hermes/profiles/coder",
+            command=[
+                "/usr/bin/python3",
+                "-m",
+                "hermes_cli.main",
+                "--profile",
+                "coder",
+                "gateway",
+                "run",
+            ],
+            include_hermes_home=False,
+        )
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+
+        installed = gateway_cli._installed_launchd_gateway_plists()
+
+        assert installed.complete is False
+        assert [(label, home) for label, _path, home in installed.plists] == [
+            ("ai.hermes.gateway", tmp_path / ".hermes")
+        ]
+        assert "missing HERMES_HOME" in installed.errors[0]
+
+    def test_graceful_restart_requires_and_retains_replacement_pid(self, monkeypatch):
+        from hermes_cli import gateway as gateway_cli
+
+        job = gateway_cli.LaunchdGatewayJob(
+            "user/501", "ai.hermes.gateway-coder", 101, Path("/profiles/coder")
+        )
+        monkeypatch.setattr(gateway_cli, "_discover_running_launchd_gateways", lambda: gateway_cli.LaunchdGatewayDiscovery((job,), True))
+        monkeypatch.setattr(gateway_cli, "_launchd_gateway_drain_budget", lambda *_: 90.0)
+        monkeypatch.setattr(gateway_cli, "_is_pid_ancestor_of_current_process", lambda _: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, drain_timeout: (pid, drain_timeout) == (101, 90.0),
+        )
+        wait_calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_gateway_relaunch",
+            lambda domain, label, pid: wait_calls.append((domain, label, pid)) or 202,
+        )
+
+        result = gateway_cli.restart_running_launchd_gateways(drain_timeout=45.0)
+
+        assert result.restarted_labels == ["ai.hermes.gateway-coder"]
+        assert result.service_pids == {101, 202}
+        assert wait_calls == [("user/501", "ai.hermes.gateway-coder", 101)]
+
+    @pytest.mark.parametrize("replacement, expected_labels", [(202, ["ai.hermes.gateway"]), (None, [])])
+    def test_kickstart_success_is_verified_by_replacement_pid(
+        self, monkeypatch, capsys, replacement, expected_labels
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        job = gateway_cli.LaunchdGatewayJob(
+            "gui/501", "ai.hermes.gateway", 101, Path("/.hermes")
+        )
+        calls = []
+        monkeypatch.setattr(gateway_cli, "_discover_running_launchd_gateways", lambda: gateway_cli.LaunchdGatewayDiscovery((job,), True))
+        monkeypatch.setattr(gateway_cli, "_launchd_gateway_drain_budget", lambda *_: 45.0)
+        monkeypatch.setattr(gateway_cli, "_is_pid_ancestor_of_current_process", lambda _: False)
+        monkeypatch.setattr(
+            gateway_cli, "_graceful_restart_via_sigusr1", lambda *args, **kwargs: False
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_gateway_relaunch",
+            lambda *args: replacement,
+        )
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        result = gateway_cli.restart_running_launchd_gateways(drain_timeout=45.0)
+
+        assert result.restarted_labels == expected_labels
+        assert result.service_pids == ({101, 202} if replacement else {101})
+        assert calls == [[
+            "launchctl",
+            "kickstart",
+            "-k",
+            "gui/501/ai.hermes.gateway",
+        ]]
+        if replacement is None:
+            assert "no replacement PID appeared" in capsys.readouterr().out
+
+    def test_per_label_failure_continues_in_original_domain(self, monkeypatch, capsys):
+        from hermes_cli import gateway as gateway_cli
+
+        jobs = [
+            gateway_cli.LaunchdGatewayJob(
+                "gui/501", "ai.hermes.gateway", 101, Path("/.hermes")
+            ),
+            gateway_cli.LaunchdGatewayJob(
+                "user/501", "ai.hermes.gateway-coder", 202, Path("/profiles/coder")
+            ),
+        ]
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            if command[-1] == "gui/501/ai.hermes.gateway":
+                raise subprocess.CalledProcessError(5, command, stderr="I/O error")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "_discover_running_launchd_gateways", lambda: gateway_cli.LaunchdGatewayDiscovery(tuple(jobs), True))
+        monkeypatch.setattr(gateway_cli, "_launchd_gateway_drain_budget", lambda *_: 45.0)
+        monkeypatch.setattr(gateway_cli, "_is_pid_ancestor_of_current_process", lambda _: False)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli, "_graceful_restart_via_sigusr1", lambda *args, **kwargs: False
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_gateway_relaunch",
+            lambda domain, _label, _pid: 303 if domain == "user/501" else None,
+        )
+
+        result = gateway_cli.restart_running_launchd_gateways(drain_timeout=45.0)
+
+        assert result.restarted_labels == ["ai.hermes.gateway-coder"]
+        assert calls[-1] == [
+            "launchctl",
+            "kickstart",
+            "-k",
+            "user/501/ai.hermes.gateway-coder",
+        ]
+        assert "ai.hermes.gateway" in capsys.readouterr().out
+
+    def test_deferred_current_restart_is_only_requested_by_finalizer(self, monkeypatch):
+        from hermes_cli import gateway as gateway_cli
+
+        current = gateway_cli.LaunchdGatewayJob(
+            "gui/501", "ai.hermes.gateway-coder", 303, Path("/profiles/coder")
+        )
+        monkeypatch.setattr(gateway_cli, "_discover_running_launchd_gateways", lambda: gateway_cli.LaunchdGatewayDiscovery((current,), True))
+        monkeypatch.setattr(
+            gateway_cli, "_is_pid_ancestor_of_current_process", lambda pid: pid == 303
+        )
+        signals = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: signals.append(pid) or True,
+        )
+
+        result = gateway_cli.restart_running_launchd_gateways(drain_timeout=45.0)
+        assert signals == []
+        assert result.deferred_current == [current]
+        assert result.service_pids == {303}
+        assert gateway_cli.restart_deferred_current_launchd_gateways(result) == [
+            "ai.hermes.gateway-coder"
+        ]
+        assert signals == [303]
+
+    def test_service_pid_discovery_uses_cross_domain_jobs(self, monkeypatch):
+        from hermes_cli import gateway as gateway_cli
+
+        jobs = [
+            gateway_cli.LaunchdGatewayJob(
+                "gui/501", "ai.hermes.gateway", 101, Path("/.hermes")
+            ),
+            gateway_cli.LaunchdGatewayJob(
+                "user/501", "ai.hermes.gateway-coder", 202, Path("/profiles/coder")
+            ),
+        ]
+        discovery = gateway_cli.LaunchdGatewayDiscovery(tuple(jobs), True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setenv("HERMES_HOME", "/.hermes")
+        monkeypatch.setattr(
+            gateway_cli,
+            "_discover_running_launchd_gateways",
+            lambda **kwargs: discovery,
+        )
+
+        assert gateway_cli._get_service_pids() == {101}
+        assert gateway_cli._get_service_pids(all_profiles=True) == {101, 202}
+
+    def test_find_gateway_pids_revalidates_replacement_service_pid(self, monkeypatch):
+        from hermes_cli import gateway as gateway_cli
+
+        snapshots = iter(
+            [
+                gateway_cli.ServicePidDiscovery(frozenset({202}), True),
+                gateway_cli.ServicePidDiscovery(frozenset({303}), True),
+            ]
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_service_pid_discovery",
+            lambda **_kwargs: next(snapshots),
+        )
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_scan_gateway_pids",
+            lambda exclude, **_kwargs: [pid for pid in (202, 303, 404) if pid not in exclude],
+        )
+
+        assert gateway_cli.find_gateway_pids(
+            exclude_pids={101},
+            all_profiles=True,
+            exclude_service_pids=True,
+        ) == [404]
+
+    def test_exclude_pids_does_not_implicitly_exclude_services(self, monkeypatch):
+        from hermes_cli import gateway as gateway_cli
+
+        # The default path intentionally preserves the historical no-argument
+        # helper call so existing callers and mocks remain compatible.
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {202})
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_scan_gateway_pids",
+            lambda exclude, **_kwargs: [pid for pid in (202, 303) if pid not in exclude],
+        )
+
+        assert gateway_cli.find_gateway_pids(exclude_pids={101}) == [202, 303]
+
+    def test_find_gateway_pids_requests_all_service_profiles_explicitly(self, monkeypatch):
+        from hermes_cli import gateway as gateway_cli
+
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_service_pids",
+            lambda **kwargs: calls.append(kwargs) or set(),
+        )
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_scan_gateway_pids", lambda *_args, **_kwargs: [])
+
+        assert gateway_cli.find_gateway_pids(all_profiles=True) == []
+        assert calls == [{"all_profiles": True}]
+
+    def test_sibling_profile_drain_budget_reads_only_its_config(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            "agent:\n  restart_drain_timeout: 240\n", encoding="utf-8"
+        )
+        job = gateway_cli.LaunchdGatewayJob(
+            "user/501", "ai.hermes.gateway-coder", 202, profile_home
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        assert gateway_cli._launchd_gateway_drain_budget(job, 45.0) == 255.0
+
+    @pytest.mark.parametrize("configured", [".nan", ".inf", "-.inf"])
+    def test_non_finite_sibling_drain_budget_falls_back(
+        self, tmp_path, monkeypatch, configured
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            f"agent:\n  restart_drain_timeout: {configured}\n", encoding="utf-8"
+        )
+        job = gateway_cli.LaunchdGatewayJob(
+            "user/501", "ai.hermes.gateway-coder", 202, profile_home
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        assert gateway_cli._launchd_gateway_drain_budget(job, 45.0) == 45.0
+
+    @pytest.mark.parametrize("fallback", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_fallback_drain_budget_is_sanitized(
+        self, tmp_path, fallback
+    ):
+        from hermes_cli import gateway as gateway_cli
+
+        job = gateway_cli.LaunchdGatewayJob(
+            "user/501", "ai.hermes.gateway-coder", 202, tmp_path
+        )
+
+        budget = gateway_cli._launchd_gateway_drain_budget(job, fallback)
+
+        assert budget > 0
+        assert budget != float("inf")
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -933,7 +933,7 @@ def test_gateway_install_noninteractive_skips_legacy_unit_prompt(monkeypatch, tm
 
 
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):
-    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda **_kwargs: set())
     monkeypatch.setattr(gateway, "is_windows", lambda: False)
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
@@ -963,7 +963,7 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
 def test_find_gateway_pids_includes_restart_managers_without_systemd(monkeypatch):
     calls = []
 
-    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda **_kwargs: set())
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
     monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
 
@@ -1011,7 +1011,7 @@ def test_reap_unsupervised_orphans_sigterms_then_sigkills_survivor(monkeypatch):
 
     assert gateway._reap_unsupervised_gateway_orphans() is True
     assert (708, signal.SIGTERM) in sent
-    assert (708, signal.SIGKILL) in sent
+    assert (708, signal.SIGKILL) in sent  # windows-footgun: ok
 
 
 def test_reap_unsupervised_orphans_returns_false_when_none_found(monkeypatch):
@@ -1027,10 +1027,10 @@ def test_reap_unsupervised_orphans_returns_false_when_none_found(monkeypatch):
 def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch):
     monkeypatch.setattr(gateway, "is_windows", lambda: True)
     monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
-    monkeypatch.setattr(gateway.shutil, "which", lambda name: "wmic.exe" if name == "wmic" else None)
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: "wmic.exe" if name == "wmic" else None)  # windows-footgun: ok
 
     def fake_run(cmd, **kwargs):
-        if cmd[:4] == ["wmic.exe", "process", "get", "ProcessId,CommandLine"]:
+        if cmd[:4] == ["wmic.exe", "process", "get", "ProcessId,CommandLine"]:  # windows-footgun: ok
             return SimpleNamespace(
                 returncode=0,
                 stdout=(


### PR DESCRIPTION
## Summary

Fix the macOS update lifecycle so a successful shared-checkout update restarts every running launchd-managed Hermes profile gateway, rather than only the profile that invoked `hermes update`.

This change:

- inventories both `gui/<uid>` and `user/<uid>` bootstrap domains;
- validates Hermes launchd plist labels, commands, profile homes, and legacy default-profile forms before acting;
- detects loaded launchd jobs whose plist was deleted and fails closed;
- treats malformed plists, inventory/probe failures, and unparseable PID/state output as incomplete ownership discovery;
- never runs destructive manual-process sweeps when service ownership cannot be proven complete;
- restarts only jobs that were running before the update;
- preserves stopped, unloaded, disabled, malformed, and unrelated jobs;
- processes sibling profiles first and defers the invoking gateway until both manual sweeps finish;
- verifies replacement PIDs after graceful restart and bounded `kickstart -k` fallback;
- snapshots service ownership before and after process-table scans to prevent launchd replacements from being classified as manual gateways;
- keeps `exclude_pids` semantics unchanged and uses an explicit manual-only discovery mode;
- restores profile-scoped launchd PID behavior for ordinary callers while allowing updater-wide enumeration;
- reads each sibling profile's drain timeout with finite-value validation;
- finalizes the invoking gateway restart even if a manual sweep raises.

## Why

All profiles execute from the same checkout. Updating that checkout while sibling gateways continue running can leave them with a mixed Python module graph: older modules cached in memory and newer modules imported lazily from disk. That caused profile gateways to fail after updates until they were manually restarted.

The updater already states that every gateway must restart after a shared-code update. Linux and manual-process paths attempt that; the previous macOS branch used only the invoking profile's launchd label and plist.

## Safety

- Restart logic runs only after the source/dependency update succeeds.
- Only running jobs discovered in qualified launchd domains are restarted.
- Candidate definitions must match Hermes-generated gateway command and home/label conventions.
- Loaded reserved labels without a valid plist cause a fail-closed warning rather than a signal.
- Unexpected launchctl failures or output cause both manual sweeps to be skipped.
- The invoking launchd gateway is signaled last from a `finally` block.
- No test signals real processes or manipulates real launchd jobs.

## Tests

- `tests/hermes_cli/test_cmd_update.py`: 86 passed
- `tests/hermes_cli/test_gateway.py`: 53 passed
- launchd/macOS-focused `test_gateway_service.py`: 47 passed
- wider update suite: 245 passed
- full `tests/hermes_cli/` run: changed suites pass; 13 environment-specific failures across 6 unrelated files reproduce on clean upstream
- Ruff, `py_compile`, Windows-footgun scan, `git diff --check`, and secret scan passed
- read-only live macOS verification: 4 validated plists and 4 running jobs in `gui/501`; current-profile PID scope returned 1 and updater-wide scope returned 4

Addresses the macOS update-lifecycle portion of #38053. The separate `gateway restart --all` command behavior remains outside this PR.

Related prior approaches: #19784 and #13358.
