### PR TITLE
fix(slack): clear stuck assistant status on /stop and resume typing after clarify

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9208,6 +9208,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Gateway intercepted clarify text response (session=%s, id=%s)",
                         _quick_key, _pending_clarify.clarify_id,
                     )
+                    # The clarify callback pauses the platform typing/status
+                    # indicator while waiting so Slack users can type their
+                    # answer. The active agent resumes as soon as this reply
+                    # resolves the wait, so re-enable its indicator here too.
+                    # Without this, Slack stays silent until the independent
+                    # long-running heartbeat fires (three minutes by default).
+                    _clarify_adapter = self._adapter_for_source(source)
+                    if _clarify_adapter:
+                        try:
+                            _clarify_adapter.resume_typing_for_chat(source.chat_id)
+                        except Exception:
+                            logger.debug(
+                                "Failed to resume typing after clarify response",
+                                exc_info=True,
+                            )
                     # Acknowledge with empty string so adapters that emit
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1112,6 +1112,26 @@ class GatewaySlashCommandsMixin:
             )
             return EphemeralReply(t("gateway.stop.stopped"))
 
+        # No running agent anywhere for this scope. A platform status
+        # indicator can still be stuck — e.g. Slack's persistent
+        # assistant.threads.setStatus survives a gateway restart or a turn
+        # that died without a final send (#32295). Best-effort clear so
+        # /stop always dismisses a phantom "is thinking...".
+        adapter = getattr(self, "adapters", {}).get(source.platform)
+        if adapter and hasattr(adapter, "_stop_typing_with_metadata"):
+            try:
+                await adapter._stop_typing_with_metadata(
+                    source.chat_id,
+                    self._thread_metadata_for_source(
+                        source, self._reply_anchor_for_event(event)
+                    ),
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to clear typing on /stop with no active agent",
+                    exc_info=True,
+                )
+
         return t("gateway.stop.no_active")
 
     async def _handle_platform_command(self, event: MessageEvent) -> str:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1609,6 +1609,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
         requested_team_id = self._metadata_team_id(metadata)
         active = None
+        ambiguous_tracked = False
         if requested_thread_ts:
             if requested_team_id:
                 active_key = self._workspace_thread_key(
@@ -1628,6 +1629,7 @@ class SlackAdapter(BasePlatformAdapter):
                 ]
                 if len(matching_keys) == 1:
                     active = self._active_status_threads.pop(matching_keys[0], None)
+                ambiguous_tracked = len(matching_keys) > 1
         else:
             # Metadata-free cleanup is safe only if exactly one status exists
             # for this channel; otherwise it may clear another Slack Connect
@@ -1648,6 +1650,18 @@ class SlackAdapter(BasePlatformAdapter):
             team_id = active.get("team_id", "")
         if metadata:
             team_id = self._metadata_team_id(metadata) or team_id
+        if not thread_ts and requested_thread_ts and not ambiguous_tracked:
+            # No tracked entry (gateway restart, eviction, or a status set
+            # before this process started) but the caller identified the exact
+            # thread to clear. Issue the clear anyway so a stuck "is
+            # thinking..." can always be dismissed — clearing an unset status
+            # is a harmless no-op on Slack's side. Skipped when MULTIPLE
+            # workspaces track this channel+thread (ambiguous_tracked): a
+            # team-less clear there could hit the wrong Slack Connect
+            # workspace. Client routing uses the caller's team when given,
+            # else the channel→team fallback.
+            thread_ts = requested_thread_ts
+            team_id = requested_team_id or team_id
         if not thread_ts:
             return
         try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -50,6 +50,7 @@ AUTHOR_MAP = {
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)
+    "KCAYAAI@users.noreply.github.com": "KCAYAAI",  # PR #62248 partial salvage (resume typing after clarify reply)
     "jake.long.vu@vucar.net": "jakelongvu-bot",  # PR #36683 partial salvage (approval: honor canonical approvals.timeout in gateway waits)
     "luigi@users.noreply.github.com": "Tortugasaur",  # PR #43205 salvage (desktop: profile-aware three-way approval mode statusbar control)
     "kavi@local.hermes": "kavioavio",  # Issue #46544 / PR #47705 evolution (smart DENY exact-operation owner override)

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -1,7 +1,7 @@
 """Regression tests for clarify replies while a gateway session is busy."""
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -85,3 +85,37 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     adapter._message_handler.assert_awaited_once_with(event)
     adapter._busy_session_handler.assert_not_awaited()
     assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_clarify_reply_resumes_typing_before_returning_empty_ack():
