### PR TITLE
fix(gateway): safely continue stale model switches after reload

### DIFF
--- a/docs/plans/2026-07-14-code-skew-model-switch-continuation.md
+++ b/docs/plans/2026-07-14-code-skew-model-switch-continuation.md
@@ -1,0 +1,48 @@
+# Code-skew `/model` continuation — completed 2026-07-14
+
+## Problem
+
+The code-skew guard is deliberately process-global: after the checkout changes, a long-lived gateway may lazy-import modules from a mismatched checkout. A `/model` request in one Telegram topic could previously trigger a process restart while an unrelated topic still had an active agent, losing that selection and interrupting unrelated work.
+
+## Implemented behavior
+
+1. A stale `/model` never runs on the stale process. It is converted into a `PendingModelSwitch` and persisted atomically under the active Hermes home.
+2. Persisted payload is intentionally narrow: allowlisted string routing fields (including Telegram `thread_id`), requested model/provider, scope, and an intent ID. It never stores a raw command, callback, event/runtime object, credentials, or nested adapter metadata.
+3. If agents are active, the gateway defers restart. When the actual final active slot releases, it latches `_draining` synchronously before requesting the service-aware restart.
+4. The inbound path checks the drain state both at initial admission and after its final pre-claim topic lookup await. A turn that was already suspended cannot claim a new slot after the safe restart decision.
+5. Fresh startup and platform reconnect replay durable requests serially. Replay invokes the standard `/model` handler directly and acknowledges only after the normalized origin session contains the requested runtime model override.
+6. Replay does not treat adapter task completion, delivery, queueing, or swallowed exceptions as success. Adapter absence, handler errors, a no-commit result, or a second code drift retain the original intent for retry.
+7. A replay marker is runtime-only and excluded from persistence. If checkout drift recurs during replay, the stale guard retains the existing intent rather than enqueueing a duplicate.
+
+## Delivery semantics
+
+The continuation is deliberately **at-least-once**. A crash after switch commit but before durable acknowledgement can repeat the same model selection; repeating an identical selected model is safe. The implementation prefers this over silently dropping the user's request.
+
+## Verification
+
+Final local gates:
+
+```text
+29 passed  tests/test_code_skew.py
+ 3 passed  tests/test_stale_utils_module_import.py
+ 3 passed  tests/gateway/test_model_picker_persist.py
+ 7 passed  tests/gateway/test_telegram_model_picker.py
+40 passed  tests/gateway/test_command_bypass_active_session.py
+50 passed  tests/gateway/test_telegram_thread_fallback.py
+ruff: passed
+py_compile: passed
+git diff --check: passed
+```
+
+The five focused gateway suites were run in separate Python processes. Their combined invocation has an unrelated pre-existing test-order contamination: `test_telegram_thread_fallback.py` passes independently both here and against clean `upstream/main`, but three `chat_type` assertions fail after preceding picker suites in the same process.
+
+## Review record
+
+Independent reviews identified and the final code addresses:
+
+- acknowledge-after-dispatch data loss;
+- zero-agent restart/admission TOCTOU race;
+- acknowledgement of queued or swallowed-failure adapter work;
+- duplicate durable intents after a second checkout drift during replay.
+
+The final focused review passed with the global stale guard, routing isolation, scalar persistence, and no-duplicate replay behavior confirmed.

--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -22,18 +22,188 @@ compiled against the old source (see ``purge_stale_pycache``).
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+import json
 import logging
 import os
 from pathlib import Path
+from typing import Any
+from uuid import uuid4
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _boot_fingerprint: str | None = None
-_last_boot_fingerprint_file = (
-    Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-    / ".gateway_boot_fingerprint"
-)
 
 logger = logging.getLogger("gateway.code_skew")
