### PR TITLE
fix(streaming): retry zero-chunk streams as transient, with anthropic zero-event parity (salvage of #64420)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, Optional
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
+from agent.errors import EmptyStreamError
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
@@ -2511,7 +2512,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             and not reasoning_parts
             and not tool_calls_acc
         ):
-            raise RuntimeError(
+            raise EmptyStreamError(
                 "Provider returned an empty stream with no finish_reason "
                 "(possible upstream error or malformed SSE response)."
             )
@@ -2734,6 +2735,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
+                    _is_empty_stream = isinstance(e, EmptyStreamError)
 
                     # If the stream died AFTER some tokens were delivered:
                     # normally we don't retry (the user already saw text,
@@ -2876,7 +2878,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 for phrase in _SSE_CONN_PHRASES
                             )
 
-                    if _is_timeout or _is_conn_err or _is_sse_conn_err or _is_stream_parse_err:
+                    if (
+                        _is_timeout
+                        or _is_conn_err
+                        or _is_sse_conn_err
+                        or _is_stream_parse_err
+                        or _is_empty_stream
+                    ):
                         # Transient network / timeout error. Retry the
                         # streaming request with a fresh connection first.
                         if _stream_attempt < _max_stream_retries:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2927,17 +2927,32 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             mid_tool_call=False,
                             diag=request_client_holder.get("diag"),
                         )
