### PR TITLE
fix(supermemory): honor SUPERMEMORY_BASE_URL for conversation ingest

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -31,7 +31,13 @@ _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
 _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
-_CONVERSATIONS_URL = "https://api.supermemory.ai/v4/conversations"
+_DEFAULT_API_BASE = "https://api.supermemory.ai"
+
+
+def _conversations_url() -> str:
+    # Honor self-hosted servers (SUPERMEMORY_BASE_URL), matching the SDK client.
+    base = os.environ.get("SUPERMEMORY_BASE_URL", "").strip() or _DEFAULT_API_BASE
+    return base.rstrip("/") + "/v4/conversations"
 _API_KEY_URL = "http://app.supermemory.ai/integrations?connect=hermes"
 _TRIVIAL_RE = re.compile(
     r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
@@ -388,7 +394,7 @@ class _SupermemoryClient:
             payload["metadata"] = self._merge_metadata(metadata)
 
         req = urllib.request.Request(
-            _CONVERSATIONS_URL,
+            _conversations_url(),
             data=json.dumps(payload).encode("utf-8"),
             headers={
                 "Authorization": f"Bearer {self._api_key}",


### PR DESCRIPTION
## Problem

The supermemory memory-provider plugin builds its SDK client without an explicit `base_url`, so the Stainless SDK correctly picks up `SUPERMEMORY_BASE_URL` from the environment — recall, the four explicit tools, and built-in-memory mirroring all reach a self-hosted server.

The session-transcript ingest path does not: `_CONVERSATIONS_URL` is hardcoded to `https://api.supermemory.ai/v4/conversations` and called via raw urllib. Running against a self-hosted supermemory server (the free single-binary `supermemory-server`, which implements `/v4/conversations`), every session end still POSTs the full cleaned transcript + API key to the cloud endpoint.

## Fix

Resolve the conversations URL at call time from the same `SUPERMEMORY_BASE_URL` env var the SDK uses, falling back to the cloud endpoint. Call-time (not import-time) so profile `.env` loading order doesn't matter.

Verified against a self-hosted supermemory-server 0.0.5: with `SUPERMEMORY_BASE_URL=http://127.0.0.1:8787` set, session ingest lands on the local server (200, queued) and cloud behavior is unchanged when the variable is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)