### PR TITLE
fix(delegate/oneshot): headless one-shots silently strand delegated subagents (same root cause as #53027 / #63169)

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -114,6 +114,26 @@ _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNS
 # propagates that into this contextvar at session-bind time.
 _SESSION_ASYNC_DELIVERY: ContextVar = ContextVar("HERMES_SESSION_ASYNC_DELIVERY", default=_UNSET)
 
+# A headless one-shot (``hermes -z``) runs exactly ONE turn and then the process
+# exits.  There is no interactive loop and no gateway channel, so a detached
+# child's completion has nowhere to re-enter — unlike the interactive CLI, whose
+# process persists and can surface the result as a new turn.  ``run_oneshot()``
+# declares this before the agent starts so tools that promise async delivery can
+# refuse a promise the (already-exiting) process can never keep.
+_HEADLESS_ONESHOT = False
+
+
+def declare_headless_oneshot() -> None:
+    """Mark this process as a headless one-shot (``hermes -z``).
+
+    Makes :func:`async_delivery_supported` return ``False`` so ``delegate_task``
+    and ``terminal`` fall back to synchronous execution instead of handing out a
+    handle that is silently dropped when the turn ends.
+    """
+    global _HEADLESS_ONESHOT
+    _HEADLESS_ONESHOT = True
+
+
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
 _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
@@ -330,10 +350,12 @@ def get_session_env(name: str, default: str = "") -> str:
 def async_delivery_supported() -> bool:
     """Whether the current session can deliver a background completion later.
 
-    Returns ``False`` only when the active session was explicitly bound by a
+    Returns ``False`` when the active session was explicitly bound by a
     stateless adapter (the API server) that cannot route a notification back to
-    the agent after the turn ends. CLI, cron, and the real gateway platforms —
-    and any path that never bound the contextvar — return ``True``.
+    the agent after the turn ends, and for a headless one-shot (``hermes -z``),
+    whose process exits when the turn does.  The interactive CLI, cron, and the
+    real gateway platforms — and any path that never bound the contextvar —
+    return ``True``.
 
     Tools that promise async delivery (``terminal`` notify_on_complete /
     watch_patterns, ``delegate_task`` background=True) consult this before
@@ -342,5 +364,8 @@ def async_delivery_supported() -> bool:
     """
     value = _SESSION_ASYNC_DELIVERY.get()
     if value is _UNSET:
-        return True
+        # Unbound: the interactive CLI and the real gateway platforms can all
+        # deliver a completion later, so the default stays True — except a
+        # headless one-shot, which exits with the turn (declare_headless_oneshot).
+        return not _HEADLESS_ONESHOT
     return bool(value)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -196,6 +196,16 @@ def run_oneshot(
     # bytes reach the terminal.
     logging.disable(logging.CRITICAL)
 
+    # A one-shot runs exactly one turn and then this process exits, so nothing can
+    # route a detached subagent / watcher completion back to the agent afterwards.
+    # Declare that up front: delegate_task and terminal consult
+    # async_delivery_supported() and fall back to SYNCHRONOUS execution rather than
+    # handing out a promise that is silently dropped.  Same class of bug as #10760
+    # on the stateless API-server path.
+    from gateway.session_context import declare_headless_oneshot
+
+    declare_headless_oneshot()
+
     # --provider without --model is ambiguous: carrying the user's configured
     # model across to a different provider is usually wrong (that provider may
     # not host it), and silently picking the provider's catalog default hides


### PR DESCRIPTION
## Summary

A headless one-shot (`hermes -z …`) runs **exactly one turn and then the process exits**. It has no interactive loop and no gateway channel, so a detached child's completion has **nowhere to re-enter**.

But `async_delivery_supported()` returns `True` for it, because the contextvar is unbound and the default is "supported":

```python
value = _SESSION_ASYNC_DELIVERY.get()
if value is _UNSET:
    return True          # comment: "CLI ... keeps working"
```

That default is correct for the **interactive** CLI (the process persists, so a completion can surface as a new turn). It is wrong for a **one-shot**, and `run_oneshot()` binds no session vars, so it has no way to opt out the way `APIServerAdapter` does (`supports_async_delivery = False`).

The consequence, via `delegate_task`:

1. `run_agent._dispatch_delegate_task` **deliberately ignores** the model's `background` argument for a top-level agent — *"the model does not get to choose"* — and forces `background=True`.
2. `delegate_task` checks `async_delivery_supported()` before detaching. It says `True`, so the subagent is dispatched to the daemon executor…
3. …and the one-shot process exits before the executor runs it.

The subagent is **stranded**: a `sessions` row with no messages, `0` tokens, and no `ended_at`. The parent reports success while the delegated work **silently never happened**.

Worse, it's a **race, not a clean failure** — sometimes the executor wins and the child runs, sometimes it doesn't. Two consecutive identical runs of the same pipeline:

| run | delegate child | joined | tokens |
|---|---|---|---|
| 1 | `…124524_357f66` | yes | 578/21 |
| 2 | `…175347_07ed7e` | **no** | **0/0** |

So delegated work is lost **non-deterministically**. The agent even passed `background: false` explicitly (twice, in two arg shapes) — it was overridden both times, and then reported to the user that *"delegate_task only supports background mode on this runtime"*.

## Root cause is shared with several open issues

This is the same root cause as the already-fixed **#10760** (stateless API-server path), just on a different surface. It also appears to be the same underlying bug behind:

- **#53027** — *Async delegation completion events lost in cron jobs* (`needs-repro`). That issue's own **Expected Behavior** proposes exactly this fix: *"Return `False` from `async_delivery_supported()` so `delegate_tool.py` falls back to synchronous execution."*
- **#63169** — *delegate_task results are lost when called from Kanban workers; parent exits even with goal_mode*.

The general invariant: **any turn-scoped, headless context whose process exits with the turn must not advertise async delivery.** This PR fixes the `-z` one-shot surface and adds the primitive (`declare_headless_oneshot()`) that the cron / Kanban-worker paths can reuse.

## The fix

**`delegate_task` and `_dispatch_delegate_task` are untouched.** Hermes already has the correct guard: when `async_delivery_supported()` is `False`, `delegate_task` falls back to `_execute_and_aggregate()`, which runs the children **synchronously and joins every one** — the machinery built for #10760.

This PR simply makes the one-shot **honestly report the same condition**, so that existing machinery does the right thing:

1. `gateway/session_context.py` — add `declare_headless_oneshot()`; `async_delivery_supported()` honours it when the contextvar is unbound.
2. `hermes_cli/oneshot.py` — `run_oneshot()` declares itself before the agent starts.

## Reproduction

```bash
hermes -z "Delegate one task via delegate_task: greet me. Wait for the result before finishing." -t delegation
```

**Before:** `delegate_task` returns `{"status":"dispatched","mode":"background", …,"note":"… Do not wait or poll — just continue."}`, the process exits, and the child session is left with no messages / `0` tokens / no `ended_at`.

**After:** the delegation runs synchronously, the result is returned into the parent's turn, and the child session completes normally.

## Verification

Verified on v0.18.2 with a headless orchestrator that launches `hermes -z` and delegates one step:

**Before** — child stranded (`0/0` tokens, no `ended_at`), parent reported success, work lost.

**After:**
```
Wave 1 complete.

greet result:
Hello Atlas, I'm delighted to see you and hope your day is going wonderfully.
```
The child session ran, returned its result to the parent, and has `ended_at` set.

Also sanity-checked that the interactive CLI still reports `async_delivery_supported() == True`:
```python
>>> async_delivery_supported()          # unbound / interactive
True
>>> declare_headless_oneshot(); async_delivery_supported()
False
```

## Blast radius

- Fixes the whole class, not just delegation: `terminal`'s `notify_on_complete` / `watch_patterns` consult the same helper and have the same silent-promise bug in one-shots.
- **Interactive CLI, TUI, cron, and every gateway platform are unaffected** — `_HEADLESS_ONESHOT` is only ever set by `run_oneshot()`.
- In `-z` runs, delegations now **block and return results** instead of returning a handle. Strictly better (the work is currently thrown away), though slower.
- Trivially reversible: drop the `declare_headless_oneshot()` call.

## Notes

Happy to add a regression test — `tests/gateway/test_async_delivery_capability.py` looks like the natural home (it already covers `BasePlatformAdapter.supports_async_delivery` / `APIServerAdapter.supports_async_delivery = False`). Also glad to extend the same primitive to the cron and Kanban-worker paths (#53027 / #63169) if you'd like that in this PR or a follow-up.
