### PR TITLE
fix(auth): canonicalize inherited Codex refresh state

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -36,6 +36,7 @@ from hermes_cli.auth import (
     _save_provider_state,
     _store_provider_state,
     read_credential_pool,
+    read_credential_pool_with_source,
     write_credential_pool,
 )
 
@@ -560,9 +561,19 @@ def _write_through_provider_state_to_global_root(
 
 
 class CredentialPool:
-    def __init__(self, provider: str, entries: List[PooledCredential]):
+    def __init__(
+        self,
+        provider: str,
+        entries: List[PooledCredential],
+        *,
+        auth_source_path: Optional[Path] = None,
+    ):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
+        self._auth_source_path = auth_source_path
+        self._persisted_entries_by_id = {
+            entry.id: entry.to_dict() for entry in self._entries
+        }
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
         self._lock = threading.Lock()
@@ -592,11 +603,45 @@ class CredentialPool:
                 return
 
     def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+        payloads = [entry.to_dict() for entry in self._entries]
+        codex_source = (
+            self._auth_source_path
+            if self.provider == "openai-codex"
+            else None
+        )
         write_credential_pool(
             self.provider,
-            [entry.to_dict() for entry in self._entries],
+            payloads,
             removed_ids=removed_ids,
+            baseline_entries=(
+                self._persisted_entries_by_id
+                if codex_source is not None
+                else None
+            ),
+            target_path=codex_source,
         )
+        if codex_source is not None:
+            # Adopt the merged canonical snapshot so a later write from this
+            # process cannot reintroduce another process's stale row.
+            auth_store = _load_auth_store(codex_source)
+            pool = auth_store.get("credential_pool")
+            rows = pool.get("openai-codex") if isinstance(pool, dict) else None
+            if isinstance(rows, list):
+                self._entries = sorted(
+                    [
+                        PooledCredential.from_dict("openai-codex", row)
+                        for row in rows
+                        if isinstance(row, dict)
+                    ],
+                    key=lambda entry: entry.priority,
+                )
+                if self._current_id and not any(
+                    entry.id == self._current_id for entry in self._entries
+                ):
+                    self._current_id = None
+        self._persisted_entries_by_id = {
+            entry.id: entry.to_dict() for entry in self._entries
+        }
 
     def _is_terminal_auth_failure(
         self,
@@ -724,9 +769,18 @@ class CredentialPool:
         if self.provider != "openai-codex" or entry.source != "device_code":
             return entry
         try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
-                state = _load_provider_state(auth_store, "openai-codex")
+            source_path = self._auth_source_path
+            with _auth_store_lock(auth_file=source_path):
+                auth_store = _load_auth_store(source_path)
+                if source_path is None:
+                    state = _load_provider_state(auth_store, "openai-codex")
+                else:
+                    providers = auth_store.get("providers")
+                    state = (
+                        providers.get("openai-codex")
+                        if isinstance(providers, dict)
+                        else None
+                    )
             if not isinstance(state, dict):
                 return entry
             tokens = state.get("tokens")
@@ -767,6 +821,35 @@ class CredentialPool:
         except Exception as exc:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
         return entry
+
+    def _reload_codex_entry_from_pool(
+        self, entry: PooledCredential,
+    ) -> Optional[PooledCredential]:
+        """Reload one Codex row from its canonical store while refresh-locked.
+
+        OpenAI refresh tokens are single-use. A second process may have rotated
+        and persisted this exact pool row before this process acquired the
+        canonical lock. Refreshing the stale in-memory row would replay an
+        invalid token, especially for manual and pool-only credentials.
+        """
+        if self.provider != "openai-codex" or self._auth_source_path is None:
+            return entry
+        auth_store = _load_auth_store(self._auth_source_path)
+        pool = auth_store.get("credential_pool")
+        rows = pool.get("openai-codex") if isinstance(pool, dict) else None
+        if not isinstance(rows, list):
+            self._persisted_entries_by_id.pop(entry.id, None)
+            return None
+        for payload in rows:
+            if not isinstance(payload, dict) or payload.get("id") != entry.id:
+                continue
+            updated = PooledCredential.from_dict("openai-codex", payload)
+            if updated != entry:
+                self._replace_entry(entry, updated)
+            self._persisted_entries_by_id[updated.id] = updated.to_dict()
+            return updated
+        self._persisted_entries_by_id.pop(entry.id, None)
+        return None
 
     def _sync_xai_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync an xAI OAuth pool entry from auth.json if tokens differ.
@@ -926,6 +1009,41 @@ class CredentialPool:
         # device-code sources (nous, openai-codex, xAI) use ``device_code``.
         if entry.source != "device_code":
             return
+        if self.provider == "openai-codex" and self._auth_source_path is not None:
+            try:
+                source_path = self._auth_source_path
+                with _auth_store_lock(auth_file=source_path):
+                    auth_store = _load_auth_store(source_path)
+                    providers = auth_store.get("providers")
+                    state = (
+                        providers.get("openai-codex")
+                        if isinstance(providers, dict)
+                        else None
+                    )
+                    if not isinstance(state, dict):
+                        return
+                    tokens = state.get("tokens")
+                    if not isinstance(tokens, dict):
+                        return
+                    tokens["access_token"] = entry.access_token
+                    if entry.refresh_token:
+                        tokens["refresh_token"] = entry.refresh_token
+                    if entry.last_refresh:
+                        state["last_refresh"] = entry.last_refresh
+                    _store_provider_state(
+                        auth_store,
+                        "openai-codex",
+                        state,
+                        set_active=False,
+                    )
+                    _save_auth_store(auth_store, target_path=source_path)
+                return
+            except Exception as exc:
+                logger.debug(
+                    "Failed to sync Codex pool entry to canonical auth store: %s",
+                    exc,
+                )
+                return
         try:
             with _auth_store_lock():
                 auth_store = _load_auth_store()
@@ -1035,12 +1153,24 @@ class CredentialPool:
                 float(auth_mod.AUTH_LOCK_TIMEOUT_SECONDS),
                 float(refresh_timeout_seconds) + 5.0,
             )
-            with _auth_store_lock(timeout_seconds=lock_timeout):
+            with _auth_store_lock(
+                timeout_seconds=lock_timeout,
+                auth_file=self._auth_source_path,
+            ):
+                synced = self._reload_codex_entry_from_pool(entry)
+                if synced is None:
+                    self._entries = [
+                        item for item in self._entries if item.id != entry.id
+                    ]
+                    if self._current_id == entry.id:
+                        self._current_id = None
+                    return None
+                entry = synced
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
-                    if not force and not self._entry_needs_refresh(entry):
-                        return entry
+                if not force and not self._entry_needs_refresh(entry):
+                    return entry
                 return self._refresh_entry_impl(entry, force=force)
         return self._refresh_entry_impl(entry, force=force)
 
@@ -1267,9 +1397,25 @@ class CredentialPool:
                         "Codex OAuth refresh token is terminally invalid; clearing local token state"
                     )
                     try:
