### PR TITLE
Restore Feishu Card 2 and CardKit streaming

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -574,6 +574,62 @@ def _build_markdown_post_payload(content: str) -> str:
     )
 
 
+def _build_feishu_card_action_button(
+    label: str,
+    *,
+    command: str,
+    button_type: str = "default",
+) -> Dict[str, Any]:
+    return {
+        "tag": "button",
+        "text": {"tag": "plain_text", "content": label},
+        "type": button_type,
+        "value": {"hermes_command": command},
+    }
+
+
+def _build_markdown_card_payload(
+    content: str,
+    *,
+    header_title: str = "",
+    header_template: str = "indigo",
+    actions: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Build a Feishu Card JSON 2.0 payload with a markdown body."""
+    template = header_template if header_template in {"indigo", "orange"} else "indigo"
+    card: Dict[str, Any] = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True},
+        "body": {
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": content or "",
+                }
+            ]
+        },
+    }
+    if header_title:
+        card["header"] = {
+            "title": {"tag": "plain_text", "content": header_title},
+            "template": template,
+        }
+    if actions:
+        _attach_feishu_card_inline_actions(card, actions)
+    return json.dumps(card, ensure_ascii=False)
+
+
+def _attach_feishu_card_inline_actions(
+    card: Dict[str, Any],
+    actions: List[Dict[str, Any]],
+) -> None:
+    """Attach Card 2.0 buttons directly to body.elements."""
+    if actions:
+        elements = card.setdefault("body", {}).setdefault("elements", [])
+        elements.append({"tag": "hr"})
+        elements.extend(actions)
+
+
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     """Build Feishu post rows while isolating fenced code blocks.
 
@@ -1911,9 +1967,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type not in {"post", "interactive"} or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning("[Feishu] Invalid rich payload rejected by API; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1922,11 +1978,11 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 if (
-                    msg_type == "post"
+                    msg_type in {"post", "interactive"}
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    logger.warning("[Feishu] Rich payload rejected by API response; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1960,8 +2016,12 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await self._run_blocking(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if (
+                not result.success
+                and msg_type in {"post", "interactive"}
+                and _POST_CONTENT_INVALID_RE.search(result.error or "")
+            ):
+                logger.warning("[Feishu] Invalid rich update rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -2012,22 +2072,22 @@ class FeishuAdapter(BasePlatformAdapter):
             actions.append(_btn("❌ Deny", "deny", "danger"))
             scope_note = "\n\n**Smart DENY:** owner override applies to this one operation only." if smart_denied else ""
             card = {
+                "schema": "2.0",
                 "config": {"wide_screen_mode": True},
-                "header": {
-                    "title": {"content": "⚠️ Command Approval Required", "tag": "plain_text"},
-                    "template": "orange",
+                "body": {
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": (
+                                "**⚠️ Command Approval Required**\n\n"
+                                f"```\n{cmd_preview}\n```\n"
+                                f"**Reason:** {description}{scope_note}"
+                            ),
+                        },
+                    ],
                 },
-                "elements": [
-                    {
-                        "tag": "markdown",
-                        "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}{scope_note}",
-                    },
-                    {
-                        "tag": "action",
-                        "actions": actions,
-                    },
-                ],
             }
+            _attach_feishu_card_inline_actions(card, actions)
 
             payload = json.dumps(card, ensure_ascii=False)
             response = await self._feishu_send_with_retry(
@@ -2065,23 +2125,26 @@ class FeishuAdapter(BasePlatformAdapter):
                 },
             }
 
-        return {
+        card = {
+            "schema": "2.0",
             "config": {"wide_screen_mode": True},
-            "header": {
-                "title": {"content": "⚕ Update Needs Your Input", "tag": "plain_text"},
-                "template": "orange",
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": f"**⚕ Update Needs Your Input**\n\n{prompt}{default_hint}",
+                    },
+                ],
             },
-            "elements": [
-                {"tag": "markdown", "content": f"{prompt}{default_hint}"},
-                {
-                    "tag": "action",
-                    "actions": [
-                        _btn("✓ Yes", "y", "primary"),
-                        _btn("✗ No", "n", "danger"),
-                    ],
-                },
-            ],
         }
+        _attach_feishu_card_inline_actions(
+            card,
+            [
+                _btn("✓ Yes", "y", "primary"),
+                _btn("✗ No", "n", "danger"),
+            ],
+        )
+        return card
 
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
@@ -2124,17 +2187,20 @@ class FeishuAdapter(BasePlatformAdapter):
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
         return {
+            "schema": "2.0",
             "config": {"wide_screen_mode": True},
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
-                "template": "red" if choice == "deny" else "green",
+                "template": "orange" if choice == "deny" else "indigo",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": f"{icon} **{label}** by {user_name}",
+                    },
+                ],
+            },
         }
 
     @staticmethod