+
+_PENDING_MODEL_SWITCH_VERSION = 1
+_PENDING_MODEL_SWITCH_SOURCE_FIELDS = frozenset(
+    {
+        "platform",
+        "chat_id",
+        "chat_name",
+        "chat_type",
+        "user_id",
+        "user_name",
+        "thread_id",
+        "chat_topic",
+        "user_id_alt",
+        "chat_id_alt",
+        "scope_id",
+        "guild_id",
+        "parent_chat_id",
+        "message_id",
+        "profile",
+    }
+)
+
+
+def _fingerprint_file() -> Path:
+    """Resolve the boot-fingerprint path at call time for the active profile."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / ".gateway_boot_fingerprint"
+
+
+def _pending_model_switches_file() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / ".pending_model_switches.json"
+
+
+@dataclass(frozen=True)
+class PendingModelSwitch:
+    """A validated model selection that must wait for a fresh gateway process.
+
+    The payload deliberately contains only routing and model-selection data.
+    It never stores a callback, raw event, provider credentials, or arbitrary
+    command text to replay after the reload.
+    """
+
+    source: dict[str, str]
+    model_input: str
+    provider: str | None
+    persist_global: bool
+    replay: bool = False
+    intent_id: str = field(default_factory=lambda: uuid4().hex)
+
+    def __post_init__(self) -> None:
+        # Persist routing scalars only. Source dictionaries can otherwise carry
+        # adapter-private nested metadata that this continuation never needs.
+        object.__setattr__(
+            self,
+            "source",
+            {
+                key: value
+                for key, value in self.source.items()
+                if key in _PENDING_MODEL_SWITCH_SOURCE_FIELDS and isinstance(value, str)
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "intent_id": self.intent_id,
+            "source": {
+                key: value
+                for key, value in self.source.items()
+                if key in _PENDING_MODEL_SWITCH_SOURCE_FIELDS
+            },
+            "model_input": self.model_input,
+            "provider": self.provider,
+            "persist_global": self.persist_global,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "PendingModelSwitch | None":
+        if not isinstance(raw, dict):
+            return None
+        source = raw.get("source")
+        if not isinstance(source, dict) or any(
+            key not in _PENDING_MODEL_SWITCH_SOURCE_FIELDS or not isinstance(value, str)
+            for key, value in source.items()
+        ):
+            return None
+        model_input = raw.get("model_input")
+        provider = raw.get("provider")
+        persist_global = raw.get("persist_global")
+        intent_id = raw.get("intent_id")
+        if not isinstance(source, dict) or not isinstance(model_input, str):
+            return None
+        if provider is not None and not isinstance(provider, str):
+            return None
+        if not isinstance(persist_global, bool) or not isinstance(intent_id, str):
+            return None
+        if not isinstance(source.get("platform"), str) or not isinstance(source.get("chat_id"), str):
+            return None
+        if not intent_id or len(intent_id) > 128:
+            return None
+        if len(model_input) > 1024 or (provider is not None and len(provider) > 256):
+            return None
+        return cls(
+            source={
+                key: value
+                for key, value in source.items()
+                if key in _PENDING_MODEL_SWITCH_SOURCE_FIELDS and isinstance(value, str)
+            },
+            model_input=model_input,
+            provider=provider,
+            persist_global=persist_global,
+            intent_id=intent_id,
+        )
+
+
+def _load_pending_model_switches() -> list[PendingModelSwitch]:
+    try:
+        raw = json.loads(_pending_model_switches_file().read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(raw, dict) or raw.get("version") != _PENDING_MODEL_SWITCH_VERSION:
+        return []
+    entries = raw.get("switches")
+    if not isinstance(entries, list):
+        return []
+    return [intent for item in entries if (intent := PendingModelSwitch.from_dict(item)) is not None]
+
+
+def _write_pending_model_switches(intents: list[PendingModelSwitch]) -> None:
+    path = _pending_model_switches_file()
+    if not intents:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": _PENDING_MODEL_SWITCH_VERSION,
+        "switches": [intent.to_dict() for intent in intents],
+    }
+    temp = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    try:
+        temp.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+        temp.replace(path)
+    finally:
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def enqueue_pending_model_switch(intent: PendingModelSwitch) -> None:
+    """Durably enqueue a typed switch before requesting a code reload."""
+    _write_pending_model_switches([*_load_pending_model_switches(), intent])
+
+
+def peek_pending_model_switch() -> PendingModelSwitch | None:
+    """Return the next continuation without removing its durable record."""
+    intents = _load_pending_model_switches()
+    return intents[0] if intents else None
+
+
+def ack_pending_model_switch(intent_id: str) -> None:
+    """Remove a continuation only after its replay task completed."""
+    _write_pending_model_switches(
+        [intent for intent in _load_pending_model_switches() if intent.intent_id != intent_id]
+    )
 
 
 def _fingerprint() -> str | None:
@@ -69,8 +239,9 @@ def _persist_boot_fingerprint(fingerprint: str | None) -> None:
     if fingerprint is None:
         return
     try:
-        _last_boot_fingerprint_file.parent.mkdir(parents=True, exist_ok=True)
-        _last_boot_fingerprint_file.write_text(fingerprint, encoding="utf-8")
+        path = _fingerprint_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(fingerprint, encoding="utf-8")
     except Exception:
         logger.debug("Failed to persist boot fingerprint", exc_info=True)
 
@@ -91,7 +262,7 @@ def purge_stale_pycache() -> bool:
     if current is None:
         return False
     try:
-        previous = _last_boot_fingerprint_file.read_text(encoding="utf-8").strip()
+        previous = _fingerprint_file().read_text(encoding="utf-8").strip()
     except (FileNotFoundError, OSError):
         return False
     if not previous or previous == current:

--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -13,14 +13,27 @@ gateway" message instead of crashing on a cryptic import error.
 
 If the revision can't be read (non-git install, IO error), the boot snapshot
 stays ``None`` and skew detection no-ops — it never produces a false positive.
+
+We also persist the boot fingerprint to ``HERMES_HOME`` so the next gateway
+boot can detect that the checkout advanced while the previous gateway was
+running, and purge stale ``__pycache__`` before any import picks up bytecode
+compiled against the old source (see ``purge_stale_pycache``).
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _boot_fingerprint: str | None = None
+_last_boot_fingerprint_file = (
+    Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    / ".gateway_boot_fingerprint"
+)
+
+logger = logging.getLogger("gateway.code_skew")
 
 
 def _fingerprint() -> str | None:
@@ -39,10 +52,70 @@ def _fingerprint() -> str | None:
 
 
 def record_boot_fingerprint() -> None:
-    """Snapshot the checkout revision at gateway startup (idempotent)."""
+    """Snapshot the checkout revision at gateway startup (idempotent).
+
+    Also persists the fingerprint to ``HERMES_HOME`` so the next boot can
+    detect drift and purge stale ``__pycache__`` before imports pick up
+    bytecode compiled against the old source.
+    """
     global _boot_fingerprint
     if _boot_fingerprint is None:
         _boot_fingerprint = _fingerprint()
+    _persist_boot_fingerprint(_boot_fingerprint)
+
+
+def _persist_boot_fingerprint(fingerprint: str | None) -> None:
+    """Write the boot fingerprint to ``HERMES_HOME`` for next-boot comparison."""
+    if fingerprint is None:
+        return
+    try:
+        _last_boot_fingerprint_file.parent.mkdir(parents=True, exist_ok=True)
+        _last_boot_fingerprint_file.write_text(fingerprint, encoding="utf-8")
+    except Exception:
+        logger.debug("Failed to persist boot fingerprint", exc_info=True)
+
+
+def purge_stale_pycache() -> bool:
+    """Purge stale ``__pycache__`` directories if the checkout advanced.
+
+    At gateway boot, compares the persisted fingerprint from the *previous*
+    gateway run with the current checkout. If they differ, Python's
+    ``__pycache__`` may contain bytecode compiled against the old source
+    (``.pyc`` files whose header mtime matches the old ``.py`` because git
+    operations can preserve mtime). Deleting the ``__pycache__`` dirs forces
+    a clean recompile on first import.
+
+    Returns ``True`` if a purge was performed, ``False`` otherwise.
+    """
+    current = _fingerprint()
+    if current is None:
+        return False
+    try:
+        previous = _last_boot_fingerprint_file.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return False
+    if not previous or previous == current:
+        return False
+
+    purged = 0
+    for pycache in _PROJECT_ROOT.rglob("__pycache__"):
+        # Skip .venv and node_modules to avoid slow/unnecessary I/O
+        if ".venv" in pycache.parts or "node_modules" in pycache.parts:
+            continue
+        try:
+            for pyc in pycache.glob("*.pyc"):
+                pyc.unlink()
+                purged += 1
+        except OSError:
+            pass
+    if purged:
+        logger.info(
+            "Purged %d stale .pyc file(s) — checkout advanced from %s to %s",
+            purged,
+            _short(previous),
+            _short(current),
+        )
+    return purged > 0
 
 
 def _short(fingerprint: str) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4415,6 +4415,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _status_action_gerund(self) -> str:
         return "restarting" if self._restart_requested else "shutting down"
 
+    def _new_turn_drain_message(self) -> str | None:
+        """Return the admission refusal if a shutdown/restart drain is latched."""
+        if not self._draining:
+            return None
+        return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+
+    async def _topic_root_lobby_or_drain(
+        self, source: SessionSource
+    ) -> tuple[bool, str | None]:
+        """Run the final pre-claim await and re-check the normal drain gate.
+
+        The thread worker can yield long enough for an unrelated final agent
+        release to start a code-skew restart.  The returned drain message must
+        be handled before the caller claims a new agent slot.
+        """
+        if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
+            if self._should_send_telegram_lobby_reminder(source):
+                return True, self._telegram_topic_root_lobby_message()
+            return True, None
+        return False, self._new_turn_drain_message()
+
     def _queue_during_drain_enabled(self) -> bool:
         # Both "queue" and "steer" modes imply the user doesn't want messages
         # to be lost during restart — queue them for the newly-spawned gateway
@@ -6504,6 +6525,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.debug("Failed to launch systemd planned-restart helper: %s", e)
 
+    def _request_code_skew_restart(self) -> bool:
+        """Restart through the same managed-service path as ``/restart``."""
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
+        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        return self.request_restart(
+            detached=not (_under_service or _in_container),
+            via_service=_under_service or _in_container,
+        )
+
+    def defer_code_skew_model_switch(self, intent: Any) -> bool:
+        """Queue a stale-process model switch and reload only when idle.
+
+        The continuation is persisted before any restart is requested.  A code
+        skew is global, but an immediate global restart must not cut off an
+        unrelated Telegram topic merely because a second topic selected a
+        model.
+        """
+        from gateway.code_skew import enqueue_pending_model_switch
+
+        enqueue_pending_model_switch(intent)
+        self._code_skew_restart_when_idle = True
+        return self._start_deferred_code_skew_restart_if_idle()
+
+    def _start_deferred_code_skew_restart_if_idle(self) -> bool:
+        if not getattr(self, "_code_skew_restart_when_idle", False):
+            return False
+        if self._running_agent_count() or getattr(self, "_restart_requested", False):
+            return False
+        # Latch the normal new-turn gate in the same synchronous turn as the
+        # zero-agent observation.  request_restart() yields before stop() sets
+        # this flag, and admitting a fresh agent in that window would make the
+        # ensuing global restart interrupt unrelated work.
+        self._draining = True
+        self._code_skew_restart_when_idle = False
+        started = self._request_code_skew_restart()
+        if not started:
+            self._draining = False
+            self._code_skew_restart_when_idle = True
+        return started
+
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
         if self._restart_task_started:
             return False
@@ -6632,6 +6695,115 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._startup_restore_in_progress = False
         if drained:
             logger.info("Drained %d inbound message(s) queued during startup restore", drained)
+
+    async def _replay_pending_code_skew_model_switches(self) -> None:
+        """Serialize durable-model replay across startup and reconnect events."""
+        lock = getattr(self, "_pending_model_switch_replay_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._pending_model_switch_replay_lock = lock
+        async with lock:
+            await self._replay_pending_code_skew_model_switches_once()
+
+    def _pending_model_switch_applied(self, intent, source: SessionSource) -> bool:
+        """Verify the direct `/model` handler committed the requested override.
+
+        A reply can be delivered for both a success and a validation/error path,
+        so adapter task completion is not evidence that a switch occurred. The
+        handler commits this runtime override only after the model resolution
+        and agent/session update succeeded.
+        """
+        session_key = self._session_key_for_source(source)
+        overrides = getattr(self, "_session_model_overrides", {})
+        override = overrides.get(session_key) if isinstance(overrides, dict) else None
+        if not isinstance(override, dict):
+            return False
+        if intent.model_input and override.get("model") != intent.model_input:
+            return False
+        if intent.provider and override.get("provider") != intent.provider:
+            return False
+        return True
+
+    async def _replay_pending_code_skew_model_switches_once(self) -> None:
+        """Replay one durable stale-checkout model request at a time.
+
+        The record remains durable until the direct `/model` handler commits
+        the requested session override. This avoids treating adapter delivery,
+        a queued busy follow-up, or a swallowed handler exception as success.
+        """
+        from gateway.code_skew import ack_pending_model_switch, peek_pending_model_switch
+
+        while (intent := peek_pending_model_switch()) is not None:
+            try:
+                source = SessionSource.from_dict(intent.source)
+                adapter = self._adapter_for_source(source)
+                if adapter is None:
+                    logger.warning(
+                        "Retaining deferred code-skew /model switch: no adapter for %s",
+                        source.platform.value,
+                    )
+                    return
+                source = await asyncio.to_thread(self._normalize_source_for_session_key, source)
+                args: list[str] = []
+                if intent.model_input:
+                    args.append(shlex.quote(intent.model_input))
+                if intent.provider:
+                    args.extend(("--provider", shlex.quote(intent.provider)))
+                args.append("--global" if intent.persist_global else "--session")
+                event = MessageEvent(
+                    text=f"/model {' '.join(args)}",
+                    message_type=MessageType.COMMAND,
+                    source=source,
+                    message_id=source.message_id,
+                    internal=True,
+                )
+                event._code_skew_model_replay = True
+                response = await self._handle_model_command(event)
+                if not self._pending_model_switch_applied(intent, source):
+                    logger.warning(
+                        "Deferred code-skew /model switch %s did not commit; retaining request",
+                        intent.intent_id,
+                    )
+                    if response:
+                        try:
+                            reply_anchor = self._reply_anchor_for_event(event)
+                            await adapter._send_with_retry(
+                                chat_id=source.chat_id,
+                                content=str(response),
+                                reply_to=reply_anchor,
+                                metadata=self._thread_metadata_for_source(source, reply_anchor),
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Failed to deliver deferred code-skew /model error",
+                                exc_info=True,
+                            )
+                    return
+                ack_pending_model_switch(intent.intent_id)
+                logger.info(
+                    "Completed deferred code-skew /model switch %s for %s:%s:%s",
+                    intent.intent_id,
+                    source.platform.value,
+                    source.chat_id,
+                    source.thread_id or "",
+                )
+                if response:
+                    try:
+                        reply_anchor = self._reply_anchor_for_event(event)
+                        await adapter._send_with_retry(
+                            chat_id=source.chat_id,
+                            content=str(response),
+                            reply_to=reply_anchor,
+                            metadata=self._thread_metadata_for_source(source, reply_anchor),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to deliver deferred code-skew /model confirmation",
+                            exc_info=True,
+                        )
+            except Exception:
+                logger.exception("Deferred code-skew /model replay failed; retaining request")
+                return
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
@@ -7412,6 +7584,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # visible for manual recovery on the next user message.
         self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
+        await self._replay_pending_code_skew_model_switches()
 
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
@@ -8035,6 +8208,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception:
                             logger.debug(
                                 "resume-pending reschedule after %s reconnect failed",
+                                platform.value,
+                                exc_info=True,
+                            )
+                        # A stale-checkout model request whose source adapter
+                        # was unavailable during startup remains durable. Retry
+                        # it now that an adapter reconnect has completed.
+                        try:
+                            task = asyncio.create_task(
+                                self._replay_pending_code_skew_model_switches()
+                            )
+                            self._background_tasks.add(task)
+                            task.add_done_callback(self._background_tasks.discard)
+                        except Exception:
+                            logger.debug(
+                                "deferred code-skew /model replay after %s reconnect failed",
                                 platform.value,
                                 exc_info=True,
                             )
@@ -10089,8 +10277,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
-        if self._draining:
-            return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+        if drain_message := self._new_turn_drain_message():
+            return drain_message
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
@@ -10322,12 +10510,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
-        if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
-            # Debounce the lobby reminder so a user who forgets about
-            # topic mode and fires ten prompts doesn't get ten copies.
-            if self._should_send_telegram_lobby_reminder(source):
-                return self._telegram_topic_root_lobby_message()
-            return None
+        topic_root_handled, post_yield_drain_message = await self._topic_root_lobby_or_drain(source)
+        if topic_root_handled:
+            return post_yield_drain_message
 
         # ── External-drain new-turn gate (Phase 2) ────────────────────
         # When NAS has engaged an external drain (.drain_request.json present,
@@ -10349,6 +10534,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "accepting new turns right now. It'll be back in a moment — "
                 "please resend shortly."
             )
+
+        if post_yield_drain_message:
+            return post_yield_drain_message
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
@@ -16245,6 +16433,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # between lifecycle transitions.  Preserves gateway_state (see
         # _persist_active_agents).
         self._persist_active_agents()
+        # A code-skew model change is intentionally deferred while another
+        # session is working. The final release is the safe point where a
+        # global reload can be requested without interrupting that work.
+        if not self._running_agents:
+            self._start_deferred_code_skew_restart_if_idle()
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20597,7 +20597,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # so a later `git pull` under this long-lived process can be detected (and
     # risky work like model switching refused) instead of crashing on a stale
     # in-memory module.
-    from gateway.code_skew import record_boot_fingerprint
+    from gateway.code_skew import purge_stale_pycache, record_boot_fingerprint
+
+    # If the checkout advanced while the previous gateway was running, purge
+    # stale __pycache__ before any import picks up bytecode compiled against
+    # the old source (git can preserve .py mtime, so .pyc headers match the
+    # old source even after a pull — Python won't recompile, and the stale
+    # bytecode causes cryptic crashes like ValueError: too many values to
+    # unpack with mismatched traceback line numbers).
+    purge_stale_pycache()
     record_boot_fingerprint()
 
     # ── Duplicate-instance guard ──────────────────────────────────────

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -27,18 +27,14 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Protocol, Union, runtime_checkable
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, cast, runtime_checkable
 
 
 @runtime_checkable
-class _RestartableRunner(Protocol):
-    """Structural type for the gateway runner's restart capability.
+class _CodeSkewModelSwitchRunner(Protocol):
+    """Runner capability used to defer a switch until a safe reload boundary."""
 
