### PR TITLE
fix(nous): restore inference-api.nousresearch.com base_url (#60715)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -194,7 +194,6 @@ def _is_nous_inference_route(provider: str, base_url: str) -> bool:
     base = str(base_url or "")
     return (
         base_url_host_matches(base, "inference-api.nousresearch.com")
-        or base_url_host_matches(base, "inference.nousresearch.com")
     )
 
 

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -51,7 +51,7 @@ nous = NousProfile(
         "hermes-3-405b",
         "hermes-3-70b",
     ),
-    base_url="https://inference.nousresearch.com/v1",
+    base_url="https://inference-api.nousresearch.com/v1",
     auth_type="oauth_device_code",
 )
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)


### PR DESCRIPTION
## Summary
The Nous provider ships a base_url that no longer resolves in DNS — `inference.nousresearch.com` returns NXDOMAIN, so every Nous model times out after 3 retries (#60715). This restores `inference-api.nousresearch.com` (verified live: `GET /v1/models` → HTTP 200 in 0.3s) and drops the stale alias from the inference route check.

## Changes
- `plugins/model-providers/nous/__init__.py`: base_url → `https://inference-api.nousresearch.com/v1` (matches `DEFAULT_NOUS_INFERENCE_URL` in `hermes_cli/auth.py`, which already used the -api host).
- `agent/conversation_loop.py`: `_is_nous_inference_route()` drops the dead `inference.nousresearch.com` host match.

## Validation
| | Before | After |
|---|---|---|
| curl provider base_url /v1/models | NXDOMAIN (HTTP 000) | HTTP 200, 0.3s |
| tests (auth_nous_provider, nous_inference_url_validation, nous_fallback_unavailable) | — | 102/102 pass |

Salvages #63360 by @webtecnica (authorship preserved). Addresses the code half of #60715 — whether an infra/migration story remains is a separate call.

## Infographic

![nous-baseurl](https://v3b.fal.media/files/b/0aa241d5/e1LajNflEf4N28_Rcdp2H_V0iVxn2X.png)
