### PR TITLE
feat(gateway): periodic memory trim in idle reaper for long-lived processes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -623,6 +623,7 @@ def init_agent(
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     agent.service_tier = service_tier
+    agent.text_verbosity = None
     agent.request_overrides = dict(request_overrides or {})
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
@@ -1463,6 +1464,19 @@ def init_agent(
     if not isinstance(_agent_section, dict):
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
+    _config_text_verbosity = _agent_section.get("text_verbosity")
+    if _config_text_verbosity is not None:
+        from agent.text_verbosity import parse_text_verbosity
+
+        agent.text_verbosity = parse_text_verbosity(_config_text_verbosity)
+        if str(_config_text_verbosity or "").strip() and agent.text_verbosity is None:
+            _ra().logger.warning(
+                "Invalid agent.text_verbosity in config.yaml: %r; "
+                "must be one of: low, medium, high. "
+                "Falling back to provider default.",
+                _config_text_verbosity,
+            )
+    agent._session_init_model_config["text_verbosity"] = agent.text_verbosity
 
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -831,6 +831,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
+        from agent.text_verbosity import supports_openai_text_verbosity
+
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
         # in tool schemas (HTTP 400 "Invalid arguments passed to the model").
         # Most commonly hit when MCP-derived tools carry JSON Schema validation
@@ -872,6 +874,13 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,
+            text_verbosity=getattr(agent, "text_verbosity", None),
+            base_url=getattr(agent, "base_url", None),
+            supports_text_verbosity=supports_openai_text_verbosity(
+                agent.model,
+                base_url_hostname=agent._base_url_hostname,
+                is_codex_backend=is_codex_backend,
+            ),
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -913,7 +913,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
-        "extra_headers", "extra_body", "timeout",
+        "text", "extra_headers", "extra_body", "timeout",
     }
     normalized: Dict[str, Any] = {
         "model": model,
@@ -934,6 +934,30 @@ def _preflight_codex_api_kwargs(
     service_tier = api_kwargs.get("service_tier")
     if isinstance(service_tier, str) and service_tier.strip():
         normalized["service_tier"] = service_tier.strip()
+    text = api_kwargs.get("text")
+    if text is not None:
+        if not isinstance(text, dict):
+            raise ValueError("Codex Responses request 'text' must be an object.")
+        normalized_text: Dict[str, Any] = {}
+        for key, value in text.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("Codex Responses request 'text' keys must be non-empty strings.")
+            normalized_key = key.strip()
+            if normalized_key == "verbosity":
+                if value is None:
+                    continue
+                from agent.text_verbosity import parse_text_verbosity
+
+                verbosity = parse_text_verbosity(value)
+                if verbosity is None:
+                    raise ValueError(
+                        "Codex Responses request 'text.verbosity' must be low, medium, or high."
+                    )
+                normalized_text["verbosity"] = verbosity
+            else:
+                normalized_text[normalized_key] = value
+        if normalized_text:
+            normalized["text"] = normalized_text
 
     # Pass through max_output_tokens and temperature
     max_output_tokens = api_kwargs.get("max_output_tokens")

--- a/agent/text_verbosity.py
+++ b/agent/text_verbosity.py
@@ -1,0 +1,36 @@
+"""OpenAI Responses API text verbosity helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+VALID_TEXT_VERBOSITIES = {"low", "medium", "high"}
+
+
+def parse_text_verbosity(raw: Any) -> str | None:
+    """Return a normalized Responses API text verbosity value, or None."""
+    value = str(raw or "").strip().lower()
+    if not value:
+        return None
+    if value in VALID_TEXT_VERBOSITIES:
+        return value
+    return None
+
+
+def supports_openai_text_verbosity(
+    model: Any,
+    *,
+    base_url_hostname: str = "",
+    is_codex_backend: bool = False,
+) -> bool:
+    """Return whether the resolved target supports GPT-5 text verbosity."""
+    model_id = str(model or "").strip().lower().rsplit("/", 1)[-1]
+    is_gpt5 = (
+        model_id == "gpt-5"
+        or model_id.startswith("gpt-5.")
+        or model_id.startswith("gpt-5-")
+    )
+    if not is_gpt5:
+        return False
+    return is_codex_backend or base_url_hostname.strip().lower() == "api.openai.com"

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -114,9 +114,9 @@ class ResponsesApiTransport(ProviderTransport):
             max_tokens: int | None — max_output_tokens
             timeout: float | None — per-request timeout forwarded to the SDK
             request_overrides: dict | None — extra kwargs merged in
-            provider: str | None — provider name for backend-specific logic
+            text_verbosity: str | None — OpenAI Responses text.verbosity
+            supports_text_verbosity: bool — resolved target capability
             base_url: str | None — endpoint URL
-            base_url_hostname: str | None — hostname for backend detection
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
@@ -303,6 +303,20 @@ class ResponsesApiTransport(ProviderTransport):
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        text_verbosity = params.get("text_verbosity")
+        if text_verbosity and params.get("supports_text_verbosity") is True:
+            from agent.text_verbosity import parse_text_verbosity
+
+            verbosity = parse_text_verbosity(text_verbosity)
+            if verbosity:
+                override_text = kwargs.get("text")
+                if override_text is None:
+                    kwargs["text"] = {"verbosity": verbosity}
+                elif isinstance(override_text, dict):
+                    merged_text = dict(override_text)
+                    merged_text.setdefault("verbosity", verbosity)
+                    kwargs["text"] = merged_text
 
         # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
         # supported: service_tier") — hit when ``/fast`` priority-processing

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -741,6 +741,12 @@ agent:
   # Controls how much "thinking" the model does before responding.
   # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
+
+  # OpenAI Responses API final-answer verbosity.
+  # Empty/unset = provider default. Options: "low", "medium", "high".
+  # Automatically applied only to GPT-5 models on Codex OAuth or the exact
+  # api.openai.com host, not xAI/Grok, GitHub Models, or custom endpoints.
+  text_verbosity: ""
   
   # Predefined personalities (use with /personality command)
   personalities:

--- a/cli.py
+++ b/cli.py
@@ -428,6 +428,7 @@ def load_cli_config() -> Dict[str, Any]:
             "prefill_messages_file": "",
             "reasoning_effort": "",
             "service_tier": "",
+            "text_verbosity": "",
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",
                 "concise": "You are a concise assistant. Keep responses brief and to the point.",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15931,6 +15931,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "codex_app_server_auto"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        ("agent", "text_verbosity"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2184,6 +2184,12 @@ DEFAULT_CONFIG = {
     # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+        # Return freed glibc allocator pages after long-running agent/TUI
+        # cleanup boundaries. Unsupported platforms are safe no-ops.
+        "memory_trim": {
+            "enabled": True,
+            "cooldown_seconds": 60.0,
+        },
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1019,6 +1019,9 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
+        # OpenAI Responses API final-answer verbosity. Empty/unset preserves
+        # the provider default. Valid values: "low", "medium", "high".
+        "text_verbosity": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/hermes_cli/mem_trim.py
+++ b/hermes_cli/mem_trim.py
@@ -1,0 +1,119 @@
+"""Rate-limited heap release for long-lived Hermes gateway processes.
+
+On Linux/glibc, ``malloc_trim(0)`` can return pages from freed Python/C
+allocations to the OS.  Other platforms and allocators are safe no-ops.
+Behavior is configured under ``context.memory_trim`` in ``config.yaml``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import gc
+import logging
+import platform
+import sys
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COOLDOWN_SECONDS = 60.0
+_trim_lock = threading.Lock()
+_last_trim_monotonic = 0.0
+_probe_done = False
+_malloc_trim: Callable[[int], int] | None = None
+
+
+def _config_settings() -> tuple[bool, float]:
+    """Return fail-open settings from the normal Hermes config path."""
+    enabled = True
+    cooldown: Any = _DEFAULT_COOLDOWN_SECONDS
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+        context = config.get("context") if isinstance(config, dict) else None
+        settings = context.get("memory_trim") if isinstance(context, dict) else None
+        if isinstance(settings, dict):
+            configured_enabled = settings.get("enabled")
+            if isinstance(configured_enabled, bool):
+                enabled = configured_enabled
+            cooldown = settings.get("cooldown_seconds", _DEFAULT_COOLDOWN_SECONDS)
+    except Exception:
+        pass
+    return enabled, _cooldown_seconds(cooldown)
+
+
+def _cooldown_seconds(value: Any) -> float:
+    if isinstance(value, bool):
+        return _DEFAULT_COOLDOWN_SECONDS
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return _DEFAULT_COOLDOWN_SECONDS
+
+
+def _probe_glibc_malloc_trim() -> Callable[[int], int] | None:
+    """Resolve glibc's malloc_trim once; return None on unsupported systems."""
+    global _malloc_trim, _probe_done
+    if _probe_done:
+        return _malloc_trim
+    _probe_done = True
+    if sys.platform != "linux":
+        return None
+    try:
+        if platform.libc_ver()[0].lower() != "glibc":
+            return None
+        libc = ctypes.CDLL(None)
+        trim = libc.malloc_trim
+        trim.argtypes = [ctypes.c_size_t]
+        trim.restype = ctypes.c_int
+        _malloc_trim = trim
+    except Exception as exc:
+        logger.debug("malloc_trim unavailable: %s", exc)
+    return _malloc_trim
+
+
+def trim_memory(
+    *,
+    force: bool = False,
+    reason: str = "",
+    cooldown_seconds: float | None = None,
+) -> bool:
+    """Collect cycles and ask glibc to release free heap pages.
+
+    Returns ``True`` only when ``malloc_trim(0)`` ran and reported success.
+    Unsupported allocators, the config kill switch, cooldown suppression, and all
+    runtime errors return ``False`` without affecting the caller.
+    """
+    enabled, configured_cooldown = _config_settings()
+    if not enabled:
+        return False
+
+    global _last_trim_monotonic
+    with _trim_lock:
+        trim = _probe_glibc_malloc_trim()
+        if trim is None:
+            return False
+        now = time.monotonic()
+        cooldown = (
+            configured_cooldown
+            if cooldown_seconds is None
+            else _cooldown_seconds(cooldown_seconds)
+        )
+        if not force and _last_trim_monotonic and now - _last_trim_monotonic < cooldown:
+            return False
+        # Record the attempt before calling into libc so repeated failures do not
+        # turn every turn boundary into an expensive full collection.
+        _last_trim_monotonic = now
+        try:
+            gc.collect()
+            released = bool(trim(0))
+            if reason:
+                logger.debug("malloc_trim(0) after %s: released=%s", reason, released)
+            return released
+        except Exception as exc:
+            logger.debug("malloc_trim failed after %s: %s", reason or "cleanup", exc)
+            return False

--- a/run_agent.py
+++ b/run_agent.py
@@ -3539,6 +3539,15 @@ class AIAgent:
         except Exception:
             pass
 
+        # The references above are now gone; on Linux/glibc, return their free
+        # heap pages immediately instead of retaining the process RSS high-water
+        # mark until exit.  This helper is a safe no-op on other allocators.
+        try:
+            from hermes_cli.mem_trim import trim_memory
+            trim_memory(force=True, reason="agent close")
+        except Exception:
+            pass
+
         # 7. Finalize the owned SQLite session row unless this agent is only a
         # temporary helper that deliberately handed session ownership forward
         # (manual compression helpers that rotate to a continuation session_id,

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -4,6 +4,11 @@ import json
 import pytest
 from types import SimpleNamespace
 
+from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+from agent.text_verbosity import (
+    parse_text_verbosity,
+    supports_openai_text_verbosity,
+)
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
 
@@ -53,6 +58,57 @@ class TestCodexBuildKwargs:
         assert kw["instructions"] == "You are helpful."
         assert "input" in kw
         assert kw["store"] is False
+
+    def test_text_verbosity_adds_top_level_text_for_supported_target(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity=" LOW ",
+            supports_text_verbosity=True,
+        )
+        assert kw.get("text") == {"verbosity": "low"}
+
+    def test_text_verbosity_skips_unsupported_target(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity="low",
+            supports_text_verbosity=False,
+        )
+        assert "text" not in kw
+
+    def test_text_verbosity_merges_with_request_override_text(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        request_overrides = {"text": {"format": {"type": "text"}}}
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity="low",
+            supports_text_verbosity=True,
+            request_overrides=request_overrides,
+        )
+        assert kw.get("text") == {
+            "format": {"type": "text"},
+            "verbosity": "low",
+        }
+        assert request_overrides == {"text": {"format": {"type": "text"}}}
+
+    def test_text_verbosity_request_override_verbosity_wins(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            text_verbosity="low",
+            supports_text_verbosity=True,
+            request_overrides={"text": {"verbosity": "high"}},
+        )
+        assert kw.get("text") == {"verbosity": "high"}
 
     def test_system_extracted_from_messages(self, transport):
         messages = [
@@ -829,6 +885,70 @@ class TestCodexTransportTimeout:
         assert kw.get("timeout") == 450.0
 
 
+class TestCodexTextVerbosityPreflight:
+
+    @pytest.mark.parametrize(
+        ("model", "hostname", "is_codex_backend", "expected"),
+        [
+            ("gpt-5.6-sol", "api.openai.com", False, True),
+            ("openai/gpt-5.5", "", True, True),
+            ("o3", "api.openai.com", False, False),
+            ("grok-4.5", "api.x.ai", False, False),
+            ("gpt-5.5", "models.github.ai", False, False),
+            ("gpt-5.5", "proxy.example", False, False),
+        ],
+    )
+    def test_text_verbosity_capability_boundary(
+        self, model, hostname, is_codex_backend, expected
+    ):
+        assert (
+            supports_openai_text_verbosity(
+                model,
+                base_url_hostname=hostname,
+                is_codex_backend=is_codex_backend,
+            )
+            is expected
+        )
+
+    def test_parse_text_verbosity_accepts_openai_values_only(self):
+        assert parse_text_verbosity("") is None
+        assert parse_text_verbosity(" LOW ") == "low"
+        assert parse_text_verbosity("medium") == "medium"
+        assert parse_text_verbosity("high") == "high"
+        assert parse_text_verbosity("verbose") is None
+
+    def test_preflight_allows_text_verbosity_with_timeout_and_extra_body(self):
+        payload = _preflight_codex_api_kwargs(
+            {
+                "model": "gpt-5.5",
+                "instructions": "system",
+                "input": [{"role": "user", "content": "hi"}],
+                "store": False,
+                "timeout": 600,
+                "extra_body": {"prompt_cache_key": "conv-1"},
+                "text": {"verbosity": "HIGH", "format": {"type": "text"}},
+            }
+        )
+        assert payload["timeout"] == 600.0
+        assert payload["extra_body"] == {"prompt_cache_key": "conv-1"}
+        assert payload["text"] == {
+            "verbosity": "high",
+            "format": {"type": "text"},
+        }
+
+    def test_preflight_rejects_invalid_text_verbosity(self):
+        with pytest.raises(ValueError, match="text.verbosity"):
+            _preflight_codex_api_kwargs(
+                {
+                    "model": "gpt-5.5",
+                    "instructions": "system",
+                    "input": [{"role": "user", "content": "hi"}],
+                    "store": False,
+                    "text": {"verbosity": "verbose"},
+                }
+            )
+
+
 class TestCodexTransportXaiServiceTierStrip:
     """xAI Responses API rejects ``service_tier`` (#28490).
 
@@ -929,7 +1049,6 @@ class TestPreflightSlashEnumStrip:
     def test_grok_model_strips_slash_enum_values(self):
         """When the model name is Grok-family, slash-containing enum
         values are stripped so xAI doesn't 400 on the tool schema."""
-        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
         kwargs = self._make_kwargs(
             "grok-4.3",
             ["Qwen/Qwen3.5-0.8B", "openai/gpt-oss-20b", "plain-id"],
@@ -945,7 +1064,6 @@ class TestPreflightSlashEnumStrip:
 
     def test_aggregator_prefixed_grok_also_strips(self):
         """Aggregator-prefixed (x-ai/grok-*) names hit the same path."""
-        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
         kwargs = self._make_kwargs(
             "x-ai/grok-4.3",
             ["Qwen/Qwen3.5-0.8B"],
@@ -958,7 +1076,6 @@ class TestPreflightSlashEnumStrip:
         enums.  The safety-net must NOT strip there or we silently
         degrade tool-schema constraints on every codex_responses
         provider that isn't xAI."""
-        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
         kwargs = self._make_kwargs(
             "gpt-5.5",
             ["Qwen/Qwen3.5-0.8B", "plain-id"],

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -243,6 +243,14 @@ class TestExtractCacheBustingConfig:
         assert out["compression.protect_last_n"] == 25
         assert out["compression.codex_app_server_auto"] == "hermes"
 
+    def test_reads_agent_text_verbosity(self):
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {"agent": {"text_verbosity": "low", "some_other_key": "ignored"}}
+        )
+        assert out["agent.text_verbosity"] == "low"
+
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""
         from gateway.run import GatewayRunner
@@ -414,6 +422,20 @@ class TestExtractCacheBustingConfig:
             "Editing compression.threshold in config.yaml must bust the "
             "gateway's cached agent so the new threshold takes effect."
         )
+
+    def test_text_verbosity_change_busts_cache(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"agent.text_verbosity": "low"},
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"agent.text_verbosity": "high"},
+        )
+        assert sig_before != sig_after
 
 
 class TestAgentCacheLifecycle:

--- a/tests/hermes_cli/test_mem_trim.py
+++ b/tests/hermes_cli/test_mem_trim.py
@@ -1,0 +1,114 @@
+"""Tests for the long-lived gateway heap-trim helper."""
+
+from unittest.mock import Mock
+
+import pytest
+
+import hermes_cli.mem_trim as mem_trim
+
+
+@pytest.fixture(autouse=True)
+def _reset_trim_state(monkeypatch):
+    monkeypatch.setattr(mem_trim, "_last_trim_monotonic", 0.0)
+    monkeypatch.setattr(mem_trim, "_probe_done", True)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", None)
+
+
+def test_unsupported_allocator_is_noop_without_gc(monkeypatch):
+    collect = Mock()
+    monkeypatch.setattr(mem_trim.gc, "collect", collect)
+
+    assert mem_trim.trim_memory(force=True, reason="test") is False
+    collect.assert_not_called()
+
+
+def test_config_kill_switch_overrides_force(monkeypatch):
+    trim = Mock(return_value=1)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", trim)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"context": {"memory_trim": {"enabled": False}}},
+    )
+
+    assert mem_trim.trim_memory(force=True) is False
+    trim.assert_not_called()
+
+
+def test_default_config_declares_memory_trim_controls():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    context = DEFAULT_CONFIG["context"]
+    assert isinstance(context, dict)
+    assert context["memory_trim"] == {
+        "enabled": True,
+        "cooldown_seconds": 60.0,
+    }
+
+
+def test_success_collects_then_trims(monkeypatch):
+    calls = []
+    monkeypatch.setattr(mem_trim.gc, "collect", lambda: calls.append("gc"))
+    monkeypatch.setattr(
+        mem_trim, "_malloc_trim", lambda pad: calls.append(("trim", pad)) or 1
+    )
+    monkeypatch.setattr(mem_trim.time, "monotonic", lambda: 100.0)
+
+    assert mem_trim.trim_memory(reason="turn", cooldown_seconds=60) is True
+    assert calls == ["gc", ("trim", 0)]
+    assert mem_trim._last_trim_monotonic == 100.0
+
+
+def test_cooldown_suppresses_repeated_collection(monkeypatch):
+    collect = Mock()
+    trim = Mock(return_value=1)
+    monkeypatch.setattr(mem_trim.gc, "collect", collect)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", trim)
+    monkeypatch.setattr(mem_trim, "_last_trim_monotonic", 95.0)
+    monkeypatch.setattr(mem_trim.time, "monotonic", lambda: 100.0)
+
+    assert mem_trim.trim_memory(cooldown_seconds=60) is False
+    collect.assert_not_called()
+    trim.assert_not_called()
+    assert mem_trim.trim_memory(force=True, cooldown_seconds=60) is True
+
+
+def test_config_cooldown_controls_rate_limit(monkeypatch):
+    trim = Mock(return_value=1)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", trim)
+    monkeypatch.setattr(mem_trim, "_last_trim_monotonic", 1.0)
+    monkeypatch.setattr(mem_trim.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "context": {
+                "memory_trim": {"enabled": True, "cooldown_seconds": 120.0}
+            }
+        },
+    )
+
+    assert mem_trim.trim_memory() is False
+    trim.assert_not_called()
+
+
+def test_legacy_environment_switch_does_not_control_behavior(monkeypatch):
+    trim = Mock(return_value=1)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", trim)
+    monkeypatch.setenv("HERMES_DISABLE_MEMORY_TRIM", "1")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"context": {"memory_trim": {"enabled": True}}},
+    )
+
+    assert mem_trim.trim_memory(force=True) is True
+    trim.assert_called_once_with(0)
+
+
+def test_libc_failure_is_fail_open_and_rate_limited(monkeypatch):
+    trim = Mock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(mem_trim, "_malloc_trim", trim)
+    monkeypatch.setattr(mem_trim.time, "monotonic", lambda: 100.0)
+
+    assert mem_trim.trim_memory(reason="test", cooldown_seconds=60) is False
+    assert mem_trim._last_trim_monotonic == 100.0
+    assert mem_trim.trim_memory(cooldown_seconds=60) is False
+    assert trim.call_count == 1

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -981,6 +981,88 @@ class TestInit:
         assert a.max_tokens == 4096
         assert kwargs["max_tokens"] == 4096
 
