### PR TITLE
fix(hindsight): acknowledge append retains after success

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1259,6 +1259,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_identity = str(kwargs.get("agent_identity") or "").strip()
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
+        self._turn_counter = 0
         with self._append_state_lock:
             self._append_state = _AppendRetainState()
             self._session_turns = self._append_state.turns
@@ -1904,17 +1905,15 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Drain any in-flight prefetch from the old session and drop
-        # its cached result so the new session doesn't see stale recall.
-        if self._prefetch_thread and self._prefetch_thread.is_alive():
-            self._prefetch_thread.join(timeout=3.0)
-        with self._prefetch_lock:
-            self._prefetch_result = ""
-
-        # 2. Queue the old-session flush and rotate buffers atomically with
+        # 1. Queue the old-session flush and rotate buffers atomically with
         # sync_turn(). Append jobs capture old_state, so their writer-time
         # ACK compaction can never touch the new session's buffer.
         with self._append_state_lock:
+            # shutdown() takes this same lock before setting the event. Either
+            # the flush is published before shutdown drains the writer, or the
+            # switch leaves the old state intact for shutdown to own.
+            if self._shutting_down.is_set():
+                return
             old_state = self._append_state
             if old_state.turns:
                 old_session_id = self._session_id
@@ -2001,10 +2000,9 @@ class HindsightMemoryProvider(MemoryProvider):
                             )
 
                 # The shared FIFO keeps this behind older old-session jobs.
-                if not self._shutting_down.is_set():
-                    self._ensure_writer()
-                    self._register_atexit()
-                    self._retain_queue.put(_flush)
+                self._ensure_writer()
+                self._register_atexit()
+                self._retain_queue.put(_flush)
 
             if parent_session_id:
                 self._parent_session_id = str(parent_session_id).strip()
@@ -2015,6 +2013,13 @@ class HindsightMemoryProvider(MemoryProvider):
             self._session_turns = self._append_state.turns
             self._turn_counter = 0
             self._turn_index = 0
+
+        # 2. Drain any in-flight prefetch from the old session and drop
+        # its cached result so the new session doesn't see stale recall.
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            self._prefetch_result = ""
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,
@@ -2024,7 +2029,8 @@ class HindsightMemoryProvider(MemoryProvider):
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
         # Stop accepting new retain jobs first so anyone still calling
         # sync_turn() during teardown is dropped, not enqueued.
-        self._shutting_down.set()
+        with self._append_state_lock:
+            self._shutting_down.set()
         # Drain the writer: it will finish in-flight work, then exit on
         # the sentinel. Bounded join keeps shutdown predictable even if
         # the daemon is wedged.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -254,6 +254,14 @@ _loop_lock = threading.Lock()
 _WRITER_SENTINEL = object()
 
 
+class _AppendRetainState:
+    """Mutable append buffer and ACK position for one session."""
+
+    def __init__(self) -> None:
+        self.turns: list[str] = []
+        self.acknowledged_turn_count = 0
+
+
 def _get_loop() -> asyncio.AbstractEventLoop:
     """Return a long-lived event loop running on a background thread."""
     global _loop, _loop_thread
@@ -669,6 +677,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._writer_thread: threading.Thread | None = None
         self._shutting_down = threading.Event()
         self._atexit_registered = False
+        self._append_state_lock = threading.Lock()
         # Legacy alias — older tests/callers reference _sync_thread directly.
         # Points at _writer_thread once the writer is running.
         self._sync_thread = None
@@ -687,11 +696,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_async = True
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
-        self._session_turns: list[str] = []  # accumulates ALL turns for the session
-        # How many turns the last append-mode retain already shipped. Used to
-        # send only the new delta on subsequent retains when the API supports
-        # update_mode='append' (legacy/overwrite path still sends everything).
-        self._last_retained_turn_count = 0
+        self._append_state = _AppendRetainState()
+        # Legacy/overwrite mode keeps the full session here. Append mode
+        # compacts acknowledged prefixes in-place after a successful retain.
+        self._session_turns = self._append_state.turns
 
         # Recall controls
         self._auto_recall = True