-    Avoids a hard import dependency on ``GatewayRunner`` (which would create a
-    cycle) while letting the skew guard trigger a graceful restart.
-    """
-
-    def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool: ...
+    def defer_code_skew_model_switch(self, intent: PendingModelSwitch) -> bool: ...
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
@@ -59,6 +55,9 @@ from utils import (
 
 logger = logging.getLogger("gateway.run")
 
+if TYPE_CHECKING:
+    from gateway.code_skew import PendingModelSwitch
+
 # Upper bound on the off-loop agent-resource cleanup during a /new or /reset
 # (see _handle_reset_command). A stuck teardown must not block the event loop;
 # past this the reset proceeds and the cleanup is left to finish (or leak) in
@@ -66,22 +65,20 @@ logger = logging.getLogger("gateway.run")
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
 
-def _model_switch_skew_guard(runner: Optional[_RestartableRunner] = None) -> Optional[str]:
-    """Refuse a model switch when the gateway is running stale code.
+def _model_switch_skew_guard(
+    runner: Optional[_CodeSkewModelSwitchRunner] = None,
+    continuation: Optional[PendingModelSwitch] = None,
+) -> Optional[str]:
+    """Refuse stale-process switching but preserve the requested selection.
 
     A long-lived gateway holds its modules in memory from boot. If the checkout
-    changed underneath it (e.g. a manual ``git pull``), switching models can hit
-    a first-time lazy import on a new code path and crash on a stale cached
-    dependency — the cryptic ``cannot import name 'env_float' from 'utils'``.
-
-    When ``runner`` is provided and drift is detected, trigger a graceful
-    restart via ``runner.request_restart()`` so the gateway reloads the new code
-    automatically — the user no longer needs to restart manually from a
-    separate shell (which is hard inside the gateway process itself).
+    changed underneath it, model switching can hit a first-time lazy import on a
+    new code path and crash on a stale cached dependency. The stale process must
+    not switch models. When a runner accepts a typed continuation, it persists
+    that request and reloads only once unrelated active work reaches a safe
+    boundary.
 
     Intentionally scoped to model switching — the known, highest-risk trigger.
-    Any first-time lazy import on a stale process is technically exposed; we
-    don't guard every import site, only this one.
     """
     from gateway.code_skew import detect_code_skew
 