+    def test_text_verbosity_from_config_populates_responses_request(self):
+        """agent.text_verbosity config populates OpenAI Responses text.verbosity."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"text_verbosity": "low"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="openai-api",
+                model="gpt-5.5",
+                base_url="https://api.openai.com/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert a.text_verbosity == "low"
+        assert kwargs["text"] == {"verbosity": "low"}
+
+    def test_text_verbosity_skips_custom_responses_endpoint(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"text_verbosity": "low"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="custom",
+                model="gpt-5.5",
+                base_url="https://proxy.example/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert a.text_verbosity == "low"
+        assert "text" not in kwargs
+
+    def test_invalid_text_verbosity_config_falls_back(self, caplog):
+        """Invalid agent.text_verbosity warns and preserves provider default."""
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"text_verbosity": "verbose"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="openai-api",
+                model="gpt-5.5",
+                base_url="https://api.openai.com/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "Hi"}])
+
+        assert a.text_verbosity is None
+        assert "text" not in kwargs
+        assert "Invalid agent.text_verbosity" in caplog.text
+
     def test_constructor_max_tokens_wins_over_config(self):
         """Explicit constructor max_tokens keeps programmatic callers stable."""
         with (

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8599,6 +8599,35 @@ def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
         server._sessions.clear()
 
 
+def test_reap_idle_sessions_calls_periodic_trim(monkeypatch):
+    """The idle reaper must call trim_memory every scan, even with no victims."""
+    trim_calls = []
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
+    monkeypatch.setattr(server, "_close_session_by_id", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_enforce_session_cap", lambda: None)
+
+    # Mock trim_memory at the import site inside _reap_idle_sessions.
+    import hermes_cli.mem_trim as mem_trim
+    real_trim = mem_trim.trim_memory
+    monkeypatch.setattr(
+        mem_trim, "trim_memory",
+        lambda **kw: trim_calls.append(kw.get("reason", "")) or True,
+    )
+    # Patch the delayed import path: the function does `from hermes_cli.mem_trim import trim_memory`.
+    import sys
+    orig_module = sys.modules.get("hermes_cli.mem_trim")
+    if orig_module:
+        monkeypatch.setattr(orig_module, "trim_memory", lambda **kw: trim_calls.append(kw.get("reason", "")) or True)
+
+    server._sessions.clear()
+    try:
+        server._reap_idle_sessions()
+        assert len(trim_calls) == 1
+        assert trim_calls[0] == "idle reaper periodic trim"
+    finally:
+        server._sessions.clear()
+
+
 def test_session_create_records_ui_model_as_session_override(monkeypatch):
     """The desktop composer owns its model as plain UI state and ships it on
     session.create. The gateway must record it as a PER-SESSION override (built
@@ -9001,3 +9030,70 @@ def test_get_usage_clamps_post_compression_sentinel():
     usage = server._get_usage(agent)
     assert "context_used" not in usage
     assert "context_percent" not in usage
+
+
+def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
+    """The trim boundary must not retain the just-pruned history snapshots."""
+    observed = {}
+    cleanup_order = []
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": "reply",
+                "messages": [{"role": "assistant", "content": "reply"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            assert self._target is not None
+            self._target()
+
+    def _inspect_trim_frame(**_kwargs):
+        import inspect
+
+        cleanup_order.append("trim")
+        frame = inspect.currentframe()
+        assert frame is not None and frame.f_back is not None
+        caller_locals = frame.f_back.f_locals
+        observed["history"] = caller_locals.get("history")
+        observed["run_kwargs"] = caller_locals.get("run_kwargs")
+
+    session = _session(agent=_Agent())
+    session["profile_home"] = "/tmp/test-profile"
+    session["history"] = [
+        {"role": "tool", "tool_call_id": "old", "content": "x" * 20_000}
+    ]
+    server._sessions["sid_trim"] = session
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "set_hermes_home_override", lambda _home: object())
+        monkeypatch.setattr(
+            server,
+            "reset_hermes_home_override",
+            lambda _token: cleanup_order.append("reset_home"),
+        )
+        monkeypatch.setattr("hermes_cli.mem_trim.trim_memory", _inspect_trim_frame)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid_trim", "text": "hi"},
+            }
+        )
+
+        assert resp is not None and resp.get("result")
+        assert not observed["history"]
+        assert not observed["run_kwargs"]
+        assert cleanup_order == ["trim", "reset_home"]
+    finally:
+        server._sessions.pop("sid_trim", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -879,6 +879,17 @@ def _reap_idle_sessions() -> None:
     for sid in victims:
         _close_session_by_id(sid, end_reason="idle_timeout")
     _enforce_session_cap()
+    # Periodic heap release for long-lived gateway processes.  Even when no
+    # session is reaped, Python's generational GC rarely runs gen2 collection
+    # under steady-state allocation, and glibc retains freed pages as RSS.
+    # Calling trim_memory here ensures every reaper scan (default every 5 min)
+    # returns releasable pages, preventing unbounded RSS growth over days/weeks.
+    try:
+        from hermes_cli.mem_trim import trim_memory
+
+        trim_memory(reason="idle reaper periodic trim")
+    except Exception:
+        pass
 
 
 # Soft LRU cap on in-memory sessions. The 6h TTL reaper above only frees
@@ -9349,6 +9360,23 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             )
             _emit("error", sid, {"message": str(e)})
         finally:
