### PR TITLE
fix(stt): prefer explicit xAI API key over Grok OAuth

### DIFF
--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -205,13 +205,7 @@ class TestTranscribeCallSitesReadDotenv:
         assert seen_keys == ["mistral-dotenv-key"]
 
     def test_transcribe_xai_forwards_dotenv_key(self):
-        """xAI STT now resolves credentials through ``tools.xai_http`` so the
-        OAuth bearer wins when present and ``XAI_API_KEY`` is the fallback.
-        Patch the resolver's ``get_env_value`` to simulate a dotenv-only key
-        and confirm it reaches the HTTP call. The per-call-site
-        ``transcription_tools.get_env_value`` is still consulted for the
-        ``XAI_STT_BASE_URL`` override (covered by ``test_custom_base_url``).
-        """
+        """An explicit XAI_API_KEY must win over Grok subscription OAuth for STT."""
         from tools import transcription_tools as tt
         from tools import xai_http
 
@@ -231,7 +225,12 @@ class TestTranscribeCallSitesReadDotenv:
                 return "xai-dotenv-key"
             return None
 
-        with patch.object(xai_http, "get_env_value", side_effect=fake_get_env_value), \
+        with patch.object(tt, "get_env_value", side_effect=fake_get_env_value), \
+             patch.object(xai_http, "resolve_xai_http_credentials", return_value={
+                 "provider": "xai-oauth",
+                 "api_key": "subscription-oauth-token",
+                 "base_url": "https://api.x.ai/v1",
+             }), \
              patch("requests.post", side_effect=fake_post), \
              patch("builtins.open", MagicMock()):
             result = tt._transcribe_xai("/tmp/fake.mp3", "grok-stt")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1472,7 +1472,21 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
     """
     from tools.xai_http import resolve_xai_http_credentials
 
-    creds = resolve_xai_http_credentials()
+    # STT is an API-billed endpoint. Prefer the explicit XAI_API_KEY over the
+    # general xAI OAuth/Grok-subscription credential; subscription OAuth may be
+    # valid for Grok while returning personal-team spending-limit errors for
+    # /v1/stt. Other xAI integrations keep their existing resolver precedence.
+    direct_api_key = str(get_env_value("XAI_API_KEY") or "").strip()
+    if direct_api_key:
+        creds = {
+            "provider": "xai",
+            "api_key": direct_api_key,
+            "base_url": str(
+                get_env_value("XAI_BASE_URL") or "https://api.x.ai/v1"
+            ).strip().rstrip("/"),
+        }
+    else:
+        creds = resolve_xai_http_credentials()
     api_key = str(creds.get("api_key") or "").strip()
     if not api_key:
         return {


### PR DESCRIPTION
## Summary
- prefer an explicit `XAI_API_KEY` for the API-billed `/v1/stt` endpoint
- retain the existing shared xAI credential resolver as fallback when no direct key is configured
- add a regression test proving a direct key wins when Grok/xAI OAuth is also available

## Root cause
The shared xAI resolver prefers Grok/xAI OAuth. A valid OAuth token can still receive `403 personal-team-blocked:spending-limit` from `/v1/stt` while the separately billed API key is healthy, so STT silently routes through the wrong billing identity.

## Scope
The precedence change is intentionally local to xAI STT; other xAI integrations keep their current resolver behavior.

## Verification
- `119 passed` across `tests/tools/test_transcription_dotenv_fallback.py` and `tests/tools/test_transcription_tools.py`
- Python compile and `git diff --check` clean
- live cached OGG transcription returned `success: true`, `provider: xai`, and a non-empty transcript
- no hardcoded credential values added