### PR TITLE
feat: add deterministic per-turn model routing

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,0 +1,115 @@
+"""Deterministic, conservative per-turn model tier selection.
+
+The router deliberately returns only a model ID: callers keep their already
+resolved provider credentials and runtime settings.  This prevents a routing
+policy from silently switching providers or bypassing shared credential and
+fallback handling.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_HARD_PATTERN = re.compile(
+    r"\b("
+    r"code|coding|debug|bug|error|exception|traceback|stack trace|"
+    r"test|pytest|unit test|implement|implementation|build|refactor|"
+    r"script|python|javascript|typescript|sql|regex|api|endpoint|"
+    r"deploy|deployment|docker|kubernetes|terraform|infra|infrastructure|"
+    r"terminal|shell|command|git|repository|repo|database|migration"
+    r")\b",
+    re.IGNORECASE,
+)
+_BALANCED_PATTERN = re.compile(
+    r"\b("
+    r"explain|compare|comparison|summari[sz]e|rewrite|draft|"
+    r"plan|design|analy[sz]e|analysis|recommend|recommendation|"
+    r"brainstorm|review|pros and cons|difference"
+    r")\b",
+    re.IGNORECASE,
+)
+_URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
+
+
+def _tier_entry(config: dict[str, Any], key: str) -> dict[str, Any]:
+    value = config.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _tier_model(entry: dict[str, Any], runtime: dict[str, Any]) -> str:
+    """Return an eligible same-provider model ID, or an empty string."""
+    model = entry.get("model")
+    if not isinstance(model, str) or not model.strip():
+        return ""
+    provider = entry.get("provider")
+    if provider and provider != runtime.get("provider"):
+        return ""
+    return model.strip()
+
+
+def _positive_limit(config: dict[str, Any], key: str, default: int) -> int:
+    try:
+        value = int(config.get(key, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _is_hard(message: str) -> bool:
+    return bool(
+        "\n" in message
+        or "```" in message
+        or _URL_PATTERN.search(message)
+        or _HARD_PATTERN.search(message)
+    )
+
+
+def resolve_smart_model_route(
+    message: str,
+    *,
+    model: str,
+    runtime: dict[str, Any],
+    config: dict[str, Any] | None,
+    platform: str,
+) -> dict[str, str]:
+    """Choose an eligible configured model tier, otherwise retain ``model``.
+
+    ``platforms`` is an allowlist.  A configured tier may optionally specify a
+    provider, but that provider must exactly match the caller's already-resolved
+    runtime; this helper never chooses credentials or a base URL.
+    """
+    primary = {"model": model, "label": "primary"}
+    config = config if isinstance(config, dict) else {}
+    if not config.get("enabled"):
+        return primary
+
+    platforms = config.get("platforms") or []
+    if isinstance(platforms, str):
+        platforms = [platforms]
+    if platform not in platforms:
+        return primary
+
+    text = (message or "").strip()
+    if not text or _is_hard(text):
+        return primary
+
+    words = len(text.split())
+    max_simple_chars = _positive_limit(config, "max_simple_chars", 160)
+    max_simple_words = _positive_limit(config, "max_simple_words", 28)
+    max_balanced_chars = _positive_limit(config, "max_balanced_chars", 512)
+    max_balanced_words = _positive_limit(config, "max_balanced_words", 96)
+
+    wants_balanced = (
+        bool(_BALANCED_PATTERN.search(text))
+        or len(text) > max_simple_chars
+        or words > max_simple_words
+    )
+    if wants_balanced:
+        if len(text) > max_balanced_chars or words > max_balanced_words:
+            return primary
+        balanced = _tier_model(_tier_entry(config, "balanced_model"), runtime)
+        return {"model": balanced, "label": "balanced"} if balanced else primary
+
+    cheap = _tier_model(_tier_entry(config, "cheap_model"), runtime)
+    return {"model": cheap, "label": "cheap"} if cheap else primary

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3970,6 +3970,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         route["request_overrides"] = overrides or {}
         return route
 
+    def _apply_smart_model_route(
+        self,
+        user_message: str,
+        route: dict,
+        *,
+        platform: str,
+    ) -> dict:
+        """Apply an opt-in same-provider tier to an already-resolved route.
+
+        Keeping this separate from ``_resolve_turn_agent_config`` preserves its
+        established three-argument call contract for integrations and test
+        doubles.  The helper copies the route and recomputes the model-sensitive
+        parts of its signature and `/fast` request overrides.
+        """
+        from agent.smart_model_routing import resolve_smart_model_route
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        runtime = route.get("runtime") or {}
+        routing = resolve_smart_model_route(
+            user_message,
+            model=str(route.get("model") or ""),
+            runtime=runtime,
+            config=(_load_gateway_config().get("smart_model_routing") or {}),
+            platform=platform,
+        )
+        updated = dict(route)
+        updated["routing_label"] = routing["label"]
+        if routing["model"] == route.get("model"):
+            return updated
+
+        updated["model"] = routing["model"]
+        signature = tuple(route.get("signature") or ())
+        updated["signature"] = (routing["model"], *signature[1:])
+        if getattr(self, "_service_tier", None):
+            try:
+                overrides = resolve_fast_mode_overrides(routing["model"])
+            except Exception:
+                overrides = None
+            updated["request_overrides"] = overrides or {}
+        return updated
+
     def _sync_session_model_from_agent(self, session_id: str, agent: Any) -> None:
         """Persist the runtime model/provider actually used by a gateway turn.
 