@@ -89,33 +86,36 @@ def _model_switch_skew_guard(runner: Optional[_RestartableRunner] = None) -> Opt
     if not skew:
         return None
     boot_rev, disk_rev = skew
-
-    # Trigger a graceful restart so the gateway reloads the new code
-    # automatically. The user can re-run /model after restart completes.
-    # Mirror the environment-detection logic from _handle_restart_command
-    # so the restart uses the same path (service-managed vs detached) the
-    # /restart command would pick — the defaults (detached=False,
-    # via_service=False) match neither path and can leave the gateway
-    # stopped instead of restarted.
-    if runner is not None:
-        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
-            "XPC_SERVICE_NAME", "0"
-        ) not in ("", "0")
-        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        restarted = runner.request_restart(
-            detached=not (_under_service or _in_container),
-            via_service=_under_service or _in_container,
+    # A replay retains its original durable record until this handler commits.
+    # If the checkout drifts again before that point, do not enqueue a second
+    # copy: refuse the stale execution and let the outer replay retry the same
+    # intent after the next fresh process starts.
+    if continuation is not None and continuation.replay:
+        return t(
+            "gateway.model.error_prefix",
+            error=(
+                f"This gateway is running code from {boot_rev} but the checkout on "
+                f"disk is now {disk_rev}. The deferred model switch remains queued "
+                "for the next safe reload."
+            ),
         )
-        if restarted:
-            return t(
-                "gateway.model.error_prefix",
-                error=(
-                    f"Gateway is running code from {boot_rev} but the checkout "
-                    f"on disk is now {disk_rev}. Restarting to load the new code "
-                    f"— re-run /model after restart to switch."
-                ),
-            )
-
+    if runner is not None and continuation is not None:
+        try:
+            restarting = runner.defer_code_skew_model_switch(continuation)
+        except Exception:
+            logger.warning("Failed to defer code-skew model switch", exc_info=True)
+        else:
+            if restarting:
+                detail = (
+                    "The requested model switch was safely queued and the gateway is "
+                    "restarting to load the new code. It will be retried after the reload."
+                )
+            else:
+                detail = (
+                    "The requested model switch was safely queued and will be retried after "
+                    "active work completes and the gateway reloads."
+                )
+            return t("gateway.model.error_prefix", error=detail)
     return t(
         "gateway.model.error_prefix",
         error=(
@@ -1563,7 +1563,17 @@ class GatewaySlashCommandsMixin:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
-                        skew_error = _model_switch_skew_guard(runner=_self)
+                        from gateway.code_skew import PendingModelSwitch
+
+                        skew_error = _model_switch_skew_guard(
+                            runner=cast(_CodeSkewModelSwitchRunner, _self),
+                            continuation=PendingModelSwitch(
+                                source=source.to_dict(),
+                                model_input=model_id,
+                                provider=provider_slug,
+                                persist_global=persist_global,
+                            ),
+                        )
                         if skew_error:
                             return skew_error
                         # Offload the switch off the event loop — switch_model()
@@ -1806,7 +1816,18 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         # Perform the switch
-        skew_error = _model_switch_skew_guard(runner=self)
+        from gateway.code_skew import PendingModelSwitch
+
+        skew_error = _model_switch_skew_guard(
+            runner=cast(_CodeSkewModelSwitchRunner, self),
+            continuation=PendingModelSwitch(
+                source=source.to_dict(),
+                model_input=model_input,
+                provider=explicit_provider,
+                persist_global=persist_global,
+                replay=bool(getattr(event, "_code_skew_model_replay", False)),
+            ),
+        )
         if skew_error:
             return skew_error
         # Offload the switch off the event loop — switch_model() can fall

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -27,7 +27,18 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Protocol, Union, runtime_checkable
+
+
+@runtime_checkable
+class _RestartableRunner(Protocol):
+    """Structural type for the gateway runner's restart capability.
+
+    Avoids a hard import dependency on ``GatewayRunner`` (which would create a
+    cycle) while letting the skew guard trigger a graceful restart.
+    """
+
+    def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool: ...
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
@@ -55,14 +66,18 @@ logger = logging.getLogger("gateway.run")
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
 
-def _model_switch_skew_guard() -> Optional[str]:
+def _model_switch_skew_guard(runner: Optional[_RestartableRunner] = None) -> Optional[str]:
     """Refuse a model switch when the gateway is running stale code.
 
     A long-lived gateway holds its modules in memory from boot. If the checkout
     changed underneath it (e.g. a manual ``git pull``), switching models can hit
     a first-time lazy import on a new code path and crash on a stale cached
     dependency — the cryptic ``cannot import name 'env_float' from 'utils'``.
-    Detect the drift and tell the user to restart instead.
+
+    When ``runner`` is provided and drift is detected, trigger a graceful
+    restart via ``runner.request_restart()`` so the gateway reloads the new code
+    automatically — the user no longer needs to restart manually from a
+    separate shell (which is hard inside the gateway process itself).
 
     Intentionally scoped to model switching — the known, highest-risk trigger.
     Any first-time lazy import on a stale process is technically exposed; we
@@ -74,6 +89,33 @@ def _model_switch_skew_guard() -> Optional[str]:
     if not skew:
         return None
     boot_rev, disk_rev = skew
+
+    # Trigger a graceful restart so the gateway reloads the new code
+    # automatically. The user can re-run /model after restart completes.
+    # Mirror the environment-detection logic from _handle_restart_command
+    # so the restart uses the same path (service-managed vs detached) the
+    # /restart command would pick — the defaults (detached=False,
+    # via_service=False) match neither path and can leave the gateway
+    # stopped instead of restarted.
+    if runner is not None:
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
+        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        restarted = runner.request_restart(
+            detached=not (_under_service or _in_container),
+            via_service=_under_service or _in_container,
+        )
+        if restarted:
+            return t(
+                "gateway.model.error_prefix",
+                error=(
+                    f"Gateway is running code from {boot_rev} but the checkout "
+                    f"on disk is now {disk_rev}. Restarting to load the new code "
+                    f"— re-run /model after restart to switch."
+                ),
+            )
+
     return t(
         "gateway.model.error_prefix",
         error=(
@@ -1521,7 +1563,7 @@ class GatewaySlashCommandsMixin:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
-                        skew_error = _model_switch_skew_guard()
+                        skew_error = _model_switch_skew_guard(runner=_self)
                         if skew_error:
                             return skew_error
                         # Offload the switch off the event loop — switch_model()
@@ -1764,7 +1806,7 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         # Perform the switch
-        skew_error = _model_switch_skew_guard()
+        skew_error = _model_switch_skew_guard(runner=self)
         if skew_error:
             return skew_error
         # Offload the switch off the event loop — switch_model() can fall

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -77,3 +77,78 @@ class TestModelSwitchSkewGuard:
         assert "abc1234567" in msg
         assert "def4567890" in msg
         assert "hermes gateway restart" in msg
+
+    def test_guard_triggers_graceful_restart_when_runner_provided(self, monkeypatch):
+        """When a runner is passed, the guard triggers a graceful restart
+        instead of only telling the user to restart manually."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        calls = []
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                calls.append((detached, via_service))
+                return True
+
+        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert msg is not None
+        assert "Restarting to load the new code" in msg
+        assert "re-run /model after restart" in msg
+        assert len(calls) == 1  # request_restart was called exactly once
+
+    def test_guard_falls_back_to_manual_when_restart_fails(self, monkeypatch):
+        """If request_restart returns False (e.g. already restarting), the
+        guard falls back to the manual restart message."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                return False  # restart already in progress
+
+        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert msg is not None
+        assert "hermes gateway restart" in msg  # manual fallback
+
+    def test_guard_falls_back_to_manual_without_runner(self, monkeypatch):
+        """Without a runner, the guard returns the manual restart message
+        (preserving backwards compatibility for any caller not yet passing one)."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        msg = slash_commands._model_switch_skew_guard()
+        assert msg is not None
+        assert "hermes gateway restart" in msg
+
+    def test_guard_passes_correct_restart_flags_for_env(self, monkeypatch):
+        """The guard must mirror _handle_restart_command's environment
+        detection: under launchd/systemd or in a container, use the service
+        path (via_service=True); otherwise detached=True. The defaults
+        (detached=False, via_service=False) match neither path and can
+        leave the gateway stopped instead of restarted."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+
+        calls = []
+
+        class FakeRunner:
+            def request_restart(self, *, detached=False, via_service=False):
+                calls.append((detached, via_service))
+                return True
+
+        # Simulate macOS launchd (XPC_SERVICE_NAME set, not "0")
+        monkeypatch.setenv("XPC_SERVICE_NAME", "com.apple.xpc.launchd")
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert calls == [(False, True)], f"service path expected, got {calls}"
+
+        # Simulate plain shell (no service manager) → detached path
+        calls.clear()
+        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        assert calls == [(True, False)], f"detached path expected, got {calls}"

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -5,6 +5,8 @@ crash; these prove the guard that turns it into a clear "restart the gateway"
 message before a model switch can hit it.
 """
 
+import asyncio
+
 import pytest
 
 from gateway import code_skew
@@ -14,6 +16,24 @@ from gateway import code_skew
 def _reset_boot_fingerprint(monkeypatch):
     """Each test starts with no recorded boot fingerprint."""
     monkeypatch.setattr(code_skew, "_boot_fingerprint", None)
+
+
+def _pending_intent() -> code_skew.PendingModelSwitch:
+    return code_skew.PendingModelSwitch(
+        source={
+            "platform": "telegram",
+            "chat_id": "-1003418564280",
+            "chat_type": "group",
+            "user_id": "29264781",
+            "thread_id": "3006",
+            "message_id": "987",
+            "profile": "default",
+            "api_key": "must-not-persist",
+        },
+        model_input="openai/gpt-5.6",
+        provider="openai-codex",
+        persist_global=False,
+    )
 
 
 class TestDetectCodeSkew:
@@ -78,40 +98,67 @@ class TestModelSwitchSkewGuard:
         assert "def4567890" in msg
         assert "hermes gateway restart" in msg
 
-    def test_guard_triggers_graceful_restart_when_runner_provided(self, monkeypatch):
-        """When a runner is passed, the guard triggers a graceful restart
-        instead of only telling the user to restart manually."""
+    def test_guard_queues_typed_intent_when_runner_provided(self, monkeypatch):
+        """Stale code queues the switch instead of executing it or cutting work."""
         from gateway import slash_commands
 
         monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
-
+        intent = _pending_intent()
         calls = []
 
         class FakeRunner:
-            def request_restart(self, *, detached=False, via_service=False):
-                calls.append((detached, via_service))
-                return True
+            def defer_code_skew_model_switch(self, queued_intent):
+                calls.append(queued_intent)
+                return False  # unrelated topic is still active
 
-        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        msg = slash_commands._model_switch_skew_guard(
+            runner=FakeRunner(), continuation=intent
+        )
         assert msg is not None
-        assert "Restarting to load the new code" in msg
-        assert "re-run /model after restart" in msg
-        assert len(calls) == 1  # request_restart was called exactly once
+        assert "safely queued" in msg
+        assert "after active work completes" in msg
+        assert calls == [intent]
 
-    def test_guard_falls_back_to_manual_when_restart_fails(self, monkeypatch):
-        """If request_restart returns False (e.g. already restarting), the
-        guard falls back to the manual restart message."""
+    def test_replay_guard_does_not_enqueue_duplicate_intent_on_fresh_drift(self, monkeypatch):
+        """The original durable intent owns retries across a second checkout drift."""
+        from gateway import slash_commands
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        calls = []
+
+        class FakeRunner:
+            def defer_code_skew_model_switch(self, queued_intent):
+                calls.append(queued_intent)
+                return False
+
+        intent = code_skew.PendingModelSwitch(
+            source=_pending_intent().source,
+            model_input="openai/gpt-5.6",
+            provider="openai-codex",
+            persist_global=False,
+            replay=True,
+        )
+        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner(), continuation=intent)
+
+        assert msg is not None
+        assert "remains queued" in msg
+        assert calls == []
+
+    def test_guard_falls_back_to_manual_when_queueing_fails(self, monkeypatch):
+        """If durable queueing fails, preserve the original safe manual guard."""
         from gateway import slash_commands
 
         monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
 
         class FakeRunner:
-            def request_restart(self, *, detached=False, via_service=False):
-                return False  # restart already in progress
+            def defer_code_skew_model_switch(self, queued_intent):
+                raise OSError("state unavailable")
 
-        msg = slash_commands._model_switch_skew_guard(runner=FakeRunner())
+        msg = slash_commands._model_switch_skew_guard(
+            runner=FakeRunner(), continuation=_pending_intent()
+        )
         assert msg is not None
-        assert "hermes gateway restart" in msg  # manual fallback
+        assert "hermes gateway restart" in msg
 
     def test_guard_falls_back_to_manual_without_runner(self, monkeypatch):
         """Without a runner, the guard returns the manual restart message
@@ -123,35 +170,78 @@ class TestModelSwitchSkewGuard:
         assert msg is not None
         assert "hermes gateway restart" in msg
 
-    def test_guard_passes_correct_restart_flags_for_env(self, monkeypatch):
-        """The guard must mirror _handle_restart_command's environment
-        detection: under launchd/systemd or in a container, use the service
-        path (via_service=True); otherwise detached=True. The defaults
-        (detached=False, via_service=False) match neither path and can
-        leave the gateway stopped instead of restarted."""
-        from gateway import slash_commands
+    def test_runner_restarts_only_after_last_active_topic_finishes(self, monkeypatch):
+        from gateway.run import GatewayRunner
 
-        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
-
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._running_agents = {"telegram:-1003418564280:1270": object()}
+        runner._running_agents_ts = {}
+        runner._active_session_leases = {}
+        runner._busy_ack_ts = {}
+        runner._restart_task_started = False
+        runner._restart_requested = False
+        runner._draining = False
+        runner._persist_active_agents = lambda: None
+        queued = []
         calls = []
+        monkeypatch.setattr(code_skew, "enqueue_pending_model_switch", queued.append)
 
-        class FakeRunner:
-            def request_restart(self, *, detached=False, via_service=False):
-                calls.append((detached, via_service))
-                return True
+        def request_restart(**kwargs):
+            calls.append(kwargs)
+            runner._restart_requested = True
+            return True
 
-        # Simulate macOS launchd (XPC_SERVICE_NAME set, not "0")
+        monkeypatch.setattr(runner, "request_restart", request_restart)
         monkeypatch.setenv("XPC_SERVICE_NAME", "com.apple.xpc.launchd")
-        monkeypatch.delenv("INVOCATION_ID", raising=False)
-        slash_commands._model_switch_skew_guard(runner=FakeRunner())
-        assert calls == [(False, True)], f"service path expected, got {calls}"
 
-        # Simulate plain shell (no service manager) → detached path
-        calls.clear()
-        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
-        monkeypatch.delenv("INVOCATION_ID", raising=False)
-        slash_commands._model_switch_skew_guard(runner=FakeRunner())
-        assert calls == [(True, False)], f"detached path expected, got {calls}"
+        assert runner.defer_code_skew_model_switch(_pending_intent()) is False
+        assert runner._new_turn_drain_message() is None
+        assert queued
+        assert calls == []
+
+        runner._release_running_agent_state("telegram:-1003418564280:1270")
+        assert runner._draining is True
+        assert "restarting" in runner._new_turn_drain_message()
+        assert calls == [{"detached": False, "via_service": True}]
+
+    @pytest.mark.asyncio
+    async def test_post_lookup_gate_blocks_turn_when_last_agent_finishes_during_yield(self, monkeypatch):
+        """The final pre-claim await must not admit work after a code-skew drain latches."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        session_key = "telegram:-1003418564280:1270"
+        runner._running_agents = {session_key: object()}
+        runner._running_agents_ts = {}
+        runner._active_session_leases = {}
+        runner._busy_ack_ts = {}
+        runner._restart_task_started = False
+        runner._restart_requested = False
+        runner._draining = False
+        runner._code_skew_restart_when_idle = True
+        runner._persist_active_agents = lambda: None
+        restart_calls = []
+
+        def request_restart(**kwargs):
+            restart_calls.append(kwargs)
+            runner._restart_requested = True
+            return True
+
+        runner.request_restart = request_restart
+        monkeypatch.setenv("XPC_SERVICE_NAME", "com.apple.xpc.launchd")
+
+        def finish_last_agent_during_lookup(_source):
+            runner._release_running_agent_state(session_key)
+            return False
+
+        runner._is_telegram_topic_root_lobby = finish_last_agent_during_lookup
+        handled, post_yield_drain_message = await runner._topic_root_lobby_or_drain(None)
+
+        assert handled is False
+        assert post_yield_drain_message is not None
+        assert "restarting" in post_yield_drain_message
+        assert runner._running_agents == {}
+        assert restart_calls == [{"detached": False, "via_service": True}]
 
 
 class TestPurgeStalePycache:
@@ -161,7 +251,7 @@ class TestPurgeStalePycache:
     def test_no_purge_when_previous_fingerprint_missing(self, monkeypatch, tmp_path):
         """No persisted fingerprint file → nothing to compare → no purge."""
         monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
-        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", tmp_path / "nonexistent")
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: tmp_path / "nonexistent")
         monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
         assert code_skew.purge_stale_pycache() is False
 
@@ -170,7 +260,7 @@ class TestPurgeStalePycache:
         fp_file = tmp_path / ".gateway_boot_fingerprint"
         fp_file.write_text("git:refs/heads/main:abc1234567")
         monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
-        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
         monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
         assert code_skew.purge_stale_pycache() is False
 
@@ -179,7 +269,7 @@ class TestPurgeStalePycache:
         fp_file = tmp_path / ".gateway_boot_fingerprint"
         fp_file.write_text("git:refs/heads/main:oldhash123")
         monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
-        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
         monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
 
         # Create a fake __pycache__ with .pyc files
@@ -197,7 +287,7 @@ class TestPurgeStalePycache:
         fp_file = tmp_path / ".gateway_boot_fingerprint"
         fp_file.write_text("git:refs/heads/main:oldhash123")
         monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
-        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
         monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
 
         venv_pycache = tmp_path / ".venv" / "lib" / "__pycache__"
@@ -210,7 +300,7 @@ class TestPurgeStalePycache:
     def test_no_purge_when_fingerprint_unreadable(self, monkeypatch, tmp_path):
         """If _fingerprint returns None (non-git), no purge."""
         monkeypatch.setattr(code_skew, "_fingerprint", lambda: None)
-        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", tmp_path / "x")
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: tmp_path / "x")
         monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
         assert code_skew.purge_stale_pycache() is False
 
