### PR TITLE
fix(tool-search): finalize provider tool surfaces

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -827,31 +827,34 @@ class HermesACPAgent(acp.Agent):
             return
 
         try:
-            from model_tools import get_tool_definitions
-            from agent.memory_manager import inject_memory_provider_tools
+            from tools.mcp_tool import refresh_agent_mcp_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
                 mcp_server_names=[server.name for server in mcp_servers],
             )
-            state.agent.enabled_toolsets = enabled_toolsets
-            disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
-            state.agent.tools = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
-                quiet_mode=True,
+            # Route through the shared full-surface rebuild used by every other
+            # surface (TUI reload.mcp, gateway reload, late-binding refresh) so
+            # ACP sessions get the same complete snapshot: registry tools plus
+            # memory-provider AND context-engine reinjection, with the Tool
+            # Search surface assembled from that same staged snapshot and every
+            # dependent attribute published atomically. A hand-rolled
+            # get_tool_definitions() assignment here would skip the finalized
+            # assembly and diverge from the session surface (#47119 review).
+            added = await asyncio.to_thread(
+                refresh_agent_mcp_tools,
+                state.agent,
+                enabled_override=enabled_toolsets,
+                disabled_override=getattr(state.agent, "disabled_toolsets", None),
             )
-            state.agent.valid_tool_names = {
-                tool["function"]["name"] for tool in state.agent.tools or []
-            }
-            inject_memory_provider_tools(state.agent)
             invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
             if callable(invalidate):
                 invalidate()
             logger.info(
-                "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
+                "Session %s: refreshed tool surface after ACP MCP registration (%d tools, %d added)",
                 state.session_id,
                 len(state.agent.tools or []),
+                len(added),
             )
         except Exception:
             logger.warning(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1161,31 +1161,34 @@ class HermesACPAgent(acp.Agent):
             return
 
         try:
-            from model_tools import get_tool_definitions
-            from agent.memory_manager import inject_memory_provider_tools
+            from tools.mcp_tool import refresh_agent_mcp_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
                 mcp_server_names=[server.name for server in mcp_servers],
             )
-            state.agent.enabled_toolsets = enabled_toolsets
-            disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
-            state.agent.tools = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
-                quiet_mode=True,
+            # Route through the shared full-surface rebuild used by every other
+            # surface (TUI reload.mcp, gateway reload, late-binding refresh) so
+            # ACP sessions get the same complete snapshot: registry tools plus
+            # memory-provider AND context-engine reinjection, with the Tool
+            # Search surface assembled from that same staged snapshot and every
+            # dependent attribute published atomically. A hand-rolled
+            # get_tool_definitions() assignment here would skip the finalized
+            # assembly and diverge from the session surface (#47119 review).
+            added = await asyncio.to_thread(
+                refresh_agent_mcp_tools,
+                state.agent,
+                enabled_override=enabled_toolsets,
+                disabled_override=getattr(state.agent, "disabled_toolsets", None),
             )