@@ -2142,14 +2208,17 @@ class FeishuAdapter(BasePlatformAdapter):
         yes = answer == "y"
         label = "Yes" if yes else "No"
         return {
+            "schema": "2.0",
             "config": {"wide_screen_mode": True},
             "header": {
                 "title": {"content": f"{'✅' if yes else '❌'} Update prompt answered: {label}", "tag": "plain_text"},
-                "template": "green" if yes else "red",
+                "template": "indigo" if yes else "orange",
             },
-            "elements": [
-                {"tag": "markdown", "content": f"Answered by **{user_name}**"},
-            ],
+            "body": {
+                "elements": [
+                    {"tag": "markdown", "content": f"Answered by **{user_name}**"},
+                ],
+            },
         }
 
     @staticmethod
@@ -4526,16 +4595,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
+        return "interactive", _build_markdown_card_payload(content)
 
     async def _send_uploaded_file_message(
         self,
@@ -4829,7 +4889,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                if msg_type in {"post", "interactive"} and _POST_CONTENT_INVALID_RE.search(str(exc)):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -88,6 +88,31 @@ except ImportError:
 try:
     import lark_oapi as lark
     from lark_oapi.api.application.v6 import GetApplicationRequest
+    from lark_oapi.api.cardkit.v1.model.card import Card as CardKitCard
+    try:
+        from lark_oapi.api.cardkit.v1.model.content_card_element_request import (
+            ContentCardElementRequest,
+        )
+        from lark_oapi.api.cardkit.v1.model.content_card_element_request_body import (
+            ContentCardElementRequestBody,
+        )
+        from lark_oapi.api.cardkit.v1.model.create_card_request import CreateCardRequest
+        from lark_oapi.api.cardkit.v1.model.create_card_request_body import (
+            CreateCardRequestBody,
+        )
+        from lark_oapi.api.cardkit.v1.model.settings_card_request import SettingsCardRequest
+        from lark_oapi.api.cardkit.v1.model.settings_card_request_body import (
+            SettingsCardRequestBody,
+        )
+    except ImportError:
+        ContentCardElementRequest = None  # type: ignore[assignment]
+        ContentCardElementRequestBody = None  # type: ignore[assignment]
+        CreateCardRequest = None  # type: ignore[assignment]
+        CreateCardRequestBody = None  # type: ignore[assignment]
+        SettingsCardRequest = None  # type: ignore[assignment]
+        SettingsCardRequestBody = None  # type: ignore[assignment]
+    from lark_oapi.api.cardkit.v1.model.update_card_request import UpdateCardRequest
+    from lark_oapi.api.cardkit.v1.model.update_card_request_body import UpdateCardRequestBody
     from lark_oapi.api.im.v1 import (
         CreateFileRequest,
         CreateFileRequestBody,
@@ -374,6 +399,13 @@ class FeishuNormalizedMessage:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass
+class FeishuStreamingCardState:
+    card_id: str
+    element_id: str
+    sequence: int = 0
+
+
 @dataclass(frozen=True)
 class FeishuAdapterSettings:
     app_id: str  # Canonical bot/app identifier (credential, not from event payloads)
@@ -616,6 +648,47 @@ def _build_markdown_card_payload(
         }
     if actions:
         _attach_feishu_card_inline_actions(card, actions)
+    return json.dumps(card, ensure_ascii=False)
+
+
+def _build_streaming_card_payload(
+    content: str = "",
+    *,
+    element_id: str = "hermes_stream_md",
+) -> str:
+    """Build a CardKit entity payload for Feishu's native text streaming."""
+    card = {
+        "schema": "2.0",
+        "config": {
+            "wide_screen_mode": True,
+            "streaming_mode": True,
+            "summary": {"content": ""},
+            "streaming_config": {
+                "print_frequency_ms": {
+                    "default": 70,
+                    "android": 70,
+                    "ios": 70,
+                    "pc": 70,
+                },
+                "print_step": {
+                    "default": 1,
+                    "android": 1,
+                    "ios": 1,
+                    "pc": 1,
+                },
+                "print_strategy": "fast",
+            },
+        },
+        "body": {
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": content or "",
+                    "element_id": element_id,
+                }
+            ]
+        },
+    }
     return json.dumps(card, ensure_ascii=False)
 
 
@@ -1425,6 +1498,31 @@ def check_feishu_requirements() -> bool:
 
     def _import():
         import lark_oapi as lark
