### PR TITLE
fix(ollama): emit top-level reasoning_effort=none on /v1/chat/completions (#25758)

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -4,7 +4,9 @@ Covers any endpoint registered as provider="custom", including local
 Ollama instances and OpenAI-compatible reasoning endpoints (GLM-5.2 on
 Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
-  - reasoning_config disabled → extra_body.think = False
+  - reasoning_config disabled → top-level reasoning_effort="none"
+    (Ollama /v1/chat/completions ignores think=False — ollama#14820)
+    + extra_body.think = False for /api/chat and proxies
   - reasoning_config enabled + effort → top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
@@ -53,6 +55,13 @@ class CustomProfile(ProviderProfile):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
+                # Ollama's /v1/chat/completions silently ignores
+                # extra_body.think (only /api/chat honours it — ollama#14820)
+                # but respects the top-level reasoning_effort field, so both
+                # are needed to actually stop a thinking-capable model from
+                # reasoning (#25758). Endpoints that recognize neither simply
+                # ignore them.
+                top_level["reasoning_effort"] = "none"
                 extra_body["think"] = False
             elif _effort:
                 top_level["reasoning_effort"] = _effort

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
+    "skosarevivan@yandex.ru": "Epoxidex",  # PR #29820 salvage (ollama: top-level reasoning_effort=none; #25758)
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "2024104039@mails.szu.edu.cn": "pixel4039",  # PR #64420 salvage (streaming: retry zero-chunk streams)

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -49,20 +49,26 @@ class TestCustomReasoningWireShape:
         assert tl == {}
 
     def test_disabled_sends_think_false(self, custom_profile):
-        """enabled=False → extra_body.think = False (Ollama thinking-off flag)."""
+        """enabled=False → reasoning_effort='none' top-level + think=False.
+
+        Both fields are required: Ollama's /v1/chat/completions silently
+        ignores extra_body.think (only /api/chat honours it — ollama#14820)
+        but respects top-level reasoning_effort (#25758). think=False stays
+        for proxies and the native /api/chat path.
+        """
         eb, tl = custom_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": False}, model="glm-5.2"
         )
         assert eb == {"think": False}
-        assert tl == {}
+        assert tl == {"reasoning_effort": "none"}
 
     def test_effort_none_sends_think_false(self, custom_profile):
-        """effort='none' is the disable alias → think=False, no effort."""
+        """effort='none' is the disable alias → same dual emission."""
         eb, tl = custom_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "none"}, model="glm-5.2"
         )
         assert eb == {"think": False}
-        assert tl == {}
+        assert tl == {"reasoning_effort": "none"}
 
     @pytest.mark.parametrize(
         "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]


### PR DESCRIPTION
## Summary
`agent.reasoning_effort: none` now actually disables thinking on Ollama's OpenAI-compatible endpoint: the custom provider profile emits top-level `reasoning_effort="none"` (which Ollama honours) alongside `extra_body.think=False` (which `/v1/chat/completions` silently ignores — [ollama#14820](https://github.com/ollama/ollama/issues/14820), kept for proxies and the native `/api/chat` path). Fixes the runaway-thinking half of #25758, where a thinking-capable local model kept reasoning despite `none` — up to 209k chars of `reasoning_content` / 65k output tokens / 28 minutes of GPU decode in the reporter's bg-review spiral.

Scope note: the issue's second defect (bg-review fork not inheriting `reasoning_config`) is already fixed on main (`agent/background_review.py` propagates it in `_fork_kwargs`), so only the provider-profile half is salvaged, resolved onto the current GLM/effort-aware profile that landed after the PR was opened.

## Changes
- `plugins/model-providers/custom/__init__.py`: disable path emits `reasoning_effort="none"` top-level + `think=False`; enabled+effort path unchanged.
- `tests/plugins/model_providers/test_custom_profile.py`: disable-path tests assert the dual emission; GLM effort passthrough coverage unchanged.

## Validation
| | Before | After |
|---|---|---|
| `reasoning_effort: none` on Ollama /v1 | only ignored `think:false` sent → model thinks anyway | `reasoning_effort:"none"` sent (honoured) + `think:false` |
| tests/plugins/model_providers/test_custom_profile.py | — | 13/13 pass |

Salvages #29820 by @Epoxidex (authorship preserved; conflict-resolved onto the newer effort-aware profile). Fixes the remaining half of #25758 (reporter's own validation table shows 0 reasoning chars / 88s vs 28 min after both fixes).

## Infographic

![ollama-reasoning](https://v3b.fal.media/files/b/0aa243a7/oUC7WHTEbTTAqgE1VSJcE_4tyxlfO4.png)
