### PR TITLE
fix(agent): guard context-file discovery against Hermes install tree

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -34,6 +34,30 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
+
+def _is_hermes_install_tree(path: str) -> bool:
+    """Check if *path* is inside the Hermes agent install/source tree.
+
+    Uses this module's __file__ location to determine the install root.
+    If *path* is an ancestor directory of this file, then context-file
+    discovery from *path* would load the Hermes project's own AGENTS.md
+    (the contributor guide) rather than user project context.
+
+    Only triggers in installed-package mode (site-packages), not when
+    running from a source clone, so developers working on Hermes from
+    the cloned tree still get their project's AGENTS.md loaded.
+    """
+    try:
+        module_path = Path(__file__).resolve()
+        # Only guard in installed mode (site-packages), not source clones.
+        if "site-packages" not in module_path.parts:
+            return False
+        check_path = Path(path).resolve()
+        return check_path in module_path.parents
+    except Exception:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Context file scanning — detect prompt injection / promptware in AGENTS.md,
 # .cursorrules, SOUL.md before they get injected into the system prompt.
@@ -1969,6 +1993,19 @@ def build_context_files_prompt(
     """
     if cwd is None:
         cwd = os.getcwd()
+        # Safeguard: when there is no explicit cwd configuration and the
+        # fallback is inside the Hermes install tree (installed package),
+        # the user did not ask for context from this directory.  Silently
+        # skip rather than loading the project's own AGENTS.md into the
+        # system prompt.  See https://github.com/NousResearch/hermes-agent/issues/64590.
+        if _is_hermes_install_tree(cwd):
+            logger.warning(
+                "Falling back to Hermes install tree for context-file "
+                "discovery (cwd=%s). No project context loaded. "
+                "Set terminal.cwd or TERMINAL_CWD to your project directory.",
+                cwd,
+            )
+            return ""
 
     cwd_path = Path(cwd).resolve()
     sections = []


### PR DESCRIPTION
Fixes #64590

## Problem

When the gateway/desktop backend falls back to `os.getcwd()` (because no explicit `TERMINAL_CWD` or `terminal.cwd` is configured, or the configured path doesn't exist), context-file discovery reads the Hermes project's own **AGENTS.md** (contributor guide, ~73KB) and injects it into the system prompt as authoritative project context. The user has no indication this happened.

## Root cause

`build_context_files_prompt` receives `cwd=None` from `resolve_context_cwd()` when `TERMINAL_CWD` is unset, and falls back to `os.getcwd()`. For the desktop app the launch directory is the Hermes install tree, which contains AGENTS.md.

## Fix

In `build_context_files_prompt`, when falling back to `os.getcwd()`, detect whether the fallback directory is the Hermes install/source tree (by checking if this module's `__file__` lives under it, in installed-package mode). If so, skip context file loading with a warning log.

- Only fires in installed-package mode (path contains `site-packages`), not in source clones — developers working on Hermes from a local clone still get AGENTS.md loaded as expected.
- The warning tells the user to set `terminal.cwd` or `TERMINAL_CWD` to their project directory.
- Existing tests pass unchanged.