### PR TITLE
fix(state): preserve session source after SQLite lock races

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -81,6 +81,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                     billing_base_url=agent.base_url,
                     billing_mode="subscription_included",
                     api_call_count=1,
+                    source=agent._session_source_for_db(),
                 )
             except Exception as exc:
                 logger.debug(
@@ -171,6 +172,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 if cost_result.status == "included" else None,
                 model=agent.model,
                 api_call_count=1,
+                source=agent._session_source_for_db(),
             )
         except Exception as exc:
             logger.debug(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2910,6 +2910,7 @@ def run_conversation(
                                 if cost_result.status == "included" else None,
                                 model=agent.model,
                                 api_call_count=1,
+                                source=agent._session_source_for_db(),
                             )
                         except Exception as e:
                             # Log token persistence failures so they're

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -38,7 +38,6 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
 
 logger = logging.getLogger(__name__)
 
-_MISSING_SESSION_REPAIR_MARKER = "_repaired_missing_session_row"
 _MISSING_SESSION_REPAIR_WRITERS = frozenset(
     {"record_auxiliary_usage", "update_token_counts"}
 )
@@ -1108,6 +1107,11 @@ CREATE TABLE IF NOT EXISTS sessions (
     archived INTEGER NOT NULL DEFAULT 0,
     pinned INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+);
+
+CREATE TABLE IF NOT EXISTS provisional_session_repairs (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    repair_writer TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS messages (
@@ -3365,37 +3369,28 @@ class SessionDB:
         user_id: Optional[str] = None,
         model_config_json: Optional[str] = None,
     ) -> None:
-        """Promote an accounting-created provisional row to a known source."""
+        """Promote an internally registered accounting-repair row."""
         source_norm = str(source or "").strip().lower()
         if source_norm in {"", "unknown"}:
             return
 
-        marker_path = f"$.{_MISSING_SESSION_REPAIR_MARKER}"
-        conn.execute(
+        promoted = conn.execute(
             """UPDATE sessions SET
                    source = ?,
                    user_id = COALESCE(user_id, ?),
-                   model_config = NULLIF(
-                       json_remove(
-                           COALESCE(?, model_config, '{}'),
-                           ?
-                       ),
-                       '{}'
-                   )
+                   model_config = COALESCE(?, model_config)
                WHERE id = ?
-                 AND source = 'unknown'
-                 AND json_valid(COALESCE(model_config, '{}'))
-                 AND json_extract(COALESCE(model_config, '{}'), ?) IN
-                     ('record_auxiliary_usage', 'update_token_counts')""",
-            (
-                source,
-                user_id,
-                model_config_json,
-                marker_path,
-                session_id,
-                marker_path,
-            ),
+                 AND EXISTS (
+                     SELECT 1 FROM provisional_session_repairs
+                      WHERE session_id = sessions.id
+                 )""",
+            (source, user_id, model_config_json, session_id),
         )
+        if promoted.rowcount:
+            conn.execute(
+                "DELETE FROM provisional_session_repairs WHERE session_id = ?",
+                (session_id,),
+            )
 
     def _insert_session_row(
         self,
@@ -4400,44 +4395,15 @@ class SessionDB:
         """Update model_config and optionally model for an existing session.
 
         Uses COALESCE so that passing model=None leaves the stored model
-        column unchanged.  Routes through _execute_write for the standard
-        BEGIN IMMEDIATE + jitter-retry + lock guarantee. Repair markers from
-        a token-accounting fallback survive this metadata refresh so a later
-        authoritative create can still promote the provisional source when the
-        replacement is a valid JSON object. Malformed/non-object legacy values
-        retain update_session_meta's original replacement semantics.
+        column unchanged. Routes through _execute_write for the standard
+        BEGIN IMMEDIATE + jitter-retry + lock guarantee. Accounting-repair
+        provenance lives in a separate internal table, so arbitrary public
+        model_config values never affect promotion eligibility.
         """
         def _do(conn):
-            config_to_store = model_config_json
-            current = conn.execute(
-                "SELECT source, model_config FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
-            if current is not None and current["source"] == "unknown":
-                try:
-                    existing_config = json.loads(current["model_config"] or "{}")
-                    replacement_config = (
-                        json.loads(model_config_json)
-                        if model_config_json is not None
-                        else None
-                    )
-                    if (
-                        isinstance(existing_config, dict)
-                        and isinstance(replacement_config, dict)
-                        and existing_config.get(_MISSING_SESSION_REPAIR_MARKER)
-                        in _MISSING_SESSION_REPAIR_WRITERS
-                    ):
-                        replacement_config[_MISSING_SESSION_REPAIR_MARKER] = (
-                            existing_config[_MISSING_SESSION_REPAIR_MARKER]
-                        )
-                        config_to_store = json.dumps(replacement_config)
-                except (TypeError, ValueError):
-                    # Preserve update_session_meta's existing permissive
-                    # behavior for malformed/non-object legacy values.
-                    pass
             conn.execute(
                 "UPDATE sessions SET model_config = ?, model = COALESCE(?, model) WHERE id = ?",
-                (config_to_store, model, session_id),
+                (model_config_json, model, session_id),
             )
         self._execute_write(_do)
 
@@ -4508,34 +4474,39 @@ class SessionDB:
             raise ValueError(f"unsupported missing-session repair writer: {repair_writer}")
 
         fallback_source = str(source or "").strip()
-        source_is_unknown = (
-            not fallback_source or fallback_source.lower() == "unknown"
-        )
-        if source_is_unknown:
+        if not fallback_source or fallback_source.lower() == "unknown":
             fallback_source = "unknown"
-            fallback_model_config = json.dumps(
-                {_MISSING_SESSION_REPAIR_MARKER: repair_writer}
-            )
-        else:
-            fallback_model_config = None
 
-        conn.execute(
+        inserted = conn.execute(
             """INSERT OR IGNORE INTO sessions
-               (id, source, model, model_config, started_at)
-               VALUES (?, ?, ?, ?, ?)""",
+               (id, source, model, started_at)
+               VALUES (?, ?, ?, ?)""",
             (
                 session_id,
                 fallback_source,
                 model,
-                fallback_model_config,
                 time.time(),
             ),
         )
-        self._promote_missing_session_repair_row(
-            conn,
-            session_id=session_id,
-            source=fallback_source,
-        )
+        if inserted.rowcount:
+            conn.execute(
+                """INSERT INTO provisional_session_repairs
+                   (session_id, repair_writer) VALUES (?, ?)""",
+                (session_id, repair_writer),
+            )
+        elif fallback_source.lower() != "unknown":
+            # A later accounting path may know the real source. Preserve that
+            # provenance without consuming provisional status; only an
+            # authoritative create_session may finish promotion/backfill.
+            conn.execute(
+                """UPDATE sessions SET source = ?
+                   WHERE id = ? AND source = 'unknown'
+                     AND EXISTS (
+                         SELECT 1 FROM provisional_session_repairs
+                          WHERE session_id = sessions.id
+                     )""",
+                (fallback_source, session_id),
+            )
 
     def update_token_counts(
         self,
@@ -4658,9 +4629,9 @@ class SessionDB:
         )
         def _do(conn):
             # Keep fallback row creation in the same write transaction as the
-            # counters. The marker lets a later authoritative create_session
-            # safely promote this provisional source without rewriting a
-            # legitimate source="unknown" row.
+            # counters. The internal repair registration lets a later
+            # authoritative create_session safely finish metadata backfill
+            # without trusting caller-controlled session fields.
             self._insert_accounting_fallback_row(
                 conn,
                 session_id=session_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -39,6 +39,9 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
 logger = logging.getLogger(__name__)
 
 _MISSING_SESSION_REPAIR_MARKER = "_repaired_missing_session_row"
+_MISSING_SESSION_REPAIR_WRITERS = frozenset(
+    {"record_auxiliary_usage", "update_token_counts"}
+)
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
 
@@ -3353,6 +3356,47 @@ class SessionDB:
     # Session lifecycle
     # =========================================================================
 
+    def _promote_missing_session_repair_row(
+        self,
+        conn,
+        *,
+        session_id: str,
+        source: str,
+        user_id: Optional[str] = None,
+        model_config_json: Optional[str] = None,
+    ) -> None:
+        """Promote an accounting-created provisional row to a known source."""
+        source_norm = str(source or "").strip().lower()
+        if source_norm in {"", "unknown"}:
+            return
+
+        marker_path = f"$.{_MISSING_SESSION_REPAIR_MARKER}"
+        conn.execute(
+            """UPDATE sessions SET
+                   source = ?,
+                   user_id = COALESCE(user_id, ?),
+                   model_config = NULLIF(
+                       json_remove(
+                           COALESCE(?, model_config, '{}'),
+                           ?
+                       ),
+                       '{}'
+                   )
+               WHERE id = ?
+                 AND source = 'unknown'
+                 AND json_valid(COALESCE(model_config, '{}'))
+                 AND json_extract(COALESCE(model_config, '{}'), ?) IN
+                     ('record_auxiliary_usage', 'update_token_counts')""",
+            (
+                source,
+                user_id,
+                model_config_json,
+                marker_path,
+                session_id,
+                marker_path,
+            ),
+        )
+
     def _insert_session_row(
         self,
         session_id: str,
@@ -3406,8 +3450,6 @@ class SessionDB:
         without a recoverable routing mapping (#59527).
         """
         model_config_json = json.dumps(model_config) if model_config else None
-        source_norm = str(source or "").strip().lower()
-
         def _do(conn):
             conn.execute(
                 """INSERT INTO sessions (
@@ -3446,38 +3488,16 @@ class SessionDB:
                     time.time(),
                 ),
             )
-            if source_norm in {"", "unknown"}:
-                return
-
-            # Token accounting can provision a missing session row after the
+            # Accounting can provision a missing session row after the
             # authoritative create path loses a transient SQLite lock race.
-            # Promote only rows carrying that explicit repair marker: a real
-            # imported/legacy source="unknown" row must remain first-writer-wins.
-            marker_path = f"$.{_MISSING_SESSION_REPAIR_MARKER}"
-            conn.execute(
-                """UPDATE sessions SET
-                       source = ?,
-                       user_id = COALESCE(user_id, ?),
-                       model_config = NULLIF(
-                           json_remove(
-                               COALESCE(?, model_config, '{}'),
-                               ?
-                           ),
-                           '{}'
-                       )
-                   WHERE id = ?
-                     AND source = 'unknown'
-                     AND json_valid(COALESCE(model_config, '{}'))
-                     AND json_extract(COALESCE(model_config, '{}'), ?)
-                         = 'update_token_counts'""",
-                (
-                    source,
-                    user_id,
-                    model_config_json,
-                    marker_path,
-                    session_id,
-                    marker_path,
-                ),
+            # Promote only rows carrying an explicit internal repair marker:
+            # a real imported/legacy source="unknown" row stays first-writer-wins.
+            self._promote_missing_session_repair_row(
+                conn,
+                session_id=session_id,
+                source=source,
+                user_id=user_id,
+                model_config_json=model_config_json,
             )
 
             if parent_session_id:
@@ -4405,10 +4425,10 @@ class SessionDB:
                         isinstance(existing_config, dict)
                         and isinstance(replacement_config, dict)
                         and existing_config.get(_MISSING_SESSION_REPAIR_MARKER)
-                        == "update_token_counts"
+                        in _MISSING_SESSION_REPAIR_WRITERS
                     ):
                         replacement_config[_MISSING_SESSION_REPAIR_MARKER] = (
-                            "update_token_counts"
+                            existing_config[_MISSING_SESSION_REPAIR_MARKER]
                         )
                         config_to_store = json.dumps(replacement_config)
                 except (TypeError, ValueError):
@@ -4473,6 +4493,49 @@ class SessionDB:
                 (provider, base_url, billing_mode, session_id),
             )
         self._execute_write(_do)
+
+    def _insert_accounting_fallback_row(
+        self,
+        conn,
+        *,
+        session_id: str,
+        source: Optional[str],
+        model: Optional[str],
+        repair_writer: str,
+    ) -> None:
+        """Create or promote the session row required by usage accounting."""
+        if repair_writer not in _MISSING_SESSION_REPAIR_WRITERS:
+            raise ValueError(f"unsupported missing-session repair writer: {repair_writer}")
+
+        fallback_source = str(source or "").strip()
+        source_is_unknown = (
+            not fallback_source or fallback_source.lower() == "unknown"
+        )
+        if source_is_unknown:
+            fallback_source = "unknown"
+            fallback_model_config = json.dumps(
+                {_MISSING_SESSION_REPAIR_MARKER: repair_writer}
+            )
+        else:
+            fallback_model_config = None
+
+        conn.execute(
+            """INSERT OR IGNORE INTO sessions
+               (id, source, model, model_config, started_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                fallback_source,
+                model,
+                fallback_model_config,
+                time.time(),
+            ),
+        )
+        self._promote_missing_session_repair_row(
+            conn,
+            session_id=session_id,
+            source=fallback_source,
+        )
 
     def update_token_counts(
         self,
@@ -4593,32 +4656,17 @@ class SessionDB:
             or cache_write_tokens or reasoning_tokens or api_call_count
             or estimated_cost_usd
         )
-        fallback_source = str(source or "").strip()
-        source_is_unknown = not fallback_source or fallback_source.lower() == "unknown"
-        if source_is_unknown:
-            fallback_source = "unknown"
-            fallback_model_config = json.dumps(
-                {_MISSING_SESSION_REPAIR_MARKER: "update_token_counts"}
-            )
-        else:
-            fallback_model_config = None
-
         def _do(conn):
             # Keep fallback row creation in the same write transaction as the
             # counters. The marker lets a later authoritative create_session
             # safely promote this provisional source without rewriting a
             # legitimate source="unknown" row.
-            conn.execute(
-                """INSERT OR IGNORE INTO sessions
-                   (id, source, model, model_config, started_at)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (
-                    session_id,
-                    fallback_source,
-                    model,
-                    fallback_model_config,
-                    time.time(),
-                ),
+            self._insert_accounting_fallback_row(
+                conn,
+                session_id=session_id,
+                source=source,
+                model=model,
+                repair_writer="update_token_counts",
             )
             row = conn.execute(
                 "SELECT model, billing_provider, api_call_count FROM sessions WHERE id = ?",
@@ -4814,12 +4862,17 @@ class SessionDB:
         """
         if not session_id or not task:
             return
-        # FK on session_model_usage.session_id → sessions.id: ensure the row
-        # exists (same INSERT OR IGNORE guard update_token_counts uses — the
-        # initial create_session() can fail under concurrent SQLite locking).
-        self._insert_session_row(session_id, "unknown")
-
         def _do(conn):
+            # Keep the FK fallback row and the auxiliary usage delta in one
+            # transaction. The marker lets a later known-source accounting
+            # write or authoritative create promote this provisional row.
+            self._insert_accounting_fallback_row(
+                conn,
+                session_id=session_id,
+                source=None,
+                model=None,
+                repair_writer="record_auxiliary_usage",
+            )
             self._record_model_usage(
                 conn,
                 session_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -38,6 +38,8 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
 
 logger = logging.getLogger(__name__)
 
+_MISSING_SESSION_REPAIR_MARKER = "_repaired_missing_session_row"
+
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
 
 
@@ -3403,6 +3405,9 @@ class SessionDB:
         crash before the gateway re-records the peer can't strand the child
         without a recoverable routing mapping (#59527).
         """
+        model_config_json = json.dumps(model_config) if model_config else None
+        source_norm = str(source or "").strip().lower()
+
         def _do(conn):
             conn.execute(
                 """INSERT INTO sessions (
@@ -3432,7 +3437,7 @@ class SessionDB:
                     chat_type,
                     thread_id,
                     model,
-                    json.dumps(model_config) if model_config else None,
+                    model_config_json,
                     system_prompt,
                     parent_session_id,
                     cwd,
@@ -3441,6 +3446,40 @@ class SessionDB:
                     time.time(),
                 ),
             )
+            if source_norm in {"", "unknown"}:
+                return
+
+            # Token accounting can provision a missing session row after the
+            # authoritative create path loses a transient SQLite lock race.
+            # Promote only rows carrying that explicit repair marker: a real
+            # imported/legacy source="unknown" row must remain first-writer-wins.
+            marker_path = f"$.{_MISSING_SESSION_REPAIR_MARKER}"
+            conn.execute(
+                """UPDATE sessions SET
+                       source = ?,
+                       user_id = COALESCE(user_id, ?),
+                       model_config = NULLIF(
+                           json_remove(
+                               COALESCE(?, model_config, '{}'),
+                               ?
+                           ),
+                           '{}'
+                       )
+                   WHERE id = ?
+                     AND source = 'unknown'
+                     AND json_valid(COALESCE(model_config, '{}'))
+                     AND json_extract(COALESCE(model_config, '{}'), ?)
+                         = 'update_token_counts'""",
+                (
+                    source,
+                    user_id,
+                    model_config_json,
+                    marker_path,
+                    session_id,
+                    marker_path,
+                ),
+            )
+
             if parent_session_id:
                 conn.execute(
                     """UPDATE sessions
@@ -4335,19 +4374,50 @@ class SessionDB:
     def update_session_meta(
         self,
         session_id: str,
-        model_config_json: str,
+        model_config_json: Optional[str],
         model: Optional[str] = None,
     ) -> None:
         """Update model_config and optionally model for an existing session.
 
         Uses COALESCE so that passing model=None leaves the stored model
         column unchanged.  Routes through _execute_write for the standard
-        BEGIN IMMEDIATE + jitter-retry + lock guarantee.
+        BEGIN IMMEDIATE + jitter-retry + lock guarantee. Repair markers from
+        a token-accounting fallback survive this metadata refresh so a later
+        authoritative create can still promote the provisional source when the
+        replacement is a valid JSON object. Malformed/non-object legacy values
+        retain update_session_meta's original replacement semantics.
         """
         def _do(conn):
+            config_to_store = model_config_json
+            current = conn.execute(
+                "SELECT source, model_config FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if current is not None and current["source"] == "unknown":
+                try:
+                    existing_config = json.loads(current["model_config"] or "{}")
+                    replacement_config = (
+                        json.loads(model_config_json)
+                        if model_config_json is not None
+                        else None
+                    )
+                    if (
+                        isinstance(existing_config, dict)
+                        and isinstance(replacement_config, dict)
+                        and existing_config.get(_MISSING_SESSION_REPAIR_MARKER)
+                        == "update_token_counts"
+                    ):
+                        replacement_config[_MISSING_SESSION_REPAIR_MARKER] = (
+                            "update_token_counts"
+                        )
+                        config_to_store = json.dumps(replacement_config)
+                except (TypeError, ValueError):
+                    # Preserve update_session_meta's existing permissive
+                    # behavior for malformed/non-object legacy values.
+                    pass
             conn.execute(
                 "UPDATE sessions SET model_config = ?, model = COALESCE(?, model) WHERE id = ?",
-                (model_config_json, model, session_id),
+                (config_to_store, model, session_id),
             )
         self._execute_write(_do)
 
@@ -4423,6 +4493,7 @@ class SessionDB:
         billing_mode: Optional[str] = None,
         api_call_count: int = 0,
         absolute: bool = False,
+        source: Optional[str] = None,
     ) -> None:
         """Update token counters and backfill model if not already set.
 
@@ -4432,12 +4503,12 @@ class SessionDB:
         When *absolute* is True, values are **set directly** — use this when
         the caller already holds cumulative totals (gateway path, where the
         cached agent accumulates across messages).
+
+        ``source`` is optional for compatibility with non-agent callers. Agent
+        runtimes pass the resolved session source so fallback row creation can
+        preserve provenance even when a one-shot run has no later turn to
+        retry ``create_session``.
         """
-        # Ensure the session row exists so the UPDATE doesn't silently affect
-        # 0 rows.  Under concurrent load (cron + kanban + delegate_task) the
-        # initial create_session() may have failed due to SQLite locking.
-        # INSERT OR IGNORE is cheap and idempotent.
-        self._insert_session_row(session_id, "unknown", model=model)
         if absolute:
             sql = """UPDATE sessions SET
                    input_tokens = ?,
@@ -4522,8 +4593,33 @@ class SessionDB:
             or cache_write_tokens or reasoning_tokens or api_call_count
             or estimated_cost_usd
         )
+        fallback_source = str(source or "").strip()
+        source_is_unknown = not fallback_source or fallback_source.lower() == "unknown"
+        if source_is_unknown:
+            fallback_source = "unknown"
+            fallback_model_config = json.dumps(
+                {_MISSING_SESSION_REPAIR_MARKER: "update_token_counts"}
+            )
+        else:
+            fallback_model_config = None
 
         def _do(conn):
+            # Keep fallback row creation in the same write transaction as the
+            # counters. The marker lets a later authoritative create_session
+            # safely promote this provisional source without rewriting a
+            # legitimate source="unknown" row.
+            conn.execute(
+                """INSERT OR IGNORE INTO sessions
+                   (id, source, model, model_config, started_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    fallback_source,
+                    model,
+                    fallback_model_config,
+                    time.time(),
+                ),
+            )
             row = conn.execute(
                 "SELECT model, billing_provider, api_call_count FROM sessions WHERE id = ?",
                 (session_id,),

--- a/run_agent.py
+++ b/run_agent.py
@@ -598,13 +598,17 @@ class AIAgent:
             logger.debug("SessionDB unavailable for recall", exc_info=True)
             return None
 
+    def _session_source_for_db(self) -> str:
+        """Resolve the authoritative source used by all state.db writes."""
+        return _session_source_for_agent(getattr(self, "platform", None))
+
     def _ensure_db_session(self) -> None:
         """Create session DB row on first use. Disables _session_db on failure."""
         if getattr(self, "_persist_disabled", False):
             return
         if self._session_db_created or not self._session_db:
             return
-        source = _session_source_for_agent(self.platform)
+        source = self._session_source_for_db()
         try:
             try:
                 from hermes_cli.profiles import get_active_profile_name

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -28,7 +28,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from agent.codex_runtime import run_codex_app_server_turn
+from agent.codex_runtime import (
+    _record_codex_app_server_usage,
+    run_codex_app_server_turn,
+)
 from hermes_state import SessionDB
 from run_agent import AIAgent
 
@@ -59,6 +62,55 @@ def _make_agent(session_db=None, session_id="sess-codex"):
     agent._session_db_created = True
     agent.session_id = session_id
     return agent
+
+
+def test_codex_usage_persistence_propagates_resolved_source():
+    """Both Codex accounting branches preserve one-shot cron provenance."""
+    usage_cases = [
+        None,
+        {
+            "inputTokens": 11,
+            "cachedInputTokens": 3,
+            "outputTokens": 7,
+            "reasoningOutputTokens": 2,
+            "totalTokens": 23,
+        },
+    ]
+
+    for token_usage in usage_cases:
+        session_db = MagicMock()
+        agent = SimpleNamespace(
+            session_api_calls=0,
+            session_prompt_tokens=0,
+            session_completion_tokens=0,
+            session_total_tokens=0,
+            session_input_tokens=0,
+            session_output_tokens=0,
+            session_cache_read_tokens=0,
+            session_cache_write_tokens=0,
+            session_reasoning_tokens=0,
+            session_estimated_cost_usd=0.0,
+            session_cost_status="unknown",
+            session_cost_source="none",
+            context_compressor=None,
+            _session_db=session_db,
+            _session_db_created=True,
+            session_id="cron-codex",
+            model="gpt-4o",
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+            api_key="test-key",
+            _session_source_for_db=lambda: "cron",
+        )
+        turn = SimpleNamespace(
+            token_usage_last=token_usage,
+            model_context_window=None,
+        )
+
+        _record_codex_app_server_usage(agent, turn)
+
+        session_db.update_token_counts.assert_called_once()
+        assert session_db.update_token_counts.call_args.kwargs["source"] == "cron"
 
 
 def test_codex_success_flushes_and_reports_persisted():

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -5,6 +5,7 @@ their token usage into session_model_usage with a ``task`` dimension via
 the ambient accounting context (agent/aux_accounting.py), making aux model
 spend visible in analytics.
 """
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -115,6 +116,49 @@ class TestRecordAuxiliaryUsage:
         db.record_auxiliary_usage("ghost", "vision", model="m", input_tokens=5)
         rows = _usage_rows(db, "ghost")
         assert len(rows) == 1
+
+    def test_missing_row_stays_promotable_after_auxiliary_usage(self, db):
+        """Aux accounting must not strand a later authoritative cron source."""
+        sid = "cron-aux-first"
+        db.record_auxiliary_usage(
+            sid,
+            "title_generation",
+            model="aux-model",
+            input_tokens=5,
+        )
+
+        provisional = db.get_session(sid)
+        assert provisional["source"] == "unknown"
+        assert json.loads(provisional["model_config"]) == {
+            "_repaired_missing_session_row": "record_auxiliary_usage"
+        }
+
+        db.update_token_counts(
+            sid,
+            input_tokens=10,
+            output_tokens=2,
+            source="cron",
+        )
+
+        accounted = db.get_session(sid)
+        assert accounted["source"] == "cron"
+        assert accounted["model_config"] is None
+
+        db.create_session(
+            sid,
+            source="cron",
+            model_config={"authoritative": True},
+        )
+
+        repaired = db.get_session(sid)
+        assert repaired["source"] == "cron"
+        assert json.loads(repaired["model_config"]) == {"authoritative": True}
+        assert repaired["input_tokens"] == 10
+        assert repaired["output_tokens"] == 2
+        assert [row["task"] for row in _usage_rows(db, sid)] == [
+            "",
+            "title_generation",
+        ]
 
 
 class TestSchemaMigrationV22:

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -129,9 +129,7 @@ class TestRecordAuxiliaryUsage:
 
         provisional = db.get_session(sid)
         assert provisional["source"] == "unknown"
-        assert json.loads(provisional["model_config"]) == {
-            "_repaired_missing_session_row": "record_auxiliary_usage"
-        }
+        assert provisional["model_config"] is None
 
         db.update_token_counts(
             sid,
@@ -159,6 +157,36 @@ class TestRecordAuxiliaryUsage:
             "",
             "title_generation",
         ]
+
+    def test_known_source_accounting_repair_backfills_authoritative_user(self, db):
+        sid = "known-source-accounting-first"
+        db.update_token_counts(
+            sid,
+            input_tokens=10,
+            source="cron",
+        )
+
+        db.create_session(sid, source="cron", user_id="owner")
+
+        repaired = db.get_session(sid)
+        assert repaired["source"] == "cron"
+        assert repaired["user_id"] == "owner"
+        assert repaired["input_tokens"] == 10
+
+    def test_public_marker_like_model_config_does_not_grant_repair_provenance(self, db):
+        sid = "legitimate-unknown"
+        marker_config = {
+            "_repaired_missing_session_row": "record_auxiliary_usage",
+            "preserve": True,
+        }
+        db.create_session(sid, source="unknown", model_config=marker_config)
+
+        db.create_session(sid, source="cron", user_id="owner")
+
+        preserved = db.get_session(sid)
+        assert preserved["source"] == "unknown"
+        assert preserved["user_id"] is None
+        assert json.loads(preserved["model_config"]) == marker_config
 
 
 class TestSchemaMigrationV22:

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -52,6 +52,7 @@ def test_run_conversation_persists_tokens_for_telegram_sessions():
     assert result["final_response"] == "done"
     session_db.update_token_counts.assert_called_once()
     assert session_db.update_token_counts.call_args.args[0] == "telegram-session"
+    assert session_db.update_token_counts.call_args.kwargs["source"] == "telegram"
 
 
 def test_run_conversation_persists_tokens_for_cron_sessions():
@@ -63,6 +64,7 @@ def test_run_conversation_persists_tokens_for_cron_sessions():
     assert result["final_response"] == "done"
     session_db.update_token_counts.assert_called_once()
     assert session_db.update_token_counts.call_args.args[0] == "cron-session"
+    assert session_db.update_token_counts.call_args.kwargs["source"] == "cron"
 
 
 def test_session_search_lazily_opens_db_when_entrypoint_did_not_pass_one(monkeypatch):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -537,9 +537,7 @@ class TestSessionLifecycle:
 
         provisional = db.get_session(sid)
         assert provisional["source"] == "unknown"
-        assert json.loads(provisional["model_config"]) == {
-            "_repaired_missing_session_row": "update_token_counts"
-        }
+        assert provisional["model_config"] is None
 
         db.create_session(
             sid,
@@ -560,8 +558,8 @@ class TestSessionLifecycle:
         assert repaired["input_tokens"] == 100
         assert repaired["output_tokens"] == 50
 
-    def test_session_meta_refresh_preserves_repair_marker_until_promotion(self, db):
-        """Valid object metadata refreshes keep a provisional row repairable."""
+    def test_session_meta_refresh_preserves_internal_repair_provenance(self, db):
+        """Metadata refreshes cannot consume internal repair provenance."""
         sid = "cron-meta-interleaving"
         db.update_token_counts(
             sid,
@@ -580,7 +578,6 @@ class TestSessionLifecycle:
         assert json.loads(refreshed["model_config"]) == {
             "runtime": "saved",
             "optional": None,
-            "_repaired_missing_session_row": "update_token_counts",
         }
 
         db.create_session(
@@ -616,7 +613,7 @@ class TestSessionLifecycle:
         assert refreshed["model_config"] == replacement
 
     def test_authoritative_create_preserves_legitimate_unknown_source(self, db):
-        """Only explicitly marked repair rows are eligible for promotion."""
+        """Only internally registered repair rows are eligible for promotion."""
         db.create_session(
             "imported-session",
             source="unknown",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -519,6 +519,152 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["model"] == "anthropic/claude-opus-4.6"
 
+    @pytest.mark.parametrize("absolute", [False, True])
+    def test_authoritative_create_promotes_token_repair_source(self, db, absolute):
+        """A cron create that catches up after lock contention repairs source.
+
+        Regression for #64573. update_token_counts may be the first successful
+        writer after create_session(source="cron") loses a SQLite lock race.
+        """
+        sid = "cron_job-123_20260714_120000"
+        db.update_token_counts(
+            sid,
+            input_tokens=100,
+            output_tokens=50,
+            model="test-model",
+            absolute=absolute,
+        )
+
+        provisional = db.get_session(sid)
+        assert provisional["source"] == "unknown"
+        assert json.loads(provisional["model_config"]) == {
+            "_repaired_missing_session_row": "update_token_counts"
+        }
+
+        db.create_session(
+            sid,
+            source="cron",
+            model="test-model",
+            model_config={"max_iterations": 90, "optional": None},
+            user_id="cron-owner",
+        )
+
+        repaired = db.get_session(sid)
+        assert repaired["source"] == "cron"
+        assert repaired["model"] == "test-model"
+        assert json.loads(repaired["model_config"]) == {
+            "max_iterations": 90,
+            "optional": None,
+        }
+        assert repaired["user_id"] == "cron-owner"
+        assert repaired["input_tokens"] == 100
+        assert repaired["output_tokens"] == 50
+
+    def test_session_meta_refresh_preserves_repair_marker_until_promotion(self, db):
+        """Valid object metadata refreshes keep a provisional row repairable."""
+        sid = "cron-meta-interleaving"
+        db.update_token_counts(
+            sid,
+            input_tokens=100,
+            output_tokens=50,
+            model="usage-model",
+        )
+        db.update_session_meta(
+            sid,
+            json.dumps({"runtime": "saved", "optional": None}),
+            model="runtime-model",
+        )
+
+        refreshed = db.get_session(sid)
+        assert refreshed["source"] == "unknown"
+        assert json.loads(refreshed["model_config"]) == {
+            "runtime": "saved",
+            "optional": None,
+            "_repaired_missing_session_row": "update_token_counts",
+        }
+
+        db.create_session(
+            sid,
+            source="cron",
+            model_config={"authoritative": True, "optional": None},
+            user_id="cron-owner",
+        )
+
+        repaired = db.get_session(sid)
+        assert repaired["source"] == "cron"
+        assert repaired["model"] == "runtime-model"
+        assert repaired["user_id"] == "cron-owner"
+        assert json.loads(repaired["model_config"]) == {
+            "authoritative": True,
+            "optional": None,
+        }
+        assert repaired["input_tokens"] == 100
+        assert repaired["output_tokens"] == 50
+
+    @pytest.mark.parametrize("replacement", [None, ""])
+    def test_session_meta_refresh_preserves_permissive_replacement_semantics(
+        self, db, replacement
+    ):
+        """None and empty-string replacements remain exact, even on repair rows."""
+        sid = f"provisional-meta-{replacement is None}"
+        db.update_token_counts(sid, input_tokens=1, output_tokens=1)
+
+        db.update_session_meta(sid, replacement)
+
+        refreshed = db.get_session(sid)
+        assert refreshed["source"] == "unknown"
+        assert refreshed["model_config"] == replacement
+
+    def test_authoritative_create_preserves_legitimate_unknown_source(self, db):
+        """Only explicitly marked repair rows are eligible for promotion."""
+        db.create_session(
+            "imported-session",
+            source="unknown",
+            model_config={"origin": "legacy-import"},
+        )
+        db.update_token_counts(
+            "imported-session",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        db.create_session("imported-session", source="cron")
+
+        session = db.get_session("imported-session")
+        assert session["source"] == "unknown"
+        assert json.loads(session["model_config"]) == {
+            "origin": "legacy-import"
+        }
+
+    @pytest.mark.parametrize("absolute", [False, True])
+    def test_token_accounting_preserves_known_source_without_retry(self, db, absolute):
+        """A one-shot cron run stays classified even without a later create."""
+        db.update_token_counts(
+            "cron-one-shot",
+            input_tokens=10,
+            output_tokens=5,
+            source="cron",
+            absolute=absolute,
+        )
+
+        session = db.get_session("cron-one-shot")
+        assert session["source"] == "cron"
+        assert session["model_config"] is None
+        assert session["input_tokens"] == 10
+        assert session["output_tokens"] == 5
+
+    def test_token_accounting_does_not_mark_existing_cron_session(self, db):
+        """The fallback marker is written only when token accounting inserts."""
+        db.create_session("cron-existing", source="cron")
+        db.update_token_counts(
+            "cron-existing",
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+        session = db.get_session("cron-existing")
+        assert session["source"] == "cron"
+        assert session["model_config"] is None
+
     def test_update_session_model_overwrites_existing(self, db):
         """A mid-session /model switch must overwrite the stored model.
 


### PR DESCRIPTION
## What does this PR do?

Repairs session provenance when token accounting is the first successful SQLite writer after authoritative session creation lost a transient lock race.

Today `update_token_counts()` materializes a missing row as `source="unknown"`. The later real `create_session(..., source="cron")` enriches nullable metadata but intentionally does not overwrite `source`, so cron sessions remain permanently misclassified and can leak into user-facing lists.

This change:

- propagates the agent's resolved session source through chat-completions and Codex usage persistence;
- writes that known source directly when token accounting must create the row, which covers one-shot cron runs with no later retry;
- marks only fallback rows created by callers that genuinely do not know the source;
- creates that fallback row in the same write transaction as the token update;
- lets a later known-source `create_session()` promote only an explicitly marked repair row;
- removes the internal marker while merging the authoritative `model_config`;
- preserves legitimate, unmarked `source="unknown"` rows and already-correct sources.

The explicit marker avoids a broad `unknown -> known` rewrite rule that could corrupt imported or legacy sessions whose source is genuinely unknown.

This is a focused salvage of the repair-marker/promotion approach introduced by @dpersek in #54479, adapted to the current `INSERT ... ON CONFLICT` implementation after #54847. It intentionally leaves #54479's TUI filtering, timestamp heuristics, pagination, and `append_message()` changes out of scope.

## Related Issue

Fixes #64573

Related: #54479, #54320, #27633, #39372, #57527.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`
  - accept an optional authoritative source for token-accounting fallback insertion;
  - add an internal marker only when that source is unavailable;
  - make fallback insertion and counter updates one transaction;
  - preserve the repair marker across valid-object `update_session_meta()` refreshes while retaining exact legacy replacement semantics for `None`, empty, malformed, and non-object values;
  - promote a marked `source="unknown"` row when authoritative creation supplies a known source;
  - remove the marker and merge real model configuration without losing counters or ownership metadata.
- `run_agent.py`, `agent/conversation_loop.py`, `agent/codex_runtime.py`
  - use one source resolver for session creation and token persistence;
  - propagate the resolved source in both chat-completions and Codex accounting paths.
- `tests/test_hermes_state.py`, `tests/run_agent/test_token_persistence_non_cli.py`, `tests/agent/test_codex_app_server_persist.py`
  - cover direct `source="cron"` fallback for one-shot runs;
  - cover promotion to `source="cron"` in incremental and absolute accounting modes;
  - verify token/model/config/user metadata survives promotion;
  - verify a valid-object metadata refresh cannot erase the marker before promotion;
  - verify `None` and empty-string metadata replacements retain their exact prior behavior;
  - verify legitimate unmarked `unknown` rows remain first-writer-wins;
  - verify an existing cron row is never marked or downgraded;
  - verify Telegram, cron, and both Codex accounting branches propagate their source.

## How to Test

1. Run the complete SessionDB file and the full `agent` / `run_agent` suites through the canonical hermetic runner:

   ```bash
   scripts/run_tests.sh tests/test_hermes_state.py -q
   scripts/run_tests.sh tests/agent/ -q
   scripts/run_tests.sh tests/run_agent/ -q
   scripts/run_tests.sh tests/acp/ tests/test_tui_gateway_server.py -q
   ```

   Observed: `8,668 passed, 0 failed` across 402 distinct test files (`375` SessionDB + `5,644` agent + `2,021` run_agent + `306` ACP + `322` TUI gateway).

2. Run lint and diff hygiene:

   ```bash
   .venv/bin/ruff check hermes_state.py run_agent.py agent/conversation_loop.py agent/codex_runtime.py tests/test_hermes_state.py tests/run_agent/test_token_persistence_non_cli.py tests/agent/test_codex_app_server_persist.py
   git diff --check
   ```

   Observed: both passed.

3. Run the minimized reproductions from #64573. Before this PR, a one-shot cron fallback was persisted as:

   ```text
   source: unknown
   ```

   After this PR, the runtime-propagated source is preserved without requiring another turn:

   ```text
   one_shot_source:       cron
   one_shot_model_config: null
   ```

   Compatibility callers that do not pass a source still get a provisional marker and safe later promotion:

   ```text
   fallback_source:          unknown
   after_retry_source:       cron
   after_retry_model_config: {"max_iterations": 90}
   ```

4. Exercise metadata refresh and authoritative creation with two real `SessionDB` connections across 100 concurrent lock-order interleavings.

   Observed: `100 iterations, 0 failures`; every row ended as `source="cron"` with no repair marker.

5. Replay permissive metadata replacements on provisional rows.

   Observed: `"{"`, `""`, `"[]"`, `"null"`, `"\"x\""`, and `None` were each stored byte-for-byte/value-for-value as before this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full repository suite not run; 8,668 affected tests passed through `scripts/run_tests.sh`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.17 aarch64, Python 3.11 test venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal persistence invariant only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — SQLite JSON1 functions used here are already required by existing session queries
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No UI change. The hermetic before/after reproduction and test output are included above.

## Credit

The explicit repair-marker/promotion design is salvaged from #54479 by @dpersek (Dustin Persek) and adapted to current `main`. Commit co-authorship is preserved.