### PR TITLE
fix(kanban): report truthful gave-up causes

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,26 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _format_gave_up_message(
+    board_tag: str,
+    assignee_tag: str,
+    task_id: str,
+    payload: Optional[dict[str, Any]],
+) -> str:
+    """Render a truthful circuit-breaker notification.
+
+    ``gave_up`` covers more than spawn failures: iteration exhaustion,
+    timeouts, crashes, and other repeated failures all share this terminal
+    event. Never invent a more specific cause than the event supplies.
+    """
+    error = str((payload or {}).get("error") or "").strip()
+    detail = error[:200] if error else "failure limit reached"
+    return (
+        f"✖ {board_tag}{assignee_tag}Kanban {task_id} gave up\n"
+        f"{detail}"
+    )
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -371,12 +391,11 @@ class GatewayKanbanWatchersMixin:
                                 reason = f": {str(ev.payload['reason'])[:160]}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
-                            err = ""
-                            if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                            msg = _format_gave_up_message(
+                                board_tag,
+                                tag,
+                                sub["task_id"],
+                                ev.payload,
                             )
                         elif kind == "crashed":
                             msg = (

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import inspect
 
-from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.kanban_watchers import (
+    GatewayKanbanWatchersMixin,
+    _format_gave_up_message,
+)
 
 KANBAN_METHODS = [
     "_kanban_notifier_watcher",
@@ -43,6 +46,25 @@ def test_watcher_loops_are_coroutines():
     # The two long-running watchers are async loops.
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_notifier_watcher)
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_dispatcher_watcher)
+
+
+def test_gave_up_notification_uses_exact_iteration_exhaustion_cause():
+    msg = _format_gave_up_message(
+        "[dsbmx04] ",
+        "@dsbmx04-coder ",
+        "t_1319666b",
+        {"error": "Iteration budget exhausted (80/80)"},
+    )
+
+    assert "Iteration budget exhausted (80/80)" in msg
+    assert "spawn" not in msg.lower()
+
+
+def test_gave_up_notification_without_error_is_cause_neutral():
+    msg = _format_gave_up_message("", "", "t_deadbeef", None)
+
+    assert "failure limit reached" in msg
+    assert "spawn" not in msg.lower()
 
 
 def test_singleton_dispatcher_lock_is_exclusive(tmp_path):


### PR DESCRIPTION
## Summary

Kanban's notifier currently describes every `gave_up` event as caused by repeated spawn failures. That is incorrect for iteration exhaustion, timeouts, crashes, and other circuit-breaker causes.

This change:

- renders the sanitized event `error` when one is present;
- otherwise uses the cause-neutral fallback `failure limit reached`;
- preserves board, task, and assignee attribution;
- leaves completed, blocked, crashed, and timed-out notification branches unchanged.

## Reproduction

An event with:

```text
kind=gave_up
error=Iteration budget exhausted (80/80)
```

previously rendered as:

```text
gave up after repeated spawn failures
Iteration budget exhausted (80/80)
```

The two lines contradicted each other and sent operators toward the wrong remediation path.

## Verification

Independent QA was performed on exact commit `8cc4aff20318d8459904b759db34c4947614ef71`:

- focused notifier and watcher tests: 13 passed;
- iteration-exhaustion producer test: 1 passed;
- isolated notifier flow verified all five terminal branches;
- `py_compile`: passed;
- `git diff --check`: passed;
- exact-head linkage recheck: approved.

## Risk

Low and limited to human-facing `gave_up` notification formatting. Event production, retry limits, dispatch behavior, and runtime lifecycle are unchanged.

## Tracker

Installation tracker and acceptance criteria: https://github.com/stevenbaert/hermes/issues/712

No runtime activation or gateway restart is included.