+            # Drop both local snapshots of the pre-turn history before asking
+            # glibc to return pages. session["history"] already points at the
+            # new/pruned result; retaining either list defeats this trim.
+            history.clear()
+            local_run_kwargs = locals().get("run_kwargs")
+            if isinstance(local_run_kwargs, dict):
+                local_run_kwargs.clear()
+
+            # Run while any profile-specific HERMES_HOME override is still active
+            # so context.memory_trim is resolved from the session's own config.
+            try:
+                from hermes_cli.mem_trim import trim_memory
+
+                trim_memory(reason="tui turn completion")
+            except Exception:
+                logger.debug("post-turn memory trim failed", exc_info=True)
+
             try:
                 if approval_token is not None:
                     reset_current_session_key(approval_token)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1301,6 +1301,17 @@ You can also change the reasoning effort at runtime with the `/reasoning` comman
 /reasoning hide      # Hide model thinking
 ```
 
+## Text Verbosity
+
+Control OpenAI Responses API final-answer length without changing reasoning effort:
+
+```yaml
+agent:
+  text_verbosity: ""   # empty = provider default. Options: low, medium, high
+```
+
+Hermes automatically sends this as top-level `text: {"verbosity": ...}` only for GPT-5 models on the Codex OAuth backend or the exact `api.openai.com` host. It is not injected for xAI/Grok, GitHub Models, Anthropic, or arbitrary custom endpoints.
+
 ## Tool-Use Enforcement
 
 Some models occasionally describe intended actions as text instead of making tool calls ("I would run the tests..." instead of actually calling the terminal). Tool-use enforcement injects system prompt guidance that steers the model back to actually calling tools.


### PR DESCRIPTION
## Problem

Long-lived gateway processes (days/weeks without restart) accumulate high RSS even though the memory trim infrastructure from #63708 is deployed. Root cause: `trim_memory()` is only called at **turn completion** and **agent close**, but the idle reaper thread (running every 5 min) never triggers it unless a session is actually reaped.

For active sessions that never hit the 6h idle TTL, `gc.collect()` + `malloc_trim(0)` are never invoked, so glibc retains freed heap pages as RSS indefinitely.

## Solution

Add `trim_memory(reason="idle reaper periodic trim")` at the end of `_reap_idle_sessions()` so every reaper scan (default 300s) releases releasable pages regardless of whether any session was reaped.

This builds on the carried #63708 infrastructure:
- `hermes_cli/mem_trim.py`: config-driven `malloc_trim(0)` with cooldown and kill-switch
- Post-turn trim in `_run_prompt_submit` finally block
- Force trim on `AIAgent.close()`
- `context.memory_trim` config schema (`enabled`, `cooldown_seconds`)

## Observability

Before (gateway running 28h, PID 115324):
```
RSS: 1033 MB
```

Expected after: periodic trim every 5 min should keep RSS bounded. The 60s cooldown in `trim_memory` prevents redundant trims when turn-completion and reaper fire close together.

## Testing

- 8 mem_trim unit tests (config, cooldown, kill-switch, libc failure)
- New `test_reap_idle_sessions_calls_periodic_trim` — verifies trim fires even with zero reaped sessions
- 324 gateway tests pass, no regressions

```bash
PYTHONPATH=. pytest tests/hermes_cli/test_mem_trim.py tests/test_tui_gateway_server.py -x -q
# 10 passed, 324 passed
```