### PR TITLE
fix(dashboard): pass backup output path with -o instead of positional arg

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11915,8 +11915,9 @@ def _new_dashboard_backup_path() -> Path:
 async def run_backup(body: BackupRequest):
     args = ["backup"]
     archive: Optional[Path] = None
-    if body.output:
-        args.append(body.output.strip())
+    output = (body.output or "").strip()
+    if output:
+        args.extend(["-o", output])
     else:
         archive = _new_dashboard_backup_path()
         try:
@@ -11926,7 +11927,7 @@ async def run_backup(body: BackupRequest):
                 status_code=500,
                 detail=f"Could not create backup directory: {exc}",
             )
-        args.append(str(archive))
+        args.extend(["-o", str(archive)])
     try:
         proc = _spawn_hermes_action(args, "backup")
     except Exception as exc:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -338,6 +338,60 @@ class TestOpsEndpoints:
     def _setup(self, _isolate_hermes_home):
         self.client, _ = _client()
 
+    def test_backup_output_uses_output_flag(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        captured = {}
+
+        class FakeProc:
+            pid = 12345
+
+        def fake_spawn_action(subcommand, name):
+            captured["subcommand"] = subcommand
+            captured["name"] = name
+            return FakeProc()
+
+        monkeypatch.setattr(ws, "_spawn_hermes_action", fake_spawn_action)
+
+        r = self.client.post(
+            "/api/ops/backup",
+            json={"output": "  /tmp/hermes-test.zip  "},
+        )
+
+        assert r.status_code == 200
+        assert captured == {
+            "subcommand": ["backup", "-o", "/tmp/hermes-test.zip"],
+            "name": "backup",
+        }
+
+    def test_backup_blank_output_uses_default_archive(self, monkeypatch):
+        from pathlib import Path
+
+        import hermes_cli.web_server as ws
+        from hermes_cli.config import get_hermes_home
+
+        captured = {}
+
+        class FakeProc:
+            pid = 12345
+
+        def fake_spawn_action(subcommand, name):
+            captured["subcommand"] = subcommand
+            captured["name"] = name
+            return FakeProc()
+
+        monkeypatch.setattr(ws, "_spawn_hermes_action", fake_spawn_action)
+
+        r = self.client.post("/api/ops/backup", json={"output": "   "})
+
+        assert r.status_code == 200
+        archive = Path(r.json()["archive"])
+        assert captured == {
+            "subcommand": ["backup", "-o", str(archive)],
+            "name": "backup",
+        }
+        assert archive.parent == get_hermes_home() / "backups"
+
     def test_hooks_list_reads_config(self):
         from hermes_cli.config import load_config, save_config
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2385,7 +2385,7 @@ class TestWebServerEndpoints:
 
         assert data["name"] == "backup"
         assert captured["name"] == "backup"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "-o", str(archive)]
         assert archive.parent == get_hermes_home() / "backups"
         assert archive.name.startswith("hermes-backup-")
         assert archive.suffix == ".zip"
@@ -2412,7 +2412,7 @@ class TestWebServerEndpoints:
         archive = Path(resp.json()["archive"])
 
         assert archive.parent == hosted_home / "backups"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "-o", str(archive)]
         assert archive.parent.is_dir()
 
     def test_ops_backup_download_streams_dashboard_backup(self, tmp_path):


### PR DESCRIPTION
## Summary
The dashboard "Create Backup" button works again: the `/api/ops/backup` endpoint now passes the archive path to the CLI via `-o` instead of as a positional argument.

Root cause: the dashboard backup feature spawned `hermes backup <path>`, but the `backup` subcommand only accepts `-o/--output` — every dashboard/portal backup failed with `hermes: error: unrecognized arguments: <path>` (issue #54801, reported on Nous Portal cloud instances).

Salvages PR #55043 by @BlackishGreen33 (earliest of three duplicate fixes), cherry-picked onto current main with authorship preserved.

## Changes
- `hermes_cli/web_server.py`: `run_backup` builds `["backup", "-o", <path>]` in both branches (explicit output + default dashboard archive); blank/whitespace-only `output` now falls back to the default archive instead of spawning a broken command
- `tests/hermes_cli/test_dashboard_admin_endpoints.py`: 2 new tests (explicit output uses `-o` + trims whitespace; blank output falls back to default archive)
- `tests/hermes_cli/test_web_server.py`: existing argv expectations updated

## Validation
| | Before | After |
|---|---|---|
| Spawned argv | `hermes backup /path.zip` | `hermes backup -o /path.zip` |
| Live subprocess run (temp HERMES_HOME) | exit 2, `unrecognized arguments` | exit 0, real zip written |
| `test_dashboard_admin_endpoints.py` + `test_web_server.py` | — | all green (385 + suite) |

Closes #54801. Duplicates #62484 and #64100 will be closed with credit.

## Infographic
![Dashboard backup fix infographic](https://v3b.fal.media/files/b/0aa24176/ULRifXS7T0JKX5CDObALV_UPodqBFb.png)
