### PR TITLE
feat(context): add Codex-style compaction engine

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1593,6 +1593,13 @@ def init_agent(
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
+    compression_strategy = str(_compression_cfg.get("strategy", "hermes") or "hermes").strip().lower()
+    if compression_strategy not in {"hermes", "codex"}:
+        _ra().logger.warning(
+            "Invalid compression.strategy=%r; using 'hermes'. Valid values: hermes, codex.",
+            compression_strategy,
+        )
+        compression_strategy = "hermes"
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
@@ -1780,7 +1787,7 @@ def init_agent(
     except Exception:
         pass
 
-    if _engine_name != "compressor":
+    if _engine_name not in {"compressor", "codex"}:
         # Try loading from plugins/context_engine/<name>/
         try:
             from plugins.context_engine import load_context_engine
@@ -1825,6 +1832,12 @@ def init_agent(
             )
     # else: config says "compressor" — use built-in, don't auto-activate plugins
 
+    # ``codex`` is a built-in engine alias, not a plugin. It shares the
+    # ContextCompressor implementation but owns an explicit first-class name
+    # and forces the Codex replacement-history strategy.
+    if _engine_name == "codex":
+        compression_strategy = "codex"
+
     if _selected_engine is not None:
         agent.context_compressor = _selected_engine
         # External engines own compaction policy: the host compression
@@ -1860,6 +1873,8 @@ def init_agent(
             protect_first_n=compression_protect_first,
             protect_last_n=compression_protect_last,
             summary_target_ratio=compression_target_ratio,
+            strategy=compression_strategy,
+            engine_name=_engine_name,
             summary_model_override=None,
             quiet_mode=agent.quiet_mode,
             base_url=agent.base_url,

--- a/agent/codex_style_compaction.py
+++ b/agent/codex_style_compaction.py
@@ -1,0 +1,125 @@
+"""Codex-style context compaction primitives.
+
+This module deliberately contains only the replacement-history algorithm from
+Codex's ``codex-rs/core/src/compact.rs``.  Provider/session lifecycle remains
+owned by Hermes' ContextCompressor.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Iterable
+
+
+# Matches Codex's COMPACT_USER_MESSAGE_MAX_TOKENS.  The production Codex
+# implementation uses its tokenizer; Hermes currently has a conservative
+# rough-token estimator, so selection here uses the same 4 chars/token rule.
+CODEX_COMPACT_USER_MESSAGE_MAX_TOKENS = 20_000
+CODEX_SUMMARIZATION_PROMPT = """You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.
+
+Include:
+- Current progress and key decisions made
+- Important context, constraints, or user preferences
+- What remains to be done (clear next steps)
+- Any critical data, examples, or references needed to continue
+
+Be concise, structured, and focused on helping the next LLM seamlessly continue the work."""
+CODEX_SUMMARY_PREFIX = """Another language model started to solve this problem and produced a summary of its thinking process. You also have access to the state of the tools that were used by that language model. Use this to build on the work that has already been done and avoid duplicating work. Here is the summary produced by the other language model, use the information in this summary to assist with your own analysis:"""
+_CHARS_PER_TOKEN = 4
+
+
+def _content_to_text(content: Any) -> str:
+    """Flatten OpenAI-style content into the text Codex keeps in history."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        pieces: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                pieces.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    pieces.append(text)
+        return "\n".join(piece for piece in pieces if piece)
+    return str(content)
+
+
+def _approx_tokens(text: str) -> int:
+    return max(1, (len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN)
+
+
+def _truncate_to_tokens(text: str, token_budget: int) -> str:
+    if token_budget <= 0:
+        return ""
+    return text[: token_budget * _CHARS_PER_TOKEN]
+
+
+def _is_summary_message(text: str, summary_prefix: str) -> bool:
+    return text.startswith(summary_prefix) or text.startswith("[CONTEXT COMPACTION")
+
+
+def collect_user_messages(
+    messages: Iterable[dict[str, Any]],
+    *,
+    summary_prefix: str = CODEX_SUMMARY_PREFIX,
+) -> list[str]:
+    """Collect real user messages, excluding prior compaction summaries.
+
+    This mirrors Codex's ``collect_user_messages``: assistant messages, tool
+    results, system messages, and old summaries are not copied into the
+    replacement history.
+    """
+    result: list[str] = []
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        text = _content_to_text(message.get("content"))
+        if text and not _is_summary_message(text, summary_prefix):
+            result.append(text)
+    return result
+
+
+def build_compacted_history(
+    messages: Iterable[dict[str, Any]],
+    summary_text: str,
+    *,
+    max_tokens: int = CODEX_COMPACT_USER_MESSAGE_MAX_TOKENS,
+    summary_prefix: str = CODEX_SUMMARY_PREFIX,
+) -> list[dict[str, Any]]:
+    """Build Codex's replacement history from recent user messages + summary.
+
+    User messages are selected newest-first under ``max_tokens`` and restored
+    to chronological order.  If the oldest selected message does not fit, it
+    is truncated to the remaining budget, matching Codex's final partial-item
+    behavior.  The new summary is always the final user message.
+    """
+    user_messages = collect_user_messages(messages, summary_prefix=summary_prefix)
+    initial_context = [
+        deepcopy(message)
+        for message in messages
+        if message.get("role") == "system"
+    ]
+    selected: list[str] = []
+    remaining = max(0, int(max_tokens))
+
+    for text in reversed(user_messages):
+        if remaining <= 0:
+            break
+        tokens = _approx_tokens(text)
+        if tokens <= remaining:
+            selected.append(text)
+            remaining -= tokens
+        else:
+            selected.append(_truncate_to_tokens(text, remaining))
+            break
+
+    selected.reverse()
+    history = initial_context + [{"role": "user", "content": text} for text in selected]
+    history.append({
+        "role": "user",
+        "content": summary_text if summary_text else "(no summary available)",
+    })
+    return deepcopy(history)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -26,6 +26,11 @@ from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error, aux_interrupt_protection
 from agent.context_engine import ContextEngine
+from agent.codex_style_compaction import (
+    CODEX_SUMMARIZATION_PROMPT,
+    CODEX_SUMMARY_PREFIX,
+    build_compacted_history,
+)
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
@@ -721,7 +726,7 @@ class ContextCompressor(ContextEngine):
 
     @property
     def name(self) -> str:
-        return "compressor"
+        return getattr(self, "_engine_name", "compressor")
 
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
@@ -1126,6 +1131,8 @@ class ContextCompressor(ContextEngine):
         summary_target_ratio: float = 0.20,
         quiet_mode: bool = False,
         summary_model_override: str = None,
+        strategy: str = "hermes",
+        engine_name: str = "compressor",
         base_url: str = "",
         api_key: str = "",
         config_context_length: int | None = None,
@@ -1135,6 +1142,13 @@ class ContextCompressor(ContextEngine):
         max_tokens: int | None = None,
     ):
         self.model = model
+        self._engine_name = str(engine_name or "compressor").strip().lower()
+        if self._engine_name not in {"compressor", "codex"}:
+            self._engine_name = "compressor"
+        self.strategy = str(strategy or "hermes").strip().lower()
+        if self.strategy not in {"hermes", "codex"}:
+            logger.warning("Unknown compression strategy %r; using 'hermes'", strategy)
+            self.strategy = "hermes"
         self.base_url = base_url
         self.api_key = api_key
         self.provider = provider
@@ -2363,7 +2377,11 @@ This compaction should PRIORITISE preserving all information related to the focu
         # mistake a merged summary message for a real user turn.
         if _MERGED_SUMMARY_DELIMITER in text:
             text = text.split(_MERGED_SUMMARY_DELIMITER, 1)[1].lstrip()
-        if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
+        if (
+            text.startswith(SUMMARY_PREFIX)
+            or text.startswith(CODEX_SUMMARY_PREFIX)
+            or text.startswith(LEGACY_SUMMARY_PREFIX)
+        ):
             return True
         return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
 
@@ -2921,6 +2939,106 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         return max(cut_idx, head_end + 1)
 
+    def _generate_codex_summary(
+        self,
+        turns: List[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Generate a summary with Codex's native compact prompt."""
+        prompt = CODEX_SUMMARIZATION_PROMPT + "\n\nCONVERSATION:\n" + self._serialize_for_summary(turns)
+        try:
+            response = call_llm(
+                task="compression",
+                main_runtime={
+                    "model": self.model,
+                    "provider": self.provider,
+                    "base_url": self.base_url,
+                    "api_key": self.api_key,
+                    "api_mode": self.api_mode,
+                },
+                messages=[{"role": "user", "content": prompt}],
+                **({"model": self.summary_model} if self.summary_model else {}),
+            )
+            message = response.choices[0].message
+            content = message.get("content") if isinstance(message, dict) else getattr(message, "content", message)
+            if not isinstance(content, str) or not content.strip():
+                raise RuntimeError("Codex-style compression returned empty content")
+            from agent.agent_runtime_helpers import strip_think_blocks
+            content = strip_think_blocks(None, content).strip()
+            content = redact_sensitive_text(content)
+            self._previous_summary = content
+            self._last_summary_error = None
+            self._clear_compression_failure_cooldown()
+            return CODEX_SUMMARY_PREFIX + "\n" + content
+        except Exception as exc:
+            self._last_summary_error = str(exc) or exc.__class__.__name__
+            logger.warning("Codex-style summary generation failed: %s", self._last_summary_error)
+            return None
+
+    def _compress_codex_style(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        current_tokens: int = None,
+        focus_topic: str = None,
+    ) -> List[Dict[str, Any]]:
+        """Apply Codex's replacement-history compaction algorithm.
+
+        Unlike Hermes' default head/middle/tail rewrite, Codex rebuilds the
+        active history from recent real user messages plus one final summary.
+        The original turns remain available to Hermes' session archive; this
+        method only changes the in-memory active message list.
+        """
+        summary_search_start = 1 if messages and messages[0].get("role") == "system" else 0
+        _summary_idx, summary_body = self._find_latest_context_summary(
+            messages, summary_search_start, len(messages)
+        )
+        if summary_body and not self._previous_summary:
+            self._previous_summary = summary_body
+
+        source_turns = [
+            message for message in messages
+            if not self._is_context_summary_content(
+                _content_text_for_contains(message.get("content"))
+            )
+        ]
+        # Codex's native compact prompt intentionally does not use Hermes'
+        # structured section template or focus-topic extension.
+        summary = self._generate_codex_summary(source_turns)
+
+        if not summary and (
+            self.abort_on_summary_failure
+            or self._last_summary_auth_failure
+            or self._last_summary_network_failure
+        ):
+            self._last_compress_aborted = True
+            return messages
+
+        if not summary:
+            self._last_summary_fallback_used = True
+            self._last_summary_dropped_count = len(source_turns)
+            summary = self._build_static_fallback_summary(
+                source_turns,
+                reason=self._last_summary_error,
+            )
+
+        compressed = build_compacted_history(
+            messages,
+            summary,
+            summary_prefix=CODEX_SUMMARY_PREFIX,
+        )
+        compressed = self._sanitize_tool_pairs(compressed)
+        compressed = _strip_historical_media(compressed)
+        _strip_persistence_markers(compressed)
+
+        self.compression_count += 1
+        self._last_compression_made_progress = len(compressed) < len(messages)
+        self._last_compression_savings_pct = (
+            max(0.0, (len(messages) - len(compressed)) / len(messages) * 100)
+            if messages else 0.0
+        )
+        self._verify_compaction_cleared_threshold = True
+        return compressed
+
     # ------------------------------------------------------------------
     # ContextEngine: manual /compress preflight
     # ------------------------------------------------------------------
@@ -2987,6 +3105,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         # this, /compress would silently no-op for 30-60s after a failure.
         if force:
             self._clear_compression_failure_cooldown()
+        if getattr(self, "strategy", "hermes") == "codex":
+            return self._compress_codex_style(
+                messages,
+                current_tokens=current_tokens,
+                focus_topic=focus_topic,
+            )
         n_messages = len(messages)
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1424,6 +1424,7 @@ DEFAULT_CONFIG = {
                                       # doesn't fire with half the window still free;
                                       # set this above 0.75 to override the floor.
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
+        "strategy": "hermes",        # "hermes" or Codex-style replacement history
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
         "protect_first_n": 3,         # non-system head messages always preserved
@@ -2182,10 +2183,11 @@ DEFAULT_CONFIG = {
     
     # Context engine -- controls how the context window is managed when
     # approaching the model's token limit.
-    # "compressor" = built-in lossy summarization (default).
+    # "compressor" = built-in Hermes lossy summarization (default).
+    # "codex" = built-in Codex-style replacement-history compaction.
     # Set to a plugin name to activate an alternative engine (e.g. "lcm"
     # for Lossless Context Management).  The engine must be installed as
-    # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
+    # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins.
     "context": {
         "engine": "compressor",
     },

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1292,20 +1292,23 @@ def _configure_context_engine() -> bool:
     current = _get_current_context_engine()
     engines = _discover_context_engines()
 
-    # Build items: "compressor" first (built-in), then discovered engines
-    items = ["compressor (default)"]
-    names = ["compressor"]
-    selected = 0
+    # Build items: built-in engines first, then discovered plugin engines.
+    items = [
+        "compressor (default)",
+        "codex — Codex-style replacement-history compaction",
+    ]
+    names = ["compressor", "codex"]
+    selected = names.index(current) if current in names else 0
 
     for name, desc in engines:
+        if name in names:
+            continue
         names.append(name)
         label = f"{name} \u2014 {desc}" if desc else name
         items.append(label)
         if name == current:
             selected = len(items) - 1
-
-    # If current engine isn't in discovered list and isn't compressor, add it
-    if current != "compressor" and current not in names:
+    if current not in {"compressor", "codex"} and current not in names:
         names.append(current)
         items.append(f"{current} (not found)")
         selected = len(items) - 1

--- a/tests/agent/test_codex_style_compaction.py
+++ b/tests/agent/test_codex_style_compaction.py
@@ -1,0 +1,80 @@
+"""Behavioral tests for the Codex-style replacement-history algorithm."""
+
+from agent.codex_style_compaction import (
+    CODEX_COMPACT_USER_MESSAGE_MAX_TOKENS,
+    build_compacted_history,
+    collect_user_messages,
+)
+
+
+def test_collect_user_messages_excludes_old_summaries_and_non_user_items():
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "[CONTEXT COMPACTION — REFERENCE ONLY]\nold summary"},
+        {"role": "tool", "content": "large tool output"},
+        {"role": "user", "content": "latest question"},
+    ]
+
+    assert collect_user_messages(messages) == [
+        "old question",
+        "latest question",
+    ]
+
+
+def test_build_history_keeps_recent_user_messages_and_appends_summary():
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "second"},
+        {"role": "tool", "content": "tool result"},
+        {"role": "user", "content": "third"},
+    ]
+
+    result = build_compacted_history(messages, "[SUMMARY]\ncompleted work")
+
+    assert result == [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+        {"role": "user", "content": "third"},
+        {"role": "user", "content": "[SUMMARY]\ncompleted work"},
+    ]
+
+
+def test_build_history_uses_recent_user_token_budget():
+    # Four characters are the Hermes rough-token convention used by the
+    # existing compressor. This makes the 20K Codex boundary deterministic.
+    old = "o" * 32_000       # ~8K tokens
+    middle = "m" * 40_000    # ~10K tokens
+    newest = "n" * 8_000     # ~2K tokens
+    messages = [
+        {"role": "user", "content": old},
+        {"role": "user", "content": middle},
+        {"role": "user", "content": newest},
+    ]
+
+    result = build_compacted_history(messages, "summary")
+    selected = result[:-1]
+
+    assert len(selected) == 3
+    assert selected[0]["content"] == old
+    assert selected[1]["content"] == middle
+    assert selected[2]["content"] == newest
+    assert sum(len(item["content"]) // 4 for item in selected) <= CODEX_COMPACT_USER_MESSAGE_MAX_TOKENS
+
+
+def test_build_history_truncates_oldest_selected_user_message_to_remaining_budget():
+    first = "a" * 80_000       # ~20K tokens
+    newest = "b" * 8_000       # ~2K tokens
+    messages = [
+        {"role": "user", "content": first},
+        {"role": "user", "content": newest},
+    ]
+
+    result = build_compacted_history(messages, "summary")
+    selected = result[:-1]
+
+    assert selected[-1]["content"] == newest
+    assert len(selected[0]["content"]) // 4 == CODEX_COMPACT_USER_MESSAGE_MAX_TOKENS - len(newest) // 4
+    assert selected[0]["content"].startswith("a")


### PR DESCRIPTION
## Summary

- Add `context.engine: codex` as a first-class built-in context engine.
- Port Codex-style replacement-history compaction into Hermes.
- Keep Hermes' existing compressor available as the default/fallback engine.
- Expose the Codex engine in config and the context-engine selector.
- Add focused behavior tests for user-message collection and 20K-token replacement-history selection.

## Configuration

```yaml
context:
  engine: codex

compression:
  enabled: true
  threshold: 0.9
  target_ratio: 0.35
  strategy: codex
```

## Verification

- Focused Codex compaction tests: 4/4 passed.
- Python compilation checks: passed.
- Loaded configuration smoke check: passed (`engine=codex`, `strategy=codex`).
- `git diff --check`: passed.
- Full pytest suite: not run locally because the available Windows environment does not have the `pytest` module installed; CI should provide the final gate.

## Review notes

The replacement-history algorithm is implemented inside Hermes' existing `ContextCompressor` lifecycle. The implementation uses Hermes' current rough token estimator rather than Codex's native tokenizer. Please review upstream Codex license/attribution requirements before merge.