-            state.agent.valid_tool_names = {
-                tool["function"]["name"] for tool in state.agent.tools or []
-            }
-            inject_memory_provider_tools(state.agent)
             invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
             if callable(invalidate):
                 invalidate()
             logger.info(
-                "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
+                "Session %s: refreshed tool surface after ACP MCP registration (%d tools, %d added)",
                 state.session_id,
                 len(state.agent.tools or []),
+                len(added),
             )
         except Exception:
             logger.warning(

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1196,6 +1196,7 @@ def init_agent(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        skip_tool_search_assembly=True,
     )
     
     # Show tool configuration and store valid tool names for validation
@@ -1971,6 +1972,21 @@ def init_agent(
             agent.valid_tool_names.add(_tname)
             agent._context_engine_tool_names.add(_tname)
             _existing_tool_names.add(_tname)
+
+    # Assemble Tool Search only after every granted session-local schema family
+    # is present. This makes the first live surface identical to a rebuilt one.
+    from agent.tool_search_surface import finalize_agent_tool_surface
+
+    finalize_agent_tool_surface(
+        agent,
+        context_length=(
+            getattr(agent.context_compressor, "context_length", None)
+            or _config_context_length
+        ),
+    )
+    agent._kanban_worker_guidance = (
+        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+    )
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1520,6 +1520,7 @@ def init_agent(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        skip_tool_search_assembly=True,
     )
     
     # Show tool configuration and store valid tool names for validation
@@ -2786,6 +2787,21 @@ def init_agent(
             agent.valid_tool_names.add(_tname)
             agent._context_engine_tool_names.add(_tname)
             _existing_tool_names.add(_tname)
+
+    # Assemble Tool Search only after every granted session-local schema family
+    # is present. This makes the first live surface identical to a rebuilt one.
+    from agent.tool_search_surface import finalize_agent_tool_surface
+
+    finalize_agent_tool_surface(
+        agent,
+        context_length=(
+            getattr(agent.context_compressor, "context_length", None)
+            or _config_context_length
+        ),
+    )
+    agent._kanban_worker_guidance = (
+        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+    )
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2371,6 +2371,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                tool_search_catalog=getattr(agent, "_tool_search_catalog", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3280,6 +3280,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                tool_search_catalog=getattr(agent, "_tool_search_catalog", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
             if skip_tool_execution_middleware:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -230,6 +230,10 @@ def _tool_search_scoped_names(agent) -> frozenset:
     generation changes (e.g. an MCP server reconnects), so the common case is
     a dict lookup, not a full tool-defs rebuild on every tool call.
     """
+    session_names = getattr(agent, "_tool_search_allowed_names", None)
+    if session_names is not None:
+        return frozenset(session_names)
+
     try:
         import model_tools
         from tools import tool_search as _ts

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -344,6 +344,10 @@ def _tool_search_scoped_names(agent) -> frozenset:
     generation changes (e.g. an MCP server reconnects), so the common case is
     a dict lookup, not a full tool-defs rebuild on every tool call.
     """
+    session_names = getattr(agent, "_tool_search_allowed_names", None)
+    if session_names is not None:
+        return frozenset(session_names)
+
     try:
         import model_tools
         from tools import tool_search as _ts

--- a/agent/tool_search_surface.py
+++ b/agent/tool_search_surface.py
@@ -1,0 +1,115 @@
+"""Finalize one agent's effective tool surface after provider injection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+from tools.tool_search import AssemblyResult, ToolSearchConfig, assemble_tool_defs, load_config
+
+
+def _deduplicate_tool_defs(tool_defs: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    result: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for tool_def in tool_defs:
+        if not isinstance(tool_def, dict):
+            continue
+        name = (tool_def.get("function") or {}).get("name")
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        result.append(tool_def)
+    return result
+
+
+@dataclass(frozen=True)
+class AgentToolSurface:
+    """One prepared, internally consistent session-local tool snapshot."""
+
+    source_defs: tuple[Dict[str, Any], ...]
+    config: ToolSearchConfig
+    context_length: Optional[int]
+    assembly: AssemblyResult
+    visible_names: frozenset[str]
+
+
+def prepare_agent_tool_surface(
+    agent: Any,
+    *,
+    source_tool_defs: Iterable[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+    context_length: Optional[int] = None,
+) -> AgentToolSurface:
+    """Build a complete surface without mutating the live agent."""
+    if config is None:
+        config = load_config()
+    source = tuple(_deduplicate_tool_defs(source_tool_defs))
+    assembly = assemble_tool_defs(
+        list(source),
+        context_length=context_length,
+        config=config,
+    )
+    visible_names = frozenset(
+        name
+        for tool in assembly.tool_defs
+        if (name := (tool.get("function") or {}).get("name"))
+    )
+    return AgentToolSurface(
+        source_defs=source,
+        config=config,
+        context_length=context_length,
+        assembly=assembly,
+        visible_names=visible_names,
+    )
+
+
+def publish_agent_tool_surface(agent: Any, surface: AgentToolSurface) -> None:
+    """Publish every dependent tool-surface attribute from one snapshot."""
+    assembly = surface.assembly
+    agent._tool_search_config = surface.config
+    agent._tool_search_context_length = surface.context_length
+    agent._tool_search_source_defs = surface.source_defs
+    if assembly.activated:
+        agent._tool_search_catalog = tuple(assembly.catalog)
+        agent._tool_search_allowed_names = frozenset(
+            entry.name for entry in assembly.catalog
+        )
+    else:
+        # ``None`` means no finalized bridge scope is active. Keep that distinct
+        # from an authoritative empty catalog so legacy/manual bridge callers can
+        # still use the scoped registry fallback when Tool Search is disabled.
+        agent._tool_search_catalog = None
+        agent._tool_search_allowed_names = None
+    agent._tool_search_assembly = assembly
+    agent.tools = list(assembly.tool_defs)
+    agent.valid_tool_names = set(surface.visible_names)
+    agent._tool_search_scope_cache = None
+
+
+def finalize_agent_tool_surface(
+    agent: Any,
+    *,
+    source_tool_defs: Optional[Iterable[Dict[str, Any]]] = None,
+    config: Optional[ToolSearchConfig] = None,
+    context_length: Optional[int] = None,
+) -> AssemblyResult:
+    """Publish visible tools and the deferred catalog from one complete snapshot."""
+    source = _deduplicate_tool_defs(
+        source_tool_defs if source_tool_defs is not None else (getattr(agent, "tools", None) or [])
+    )
+    surface = prepare_agent_tool_surface(
+        agent,
+        source_tool_defs=source,
+        context_length=context_length,
+        config=config,
+    )
+    publish_agent_tool_surface(agent, surface)
+    return surface.assembly
+
+
+__all__ = [
+    "AgentToolSurface",
+    "finalize_agent_tool_surface",
+    "prepare_agent_tool_surface",
+    "publish_agent_tool_surface",
+]

--- a/model_tools.py
+++ b/model_tools.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 import threading
 import time
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, Iterable, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
@@ -1037,6 +1037,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    tool_search_catalog: Optional[Iterable[Any]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1102,13 +1103,26 @@ def handle_function_call(
         except Exception:
             current_defs = []
         if function_name == _ts_mod.TOOL_SEARCH_NAME:
-            return _ts_mod.dispatch_tool_search(function_args or {},
-                                                current_tool_defs=current_defs)
+            return _ts_mod.dispatch_tool_search(
+                function_args or {},
+                current_tool_defs=current_defs,
+                catalog=tool_search_catalog,
+            )
         if function_name == _ts_mod.TOOL_DESCRIBE_NAME:
-            return _ts_mod.dispatch_tool_describe(function_args or {},
-                                                  current_tool_defs=current_defs)
+            return _ts_mod.dispatch_tool_describe(
+                function_args or {},
+                current_tool_defs=current_defs,
+                catalog=tool_search_catalog,
+            )
         if function_name == _ts_mod.TOOL_CALL_NAME:
-            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(function_args or {})
+            catalog_names = (
+                frozenset(entry.name for entry in tool_search_catalog)
+                if tool_search_catalog is not None
+                else None
+            )
+            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(
+                function_args or {}
+            )
             if err or not underlying_name:
                 return json.dumps({"error": err or "tool_call could not be resolved"},
                                   ensure_ascii=False)
@@ -1118,7 +1132,11 @@ def handle_function_call(
             # additionally rejects any tool the session was not granted, so a
             # restricted session can never invoke an out-of-scope tool through
             # the bridge even if the catalog scoping above regressed.
-            _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
+            _scoped_deferrable = (
+                catalog_names
+                if catalog_names is not None
+                else _ts_mod.scoped_deferrable_names(current_defs)
+            )
             if underlying_name not in _scoped_deferrable:
                 return json.dumps({
                     "error": (
@@ -1141,6 +1159,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                tool_search_catalog=tool_search_catalog,
             )
 
     _tool_original_args = dict(function_args)

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,7 +29,7 @@ from contextvars import ContextVar
 import logging
 import threading
 import time
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, Iterable, List, Optional, Tuple
 
 from tools.registry import (
     CHECK_FN_CACHE_BYPASS,
@@ -1205,6 +1205,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    tool_search_catalog: Optional[Iterable[Any]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1291,6 +1292,7 @@ def handle_function_call(
                 _ts_mod.dispatch_tool_search(
                     function_args or {},
                     current_tool_defs=current_defs,
+                    catalog=tool_search_catalog,
                 )
             )
         if function_name == _ts_mod.TOOL_DESCRIBE_NAME:
@@ -1298,10 +1300,18 @@ def handle_function_call(
                 _ts_mod.dispatch_tool_describe(
                     function_args or {},
                     current_tool_defs=current_defs,
+                    catalog=tool_search_catalog,
                 )
             )
         if function_name == _ts_mod.TOOL_CALL_NAME:
-            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(function_args or {})
+            catalog_names = (
+                frozenset(entry.name for entry in tool_search_catalog)
+                if tool_search_catalog is not None
+                else None
+            )
+            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(
+                function_args or {}
+            )
             if err or not underlying_name:
                 return _return_bridge_result(
                     tool_error(err or "tool_call could not be resolved")
@@ -1312,7 +1322,11 @@ def handle_function_call(
             # additionally rejects any tool the session was not granted, so a
             # restricted session can never invoke an out-of-scope tool through
             # the bridge even if the catalog scoping above regressed.
-            _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
+            _scoped_deferrable = (
+                catalog_names
+                if catalog_names is not None
+                else _ts_mod.scoped_deferrable_names(current_defs)
+            )
             if underlying_name not in _scoped_deferrable:
                 return _return_bridge_result(
                     tool_error(
@@ -1344,6 +1358,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                tool_search_catalog=tool_search_catalog,
             )
 
     _tool_original_args = dict(function_args)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1788,7 +1788,14 @@ class TestRegisterSessionMcpServers:
 
     @pytest.mark.asyncio
     async def test_refreshes_agent_tool_surface(self, agent, mock_manager):
-        """After MCP registration, agent.tools and valid_tool_names are refreshed."""
+        """After MCP registration, the shared full-surface rebuild runs.
+
+        #47119 review: this path must route through refresh_agent_mcp_tools
+        (the same rebuild the TUI/gateway/late-binding refresh use), not a
+        hand-rolled get_tool_definitions() assignment — so memory-provider
+        reinjection and the finalized Tool Search surface can't diverge from
+        the session surface.
+        """
         from acp.schema import McpServerStdio
 
         state = mock_manager.create_session(cwd="/tmp")
@@ -1820,13 +1827,17 @@ class TestRegisterSessionMcpServers:
              patch("model_tools.get_tool_definitions", return_value=fake_tools) as mock_defs:
             await agent._register_session_mcp_servers(state, [server])
 
+        # The shared rebuild re-derives with the expanded toolsets and defers
+        # Tool Search assembly to its own atomic finalize step.
         mock_defs.assert_called_once_with(
             enabled_toolsets=["hermes-acp", "mcp-srv"],
             disabled_toolsets=None,
             quiet_mode=True,
+            skip_tool_search_assembly=True,
         )
         assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-srv"]
-        assert state.agent.tools is fake_tools
+        # The rebuild publishes a fresh finalized snapshot (not the raw
+        # registry list), with the memory-provider schema reinjected.
         assert state.agent.tools[-1] == {
             "type": "function",
             "function": {
@@ -1841,6 +1852,8 @@ class TestRegisterSessionMcpServers:
             "mcp_srv_search",
             "terminal",
         }
+        # The visible surface and the name guard stay in lockstep.
+        assert {t["function"]["name"] for t in state.agent.tools} == state.agent.valid_tool_names
         # _invalidate_system_prompt should have been called
         state.agent._invalidate_system_prompt.assert_called_once()
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -654,7 +654,14 @@ class TestRegisterSessionMcpServers:
 
     @pytest.mark.asyncio
     async def test_refreshes_agent_tool_surface(self, agent, mock_manager):
-        """After MCP registration, agent.tools and valid_tool_names are refreshed."""
+        """After MCP registration, the shared full-surface rebuild runs.
+
+        #47119 review: this path must route through refresh_agent_mcp_tools
+        (the same rebuild the TUI/gateway/late-binding refresh use), not a
+        hand-rolled get_tool_definitions() assignment — so memory-provider
+        reinjection and the finalized Tool Search surface can't diverge from
+        the session surface.
+        """
         from acp.schema import McpServerStdio
 
         state = mock_manager.create_session(cwd="/tmp")
@@ -686,13 +693,17 @@ class TestRegisterSessionMcpServers:
              patch("model_tools.get_tool_definitions", return_value=fake_tools) as mock_defs:
             await agent._register_session_mcp_servers(state, [server])
 
+        # The shared rebuild re-derives with the expanded toolsets and defers
+        # Tool Search assembly to its own atomic finalize step.
         mock_defs.assert_called_once_with(
             enabled_toolsets=["hermes-acp", "mcp-srv"],
             disabled_toolsets=None,
             quiet_mode=True,
+            skip_tool_search_assembly=True,
         )
         assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-srv"]
-        assert state.agent.tools is fake_tools
+        # The rebuild publishes a fresh finalized snapshot (not the raw
+        # registry list), with the memory-provider schema reinjected.
         assert state.agent.tools[-1] == {
             "type": "function",
             "function": {
@@ -707,6 +718,8 @@ class TestRegisterSessionMcpServers:
             "mcp_srv_search",
             "terminal",
         }
+        # The visible surface and the name guard stay in lockstep.
+        assert {t["function"]["name"] for t in state.agent.tools} == state.agent.valid_tool_names
         # _invalidate_system_prompt should have been called
         state.agent._invalidate_system_prompt.assert_called_once()
 

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -25,6 +25,17 @@ class RecordingMemoryProvider:
         pass
 
 
+class ToolProvidingMemoryProvider(RecordingMemoryProvider):
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "provider_stats",
+                "description": "Show memory provider statistics",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+
 def test_blank_memory_provider_does_not_auto_enable_honcho():
     """Blank memory.provider should remain opt-out even if Honcho fallback looks configured."""
     cfg = {"memory": {"provider": ""}, "agent": {}}
@@ -92,6 +103,42 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert provider.init_kwargs["platform"] == "feishu"
     assert "warning_callback" not in provider.init_kwargs
     assert "status_callback" not in provider.init_kwargs
+
+
+def test_fresh_agent_finalizes_provider_tools_into_first_surface():
+    """#47119: provider schemas must join the first model-facing surface."""
+    provider = ToolProvidingMemoryProvider()
+    cfg = {
+        "memory": {"provider": "recording"},
+        "agent": {},
+        "tools": {"tool_search": {"enabled": "on"}},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            enabled_toolsets=["memory"],
+        )
+
+    visible_names = {tool["function"]["name"] for tool in agent.tools}
+    assert visible_names == agent.valid_tool_names
+    # Provider-owned names are not registry tools, so they stay directly visible.
+    # PR #34523 separately owns routing provider names through tool_call.
+    assert "provider_stats" in visible_names
+    assert getattr(agent, "_tool_search_catalog", None) is None
+    assert getattr(agent, "_tool_search_allowed_names", None) is None
 
 
 class CoreShadowProvider:

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -141,6 +141,78 @@ def test_fresh_agent_finalizes_provider_tools_into_first_surface():
     assert getattr(agent, "_tool_search_allowed_names", None) is None
 
 
+def test_fresh_agent_active_tool_search_builds_catalog_with_provider_tools():
+    """#47119 review: exercise an ACTIVE deferred catalog on a fresh agent.
+
+    A real MCP-toolset schema is registered in the live registry (so
+    ``is_deferrable_tool_name`` classifies it deferrable) and returned from the
+    build-time ``get_tool_definitions``, alongside a memory-provider schema
+    injected post-build. With Tool Search forced on, the finalized first
+    surface must defer the MCP schema into the session catalog while keeping
+    the provider schema directly visible — proving the assembly ran AFTER
+    provider injection, not on the early registry-only snapshot.
+    """
+    provider = ToolProvidingMemoryProvider()
+    cfg = {
+        "memory": {"provider": "recording"},
+        "agent": {},
+        "tools": {"tool_search": {"enabled": "on"}},
+    }
+    deferrable_def = {
+        "type": "function",
+        "function": {
+            "name": "mcp_initsrv_lookup",
+            "description": "Look up a record from the init-test MCP server",
+            "parameters": {"type": "object", "properties": {"id": {"type": "string"}}},
+        },
+    }
+
+    from tools.registry import registry
+
+    registry.register(
+        name="mcp_initsrv_lookup",
+        toolset="mcp-initsrv",
+        schema=deferrable_def["function"],
+        handler=lambda args, task_id=None, **kw: "{}",
+    )
+    try:
+        with (
+            patch("hermes_cli.config.load_config", return_value=cfg),
+            patch("plugins.memory.load_memory_provider", return_value=provider),
+            patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+            patch("run_agent.get_tool_definitions", return_value=[deferrable_def]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                enabled_toolsets=["memory"],
+            )
+    finally:
+        registry.deregister("mcp_initsrv_lookup")
+
+    visible_names = {tool["function"]["name"] for tool in getattr(agent, "tools", [])}
+    assert visible_names == getattr(agent, "valid_tool_names", None)
+    # The registered MCP schema is deferred out of the model-facing array…
+    assert "mcp_initsrv_lookup" not in visible_names
+    # …into the finalized session catalog, reachable through the bridge tools.
+    assert {"tool_search", "tool_describe", "tool_call"} <= visible_names
+    catalog = getattr(agent, "_tool_search_catalog", None)
+    assert catalog is not None
+    assert [entry.name for entry in catalog] == ["mcp_initsrv_lookup"]
+    assert getattr(agent, "_tool_search_allowed_names", None) == frozenset(
+        {"mcp_initsrv_lookup"}
+    )
+    # The provider schema, injected after the registry snapshot, stays directly
+    # visible in the SAME finalized surface (it is not registry-deferrable).
+    assert "provider_stats" in visible_names
+
+
 class CoreShadowProvider:
     """Provider that tries to register tools shadowing built-in core tools."""
 

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -43,6 +43,17 @@ def test_shutdown_memory_provider_is_idempotent():
     manager.shutdown_all.assert_called_once()
 
 
+class ToolProvidingMemoryProvider(RecordingMemoryProvider):
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "provider_stats",
+                "description": "Show memory provider statistics",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+
 def test_blank_memory_provider_does_not_auto_enable_honcho():
     """Blank memory.provider should remain opt-out even if Honcho fallback looks configured."""
     cfg = {"memory": {"provider": ""}, "agent": {}}
@@ -126,6 +137,42 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert provider.init_kwargs["platform"] == "feishu"
     assert "warning_callback" not in provider.init_kwargs
     assert "status_callback" not in provider.init_kwargs
+
+
+def test_fresh_agent_finalizes_provider_tools_into_first_surface():
+    """#47119: provider schemas must join the first model-facing surface."""
+    provider = ToolProvidingMemoryProvider()
+    cfg = {
+        "memory": {"provider": "recording"},
+        "agent": {},
+        "tools": {"tool_search": {"enabled": "on"}},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            enabled_toolsets=["memory"],
+        )
+
+    visible_names = {tool["function"]["name"] for tool in agent.tools}
+    assert visible_names == agent.valid_tool_names
+    # Provider-owned names are not registry tools, so they stay directly visible.
+    # PR #34523 separately owns routing provider names through tool_call.
+    assert "provider_stats" in visible_names
+    assert getattr(agent, "_tool_search_catalog", None) is None
+    assert getattr(agent, "_tool_search_allowed_names", None) is None
 
 
 class CoreShadowProvider:

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -150,6 +150,7 @@ def test_fresh_agent_finalizes_provider_tools_into_first_surface():
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_cli.config.load_config_readonly", return_value=cfg),
         patch("plugins.memory.load_memory_provider", return_value=provider),
         patch("agent.model_metadata.get_model_context_length", return_value=204_800),
         patch("run_agent.get_tool_definitions", return_value=[]),
@@ -173,6 +174,79 @@ def test_fresh_agent_finalizes_provider_tools_into_first_surface():
     assert "provider_stats" in visible_names
     assert getattr(agent, "_tool_search_catalog", None) is None
     assert getattr(agent, "_tool_search_allowed_names", None) is None
+
+
+def test_fresh_agent_active_tool_search_builds_catalog_with_provider_tools():
+    """#47119 review: exercise an ACTIVE deferred catalog on a fresh agent.
+
+    A real MCP-toolset schema is registered in the live registry (so
+    ``is_deferrable_tool_name`` classifies it deferrable) and returned from the
+    build-time ``get_tool_definitions``, alongside a memory-provider schema
+    injected post-build. With Tool Search forced on, the finalized first
+    surface must defer the MCP schema into the session catalog while keeping
+    the provider schema directly visible — proving the assembly ran AFTER
+    provider injection, not on the early registry-only snapshot.
+    """
+    provider = ToolProvidingMemoryProvider()
+    cfg = {
+        "memory": {"provider": "recording"},
+        "agent": {},
+        "tools": {"tool_search": {"enabled": "on"}},
+    }
+    deferrable_def = {
+        "type": "function",
+        "function": {
+            "name": "mcp_initsrv_lookup",
+            "description": "Look up a record from the init-test MCP server",
+            "parameters": {"type": "object", "properties": {"id": {"type": "string"}}},
+        },
+    }
+
+    from tools.registry import registry
+
+    registry.register(
+        name="mcp_initsrv_lookup",
+        toolset="mcp-initsrv",
+        schema=deferrable_def["function"],
+        handler=lambda args, task_id=None, **kw: "{}",
+    )
+    try:
+        with (
+            patch("hermes_cli.config.load_config", return_value=cfg),
+            patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+            patch("plugins.memory.load_memory_provider", return_value=provider),
+            patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+            patch("run_agent.get_tool_definitions", return_value=[deferrable_def]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                enabled_toolsets=["memory"],
+            )
+    finally:
+        registry.deregister("mcp_initsrv_lookup")
+
+    visible_names = {tool["function"]["name"] for tool in getattr(agent, "tools", [])}
+    assert visible_names == getattr(agent, "valid_tool_names", None)
+    # The registered MCP schema is deferred out of the model-facing array…
+    assert "mcp_initsrv_lookup" not in visible_names
+    # …into the finalized session catalog, reachable through the bridge tools.
+    assert {"tool_search", "tool_describe", "tool_call"} <= visible_names
+    catalog = getattr(agent, "_tool_search_catalog", None)
+    assert catalog is not None
+    assert [entry.name for entry in catalog] == ["mcp_initsrv_lookup"]
+    assert getattr(agent, "_tool_search_allowed_names", None) == frozenset(
+        {"mcp_initsrv_lookup"}
+    )
+    # The provider schema, injected after the registry snapshot, stays directly
+    # visible in the SAME finalized surface (it is not registry-deferrable).
+    assert "provider_stats" in visible_names
 
 
 class CoreShadowProvider:

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -140,6 +140,50 @@ def test_refresh_preserves_memory_provider_and_context_engine_tools(monkeypatch)
     assert added == {"mcp_new_server_tool"}
 
 
+def test_refresh_rebuilds_provider_tool_search_catalog(monkeypatch):
+    """A registry refresh must publish the full effective surface and catalog."""
+    from tools import tool_search
+    from tools.tool_search import ToolSearchConfig
+
+    agent = _agent(["tool_search", "tool_describe", "tool_call"])
+    agent._memory_manager = types.SimpleNamespace(
+        get_all_tool_schemas=lambda: [
+            {
+                "name": "provider_stats",
+                "description": "Show memory provider statistics",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+    )
+    agent._tool_search_config = ToolSearchConfig.from_raw({"enabled": "on"})
+    agent._tool_search_context_length = 204_800
+    agent._tool_search_catalog = ()
+
+    import model_tools
+    seen = {}
+
+    def _defs(**kwargs):
+        seen.update(kwargs)
+        return [_tool("read_file"), _tool("mcp_new_server_tool")]
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _defs)
+    original_is_deferrable = tool_search.is_deferrable_tool_name
+    monkeypatch.setattr(
+        tool_search,
+        "is_deferrable_tool_name",
+        lambda name: name == "mcp_new_server_tool" or original_is_deferrable(name),
+    )
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert seen["skip_tool_search_assembly"] is True
+    assert added == {"read_file", "provider_stats"}
+    assert "provider_stats" in agent.valid_tool_names
+    assert "mcp_new_server_tool" not in added
+    assert [entry.name for entry in agent._tool_search_catalog] == [
+        "mcp_new_server_tool",
+    ]
+
+
 def test_refresh_respects_context_engine_toolset_gate(monkeypatch):
     """#5544: context-engine tools must NOT be re-injected on a restricted
     toolset. A platform with enabled_toolsets that excludes context_engine

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -112,6 +112,50 @@ def test_refresh_does_not_reinject_disabled_memory_provider_tools(monkeypatch):
     assert all(t["function"]["name"] != "memory_search" for t in agent.tools)
 
 
+def test_refresh_rebuilds_provider_tool_search_catalog(monkeypatch):
+    """A registry refresh must publish the full effective surface and catalog."""
+    from tools import tool_search
+    from tools.tool_search import ToolSearchConfig
+
+    agent = _agent(["tool_search", "tool_describe", "tool_call"])
+    agent._memory_manager = types.SimpleNamespace(
+        get_all_tool_schemas=lambda: [
+            {
+                "name": "provider_stats",
+                "description": "Show memory provider statistics",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+    )
+    agent._tool_search_config = ToolSearchConfig.from_raw({"enabled": "on"})
+    agent._tool_search_context_length = 204_800
+    agent._tool_search_catalog = ()
+
+    import model_tools
+    seen = {}
+
+    def _defs(**kwargs):
+        seen.update(kwargs)
+        return [_tool("read_file"), _tool("mcp_new_server_tool")]
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _defs)
+    original_is_deferrable = tool_search.is_deferrable_tool_name
+    monkeypatch.setattr(
+        tool_search,
+        "is_deferrable_tool_name",
+        lambda name: name == "mcp_new_server_tool" or original_is_deferrable(name),
+    )
+    added = mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert seen["skip_tool_search_assembly"] is True
+    assert added == {"read_file", "provider_stats"}
+    assert "provider_stats" in agent.valid_tool_names
+    assert "mcp_new_server_tool" not in added
+    assert [entry.name for entry in agent._tool_search_catalog] == [
+        "mcp_new_server_tool",
+    ]
+
+
 def test_refresh_respects_context_engine_toolset_gate(monkeypatch):
     """#5544: context-engine tools must NOT be re-injected on a restricted
     toolset. A platform with enabled_toolsets that excludes context_engine

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5302,6 +5302,7 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            skip_tool_search_assembly=True,
         )
         or []
     )
@@ -5317,6 +5318,19 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Tool Search must be assembled from that same complete staged snapshot.
+    # Preparing outside the lock keeps registry/config work off the reader path;
+    # every dependent attribute is published together below.
+    from agent.tool_search_surface import prepare_agent_tool_surface
+    from tools.tool_search import BRIDGE_TOOL_NAMES
+
+    staged_surface = prepare_agent_tool_surface(
+        agent,
+        source_tool_defs=new_defs,
+        config=getattr(agent, "_tool_search_config", None),
+        context_length=getattr(agent, "_tool_search_context_length", None),
+    )
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.
@@ -5330,24 +5344,52 @@ def refresh_agent_mcp_tools(
         if snapshot_generation < published_gen:
             # A newer snapshot already won; our set is stale — drop it.
             return set()
-        current = {
+        current_visible = {
             t["function"]["name"]
             for t in (getattr(agent, "tools", None) or [])
         }
-        if new_names == current:
+        current_available = set(current_visible)
+        current_available.update(
+            entry.name for entry in (getattr(agent, "_tool_search_catalog", None) or ())
+        )
+        memory_manager = getattr(agent, "_memory_manager", None)
+        if memory_manager is not None:
+            try:
+                current_available.update(memory_manager.get_all_tool_names())
+            except Exception:
+                try:
+                    current_available.update(
+                        schema.get("name", "")
+                        for schema in memory_manager.get_all_tool_schemas()
+                        if isinstance(schema, dict)
+                    )
+                except Exception:
+                    pass
+        current_available.update(getattr(agent, "_context_engine_tool_names", None) or ())
+        current_available.difference_update(BRIDGE_TOOL_NAMES)
+
+        same_published_surface = (
+            list(getattr(agent, "tools", None) or []) == staged_surface.assembly.tool_defs
+            and tuple(getattr(agent, "_tool_search_catalog", ()) or ()) == staged_surface.assembly.catalog
+        )
+        if same_published_surface and (
+            tuple(getattr(agent, "_tool_search_source_defs", ())) == staged_surface.source_defs
+            or new_names == current_available
+        ):
             # No change → leave the live snapshot untouched (no churn), but
             # record the generation so an in-flight older caller can't clobber.
             agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
             return set()
-        agent.tools = new_defs
-        agent.valid_tool_names = new_names
+        from agent.tool_search_surface import publish_agent_tool_surface
+
+        publish_agent_tool_surface(agent, staged_surface)
         # Publish context-engine routing names atomically with the snapshot.
         engine_names = getattr(agent, "_context_engine_tool_names", None)
         if isinstance(engine_names, set):
             engine_names.clear()
             engine_names.update(staged_engine_names)
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
-        return new_names - current
+        return set(staged_surface.visible_names) - current_visible
 
 
 def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7743,6 +7743,7 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            skip_tool_search_assembly=True,
         )
         or []
     )
@@ -7758,6 +7759,19 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Tool Search must be assembled from that same complete staged snapshot.
+    # Preparing outside the lock keeps registry/config work off the reader path;
+    # every dependent attribute is published together below.
+    from agent.tool_search_surface import prepare_agent_tool_surface
+    from tools.tool_search import BRIDGE_TOOL_NAMES
+
+    staged_surface = prepare_agent_tool_surface(
+        agent,
+        source_tool_defs=new_defs,
+        config=getattr(agent, "_tool_search_config", None),
+        context_length=getattr(agent, "_tool_search_context_length", None),
+    )
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.
@@ -7771,24 +7785,52 @@ def refresh_agent_mcp_tools(
         if snapshot_generation < published_gen:
             # A newer snapshot already won; our set is stale — drop it.
             return set()
-        current = {
+        current_visible = {
             t["function"]["name"]
             for t in (getattr(agent, "tools", None) or [])
         }
-        if new_names == current:
+        current_available = set(current_visible)
+        current_available.update(
+            entry.name for entry in (getattr(agent, "_tool_search_catalog", None) or ())
+        )
+        memory_manager = getattr(agent, "_memory_manager", None)
+        if memory_manager is not None:
+            try:
+                current_available.update(memory_manager.get_all_tool_names())
+            except Exception:
+                try:
+                    current_available.update(
+                        schema.get("name", "")
+                        for schema in memory_manager.get_all_tool_schemas()
+                        if isinstance(schema, dict)
+                    )
+                except Exception:
+                    pass
+        current_available.update(getattr(agent, "_context_engine_tool_names", None) or ())
+        current_available.difference_update(BRIDGE_TOOL_NAMES)
+
+        same_published_surface = (
+            list(getattr(agent, "tools", None) or []) == staged_surface.assembly.tool_defs
+            and tuple(getattr(agent, "_tool_search_catalog", ()) or ()) == staged_surface.assembly.catalog
+        )
+        if same_published_surface and (
+            tuple(getattr(agent, "_tool_search_source_defs", ())) == staged_surface.source_defs
+            or new_names == current_available
+        ):
             # No change → leave the live snapshot untouched (no churn), but
             # record the generation so an in-flight older caller can't clobber.
             agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
             return set()
-        agent.tools = new_defs
-        agent.valid_tool_names = new_names
+        from agent.tool_search_surface import publish_agent_tool_surface
+
+        publish_agent_tool_surface(agent, staged_surface)
         # Publish context-engine routing names atomically with the snapshot.
         engine_names = getattr(agent, "_context_engine_tool_names", None)
         if isinstance(engine_names, set):
             engine_names.clear()
             engine_names.update(staged_engine_names)
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
-        return new_names - current
+        return set(staged_surface.visible_names) - current_visible
 
 
 def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -524,6 +524,7 @@ class AssemblyResult:
     deferred_count: int = 0
     deferred_tokens: int = 0
     threshold_tokens: int = 0
+    catalog: Tuple[CatalogEntry, ...] = ()
 
 
 def assemble_tool_defs(
@@ -565,6 +566,7 @@ def assemble_tool_defs(
             threshold_tokens=int((context_length or 0) * (config.threshold_pct / 100.0)),
         )
 
+    catalog = tuple(build_catalog(deferrable))
     bridge = bridge_tool_schemas(len(deferrable))
     result = visible + bridge
     threshold_tokens = int((context_length or 0) * (config.threshold_pct / 100.0))
@@ -580,6 +582,7 @@ def assemble_tool_defs(
         deferred_count=len(deferrable),
         deferred_tokens=deferrable_tokens,
         threshold_tokens=threshold_tokens,
+        catalog=catalog,
     )
 
 
@@ -605,7 +608,8 @@ def _format_search_hit(entry: CatalogEntry) -> Dict[str, Any]:
 def dispatch_tool_search(args: Dict[str, Any],
                          *,
                          current_tool_defs: List[Dict[str, Any]],
-                         config: Optional[ToolSearchConfig] = None) -> str:
+                         config: Optional[ToolSearchConfig] = None,
+                         catalog: Optional[Iterable[CatalogEntry]] = None) -> str:
     """Execute the ``tool_search`` bridge tool. Returns a JSON string."""
     if config is None:
         config = load_config()
@@ -619,23 +623,39 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
-    catalog = build_catalog(deferrable)
-    hits = search_catalog(catalog, query, limit=limit)
+    if catalog is None:
+        _, deferrable = classify_tools(current_tool_defs)
+        resolved_catalog = build_catalog(deferrable)
+    else:
+        resolved_catalog = list(catalog)
+    hits = search_catalog(resolved_catalog, query, limit=limit)
     return json.dumps({
         "query": query,
-        "total_available": len(catalog),
+        "total_available": len(resolved_catalog),
         "matches": [_format_search_hit(h) for h in hits],
     }, ensure_ascii=False)
 
 
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
-                           current_tool_defs: List[Dict[str, Any]]) -> str:
+                           current_tool_defs: List[Dict[str, Any]],
+                           catalog: Optional[Iterable[CatalogEntry]] = None) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
     name = str(args.get("name") or "").strip()
     if not name:
         return json.dumps({"error": "name is required"}, ensure_ascii=False)
+    if catalog is not None:
+        for entry in catalog:
+            if entry.name == name:
+                fn = entry.schema.get("function") or {}
+                return json.dumps({
+                    "name": name,
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }, ensure_ascii=False)
+        return json.dumps({
+            "error": f"'{name}' is not currently available. Re-run tool_search to refresh.",
+        }, ensure_ascii=False)
     if not is_deferrable_tool_name(name):
         return json.dumps({
             "error": (

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -780,6 +780,7 @@ class AssemblyResult:
     #   2 = bare bridge — catalog too large for any listing form
     tier: int = 0
     listing_form: str = "none"  # "full" | "names" | "none"
+    catalog: Tuple[CatalogEntry, ...] = ()
 
 
 def assemble_tool_defs(
@@ -822,6 +823,7 @@ def assemble_tool_defs(
             tier=0,
         )
 
+    catalog = tuple(build_catalog(deferrable))
     listing = None
     listing_form = "none"
     listing_budget = listing_token_budget(config, context_length)
@@ -852,6 +854,7 @@ def assemble_tool_defs(
         threshold_tokens=listing_budget,
         tier=tier,
         listing_form=listing_form,
+        catalog=catalog,
     )
 
 
@@ -897,7 +900,8 @@ def _available_source_summary(catalog: List[CatalogEntry]) -> List[Dict[str, Any
 def dispatch_tool_search(args: Dict[str, Any],
                          *,
                          current_tool_defs: List[Dict[str, Any]],
-                         config: Optional[ToolSearchConfig] = None) -> str:
+                         config: Optional[ToolSearchConfig] = None,
+                         catalog: Optional[Iterable[CatalogEntry]] = None) -> str:
     """Execute the ``tool_search`` bridge tool. Returns a JSON string."""
     if config is None:
         config = load_config()
@@ -911,16 +915,19 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
-    catalog = build_catalog(deferrable)
-    hits = search_catalog(catalog, query, limit=limit)
+    if catalog is None:
+        _, deferrable = classify_tools(current_tool_defs)
+        resolved_catalog = build_catalog(deferrable)
+    else:
+        resolved_catalog = list(catalog)
+    hits = search_catalog(resolved_catalog, query, limit=limit)
     result: Dict[str, Any] = {
         "query": query,
-        "total_available": len(catalog),
+        "total_available": len(resolved_catalog),
         "matches": [_format_search_hit(h) for h in hits],
     }
-    if not hits and catalog:
-        result["available_sources"] = _available_source_summary(catalog)
+    if not hits and resolved_catalog:
+        result["available_sources"] = _available_source_summary(resolved_catalog)
         result["hint"] = (
             "No lexical match was found, but the sources above are connected "
             "and their tools remain available. Retry tool_search with the "
@@ -932,11 +939,24 @@ def dispatch_tool_search(args: Dict[str, Any],
 
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
-                           current_tool_defs: List[Dict[str, Any]]) -> str:
+                           current_tool_defs: List[Dict[str, Any]],
+                           catalog: Optional[Iterable[CatalogEntry]] = None) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
     name = str(args.get("name") or "").strip()
     if not name:
         return tool_error("name is required")
+    if catalog is not None:
+        for entry in catalog:
+            if entry.name == name:
+                fn = entry.schema.get("function") or {}
+                return json.dumps({
+                    "name": name,
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }, ensure_ascii=False)
+        return tool_error(
+            f"'{name}' is not currently available. Re-run tool_search to refresh."
+        )
     if not is_deferrable_tool_name(name):
         return tool_error(
             f"'{name}' is not a deferrable tool. If you see it in the tools list "


### PR DESCRIPTION
## Problem

Memory-provider and context-engine tools are injected after the base registry tool definitions are built. Tool Search can therefore snapshot the session surface before those provider-owned schemas exist, leaving startup and rebuild paths with different effective tool sets. This matches the fresh-vs-resumed behavior reported in #47119.

## Fix

- build the base registry definitions without early Tool Search assembly
- finalize one session-local tool surface only after memory-provider and context-engine injection
- publish visible definitions, validation names, source definitions, and the active deferred catalog from the same snapshot
- rebuild and publish the same complete surface atomically during MCP refresh
- preserve inactive/off-mode fallback semantics by publishing `None` rather than an authoritative empty catalog
- keep `refresh_agent_mcp_tools()` returning newly visible names rather than deferred catalog entries

Provider-owned names intentionally remain directly visible on current `main`. Routing provider-owned names through `tool_call` remains the separate concern handled by #34523; this PR does not depend on or duplicate that change.

## Tests

```text
scripts/run_tests.sh \
  tests/run_agent/test_memory_provider_init.py \
  tests/agent/test_memory_provider.py \
  tests/tools/test_tool_search.py \
  tests/tools/test_refresh_agent_mcp_tools.py \
  tests/test_tui_gateway_server.py \
  tests/test_tui_mcp_late_refresh.py -q

486 passed
```

```text
scripts/run_tests.sh \
  tests/test_model_tools.py \
  tests/test_model_tools_async_bridge.py \
  tests/run_agent/test_tool_executor_contextvar_propagation.py \
  tests/tools/test_mcp_tool.py \
  tests/tools/test_mcp_tool_session_expired.py \
  tests/tools/test_mcp_tool_issue_948.py \
  tests/tools/test_mcp_tool_401_handling.py -q

294 passed
```

Fixes #47119.

Related: #34523 — independent bridge-routing work.