+        from lark_oapi.api.cardkit.v1.model.card import Card as CardKitCard
+        try:
+            from lark_oapi.api.cardkit.v1.model.content_card_element_request import (
+                ContentCardElementRequest,
+            )
+            from lark_oapi.api.cardkit.v1.model.content_card_element_request_body import (
+                ContentCardElementRequestBody,
+            )
+            from lark_oapi.api.cardkit.v1.model.create_card_request import CreateCardRequest
+            from lark_oapi.api.cardkit.v1.model.create_card_request_body import (
+                CreateCardRequestBody,
+            )
+            from lark_oapi.api.cardkit.v1.model.settings_card_request import SettingsCardRequest
+            from lark_oapi.api.cardkit.v1.model.settings_card_request_body import (
+                SettingsCardRequestBody,
+            )
+        except ImportError:
+            ContentCardElementRequest = None
+            ContentCardElementRequestBody = None
+            CreateCardRequest = None
+            CreateCardRequestBody = None
+            SettingsCardRequest = None
+            SettingsCardRequestBody = None
+        from lark_oapi.api.cardkit.v1.model.update_card_request import UpdateCardRequest
+        from lark_oapi.api.cardkit.v1.model.update_card_request_body import UpdateCardRequestBody
         from lark_oapi.api.application.v6 import GetApplicationRequest
         from lark_oapi.api.im.v1 import (
             CreateFileRequest, CreateFileRequestBody,
@@ -1445,6 +1543,15 @@ def check_feishu_requirements() -> bool:
         from lark_oapi.ws import Client as FeishuWSClient
         return {
             "lark": lark,
+            "CardKitCard": CardKitCard,
+            "ContentCardElementRequest": ContentCardElementRequest,
+            "ContentCardElementRequestBody": ContentCardElementRequestBody,
+            "CreateCardRequest": CreateCardRequest,
+            "CreateCardRequestBody": CreateCardRequestBody,
+            "SettingsCardRequest": SettingsCardRequest,
+            "SettingsCardRequestBody": SettingsCardRequestBody,
+            "UpdateCardRequest": UpdateCardRequest,
+            "UpdateCardRequestBody": UpdateCardRequestBody,
             "GetApplicationRequest": GetApplicationRequest,
             "CreateFileRequest": CreateFileRequest,
             "CreateFileRequestBody": CreateFileRequestBody,
@@ -1481,10 +1588,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    REQUIRES_EDIT_FINALIZE = True
 
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
+    STREAMING_CARD_STATE_MAX_SIZE: int = 256
+    STREAMING_CARD_ELEMENT_ID = "hermes_stream_md"
     # Threshold for detecting Feishu client-side message splits.
     # When a chunk is near the ~4096-char practical limit, a continuation
     # is almost certain.
@@ -1551,6 +1661,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        self._streaming_cards: "OrderedDict[str, FeishuStreamingCardState]" = OrderedDict()
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -1822,6 +1933,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
         self._running = False
+        self._streaming_cards.clear()
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
@@ -1956,6 +2068,27 @@ class FeishuAdapter(BasePlatformAdapter):
         last_response = None
 
         try:
+            if (metadata or {}).get("expect_edits") is True and len(chunks) == 1:
+                try:
+                    streaming_result = await self._send_streaming_card_entity(
+                        chat_id=chat_id,
+                        content=chunks[0],
+                        reply_to=reply_to,
+                        metadata=metadata,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "[Feishu] CardKit streaming setup failed; using normal card",
+                        exc_info=True,
+                    )
+                    streaming_result = SendResult(success=False, error=str(exc))
+                if streaming_result.success:
+                    return streaming_result
+                logger.warning(
+                    "[Feishu] CardKit streaming unavailable; falling back to a normal "
+                    "interactive card: %s",
+                    streaming_result.error,
+                )
             for chunk in chunks:
                 msg_type, payload = self._build_outbound_payload(chunk)
                 try:
@@ -2011,6 +2144,19 @@ class FeishuAdapter(BasePlatformAdapter):
 
         content = self.format_message(content)
         try:
+            streaming_state = self._streaming_cards.get(message_id)
+            if streaming_state is not None:
+                result = await self._update_streaming_card_text(streaming_state, content)
+                if finalize:
+                    close_result = await self._close_streaming_card(streaming_state)
+                    if close_result.success:
+                        self._streaming_cards.pop(message_id, None)
+                    if result.success and not close_result.success:
+                        result = close_result
+                if result.success:
+                    result.message_id = message_id
+                return result
+
             msg_type, payload = self._build_outbound_payload(content)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
             request = self._build_update_message_request(message_id=message_id, request_body=body)
@@ -3055,10 +3201,14 @@ class FeishuAdapter(BasePlatformAdapter):
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
 
-        synthetic_text = f"/card {action_tag}"
+        hermes_command = ""
+        if isinstance(action_value, dict):
+            hermes_command = str(action_value.get("hermes_command") or "").strip()
+        synthetic_text = hermes_command if hermes_command.startswith("/") else f"/card {action_tag}"
         if action_value:
             try:
-                synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
+                if not hermes_command:
+                    synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
             except Exception:
                 pass
 
@@ -4597,6 +4747,184 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         return "interactive", _build_markdown_card_payload(content)
 
+    async def _send_streaming_card_entity(
+        self,
+        *,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        """Create an empty CardKit entity, seed its text, then send it."""
+        cardkit_v1 = getattr(getattr(self._client, "cardkit", None), "v1", None)
+        card_api = getattr(cardkit_v1, "card", None)
+        element_api = getattr(cardkit_v1, "card_element", None)
+        if (
+            card_api is None
+            or not hasattr(card_api, "create")
+            or element_api is None
+            or not hasattr(element_api, "content")
+        ):
+            return SendResult(success=False, error="Feishu CardKit streaming API unavailable")
+
+        create_request = self._build_create_card_request(
+            card_payload=_build_streaming_card_payload(
+                "",
+                element_id=self.STREAMING_CARD_ELEMENT_ID,
+            )
+        )
+        create_response = await self._run_blocking(card_api.create, create_request)
+        if not self._response_succeeded(create_response):
+            return self._response_error_result(
+                create_response,
+                default_message="card entity creation failed",
+            )
+        card_id = self._extract_response_field(create_response, "card_id")
+        if not card_id:
+            return SendResult(
+                success=False,
+                error="Feishu CardKit create response omitted card_id",
+                raw_response=create_response,
+            )
+
+        state = FeishuStreamingCardState(
+            card_id=str(card_id),
+            element_id=self.STREAMING_CARD_ELEMENT_ID,
+        )
+        seed_result = await self._update_streaming_card_text(state, content)
+        if not seed_result.success:
+            return seed_result
+
+        entity_payload = json.dumps(
+            {"type": "card", "data": {"card_id": str(card_id)}},
+            ensure_ascii=False,
+        )
+        send_response = await self._feishu_send_with_retry(
+            chat_id=chat_id,
+            msg_type="interactive",
+            payload=entity_payload,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        result = self._finalize_send_result(send_response, "streaming card send failed")
+        if not result.success or not result.message_id:
+            if result.success:
+                return SendResult(
+                    success=False,
+                    error="Feishu streaming card send response omitted message_id",
+                    raw_response=send_response,
+                )
+            return result
+
+        message_id = str(result.message_id)
+        self._streaming_cards[message_id] = state
+        self._streaming_cards.move_to_end(message_id)
+        while len(self._streaming_cards) > self.STREAMING_CARD_STATE_MAX_SIZE:
+            self._streaming_cards.popitem(last=False)
+        result.message_id = message_id
+        return result
+
+    async def _update_streaming_card_text(
+        self,
+        state: FeishuStreamingCardState,
+        content: str,
+    ) -> SendResult:
+        cardkit_v1 = getattr(getattr(self._client, "cardkit", None), "v1", None)
+        element_api = getattr(cardkit_v1, "card_element", None)
+        if element_api is None or not hasattr(element_api, "content"):
+            return SendResult(success=False, error="Feishu CardKit text streaming API unavailable")
+
+        state.sequence += 1
+        request = self._build_content_card_element_request(
+            card_id=state.card_id,
+            element_id=state.element_id,
+            content=content,
+            sequence=state.sequence,
+            uuid_value=str(uuid.uuid4()),
+        )
+        try:
+            response = await self._run_blocking(element_api.content, request)
+            return self._finalize_send_result(response, "streaming card text update failed")
+        except Exception as exc:
+            logger.error(
+                "[Feishu] Failed to stream text to card %s: %s",
+                state.card_id,
+                exc,
+                exc_info=True,
+            )
+            return SendResult(success=False, error=str(exc))
+
+    async def _close_streaming_card(
+        self,
+        state: FeishuStreamingCardState,
+    ) -> SendResult:
+        cardkit_v1 = getattr(getattr(self._client, "cardkit", None), "v1", None)
+        card_api = getattr(cardkit_v1, "card", None)
+        if card_api is None or not hasattr(card_api, "settings"):
+            return SendResult(success=False, error="Feishu CardKit settings API unavailable")
+
+        state.sequence += 1
+        request = self._build_settings_card_request(
+            card_id=state.card_id,
+            settings=json.dumps({"config": {"streaming_mode": False}}),
+            sequence=state.sequence,
+            uuid_value=str(uuid.uuid4()),
+        )
+        try:
+            response = await self._run_blocking(card_api.settings, request)
+            return self._finalize_send_result(response, "streaming card close failed")
+        except Exception as exc:
+            logger.error(
+                "[Feishu] Failed to close streaming mode for card %s: %s",
+                state.card_id,
+                exc,
+                exc_info=True,
+            )
+            return SendResult(success=False, error=str(exc))
+
+    async def update_card_content(
+        self,
+        *,
+        card_id: str,
+        content: str,
+        sequence: int = 0,
+        uuid_value: Optional[str] = None,
+        header_title: str = "",
+        header_template: str = "indigo",
+        actions: Optional[List[Dict[str, Any]]] = None,
+    ) -> SendResult:
+        """Update a Feishu cardkit card with the same schema 2.0 markdown body.
+
+        This is the adapter-side hook expected by StreamingCard-style callers:
+        create an empty card, then call cardkit ``update`` with increasing
+        sequence values as content streams in.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        if not card_id:
+            return SendResult(success=False, error="Missing card_id")
+        try:
+            payload = _build_markdown_card_payload(
+                content,
+                header_title=header_title,
+                header_template=header_template,
+                actions=actions,
+            )
+            request = self._build_update_card_request(
+                card_id=card_id,
+                card_payload=payload,
+                sequence=sequence,
+                uuid_value=uuid_value or str(uuid.uuid4()),
+            )
+            card_api = getattr(getattr(getattr(self._client, "cardkit", None), "v1", None), "card", None)
+            if card_api is None or not hasattr(card_api, "update"):
+                return SendResult(success=False, error="Feishu cardkit update API unavailable")
+            response = await self._run_blocking(card_api.update, request)
+            return self._finalize_send_result(response, "card update failed")
+        except Exception as exc:
+            logger.error("[Feishu] Failed to update card %s: %s", card_id, exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
     async def _send_uploaded_file_message(
         self,
         *,
@@ -5004,6 +5332,113 @@ class FeishuAdapter(BasePlatformAdapter):
                 .build()
             )
         return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_update_card_request(
+        *,
+        card_id: str,
+        card_payload: str,
+        sequence: int,
+        uuid_value: str,
+    ) -> Any:
+        if (
+            "CardKitCard" in globals()
+            and "UpdateCardRequestBody" in globals()
+            and "UpdateCardRequest" in globals()
+        ):
+            card = CardKitCard.builder().type("raw").data(card_payload).build()
+            body = (
+                UpdateCardRequestBody.builder()
+                .card(card)
+                .uuid(uuid_value)
+                .sequence(sequence)
+                .build()
+            )
+            return (
+                UpdateCardRequest.builder()
+                .card_id(card_id)
+                .request_body(body)
+                .build()
+            )
+        card = SimpleNamespace(type="raw", data=card_payload)
+        body = SimpleNamespace(card=card, uuid=uuid_value, sequence=sequence)
+        return SimpleNamespace(card_id=card_id, request_body=body)
+
+    @staticmethod
+    def _build_create_card_request(*, card_payload: str) -> Any:
+        create_request = globals().get("CreateCardRequest")
+        create_body = globals().get("CreateCardRequestBody")
+        if create_request is not None and create_body is not None:
+            body = (
+                create_body.builder()
+                .type("card_json")
+                .data(card_payload)
+                .build()
+            )
+            return create_request.builder().request_body(body).build()
+        return SimpleNamespace(
+            request_body=SimpleNamespace(type="card_json", data=card_payload)
+        )
+
+    @staticmethod
+    def _build_content_card_element_request(
+        *,
+        card_id: str,
+        element_id: str,
+        content: str,
+        sequence: int,
+        uuid_value: str,
+    ) -> Any:
+        content_request = globals().get("ContentCardElementRequest")
+        content_body = globals().get("ContentCardElementRequestBody")
+        if content_request is not None and content_body is not None:
+            body = (
+                content_body.builder()
+                .uuid(uuid_value)
+                .content(content)
+                .sequence(sequence)
+                .build()
+            )
+            return (
+                content_request.builder()
+                .card_id(card_id)
+                .element_id(element_id)
+                .request_body(body)
+                .build()
+            )
+        body = SimpleNamespace(uuid=uuid_value, content=content, sequence=sequence)
+        return SimpleNamespace(
+            card_id=card_id,
+            element_id=element_id,
+            request_body=body,
+        )
+
+    @staticmethod
+    def _build_settings_card_request(
+        *,
+        card_id: str,
+        settings: str,
+        sequence: int,
+        uuid_value: str,
+    ) -> Any:
+        settings_request = globals().get("SettingsCardRequest")
+        settings_body = globals().get("SettingsCardRequestBody")
+        if settings_request is not None and settings_body is not None:
+            body = (
+                settings_body.builder()
+                .settings(settings)
+                .uuid(uuid_value)
+                .sequence(sequence)
+                .build()
+            )
+            return (
+                settings_request.builder()
+                .card_id(card_id)
+                .request_body(body)
+                .build()
+            )
+        body = SimpleNamespace(settings=settings, uuid=uuid_value, sequence=sequence)
+        return SimpleNamespace(card_id=card_id, request_body=body)
 
     @staticmethod
     def _build_create_message_body(*, receive_id: str, msg_type: str, content: str, uuid_value: str) -> Any:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2702,7 +2702,279 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_interactive_card_for_inline_markdown(self):
+    def test_markdown_card_payload_supports_header_and_buttons(self):
+        from plugins.platforms.feishu.adapter import (
+            _build_feishu_card_action_button,
+            _build_markdown_card_payload,
+        )
+
+        payload = json.loads(
+            _build_markdown_card_payload(
+                "请选择操作",
+                header_title="操作",
+                header_template="orange",
+                actions=[
+                    _build_feishu_card_action_button("Help", command="/help"),
+                    _build_feishu_card_action_button("新会话", command="/new", button_type="primary"),
+                ],
+            )
+        )
+
+        self.assertEqual(payload["schema"], "2.0")
+        self.assertEqual(payload["header"]["template"], "orange")
+        elements = payload["body"]["elements"]
+        self.assertEqual(elements[0], {"tag": "markdown", "content": "请选择操作"})
+        self.assertEqual(elements[1], {"tag": "hr"})
+        actions = elements[2:]
+        self.assertEqual(
+            [action["value"]["hermes_command"] for action in actions],
+            ["/help", "/new"],
+        )
+        self.assertNotIn("footer", payload)
+        self.assertNotIn("action", {element.get("tag") for element in elements})
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_streaming_card_uses_cardkit_entity_lifecycle(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        captured = {"create": [], "content": [], "settings": [], "send": []}
+
+        class _CardAPI:
+            def create(self, request):
+                captured["create"].append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(card_id="card_stream_1"),
+                )
+
+            def settings(self, request):
+                captured["settings"].append(request)
+                return SimpleNamespace(success=lambda: True)
+
+        class _CardElementAPI:
+            def content(self, request):
+                captured["content"].append(request)
+                return SimpleNamespace(success=lambda: True)
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            cardkit=SimpleNamespace(
+                v1=SimpleNamespace(card=_CardAPI(), card_element=_CardElementAPI())
+            )
+        )
+
+        async def _direct(func, *args):
+            return func(*args)
+
+        async def _send(**kwargs):
+            captured["send"].append(kwargs)
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(message_id="om_stream_1"),
+            )
+
+        adapter._run_blocking = _direct
+        adapter._feishu_send_with_retry = _send
+
+        result = asyncio.run(
+            adapter.send(
+                chat_id="oc_chat",
+                content="first chunk",
+                metadata={"expect_edits": True},
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_stream_1")
+        create_request = captured["create"][0]
+        self.assertEqual(create_request.request_body.type, "card_json")
+        card = json.loads(create_request.request_body.data)
+        self.assertEqual(card["schema"], "2.0")
+        self.assertTrue(card["config"]["streaming_mode"])
+        self.assertNotIn("header", card)
+        self.assertEqual(
+            card["body"]["elements"][0],
+            {
+                "tag": "markdown",
+                "content": "",
+                "element_id": "hermes_stream_md",
+            },
+        )
+
+        seed_request = captured["content"][0]
+        self.assertEqual(seed_request.card_id, "card_stream_1")
+        self.assertEqual(seed_request.element_id, "hermes_stream_md")
+        self.assertEqual(seed_request.request_body.content, "first chunk")
+        self.assertEqual(seed_request.request_body.sequence, 1)
+        self.assertEqual(captured["send"][0]["msg_type"], "interactive")
+        self.assertEqual(
+            json.loads(captured["send"][0]["payload"]),
+            {"type": "card", "data": {"card_id": "card_stream_1"}},
+        )
+        self.assertIn("om_stream_1", adapter._streaming_cards)
+
+        partial = asyncio.run(
+            adapter.edit_message(
+                chat_id="oc_chat",
+                message_id="om_stream_1",
+                content="first chunk plus more",
+                finalize=False,
+            )
+        )
+        final = asyncio.run(
+            adapter.edit_message(
+                chat_id="oc_chat",
+                message_id="om_stream_1",
+                content="final answer",
+                finalize=True,
+            )
+        )
+
+        self.assertTrue(partial.success)
+        self.assertTrue(final.success)
+        self.assertEqual(
+            [request.request_body.sequence for request in captured["content"]],
+            [1, 2, 3],
+        )
+        self.assertEqual(captured["content"][-1].request_body.content, "final answer")
+        close_request = captured["settings"][0]
+        self.assertEqual(close_request.request_body.sequence, 4)
+        self.assertEqual(
+            json.loads(close_request.request_body.settings),
+            {"config": {"streaming_mode": False}},
+        )
+        self.assertNotIn("om_stream_1", adapter._streaming_cards)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_streaming_card_creation_failure_falls_back_to_normal_card(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        captured = {"send": []}
+
+        class _CardAPI:
+            def create(self, _request):
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=999,
+                    msg="cardkit unavailable",
+                )
+
+        class _CardElementAPI:
+            def content(self, _request):
+                raise AssertionError("content must not be called after create failure")
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            cardkit=SimpleNamespace(
+                v1=SimpleNamespace(card=_CardAPI(), card_element=_CardElementAPI())
+            )
+        )
+
+        async def _direct(func, *args):
+            return func(*args)
+
+        async def _send(**kwargs):
+            captured["send"].append(kwargs)
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(message_id="om_fallback"),
+            )
+
+        adapter._run_blocking = _direct
+        adapter._feishu_send_with_retry = _send
+
+        result = asyncio.run(
+            adapter.send(
+                chat_id="oc_chat",
+                content="fallback body",
+                metadata={"expect_edits": True},
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_fallback")
+        self.assertEqual(len(captured["send"]), 1)
+        self.assertEqual(captured["send"][0]["msg_type"], "interactive")
+        fallback_card = json.loads(captured["send"][0]["payload"])
+        self.assertEqual(fallback_card["schema"], "2.0")
+        self.assertEqual(
+            fallback_card["body"]["elements"][0],
+            {"tag": "markdown", "content": "fallback body"},
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_update_card_content_uses_cardkit_schema_2_payload(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _CardAPI:
+            def update(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            cardkit=SimpleNamespace(v1=SimpleNamespace(card=_CardAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.update_card_content(
+                    card_id="card_123",
+                    content="streaming body",
+                    sequence=7,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].card_id, "card_123")
+        self.assertEqual(captured["request"].request_body.sequence, 7)
+        payload = json.loads(captured["request"].request_body.card.data)
+        self.assertEqual(payload["schema"], "2.0")
+        self.assertEqual(payload["body"]["elements"][0], {"tag": "markdown", "content": "streaming body"})
+        self.assertNotIn("header", payload)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_action_hermes_command_routes_direct_command(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={
+                "user_id": "ou_user",
+                "user_id_alt": "ou_user",
+                "user_name": "User",
+            }
+        )
+        adapter.get_chat_info = AsyncMock(return_value={"name": "Chat"})
+        adapter._handle_message_with_guards = AsyncMock()
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                token="token_1",
+                context=SimpleNamespace(open_chat_id="oc_chat"),
+                operator=SimpleNamespace(open_id="ou_user"),
+                action=SimpleNamespace(
+                    tag="button",
+                    value={"hermes_command": "/new"},
+                ),
+            )
+        )
+
+        asyncio.run(adapter._handle_card_action_event(data))
+
+        event = adapter._handle_message_with_guards.await_args.args[0]
+        self.assertEqual(event.text, "/new")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_schema_2_interactive_card_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -45,6 +45,17 @@ def _mock_event_dispatcher_builder(mock_handler_class):
     return mock_builder
 
 
+def _assert_interactive_markdown_card(testcase, request, expected_content, *, has_header=False):
+    testcase.assertEqual(request.request_body.msg_type, "interactive")
+    payload = json.loads(request.request_body.content)
+    testcase.assertEqual(payload["schema"], "2.0")
+    testcase.assertEqual(
+        payload["body"]["elements"][0],
+        {"tag": "markdown", "content": expected_content},
+    )
+    testcase.assertEqual("header" in payload, has_header)
+
+
 class TestConfigEnvOverrides(unittest.TestCase):
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_xxx",
@@ -519,10 +530,10 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_progress")
         self.assertEqual(captured["request"].message_id, "om_progress")
-        self.assertEqual(captured["request"].request_body.msg_type, "text")
-        self.assertEqual(
-            captured["request"].request_body.content,
-            json.dumps({"text": "📖 read_file: \"/tmp/image.png\""}, ensure_ascii=False),
+        _assert_interactive_markdown_card(
+            self,
+            captured["request"],
+            "📖 read_file: \"/tmp/image.png\"",
         )
 
     @patch.dict(os.environ, {}, clear=True)
@@ -561,7 +572,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2691,7 +2702,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_post_for_inline_markdown(self):
+    def test_send_uses_interactive_card_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2726,13 +2737,14 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
-        payload = json.loads(captured["request"].request_body.content)
-        elements = payload["zh_cn"]["content"][0]
-        self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+        _assert_interactive_markdown_card(
+            self,
+            captured["request"],
+            "可以用 **粗体** 和 *斜体*。",
+        )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
+    def test_send_keeps_fenced_code_blocks_in_card_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2777,22 +2789,7 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
-        payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [
-                [
-                    {
-                        "tag": "md",
-                        "text": "确认已入库 ✓\n文件路径：`/root/.hermes/profiles/agent_cto/cron/jobs.json`\n**解码后的内容：**",
-                    }
-                ],
-                [{"tag": "md", "text": "```json\n{\"cron\": \"list\"}\n```"}],
-                [{"tag": "md", "text": "后续说明仍应保留。"}],
-            ],
-        )
+        _assert_interactive_markdown_card(self, captured["request"], content)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
@@ -2897,7 +2894,7 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2942,7 +2939,7 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2950,7 +2947,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_post_for_advanced_markdown_lines(self):
+    def test_send_uses_interactive_card_for_advanced_markdown_lines(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2985,12 +2982,10 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
-        payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
+        _assert_interactive_markdown_card(
+            self,
+            captured["request"],
+            "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~",
         )
 
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -116,17 +116,22 @@ class TestFeishuExecApproval:
 
         # Verify card payload contains the command and buttons
         card = json.loads(kwargs["payload"])
-        assert card["header"]["template"] == "orange"
-        assert "rm -rf /important" in card["elements"][0]["content"]
-        assert "dangerous deletion" in card["elements"][0]["content"]
+        assert card["schema"] == "2.0"
+        elements = card["body"]["elements"]
+        assert "header" not in card
+        assert "rm -rf /important" in elements[0]["content"]
+        assert "dangerous deletion" in elements[0]["content"]
 
         # Check buttons
-        actions = card["elements"][1]["actions"]
+        assert elements[1] == {"tag": "hr"}
+        actions = elements[2:]
         assert len(actions) == 4
         action_names = [a["value"]["hermes_action"] for a in actions]
         assert action_names == [
             "approve_once", "approve_session", "approve_always", "deny"
         ]
+        assert "footer" not in card
+        assert "action" not in {element.get("tag") for element in elements}
 
     @pytest.mark.asyncio
     async def test_stores_approval_state(self):
@@ -180,7 +185,7 @@ class TestFeishuExecApproval:
             )
 
         card = json.loads(mock_send.call_args[1]["payload"])
-        content = card["elements"][0]["content"]
+        content = card["body"]["elements"][0]["content"]
         assert "..." in content
         assert len(content) < 5000
 
@@ -244,11 +249,16 @@ class TestFeishuUpdatePrompt:
         assert kwargs["metadata"] == {"thread_id": "th_1"}
 
         card = json.loads(kwargs["payload"])
-        assert card["header"]["template"] == "orange"
-        assert "Restore stashed changes after update?" in card["elements"][0]["content"]
-        assert "Default: `y`" in card["elements"][0]["content"]
-        actions = card["elements"][1]["actions"]
+        assert card["schema"] == "2.0"
+        elements = card["body"]["elements"]
+        assert "header" not in card
+        assert "Restore stashed changes after update?" in elements[0]["content"]
+        assert "Default: `y`" in elements[0]["content"]
+        assert elements[1] == {"tag": "hr"}
+        actions = elements[2:]
         assert [a["value"]["hermes_update_prompt_action"] for a in actions] == ["y", "n"]
+        assert "footer" not in card
+        assert "action" not in {element.get("tag") for element in elements}
 
     @pytest.mark.asyncio
     async def test_stores_prompt_state(self):
@@ -498,9 +508,10 @@ class TestCardActionCallbackResponse:
         assert response.card is not None
         assert response.card.type == "raw"
         card = response.card.data
-        assert card["header"]["template"] == "green"
+        assert card["schema"] == "2.0"
+        assert card["header"]["template"] == "indigo"
         assert "Approved once" in card["header"]["title"]["content"]
-        assert "Bob" in card["elements"][0]["content"]
+        assert "Bob" in card["body"]["elements"][0]["content"]
 
     def test_returns_card_for_deny_action(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -521,7 +532,8 @@ class TestCardActionCallbackResponse:
 
         assert response.card is not None
         card = response.card.data
-        assert card["header"]["template"] == "red"
+        assert card["schema"] == "2.0"
+        assert card["header"]["template"] == "orange"
         assert "Denied" in card["header"]["title"]["content"]
 
     def test_ignores_missing_approval_id(self, _patch_callback_card_types):
@@ -568,7 +580,7 @@ class TestCardActionCallbackResponse:
             response = adapter._on_card_action_trigger(data)
 
         card = response.card.data
-        assert "ou_unknown" in card["elements"][0]["content"]
+        assert "ou_unknown" in card["body"]["elements"][0]["content"]
 
     def test_ignores_expired_cached_name(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -590,8 +602,8 @@ class TestCardActionCallbackResponse:
             response = adapter._on_card_action_trigger(data)
 
         card = response.card.data
-        assert "Old Name" not in card["elements"][0]["content"]
-        assert "ou_expired" in card["elements"][0]["content"]
+        assert "Old Name" not in card["body"]["elements"][0]["content"]
+        assert "ou_expired" in card["body"]["elements"][0]["content"]
 
     def test_rejects_approval_click_from_unauthorized_user(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -660,9 +672,10 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is not None
         card = response.card.data
-        assert card["header"]["template"] == "green"
+        assert card["schema"] == "2.0"
+        assert card["header"]["template"] == "indigo"
         assert "answered: Yes" in card["header"]["title"]["content"]
-        assert "Bob" in card["elements"][0]["content"]
+        assert "Bob" in card["body"]["elements"][0]["content"]
 
     def test_returns_card_for_update_prompt_no(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -684,7 +697,8 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is not None
         card = response.card.data
-        assert card["header"]["template"] == "red"
+        assert card["schema"] == "2.0"
+        assert card["header"]["template"] == "orange"
         assert "answered: No" in card["header"]["title"]["content"]
 
     def test_ignores_missing_update_prompt_id(self, _patch_callback_card_types):


### PR DESCRIPTION
## What changed

- Send normal Feishu replies, approvals, and update prompts as schema 2.0 interactive cards.
- Place Card 2.0 buttons directly in `body.elements` and preserve the current `allow_permanent` / `smart_denied` approval semantics.
- Route inline `hermes_command` buttons such as `/help` and `/new` directly.
- Add the CardKit streaming lifecycle: create an empty card entity, update a stable markdown element with increasing sequences, close `streaming_mode` on finalize, and fall back to a normal Card 2.0 message if CardKit setup fails.

## Why

The current Feishu adapter falls back to text/post output and legacy card layouts, which removes approval buttons and prevents CardKit streaming. Feishu Card 2.0 requires direct button elements; the legacy `action` container is rejected.

## Validation

- `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py tests/gateway/test_feishu_approval_buttons.py`
- `328 passed, 47 skipped` across Feishu adapter, approval, and stream-consumer tests
- Contract verifier passed 9 Card 2.0 / CardKit lifecycle checks
- Live Feishu canary passed create, text update, finalize, and state cleanup

The two commits are intentionally isolated from local skill/memory governance changes.