### PR TITLE
feat(cron): per-job reasoning_effort override

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1036,6 +1036,34 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _normalize_job_reasoning_effort(value: Any) -> Optional[str]:
+    """Normalize/validate a per-job reasoning_effort value.
+
+    Accepts the same levels as ``agent.reasoning_effort`` ("none", "minimal",
+    "low", "medium", "high", "xhigh", "max", "ultra" — plus disable aliases).
+    Returns the normalized lowercase string, or None when the value is
+    empty/absent (meaning: no per-job override).
+
+    Raises ValueError for a non-empty value that isn't a recognized level, so
+    bad configs surface at create/update time instead of silently running at
+    the global effort.
+    """
+    if value is None or value is True:
+        return None
+    if value is False:
+        return "none"
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    from hermes_constants import parse_reasoning_effort
+    if parse_reasoning_effort(text) is None:
+        raise ValueError(
+            f"Invalid reasoning_effort {value!r} — valid levels: "
+            "none, minimal, low, medium, high, xhigh, max, ultra"
+        )
+    return text
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1048,6 +1076,7 @@ def create_job(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
@@ -1071,6 +1100,10 @@ def create_job(
         model: Optional per-job model override
         provider: Optional per-job provider override
         base_url: Optional per-job base URL override
+        reasoning_effort: Optional per-job reasoning effort ("none", "minimal",
+                "low", "medium", "high", "xhigh", "max", "ultra"). Wins over
+                agent.reasoning_overrides and agent.reasoning_effort for this
+                job. Ignored when ``no_agent=True``.
         script: Optional path to a script whose stdout feeds the job. With
                 ``no_agent=True`` the script IS the job — its stdout is
                 delivered verbatim. Without ``no_agent``, its stdout is
@@ -1123,6 +1156,7 @@ def create_job(
     normalized_model = _normalize_job_optional_text(model)
     normalized_provider = _normalize_job_optional_text(provider)
     normalized_base_url = _normalize_job_optional_text(base_url, strip_trailing_slash=True)
+    normalized_reasoning = _normalize_job_reasoning_effort(reasoning_effort)
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
@@ -1195,6 +1229,7 @@ def create_job(
         "provider_snapshot": provider_snapshot,
         "model_snapshot": model_snapshot,
         "base_url": normalized_base_url,
+        "reasoning_effort": normalized_reasoning,
         "script": normalized_script,
         "no_agent": normalized_no_agent,
         "context_from": context_from,
@@ -1314,6 +1349,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            # Validate / normalize per-job reasoning_effort. Empty string or
+            # None clears the override (job reverts to per-model/global).
+            if "reasoning_effort" in updates:
+                updates["reasoning_effort"] = _normalize_job_reasoning_effort(
+                    updates["reasoning_effort"]
+                )
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2988,13 +2988,17 @@ def run_job(
         except Exception:
             pass
 
-        # Reasoning config from config.yaml (per-model override > global) —
-        # resolved through the shared chokepoint against the job's effective
-        # model (per-job override > HERMES_MODEL env > config.yaml default).
-        from hermes_constants import resolve_reasoning_config
-        reasoning_config = resolve_reasoning_config(
-            _cfg if isinstance(_cfg, dict) else {}, str(model)
-        )
+        # Reasoning config: per-job override > per-model override > global.
+        # The job field is a plain effort level ("high", "none", ...) validated
+        # at create/update time; per-model/global resolve through the shared
+        # chokepoint against the job's effective model.
+        from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+        _job_effort = str(job.get("reasoning_effort") or "").strip()
+        reasoning_config = parse_reasoning_effort(_job_effort) if _job_effort else None
+        if reasoning_config is None:
+            reasoning_config = resolve_reasoning_config(
+                _cfg if isinstance(_cfg, dict) else {}, str(model)
+            )
 
         # Prefill messages from env or config.yaml. The top-level
         # prefill_messages_file key is canonical; agent.prefill_messages_file is

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -163,6 +163,8 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        if job.get("reasoning_effort"):
+            print(f"    Reasoning: {job['reasoning_effort']}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -310,6 +312,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        reasoning_effort=getattr(args, "reasoning_effort", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -326,6 +329,8 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("reasoning_effort"):
+        print(f"  Reasoning: {job_data['reasoning_effort']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -373,6 +378,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        reasoning_effort=getattr(args, "reasoning_effort", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -392,6 +398,8 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("reasoning_effort"):
+        print(f"  Reasoning: {updated['reasoning_effort']}")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -70,6 +70,15 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument(
+        "--reasoning-effort",
+        dest="reasoning_effort",
+        help=(
+            "Per-job reasoning effort override (none, minimal, low, medium, "
+            "high, xhigh, max, ultra). Wins over agent.reasoning_overrides "
+            "and the global agent.reasoning_effort for this job."
+        ),
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -133,6 +142,15 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument(
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--reasoning-effort",
+        dest="reasoning_effort",
+        help=(
+            "Per-job reasoning effort override (none, minimal, low, medium, "
+            "high, xhigh, max, ultra). Pass empty string to clear (revert to "
+            "per-model/global resolution)."
+        ),
     )
 
     # lifecycle actions

--- a/tests/cron/test_reasoning_config_per_model.py
+++ b/tests/cron/test_reasoning_config_per_model.py
@@ -104,3 +104,97 @@ class TestCronPerModelReasoningConfig:
         )
         assert result is not None
         assert result.get("enabled") is False
+
+
+class TestPerJobReasoningEffort:
+    """Per-job reasoning_effort field: validation, storage, and resolution
+    priority (job > per-model override > global)."""
+
+    def test_normalize_accepts_valid_levels(self):
+        from cron.jobs import _normalize_job_reasoning_effort
+        for level in ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"):
+            assert _normalize_job_reasoning_effort(level) == level
+        # Case/whitespace normalized
+        assert _normalize_job_reasoning_effort("  HIGH ") == "high"
+        # YAML boolean False = disable alias
+        assert _normalize_job_reasoning_effort(False) == "none"
+
+    def test_normalize_empty_clears(self):
+        from cron.jobs import _normalize_job_reasoning_effort
+        assert _normalize_job_reasoning_effort(None) is None
+        assert _normalize_job_reasoning_effort("") is None
+        assert _normalize_job_reasoning_effort("   ") is None
+
+    def test_normalize_rejects_invalid(self):
+        from cron.jobs import _normalize_job_reasoning_effort
+        with pytest.raises(ValueError, match="Invalid reasoning_effort"):
+            _normalize_job_reasoning_effort("turbo-max")
+
+    def test_create_job_stores_and_validates(self, tmp_path):
+        from cron.jobs import use_cron_store, create_job
+        with use_cron_store(tmp_path):
+            job = create_job(
+                prompt="test", schedule="every 1h", reasoning_effort="XHigh"
+            )
+            assert job["reasoning_effort"] == "xhigh"
+            with pytest.raises(ValueError, match="Invalid reasoning_effort"):
+                create_job(prompt="t2", schedule="every 1h", reasoning_effort="bogus")
+
+    def test_update_job_sets_and_clears(self, tmp_path):
+        from cron.jobs import use_cron_store, create_job, update_job
+        with use_cron_store(tmp_path):
+            job = create_job(prompt="test", schedule="every 1h")
+            assert job["reasoning_effort"] is None
+            updated = update_job(job["id"], {"reasoning_effort": "low"})
+            assert updated is not None
+            assert updated["reasoning_effort"] == "low"
+            cleared = update_job(job["id"], {"reasoning_effort": ""})
+            assert cleared is not None
+            assert cleared["reasoning_effort"] is None
+            with pytest.raises(ValueError, match="Invalid reasoning_effort"):
+                update_job(job["id"], {"reasoning_effort": "hyper"})
+
+    def test_resolution_priority_job_beats_per_model_and_global(self):
+        """Mirror of the scheduler's resolution block: job field wins."""
+        from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+
+        _cfg = {
+            "model": {"default": "gpt-5"},
+            "agent": {
+                "reasoning_effort": "medium",
+                "reasoning_overrides": {"gpt-5": "low"},
+            },
+        }
+        job = {"reasoning_effort": "xhigh"}
+
+        # This is the scheduler's exact resolution sequence.
+        _job_effort = str(job.get("reasoning_effort") or "").strip()
+        reasoning_config = parse_reasoning_effort(_job_effort) if _job_effort else None
+        if reasoning_config is None:
+            reasoning_config = resolve_reasoning_config(_cfg, "gpt-5")
+        assert reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+        # Without the job field, per-model override applies.
+        job = {}
+        _job_effort = str(job.get("reasoning_effort") or "").strip()
+        reasoning_config = parse_reasoning_effort(_job_effort) if _job_effort else None
+        if reasoning_config is None:
+            reasoning_config = resolve_reasoning_config(_cfg, "gpt-5")
+        assert reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_job_none_disables_despite_per_model_override(self):
+        from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+
+        _cfg = {
+            "model": {"default": "gpt-5"},
+            "agent": {
+                "reasoning_effort": "medium",
+                "reasoning_overrides": {"gpt-5": "xhigh"},
+            },
+        }
+        job = {"reasoning_effort": "none"}
+        _job_effort = str(job.get("reasoning_effort") or "").strip()
+        reasoning_config = parse_reasoning_effort(_job_effort) if _job_effort else None
+        if reasoning_config is None:
+            reasoning_config = resolve_reasoning_config(_cfg, "gpt-5")
+        assert reasoning_config == {"enabled": False}

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -578,6 +578,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "reasoning_effort": job.get("reasoning_effort"),
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -670,6 +671,7 @@ def cronjob(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
@@ -744,6 +746,7 @@ def cronjob(
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                reasoning_effort=_normalize_optional_job_value(reasoning_effort),
                 script=_normalize_optional_job_value(script),
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
@@ -875,6 +878,10 @@ def cronjob(
                 updates["provider"] = _normalize_optional_job_value(provider)
             if base_url is not None:
                 updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+            if reasoning_effort is not None:
+                # Empty string clears the per-job override (revert to
+                # per-model/global). Validation happens in update_job().
+                updates["reasoning_effort"] = _normalize_optional_job_value(reasoning_effort)
             # Re-validate the EFFECTIVE provider/base_url on EVERY update, not
             # only when this update supplies provider/base_url. A job persisted
             # before this guard (or written directly to the jobs store) may
@@ -1041,6 +1048,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
             },
+            "reasoning_effort": {
+                "type": "string",
+                "description": "Optional per-job reasoning effort override: none, minimal, low, medium, high, xhigh, max, or ultra. Wins over the per-model overrides (agent.reasoning_overrides) and the global agent.reasoning_effort for this job only — use it to run a lightweight job at low/none or a deep-synthesis job at high/xhigh without touching global config. Ignored when no_agent=True. On update, pass an empty string to clear (job reverts to per-model/global resolution)."
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -1134,6 +1145,7 @@ registry.register(
         model=_mo[1],
         provider=_mo[0] or args.get("provider"),
         base_url=args.get("base_url"),
+        reasoning_effort=args.get("reasoning_effort"),
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -125,6 +125,39 @@ When `workdir` is set:
 Jobs with a `workdir` run sequentially on the scheduler tick, not in the parallel pool. This is deliberate: the cron worker applies the job workdir through process-global terminal state, so two workdir jobs running at the same time would corrupt each other's cwd. Workdir-less jobs still run in parallel as before.
 :::
 
+## Per-job reasoning effort
+
+Different jobs need different thinking depth: an hourly inbox scan doesn't need the reasoning budget of a morning briefing that synthesizes calendar, email, and weather. Set a per-job effort with `--reasoning-effort` (CLI) or `reasoning_effort=` (tool call):
+
+```bash
+# A lightweight classifier job — no deep thinking needed
+hermes cron create "every 1h" "Scan the inbox and flag urgent items" \
+  --reasoning-effort low
+
+# A deep-synthesis job on the same model
+hermes cron create "every 1d at 07:00" "Compile my morning briefing" \
+  --reasoning-effort xhigh
+```
+
+```python
+cronjob(
+    action="create",
+    schedule="every 1h",
+    prompt="Scan the inbox and flag urgent items",
+    reasoning_effort="low",
+)
+```
+
+Valid levels: `none` (disable thinking), `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. Invalid values are rejected at create/update time.
+
+Resolution priority for a job's reasoning effort:
+
+1. The job's own `reasoning_effort` (this section)
+2. A matching per-model entry in `agent.reasoning_overrides` for the job's effective model
+3. The global `agent.reasoning_effort`
+
+Pass `--reasoning-effort ""` (or `reasoning_effort=""` via the tool) on edit to clear the override and revert to per-model/global resolution. The field is ignored for `no_agent` jobs, which never touch the inference layer.
+
 ## Editing jobs
 
 You do not need to delete and recreate jobs just to change them.


### PR DESCRIPTION
## Summary

Cron jobs can now set their own reasoning effort — a first-class `reasoning_effort` field on the job record, so a lightweight hourly scan runs at `low` while a morning-briefing job on the same model runs at `xhigh`. Fixes #23524.

```bash
hermes cron create "every 1h" "Scan the inbox and flag urgent items" --reasoning-effort low
hermes cron create "every 1d at 07:00" "Compile my morning briefing" --reasoning-effort xhigh
```

Resolution priority per run: **job field > `agent.reasoning_overrides` (per-model) > global `agent.reasoning_effort`** — the lower two tiers resolve through the shared chokepoint from #64458.

## Changes

- `cron/jobs.py`: `reasoning_effort` on `create_job`/`update_job` with write-time validation (`_normalize_job_reasoning_effort` — unknown levels raise ValueError at create/update, never at run time; empty string clears)
- `cron/scheduler.py`: job field consulted before per-model/global resolution
- `tools/cronjob_tools.py`: `reasoning_effort` param on the `cronjob` tool (create/update), surfaced in list/show output
- `hermes_cli/subcommands/cron.py` + `hermes_cli/cron.py`: `--reasoning-effort` on `hermes cron create/edit`, echoed in create/edit/list detail
- `website/docs/user-guide/features/cron.md`: new "Per-job reasoning effort" section
- Tests: 7 new cases (level validation incl. YAML-False alias, create/update storage round-trip, clear semantics, priority order incl. job-`none`-beats-per-model)

`no_agent` jobs ignore the field (they never touch the inference layer). Existing jobs are unaffected — absent field means per-model/global resolution, exactly as before.

## Validation

| Check | Result |
|---|---|
| Targeted cron suite | 11/11 pass (`tests/cron/test_reasoning_config_per_model.py`) |
| Sibling suites (`tests/cron/`, cronjob tool, cron CLI) | 777/777 pass |
| Isolated E2E (real tool entry, real jobs.json store) | 8/8 — create/store, invalid rejected, clear→per-model fallback, `none` disables, list surfaces field, disk persistence |
| Live scheduler runs (real `hermes cron create` + `cron run`, logging proxy → real OpenRouter) | job `xhigh` → `reasoning: {effort: "xhigh"}` on the wire; no job field → per-model `low` applied; 3/3 jobs completed |

## Infographic

![Per-job reasoning effort](https://v3b.fal.media/files/b/0aa24194/KmgFZLyHpnwHpOgIlniR-_hJpWrBXU.png)
