### PR TITLE
fix(mcp): materialize ResourceLink/EmbeddedResource/Audio blocks instead of dropping them (salvage #64061)

### DIFF
--- a/tests/tools/test_mcp_resource_content.py
+++ b/tests/tools/test_mcp_resource_content.py
@@ -70,7 +70,9 @@ class TestRenderResourceBlock:
         )
         out = _render_mcp_resource_block(link, "slack")
         assert "slack://files/F123" in out
-        assert "slack_read_resource" in out
+        # Must be the real wire name (mcp__<server>__read_resource), not a
+        # made-up "<server>_read_resource" the agent can't actually call.
+        assert "mcp__slack__read_resource" in out
         assert "report.pdf" in out
 
     def test_oversized_blob_fails_explicitly_without_writing(self, doc_cache, monkeypatch):
@@ -208,3 +210,72 @@ class TestToolResultLoopOrdering:
             mimeType="application/pdf",
         )
         assert _cache_mcp_image_block(block) == ""
+
+
+class TestErrorPathResourceText:
+    """isError payloads must surface EmbeddedResource text, not drop it."""
+
+    @pytest.fixture()
+    def _handler(self, monkeypatch):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch as mock_patch
+
+        from tools import mcp_tool
+
+        fake_session = MagicMock()
+        fake_server = SimpleNamespace(session=fake_session, _rpc_lock=None)
+
+        def _fake_run_on_mcp_loop(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            loop = asyncio.new_event_loop()
+            try:
+                async def _install_lock_and_run():
+                    for srv in list(mcp_tool._servers.values()):
+                        if getattr(srv, "_rpc_lock", None) is None:
+                            srv._rpc_lock = asyncio.Lock()
+                    return await coro
+
+                return loop.run_until_complete(_install_lock_and_run())
+            finally:
+                loop.close()
+
+        with mock_patch.dict(mcp_tool._servers, {"test-server": fake_server}), \
+             mock_patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_fake_run_on_mcp_loop):
+            fake_session.call_tool = AsyncMock()
+            yield fake_session, mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+
+    def test_error_embedded_resource_text_surfaced(self, _handler):
+        from unittest.mock import AsyncMock
+
+        session, handler = _handler
+        res = SimpleNamespace(uri="mem://err", mimeType="text/plain",
+                              text="quota exceeded for workspace W1", blob=None)
+        session.call_tool = AsyncMock(return_value=SimpleNamespace(
+            content=[_embedded(res)], isError=True, structuredContent=None,
+        ))
+        data = json.loads(handler({}))
+        assert "quota exceeded for workspace W1" in data["error"]
+
+    def test_error_mixed_text_and_resource(self, _handler):
+        from unittest.mock import AsyncMock
+
+        session, handler = _handler
+        res = SimpleNamespace(uri="mem://err", mimeType="text/plain",
+                              text=" — details in resource", blob=None)
+        session.call_tool = AsyncMock(return_value=SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="tool failed"), _embedded(res)],
+            isError=True, structuredContent=None,
+        ))
+        data = json.loads(handler({}))
+        assert "tool failed" in data["error"]
+        assert "details in resource" in data["error"]
+
+    def test_error_with_no_text_blocks_falls_back(self, _handler):
+        from unittest.mock import AsyncMock
+
+        session, handler = _handler
+        session.call_tool = AsyncMock(return_value=SimpleNamespace(
+            content=[], isError=True, structuredContent=None,
+        ))
+        data = json.loads(handler({}))
+        assert data["error"] == "MCP tool returned an error"