-                        with _auth_store_lock():
-                            auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "openai-codex") or {}
+                        source_path = self._auth_source_path
+                        with _auth_store_lock(auth_file=source_path):
+                            auth_store = _load_auth_store(source_path)
+                            if source_path is None:
+                                state = _load_provider_state(
+                                    auth_store, "openai-codex"
+                                ) or {}
+                            else:
+                                providers = auth_store.get("providers")
+                                raw_state = (
+                                    providers.get("openai-codex")
+                                    if isinstance(providers, dict)
+                                    else None
+                                )
+                                state = (
+                                    dict(raw_state)
+                                    if isinstance(raw_state, dict)
+                                    else {}
+                                )
                             if isinstance(state, dict):
                                 tokens = state.get("tokens") or {}
                                 if isinstance(tokens, dict):
@@ -1288,7 +1434,10 @@ class CredentialPool:
                                             "at": datetime.now(timezone.utc).isoformat(),
                                         }
                                         _save_provider_state(auth_store, "openai-codex", state)
-                                        _save_auth_store(auth_store)
+                                        _save_auth_store(
+                                            auth_store,
+                                            target_path=source_path,
+                                        )
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal Codex OAuth state: %s", clear_exc
@@ -1711,11 +1860,7 @@ class CredentialPool:
             replace(entry, priority=new_priority)
             for new_priority, entry in enumerate(self._entries)
         ]
-        write_credential_pool(
-            self.provider,
-            [entry.to_dict() for entry in self._entries],
-            removed_ids=[removed.id],
-        )
+        self._persist(removed_ids=[removed.id])
         if self._current_id == removed.id:
             self._current_id = None
         return removed