@@ -1251,8 +1259,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_identity = str(kwargs.get("agent_identity") or "").strip()
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
-        self._session_turns = []
-        self._last_retained_turn_count = 0
+        with self._append_state_lock:
+            self._append_state = _AppendRetainState()
+            self._session_turns = self._append_state.turns
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1600,6 +1609,68 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["observation_scopes"] = self._observation_scopes
         return kwargs
 
+    def _retain_append_prefix(
+        self,
+        state: _AppendRetainState,
+        target_turn_count: int,
+        *,
+        bank_id: str,
+        document_id: str,
+        retain_async: bool,
+        context: str,
+        metadata: Dict[str, str],
+        tags: List[str] | None,
+        operation_name: str,
+    ) -> None:
+        """Retain and acknowledge the pending prefix through a queued target."""
+        with self._append_state_lock:
+            pending_count = target_turn_count - state.acknowledged_turn_count
+            if pending_count <= 0:
+                logger.debug(
+                    "Hindsight %s skipped: target %d already acknowledged",
+                    operation_name, target_turn_count,
+                )
+                return
+            turns_to_retain = list(state.turns[:pending_count])
+            if len(turns_to_retain) != pending_count:
+                raise RuntimeError(
+                    "Hindsight append buffer ended before queued retain target"
+                )
+
+        content = "[" + ",".join(turns_to_retain) + "]"
+        metadata_snapshot = dict(metadata)
+        metadata_snapshot["message_count"] = str(len(turns_to_retain) * 2)
+        item = self._build_retain_kwargs(
+            content,
+            context=context,
+            metadata=metadata_snapshot,
+            tags=tags,
+        )
+        item.pop("bank_id", None)
+        item.pop("retain_async", None)
+        item["update_mode"] = "append"
+        logger.debug(
+            "Hindsight %s: bank=%s, doc=%s, mode=append, async=%s, "
+            "content_len=%d, num_turns=%d",
+            operation_name, bank_id, document_id, retain_async,
+            len(content), len(turns_to_retain),
+        )
+        self._run_hindsight_operation(
+            lambda client: client.aretain_batch(
+                bank_id=bank_id,
+                items=[item],
+                document_id=document_id,
+                retain_async=retain_async,
+            )
+        )
+
+        # aretain_batch returning successfully is the ACK. Only now may the
+        # exact prefix be removed; failures leave it for the next FIFO target.
+        with self._append_state_lock:
+            del state.turns[:len(turns_to_retain)]
+            state.acknowledged_turn_count += len(turns_to_retain)
+        logger.debug("Hindsight %s succeeded", operation_name)
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
@@ -1615,85 +1686,102 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("sync_turn: skipped (shutting down)")
             return
 
-        if session_id:
-            self._session_id = str(session_id).strip()
-
         turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
-        self._session_turns.append(turn)
-        self._turn_counter += 1
-        self._turn_index = self._turn_counter
-
-        if self._turn_counter % self._retain_every_n_turns != 0:
-            logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
-                         self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
-            return
-
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
-
-        # On append-capable APIs each retain only needs to ship the turns
-        # accumulated since the last retain — the server appends them to the
-        # existing document. On legacy/overwrite APIs we must resend the whole
-        # session because each retain replaces the document.
-        if update_mode == "append":
-            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
-            if not turns_to_retain:
-                logger.debug("sync_turn: skipped append retain; no new turns since last retain")
+        with self._append_state_lock:
+            if self._shutting_down.is_set():
+                logger.debug("sync_turn: skipped (shutting down)")
                 return
-        else:
-            turns_to_retain = list(self._session_turns)
+            if session_id:
+                self._session_id = str(session_id).strip()
 
-        logger.debug("sync_turn: retaining %d/%d turns, payload %d chars",
-                     len(turns_to_retain), len(self._session_turns),
-                     sum(len(t) for t in turns_to_retain))
-        content = "[" + ",".join(turns_to_retain) + "]"
+            state = self._append_state
+            state.turns.append(turn)
+            self._turn_counter += 1
+            self._turn_index = self._turn_counter
 
