### PR TITLE
fix(vision): flatten transparent images onto white before embedding

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -1318,3 +1318,102 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# _flatten_alpha_to_opaque — transparent PNGs decode as noise on llama.cpp
+# backends (stb_image drops alpha; garbage RGB under transparent pixels
+# reaches the vision encoder). Flatten onto white before embedding.
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenAlphaToOpaque:
+    @staticmethod
+    def _write_rgba_with_garbage(path):
+        """Half-transparent PNG whose transparent pixels hide garbage RGB."""
+        from PIL import Image
+        img = Image.new("RGBA", (8, 8), (37, 201, 93, 0))  # transparent garbage
+        for x in range(4):
+            for y in range(8):
+                img.putpixel((x, y), (10, 20, 30, 255))  # opaque left half
+        img.save(path, format="PNG")
+
+    def test_transparent_png_flattened_to_white(self, tmp_path):
+        from PIL import Image
+        from tools.vision_tools import _flatten_alpha_to_opaque
+        src = tmp_path / "t.png"
+        self._write_rgba_with_garbage(src)
+        out, mime = _flatten_alpha_to_opaque(src, "image/png")
+        assert mime == "image/png"
+        assert out != src, "transparent PNG should produce a new flattened file"
+        try:
+            with Image.open(out) as flat:
+                assert flat.mode == "RGB"
+                assert flat.getpixel((7, 0)) == (255, 255, 255)  # was transparent
+                assert flat.getpixel((0, 0)) == (10, 20, 30)     # opaque preserved
+        finally:
+            out.unlink(missing_ok=True)
+
+    def test_opaque_png_untouched(self, tmp_path):
+        from PIL import Image
+        from tools.vision_tools import _flatten_alpha_to_opaque
+        src = tmp_path / "o.png"
+        Image.new("RGB", (4, 4), (1, 2, 3)).save(src, format="PNG")
+        out, mime = _flatten_alpha_to_opaque(src, "image/png")
+        assert out == src and mime == "image/png"
+
+    def test_jpeg_mime_untouched(self, tmp_path):
+        from tools.vision_tools import _flatten_alpha_to_opaque
+        src = tmp_path / "x.jpg"
+        src.write_bytes(b"\xff\xd8\xff\xe0 not really a jpeg")
+        out, mime = _flatten_alpha_to_opaque(src, "image/jpeg")
+        assert out == src and mime == "image/jpeg"
+
+    def test_palette_png_with_transparency_flattened(self, tmp_path):
+        from PIL import Image
+        from tools.vision_tools import _flatten_alpha_to_opaque
+        src = tmp_path / "p.png"
+        img = Image.new("RGBA", (4, 4), (0, 0, 0, 0)).convert(
+            "P", palette=Image.ADAPTIVE)
+        img.save(src, format="PNG", transparency=0)
+        out, mime = _flatten_alpha_to_opaque(src, "image/png")
+        try:
+            assert out != src and mime == "image/png"
+        finally:
+            if out != src:
+                out.unlink(missing_ok=True)
+
+    def test_in_place_flatten(self, tmp_path):
+        from PIL import Image
+        from tools.vision_tools import _flatten_alpha_to_opaque
+        src = tmp_path / "ip.png"
+        self._write_rgba_with_garbage(src)
+        out, mime = _flatten_alpha_to_opaque(src, "image/png", out_path=src)
+        assert out == src and mime == "image/png"
+        with Image.open(src) as flat:
+            assert flat.mode == "RGB"
+            assert flat.getpixel((7, 7)) == (255, 255, 255)
+
+    def test_corrupt_file_soft_fails_to_original(self, tmp_path):
+        from tools.vision_tools import _flatten_alpha_to_opaque
+        src = tmp_path / "bad.png"
+        src.write_bytes(b"\x89PNG\r\n\x1a\n truncated garbage")
+        out, mime = _flatten_alpha_to_opaque(src, "image/png")
+        assert out == src and mime == "image/png"
+
+    def test_normalize_flattens_supported_transparent_png(self, tmp_path):
+        """The passthrough branch of _normalize_to_supported_image must
+        flatten — this is the exact path a downloaded transparent PNG takes
+        into vision_analyze."""
+        from PIL import Image
+        from tools.vision_tools import _normalize_to_supported_image
+        src = tmp_path / "n.png"
+        self._write_rgba_with_garbage(src)
+        path, mime, err = _normalize_to_supported_image(src, "image/png")
+        assert err is None and mime == "image/png"
+        assert path != src, "normalize should hand back the flattened temp file"
+        try:
+            with Image.open(path) as flat:
+                assert flat.mode == "RGB"
+        finally:
+            path.unlink(missing_ok=True)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -300,6 +300,55 @@ def _rasterize_svg_to_png(svg_path: Path, out_path: Path) -> bool:
     return False
 
 