@@ -2397,9 +2542,14 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
-    raw_entries = read_credential_pool(provider)
-    disk_ids = {
-        entry.get("id")
+    auth_source_path: Optional[Path] = None
+    if provider == "openai-codex":
+        raw_entries, auth_source_path = read_credential_pool_with_source(provider)
+    else:
+        raw_pool = read_credential_pool(provider)
+        raw_entries = raw_pool if isinstance(raw_pool, list) else []
+    disk_ids: Set[str] = {
+        str(entry.get("id"))
         for entry in raw_entries
         if isinstance(entry, dict) and entry.get("id")
     }
@@ -2457,5 +2607,10 @@ def load_pool(provider: str) -> CredentialPool:
             provider,
             [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
             removed_ids=disk_ids - new_ids,
+            target_path=auth_source_path,
         )
-    return CredentialPool(provider, entries)
+    return CredentialPool(
+        provider,
+        entries,
+        auth_source_path=auth_source_path,
+    )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -980,8 +980,8 @@ def _load_global_auth_store() -> Dict[str, Any]:
         return {}
 
 
-def _auth_lock_path() -> Path:
-    return _auth_file_path().with_suffix(".lock")
+def _auth_lock_path(auth_file: Optional[Path] = None) -> Path:
+    return (auth_file or _auth_file_path()).with_suffix(".lock")
 
 
 _auth_lock_holder = threading.local()
@@ -996,29 +996,38 @@ def _file_lock(
 ):
     """Cross-process advisory flock helper.
 
-    Reentrant per-thread via ``holder.depth``. Falls back to a depth-only
-    guard when neither ``fcntl`` nor ``msvcrt`` is available (rare).
-    Callers supply their own ``threading.local`` so independent locks
-    (e.g. profile auth.json vs shared Nous store) don't share reentrancy
-    state — that would let one lock's reentrant acquisition silently skip
-    the other's kernel-level flock.
+    Reentrant per-thread and per normalized lock path. Different paths must
+    acquire distinct kernel locks even when nested in the same thread; treating
+    a root auth lock as reentrant while holding a profile auth lock would leave
+    rotating OAuth refresh tokens unprotected across profiles. Falls back to a
+    path-scoped depth guard when neither ``fcntl`` nor ``msvcrt`` is available.
     """
-    if getattr(holder, "depth", 0) > 0:
-        holder.depth += 1
+    try:
+        lock_key = str(lock_path.resolve(strict=False))
+    except Exception:
+        lock_key = str(lock_path)
+    depths = getattr(holder, "depths", None)
+    if not isinstance(depths, dict):
+        depths = {}
+        holder.depths = depths
+    if depths.get(lock_key, 0) > 0:
+        depths[lock_key] += 1
         try:
             yield
         finally:
-            holder.depth -= 1
+            depths[lock_key] -= 1
+            if depths[lock_key] <= 0:
+                depths.pop(lock_key, None)
         return
 
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
     if fcntl is None and msvcrt is None:
-        holder.depth = 1
+        depths[lock_key] = 1
         try:
             yield
         finally:
-            holder.depth = 0
+            depths.pop(lock_key, None)
         return
 
     # On Windows, msvcrt.locking needs the file to have content and the
@@ -1041,11 +1050,11 @@ def _file_lock(
                     raise TimeoutError(timeout_message)
                 time.sleep(0.05)
 
-        holder.depth = 1
+        depths[lock_key] = 1
         try:
             yield
         finally:
-            holder.depth = 0
+            depths.pop(lock_key, None)
             if fcntl:
                 try:
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
@@ -1060,7 +1069,10 @@ def _file_lock(
 
 
 @contextmanager
-def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+def _auth_store_lock(
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+    auth_file: Optional[Path] = None,
+):
     """Cross-process advisory lock for auth.json reads+writes.  Reentrant.
 
     Lock ordering invariant: when this lock is held together with
@@ -1070,7 +1082,7 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
     against a concurrent import on the shared store.
     """
     with _file_lock(
-        _auth_lock_path(),
+        _auth_lock_path(auth_file),
         _auth_lock_holder,
         timeout_seconds,
         "Timed out waiting for auth store lock",
@@ -1366,11 +1378,66 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     return list(global_entries) if isinstance(global_entries, list) else []
 
 
+def read_credential_pool_with_source(
+    provider_id: str,
+) -> tuple[List[Dict[str, Any]], Path]:
+    """Return one provider's pool entries and the auth store that owns them.
+
+    A local provider singleton is ownership even when its pool has not been
+    seeded yet. Otherwise a non-empty global pool or global singleton is owned
+    by the global root. Rotating OAuth refresh paths can therefore update one
+    canonical store instead of creating a profile-local shadow.
+    """
+    local_path = _auth_file_path()
+    local_store = _load_auth_store(local_path)
+    local_pool = local_store.get("credential_pool")
+    local_entries = (
+        local_pool.get(provider_id) if isinstance(local_pool, dict) else None
+    )
+    local_providers = local_store.get("providers")
+    local_state = (
+        local_providers.get(provider_id)
+        if isinstance(local_providers, dict)
+        else None
+    )
+    if (isinstance(local_entries, list) and local_entries) or isinstance(
+        local_state, dict
+    ):
+        return (
+            list(local_entries) if isinstance(local_entries, list) else [],
+            local_path,
+        )
+
+    global_path = _global_auth_file_path()
+    global_store = _load_global_auth_store()
+    global_pool = global_store.get("credential_pool") if global_store else None
+    global_entries = (
+        global_pool.get(provider_id) if isinstance(global_pool, dict) else None
+    )
+    global_providers = global_store.get("providers") if global_store else None
+    global_state = (
+        global_providers.get(provider_id)
+        if isinstance(global_providers, dict)
+        else None
+    )
+    if global_path is not None and (
+        (isinstance(global_entries, list) and global_entries)
+        or isinstance(global_state, dict)
+    ):
+        return (
+            list(global_entries) if isinstance(global_entries, list) else [],
+            global_path,
+        )
+    return [], local_path
+
+
 def write_credential_pool(
     provider_id: str,
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    baseline_entries: Optional[Dict[str, Dict[str, Any]]] = None,
+    target_path: Optional[Path] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1385,10 +1452,17 @@ def write_credential_pool(
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
+
+    When ``baseline_entries`` is supplied, perform a three-way merge per row:
+    fields changed by this caller relative to its baseline are authoritative,
+    while fields changed only on disk are preserved. This prevents a stale
+    snapshot from rolling back another process's rotated OAuth token when the
+    local operation changed an unrelated field such as priority or status.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+
+    with _auth_store_lock(auth_file=target_path):
+        auth_store = _load_auth_store(target_path)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1405,7 +1479,39 @@ def write_credential_pool(
             for entry in sanitized_entries
             if isinstance(entry, dict) and entry.get("id")
         }
-        merged: List[Dict[str, Any]] = list(sanitized_entries)
+        existing_by_id = {
+            entry.get("id"): entry
+            for entry in existing_list
+            if isinstance(entry, dict) and entry.get("id")
+        }
+        merged: List[Dict[str, Any]] = []
+        for incoming in sanitized_entries:
+            incoming_id = incoming.get("id") if isinstance(incoming, dict) else None
+            if (
+                baseline_entries is not None
+                and isinstance(incoming_id, str)
+                and incoming_id
+                and incoming_id in baseline_entries
+                and incoming_id in existing_by_id
+            ):
+                baseline = baseline_entries[incoming_id]
+                disk_entry = existing_by_id[incoming_id]
+                three_way = dict(disk_entry)
+                missing = object()
+                for key in set(baseline) | set(incoming):
+                    baseline_value = baseline.get(key, missing)
+                    incoming_value = incoming.get(key, missing)
+                    if incoming_value == baseline_value:
+                        continue
+                    if incoming_value is missing:
+                        three_way.pop(key, None)
+                    else:
+                        three_way[key] = incoming_value
+                merged.append(
+                    sanitize_borrowed_credential_payload(three_way, provider_id)
+                )
+            else:
+                merged.append(incoming)
         for disk_entry in existing_list:
             if not isinstance(disk_entry, dict):
                 continue
@@ -1414,7 +1520,7 @@ def write_credential_pool(
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged
-        return _save_auth_store(auth_store)
+        return _save_auth_store(auth_store, target_path=target_path)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:
@@ -3229,19 +3335,30 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
-def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
-    """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
-    Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
-    Raises AuthError if no Codex tokens are stored.
-    """
+def _read_codex_tokens_with_source(
+    *,
+    _lock: bool = True,
+    auth_file: Optional[Path] = None,
+) -> tuple[Dict[str, Any], Path]:
+    """Read validated Codex tokens plus the exact auth store that owns them."""
     if _lock:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
+        with _auth_store_lock(auth_file=auth_file):
+            auth_store = _load_auth_store(auth_file)
     else:
-        auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
-    if not state:
+        auth_store = _load_auth_store(auth_file)
+    if auth_file is None:
+        state, source_path = _load_provider_state_with_source(
+            auth_store, "openai-codex",
+        )
+    else:
+        providers = auth_store.get("providers")
+        state = (
+            providers.get("openai-codex")
+            if isinstance(providers, dict)
+            else None
+        )
+        source_path = auth_file
+    if not state or source_path is None:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
             provider="openai-codex",
@@ -3275,7 +3392,13 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     return {
         "tokens": tokens,
         "last_refresh": state.get("last_refresh"),
-    }
+    }, source_path
+
+
+def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    """Read Codex tokens while preserving the historical return shape."""
+    data, _source_path = _read_codex_tokens_with_source(_lock=_lock)
+    return data
 
 
 def _sync_codex_pool_entries(
@@ -3379,13 +3502,31 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: Optional[str] = None,
+    label: Optional[str] = None,
+    *,
+    target_path: Optional[Path] = None,
+    _lock: bool = True,
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
-        state = _load_provider_state(auth_store, "openai-codex") or {}
+
+    def _persist() -> None:
+        auth_store = _load_auth_store(target_path)
+        state: Dict[str, Any]
+        if target_path is None:
+            state = _load_provider_state(auth_store, "openai-codex") or {}
+        else:
+            providers = auth_store.get("providers")
+            raw_state = (
+                providers.get("openai-codex")
+                if isinstance(providers, dict)
+                else None
+            )
+            state = dict(raw_state) if isinstance(raw_state, dict) else {}
         # Capture the previous singleton tokens BEFORE overwriting them.  The
         # pool-sync step uses this to distinguish legacy singleton-aliases
         # (which should be refreshed) from independent accounts that
@@ -3404,10 +3545,21 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             last_refresh,
             previous_singleton_tokens=previous_singleton_tokens,
         )
-        _save_auth_store(auth_store)
+        _save_auth_store(auth_store, target_path=target_path)
+
+    if _lock:
+        with _auth_store_lock(auth_file=target_path):
+            _persist()
+    else:
+        _persist()
 
 
-def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
+def _recover_codex_tokens_from_cli(
+    reason: str,
+    *,
+    target_path: Optional[Path] = None,
+    _lock: bool = True,
+) -> Optional[Dict[str, str]]:
     """Adopt a valid Codex CLI token pair into Hermes auth, if available."""
     imported = _import_codex_cli_tokens()
     # Require BOTH tokens before adopting: persisting a payload without a
@@ -3419,7 +3571,7 @@ def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
     ):
         return None
     logger.info("Codex auth recovered from Codex CLI auth.json (%s).", reason)
-    _save_codex_tokens(imported)
+    _save_codex_tokens(imported, target_path=target_path, _lock=_lock)
     return dict(imported)
 
 
@@ -3560,6 +3712,9 @@ def refresh_codex_oauth_pure(
 def _refresh_codex_auth_tokens(
     tokens: Dict[str, str],
     timeout_seconds: float,
+    *,
+    target_path: Optional[Path] = None,
+    _lock: bool = True,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
     
@@ -3587,7 +3742,9 @@ def _refresh_codex_auth_tokens(
         if not getattr(exc, "relogin_required", False):
             raise
         imported = _recover_codex_tokens_from_cli(
-            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
+            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}",
+            target_path=target_path,
+            _lock=_lock,
         )
         if not imported:
             raise
@@ -3597,7 +3754,11 @@ def _refresh_codex_auth_tokens(
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
-    _save_codex_tokens(updated_tokens)
+    _save_codex_tokens(
+        updated_tokens,
+        target_path=target_path,
+        _lock=_lock,
+    )
     return updated_tokens
 
 
@@ -3653,18 +3814,36 @@ def resolve_codex_runtime_credentials(
     credential. See issue #32992.
     """
     read_error: Optional[AuthError] = None
+    source_path = _auth_file_path()
     try:
-        data = _read_codex_tokens()
+        data, source_path = _read_codex_tokens_with_source()
     except AuthError as exc:
         read_error = exc
+        # Validation can fail after ownership was discovered. Preserve that
+        # ownership so Codex CLI recovery repairs the inherited root instead of
+        # creating a profile-local shadow.
+        try:
+            _state, discovered_source = _load_provider_state_with_source(
+                _load_auth_store(), "openai-codex",
+            )
+            if discovered_source is not None:
+                source_path = discovered_source
+        except Exception:
+            pass
         if getattr(exc, "relogin_required", False) and getattr(exc, "code", None) in {
             "codex_auth_missing_access_token",
             "codex_auth_missing_refresh_token",
             "codex_auth_invalid_shape",
         }:
-            imported = _recover_codex_tokens_from_cli(str(getattr(exc, "code", None) or "auth_error"))
+            imported = _recover_codex_tokens_from_cli(
+                str(getattr(exc, "code", None) or "auth_error"),
+                target_path=source_path,
+            )
             if imported:
-                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
+                data = {
+                    "tokens": imported,
+                    "last_refresh": imported.get("last_refresh"),
+                }
             else:
                 data = None
         else:
@@ -3722,9 +3901,19 @@ def resolve_codex_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        # Re-read under lock to avoid racing with other Hermes processes
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_codex_tokens(_lock=False)
+        # Re-read under the canonical source lock to avoid racing with another
+        # profile that is rotating the same single-use refresh token.
+        with _auth_store_lock(
+            timeout_seconds=max(
+                float(AUTH_LOCK_TIMEOUT_SECONDS),
+                refresh_timeout_seconds + 5.0,
+            ),
+            auth_file=source_path,
+        ):
+            data, _locked_source = _read_codex_tokens_with_source(
+                _lock=False,
+                auth_file=source_path,
+            )
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
 
@@ -3733,7 +3922,12 @@ def resolve_codex_runtime_credentials(
                 should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                tokens = _refresh_codex_auth_tokens(
+                    tokens,
+                    refresh_timeout_seconds,
+                    target_path=source_path,
+                    _lock=False,
+                )
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
@@ -3778,14 +3972,7 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
         return None
 
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return None
-        entries = pool.get("openai-codex")
-        if not isinstance(entries, list):
-            return None
+        entries, _source_path = read_credential_pool_with_source("openai-codex")
         now = time.time()
         for entry in entries:
             if not isinstance(entry, dict):
@@ -3835,14 +4022,7 @@ def _pool_codex_access_token() -> str:
     the original AuthError).
     """
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return ""
-        entries = pool.get("openai-codex")
-        if not isinstance(entries, list):
-            return ""
+        entries, _source_path = read_credential_pool_with_source("openai-codex")
 
         def _entry_usable(entry: Dict[str, Any]) -> bool:
             if not isinstance(entry, dict):

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -256,3 +256,262 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     # The invariant: the single-use token POST ran inside the auth-store lock.
     assert lock_held["during_post"] is True
 
+
+def test_inherited_codex_pool_refresh_updates_only_root(
+    profile_and_root, monkeypatch
+):
+    """A loaded inherited Codex pool keeps root as its canonical owner."""
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {"version": 1, "providers": {}, "credential_pool": {}},
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "root-access-old",
+                        "refresh_token": "root-refresh-old",
+                    },
+                    "last_refresh": "2020-01-01T00:00:00Z",
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [{
+                    "id": "default",
+                    "label": "default",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "device_code",
+                    "access_token": "root-access-old",
+                    "refresh_token": "root-refresh-old",
+                }]
+            },
+        },
+    )
+    monkeypatch.setattr(
+        A,
+        "refresh_codex_oauth_pure",
+        lambda access_token, refresh_token, **kwargs: {
+            "access_token": "root-access-new",
+            "refresh_token": "root-refresh-new",
+            "last_refresh": "2020-01-02T00:00:00Z",
+        },
+    )
+
+    pool = CP.load_pool("openai-codex")
+    entry = pool.entries()[0]
+    refreshed = pool._refresh_entry(entry, force=True)
+
+    assert refreshed is not None
+    assert refreshed.refresh_token == "root-refresh-new"
+    root = _read_store(root_path)
+    assert (
+        root["providers"]["openai-codex"]["tokens"]["refresh_token"]
+        == "root-refresh-new"
+    )
+    assert (
+        root["credential_pool"]["openai-codex"][0]["refresh_token"]
+        == "root-refresh-new"
+    )
+    profile = _read_store(profile_path)
+    assert "openai-codex" not in profile.get("providers", {})
+    assert "openai-codex" not in profile.get("credential_pool", {})
+
+
+def test_two_loaded_inherited_manual_codex_pools_reload_rotated_row(
+    profile_and_root, monkeypatch
+):
+    """A waiter must not replay a manual pool row's consumed refresh token."""
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {"version": 1, "providers": {}, "credential_pool": {}},
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [{
+                    "id": "manual-1",
+                    "label": "manual",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:device_code",
+                    "access_token": "access-0",
+                    "refresh_token": "refresh-0",
+                }]
+            },
+        },
+    )
+    submitted = []
+
+    def fake_refresh(access_token, refresh_token, **kwargs):
+        submitted.append((access_token, refresh_token))
+        generation = len(submitted)
+        return {
+            "access_token": f"access-{generation}",
+            "refresh_token": f"refresh-{generation}",
+            "last_refresh": f"2020-01-0{generation + 1}T00:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+    first_pool = CP.load_pool("openai-codex")
+    second_pool = CP.load_pool("openai-codex")
+
+    assert first_pool._refresh_entry(first_pool.entries()[0], force=True)
+    assert second_pool._refresh_entry(second_pool.entries()[0], force=True)
+
+    assert submitted == [
+        ("access-0", "refresh-0"),
+        ("access-1", "refresh-1"),
+    ]
+    root = _read_store(root_path)
+    assert (
+        root["credential_pool"]["openai-codex"][0]["refresh_token"]
+        == "refresh-2"
+    )
+    profile = _read_store(profile_path)
+    assert "openai-codex" not in profile.get("credential_pool", {})
+
+
+def test_remove_from_inherited_codex_pool_updates_root_without_shadow(
+    profile_and_root,
+):
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {"version": 1, "providers": {}, "credential_pool": {}},
+    )
+    rows = [
+        {
+            "id": entry_id,
+            "label": entry_id,
+            "auth_type": "oauth",
+            "priority": priority,
+            "source": "manual:device_code",
+            "access_token": f"access-{priority}",
+            "refresh_token": f"refresh-{priority}",
+        }
+        for priority, entry_id in enumerate(("first", "second"))
+    ]
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {"openai-codex": rows},
+        },
+    )
+
+    pool = CP.load_pool("openai-codex")
+    removed = pool.remove_index(1)
+
+    assert removed is not None and removed.id == "first"
+    root = _read_store(root_path)
+    assert [
+        item["id"] for item in root["credential_pool"]["openai-codex"]
+    ] == ["second"]
+    profile = _read_store(profile_path)
+    assert "openai-codex" not in profile.get("credential_pool", {})
+
+
+def test_refreshing_different_rows_preserves_concurrent_rotation(
+    profile_and_root, monkeypatch
+):
+    """Writing row B must not overwrite a newer on-disk version of row A."""
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}, "credential_pool": {}})
+    rows = [
+        {
+            "id": entry_id,
+            "label": entry_id,
+            "auth_type": "oauth",
+            "priority": priority,
+            "source": "manual:device_code",
+            "access_token": f"access-{entry_id}-0",
+            "refresh_token": f"refresh-{entry_id}-0",
+        }
+        for priority, entry_id in enumerate(("a", "b"))
+    ]
+    _write_store(root_path, {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {"openai-codex": rows},
+    })
+
+    def fake_refresh(access_token, refresh_token, **kwargs):
+        return {
+            "access_token": f"{access_token}-new",
+            "refresh_token": f"{refresh_token}-new",
+            "last_refresh": "2020-01-02T00:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+    first_pool = CP.load_pool("openai-codex")
+    second_pool = CP.load_pool("openai-codex")
+
+    assert first_pool._refresh_entry(first_pool.entries()[0], force=True)
+    assert second_pool._refresh_entry(second_pool.entries()[1], force=True)
+
+    root = _read_store(root_path)
+    final = {
+        item["id"]: item["refresh_token"]
+        for item in root["credential_pool"]["openai-codex"]
+    }
+    assert final == {
+        "a": "refresh-a-0-new",
+        "b": "refresh-b-0-new",
+    }
+
+
+def test_stale_snapshot_removal_preserves_other_row_rotation(
+    profile_and_root, monkeypatch
+):
+    """Removing row B must not roll back concurrently refreshed row A."""
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}, "credential_pool": {}})
+    rows = [
+        {
+            "id": entry_id,
+            "label": entry_id,
+            "auth_type": "oauth",
+            "priority": priority,
+            "source": "manual:device_code",
+            "access_token": f"access-{entry_id}-0",
+            "refresh_token": f"refresh-{entry_id}-0",
+        }
+        for priority, entry_id in enumerate(("a", "b"))
+    ]
+    _write_store(root_path, {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {"openai-codex": rows},
+    })
+    monkeypatch.setattr(
+        A,
+        "refresh_codex_oauth_pure",
+        lambda access_token, refresh_token, **kwargs: {
+            "access_token": f"{access_token}-new",
+            "refresh_token": f"{refresh_token}-new",
+            "last_refresh": "2020-01-02T00:00:00Z",
+        },
+    )
+    refreshing_pool = CP.load_pool("openai-codex")
+    removing_pool = CP.load_pool("openai-codex")
+
+    assert refreshing_pool._refresh_entry(refreshing_pool.entries()[1], force=True)
+    removed = removing_pool.remove_index(1)
+
+    assert removed is not None and removed.id == "a"
+    root = _read_store(root_path)
+    final_rows = root["credential_pool"]["openai-codex"]
+    assert len(final_rows) == 1
+    assert final_rows[0]["id"] == "b"
+    assert final_rows[0]["priority"] == 0
+    assert final_rows[0]["refresh_token"] == "refresh-b-0-new"

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -92,7 +92,7 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
     called = {"count": 0}
 