-        lineage_tags: list[str] = []
-        if self._session_id:
-            lineage_tags.append(f"session:{self._session_id}")
-        if self._parent_session_id:
-            lineage_tags.append(f"parent:{self._parent_session_id}")
-
-        # Snapshot the state needed for the retain. The writer may run after
-        # _session_turns / _turn_index are mutated by a later sync_turn().
-        metadata_snapshot = self._build_metadata(
-            message_count=len(turns_to_retain) * 2,
-            turn_index=self._turn_index,
-        )
-        num_turns = len(turns_to_retain)
-        bank_id = self._bank_id
-        retain_async_flag = self._retain_async
-        retain_context = self._retain_context
-
-        def _do_retain() -> None:
-            item = self._build_retain_kwargs(
-                content,
-                context=retain_context,
-                metadata=metadata_snapshot,
-                tags=lineage_tags or None,
-            )
-            item.pop("bank_id", None)
-            item.pop("retain_async", None)
-            if update_mode is not None:
-                item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
-            self._run_hindsight_operation(
-                lambda client: client.aretain_batch(
-                    bank_id=bank_id,
-                    items=[item],
-                    document_id=document_id,
-                    retain_async=retain_async_flag,
+            if self._turn_counter % self._retain_every_n_turns != 0:
+                logger.debug(
+                    "sync_turn: buffered turn %d (will retain at turn %d)",
+                    self._turn_counter,
+                    self._turn_counter + (
+                        self._retain_every_n_turns
+                        - self._turn_counter % self._retain_every_n_turns
+                    ),
                 )
-            )
-            logger.debug("Hindsight retain succeeded")
+                return
 
-        self._ensure_writer()
-        self._register_atexit()
-        self._retain_queue.put(_do_retain)
-        # Advance the append watermark only after the delta is queued, so a
-        # later retain doesn't re-ship turns we've already handed to the writer.
-        if update_mode == "append":
-            self._last_retained_turn_count = len(self._session_turns)
+            document_id, update_mode = self._resolve_retain_target(self._document_id)
+            target_turn_count = self._turn_counter
+            lineage_tags: list[str] = []
+            if self._session_id:
+                lineage_tags.append(f"session:{self._session_id}")
+            if self._parent_session_id:
+                lineage_tags.append(f"parent:{self._parent_session_id}")
+
+            bank_id = self._bank_id
+            retain_async_flag = self._retain_async
+            retain_context = self._retain_context
+
+            if update_mode == "append":
+                # The payload is deliberately resolved by the writer, not
+                # here: an earlier queued append may still fail or ACK before
+                # this job runs.
+                metadata_snapshot = self._build_metadata(
+                    message_count=0,
+                    turn_index=target_turn_count,
+                )
+
+                def _do_retain() -> None:
+                    self._retain_append_prefix(
+                        state,
+                        target_turn_count,
+                        bank_id=bank_id,
+                        document_id=document_id,
+                        retain_async=retain_async_flag,
+                        context=retain_context,
+                        metadata=metadata_snapshot,
+                        tags=lineage_tags or None,
+                        operation_name="retain",
+                    )
+            else:
+                # Legacy/overwrite APIs must continue to receive a snapshot
+                # of the full session at each boundary.
+                turns_to_retain = list(state.turns)
+                content = "[" + ",".join(turns_to_retain) + "]"
+                metadata_snapshot = self._build_metadata(
+                    message_count=len(turns_to_retain) * 2,
+                    turn_index=target_turn_count,
+                )
+                num_turns = len(turns_to_retain)
+
+                def _do_retain() -> None:
+                    item = self._build_retain_kwargs(
+                        content,
+                        context=retain_context,
+                        metadata=metadata_snapshot,
+                        tags=lineage_tags or None,
+                    )
+                    item.pop("bank_id", None)
+                    item.pop("retain_async", None)
+                    logger.debug(
+                        "Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, "
+                        "content_len=%d, num_turns=%d",
+                        bank_id, document_id, update_mode, retain_async_flag,
+                        len(content), num_turns,
+                    )
+                    self._run_hindsight_operation(
+                        lambda client: client.aretain_batch(
+                            bank_id=bank_id,
+                            items=[item],
+                            document_id=document_id,
+                            retain_async=retain_async_flag,
+                        )
+                    )
+                    logger.debug("Hindsight retain succeeded")
+
+            self._ensure_writer()
+            self._register_atexit()
+            self._retain_queue.put(_do_retain)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
@@ -1816,87 +1904,117 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
-        # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
-        if self._session_turns:
-            old_turns = list(self._session_turns)
-            old_session_id = self._session_id
-            old_parent_session_id = self._parent_session_id
-            old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
-            old_document_id, old_update_mode = self._resolve_retain_target(
-                self._document_id
-            )
-
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
-
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
-
-        # 2. Drain any in-flight prefetch from the old session and drop
+        # 1. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
 
-        # 3. Now rotate to the new session.
-        if parent_session_id:
-            self._parent_session_id = str(parent_session_id).strip()
-        self._session_id = new_id
-        start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        self._document_id = f"{self._session_id}-{start_ts}"
-        self._session_turns = []
-        self._turn_counter = 0
-        self._turn_index = 0
-        self._last_retained_turn_count = 0
+        # 2. Queue the old-session flush and rotate buffers atomically with
+        # sync_turn(). Append jobs capture old_state, so their writer-time
+        # ACK compaction can never touch the new session's buffer.
+        with self._append_state_lock:
+            old_state = self._append_state
+            if old_state.turns:
+                old_session_id = self._session_id
+                old_parent_session_id = self._parent_session_id
+                old_turn_index = self._turn_index
+                old_target_turn_count = self._turn_counter
+                old_lineage_tags: list[str] = []
+                if old_session_id:
+                    old_lineage_tags.append(f"session:{old_session_id}")
+                if old_parent_session_id:
+                    old_lineage_tags.append(f"parent:{old_parent_session_id}")
+
+                # Resolve against the OLD session before rotating identifiers.
+                old_document_id, old_update_mode = self._resolve_retain_target(
+                    self._document_id
+                )
+                old_bank_id = self._bank_id
+                old_retain_async = self._retain_async
+                old_retain_context = self._retain_context
+
+                if old_update_mode == "append":
+                    old_metadata = self._build_metadata(
+                        message_count=0,
+                        turn_index=old_turn_index,
+                    )
+
+                    def _flush() -> None:
+                        try:
+                            self._retain_append_prefix(
+                                old_state,
+                                old_target_turn_count,
+                                bank_id=old_bank_id,
+                                document_id=old_document_id,
+                                retain_async=old_retain_async,
+                                context=old_retain_context,
+                                metadata=old_metadata,
+                                tags=old_lineage_tags or None,
+                                operation_name="flush-on-switch",
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Hindsight flush-on-switch failed: %s",
+                                e,
+                                exc_info=True,
+                            )
+                else:
+                    # Legacy overwrite mode still flushes the full old session.
+                    old_turns = list(old_state.turns)
+                    old_content = "[" + ",".join(old_turns) + "]"
+                    old_metadata = self._build_metadata(
+                        message_count=len(old_turns) * 2,
+                        turn_index=old_turn_index,
+                    )
+
+                    def _flush() -> None:
+                        try:
+                            item = self._build_retain_kwargs(
+                                old_content,
+                                context=old_retain_context,
+                                metadata=old_metadata,
+                                tags=old_lineage_tags or None,
+                            )
+                            item.pop("bank_id", None)
+                            item.pop("retain_async", None)
+                            logger.debug(
+                                "Hindsight flush-on-switch: bank=%s, doc=%s, "
+                                "mode=%s, num_turns=%d",
+                                old_bank_id, old_document_id, old_update_mode,
+                                len(old_turns),
+                            )
+                            self._run_hindsight_operation(
+                                lambda client: client.aretain_batch(
+                                    bank_id=old_bank_id,
+                                    items=[item],
+                                    document_id=old_document_id,
+                                    retain_async=old_retain_async,
+                                )
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Hindsight flush-on-switch failed: %s",
+                                e,
+                                exc_info=True,
+                            )
+
+                # The shared FIFO keeps this behind older old-session jobs.
+                if not self._shutting_down.is_set():
+                    self._ensure_writer()
+                    self._register_atexit()
+                    self._retain_queue.put(_flush)
+
+            if parent_session_id:
+                self._parent_session_id = str(parent_session_id).strip()
+            self._session_id = new_id
+            start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            self._document_id = f"{self._session_id}-{start_ts}"
+            self._append_state = _AppendRetainState()
+            self._session_turns = self._append_state.turns
+            self._turn_counter = 0
+            self._turn_index = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -212,7 +212,10 @@ def _make_hindsight_provider():
     provider._session_id = "old-sid"
     provider._parent_session_id = ""
     provider._document_id = "old-sid-20260101_000000_000000"
-    provider._session_turns = ["turn-1", "turn-2"]
+    provider._append_state_lock = threading.Lock()
+    provider._append_state = hindsight_mod._AppendRetainState()
+    provider._append_state.turns.extend(["turn-1", "turn-2"])
+    provider._session_turns = provider._append_state.turns
     provider._turn_counter = 2
     provider._turn_index = 2
     # Attrs read by _build_metadata / _build_retain_kwargs when the

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1688,6 +1688,77 @@ class TestAppendRetainAcknowledgements:
         assert p._session_id == "new-sid"
         assert p._session_turns == []
 
+    def test_session_switch_queues_old_flush_before_concurrent_shutdown(
+        self, append_provider
+    ):
+        """Shutdown during the prefetch wait cannot discard the old buffer."""
+        import threading
+
+        join_started = threading.Event()
+        release_prefetch = threading.Event()
+        calls = []
+
+        async def _record_retain(**kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(ok=True)
+
+        class _BlockedPrefetch:
+            def is_alive(self):
+                return not release_prefetch.is_set()
+
+            def join(self, timeout=None):
+                join_started.set()
+                release_prefetch.wait(timeout=timeout)
+
+        p = append_provider(
+            retain_every_n_turns=2,
+            retain_async=False,
+            release_on_cleanup=release_prefetch,
+        )
+        p._client.aretain_batch = AsyncMock(side_effect=_record_retain)
+        p._prefetch_thread = _BlockedPrefetch()
+        p.sync_turn("turn1-user", "turn1-asst")
+
+        switch = threading.Thread(
+            target=lambda: p.on_session_switch(
+                "new-sid", parent_session_id="test-session", reset=True
+            )
+        )
+        switch.start()
+        assert join_started.wait(timeout=5.0), "switch never waited for prefetch"
+
+        shutdown = threading.Thread(target=p.shutdown)
+        shutdown.start()
+        assert p._shutting_down.wait(timeout=5.0), "shutdown never started"
+        release_prefetch.set()
+        switch.join(timeout=5.0)
+        shutdown.join(timeout=5.0)
+
+        assert not switch.is_alive()
+        assert not shutdown.is_alive()
+        assert p._client is None
+        assert self._payloads(calls) == [[self._turn(1)]]
+
+    def test_reinitialize_resets_append_target_accounting(self, append_provider):
+        """A fresh append state starts its queued targets from zero again."""
+        calls = []
+
+        async def _record_retain(**kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(ok=True)
+
+        p = append_provider(retain_every_n_turns=1)
+        p._client.aretain_batch = AsyncMock(side_effect=_record_retain)
+        p.sync_turn("turn1-user", "turn1-asst")
+        p._retain_queue.join()
+
+        p.initialize(session_id="reinitialized-session", platform="cli")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        assert self._payloads(calls) == [[self._turn(1)], [self._turn(2)]]
+        assert p._session_turns == []
+
     def test_successful_append_retain_prunes_acknowledged_turns_from_buffer(
         self, append_provider
     ):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1437,6 +1437,270 @@ class TestUpdateModeAppendCapability:
 
 
 # ---------------------------------------------------------------------------
+# Append retain acknowledgement behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def append_provider(provider_with_config, monkeypatch):
+    """Build deterministic append providers and clean up all shared state."""
+    import asyncio
+    from plugins.memory.hindsight import (
+        _append_capability_cache,
+        _append_capability_lock,
+    )
+
+    providers = []
+    release_events = []
+
+    def clear_capability_cache():
+        with _append_capability_lock:
+            _append_capability_cache.clear()
+
+    def make(*, release_on_cleanup=None, **config):
+        p = provider_with_config(**config)
+        p._run_sync = lambda coro: asyncio.run(coro)
+        providers.append(p)
+        if release_on_cleanup is not None:
+            release_events.append(release_on_cleanup)
+        return p
+
+    clear_capability_cache()
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._fetch_hindsight_api_version",
+        lambda *args, **kwargs: "0.5.6",
+    )
+    yield make
+    for event in release_events:
+        event.set()
+    try:
+        for p in reversed(providers):
+            p.shutdown()
+    finally:
+        clear_capability_cache()
+
+
+class TestAppendRetainAcknowledgements:
+    @staticmethod
+    def _turns(call):
+        payload = json.loads(call["items"][0]["content"])
+        return [(turn[0]["content"], turn[1]["content"]) for turn in payload]
+
+    @staticmethod
+    def _turn(number):
+        return (f"User: turn{number}-user", f"Assistant: turn{number}-asst")
+
+    @classmethod
+    def _payloads(cls, calls):
+        return [cls._turns(call) for call in calls]
+
+    def test_failed_append_retain_is_retried_with_next_boundary(
+        self, append_provider
+    ):
+        """A queued append is not acknowledged until aretain_batch succeeds."""
+        calls = []
+
+        async def _fail_first_retain(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError("first append failed")
+            return SimpleNamespace(ok=True)
+
+        p = append_provider(retain_every_n_turns=1)
+        p._client.aretain_batch = AsyncMock(side_effect=_fail_first_retain)
+        p.sync_turn("turn1-user", "turn1-asst")
+        p._retain_queue.join()
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        assert self._payloads(calls) == [
+            [self._turn(1)],
+            [self._turn(1), self._turn(2)],
+        ]
+
+    def test_in_flight_append_failure_preserves_queued_turns_exactly_once(
+        self, append_provider
+    ):
+        """Queued work observes the first append's eventual failure in FIFO order."""
+        import threading
+
+        first_started = threading.Event()
+        release_first = threading.Event()
+        successful_calls = []
+        call_count = 0
+
+        async def _block_then_fail_first_retain(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+                if not release_first.wait(timeout=5.0):
+                    raise AssertionError("test did not release the first retain")
+                raise RuntimeError("in-flight append failed")
+            successful_calls.append(kwargs)
+            return SimpleNamespace(ok=True)
+
+        p = append_provider(
+            retain_every_n_turns=1, release_on_cleanup=release_first
+        )
+        p._client.aretain_batch = AsyncMock(
+            side_effect=_block_then_fail_first_retain
+        )
+        p.sync_turn("turn1-user", "turn1-asst")
+        assert first_started.wait(timeout=5.0), (
+            "first retain never entered aretain_batch"
+        )
+        p.sync_turn("turn2-user", "turn2-asst")
+        p.sync_turn("turn3-user", "turn3-asst")
+        release_first.set()
+        p._retain_queue.join()
+
+        assert self._payloads(successful_calls) == [
+            [self._turn(1), self._turn(2)],
+            [self._turn(3)],
+        ]
+
+    def test_in_flight_append_success_preserves_queued_turns_exactly_once(
+        self, append_provider
+    ):
+        """Queued append targets account for an earlier in-flight ACK."""
+        import threading
+
+        first_started = threading.Event()
+        release_first = threading.Event()
+        writer_drained = threading.Event()
+        successful_calls = []
+        call_count = 0
+
+        async def _block_then_succeed_first_retain(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+                if not release_first.wait(timeout=5.0):
+                    raise AssertionError("test did not release the first retain")
+            successful_calls.append(kwargs)
+            return SimpleNamespace(ok=True)
+
+        p = append_provider(
+            retain_every_n_turns=1, release_on_cleanup=release_first
+        )
+        p._client.aretain_batch = AsyncMock(
+            side_effect=_block_then_succeed_first_retain
+        )
+        p.sync_turn("turn1-user", "turn1-asst")
+        assert first_started.wait(timeout=5.0), (
+            "first retain never entered aretain_batch"
+        )
+        p.sync_turn("turn2-user", "turn2-asst")
+        p.sync_turn("turn3-user", "turn3-asst")
+        p._retain_queue.put(writer_drained.set)
+        release_first.set()
+        assert writer_drained.wait(timeout=5.0), "retain queue did not drain"
+
+        assert self._payloads(successful_calls) == [
+            [self._turn(1)],
+            [self._turn(2)],
+            [self._turn(3)],
+        ]
+
+    def test_session_switch_flushes_only_unacknowledged_append_turn(
+        self, append_provider
+    ):
+        """A switch flush uses the old stable document after an earlier ACK."""
+        import threading
+
+        batch_acknowledged = threading.Event()
+        switch_flush_finished = threading.Event()
+        successful_calls = []
+
+        async def _record_successful_retain(**kwargs):
+            successful_calls.append(kwargs)
+            return SimpleNamespace(ok=True)
+
+        p = append_provider(retain_every_n_turns=2)
+        p._client.aretain_batch = AsyncMock(side_effect=_record_successful_retain)
+        old_stable_document = p._session_id
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.put(batch_acknowledged.set)
+        assert batch_acknowledged.wait(timeout=5.0), (
+            "initial batch was not acknowledged"
+        )
+        assert p._session_turns == []
+
+        p.sync_turn("turn3-user", "turn3-asst")
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        p._retain_queue.put(switch_flush_finished.set)
+        assert switch_flush_finished.wait(timeout=5.0), (
+            "switch flush did not finish"
+        )
+
+        assert p._client.aretain_batch.await_count == 2
+        flush = successful_calls[1]
+        assert flush["document_id"] == old_stable_document
+        assert flush["items"][0]["update_mode"] == "append"
+        assert self._turns(flush) == [self._turn(3)]
+
+    @pytest.mark.parametrize(
+        ("fail_first", "expected_call_count"), [(False, 1), (True, 2)]
+    )
+    def test_session_switch_while_append_is_in_flight_keeps_old_state_isolated(
+        self,
+        append_provider,
+        fail_first,
+        expected_call_count,
+    ):
+        """A switch neither duplicates an ACK nor drops a failed old-session turn."""
+        import threading
+
+        first_started = threading.Event()
+        release_first = threading.Event()
+        calls = []
+
+        async def _block_first_retain(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                first_started.set()
+                if not release_first.wait(timeout=5.0):
+                    raise AssertionError("test did not release the first retain")
+                if fail_first:
+                    raise RuntimeError("in-flight append failed")
+            return SimpleNamespace(ok=True)
+
+        p = append_provider(
+            retain_every_n_turns=1, release_on_cleanup=release_first
+        )
+        p._client.aretain_batch = AsyncMock(side_effect=_block_first_retain)
+        old_document_id = p._session_id
+        p.sync_turn("turn1-user", "turn1-asst")
+        assert first_started.wait(timeout=5.0), (
+            "first retain never entered aretain_batch"
+        )
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        release_first.set()
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.await_count == expected_call_count
+        assert all(call["document_id"] == old_document_id for call in calls)
+        assert all(call["items"][0]["update_mode"] == "append" for call in calls)
+        assert self._payloads(calls) == [[self._turn(1)]] * expected_call_count
+        assert p._session_id == "new-sid"
+        assert p._session_turns == []
+
+    def test_successful_append_retain_prunes_acknowledged_turns_from_buffer(
+        self, append_provider
+    ):
+        """Append mode prunes acknowledged turns from its in-memory buffer."""
+        p = append_provider(retain_every_n_turns=2)
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        assert p._session_turns == []
+
+
+# ---------------------------------------------------------------------------
 # System prompt tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Hindsight append-mode retains currently advance the turn watermark as soon as a background write is queued. If that write fails, the writer logs the exception and drops the job, while the advanced watermark prevents the failed turns from being included in the next retain. That silently loses conversation turns from Hindsight.

This PR gives append retains acknowledgement-on-success semantics:

- queued append jobs capture a target turn boundary;
- turns are removed from the in-memory append buffer only after `aretain_batch` succeeds;
- a failed prefix remains pending and is included in the next append boundary;
- FIFO jobs resolve only the still-unacknowledged part of their own target, preventing loss, duplication, or reordering while writes are in flight;
- session switches replace the active append state while queued old-session jobs continue to reference only the old state.

`sync_turn()` remains non-blocking, successful append retains still bound the buffer, and overwrite/legacy retention behavior is unchanged.

## Related Issue

Related to #62977.

That PR identifies the unbounded append buffer, but its enqueue-time clear still makes queued turns unrecoverable when the background Hindsight write fails. This PR addresses the missing delivery/acknowledgement semantics while preserving the bounded-memory goal.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added per-session append-retain state with lock-protected pending-turn accounting in `plugins/memory/hindsight/__init__.py`.
- Changed append queue jobs to acknowledge and prune only the prefix confirmed by a successful `aretain_batch` call.
- Kept failed append prefixes available for a later boundary or old-session switch flush.
- Isolated queued old-session work from newly switched session state.
- Synchronized switch flush publication and state rotation with shutdown ownership.
- Reset append target accounting when a provider is reinitialized.
- Added deterministic regression coverage for failed retries, successful and failed in-flight writes, exact batch partitioning, post-ACK compaction, reinitialization, and session-switch/shutdown races.
- Updated the hermetic session-switch test provider to initialize the new append state.

## How to Test

1. Run the Hindsight provider and session-switch suites:

   ```bash
   python -m pytest \
     tests/agent/test_memory_session_switch.py \
     tests/plugins/memory/test_hindsight_provider.py -q
   ```

   Result: **137 passed**.

2. Run the append acknowledgement regressions directly:

   ```bash
   python -m pytest tests/plugins/memory/test_hindsight_provider.py \
     -q -k 'TestAppendRetainAcknowledgements'
   ```

   Result: **9 passed**. The delivery-failure, concurrent shutdown, and reinitialization regressions were observed failing against the corresponding pre-fix behavior before their implementations were added.

3. Attempt the repository test suite:

   ```bash
   scripts/run_tests.sh tests
   ```

   The run was interrupted by the host's `/tmp` tmpfs user quota (`OSError: [Errno 122] Disk quota exceeded`) after the relevant Hindsight files had passed. Re-running the affected files with `TMPDIR` on the root filesystem eliminated most failures; the remaining unrelated files either hardcode `/tmp/hermes_test` or depend on the runner's original temp environment. The focused Hindsight/session-switch suite above is green; CI remains the authoritative repository-wide gate.

4. Run static and compatibility checks:

   ```bash
   ruff check \
     plugins/memory/hindsight/__init__.py \
     tests/agent/test_memory_session_switch.py \
     tests/plugins/memory/test_hindsight_provider.py
   python3 -m compileall -q plugins/memory/hindsight
   python3 scripts/check-windows-footguns.py \
     plugins/memory/hindsight/__init__.py \
     tests/agent/test_memory_session_switch.py \
     tests/plugins/memory/test_hindsight_provider.py
   git diff --check
   ```

   Result: all checks passed. Scoped `ty` reports the same existing diagnostic categories and counts as clean `main`; this change introduces no new type diagnostics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the diff uses only cross-platform Python threading/queue primitives and passes the repository footgun check
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is a background memory-provider correctness fix with deterministic regression tests.
