### PR TITLE
fix(email): restore gateway setup wizard

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1237,19 +1237,143 @@ async def _standalone_send(
 
 
 def _is_connected(config) -> bool:
-    """Email is connected when an address is configured (in PlatformConfig.extra
-    or via EMAIL_ADDRESS). Mirrors the legacy
-    _PLATFORM_CONNECTED_CHECKERS[Platform.EMAIL] = bool(extra.get('address'))."""
-    extra = getattr(config, "extra", {}) or {}
-    if extra.get("address"):
-        return True
+    """Return whether all credentials required by the Email adapter are set."""
     import hermes_cli.gateway as gateway_mod
-    return bool((gateway_mod.get_env_value("EMAIL_ADDRESS") or "").strip())
+
+    extra = getattr(config, "extra", {}) or {}
+    address = gateway_mod.get_env_value("EMAIL_ADDRESS") or extra.get("address", "")
+    password = gateway_mod.get_env_value("EMAIL_PASSWORD") or ""
+    imap_host = gateway_mod.get_env_value("EMAIL_IMAP_HOST") or extra.get("imap_host", "")
+    smtp_host = gateway_mod.get_env_value("EMAIL_SMTP_HOST") or extra.get("smtp_host", "")
+    return all(str(value).strip() for value in (address, password, imap_host, smtp_host))
 
 
 def _build_adapter(config):
     """Factory wrapper that constructs EmailAdapter from a PlatformConfig."""
     return EmailAdapter(config)
+
+
+def interactive_setup() -> None:
+    """Guide the user through configuring the Email gateway adapter."""
+    from hermes_cli.cli_output import (
+        print_header,
+        print_info,
+        print_success,
+        print_warning,
+        prompt,
+        prompt_yes_no,
+    )
+    from hermes_cli.config import get_env_value, remove_env_value, save_env_value
+
+    print_header("Email")
+
+    existing = {
+        "EMAIL_ADDRESS": get_env_value("EMAIL_ADDRESS") or "",
+        "EMAIL_PASSWORD": get_env_value("EMAIL_PASSWORD") or "",
+        "EMAIL_IMAP_HOST": get_env_value("EMAIL_IMAP_HOST") or "",
+        "EMAIL_SMTP_HOST": get_env_value("EMAIL_SMTP_HOST") or "",
+    }
+    if all(value.strip() for value in existing.values()):
+        print_info("Email: already configured")
+        if not prompt_yes_no("Reconfigure Email?", False):
+            return
+
+    print_info("Use a dedicated mailbox with IMAP enabled.")
+    print_info("Gmail and other 2FA accounts require an app password.")
+    print_info(
+        "Guide: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/email"
+    )
+    print()
+
+    address = prompt("Email address", default=existing["EMAIL_ADDRESS"] or None)
+    password = prompt("Email password / app password", password=True)
+    if not password:
+        password = existing["EMAIL_PASSWORD"]
+
+    domain = address.rpartition("@")[2].lower()
+    default_imap = existing["EMAIL_IMAP_HOST"]
+    default_smtp = existing["EMAIL_SMTP_HOST"]
+    if not default_imap and domain in {"gmail.com", "googlemail.com"}:
+        default_imap = "imap.gmail.com"
+    if not default_smtp and domain in {"gmail.com", "googlemail.com"}:
+        default_smtp = "smtp.gmail.com"
+    if not default_imap and domain in {"outlook.com", "hotmail.com", "live.com"}:
+        default_imap = "outlook.office365.com"
+    if not default_smtp and domain in {"outlook.com", "hotmail.com", "live.com"}:
+        default_smtp = "smtp.office365.com"
+
+    imap_host = prompt("IMAP host", default=default_imap or None)
+    smtp_host = prompt("SMTP host", default=default_smtp or None)
+
+    required = {
+        "email address": address,
+        "password": password,
+        "IMAP host": imap_host,
+        "SMTP host": smtp_host,
+    }
+    missing = [label for label, value in required.items() if not value.strip()]
+    if missing:
+        print_warning(
+            f"Email setup incomplete (missing {', '.join(missing)}); no changes saved."
+        )
+        return
+
+    save_env_value("EMAIL_ADDRESS", address)
+    save_env_value("EMAIL_PASSWORD", password)
+    save_env_value("EMAIL_IMAP_HOST", imap_host)
+    save_env_value("EMAIL_SMTP_HOST", smtp_host)
+
+    imap_port = prompt(
+        "IMAP port", default=get_env_value("EMAIL_IMAP_PORT") or "993"
+    )
+    smtp_port = prompt(
+        "SMTP port", default=get_env_value("EMAIL_SMTP_PORT") or "587"
+    )
+    if imap_port:
+        save_env_value("EMAIL_IMAP_PORT", imap_port)
+    if smtp_port:
+        save_env_value("EMAIL_SMTP_PORT", smtp_port)
+
+    print()
+    print_info("Restrict senders to avoid processing unrelated inbox mail.")
+    allowed_users = prompt(
+        "Allowed sender addresses (comma-separated)",
+        default=get_env_value("EMAIL_ALLOWED_USERS") or None,
+    )
+    truthy = {"true", "1", "yes"}
+    email_allow_all = (get_env_value("EMAIL_ALLOW_ALL_USERS") or "").strip().lower() in truthy
+    global_allow_all = (get_env_value("GATEWAY_ALLOW_ALL_USERS") or "").strip().lower() in truthy
+    if allowed_users:
+        normalized_users = ",".join(
+            address.strip() for address in allowed_users.split(",") if address.strip()
+        )
+        save_env_value("EMAIL_ALLOWED_USERS", normalized_users)
+        if email_allow_all:
+            remove_env_value("EMAIL_ALLOW_ALL_USERS")
+        print_success("Email sender allowlist configured.")
+    elif email_allow_all:
+        if prompt_yes_no(
+            "Open access is enabled. Keep accepting email from any sender?", False
+        ):
+            print_warning("Email open access remains enabled — any sender can use the bot.")
+        else:
+            remove_env_value("EMAIL_ALLOW_ALL_USERS")
+            print_success("Email open access disabled; unknown senders will be ignored.")
+    elif global_allow_all:
+        print_warning(
+            "Global gateway open access is enabled; any email sender can still use the bot."
+        )
+    else:
+        print_info("No allowlist set; unknown senders will be ignored by default.")
+
+    home_address = prompt(
+        "Home address for cron/notification delivery (optional)",
+        default=get_env_value("EMAIL_HOME_ADDRESS") or None,
+    )
+    if home_address:
+        save_env_value("EMAIL_HOME_ADDRESS", home_address)
+
+    print_success("Email configured!")
 
 
 def register(ctx) -> None:
@@ -1260,8 +1384,14 @@ def register(ctx) -> None:
         adapter_factory=_build_adapter,
         check_fn=check_email_requirements,
         is_connected=_is_connected,
-        required_env=["EMAIL_ADDRESS", "EMAIL_PASSWORD", "EMAIL_SMTP_HOST"],
+        required_env=[
+            "EMAIL_ADDRESS",
+            "EMAIL_PASSWORD",
+            "EMAIL_IMAP_HOST",
+            "EMAIL_SMTP_HOST",
+        ],
         install_hint="Email uses the Python stdlib (smtplib/imaplib) — no extra deps",
+        setup_fn=interactive_setup,
         allowed_users_env="EMAIL_ALLOWED_USERS",
         allow_all_env="EMAIL_ALLOW_ALL_USERS",
         cron_deliver_env_var="EMAIL_HOME_ADDRESS",

--- a/tests/gateway/test_email_plugin_setup.py
+++ b/tests/gateway/test_email_plugin_setup.py
@@ -1,0 +1,178 @@
+"""Regression tests for the Email gateway plugin setup flow."""
+
+from types import SimpleNamespace
+
+from plugins.platforms.email import adapter as email_adapter
+
+
+class _RegistrationContext:
+    def __init__(self):
+        self.kwargs = None
+
+    def register_platform(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_email_plugin_registers_complete_interactive_setup():
+    ctx = _RegistrationContext()
+
+    email_adapter.register(ctx)
+
+    assert ctx.kwargs["setup_fn"] is email_adapter.interactive_setup
+    assert ctx.kwargs["required_env"] == [
+        "EMAIL_ADDRESS",
+        "EMAIL_PASSWORD",
+        "EMAIL_IMAP_HOST",
+        "EMAIL_SMTP_HOST",
+    ]
+
+
+def test_email_connection_status_requires_complete_configuration(monkeypatch):
+    import hermes_cli.gateway as gateway
+
+    values = {"EMAIL_ADDRESS": "agent@example.com"}
+    monkeypatch.setattr(gateway, "get_env_value", lambda name: values.get(name, ""))
+
+    assert email_adapter._is_connected(object()) is False
+
+    values.update(
+        {
+            "EMAIL_PASSWORD": "app-password",
+            "EMAIL_IMAP_HOST": "imap.example.com",
+            "EMAIL_SMTP_HOST": "smtp.example.com",
+        }
+    )
+    assert email_adapter._is_connected(object()) is True
+
+
+def test_email_connection_status_honors_platform_config_extra(monkeypatch):
+    import hermes_cli.gateway as gateway
+
+    values = {"EMAIL_PASSWORD": "app-password"}
+    monkeypatch.setattr(gateway, "get_env_value", lambda name: values.get(name, ""))
+    platform_config = SimpleNamespace(
+        extra={
+            "address": "agent@example.com",
+            "imap_host": "imap.example.com",
+            "smtp_host": "smtp.example.com",
+        }
+    )
+
+    assert email_adapter._is_connected(platform_config) is True
+
+
+def test_email_interactive_setup_collects_and_saves_gateway_configuration(monkeypatch):
+    import hermes_cli.cli_output as cli_output
+    import hermes_cli.config as config
+
+    answers = {
+        "Email address": "agent@gmail.com",
+        "Email password / app password": "app-password",
+        "IMAP host": "imap.gmail.com",
+        "SMTP host": "smtp.gmail.com",
+        "IMAP port": "993",
+        "SMTP port": "587",
+        "Allowed sender addresses (comma-separated)": " owner@example.com, , team@example.com ",
+        "Home address for cron/notification delivery (optional)": "owner@example.com",
+    }
+    saved = {}
+
+    monkeypatch.setattr(config, "get_env_value", lambda name: "")
+    monkeypatch.setattr(config, "save_env_value", saved.__setitem__)
+    monkeypatch.setattr(
+        cli_output,
+        "prompt",
+        lambda question, default=None, password=False: answers.get(question, default or ""),
+    )
+    monkeypatch.setattr(cli_output, "print_header", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_info", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_success", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_warning", lambda *_args, **_kwargs: None)
+
+    email_adapter.interactive_setup()
+
+    assert saved == {
+        "EMAIL_ADDRESS": "agent@gmail.com",
+        "EMAIL_PASSWORD": "app-password",
+        "EMAIL_IMAP_HOST": "imap.gmail.com",
+        "EMAIL_SMTP_HOST": "smtp.gmail.com",
+        "EMAIL_IMAP_PORT": "993",
+        "EMAIL_SMTP_PORT": "587",
+        "EMAIL_ALLOWED_USERS": "owner@example.com,team@example.com",
+        "EMAIL_HOME_ADDRESS": "owner@example.com",
+    }
+
+
+def test_email_interactive_setup_disables_unconfirmed_open_access(monkeypatch):
+    import hermes_cli.cli_output as cli_output
+    import hermes_cli.config as config
+
+    current = {"EMAIL_ALLOW_ALL_USERS": "true"}
+    answers = {
+        "Email address": "agent@example.com",
+        "Email password / app password": "app-password",
+        "IMAP host": "imap.example.com",
+        "SMTP host": "smtp.example.com",
+        "IMAP port": "993",
+        "SMTP port": "587",
+        "Allowed sender addresses (comma-separated)": "",
+        "Home address for cron/notification delivery (optional)": "",
+    }
+    removed = []
+    confirmations = []
+
+    monkeypatch.setattr(config, "get_env_value", lambda name: current.get(name, ""))
+    monkeypatch.setattr(config, "save_env_value", lambda *_args: None)
+    monkeypatch.setattr(config, "remove_env_value", removed.append)
+    monkeypatch.setattr(
+        cli_output,
+        "prompt",
+        lambda question, default=None, password=False: answers.get(question, default or ""),
+    )
+    monkeypatch.setattr(
+        cli_output,
+        "prompt_yes_no",
+        lambda question, default=True: confirmations.append((question, default)) or False,
+    )
+    monkeypatch.setattr(cli_output, "print_header", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_info", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_success", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_warning", lambda *_args, **_kwargs: None)
+
+    email_adapter.interactive_setup()
+
+    assert confirmations == [("Open access is enabled. Keep accepting email from any sender?", False)]
+    assert removed == ["EMAIL_ALLOW_ALL_USERS"]
+
+
+def test_email_interactive_setup_suggests_common_provider_hosts(monkeypatch):
+    import hermes_cli.cli_output as cli_output
+    import hermes_cli.config as config
+
+    monkeypatch.setattr(config, "get_env_value", lambda _name: "")
+    monkeypatch.setattr(config, "save_env_value", lambda *_args: None)
+    monkeypatch.setattr(cli_output, "print_header", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_info", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_success", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_output, "print_warning", lambda *_args, **_kwargs: None)
+
+    cases = {
+        "agent@gmail.com": ("imap.gmail.com", "smtp.gmail.com"),
+        "agent@outlook.com": ("outlook.office365.com", "smtp.office365.com"),
+    }
+    for email_address, expected_hosts in cases.items():
+        defaults = {}
+
+        def fake_prompt(question, default=None, password=False):
+            if question == "Email address":
+                return email_address
+            if question == "Email password / app password":
+                return "app-password"
+            if question in {"IMAP host", "SMTP host"}:
+                defaults[question] = default
+            return default or ""
+
+        monkeypatch.setattr(cli_output, "prompt", fake_prompt)
+        email_adapter.interactive_setup()
+
+        assert (defaults["IMAP host"], defaults["SMTP host"]) == expected_hosts


### PR DESCRIPTION
## Summary

- restore an interactive Email setup flow in `hermes gateway setup`
- register the Email plugin's `setup_fn` and complete required-env metadata
- preserve `PlatformConfig.extra` fallback semantics in setup status detection
- make existing Email/global open-access policy explicit during configuration
- add Gmail and Outlook host suggestions plus focused regression coverage

## Root cause

The bundled-platform migration in #49408 moved Email into a plugin, but Email did not register an interactive setup function. Selecting Email therefore fell through to environment-variable guidance instead of prompting for configuration. The plugin metadata also omitted `EMAIL_IMAP_HOST` and considered an address alone sufficient for connected status.

## Duplicate search

Searched open, closed, and merged issues/PRs for Email gateway setup, interactive setup, `setup_fn`, and `EMAIL_IMAP_HOST`. No existing PR fixes this setup-hook regression. Related migration tracker: #41112.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_email_plugin_setup.py tests/gateway/test_email.py tests/gateway/test_email_robustness.py tests/hermes_cli/test_gateway_platform_gating.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_setup_irc.py -v --tb=short`
- [x] 133 targeted tests passed
- [x] Ruff passed for changed files
- [x] `git diff --check` passed
- [x] Static security scan passed
- [x] Independent Qwen 3.6 35B review passed with no security concerns or logic errors
