### PR TITLE
fix(desktop): exclude empty-valued fields from tool-result "more fields" count

### DIFF
--- a/apps/desktop/src/lib/tool-result-summary.test.ts
+++ b/apps/desktop/src/lib/tool-result-summary.test.ts
@@ -64,6 +64,13 @@ describe('formatToolResultSummary', () => {
     expect(summary).toContain('- Title: Build report')
     expect(summary).toContain('- Completed: true')
   })
+
+  it('does not count empty-valued fields as hidden "more fields"', () => {
+    const summary = formatToolResultSummary({ name: 'deploy', warnings: [], tags: [] })
+
+    expect(summary).toContain('- Name: deploy')
+    expect(summary).not.toContain('more field')
+  })
 })
 
 describe('extractToolErrorMessage', () => {

--- a/apps/desktop/src/lib/tool-result-summary.ts
+++ b/apps/desktop/src/lib/tool-result-summary.ts
@@ -260,28 +260,19 @@ function formatRecordSummary(record: Json, depth: number): string {
 
   const candidates = orderedKeys(keys).filter(k => !skipField(k, record[k]))
   const max = 8
-  const lines: string[] = []
 
-  for (const k of candidates) {
-    const v = formatFieldValue(record[k], depth + 1)
+  const rendered = candidates
+    .map(k => ({ k, v: formatFieldValue(record[k], depth + 1) }))
+    .filter(({ v }) => v)
 
-    if (!v) {
-      continue
-    }
-
-    lines.push(`- ${titleCase(k)}: ${v}`)
-
-    if (lines.length >= max) {
-      break
-    }
-  }
-
-  if (!lines.length) {
+  if (!rendered.length) {
     return ''
   }
 
-  if (candidates.length > lines.length) {
-    const remaining = candidates.length - lines.length
+  const lines = rendered.slice(0, max).map(({ k, v }) => `- ${titleCase(k)}: ${v}`)
+
+  if (rendered.length > max) {
+    const remaining = rendered.length - max
     lines.push(`- … ${remaining} more ${remaining === 1 ? 'field' : 'fields'}`)
   }
 


### PR DESCRIPTION
## What does this PR do?

In the desktop tool-result summary formatter, `formatRecordSummary` counted candidate keys whose rendered value is empty — empty arrays, `null`, empty strings — toward the "N more fields" truncation hint. Those fields are correctly skipped while building the visible lines (`if (!v) continue`), but the "more" count was computed as `candidates.length - lines.length`, so fields that render as nothing still inflated the hint.

The result is a phantom truncation notice: expanding or viewing the raw payload shows no additional fields, yet the summary claims some are hidden.

The fix renders all candidates first, drops the empty ones, and only then applies the `max = 8` cap — so "N more fields" reflects real overflow. This mirrors the sibling `formatArraySummary` in the same file, which already gates its "… N more items" line on genuine truncation (it filters empties before counting overflow past its cap). The record path now behaves consistently with the array path.

Behavior is preserved for the real-truncation case (>8 non-empty fields still produces an accurate "N more fields" line) and for all existing summary output.

## Related Issue

<!-- Code-originated correctness fix; no filed issue. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/tool-result-summary.ts`: in `formatRecordSummary`, render candidate fields first and filter out empty-valued ones before applying the `max = 8` cap; compute the "N more fields" count from real overflow (`rendered.length > max`) instead of `candidates.length - lines.length`.
- `apps/desktop/src/lib/tool-result-summary.test.ts`: add a regression test asserting empty-valued fields don't produce a phantom "more fields" line.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/lib/tool-result-summary.test.ts`
2. Fail-before / pass-after: on `main`, `formatToolResultSummary({ name: 'deploy', warnings: [], tags: [] })` returns `- Name: deploy\n- … 2 more fields`. The new test asserts the output contains `- Name: deploy` and does **not** contain `more field`. It fails before the production change and passes after.
3. Full file suite is green (8 tests) and the existing path/status/lines-written, object-array, truncation, and stringified-JSON cases are unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite for this package (`npx vitest run --project ui src/lib/tool-result-summary.test.ts`) and all tests pass (`pytest tests/` does not cover `apps/desktop`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (desktop renderer unit tests via vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string-formatting logic, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A