### PR TITLE
fix(tools): don't report platform-restricted toolsets as enabled

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4251,7 +4251,9 @@ def tools_disable_enable_command(args):
 
     successful = [
         t for t in targets
-        if t not in unknown_toolsets and (":" not in t or t.split(":")[0] not in failed_servers)
+        if t not in unknown_toolsets
+        and t not in restricted_targets
+        and (":" not in t or t.split(":")[0] not in failed_servers)
     ]
     if successful:
         verb = "Disabled" if action == "disable" else "Enabled"

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -212,6 +212,31 @@ class TestToolsValidation:
         assert "web" in saved["platform_toolsets"]["cli"]
         assert "memory" in saved["platform_toolsets"]["cli"]
 
+    def test_restricted_toolset_not_reported_as_enabled(self, capsys):
+        config = {"platform_toolsets": {"telegram": ["web"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["discord"], platform="telegram")
+            )
+        out = capsys.readouterr().out
+        assert "not available on platform 'telegram'" in out
+        assert "Enabled" not in out
+
+    def test_mixed_allowed_and_restricted_reports_allowed_only(self, capsys):
+        config = {"platform_toolsets": {"telegram": []}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["web", "discord"], platform="telegram")
+            )
+        out = capsys.readouterr().out
+        assert "Enabled: web" in out
+        assert "discord" not in out.split("Enabled:")[-1]
+        saved = mock_save.call_args[0][0]
+        assert "web" in saved["platform_toolsets"]["telegram"]
+        assert "discord" not in saved["platform_toolsets"]["telegram"]
+
     def test_mixed_valid_and_invalid_applies_valid_only(self):
         config = {"platform_toolsets": {"cli": ["web", "memory"]}}
         with patch("hermes_cli.tools_config.load_config", return_value=config), \


### PR DESCRIPTION
## What does this PR do?

`hermes tools enable <toolset> --platform <p>` correctly rejects platform-restricted toolsets (e.g. `discord`, which is restricted to the Discord platform via `_TOOLSET_PLATFORM_RESTRICTIONS`) — it prints the *"Toolset 'discord' is not available on platform 'telegram'"* error and filters the toolset out of `toolset_targets`, so nothing is written to the config.

But the success summary at the end of `tools_disable_enable_command` is built from the **raw `targets` list** and only excludes unknown toolsets and failed MCP servers:

```python
successful = [
    t for t in targets
    if t not in unknown_toolsets and (":" not in t or t.split(":")[0] not in failed_servers)
]
```

So the same invocation prints both messages back to back:

```
$ hermes tools enable discord --platform telegram
✗ Toolset 'discord' is not available on platform 'telegram' (only: discord)
✓ Enabled: discord
```

The user is told the toolset was enabled when it was never written to the config. This PR excludes `restricted_targets` from the summary, matching how the other two rejection paths (unknown toolsets, missing MCP servers) are already handled.

## Related Issue

No existing issue — found by reading the three rejection paths in `tools_disable_enable_command` and noticing only two of them are reflected in the success summary.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/tools_config.py`: add `t not in restricted_targets` to the `successful` comprehension.
- `tests/hermes_cli/test_tools_disable_enable.py`: two regression tests — a restricted toolset alone must not print `Enabled`, and a mixed allowed+restricted invocation must report only the allowed toolset and only write the allowed one to config. Both fail before the fix.

## How to Test

1. `python -m pytest tests/hermes_cli/test_tools_disable_enable.py -q` — 19 passed (17 pre-existing + 2 new).
2. Revert the `hermes_cli/tools_config.py` hunk and re-run: the two new tests fail with `Enabled: discord` in the captured output.
3. Manual: `hermes tools enable discord --platform telegram` — prints only the restriction error, no success line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest is #29626, which fixes `--platform` scoping for **MCP exclusions** on the write path — different bug, no overlap with the built-in-toolset success summary)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 (Python 3.14)

### Documentation & Housekeeping

- [x] Docs — N/A (no behavior documented for the summary line)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered: pure list filtering, platform-independent
- [x] Tool descriptions/schemas — N/A


## Infographic

![honest-cli-summaries](https://v3b.fal.media/files/b/0aa2752a/HYnh78wIph6GrMlxN8diu_WYShpUYJ.png)
