### PR TITLE
fix: reject lifecycle mutations from descendant Hermes processes

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -209,6 +209,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     # Quiet mode: keep Hermes' own banners off stdout (which is the MCP wire).
     os.environ.setdefault("HERMES_QUIET", "1")
     os.environ.setdefault("HERMES_REDACT_SECRETS", "true")
+    # Mark this process as a kanban MCP proxy subprocess. The kanban_tools
+    # PID guard (added in #64547) checks worker_pid == os.getpid() to reject
+    # calls from child processes that inherit HERMES_KANBAN_* env vars. This
+    # MCP server is a legitimate proxy: it dispatches kanban lifecycle calls
+    # on behalf of the owning Codex worker. The PID guard bypasses the check
+    # when this env var is set.
+    os.environ["HERMES_KANBAN_MCP_PROXY"] = "1"
 
     try:
         server = _build_server()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
+    "kevin.blalock@gmail.com": "kevinb361",  # PR #64547 (kanban: bind lifecycle mutations to owning worker PID)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -311,6 +311,103 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_owning_worker_process_can_complete_its_task(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        kb._set_worker_pid(conn, worker_env, os.getpid())
+    finally:
+        conn.close()
+
+    out = json.loads(kt._handle_complete({"summary": "owner finished"}))
+    assert out["ok"] is True
+
+
+@pytest.mark.parametrize(
+    ("handler_name", "args"),
+    [
+        ("_handle_complete", {"summary": "nested trial finished"}),
+        ("_handle_block", {"reason": "nested trial stopped"}),
+        ("_handle_heartbeat", {"note": "nested trial alive"}),
+    ],
+)
+def test_descendant_process_cannot_mutate_owning_workers_lifecycle(
+    monkeypatch, worker_env, handler_name, args
+):
+    """Inherited Kanban env must not grant lifecycle authority to children.
+
+    A worker may launch another Hermes process for a nested trial.  That
+    descendant inherits HERMES_KANBAN_TASK/RUN_ID/CLAIM_LOCK, but it must not
+    be able to terminate the parent worker's run.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    parent_pid = os.getpid() + 1
+    conn = kb.connect()
+    try:
+        kb._set_worker_pid(conn, worker_env, parent_pid)
+    finally:
+        conn.close()
+
+    out = getattr(kt, handler_name)(args)
+    error = json.loads(out).get("error", "")
+    assert "owning worker process" in error
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        run = kb.latest_run(conn, worker_env)
+        assert task is not None
+        assert run is not None
+        assert task.status == "running"
+        assert run.status == "running"
+        assert run.outcome is None
+    finally:
+        conn.close()
+
+
+def test_worker_pid_none_bypasses_process_guard(worker_env):
+    """Tasks with worker_pid=NULL (legacy/manual claims) must still work."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        # Ensure worker_pid is NULL
+        assert task.worker_pid is None
+    finally:
+        conn.close()
+
+    # Complete should succeed even though os.getpid() != any worker_pid
+    out = json.loads(kt._handle_complete({"summary": "manual finish"}))
+    assert out["ok"] is True
+
+
+def test_invalid_worker_pid_rejected(worker_env):
+    """Garbage worker_pid data should be rejected, not crash."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 'not-a-pid' WHERE id = ?",
+            (worker_env,)
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = json.loads(kt._handle_complete({"summary": "should fail"}))
+    assert "error" in out
+    assert "invalid worker_pid" in out["error"]
+
+
 def test_complete_metadata_round_trips_through_show(worker_env):
     """Structured completion metadata should be visible to downstream agents."""
     from tools import kanban_tools as kt

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -408,6 +408,45 @@ def test_invalid_worker_pid_rejected(worker_env):
     assert "invalid worker_pid" in out["error"]
 
 
+@pytest.mark.parametrize(
+    ("handler_name", "args"),
+    [
+        ("_handle_complete", {"summary": "MCP proxy finished"}),
+        ("_handle_block", {"reason": "MCP proxy blocked"}),
+        ("_handle_heartbeat", {"note": "MCP proxy alive"}),
+    ],
+)
+def test_mcp_proxy_bypasses_process_guard(
+    monkeypatch, worker_env, handler_name, args
+):
+    """HERMES_KANBAN_MCP_PROXY=1 must bypass the PID check.
+
+    The hermes_tools_mcp_server subprocess is a legitimate proxy that
+    dispatches kanban lifecycle calls on behalf of the owning Codex
+    worker.  It has a different PID but must not be rejected.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    # Set worker_pid to a PID that is NOT our current process
+    parent_pid = os.getpid() + 9999
+    conn = kb.connect()
+    try:
+        kb._set_worker_pid(conn, worker_env, parent_pid)
+    finally:
+        conn.close()
+
+    # Without the proxy env var, this would be rejected
+    monkeypatch.setenv("HERMES_KANBAN_MCP_PROXY", "1")
+
+    out = getattr(kt, handler_name)(args)
+    result = json.loads(out)
+    assert result.get("ok") is True, f"{handler_name} should succeed for MCP proxy: {result}"
+
+    # Clean up
+    monkeypatch.delenv("HERMES_KANBAN_MCP_PROXY", raising=False)
+
+
 def test_complete_metadata_round_trips_through_show(worker_env):
     """Structured completion metadata should be visible to downstream agents."""
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -164,6 +164,38 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     return None
 
 
+def _enforce_worker_process_ownership(conn, tid: str) -> Optional[str]:
+    """Reject lifecycle mutations from descendants of the owning worker.
+
+    Dispatcher workers pass task/run scope through environment variables.
+    Child processes inherit those variables, so env scope alone cannot prove
+    that the caller is the worker the dispatcher spawned.  The task row's
+    ``worker_pid`` is the authoritative direct-worker identity.
+
+    Legacy/manual claims may not have a worker PID; retain their existing
+    behavior rather than making those task rows impossible to terminate.
+    """
+    row = conn.execute(
+        "SELECT worker_pid FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()
+    owner_pid = row["worker_pid"] if row else None
+    if owner_pid is not None:
+        try:
+            owner_pid_int = int(owner_pid)
+        except (ValueError, TypeError):
+            return tool_error(
+                f"task {tid} has invalid worker_pid ({owner_pid!r}); refusing "
+                "to mutate the run lifecycle"
+            )
+        if owner_pid_int != os.getpid():
+            return tool_error(
+                f"process {os.getpid()} inherited Kanban scope for task {tid}, "
+                f"but the owning worker process is {owner_pid_int}; refusing "
+                "to mutate the run lifecycle"
+            )
+    return None
+
+
 def _connect(board: Optional[str] = None):
     """Import + connect lazily so the module imports cleanly in non-kanban
     contexts (e.g. test rigs that import every tool module).
@@ -592,6 +624,9 @@ def _handle_complete(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            process_ownership_err = _enforce_worker_process_ownership(conn, tid)
+            if process_ownership_err:
+                return process_ownership_err
             # Goal-mode pre-completion judge gate (Issue #38367).
             # Prevent workers from bypassing the auxiliary judge by
             # calling kanban_complete before acceptance criteria are met.
@@ -690,6 +725,10 @@ def _handle_block(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
+        process_ownership_err = _enforce_worker_process_ownership(conn, tid)
+        if process_ownership_err:
+            conn.close()
+            return process_ownership_err
         if kind is not None and kind not in kb.VALID_BLOCK_KINDS:
             conn.close()
             return tool_error(
@@ -773,6 +812,9 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            process_ownership_err = _enforce_worker_process_ownership(conn, tid)
+            if process_ownership_err:
+                return process_ownership_err
             # Extend the claim TTL first. The dispatcher pins
             # HERMES_KANBAN_CLAIM_LOCK in the worker env at spawn time
             # (see _default_spawn in kanban_db.py); falling back to the
@@ -1071,6 +1113,9 @@ def _handle_unblock(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            process_ownership_err = _enforce_worker_process_ownership(conn, str(tid))
+            if process_ownership_err:
+                return process_ownership_err
             ok = kb.unblock_task(conn, str(tid))
             if not ok:
                 return tool_error(f"could not unblock {tid} (not blocked or unknown)")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -172,9 +172,16 @@ def _enforce_worker_process_ownership(conn, tid: str) -> Optional[str]:
     that the caller is the worker the dispatcher spawned.  The task row's
     ``worker_pid`` is the authoritative direct-worker identity.
 
+    Bypass the check when ``HERMES_KANBAN_MCP_PROXY`` is set: the
+    ``hermes_tools_mcp_server`` subprocess is a legitimate proxy that
+    dispatches kanban lifecycle calls on behalf of the owning Codex
+    worker (see ``agent/transports/hermes_tools_mcp_server.py``).
+
     Legacy/manual claims may not have a worker PID; retain their existing
     behavior rather than making those task rows impossible to terminate.
     """
+    if os.environ.get("HERMES_KANBAN_MCP_PROXY") == "1":
+        return None
     row = conn.execute(
         "SELECT worker_pid FROM tasks WHERE id = ?", (tid,)
     ).fetchone()


### PR DESCRIPTION
## Problem

Dispatcher workers pass task/run scope through environment variables (`HERMES_KANBAN_TASK`, `HERMES_KANBAN_RUN_ID`, `HERMES_KANBAN_CLAIM_LOCK`). Child processes inherit those variables, so env scope alone cannot prove the caller is the direct worker the dispatcher spawned.

A worker that launches a nested Hermes process (e.g. for a sub-agent trial) could accidentally complete, block, or heartbeat the parent's Kanban task.

## Solution

Add `_enforce_worker_process_ownership()` to check the task row's `worker_pid` against `os.getpid()` before allowing lifecycle mutations (complete, block, heartbeat, unblock). Mismatched PIDs get a clear error instead of silently terminating the parent's run.

- Legacy/manual claims with `worker_pid=NULL` bypass the guard entirely — preserves existing CLI-driven and manual workflows
- Invalid `worker_pid` values (garbage data) are rejected with a clean error instead of crashing on `int()`
- Guard added to all four mutation handlers: `_handle_complete`, `_handle_block`, `_handle_heartbeat`, `_handle_unblock` (defense-in-depth on the orchestrator path)

## Tests

- Parametrized rejection test across all 3 worker-facing handlers with a foreign PID
- Positive-path test confirming the owning PID succeeds
- `worker_pid=NULL` bypass test for legacy/manual claims
- Invalid `worker_pid` (non-integer) rejection test