@@ -218,12 +308,144 @@ class TestPurgeStalePycache:
 class TestPersistBootFingerprint:
     def test_persists_fingerprint_to_file(self, monkeypatch, tmp_path):
         fp_file = tmp_path / ".gateway_boot_fingerprint"
-        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
         code_skew._persist_boot_fingerprint("git:refs/heads/main:abcdef1234")
         assert fp_file.read_text() == "git:refs/heads/main:abcdef1234"
 
     def test_does_not_persist_none(self, monkeypatch, tmp_path):
         fp_file = tmp_path / ".gateway_boot_fingerprint"
-        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_fingerprint_file", lambda: fp_file)
         code_skew._persist_boot_fingerprint(None)
         assert not fp_file.exists()
+
+
+class TestPendingModelSwitch:
+    def test_queue_preserves_topic_and_never_serializes_secrets(self, monkeypatch, tmp_path):
+        state_file = tmp_path / ".pending_model_switches.json"
+        monkeypatch.setattr(code_skew, "_pending_model_switches_file", lambda: state_file)
+        intent = code_skew.PendingModelSwitch(
+            source=_pending_intent().source,
+            model_input="openai/gpt-5.6",
+            provider="openai-codex",
+            persist_global=False,
+            replay=True,
+        )
+
+        code_skew.enqueue_pending_model_switch(intent)
+
+        stored = state_file.read_text(encoding="utf-8")
+        assert "api_key" not in stored
+        assert "must-not-persist" not in stored
+        assert '"replay"' not in stored
+        pending = code_skew.peek_pending_model_switch()
+        assert pending is not None
+        assert pending.model_input == intent.model_input
+        assert pending.provider == intent.provider
+        assert pending.persist_global is intent.persist_global
+        assert pending.replay is False
+        assert pending.source["thread_id"] == "3006"
+        assert "api_key" not in pending.source
+        code_skew.ack_pending_model_switch(pending.intent_id)
+        assert code_skew.peek_pending_model_switch() is None
+
+    @pytest.mark.asyncio
+    async def test_fresh_gateway_replays_switch_in_original_topic(self, monkeypatch, tmp_path):
+        from gateway.run import GatewayRunner
+
+        state_file = tmp_path / ".pending_model_switches.json"
+        monkeypatch.setattr(code_skew, "_pending_model_switches_file", lambda: state_file)
+        intent = _pending_intent()
+        code_skew.enqueue_pending_model_switch(intent)
+        events = []
+
+        class FakeAdapter:
+            pass
+
+        adapter = FakeAdapter()
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._adapter_for_source = lambda source: adapter
+        runner._normalize_source_for_session_key = lambda source: source
+        runner._session_key_for_source = lambda source: "telegram:-1003418564280:3006"
+        runner._session_model_overrides = {}
+        completed = asyncio.Event()
+
+        async def handle_model(event):
+            events.append(event)
+            await completed.wait()
+            runner._session_model_overrides["telegram:-1003418564280:3006"] = {
+                "model": intent.model_input,
+                "provider": intent.provider,
+            }
+            return None
+
+        runner._handle_model_command = handle_model
+        replay_task = asyncio.create_task(runner._replay_pending_code_skew_model_switches())
+        duplicate_replay_task = asyncio.create_task(runner._replay_pending_code_skew_model_switches())
+        await asyncio.sleep(0)
+        assert code_skew.peek_pending_model_switch() is not None
+        assert not replay_task.done()
+        assert not duplicate_replay_task.done()
+        completed.set()
+        await asyncio.gather(replay_task, duplicate_replay_task)
+
+        assert len(events) == 1
+        event = events[0]
+        assert event.source.thread_id == "3006"
+        assert event.source.chat_id == "-1003418564280"
+        assert event.internal is True
+        assert event.text == "/model openai/gpt-5.6 --provider openai-codex --session"
+        assert code_skew.peek_pending_model_switch() is None
+
+    def test_peek_keeps_request_until_explicit_ack(self, monkeypatch, tmp_path):
+        state_file = tmp_path / ".pending_model_switches.json"
+        monkeypatch.setattr(code_skew, "_pending_model_switches_file", lambda: state_file)
+        intent = _pending_intent()
+        code_skew.enqueue_pending_model_switch(intent)
+
+        assert code_skew.peek_pending_model_switch() == intent
+        assert code_skew.peek_pending_model_switch() == intent
+        code_skew.ack_pending_model_switch(intent.intent_id)
+        assert code_skew.peek_pending_model_switch() is None
+
+    def test_rejects_nested_source_metadata(self):
+        raw = _pending_intent().to_dict()
+        raw["source"]["chat_name"] = {"api_key": "must-not-persist"}
+        assert code_skew.PendingModelSwitch.from_dict(raw) is None
+
+    @pytest.mark.asyncio
+    async def test_replay_retains_request_when_model_handler_does_not_commit(self, monkeypatch, tmp_path):
+        from gateway.run import GatewayRunner
+
+        state_file = tmp_path / ".pending_model_switches.json"
+        monkeypatch.setattr(code_skew, "_pending_model_switches_file", lambda: state_file)
+        intent = _pending_intent()
+        code_skew.enqueue_pending_model_switch(intent)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._adapter_for_source = lambda source: object()
+        runner._normalize_source_for_session_key = lambda source: source
+        runner._session_key_for_source = lambda source: "telegram:-1003418564280:3006"
+        runner._session_model_overrides = {}
+
+        async def handle_model(event):
+            return None  # Mirrors an adapter-delivered error path with no commit.
+
+        runner._handle_model_command = handle_model
+        await runner._replay_pending_code_skew_model_switches()
+
+        assert code_skew.peek_pending_model_switch() == intent
+
+    @pytest.mark.asyncio
+    async def test_replay_keeps_request_when_source_adapter_is_unavailable(self, monkeypatch, tmp_path):
+        from gateway.run import GatewayRunner
+
+        state_file = tmp_path / ".pending_model_switches.json"
+        monkeypatch.setattr(code_skew, "_pending_model_switches_file", lambda: state_file)
+        intent = _pending_intent()
+        code_skew.enqueue_pending_model_switch(intent)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._adapter_for_source = lambda source: None
+        await runner._replay_pending_code_skew_model_switches()
+
+        assert code_skew.peek_pending_model_switch() == intent

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -152,3 +152,78 @@ class TestModelSwitchSkewGuard:
         monkeypatch.delenv("INVOCATION_ID", raising=False)
         slash_commands._model_switch_skew_guard(runner=FakeRunner())
         assert calls == [(True, False)], f"detached path expected, got {calls}"
