### PR TITLE
fix(kanban): fail closed invalid dependency waits

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -108,10 +108,9 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # unblocks → worker re-blocks → cron unblocks … forever.
 #
 #   * ``dependency``   — can't proceed until another task finishes. Routed to
-#                        ``todo`` (NOT ``blocked``) so the existing
-#                        parent-gating / ``recompute_ready`` machinery promotes
-#                        it automatically once parents are done. No human, no
-#                        cron, no retry storm.
+#                        ``todo`` only when a persisted parent edge exists, so
+#                        parent-gating / ``recompute_ready`` can promote it.
+#                        Zero-parent waits fail closed in ``blocked``.
 #   * ``needs_input``  — needs a human decision/answer it cannot derive.
 #   * ``capability``   — hit a hard wall (no access, missing creds, an action no
 #                        AI agent can perform). Genuinely human-only.
@@ -3260,10 +3259,10 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       finish, transient infra error clears).
 
     The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    explicit-block / ``"unblocked"`` event for the task. Explicit blocks are
+    either the generic ``"blocked"`` event or ``"dependency_wait_invalid"``
+    for a dependency wait with no persisted parent edge. If one of those is
+    most recent, ``recompute_ready`` must *not* auto-promote the task.
 
     Returns ``False`` when there is no such event at all (e.g. the task
     was set to ``status='blocked'`` by the circuit breaker or by direct
@@ -3272,11 +3271,12 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "WHERE task_id = ? "
+        "AND kind IN ('blocked', 'dependency_wait_invalid', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    return bool(row) and row["kind"] != "unblocked"
 
 
 def recompute_ready(
@@ -4776,11 +4776,11 @@ def block_task(
     un-typed block) drives routing instead of every block landing in one
     undifferentiated ``blocked`` bucket:
 
-    * ``dependency`` — the task is only waiting on another task. It does NOT
-      sit in ``blocked`` (where a cron would keep "unblocking" it); it goes to
-      ``todo`` so the existing parent-gating / ``recompute_ready`` machinery
-      promotes it automatically once its parents finish. No human, no cron, no
-      retry storm. This is Dale's "Type 2 — dependency blocked".
+    * ``dependency`` — the task is only waiting on another task. With at least
+      one persisted parent edge it goes to ``todo`` so parent-gating /
+      ``recompute_ready`` promotes it automatically once all parents finish.
+      Without a parent edge it fails closed in ``blocked`` and emits a typed
+      diagnostic instead of entering an immediate redispatch loop.
 
     * ``needs_input`` / ``capability`` / ``None`` — "truly blocked" (Dale's
       "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
@@ -4818,11 +4818,62 @@ def block_task(
             else 0
         )
 
-        # Dependency blocks never enter the human ``blocked`` bucket — they
-        # wait in ``todo`` and let ``recompute_ready`` gate on parents. Routing
-        # here (rather than ``blocked``) is what keeps a cron from ever seeing
-        # a dependency-wait as something to "unblock".
+        # A dependency wait is auto-resumable only when a persisted parent edge
+        # exists. Without one, ``all(parents)`` in ``recompute_ready`` would be
+        # vacuously true and redispatch the task on every dispatcher pass.
         if kind == "dependency":
+            has_parent = conn.execute(
+                "SELECT 1 FROM task_links WHERE child_id = ? LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            if not has_parent:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status        = 'blocked',
+                           claim_lock    = NULL,
+                           claim_expires = NULL,
+                           worker_pid    = NULL,
+                           block_kind    = ?
+                     WHERE id = ?
+                       AND status IN ('running', 'ready')
+                    """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                    (kind, task_id) if expected_run_id is None
+                    else (kind, task_id, int(expected_run_id)),
+                )
+                if cur.rowcount != 1:
+                    return False
+                run_id = _end_run(
+                    conn, task_id,
+                    outcome="blocked", status="blocked",
+                    summary=reason,
+                )
+                if run_id is None and reason:
+                    run_id = _synthesize_ended_run(
+                        conn, task_id, outcome="blocked", summary=reason,
+                    )
+                _append_event(
+                    conn, task_id, "dependency_wait_invalid",
+                    {
+                        "reason": reason,
+                        "kind": kind,
+                        "diagnostic": (
+                            "dependency wait requires at least one persisted parent edge"
+                        ),
+                    },
+                    run_id=run_id,
+                )
+                _blocked_task = get_task(conn, task_id)
+                _fire_kanban_lifecycle_hook(
+                    "kanban_task_blocked",
+                    task_id,
+                    board=get_current_board(),
+                    assignee=_blocked_task.assignee if _blocked_task else None,
+                    run_id=run_id,
+                    reason=reason,
+                )
+                return True
+
             cur = conn.execute(
                 """
                 UPDATE tasks

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -5,8 +5,8 @@ task, a cron unblocks it, the worker re-blocks for the same reason, repeat
 forever. The fix gives ``block_task`` a typed ``kind`` and a persistent
 ``block_recurrences`` counter:
 
-* ``dependency`` blocks route to ``todo`` (parent-gated, auto-resumed) and
-  never enter the human ``blocked`` bucket a cron would keep unblocking.
+* ``dependency`` blocks route to ``todo`` only when a persisted parent edge
+  exists. A zero-parent dependency wait fails closed in ``blocked``.
 * ``needs_input`` / ``capability`` / un-typed blocks land in ``blocked``;
   each same-cause re-block after an unblock increments ``block_recurrences``,
   and at ``BLOCK_RECURRENCE_LIMIT`` the task routes to ``triage`` for a human.
@@ -135,31 +135,60 @@ def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_dependency_block_routes_to_todo(kanban_home: Path) -> None:
-    """Dependency waits never enter the human 'blocked' bucket."""
+def test_zero_parent_dependency_wait_fails_closed_across_recompute(kanban_home: Path) -> None:
+    """A dependency wait without a parent edge must never redispatch."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
         assert kb.block_task(conn, tid, reason="need X first", kind="dependency")
         t = kb.get_task(conn, tid)
-        assert t.status == "todo"
+        assert t.status == "blocked"
         assert t.block_kind == "dependency"
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        assert run.summary == "need X first"
+
+        events = [
+            event for event in kb.list_events(conn, tid)
+            if event.kind == "dependency_wait_invalid"
+        ]
+        assert len(events) == 1
+        assert events[0].payload == {
+            "reason": "need X first",
+            "kind": "dependency",
+            "diagnostic": "dependency wait requires at least one persisted parent edge",
+        }
+
+        for _ in range(5):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, tid).status == "blocked"
 
 
 def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
-    """A dependency-parked child becomes ready once its parent completes."""
+    """Parent → child means the child waits for that parent, then promotes once."""
     with kb.connect_closing() as conn:
         parent = kb.create_task(conn, title="parent", assignee="worker")
         child = _running_task(conn, title="child")
         kb.link_tasks(conn, parent_id=parent, child_id=child)
         kb.block_task(conn, child, reason="wait", kind="dependency")
         assert kb.get_task(conn, child).status == "todo"
+
+        for _ in range(3):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, child).status == "todo"
+
         # Finish the parent, then let recompute_ready run.
         with kb.write_txn(conn):
             conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
         kb.claim_task(conn, parent, claimer="worker")
         kb.complete_task(conn, parent, result="done")
-        kb.recompute_ready(conn)
+        # Parent completion promotes dependants in the same event-driven path.
         assert kb.get_task(conn, child).status == "ready"
+        assert kb.recompute_ready(conn) == 0
+        promoted = [
+            event for event in kb.list_events(conn, child)
+            if event.kind == "promoted"
+        ]
+        assert len(promoted) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -809,14 +809,20 @@ def test_block_goal_mode_allows_dependency_kind(monkeypatch, tmp_path):
     """`dependency` and `needs_input` represent a genuine external blocker
     the worker cannot resolve itself — these remain ungated.
 
-    `dependency` routes to status='todo' (not 'blocked') per block_task's
-    own kind-routing — the goal loop still treats anything outside
-    running/ready/done/blocked as a stop, so this is still a legitimate,
-    judge-free exit; it's just not the literal 'blocked' status."""
+    With a persisted parent edge, `dependency` routes to status='todo' per
+    block_task's kind-routing — the goal loop still treats anything outside
+    running/ready/done/blocked as a legitimate, judge-free exit."""
     from tools import kanban_tools as kt
     from hermes_cli import kanban_db as kb
 
     tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="prerequisite", assignee="worker")
+        kb.link_tasks(conn, parent_id=parent, child_id=tid)
+    finally:
+        conn.close()
+
     out = kt._handle_block({"reason": "waiting on another task", "kind": "dependency"})
     d = json.loads(out)
     assert d.get("ok") is True

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -268,12 +268,19 @@ hermes kanban block    t_abc "need input" --ids t_def t_hij
 | `kanban_show` | Read the current task (title, body, prior attempts, parent handoffs, comments, full pre-formatted `worker_context`). Defaults to the env's task id. | — |
 | `kanban_list` | List task summaries with filters for `assignee`, `status`, `tenant`, archived visibility, and limit. Intended for orchestrators discovering board work. | — |
 | `kanban_complete` | Finish with `summary` + `metadata` structured handoff. | at least one of `summary` / `result` |
-| `kanban_block` | Stop work and route by why: `kind=dependency` (waits in `todo`, auto-resumes), `needs_input`/`capability`/`transient` (surface to a human). Repeated same-kind re-blocks auto-escalate to `triage`. | `reason` |
+| `kanban_block` | Stop work and route by why: `kind=dependency` waits in `todo` and auto-resumes only when the task has a persisted parent edge; a zero-parent dependency wait fails closed for operator repair. `needs_input`/`capability`/`transient` surface to a human. Repeated same-kind re-blocks auto-escalate to `triage`. | `reason` |
 | `kanban_heartbeat` | Signal liveness during long operations. Pure side-effect. | — |
 | `kanban_comment` | Append a durable note to the task thread. | `task_id`, `body` |
 | `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
 | `kanban_link` | (Orchestrators) add a `parent_id → child_id` dependency edge after the fact. | `parent_id`, `child_id` |
 | `kanban_unblock` | (Orchestrators) move a blocked task back to `ready`. | `task_id` |
+
+A dependency edge is directional: `parent_id → child_id` means the **child
+waits for the parent** and becomes eligible only after that parent is done or
+archived. Logical ownership is separate from execution order; making an
+orchestration card the conceptual owner of another card does not mean the
+owned card should wait for the orchestrator. Encode the prerequisite as the
+parent and the waiting work as the child.
 
 A typical worker turn looks like:
 


### PR DESCRIPTION
## Summary

Fail closed when a worker reports `kind=dependency` but the task has no persisted parent dependency edge.

Previously this invalid state was routed back to `todo`; the readiness recomputation could then redispatch it indefinitely, wasting Goal Mode/model runs. The patch keeps the task blocked until explicit operator repair while preserving the existing behavior for valid dependency chains.

## Behavior

- zero-parent dependency wait → durable blocked state, no automatic redispatch;
- valid parent dependency wait → unchanged `todo` wait and exactly one wake-up after parents complete;
- repeated invalid dependency reports remain blocked;
- operator guidance is included in CLI/tool responses and user documentation.

## Verification

Exact candidate: `4efc5ae3b8462d0dfca44be7bd414ae4086cb6aa`

```text
345 passed
python -m py_compile hermes_cli/kanban_db.py: passed
git diff --check: passed
```

Independent exact-HEAD QA approved the candidate and verified both fail-closed and valid-chain semantics.

## Scope / non-actions

No existing task data is migrated or mutated. No gateway/runtime configuration or release policy changes are included.

Tracks: stevenbaert/hermes#706