--- a/tests/tools/test_mcp_resource_content.py
+++ b/tests/tools/test_mcp_resource_content.py
@@ -1,0 +1,210 @@
+"""Tests for MCP ResourceLink / EmbeddedResource / AudioContent handling.
+
+Regression coverage for a customer report (2026-07): non-image binary
+resources returned through MCP resource blocks were silently dropped from
+tool results, so a PDF-returning MCP tool appeared to return metadata only.
+"""
+
+import base64
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+PDF_BYTES = b"%PDF-1.4 fake pdf payload for tests"
+
+
+def _blob_resource(data: bytes, uri="slack://files/F123/report.pdf", mime="application/pdf"):
+    return SimpleNamespace(
+        uri=uri,
+        mimeType=mime,
+        blob=base64.b64encode(data).decode("ascii"),
+        text=None,
+    )
+
+
+def _embedded(resource):
+    return SimpleNamespace(type="resource", resource=resource)
+
+
+@pytest.fixture()
+def doc_cache(tmp_path, monkeypatch):
+    """Point the document cache at a temp dir."""
+    import gateway.platforms.base as base
+
+    monkeypatch.setattr(base, "DOCUMENT_CACHE_DIR", tmp_path)
+    monkeypatch.setenv("HERMES_DOCUMENT_CACHE_DIR", str(tmp_path))
+    # _resolve_cache_dir consults the module constant; patching the constant
+    # is sufficient because the import-default comparison detects the change.
+    return tmp_path
+
+
+class TestRenderResourceBlock:
+    def test_embedded_pdf_blob_is_materialized(self, doc_cache):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        out = _render_mcp_resource_block(_embedded(_blob_resource(PDF_BYTES)), "slack")
+        assert "saved to" in out
+        assert "application/pdf" in out
+        # Extract path and verify bytes round-trip
+        path = out.split("saved to ", 1)[1].split(" (", 1)[0]
+        with open(path, "rb") as fh:
+            assert fh.read() == PDF_BYTES
+        assert "report.pdf" in path
+
+    def test_embedded_text_resource_is_inlined(self):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        res = SimpleNamespace(uri="mem://notes", mimeType="text/plain", text="hello world", blob=None)
+        assert _render_mcp_resource_block(_embedded(res), "srv") == "hello world"
+
+    def test_resource_link_preserves_uri_and_points_at_reader(self):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        link = SimpleNamespace(
+            type="resource_link",
+            uri="slack://files/F123",
+            name="report.pdf",
+            mimeType="application/pdf",
+        )
+        out = _render_mcp_resource_block(link, "slack")
+        assert "slack://files/F123" in out
+        assert "slack_read_resource" in out
+        assert "report.pdf" in out
+
+    def test_oversized_blob_fails_explicitly_without_writing(self, doc_cache, monkeypatch):
+        import tools.mcp_tool as m
+
+        monkeypatch.setattr(m, "_MCP_RESOURCE_MAX_BYTES", 8)
+        out = m._render_mcp_resource_block(_embedded(_blob_resource(PDF_BYTES)), "srv")
+        assert "too large" in out
+        assert not list(doc_cache.glob("doc_*"))
+
+    def test_malformed_base64_fails_explicitly(self):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        res = SimpleNamespace(uri="x://y", mimeType="application/pdf", blob="!!!not-base64!!!", text=None)
+        out = _render_mcp_resource_block(_embedded(res), "srv")
+        assert "could not be decoded" in out
+
+    def test_non_resource_block_returns_empty(self):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        assert _render_mcp_resource_block(SimpleNamespace(type="text", text="hi"), "srv") == ""
+
+    def test_path_traversal_uri_is_neutralized(self, doc_cache):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        res = _blob_resource(PDF_BYTES, uri="evil://host/../../etc/passwd")
+        out = _render_mcp_resource_block(_embedded(res), "srv")
+        assert "saved to" in out
+        path = out.split("saved to ", 1)[1].split(" (", 1)[0]
+        assert str(doc_cache) in path
+        assert "/etc/passwd" not in path
+
+
+class TestResourceFilename:
+    def test_uri_last_segment_used(self):
+        from tools.mcp_tool import _mcp_resource_filename
+
+        assert _mcp_resource_filename("slack://f/ABC/quarterly.pdf", "application/pdf") == "quarterly.pdf"
+
+    def test_fallback_to_mime_extension(self):
+        from tools.mcp_tool import _mcp_resource_filename
+
+        name = _mcp_resource_filename("", "application/pdf")
+        assert name.endswith(".pdf")
+
+    def test_dotdot_rejected(self):
+        from tools.mcp_tool import _mcp_resource_filename
+
+        assert _mcp_resource_filename("x://y/..", "application/pdf") != ".."
+
+    def test_control_chars_stripped(self):
+        from tools.mcp_tool import _mcp_resource_filename
+
+        name = _mcp_resource_filename("x://h/report.pdf%0Ainjected%1b[31m", "application/pdf")
+        assert "\n" not in name and "\x1b" not in name
+
+    def test_long_filename_capped_preserving_extension(self):
+        from tools.mcp_tool import _mcp_resource_filename
+
+        name = _mcp_resource_filename("x://h/" + "a" * 500 + ".pdf", "application/pdf")
+        assert len(name) <= 150
+        assert name.endswith(".pdf")
+
+
+class TestPreDecodeSizeCap:
+    def test_oversized_b64_rejected_before_decode(self, monkeypatch):
+        import tools.mcp_tool as m
+
+        monkeypatch.setattr(m, "_MCP_RESOURCE_MAX_B64_CHARS", 16)
+        res = SimpleNamespace(
+            uri="x://y/big.pdf", mimeType="application/pdf",
+            blob="A" * 100, text=None,
+        )
+        called = []
+        monkeypatch.setattr(base64, "b64decode", lambda *a, **k: called.append(1))
+        out = m._render_mcp_resource_block(_embedded(res), "srv")
+        assert "too large" in out
+        assert not called
+
+
+class TestAudioBlock:
+    def test_non_audio_returns_empty(self):
+        from tools.mcp_tool import _cache_mcp_audio_block
+
+        block = SimpleNamespace(data=base64.b64encode(b"x").decode(), mimeType="application/pdf")
+        assert _cache_mcp_audio_block(block) == ""
+
+    def test_audio_block_cached_as_media(self, tmp_path, monkeypatch):
+        import gateway.platforms.base as base
+        from tools.mcp_tool import _cache_mcp_audio_block
+
+        monkeypatch.setattr(base, "AUDIO_CACHE_DIR", tmp_path)
+        block = SimpleNamespace(
+            data=base64.b64encode(b"RIFFfakewav").decode(),
+            mimeType="audio/wav",
+        )
+        out = _cache_mcp_audio_block(block)
+        assert out.startswith("MEDIA:")
+
+
+class TestToolResultLoopOrdering:
+    def test_mixed_blocks_preserve_order(self, doc_cache):
+        """Simulate the tool-result block loop with text + pdf resource."""
+        from tools.mcp_tool import (
+            _cache_mcp_image_block,
+            _cache_mcp_audio_block,
+            _render_mcp_resource_block,
+        )
+
+        blocks = [
+            SimpleNamespace(type="text", text="File ID: F123\nMIME Type: application/pdf"),
+            _embedded(_blob_resource(PDF_BYTES)),
+        ]
+        parts = []
+        for block in blocks:
+            if getattr(block, "text", None):
+                parts.append(block.text)
+                continue
+            tag = _cache_mcp_image_block(block) or _cache_mcp_audio_block(block)
+            if tag:
+                parts.append(tag)
+                continue
+            rendered = _render_mcp_resource_block(block, "slack")
+            if rendered:
+                parts.append(rendered)
+        assert len(parts) == 2
+        assert parts[0].startswith("File ID")
+        assert "saved to" in parts[1]
+
+    def test_existing_image_behavior_unchanged(self):
+        from tools.mcp_tool import _cache_mcp_image_block
+
+        block = SimpleNamespace(
+            data=base64.b64encode(b"some bytes").decode("ascii"),
+            mimeType="application/pdf",
+        )
+        assert _cache_mcp_image_block(block) == ""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -102,6 +102,7 @@ import shutil
 import sys
 import threading
 import time
