### PR TITLE
fix(update): stream update child output to the live log (PYTHONUNBUFFERED)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -733,6 +733,13 @@ fn update_child_env(install_root: &Path) -> Vec<(String, OsString)> {
         "HERMES_HOME".to_string(),
         hermes_home.as_os_str().to_os_string(),
     )];
+    // `hermes update` is a Python CLI writing to a pipe here, so CPython
+    // block-buffers its stdout: nothing reaches run_streamed (and the live
+    // log UI) until 8 KB accumulate or the process exits. Long quiet steps —
+    // the pre-update backup can zip multi-GB archives for minutes — render as
+    // a frozen stage, and users cancel a healthy update. Force line-by-line
+    // output instead.
+    envs.push(("PYTHONUNBUFFERED".to_string(), OsString::from("1")));
     if let Some(path) = path_with_prepended_entries(&[
         hermes_home.join("node").join("bin"),
         venv_bin_dir(install_root),
@@ -1047,6 +1054,16 @@ mod tests {
     }
 
     #[test]
+    fn update_child_env_forces_unbuffered_python() {
+        let envs = update_child_env(Path::new("/x/hermes-agent"));
+        assert!(
+            envs.iter()
+                .any(|(k, v)| k == "PYTHONUNBUFFERED" && v.to_str() == Some("1")),
+            "update children must run unbuffered so long steps stream to the live log"
+        );
+    }
+
+    #[test]
     fn lock_probe_paths_include_desktop_app_payload() {
         let root = Path::new("/x/hermes-agent");
         let probes = install_lock_probe_paths(root);
@@ -1056,7 +1073,12 @@ mod tests {
             "venv shim remains part of the update lock probe"
         );
         assert!(
-            probes.iter().any(|p| p.ends_with(Path::new("resources/app.asar"))),
+            // Windows/Linux payloads live under `resources/`, the macOS bundle
+            // under `Contents/Resources/` — Path::ends_with is case-sensitive.
+            probes.iter().any(|p| {
+                p.ends_with(Path::new("resources/app.asar"))
+                    || p.ends_with(Path::new("Resources/app.asar"))
+            }),
             "packaged app.asar must be probed so repair/re-clone waits for the old desktop to exit"
         );
     }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2715,8 +2715,13 @@ async function applyUpdatesPosixInApp(opts: any) {
   // Put the Hermes-managed Node and the venv on PATH so `hermes desktop`'s
   // npm build can find them on a machine with no system Node. Windows portable
   // Node lives directly under %LOCALAPPDATA%\hermes\node, not node\bin.
+  // PYTHONUNBUFFERED: `hermes update` writes to a pipe here, so CPython
+  // block-buffers stdout and long quiet steps (the pre-update backup can zip
+  // multi-GB archives for minutes) stream nothing to the progress UI — users
+  // read the silence as a hang and cancel a healthy update.
   const env: Record<string, string> = {
     HERMES_HOME,
+    PYTHONUNBUFFERED: '1',
     PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
   }
 


### PR DESCRIPTION
## Problem

When the desktop app updates itself (Tauri `Hermes-Setup --update` hand-off, or the in-app POSIX path), the spawned `hermes update` is a Python CLI writing to a pipe, so CPython block-buffers its stdout. Nothing reaches the live log until 8 KB accumulate or the process exits.

The worst case is the pre-update backup (`updates.pre_update_backup: true`): it can zip multi-GB archives for minutes while the updater UI still shows the previous line. On my install the updater sat on `[update] waiting for Hermes to exit…` for over 3 minutes while a 4.2 GB `pre-update-*.zip` was being written:

```
# ~/.hermes/logs/bootstrap-installer.log (frozen from 19:23:31Z)
2026-07-14T19:23:30Z INFO Hermes Setup starting mode=Update
2026-07-14T19:23:31Z INFO bootstrap.log: [update] waiting for Hermes to exit… stage=update

# meanwhile:
-rw-r--r-- 4185664739 Jul 15 05:26 ~/.hermes/backups/pre-update-2026-07-15-052331.zip
```

A user reads that silence as a hang and cancels — and because the child is not killed with the updater, the orphaned `hermes update` keeps mutating the install headless. The same silent-stage behaviour applies to the desktop's in-app POSIX update path.

## Fix

Set `PYTHONUNBUFFERED=1` at both spawn sites so the child streams line by line:

- `update_child_env()` in `apps/bootstrap-installer/src-tauri/src/update.rs` (covers the `hermes update` and `hermes desktop --build-only` stages of the Tauri hand-off)
- the `env` handed to `runStreamedUpdate` in `applyUpdatesPosixInApp` (`apps/desktop/electron/main.ts`)

With this, the "Creating pre-update backup…" line (and everything after) appears in the live log the moment it is printed, so a long backup reads as progress instead of a freeze.

## Also in this PR

`cargo test` for the installer never passed on macOS: `lock_probe_paths_include_desktop_app_payload` asserts a probe ends with `resources/app.asar`, but the macOS payload lives under `Contents/Resources/` and `Path::ends_with` is case-sensitive. The assertion now accepts both layouts.

## Validation

- `cargo test --lib` (apps/bootstrap-installer/src-tauri): 28 passed, 0 failed on macOS arm64, including a new unit test asserting `PYTHONUNBUFFERED=1` is present in the update child env
- `npx tsc -p apps/desktop --noEmit`: clean
- Reproduced the buffering silence on a real install (macOS 15 / Darwin 25.5.0) before the change; logs above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
