### PR TITLE
fix(proxy): abort downstream on broken upstream stream

### DIFF
--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -223,15 +223,25 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         )
         await resp.prepare(request)
 
+        stream_failed = False
         try:
             async for chunk in upstream_resp.content.iter_any():
                 if chunk:
                     await resp.write(chunk)
-        except (aiohttp.ClientError, asyncio.CancelledError) as exc:
+        except asyncio.CancelledError:
+            raise
+        except aiohttp.ClientError as exc:
+            stream_failed = True
             logger.warning("proxy: streaming interrupted: %s", exc)
         finally:
             upstream_resp.release()
             await session.close()
+
+        if stream_failed:
+            transport = request.transport
+            if transport is not None:
+                transport.close()
+            return resp
 
         await resp.write_eof()
         return resp

--- a/pr-bodies/proxy-stream-upstream-failure.md
+++ b/pr-bodies/proxy-stream-upstream-failure.md
@@ -1,0 +1,23 @@
+## Summary
+
+`hermes proxy` now aborts the downstream client connection when the upstream streaming response breaks mid-body instead of ending the response with a clean EOF.
+
+## Why
+
+The proxy is a credential-attaching forwarder for OpenAI-compatible streaming calls. Before this change, if the upstream provider sent a partial chunked/SSE response and then dropped the connection without the terminating chunk, the proxy caught the `aiohttp.ClientError`, logged `proxy: streaming interrupted`, and still called `write_eof()` on the downstream response.
+
+That converts a broken upstream stream into a clean client-side EOF. For streaming chat/completions or responses, the caller can treat the truncated output as a successful finished stream instead of retrying or surfacing a provider failure.
+
+## Changes
+
+- Track upstream streaming failures while forwarding the response body.
+- Re-raise local cancellation instead of swallowing it as a streaming interruption.
+- On upstream `aiohttp.ClientError`, release the upstream response/session and close the downstream transport without writing a final chunk.
+- Add a regression test with a fake upstream that sends one SSE frame and then closes the transport before the chunked stream terminates.
+
+## Validation
+
+```text
+python -m pytest tests/hermes_cli/test_proxy.py -q --timeout-method=thread
+40 passed
+```

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -655,10 +655,22 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
         await resp.write_eof()
         return resp
 
+    async def broken_sse(request):
+        resp = web.StreamResponse(
+            status=200, headers={"Content-Type": "text/event-stream"},
+        )
+        await resp.prepare(request)
+        await resp.write(b"data: partial\n\n")
+        transport = request.transport
+        if transport is not None:
+            transport.close()
+        return resp
+
     app = web.Application()
     app.router.add_route("*", "/v1/chat/completions", echo)
     app.router.add_route("*", "/v1/embeddings", echo)
     app.router.add_route("*", "/v1/sse", sse)
+    app.router.add_route("*", "/v1/broken-sse", broken_sse)
     return app
 
 
@@ -739,6 +751,33 @@ def test_server_retries_once_with_adapter_retry_credential_on_401():
                 "Bearer jwt-bearer",
                 "Bearer legacy-bearer",
             ]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_aborts_downstream_when_upstream_stream_breaks():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="real-portal-key",
+            allowed=["/broken-sse"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/broken-sse",
+                    json={"model": "Hermes-4-70B", "stream": True},
+                ) as resp:
+                    assert resp.status == 200
+                    with pytest.raises(aiohttp.ClientPayloadError):
+                        await resp.text()
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()


### PR DESCRIPTION
## Summary

`hermes proxy` now aborts the downstream client connection when the upstream streaming response breaks mid-body instead of ending the response with a clean EOF.

## Why

The proxy is a credential-attaching forwarder for OpenAI-compatible streaming calls. Before this change, if the upstream provider sent a partial chunked/SSE response and then dropped the connection without the terminating chunk, the proxy caught the `aiohttp.ClientError`, logged `proxy: streaming interrupted`, and still called `write_eof()` on the downstream response.

That converts a broken upstream stream into a clean client-side EOF. For streaming chat/completions or responses, the caller can treat the truncated output as a successful finished stream instead of retrying or surfacing a provider failure.

## Changes

- Track upstream streaming failures while forwarding the response body.
- Re-raise local cancellation instead of swallowing it as a streaming interruption.
- On upstream `aiohttp.ClientError`, release the upstream response/session and close the downstream transport without writing a final chunk.
- Add a regression test with a fake upstream that sends one SSE frame and then closes the transport before the chunked stream terminates.

## Validation

```text
python -m pytest tests/hermes_cli/test_proxy.py -q --timeout-method=thread
40 passed
```