-                        agent._buffer_status(
-                            "❌ Provider returned malformed streaming data after "
-                            f"{_max_stream_retries + 1} attempts. "
-                            "The provider may be experiencing issues — "
-                            "try again in a moment."
-                            if _is_stream_parse_err else
-                            "❌ Connection to provider failed after "
-                            f"{_max_stream_retries + 1} attempts. "
-                            "The provider may be experiencing issues — "
-                            "try again in a moment."
-                        )
+                        if _is_stream_parse_err:
+                            _exhausted_msg = (
+                                "❌ Provider returned malformed streaming data after "
+                                f"{_max_stream_retries + 1} attempts. "
+                                "The provider may be experiencing issues — "
+                                "try again in a moment."
+                            )
+                        elif _is_empty_stream:
+                            # The connection SUCCEEDED (stream opened) but the
+                            # provider sent no chunks — saying "connection
+                            # failed" here sends users chasing network issues
+                            # when the problem is the provider/endpoint.
+                            _exhausted_msg = (
+                                "❌ Provider returned an empty response stream "
+                                f"after {_max_stream_retries + 1} attempts. "
+                                "The provider may be experiencing issues — "
+                                "try again in a moment."
+                            )
+                        else:
+                            _exhausted_msg = (
+                                "❌ Connection to provider failed after "
+                                f"{_max_stream_retries + 1} attempts. "
+                                "The provider may be experiencing issues — "
+                                "try again in a moment."
+                            )
+                        agent._buffer_status(_exhausted_msg)
                     else:
                         _err_lower = str(e).lower()
                         _is_stream_unsupported = (

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2601,6 +2601,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         works unchanged.
         """
         has_tool_use = False
+        # Zero-event guard parity with the chat_completions path: track
+        # whether the provider delivered ANY stream event. On an eventless
+        # stream the real Anthropic SDK's get_final_message() raises
+        # AssertionError (no message_start ⇒ no final-message snapshot);
+        # OpenAI-compat shims may instead fabricate a contentless Message
+        # with no stop_reason, or return None under ``python -O`` (assert
+        # stripped). Every one of those shapes is normalized below to
+        # EmptyStreamError so the shared _call() retry loop treats it as
+        # transient instead of surfacing a raw AssertionError or a
+        # fabricated "successful" empty turn.
+        saw_stream_event = False
 
         # Reset stale-stream timer for this attempt
         last_chunk_time["t"] = time.time()
@@ -2628,6 +2639,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             except Exception:
                 pass
             for event in stream:
+                saw_stream_event = True
                 # Update stale-stream timer on every event so the
                 # outer poll loop knows data is flowing.  Without
                 # this, the detector kills healthy long-running
@@ -2688,7 +2700,38 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # this return value is discarded anyway.
             if agent._interrupt_requested:
                 return None
-            return stream.get_final_message()
+            # Zero-event guard (parity with the chat_completions zero-chunk
+            # guard above). Real SDK: an eventless stream has no
+            # message_start, so get_final_message() raises AssertionError
+            # (final-message snapshot is None) — normalize that to
+            # EmptyStreamError so it gets the transient retry budget
+            # instead of surfacing raw.
+            try:
+                _final_message = stream.get_final_message()
+            except AssertionError:
+                if not saw_stream_event:
+                    raise EmptyStreamError(
+                        "Provider returned an empty stream with no events "
+                        "(possible upstream error or malformed event stream)."
+                    ) from None
+                raise
+            # Shim variants of the same failure: an OpenAI-compat adapter
+            # may fabricate a contentless Message with no stop_reason, or
+            # return None where the SDK assert would have fired (e.g.
+            # ``python -O``). A real completed response always carries a
+            # stop_reason, so this cannot fire on legitimate turns.
+            if not saw_stream_event and (
+                _final_message is None
+                or (
+                    not getattr(_final_message, "content", None)
+                    and getattr(_final_message, "stop_reason", None) is None
+                )
+            ):
+                raise EmptyStreamError(
+                    "Provider returned an empty stream with no stop_reason "
+                    "(possible upstream error or malformed event stream)."
+                )
+            return _final_message
 
     def _call():
         import httpx as _httpx

--- a/agent/errors.py
+++ b/agent/errors.py
@@ -1,3 +1,9 @@
 class SSLConfigurationError(Exception):
     """Raised when SSL/TLS certificate bundle configuration fails."""
     pass
+
+
+class EmptyStreamError(RuntimeError):
+    """Raised when a provider closes a stream without yielding a response."""
+
+    pass

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
+    "2024104039@mails.szu.edu.cn": "pixel4039",  # PR #64420 salvage (streaming: retry zero-chunk streams)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "jake.long.vu@vucar.net": "jakelongvu-bot",  # PR #36683 partial salvage (approval: honor canonical approvals.timeout in gateway waits)

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -773,6 +773,34 @@ class TestStreamingFallback:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_zero_chunk_stream_retried_as_transient(self, mock_close, mock_create):
+        """A stream that yields no chunks gets the same retry budget as a drop."""
+        from agent.errors import EmptyStreamError
+        from run_agent import AIAgent
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(())
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with pytest.raises(EmptyStreamError):
+            agent._interruptible_streaming_api_call({})
+
+        assert mock_client.chat.completions.create.call_count == 3
+        assert mock_close.call_count >= 1
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_sse_connection_lost_retried_as_transient(self, mock_close, mock_create):
         """SSE 'Network connection lost' (APIError w/ no status_code) retries like httpx errors.
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1293,6 +1293,90 @@ class TestAnthropicStreamCallbacks:
         assert agent._anthropic_client.messages.stream.call_count == 1
         assert mock_replace.call_count == 0
 
+    @patch("run_agent.AIAgent._try_refresh_anthropic_client_credentials")
+    @patch("run_agent.AIAgent._rebuild_anthropic_client")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    def test_anthropic_zero_event_stream_retried_as_transient(
+        self, mock_replace, mock_rebuild, mock_refresh,
+    ):
+        """An eventless Anthropic stream with an empty final Message gets the
+        same transient retry budget as the chat_completions zero-chunk guard
+        (parity follow-up to #64420)."""
+        from agent.errors import EmptyStreamError
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.anthropic.com",
+            provider="anthropic",
+            model="claude-test",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+
+        empty_message = SimpleNamespace(content=[], stop_reason=None)
+        empty_stream = MagicMock()
+        empty_stream.__enter__ = MagicMock(return_value=empty_stream)
+        empty_stream.__exit__ = MagicMock(return_value=False)
+        empty_stream.__iter__ = MagicMock(side_effect=lambda: iter([]))
+        empty_stream.get_final_message.return_value = empty_message
+
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = empty_stream
+
+        with pytest.raises(EmptyStreamError):
+            agent._interruptible_streaming_api_call({})
+
+        assert agent._anthropic_client.messages.stream.call_count == 3
+        # Anthropic-native cleanup between attempts: rebuild the Anthropic
+        # client, never the OpenAI primary client.
+        assert mock_replace.call_count == 0
+        assert mock_rebuild.call_count == 2
+
+    @patch("run_agent.AIAgent._try_refresh_anthropic_client_credentials")
+    @patch("run_agent.AIAgent._rebuild_anthropic_client")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    def test_anthropic_eventless_sdk_assertion_normalized_to_empty_stream(
+        self, mock_replace, mock_rebuild, mock_refresh,
+    ):
+        """Real-SDK shape: an eventless stream has no message_start, so
+        get_final_message() raises AssertionError (final snapshot is None).
+        That must be normalized to EmptyStreamError and retried as
+        transient — not surface as a raw AssertionError."""
+        from agent.errors import EmptyStreamError
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.anthropic.com",
+            provider="anthropic",
+            model="claude-test",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+
+        empty_stream = MagicMock()
+        empty_stream.__enter__ = MagicMock(return_value=empty_stream)
+        empty_stream.__exit__ = MagicMock(return_value=False)
+        empty_stream.__iter__ = MagicMock(side_effect=lambda: iter([]))
+        empty_stream.get_final_message.side_effect = AssertionError()
+
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = empty_stream
+
+        with pytest.raises(EmptyStreamError):
+            agent._interruptible_streaming_api_call({})
+
+        assert agent._anthropic_client.messages.stream.call_count == 3
+        assert mock_replace.call_count == 0
+        assert mock_rebuild.call_count == 2
+
 
 class TestPartialToolCallWarning:
     """Regression: when a stream dies mid tool-call argument generation after


### PR DESCRIPTION
## Summary

Salvage of #64420 by @pixel4039 (cherry-picked, authorship preserved) plus two maintainer follow-up commits from the review.

**Contributor commit** — `fix(streaming): retry zero-chunk streams`
Introduces `EmptyStreamError(RuntimeError)` in `agent/errors.py`, raises it from the chat_completions zero-chunk guard (unchanged message string, so `classify_api_error` behavior is identical to the old bare `RuntimeError` — verified empirically: `unknown`/retryable for both), and adds `_is_empty_stream` to the stream retry loop's transient set so a stream that yields zero chunks gets the same 3-attempt retry budget as a connection drop.

**Maintainer commit 1** — empty-stream-specific exhaustion message
The exhaustion `_buffer_status` ternary only distinguished parse errors; an exhausted `EmptyStreamError` reported "Connection to provider failed" — factually wrong (HTTP succeeded, the provider sent nothing), sending users chasing network issues instead of provider config. Now a dedicated third branch.

**Maintainer commit 2** — zero-event guard parity for the anthropic_messages path
Sibling-path audit found `_call_anthropic()` had no equivalent guard, and the eventless failure surfaces differently by client:
- Real Anthropic SDK (verified against 0.87.0 source): no `message_start` ⇒ no final-message snapshot ⇒ `get_final_message()` raises a bare `AssertionError` — not in the transient set, so it burned no retries and surfaced raw.
- OpenAI-compat shims: may fabricate a contentless Message with no `stop_reason` (or return `None` under `python -O`), flowing out as a "successful" empty turn.

Both shapes are now normalized to `EmptyStreamError` (transient retry budget). An `AssertionError` *after* events were seen is re-raised raw — a genuine SDK invariant violation must surface, not be masked as transient. A real completed Message always carries `stop_reason`, so the guard cannot fire on legitimate turns (adversarially verified: false positives impossible against the real SDK).

Retry-cost note: a persistently-empty provider now burns 3 stream attempts × 3 main-loop retries (9 requests worst case) vs 3 before — the documented trade-off for surviving transient flakes. The pathological non-SSE-JSON case (#21535) is intercepted earlier by the completed-object check and never reaches the guard. Issue #56516's claimed false positive (reasoning-only stream + finish_reason=length) fails two of the guard's conditions and cannot fire — verified by test.

## Validation

- `tests/run_agent/test_streaming.py`: 47 passed (3 new regression tests: chat_completions zero-chunk retry, anthropic zero-event shim shape, anthropic SDK-AssertionError shape)
- `tests/run_agent/test_stream_stale_circuit_breaker.py` + `tests/agent/test_error_classifier.py` + `tests/run_agent/test_run_agent.py`: 621 passed
- E2E (real `AIAgent` + real retry loop, provider client mocked): 13/13 — all three eventless shapes retried 3×; legit eventless mock with `stop_reason="end_turn"` passes through untouched in 1 attempt; events-seen AssertionError re-raised raw; anthropic path rebuilds the anthropic client between attempts, never the OpenAI primary; classifier parity across all message variants

Closes #64420.