@@ -13495,6 +13536,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._apply_smart_model_route(
+                prompt, turn_route, platform=platform_key
+            )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -18361,6 +18405,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route = self._apply_smart_model_route(
+                message,
+                turn_route,
+                platform=_platform_config_key(source.platform),
+            )
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import sys
 
+from hermes_cli.config import load_config
 from rich.markup import escape as _escape
 
 
@@ -172,13 +173,13 @@ class CLIAgentSetupMixin:
         return True
 
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
-        """Build the effective model/runtime config for a single user turn.
+        """Build the effective model/runtime config for one CLI turn.
 
-        Always uses the session's primary model/provider.  If the user has
-        toggled `/fast` on and the current model supports Priority
-        Processing / Anthropic fast mode, attach `request_overrides` so the
-        API call is marked accordingly.
+        The optional smart router may select a configured **same-provider**
+        model tier before the agent is created. It never changes credentials,
+        base URL, API mode, or provider routing.
         """
+        from agent.smart_model_routing import resolve_smart_model_route
         from hermes_cli.models import resolve_fast_mode_overrides
 
         runtime = {
@@ -190,11 +191,19 @@ class CLIAgentSetupMixin:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        routing = resolve_smart_model_route(
+            user_message,
+            model=self.model,
+            runtime=runtime,
+            config=(load_config().get("smart_model_routing") or {}),
+            platform="cli",
+        )
         route = {
-            "model": self.model,
+            "model": routing["model"],
             "runtime": runtime,
+            "routing_label": routing["label"],
             "signature": (
-                self.model,
+                routing["model"],
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -975,6 +975,19 @@ def _ensure_hermes_home_managed(home: Path):
 
 DEFAULT_CONFIG = {
     "model": "",
+    # Deterministic per-turn routing is opt-in. Tiers only select a model ID
+    # under the already-resolved provider/runtime, so credentials and fallback
+    # policy remain owned by the core resolver.
+    "smart_model_routing": {
+        "enabled": False,
+        "platforms": [],
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+        "max_balanced_chars": 512,
+        "max_balanced_words": 96,
+        "cheap_model": {},
+        "balanced_model": {},
+    },
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
@@ -5249,7 +5262,7 @@ def check_config_version() -> Tuple[int, int]:
 
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
+    "_config_version", "model", "smart_model_routing", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,0 +1,76 @@
+"""Behavior tests for deterministic per-turn model routing."""
+
+from agent.smart_model_routing import resolve_smart_model_route
+
+
+RUNTIME = {
+    "provider": "openai-codex",
+    "base_url": "https://chatgpt.com/backend-api/codex",
+    "api_mode": "chat_completions",
+    "api_key": "test-key",
+}
+
+CONFIG = {
+    "enabled": True,
+    "platforms": ["discord"],
+    "max_simple_chars": 160,
+    "max_simple_words": 28,
+    "max_balanced_chars": 512,
+    "max_balanced_words": 96,
+    "cheap_model": {"model": "gpt-5.6-luna"},
+    "balanced_model": {"model": "gpt-5.6-terra"},
+}
+
+
+def test_short_plain_gateway_message_uses_cheap_tier():
+    route = resolve_smart_model_route(
+        "hi",
+        model="gpt-5.6-sol",
+        runtime=RUNTIME,
+        config=CONFIG,
+        platform="discord",
+    )
+
+    assert route == {"model": "gpt-5.6-luna", "label": "cheap"}
+
+
+def test_explanation_request_uses_balanced_tier():
+    route = resolve_smart_model_route(
+        "Explain the practical differences between webhooks and polling.",
+        model="gpt-5.6-sol",
+        runtime=RUNTIME,
+        config=CONFIG,
+        platform="discord",
+    )
+
+    assert route == {"model": "gpt-5.6-terra", "label": "balanced"}
+
+
+def test_code_request_stays_on_primary_model():
+    route = resolve_smart_model_route(
+        "Write a Python script that parses JSONL and reports invalid rows.",
+        model="gpt-5.6-sol",
+        runtime=RUNTIME,
+        config=CONFIG,
+        platform="discord",
+    )
+
+    assert route == {"model": "gpt-5.6-sol", "label": "primary"}
+
+
+def test_disabled_or_unconfigured_platform_stays_on_primary_model():
+    disabled = {**CONFIG, "enabled": False}
+    assert resolve_smart_model_route(
+        "hi", model="gpt-5.6-sol", runtime=RUNTIME, config=disabled, platform="discord"
+    ) == {"model": "gpt-5.6-sol", "label": "primary"}
+    assert resolve_smart_model_route(
+        "hi", model="gpt-5.6-sol", runtime=RUNTIME, config=CONFIG, platform="telegram"
+    ) == {"model": "gpt-5.6-sol", "label": "primary"}
+
+
+def test_tier_configured_for_a_different_provider_is_ignored():
+    config = {**CONFIG, "cheap_model": {"model": "gpt-5.6-luna", "provider": "openrouter"}}
+
+    assert resolve_smart_model_route(
+        "hi", model="gpt-5.6-sol", runtime=RUNTIME, config=config, platform="discord"
+    ) == {"model": "gpt-5.6-sol", "label": "primary"}

--- a/tests/gateway/test_smart_model_routing.py
+++ b/tests/gateway/test_smart_model_routing.py
@@ -1,0 +1,65 @@
+"""Gateway integration tests for smart model routing."""
+
+from gateway import run as gateway_run
+
+
+class _Runner:
+    _service_tier = None
+
+
+RUNTIME = {
+    "provider": "openai-codex",
+    "base_url": "https://chatgpt.com/backend-api/codex",
+    "api_mode": "chat_completions",
+    "api_key": "test-key",
+    "args": [],
+}
+
+
+def test_turn_route_uses_configured_smart_model_tier(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "smart_model_routing": {
+                "enabled": True,
+                "platforms": ["discord"],
+                "cheap_model": {"model": "gpt-5.6-luna"},
+            }
+        },
+    )
+
+    base_route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        _Runner(), "hi", "gpt-5.6-terra", RUNTIME
+    )
+    route = gateway_run.GatewayRunner._apply_smart_model_route(
+        _Runner(), "hi", base_route, platform="discord"
+    )
+
+    assert route["model"] == "gpt-5.6-luna"
+    assert route["signature"][0] == "gpt-5.6-luna"
+    assert route["routing_label"] == "cheap"
+
+
+def test_turn_route_keeps_primary_without_a_matching_platform(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "smart_model_routing": {
+                "enabled": True,
+                "platforms": ["telegram"],
+                "cheap_model": {"model": "gpt-5.6-luna"},
+            }
+        },
+    )
+
+    base_route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        _Runner(), "hi", "gpt-5.6-terra", RUNTIME
+    )
+    route = gateway_run.GatewayRunner._apply_smart_model_route(
+        _Runner(), "hi", base_route, platform="discord"
+    )
+
+    assert route["model"] == "gpt-5.6-terra"
+    assert route["routing_label"] == "primary"

--- a/tests/hermes_cli/test_smart_model_routing.py
+++ b/tests/hermes_cli/test_smart_model_routing.py
@@ -1,0 +1,35 @@
+"""CLI integration tests for smart model routing."""
+
+from hermes_cli import cli_agent_setup_mixin
+
+
+class _CLI:
+    model = "gpt-5.6-terra"
+    api_key = "test-key"
+    base_url = "https://chatgpt.com/backend-api/codex"
+    provider = "openai-codex"
+    api_mode = "chat_completions"
+    acp_command = None
+    acp_args = []
+    service_tier = None
+    _credential_pool = None
+
+
+def test_cli_turn_route_uses_configured_cheap_model(monkeypatch):
+    monkeypatch.setattr(
+        cli_agent_setup_mixin,
+        "load_config",
+        lambda: {
+            "smart_model_routing": {
+                "enabled": True,
+                "platforms": ["cli"],
+                "cheap_model": {"model": "gpt-5.6-luna"},
+            }
+        },
+    )
+
+    route = cli_agent_setup_mixin.CLIAgentSetupMixin._resolve_turn_agent_config(_CLI(), "hi")
+
+    assert route["model"] == "gpt-5.6-luna"
+    assert route["signature"][0] == "gpt-5.6-luna"
+    assert route["routing_label"] == "cheap"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -923,6 +923,34 @@ prompt_caching:
 
 `cache_ttl` selects the breakpoint TTL Hermes attaches for Claude via the native Anthropic API, OpenRouter, and Nous Portal. Only the two Anthropic-supported tiers (`"5m"`, `"1h"`) are honored — any other value is ignored. Providers with their own caps (e.g. Qwen Cloud, which maxes at 5 minutes) still clamp to what the upstream allows.
 
+## Smart Model Routing
+
+Smart model routing is an opt-in, deterministic per-turn policy for **CLI and gateway** conversations. It selects a cheaper same-provider model only for clearly simple prompts; code, tools, URLs, multiline prompts, long prompts, and ambiguous work remain on the configured primary model.
+
+The router never chooses a provider, credential, base URL, or API mode. It only selects a model ID under Hermes's already-resolved runtime, so credential pools, provider fallback, and authentication continue through the normal path.
+
+```yaml
+model:
+  default: gpt-5.6-sol       # primary tier
+  provider: openai-codex
+
+smart_model_routing:
+  enabled: true
+  platforms: [discord, cli]  # explicit allowlist
+  cheap_model:
+    model: gpt-5.6-luna
+  balanced_model:
+    model: gpt-5.6-terra
+  max_simple_chars: 160
+  max_simple_words: 28
+  max_balanced_chars: 512
+  max_balanced_words: 96
+```
+
+`cheap_model` handles short, plain messages. `balanced_model` handles bounded explanation, comparison, drafting, summarization, and planning requests. Each tier may include an optional `provider`, but it is only used when it exactly matches the resolved primary provider; mismatches fail closed to the primary model. Leave a tier empty to disable it.
+
+Changes take effect in a new CLI session or after the gateway restarts. Routing changes the effective agent signature, so a session safely rebuilds its agent when a different tier is selected.
+
 ## Auxiliary Models
 
 Hermes uses "auxiliary" models for side tasks like image analysis, web page summarization, browser screenshot analysis, session-title generation, and context compression. By default (`auxiliary.*.provider: "auto"`), Hermes routes every auxiliary task to your **main chat model** — the same provider/model you picked in `hermes model`. You don't need to configure anything to get started, but be aware that on expensive reasoning models (Opus, MiniMax M2.7, etc.) auxiliary tasks add meaningful cost. If you want cheap-and-fast side tasks regardless of your main model, set `auxiliary.<task>.provider` and `auxiliary.<task>.model` explicitly (for example, Gemini Flash on OpenRouter for vision and web extraction).


### PR DESCRIPTION
## Summary
- add opt-in, deterministic routing tiers for simple and balanced prompts
- preserve the existing provider/runtime, credential pooling, fallback behavior, and agent cache safety
- apply routing on CLI and gateway paths without changing the existing turn-route call contract
- document configuration and cover routing policy plus CLI/gateway integration

## Safety
- routing only changes a model ID under the already-resolved provider
- provider mismatches, malformed config, unsupported platforms, and hard/long prompts fail closed to the primary model
- model changes update the route signature and re-evaluate fast-mode overrides

## Test plan
- `venv/bin/python -m pytest tests/agent/test_smart_model_routing.py tests/gateway/test_smart_model_routing.py tests/gateway/test_fast_command.py tests/hermes_cli/test_smart_model_routing.py tests/gateway/test_compression_failure_session_sync.py -q`
- `venv/bin/python -m compileall -q agent/smart_model_routing.py gateway/run.py hermes_cli/cli_agent_setup_mixin.py hermes_cli/config.py`
- `git diff --check`