+from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
 from typing import Any, Coroutine, Dict, List, Optional
@@ -712,6 +713,165 @@ def _cache_mcp_image_block(block) -> str:
         return ""
 
     return f"MEDIA:{image_path}"
+
+
+# ---------------------------------------------------------------------------
+# MCP resource blocks (ResourceLink / EmbeddedResource / AudioContent)
+# ---------------------------------------------------------------------------
+
+# Hard cap on decoded resource bytes materialized from an MCP tool result.
+# Prevents a misbehaving server from filling the cache disk via one block.
+_MCP_RESOURCE_MAX_BYTES = 50 * 1024 * 1024
+
+# Base64 expands raw bytes by ~4/3; reject oversized payloads before decoding
+# so a multi-GB blob string is never transiently doubled in memory.
+_MCP_RESOURCE_MAX_B64_CHARS = _MCP_RESOURCE_MAX_BYTES * 4 // 3 + 4
+
+
+def _mcp_resource_filename(uri: str, mime_type: str) -> str:
+    """Derive a safe display filename for an MCP resource.
+
+    Only the last path segment of the URI is considered, and only as a
+    *name hint* — `cache_document_from_bytes` re-sanitizes and prefixes it,
+    so remote path components can't influence the cache location.
+    """
+    import mimetypes
+    import re as _re
+    from pathlib import Path
+    from urllib.parse import urlparse, unquote
+
+    name = ""
+    if uri:
+        try:
+            name = Path(unquote(urlparse(str(uri)).path or "")).name
+        except (ValueError, TypeError):
+            name = ""
+    # Strip control characters (newlines/ANSI escapes from hostile URIs would
+    # otherwise land in the filename and the transcript marker) and cap the
+    # length, preserving the extension.
+    name = _re.sub(r"[\x00-\x1f\x7f]", "", name).strip()
+    if len(name) > 150:
+        stem, dot, ext = name.rpartition(".")
+        if dot and 0 < len(ext) <= 12:
+            name = stem[: 150 - len(ext) - 1] + "." + ext
+        else:
+            name = name[:150]
+    if not name or name in {".", ".."}:
+        normalized = (mime_type or "").split(";", 1)[0].strip().lower()
+        ext = mimetypes.guess_extension(normalized) or ".bin"
+        name = f"resource{ext}"
+    return name
+
+
+def _cache_mcp_audio_block(block) -> str:
+    """Cache an MCP ``AudioContent`` block and return a ``MEDIA:`` tag.
+
+    Returns an empty string when *block* is not audio or on any failure —
+    same fail-open contract as ``_cache_mcp_image_block``.
+    """
+    import base64
+
+    data = getattr(block, "data", None)
+    mime_type = str(getattr(block, "mimeType", None) or "").split(";", 1)[0].strip().lower()
+    if data is None or not mime_type.startswith("audio/"):
+        return ""
+    if len(data) > _MCP_RESOURCE_MAX_B64_CHARS:
+        return f"[MCP audio resource too large to cache: ~{len(data) * 3 // 4} bytes]"
+    try:
+        raw_bytes = base64.b64decode(data)
+    except (TypeError, ValueError) as exc:
+        logger.warning("MCP audio block decode failed (%s): %s", mime_type, exc)
+        return ""
+    if len(raw_bytes) > _MCP_RESOURCE_MAX_BYTES:
+        return f"[MCP audio resource too large to cache: {len(raw_bytes)} bytes]"
+    try:
+        from gateway.platforms.base import cache_audio_from_bytes
+        import mimetypes
+
+        ext = (
+            {"audio/wav": ".wav", "audio/x-wav": ".wav", "audio/wave": ".wav"}.get(mime_type)
+            or mimetypes.guess_extension(mime_type)
+            or ".ogg"
+        )
+        audio_path = cache_audio_from_bytes(raw_bytes, ext=ext)
+    except ImportError:
+        logger.debug("MCP audio caching skipped — gateway.platforms.base unavailable")
+        return ""
+    except Exception as exc:
+        logger.warning("MCP audio block cache failed: %s", exc)
+        return ""
+    return f"MEDIA:{audio_path}"
+
+
+def _render_mcp_resource_block(block, server_name: str = "") -> str:
+    """Render an MCP ``ResourceLink`` or ``EmbeddedResource`` block as text.
+
+    - ``EmbeddedResource`` with text contents → the text itself.
+    - ``EmbeddedResource`` with blob contents → bytes are decoded (size-capped)
+      and materialized into the Hermes document cache; returns a marker with
+      the local path so file/terminal tools can consume it.
+    - ``ResourceLink`` → the URI plus a pointer at the server's read_resource
+      tool. No network fetch happens here; the link is only readable through
+      the originating MCP session.
+
+    Returns an empty string for non-resource blocks. Failures are logged and
+    reported inline rather than silently dropping the block.
+    """
+    block_type = getattr(block, "type", "")
+
+    if block_type == "resource_link" or (
+        hasattr(block, "uri") and not hasattr(block, "resource") and block_type != "text"
+    ):
+        uri = getattr(block, "uri", None)
+        if not uri:
+            return ""
+        name = getattr(block, "name", "") or ""
+        mime = getattr(block, "mimeType", "") or ""
+        details = f"uri={uri}"
+        if name:
+            details += f", name={name}"
+        if mime:
+            details += f", mimeType={mime}"
+        reader = f"{server_name}_read_resource" if server_name else "the MCP server's read_resource tool"
+        return f"[MCP resource link: {details} — fetch it with {reader}]"
+
+    resource = getattr(block, "resource", None)
+    if resource is None:
+        return ""
+
+    text = getattr(resource, "text", None)
+    if text is not None:
+        return str(text)
+
+    blob = getattr(resource, "blob", None)
+    if blob is None:
+        return ""
+
+    import base64
+
+    uri = str(getattr(resource, "uri", "") or "")
+    mime = str(getattr(resource, "mimeType", "") or "")
+    if len(blob) > _MCP_RESOURCE_MAX_B64_CHARS:
+        return f"[MCP embedded resource too large to cache: ~{len(blob) * 3 // 4} bytes, uri={uri}]"
+    try:
+        raw_bytes = base64.b64decode(blob)
+    except (TypeError, ValueError) as exc:
+        logger.warning("MCP embedded resource decode failed (%s): %s", mime or uri, exc)
+        return f"[MCP embedded resource could not be decoded: {mime or uri}]"
+    if len(raw_bytes) > _MCP_RESOURCE_MAX_BYTES:
+        return f"[MCP embedded resource too large to cache: {len(raw_bytes)} bytes, uri={uri}]"
+    try:
+        from gateway.platforms.base import cache_document_from_bytes
+
+        path = cache_document_from_bytes(raw_bytes, _mcp_resource_filename(uri, mime))
+    except ImportError:
+        logger.debug("MCP resource caching skipped — gateway.platforms.base unavailable")
+        return f"[MCP embedded resource received ({len(raw_bytes)} bytes, {mime or 'unknown type'}) but document cache unavailable in this process]"
+    except Exception as exc:
+        logger.warning("MCP embedded resource cache failed: %s", exc)
+        return f"[MCP embedded resource could not be cached: {mime or uri}]"
+    detail = mime or "unknown type"
+    return f"[MCP resource saved to {path} ({detail}, {len(raw_bytes)} bytes) — read it with read_file or terminal tools]"
 
 
 # ---------------------------------------------------------------------------