+
+
+class TestPurgeStalePycache:
+    """Tests for purge_stale_pycache — purging __pycache__ when the checkout
+    advanced between the previous gateway boot and the current one."""
+
+    def test_no_purge_when_previous_fingerprint_missing(self, monkeypatch, tmp_path):
+        """No persisted fingerprint file → nothing to compare → no purge."""
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", tmp_path / "nonexistent")
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+    def test_no_purge_when_fingerprints_match(self, monkeypatch, tmp_path):
+        """Same checkout as previous boot → no drift → no purge."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+    def test_purges_pyc_files_on_drift(self, monkeypatch, tmp_path):
+        """Drift detected → .pyc files inside __pycache__ are deleted."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:oldhash123")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+
+        # Create a fake __pycache__ with .pyc files
+        pycache = tmp_path / "gateway" / "__pycache__"
+        pycache.mkdir(parents=True)
+        (pycache / "slash_commands.cpython-311.pyc").write_bytes(b"stale bytecode")
+        (pycache / "run.cpython-311.pyc").write_bytes(b"stale bytecode")
+
+        assert code_skew.purge_stale_pycache() is True
+        assert not (pycache / "slash_commands.cpython-311.pyc").exists()
+        assert not (pycache / "run.cpython-311.pyc").exists()
+
+    def test_skips_venv_pycache(self, monkeypatch, tmp_path):
+        """.pyc inside .venv are not purged (they're managed by pip)."""
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        fp_file.write_text("git:refs/heads/main:oldhash123")
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:newhash456")
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+
+        venv_pycache = tmp_path / ".venv" / "lib" / "__pycache__"
+        venv_pycache.mkdir(parents=True)
+        (venv_pycache / "site.cpython-311.pyc").write_bytes(b"should not be touched")
+
+        code_skew.purge_stale_pycache()
+        assert (venv_pycache / "site.cpython-311.pyc").exists()
+
+    def test_no_purge_when_fingerprint_unreadable(self, monkeypatch, tmp_path):
+        """If _fingerprint returns None (non-git), no purge."""
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: None)
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", tmp_path / "x")
+        monkeypatch.setattr(code_skew, "_PROJECT_ROOT", tmp_path)
+        assert code_skew.purge_stale_pycache() is False
+
+
+class TestPersistBootFingerprint:
+    def test_persists_fingerprint_to_file(self, monkeypatch, tmp_path):
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        code_skew._persist_boot_fingerprint("git:refs/heads/main:abcdef1234")
+        assert fp_file.read_text() == "git:refs/heads/main:abcdef1234"
+
+    def test_does_not_persist_none(self, monkeypatch, tmp_path):
+        fp_file = tmp_path / ".gateway_boot_fingerprint"
+        monkeypatch.setattr(code_skew, "_last_boot_fingerprint_file", fp_file)
+        code_skew._persist_boot_fingerprint(None)
+        assert not fp_file.exists()


