### PR TITLE
fix(auxiliary_client): survive version-skewed process_bootstrap (#64333)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -102,7 +102,6 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
-from agent.process_bootstrap import build_keepalive_http_client
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -162,15 +161,26 @@ def _openai_http_client_kwargs(
     async_mode: bool = False,
 ) -> Dict[str, Any]:
     """Inject keepalive httpx client with env-only proxy (not macOS system proxy)."""
-    client = build_keepalive_http_client(
-        str(base_url or ""),
-        async_mode=async_mode,
-        verify=_resolve_aux_verify(base_url),
-    )
+    try:
+        from agent.process_bootstrap import build_keepalive_http_client
+        client = build_keepalive_http_client(
+            str(base_url or ""),
+            async_mode=async_mode,
+            verify=_resolve_aux_verify(base_url),
+        )
+    except (ImportError, AttributeError):
+        # Fallback for older hermes-agent versions without build_keepalive_http_client.
+        # This can happen when Desktop users run with stale code (#64333).
+        # Without the keepalive client, auxiliary calls use the OpenAI SDK's default
+        # httpx client, which respects macOS system proxy (less predictable for env-only
+        # proxy use) and has no pool-level keepalive expiry (connections may live longer).
+        # This is a graceful degradation — functionality still works, just with slightly
+        # different proxy/keepalive behavior.
+        client = None
+    
     if client is None:
         return {}
     return {"http_client": client}
-
 
 def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     kwargs = {**_openai_http_client_kwargs(base_url), **kwargs}

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -155,6 +155,9 @@ def _resolve_aux_verify(base_url: Optional[str]) -> Any:
         return True
 
 
+_WARNED_KEEPALIVE_IMPORT_SKEW = False
+
+
 def _openai_http_client_kwargs(
     base_url: Optional[str],
     *,
@@ -169,15 +172,26 @@ def _openai_http_client_kwargs(
             verify=_resolve_aux_verify(base_url),
         )
     except (ImportError, AttributeError):
-        # Fallback for older hermes-agent versions without build_keepalive_http_client.
-        # This can happen when Desktop users run with stale code (#64333).
-        # Without the keepalive client, auxiliary calls use the OpenAI SDK's default
-        # httpx client, which respects macOS system proxy (less predictable for env-only
-        # proxy use) and has no pool-level keepalive expiry (connections may live longer).
-        # This is a graceful degradation — functionality still works, just with slightly
-        # different proxy/keepalive behavior.
+        # Version-skewed installs (#64333): a process whose sys.path resolves
+        # an older agent/process_bootstrap.py without this helper — seen when
+        # the Desktop app's bundled runtime lags a git-installed source tree
+        # that newer callers (cron scheduler) were written against. Every cron
+        # job died on this ImportError before any agent logic ran. Degrade
+        # gracefully to the OpenAI SDK's default httpx client (respects macOS
+        # system proxy, no pool-level keepalive expiry) instead of failing the
+        # whole job, and say so once — silent version skew is how this bug
+        # went unnoticed until jobs were already dead on arrival.
+        global _WARNED_KEEPALIVE_IMPORT_SKEW
+        if not _WARNED_KEEPALIVE_IMPORT_SKEW:
+            _WARNED_KEEPALIVE_IMPORT_SKEW = True
+            logger.warning(
+                "agent.process_bootstrap.build_keepalive_http_client is "
+                "unavailable — mixed/stale install detected (#64333). Falling "
+                "back to the SDK default HTTP client. Run `hermes update` (or "
+                "reinstall the Desktop app) to resync the runtime."
+            )
         client = None
-    
+
     if client is None:
         return {}
     return {"http_client": client}

--- a/tests/agent/test_auxiliary_client_bootstrap_skew.py
+++ b/tests/agent/test_auxiliary_client_bootstrap_skew.py
@@ -1,0 +1,47 @@
+"""Regression for #64333 — auxiliary client must survive a version-skewed
+agent.process_bootstrap that lacks build_keepalive_http_client.
+
+Desktop installs can run a runtime whose agent/process_bootstrap.py predates
+the helper while newer callers (cron scheduler → auxiliary_client) expect it.
+Before the fix the module-level import made every cron job die with
+ImportError before any agent logic ran.
+"""
+
+import builtins
+import logging
+
+import agent.auxiliary_client as aux
+
+
+def test_missing_bootstrap_helper_degrades_instead_of_raising(monkeypatch, caplog):
+    """ImportError from process_bootstrap → empty kwargs + one-time warning."""
+    real_import = builtins.__import__
+
+    def _fail_bootstrap(name, *args, **kwargs):
+        if name == "agent.process_bootstrap":
+            raise ImportError(
+                "cannot import name 'build_keepalive_http_client' "
+                "from 'agent.process_bootstrap'"
+            )
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fail_bootstrap)
+    monkeypatch.setattr(aux, "_WARNED_KEEPALIVE_IMPORT_SKEW", False)
+
+    with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+        result = aux._openai_http_client_kwargs("https://api.example.com/v1")
+        again = aux._openai_http_client_kwargs("https://api.example.com/v1")
+
+    assert result == {}
+    assert again == {}
+    skew_warnings = [
+        r for r in caplog.records if "mixed/stale install" in r.getMessage()
+    ]
+    assert len(skew_warnings) == 1  # warned once, not per call
+
+
+def test_healthy_bootstrap_still_injects_keepalive_client():
+    """With the helper present, the keepalive http_client is injected."""
+    result = aux._openai_http_client_kwargs("https://api.example.com/v1")
+    assert "http_client" in result
+    assert result["http_client"] is not None


### PR DESCRIPTION
## Summary
Desktop cron jobs no longer die at import when the runtime is version-skewed (#64333): `agent/auxiliary_client.py`'s hard module-level dependency on `agent.process_bootstrap.build_keepalive_http_client` becomes a lazy import with a graceful fallback and a one-time warning naming the skew and the fix (`hermes update` / reinstall).

Root cause (verified — the reporter's app.asar theory is wrong; no Python ships in the asar): classic mixed-version process state. The long-running desktop backend imported the pre-#53702 `agent.process_bootstrap` at startup and cached it in `sys.modules`; an in-place update refreshed the tree on disk; when cron later fired, it lazily imported the *new* `auxiliary_client.py`, whose module-level import looked up the helper on the *stale cached* `process_bootstrap` module → ImportError citing the on-disk path. A fresh terminal Python imports fine, matching the report. The scheduler ticked on time every night and every job died before any agent logic ran.

## Changes
- `agent/auxiliary_client.py`: lazy import inside `_openai_http_client_kwargs()`; on `ImportError`/`AttributeError`, fall back to the SDK's default HTTP client (jobs run; only pool-keepalive/proxy-pinning behavior differs) and log a one-time WARNING with the resync hint instead of degrading silently.
- `tests/agent/test_auxiliary_client_bootstrap_skew.py`: skewed path (empty kwargs + exactly one warning across calls) and healthy path (keepalive client injected).

## Validation
| | Before | After |
|---|---|---|
| Skewed runtime (helper missing) | ImportError at module import — every cron job dead | jobs run on SDK default client; one WARNING with fix hint |
| tests (bootstrap_skew + auxiliary_client suite) | — | 308/308 pass |

Salvages #64359 by @liuhao1024 (authorship preserved) + our warning/tests follow-up. Fixes the dead-on-arrival symptom of #64333; the systemic fix (restart-on-update for the desktop-managed backend, or pre-importing the agent stack at scheduler startup) is a follow-up candidate on the issue.

## Infographic

![desktop-cron-import](https://v3b.fal.media/files/b/0aa24420/cY41GSPGzKb4G28tenlcf_Ie7LWxRY.png)