@@ -3974,6 +4134,34 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:
                     parts.append(image_tag)
+                    continue
+                audio_tag = _cache_mcp_audio_block(block)
+                if audio_tag:
+                    parts.append(audio_tag)
+                    continue
+                # ResourceLink / EmbeddedResource blocks (PDFs, archives,
+                # office docs, ...). Previously these were silently dropped,
+                # so document-oriented MCP tools appeared to return metadata
+                # only (enterprise customer report, 2026-07).
+                resource_text = _render_mcp_resource_block(block, server_name)
+                if resource_text:
+                    parts.append(resource_text)
+                    continue
+                # Benign empty renders (empty text blocks, empty text
+                # resources, audio in a process without the gateway cache)
+                # aren't data loss — log at debug. Warn only for genuinely
+                # unrecognized block shapes.
+                block_type = getattr(block, "type", None) or type(block).__name__
+                if block_type in {"text", "resource", "audio", "image"}:
+                    logger.debug(
+                        "MCP %s: content block type %r rendered empty",
+                        server_name, block_type,
+                    )
+                else:
+                    logger.warning(
+                        "MCP %s: dropping unsupported content block type %r",
+                        server_name, block_type,
+                    )
             text_result = "\n".join(parts) if parts else ""
 
             # Combine content + structuredContent when both are present.