-    def _fake_refresh(tokens, timeout_seconds):
+    def _fake_refresh(tokens, timeout_seconds, **kwargs):
         called["count"] += 1
         return {"access_token": "access-new", "refresh_token": "refresh-new"}
 
@@ -111,7 +111,7 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
 
     called = {"count": 0}
 
-    def _fake_refresh(tokens, timeout_seconds):
+    def _fake_refresh(tokens, timeout_seconds, **kwargs):
         called["count"] += 1
         return {"access_token": "access-forced", "refresh_token": "refresh-new"}
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -352,6 +352,174 @@ def test_load_provider_state_classic_mode_no_fallback(tmp_path, monkeypatch):
     assert _load_provider_state(auth_store, "anthropic") is None
 
 
+def test_profile_codex_refresh_updates_global_source_without_local_shadow(
+    profile_env, monkeypatch,
+):
+    """Refreshing inherited Codex OAuth must rotate the canonical root store.
+
+    Codex refresh tokens can be single-use.  Persisting the rotated pair into
+    the active profile would leave the root token stale and create a local
+    entry that shadows future root re-authentication.
+    """
+    from hermes_cli import auth
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        providers={
+            "openai-codex": {
+                "tokens": {
+                    "access_token": "root-access-old",
+                    "refresh_token": "root-refresh-old",
+                },
+                "last_refresh": "2026-01-01T00:00:00Z",
+            },
+        },
+        pool={
+            "openai-codex": [{
+                "id": "default",
+                "label": "default",
+                "auth_type": "oauth",
+                "source": "device_code",
+                "access_token": "root-access-old",
+                "refresh_token": "root-refresh-old",
+            }],
+        },
+    ))
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(providers={}, pool={}),
+    )
+
+    monkeypatch.setattr(
+        auth,
+        "refresh_codex_oauth_pure",
+        lambda access_token, refresh_token, timeout_seconds=20.0: {
+            "access_token": "root-access-new",
+            "refresh_token": "root-refresh-new",
+            "last_refresh": "2026-01-02T00:00:00Z",
+        },
+    )
+
+    resolved = auth.resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "root-access-new"
+    root_store = json.loads((profile_env["global"] / "auth.json").read_text())
+    assert (
+        root_store["providers"]["openai-codex"]["tokens"]["refresh_token"]
+        == "root-refresh-new"
+    )
+    assert (
+        root_store["credential_pool"]["openai-codex"][0]["refresh_token"]
+        == "root-refresh-new"
+    )
+    profile_store = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert "openai-codex" not in profile_store.get("providers", {})
+    assert "openai-codex" not in profile_store.get("credential_pool", {})
+
+
+def test_profile_codex_cli_recovery_repairs_invalid_global_source(
+    profile_env, monkeypatch,
+):
+    """CLI recovery of malformed inherited state must not create a shadow."""
+    from hermes_cli import auth
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        providers={
+            "openai-codex": {
+                "tokens": {"refresh_token": "invalid-root-refresh"},
+            },
+        },
+        pool={},
+    ))
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(providers={}, pool={}),
+    )
+    monkeypatch.setattr(
+        auth,
+        "_import_codex_cli_tokens",
+        lambda: {
+            "access_token": "recovered-access",
+            "refresh_token": "recovered-refresh",
+        },
+    )
+
+    resolved = auth.resolve_codex_runtime_credentials(
+        refresh_if_expiring=False,
+    )
+
+    assert resolved["api_key"] == "recovered-access"
+    root_store = json.loads((profile_env["global"] / "auth.json").read_text())
+    assert (
+        root_store["providers"]["openai-codex"]["tokens"]["refresh_token"]
+        == "recovered-refresh"
+    )
+    profile_store = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert "openai-codex" not in profile_store.get("providers", {})
+
+
+def test_file_lock_reentrancy_is_scoped_to_lock_path(tmp_path, monkeypatch):
+    """Nested profile/root locks must each acquire a kernel-level lock."""
+    import threading
+
+    from hermes_cli import auth
+
+    if auth.fcntl is None:
+        pytest.skip("fcntl unavailable")
+    real_flock = auth.fcntl.flock
+    exclusive_acquires = []
+
+    def tracking_flock(fd, operation):
+        if operation & auth.fcntl.LOCK_EX:
+            exclusive_acquires.append(fd)
+        return real_flock(fd, operation)
+
+    monkeypatch.setattr(auth.fcntl, "flock", tracking_flock)
+    holder = threading.local()
+    with auth._file_lock(
+        tmp_path / "profile.lock", holder, 1.0, "profile lock timeout"
+    ):
+        with auth._file_lock(
+            tmp_path / "root.lock", holder, 1.0, "root lock timeout"
+        ):
+            pass
+
+    assert len(exclusive_acquires) == 2
+
+
+def test_profile_codex_resolver_sees_global_pool_only_credential(profile_env):
+    """Direct resolver fallback must honor the same global pool ownership."""
+    from hermes_cli import auth
+
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            providers={},
+            pool={
+                "openai-codex": [{
+                    "id": "manual-1",
+                    "label": "manual",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:device_code",
+                    "access_token": "root-pool-access",
+                    "refresh_token": "root-pool-refresh",
+                }]
+            },
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(providers={}, pool={}),
+    )
+
+    resolved = auth.resolve_codex_runtime_credentials(
+        refresh_if_expiring=False,
+    )
+
+    assert resolved["api_key"] == "root-pool-access"
+    assert resolved["source"] == "credential_pool"
+
+
 def test_load_provider_state_malformed_global_does_not_break_profile(profile_env):
     """A corrupt global auth.json must not break profile reads."""
     (profile_env["global"] / "auth.json").write_text("{not valid json")


