### PR TITLE
fix(cli): clarify /usage 'no agent' message on fresh sessions (#64360)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9681,7 +9681,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         if not self.agent:
             if not self._print_nous_credits_block():
-                print("(._.) No active agent -- send a message first.")
+                print("(._.) No usage yet -- the agent is created on the first message; send one to start tracking tokens.")
             return
 
         agent = self.agent


### PR DESCRIPTION
## Summary

Replace the misleading "(._.) No active agent -- send a message first." string in the `/usage` slash command with a message that explains the expected behavior and tells the user what will happen next.

## Problem

On a fresh session, `/usage` early-returns with a message that reads like an error condition:

    (._.) No active agent -- send a message first.

The behavior is expected: the `agent` object is lazily instantiated on the first real message, so there is genuinely nothing to report. The current wording obscures that and the user reads it as a failure.

## Fix

Single-line change in `cli.py` (cmd_usage handler, ~line 9684). The new message:

- Acknowledges the expected behavior ("No usage yet")
- Tells the user what will happen on the next message ("the agent is created on the first message; send one to start tracking tokens")
- Keeps the existing `(._.)` emoticon prefix so the message styling matches sibling commands (`/compress`, "Not enough conversation to compress", etc.)

## Scope

Only the `/usage` site is changed. The `/compress` slash command has a similar `"(._.) No active agent -- send a message first."` line (~line 9465) but it is a different command with a different early-return reason (no agent means /compress has nothing to compress yet), so it is intentionally left alone.

## Verification

- `python3 -m py_compile cli.py` passes
- A small smoke test (`/tmp/test_issue_64360.py`) confirms:
  - The old message appears exactly 1× after the fix (the /compress site)
  - The new message is present at the /usage site
  - The new message is in the correct code path (next to `_print_nous_credits_block`)
- The git-stash three-step dance was run: the test fails on `main` (old count = 2) and passes after the fix (count = 1).

Closes #64360