### PR DESCRIPTION
## Summary

Extends the existing graceful code-skew reload guard so a stale-checkout `/model` request does not restart the whole gateway through an unrelated active topic and make the user repeat the selection.

The guard remains process-global and continues to refuse model changes in a process whose checkout fingerprint has drifted.

## Why

A model switch can trigger a lazy import. If `git pull` changed the checkout under a long-lived gateway, the process can mix fresh consumer modules with stale cached dependencies and crash. The original guard correctly prevents that switch, but a self-restart initiated immediately from a quiet topic could interrupt an agent turn in another Telegram topic.

## Behavior

1. A stale `/model` request is converted to a `PendingModelSwitch` containing only scalar routing fields plus the model/provider/scope request.
2. The request is written atomically under `HERMES_HOME`; no raw command, event, callback, or credential fields are persisted.
3. If any agent is active, the gateway does not restart. On the final agent release, it synchronously latches the normal draining gate before scheduling the global restart; the inbound pipeline checks that gate both before work dispatch and again after its last pre-claim yield, closing the zero-agent/new-turn admission race.
4. A fresh process reconstructs a typed internal `/model` event for the original source, including Telegram `thread_id`.
5. A fresh process invokes the normal `/model` handler directly and acknowledges the record only after the normalized origin session has the requested runtime model override. If the source adapter is unavailable, the handler throws, the handler returns without committing the override, or the checkout drifts again during replay, the original request stays queued for retry; replay never creates a second durable copy. This is intentionally at-least-once; re-applying the same selected model is idempotent.
6. Validation/application errors are returned through the normal `/model` command path in the origin topic; the queue acknowledgement accurately says the selection will be retried rather than promising an invalid model will apply.

## Additional correction

The boot-fingerprint path is resolved through `get_hermes_home()` at call time instead of at module import, so profile/test home routing is not frozen before Hermes bootstrap/configuration completes.

## Tests

Focused suites run in separate Python processes:

```text
29 passed  tests/test_code_skew.py
 3 passed  tests/test_stale_utils_module_import.py
 3 passed  tests/gateway/test_model_picker_persist.py
 7 passed  tests/gateway/test_telegram_model_picker.py
40 passed  tests/gateway/test_command_bypass_active_session.py
50 passed  tests/gateway/test_telegram_thread_fallback.py
```

The code-skew regressions cover stale guard preservation, delayed restart after the last active topic, a final agent release during the last pre-claim yield, draining-gate latching, persisted topic routing, replay handler commit before acknowledgement, unavailable/no-commit retention, scalar-only source persistence, nested metadata rejection, and no top-level credential persistence.