+def _flatten_alpha_to_opaque(
+    image_path: Path, detected_mime: str, out_path: Optional[Path] = None
+) -> tuple[Path, str]:
+    """Composite a transparent image onto a white background.
+
+    llama.cpp's stb_image loader DROPS the alpha channel instead of
+    compositing it, so the RGB values of fully-transparent pixels — which
+    encoders store as arbitrary garbage — reach the vision encoder verbatim.
+    A transparent-background PNG then reads as heavy horizontal-line "glitch"
+    noise (reproduced 2026-07-14 against Qwen3-VL-30B on :8005; the flattened
+    copy of the same image was described clean). Cloud providers composite
+    server-side, so flattening is a no-op for them and makes behaviour
+    uniform across backends.
+
+    Returns ``(path, mime)``. When flattening applies, the result is a new
+    RGB PNG (written to ``out_path`` if given, else a fresh temp file the
+    caller cleans up like any converted image). Anything without an actual
+    alpha channel — plus animated GIF/WebP, where flattening would drop the
+    animation — is returned untouched. Soft-fails to the original on any
+    error: a missing Pillow must never break the embed path.
+    """
+    if detected_mime not in ("image/png", "image/webp"):
+        return image_path, detected_mime
+    try:
+        from PIL import Image as _PILImage
+        with _PILImage.open(image_path) as _img:
+            if getattr(_img, "is_animated", False):
+                return image_path, detected_mime
+            has_alpha = (
+                _img.mode in ("RGBA", "LA")
+                or (_img.mode == "P" and "transparency" in _img.info)
+            )
+            if not has_alpha:
+                return image_path, detected_mime
+            rgba = _img.convert("RGBA")
+            flat = _PILImage.new("RGB", rgba.size, (255, 255, 255))
+            flat.paste(rgba, mask=rgba.getchannel("A"))
+        if out_path is None:
+            out_dir = get_hermes_dir("cache/vision", "temp_vision_images")
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = out_dir / f"flattened_{uuid.uuid4()}.png"
+        flat.save(out_path, format="PNG")
+        if out_path.exists() and out_path.stat().st_size > 0:
+            return out_path, "image/png"
+    except Exception as exc:
+        logger.warning("Alpha flatten failed; sending original image: %s", exc)
+    return image_path, detected_mime
+
+
 def _normalize_to_supported_image(
     image_path: Path, detected_mime: str
 ) -> tuple[Optional[Path], Optional[str], Optional[str]]:
@@ -312,12 +361,15 @@ def _normalize_to_supported_image(
       - If conversion is impossible: ``(None, None, <error message>)``.
 
     SVG is rasterized to PNG (best-effort, soft deps).  Other raster formats
-    Pillow can read (BMP, TIFF, etc.) are re-encoded to PNG.  This runs BEFORE
+    Pillow can read (BMP, TIFF, etc.) are re-encoded to PNG.  Transparent
+    images are composited onto white (see :func:`_flatten_alpha_to_opaque` —
+    llama.cpp backends decode the alpha channel as noise).  This runs BEFORE
     the image is base64-embedded into conversation history, so an unsupported
     media_type can never reach the provider and wedge the session.
     """
     if detected_mime in _ANTHROPIC_SUPPORTED_MEDIA_TYPES:
-        return image_path, detected_mime, None
+        flat_path, flat_mime = _flatten_alpha_to_opaque(image_path, detected_mime)
+        return flat_path, flat_mime, None
 
     out_dir = get_hermes_dir("cache/vision", "temp_vision_images")
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -326,6 +378,9 @@ def _normalize_to_supported_image(
     # SVG: needs a rasterizer (Pillow cannot render SVG).
     if detected_mime == "image/svg+xml":
         if _rasterize_svg_to_png(image_path, out_path):
+            # Rasterizers typically emit RGBA with a transparent background —
+            # the exact shape that decodes as noise on llama.cpp backends.
+            _flatten_alpha_to_opaque(out_path, "image/png", out_path=out_path)
             return out_path, "image/png", None
         return (
             None,
@@ -345,6 +400,7 @@ def _normalize_to_supported_image(
                 _img = _img.convert("RGBA")
             _img.save(out_path, format="PNG")
         if out_path.exists() and out_path.stat().st_size > 0:
+            _flatten_alpha_to_opaque(out_path, "image/png", out_path=out_path)
             return out_path, "image/png", None
     except Exception as _exc:
         logger.warning("Failed to normalize %s image to PNG: %s",


### PR DESCRIPTION
Fixes #64548.

### Problem

llama.cpp's stb_image loader drops the alpha channel instead of compositing it, so the
arbitrary garbage RGB values PNG encoders store under fully-transparent pixels reach the
vision encoder verbatim. A transparent-background PNG (e.g. the Google logo) is described
as "heavily distorted by a glitch effect... horizontal lines of varying colors"; the same
image composited onto white reads clean. Full repro matrix in the issue.

### Change

New helper `_flatten_alpha_to_opaque()` in `tools/vision_tools.py`, called from
`_normalize_to_supported_image` so every embed path is covered (vision_analyze, native
embed, rasterized-SVG output, converted-raster output):

- Composites RGBA / LA / palette-with-transparency PNG and WebP onto a white background,
  emitting an RGB PNG.
- Rasterized SVGs are flattened in place — rasterizers typically emit RGBA with a
  transparent background, the exact shape that decodes as noise.
- Animated GIF/WebP are left untouched (flattening would drop the animation).
- Soft-fails to the original bytes on any error (missing Pillow, corrupt file) — the
  flatten step can never break the embed path.
- No-op for images without an actual alpha channel, and effectively a no-op for cloud
  providers (they composite server-side), so behaviour is now uniform across backends.

### Tests

7 new tests in `tests/tools/test_vision_tools.py`, including a regression case that hides
garbage RGB under transparent pixels and asserts it never reaches the output:

- transparent PNG flattened to white / opaque PNG untouched / JPEG mime untouched
- palette-PNG-with-transparency flattened
- in-place flatten (rasterized-SVG path)
- corrupt file soft-fails to original
- `_normalize_to_supported_image` passthrough branch flattens supported transparent PNGs

Full vision suite: 96 passed. Verified end-to-end against a local llama.cpp backend:
the original repro URL now reads clean.