### PR DESCRIPTION
## What does this PR do?

Makes the default/root Hermes auth store the canonical source for inherited `openai-codex` OAuth state across named profiles.

Codex refresh tokens rotate and are single-use. A named profile could previously read an inherited root grant, refresh it while locking or persisting the active profile store, and leave root or another in-memory pool snapshot holding stale state. That can cause `refresh_token_reused`, recreate local profile shadows, or roll a separately refreshed pool row backward.

This ports and completes the canonical-root direction proposed in #28277 on current `main`, including the credential-pool path requested by its review. It complements #41705 without scanning sibling profile stores, and extends the root write-through landed in #52760 with canonical ownership, locking, and stale-snapshot-safe persistence.

## Related Issue

Fixes #6653

Related: #28277, #41705, #52760

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/auth.py`
  - preserve the exact auth-store source used by inherited Codex singleton and pool reads
  - lock and persist refreshes against that canonical source path
  - make nested file-lock reentrancy path-scoped so profile and root locks are never conflated
  - add source-aware credential-pool reads/writes
  - perform a baseline-aware three-way field merge under the canonical lock, preserving independent on-disk token rotations while applying local status/priority changes and explicit removals
  - allow direct Codex resolution to consume root pool-only credentials
- `agent/credential_pool.py`
  - carry the canonical Codex auth source path through pool lifetime
  - re-read the exact pool row after taking the canonical lock before spending a rotating refresh token
  - persist refresh, status, quarantine, and removal changes to the canonical store without creating profile-local shadows
  - adopt the merged canonical rows after writes so subsequent mutations use a current baseline
- Regression tests cover inherited singleton and pool refresh, malformed-token quarantine, same-row and different-row stale snapshots, concurrent rotation plus removal/reprioritization, root pool-only resolution, path-scoped locks, and profile-shadow prevention.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_auth*.py tests/agent/test_credential_pool*.py -q -o 'addopts='
# 449 passed

python -m ruff check hermes_cli/auth.py agent/credential_pool.py \
  tests/hermes_cli/test_auth_profile_fallback.py \
  tests/hermes_cli/test_auth_codex_provider.py \
  tests/agent/test_credential_pool_oauth_writethrough.py
# All checks passed

python scripts/check-windows-footguns.py hermes_cli/auth.py agent/credential_pool.py \
  tests/hermes_cli/test_auth_profile_fallback.py \
  tests/hermes_cli/test_auth_codex_provider.py \
  tests/agent/test_credential_pool_oauth_writethrough.py
# No Windows footguns found

git diff --check origin/main...HEAD
```