@@ -4124,10 +4312,17 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             parts: List[str] = []
             contents = result.contents if hasattr(result, "contents") else []
             for block in contents:
-                if hasattr(block, "text"):
+                if getattr(block, "text", None) is not None:
                     parts.append(block.text)
-                elif hasattr(block, "blob"):
-                    parts.append(f"[binary data, {len(block.blob)} bytes]")
+                elif getattr(block, "blob", None) is not None:
+                    # Materialize binary resource contents into the document
+                    # cache instead of discarding them (same contract as
+                    # EmbeddedResource blocks in tool results).
+                    rendered = _render_mcp_resource_block(
+                        SimpleNamespace(type="resource", resource=block),
+                        server_name,
+                    )
+                    parts.append(rendered or f"[binary data, {len(block.blob)} bytes]")
             return json.dumps({"result": "\n".join(parts) if parts else ""}, ensure_ascii=False)
 
         def _call_once():

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -832,7 +832,11 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
             details += f", name={name}"
         if mime:
             details += f", mimeType={mime}"
-        reader = f"{server_name}_read_resource" if server_name else "the MCP server's read_resource tool"
+        reader = (
+            mcp_prefixed_tool_name(server_name, "read_resource")
+            if server_name
+            else "the MCP server's read_resource tool"
+        )
         return f"[MCP resource link: {details} — fetch it with {reader}]"
 
     resource = getattr(block, "resource", None)