+    """A clarify answer must re-enable the active run's typing indicator.
+
+    Clarify pauses typing while waiting so Slack's Assistant API does not
+    disable the compose box. The typed answer is intercepted by the gateway
+    and returns an empty acknowledgment instead of starting a second run; that
+    interception path must therefore resume the original run's indicator.
+    """
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter.pause_typing_for_chat("12345")
+    event = _event("the missing details")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._startup_restore_in_progress = False
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda source: True
+    runner._session_key_for_source = lambda source: "clarify-session"
+    runner._adapter_for_source = lambda source: adapter
+    runner._update_prompt_pending = {}
+
+    cm.register("clarify-2", "clarify-session", "What is missing?", None)
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        result = await runner._handle_message(event)
+
+    assert result == ""
+    assert "12345" not in adapter._typing_paused

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2108,6 +2108,45 @@ class TestSendTyping:
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_stop_typing_clears_untracked_thread_from_metadata(self, adapter):
+        """Explicit thread metadata clears a status the map no longer tracks.
+
+        A gateway restart (or cache eviction) wipes _active_status_threads
+        while Slack's persistent assistant status stays visible. A caller
+        that names the exact thread must still be able to dismiss it (#32295).
+        """
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        assert adapter._active_status_threads == {}
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "stuck_ts"})
+
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="stuck_ts",
+            status="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_untracked_fallback_respects_ambiguous_workspaces(
+        self, adapter
+    ):
+        """Team-less clear must NOT fire when multiple workspaces track the thread."""
+        team_one, team_two = AsyncMock(), AsyncMock()
+        adapter._team_clients.update({"T_ONE": team_one, "T_TWO": team_two})
+        for team_id in ("T_ONE", "T_TWO"):
+            await adapter.send_typing(
+                "D_SHARED",
+                metadata={"thread_id": "171.000", "slack_team_id": team_id},
+            )
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.stop_typing("D_SHARED", metadata={"thread_id": "171.000"})
+
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+        assert ("T_ONE", "D_SHARED", "171.000") in adapter._active_status_threads
+        assert ("T_TWO", "D_SHARED", "171.000") in adapter._active_status_threads
+
+    @pytest.mark.asyncio
     async def test_stop_typing_handles_api_error_gracefully(self, adapter):
         adapter._active_status_threads[("", "C123", "parent_ts")] = {
             "thread_ts": "parent_ts",

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -156,3 +156,67 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
 
     assert interrupted == []
     assert "no active" in str(getattr(result, "text", result)).lower()
+
+
+# ---------------------------------------------------------------------------
+# /stop with no active agent still clears a stuck platform status (#32295)
+# ---------------------------------------------------------------------------
+
+
+class _FakeStatusAdapter:
+    def __init__(self):
+        self.cleared = []
+
+    async def _stop_typing_with_metadata(self, chat_id, metadata=None):
+        self.cleared.append((chat_id, metadata))
+
+
+@pytest.mark.asyncio
+async def test_stop_no_active_agent_clears_stuck_status():
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    key = _per_user_key("userA")
+    runner.session_store = _FakeStore(key)
+    runner._is_user_authorized = lambda source: True
+
+    adapter = _FakeStatusAdapter()
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._thread_metadata_for_source = (
+        lambda source, reply_to_message_id=None: {"thread_id": source.thread_id}
+    )
+    runner._reply_anchor_for_event = lambda event: None
+
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+    result = await runner._handle_stop_command(event)
+
+    assert "no active" in str(getattr(result, "text", result)).lower()
+    assert adapter.cleared == [("chan1", {"thread_id": "thr1"})]
+
+
+@pytest.mark.asyncio
+async def test_stop_no_active_agent_survives_status_clear_failure():
+    """A failing adapter clear must not break the /stop reply."""
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    key = _per_user_key("userA")
+    runner.session_store = _FakeStore(key)
+    runner._is_user_authorized = lambda source: True
+
+    class _BoomAdapter:
+        async def _stop_typing_with_metadata(self, chat_id, metadata=None):
+            raise RuntimeError("boom")
+
+    runner.adapters = {Platform.DISCORD: _BoomAdapter()}
+    runner._thread_metadata_for_source = (
+        lambda source, reply_to_message_id=None: None
+    )
+    runner._reply_anchor_for_event = lambda event: None
+
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+    result = await runner._handle_stop_command(event)
+
+    assert "no active" in str(getattr(result, "text", result)).lower()


### PR DESCRIPTION
## Summary

Slack's persistent assistant status ("is thinking...") can no longer get stuck with no way to dismiss it, and the typing indicator resumes after a user answers a clarify prompt. Salvages the two halves of #32340 (@LeonSGP43) and #62248 (@KCAYAAI) that survived the #63709 Agent View merge, adapted to the new workspace-scoped status tracking. Closes #32295.

## Root cause

Two lifecycle gaps remained after #63709:

1. `/stop` with no running agent returned "no active task" without touching the platform status indicator — the exact stuck-status scenario in #32295 (status set by a turn that died without a final send, or by a previous gateway process). Compounding it, `stop_typing` only cleared statuses present in the in-memory tracking map, so a status surviving a gateway restart was permanently unclearable.
2. The clarify prompt path pauses the typing indicator so Slack users can type an answer, but the clarify text-response interception never resumed it — the indicator stayed dead until the 3-minute heartbeat. (`/approve` already resumed; clarify was the asymmetric path.)

## Changes

- `gateway/slash_commands.py`: `/stop`'s no-active-agent branch now best-effort clears the platform status indicator via `_stop_typing_with_metadata`, with thread/workspace routing metadata.
- `plugins/platforms/slack/adapter.py`: `stop_typing` with explicit thread metadata clears the status even when the tracking map has no entry (restart/eviction). The fallback is skipped when multiple Slack Connect workspaces track the same channel+thread and no team_id is given — #63709's cross-workspace safety guarantee is preserved.
- `gateway/run.py`: clarify text-response interception calls `resume_typing_for_chat` so the resumed agent's indicator comes back immediately (cherry-picked from #62248, @KCAYAAI's authorship preserved).
- Tests: untracked-clear, ambiguous-workspace guard, /stop no-active clear + failure tolerance, clarify resume.

## Validation

| | Before | After |
|---|---|---|
| `/stop` with stuck status, no agent | status stays forever | cleared |
| `stop_typing` after gateway restart | unclearable | cleared via explicit metadata |
| Ambiguous Slack Connect channel, no team_id | n/a | refuses to guess (unchanged guarantee) |
| Typing after clarify answer | silent ~3 min | resumes immediately |

Targeted suites green: `test_stop_thread_sibling.py`, `test_slack.py`, `test_clarify_active_session_bypass.py` — 252 tests, 0 failed. E2E: real adapter + real `_handle_stop_command` exercised against all four scenarios with an isolated HERMES_HOME.

Contributor commits cherry-picked with authorship preserved; rebase-merge required.

## Infographic

![Slack status lifecycle gap closure](https://v3b.fal.media/files/b/0aa2442f/0NBdw9UNXV_QZkW6QQwiP_kmH81URR.png)