A live Linux/ARM64 multi-profile deployment was also migrated to one root Codex pool. Five independent profile invocations returned successful Codex responses, named-profile stores remained shadow-free after the calls, and all persistent gateways remained healthy.

The full repository suite was attempted on the ARM64 Raspberry Pi host but was stopped at 16% after roughly nine minutes because it was not practical to complete there. CI should provide the complete repository result; the entire affected auth and credential-pool suite passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed related PRs/issues
- [x] My PR contains only related changes
- [ ] I've run the entire `pytest tests/ -q` suite locally (affected suite: 449 passed; full suite deferred to CI)
- [x] I've added regression tests
- [x] Tested on Linux ARM64 (Raspberry Pi)

### Documentation & Housekeeping

- [x] Documentation update: N/A; internal auth persistence semantics, no new user-facing configuration
- [x] `cli-config.yaml.example`: N/A; no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no contributor workflow change
- [x] Cross-platform impact considered; platform-neutral file/path logic and Windows-footgun checks pass
- [x] Tool descriptions/schemas: N/A

## Design lineage

Credit to #28277 for proposing the canonical-root Codex store direction. This PR is a current-main completion of that approach across both singleton and credential-pool paths, incorporating the maintainer review request to retain current pool behavior and avoid sibling-store freshness heuristics.