@@ -4107,8 +4111,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             if result.isError:
                 error_text = ""
                 for block in (result.content or []):
-                    if hasattr(block, "text"):
+                    if getattr(block, "text", None):
                         error_text += block.text
+                        continue
+                    # EmbeddedResource blocks inside error payloads carry
+                    # their text under .resource.text — previously dropped,
+                    # leaving a bare "MCP tool returned an error".
+                    res_text = getattr(getattr(block, "resource", None), "text", None)
+                    if res_text:
+                        error_text += str(res_text)
                 return json.dumps({
                     "error": _sanitize_error(
                         error_text or "MCP tool returned an error"


### PR DESCRIPTION
## Summary

MCP tool results carrying `ResourceLink`, `EmbeddedResource`, or `AudioContent` blocks are now materialized instead of silently dropped — a PDF-returning MCP tool no longer appears to return metadata only.

Salvage of #64061 by @victor-kyriazakos (cherry-picked onto current main, authorship preserved), plus two follow-up fixes on top.

## Changes

**Cherry-picked from #64061** (@victor-kyriazakos):
- `tools/mcp_tool.py`: new `_render_mcp_resource_block()` — embedded blob resources are decoded (50 MB cap, enforced on b64 length *before* decode) and written to the document cache via existing `cache_document_from_bytes()`; text resources inline; `ResourceLink` blocks keep URI/name/MIME with a pointer to the server's read_resource tool (no network fetch); `AudioContent` cached via `cache_audio_from_bytes()` as a `MEDIA:` tag; unrecognized shapes logged instead of dropped.
- `read_resource` handler: blob contents materialized instead of `"[binary data, N bytes]"`.
- Filenames from resource URIs: last path segment only, control chars stripped, 150-char cap, traversal-safe.
- 26 tests including hostile-input negatives (traversal, control chars, oversize, malformed base64).

**Follow-ups (ours)**:
- ResourceLink markers now point at the real wire name `mcp__<server>__read_resource` (via `mcp_prefixed_tool_name()`) instead of a nonexistent `<server>_read_resource` the agent could hallucinate-call.
- `isError` path now surfaces `EmbeddedResource` text instead of dropping it — error payloads carried in resources no longer collapse to a bare "MCP tool returned an error". (Same-class gap flagged in #64061's follow-ups and independently fixed in #63576 by @alauer — credited.)
- 3 new error-path tests.

## Validation

| Check | Result |
|---|---|
| `tests/tools -k mcp` (full MCP suite) | pass |
| New resource-content tests (29) | pass |
| E2E: PDF blob → document cache byte round-trip (isolated HERMES_HOME) | pass |
| E2E: hostile URI (traversal + control chars) stays inside cache dir | pass |
| E2E: ResourceLink marker carries real `mcp__slack__read_resource` name | pass |
| E2E: oversized blob rejected pre-decode, nothing written | pass |

## Duplicate cluster

Same underlying bug reported/fixed in #29962 (@haha0815, earliest), #31356 (@Tranquil-Flow), #38463 (@janrenz), #50999 (@kingofkillers91), #63576 (@alauer). This PR is the most complete implementation — the only one that materializes binary payloads and covers ResourceLink + Audio with size caps and hostile-input tests. The others will be closed with credit.

## Infographic

![MCP resource blocks infographic](https://v3b.fal.media/files/b/0aa240b5/oodGxac7KM28g-f1XEU7Q_PZAJpH9o.png)
