### PR TITLE
feat(kanban): add per-board profile allowlists

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1301,9 +1301,9 @@ class GatewayKanbanWatchersMixin:
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
-                    if _kb.has_spawnable_ready(conn):
+                    if _kb.has_spawnable_ready(conn, board=slug):
                         return True
-                    if _kb.has_spawnable_review(conn):
+                    if _kb.has_spawnable_review(conn, board=slug):
                         return True
                 except Exception:
                     continue

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1356,13 +1356,11 @@ class GatewayKanbanWatchersMixin:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 if attempted >= auto_decompose_per_tick:
                     break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
-                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-                try:
-                    os.environ["HERMES_KANBAN_BOARD"] = slug
+                # Pin this board only in the decomposer thread's context.
+                # Mutating HERMES_KANBAN_BOARD here would leak the selected
+                # board to concurrent dashboard/tool requests for the full
+                # duration of the auxiliary-model call.
+                with _kb.scoped_current_board(slug):
                     try:
                         triage_ids = _decomp.list_triage_ids()
                     except Exception as exc:
@@ -1404,11 +1402,6 @@ class GatewayKanbanWatchersMixin:
                                 "kanban auto-decompose [%s]: %s skipped: %s",
                                 slug, tid, outcome.reason,
                             )
-                finally:
-                    if prev_env is None:
-                        os.environ.pop("HERMES_KANBAN_BOARD", None)
-                    else:
-                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
             return successes
 
         logger.info(

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -291,6 +291,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Switch to the new board after creating it")
     b_create.add_argument("--default-workdir", default=None,
                           help="Default workspace path for tasks created on this board")
+    b_create.add_argument(
+        "--allowed-profile",
+        action="append",
+        default=None,
+        help=(
+            "Profile allowed to own/execute board work (repeatable). "
+            "Omit for unrestricted."
+        ),
+    )
 
     b_rm = boards_sub.add_parser(
         "rm", aliases=["remove", "delete"],
@@ -326,6 +335,22 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     b_set_wd.add_argument("slug")
     b_set_wd.add_argument("path", nargs="?", default=None,
                           help="Absolute path to use as default workdir. Omit to clear.")
+
+    b_set_profiles = boards_sub.add_parser(
+        "set-allowed-profiles",
+        help="Restrict board execution to an explicit profile allowlist",
+    )
+    b_set_profiles.add_argument("slug")
+    b_set_profiles.add_argument(
+        "profiles",
+        nargs="*",
+        help="Allowed profile names. No names means deny all profiles.",
+    )
+    b_set_profiles.add_argument(
+        "--unrestricted",
+        action="store_true",
+        help="Remove the allowlist and restore unrestricted profile routing",
+    )
 
     # --- create ---
     p_create = sub.add_parser("create", help="Create a new task")
@@ -1202,6 +1227,8 @@ def _dispatch_boards(args: argparse.Namespace) -> int:
         return _cmd_boards_rename(args)
     if sub == "set-default-workdir":
         return _cmd_boards_set_default_workdir(args)
+    if sub == "set-allowed-profiles":
+        return _cmd_boards_set_allowed_profiles(args)
     print(f"kanban boards: unknown action {sub!r}", file=sys.stderr)
     return 2
 
@@ -1266,6 +1293,12 @@ def _cmd_boards_create(args: argparse.Namespace) -> int:
         print("kanban boards create: slug is required", file=sys.stderr)
         return 2
     already = kb.board_exists(normed) and normed != kb.DEFAULT_BOARD
+    allowed_profiles = getattr(args, "allowed_profile", None)
+    policy_kwargs = (
+        {"allowed_profiles": allowed_profiles}
+        if allowed_profiles is not None
+        else {}
+    )
     meta = kb.create_board(
         normed,
         name=args.name,
@@ -1273,6 +1306,7 @@ def _cmd_boards_create(args: argparse.Namespace) -> int:
         icon=args.icon,
         color=args.color,
         default_workdir=args.default_workdir,
+        **policy_kwargs,
     )
     verb = "already exists" if already else "created"
     print(f"Board {meta['slug']!r} {verb}.")
@@ -1337,6 +1371,13 @@ def _cmd_boards_show(args: argparse.Namespace) -> int:
     if meta.get("description"):
         print(f"  Description:  {meta['description']}")
     print(f"  DB path:      {meta['db_path']}")
+    allowed_profiles = meta.get("allowed_profiles")
+    if allowed_profiles is None:
+        print("  Profiles:     unrestricted")
+    elif allowed_profiles:
+        print(f"  Profiles:     {', '.join(allowed_profiles)}")
+    else:
+        print("  Profiles:     none (board execution frozen)")
     print(f"  Tasks:        {total} total"
           + (f" ({', '.join(f'{k}={v}' for k, v in sorted(counts.items()))})"
              if counts else ""))
@@ -1374,6 +1415,39 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
         print(f"Board {normed!r} default workdir set to {new_val!r}.")
     else:
         print(f"Board {normed!r} default workdir cleared.")
+    return 0
+
+
+def _cmd_boards_set_allowed_profiles(args: argparse.Namespace) -> int:
+    command = "kanban boards set-allowed-profiles"
+    try:
+        normed = kb._normalize_board_slug(args.slug)
+    except ValueError as exc:
+        print(f"{command}: {exc}", file=sys.stderr)
+        return 2
+    if not normed or not kb.board_exists(normed):
+        print(f"{command}: board {args.slug!r} does not exist", file=sys.stderr)
+        return 1
+    profiles = list(getattr(args, "profiles", None) or [])
+    unrestricted = bool(getattr(args, "unrestricted", False))
+    if unrestricted and profiles:
+        print(f"{command}: --unrestricted cannot be combined with profile names", file=sys.stderr)
+        return 2
+    try:
+        meta = kb.write_board_metadata(
+            normed,
+            allowed_profiles=None if unrestricted else profiles,
+        )
+    except ValueError as exc:
+        print(f"{command}: {exc}", file=sys.stderr)
+        return 2
+    allowed = meta.get("allowed_profiles")
+    if allowed is None:
+        print(f"Board {normed!r} profile routing is unrestricted.")
+    elif allowed:
+        print(f"Board {normed!r} allowed profiles: {', '.join(allowed)}")
+    else:
+        print(f"Board {normed!r} allows no profiles; execution is frozen.")
     return 0
 
 
@@ -1496,32 +1570,37 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    with kb.connect_closing() as conn:
-        task_id = kb.create_task(
-            conn,
-            title=args.title,
-            body=args.body,
-            assignee=args.assignee,
-            created_by=args.created_by or _profile_author(),
-            workspace_kind=ws_kind,
-            workspace_path=ws_path,
-            branch_name=branch_name,
-            project_id=getattr(args, "project", None),
-            tenant=args.tenant,
-            priority=args.priority,
-            parents=tuple(args.parent or ()),
-            triage=bool(getattr(args, "triage", False)),
-            idempotency_key=getattr(args, "idempotency_key", None),
-            max_runtime_seconds=max_runtime,
-            skills=getattr(args, "skills", None) or None,
-            max_retries=max_retries,
-            model_override=getattr(args, "model_override", None),
-            provider_override=getattr(args, "provider_override", None),
-            goal_mode=bool(getattr(args, "goal_mode", False)),
-            goal_max_turns=getattr(args, "goal_max_turns", None),
-            initial_status=getattr(args, "initial_status", "running"),
-        )
-        task = kb.get_task(conn, task_id)
+    try:
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(
+                conn,
+                title=args.title,
+                body=args.body,
+                assignee=args.assignee,
+                created_by=args.created_by or _profile_author(),
+                workspace_kind=ws_kind,
+                workspace_path=ws_path,
+                branch_name=branch_name,
+                project_id=getattr(args, "project", None),
+                tenant=args.tenant,
+                priority=args.priority,
+                parents=tuple(args.parent or ()),
+                triage=bool(getattr(args, "triage", False)),
+                idempotency_key=getattr(args, "idempotency_key", None),
+                max_runtime_seconds=max_runtime,
+                skills=getattr(args, "skills", None) or None,
+                max_retries=max_retries,
+                model_override=getattr(args, "model_override", None),
+                provider_override=getattr(args, "provider_override", None),
+                goal_mode=bool(getattr(args, "goal_mode", False)),
+                goal_max_turns=getattr(args, "goal_max_turns", None),
+                initial_status=getattr(args, "initial_status", "running"),
+                board=kb.get_current_board(),
+            )
+            task = kb.get_task(conn, task_id)
+    except ValueError as exc:
+        print(f"kanban create: {exc}", file=sys.stderr)
+        return 2
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
@@ -1561,6 +1640,7 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
             created_by=args.created_by or _profile_author(),
             priority=args.priority,
             idempotency_key=getattr(args, "idempotency_key", None),
+            board=kb.get_current_board(),
         )
     if getattr(args, "json", False):
         print(json.dumps(created.as_dict(), indent=2, ensure_ascii=False))
@@ -1791,8 +1871,14 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
-    with kb.connect_closing() as conn:
-        ok = kb.assign_task(conn, args.task_id, profile)
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.assign_task(
+                conn, args.task_id, profile, board=kb.get_current_board()
+            )
+    except ValueError as exc:
+        print(f"kanban assign: {exc}", file=sys.stderr)
+        return 2
     if not ok:
         print(f"no such task: {args.task_id}", file=sys.stderr)
         return 1
@@ -1842,12 +1928,17 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
 
 def _cmd_reassign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
-    with kb.connect_closing() as conn:
-        ok = kb.reassign_task(
-            conn, args.task_id, profile,
-            reclaim_first=bool(getattr(args, "reclaim", False)),
-            reason=getattr(args, "reason", None),
-        )
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.reassign_task(
+                conn, args.task_id, profile,
+                reclaim_first=bool(getattr(args, "reclaim", False)),
+                reason=getattr(args, "reason", None),
+                board=kb.get_current_board(),
+            )
+    except ValueError as exc:
+        print(f"kanban reassign: {exc}", file=sys.stderr)
+        return 2
     if not ok:
         print(
             f"cannot reassign {args.task_id} "
@@ -2013,7 +2104,12 @@ def _cmd_unlink(args: argparse.Namespace) -> int:
 
 def _cmd_claim(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
-        task = kb.claim_task(conn, args.task_id, ttl_seconds=args.ttl)
+        task = kb.claim_task(
+            conn,
+            args.task_id,
+            ttl_seconds=args.ttl,
+            board=kb.get_current_board(),
+        )
         if task is None:
             # Report why
             existing = kb.get_task(conn, args.task_id)
@@ -2479,6 +2575,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             max_spawn=max_spawn,
             max_in_progress=max_in_progress,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+            board=kb.get_current_board(),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
@@ -2496,6 +2593,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_disallowed": res.skipped_disallowed,
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
@@ -2528,6 +2626,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if res.skipped_unassigned:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
+    if res.skipped_disallowed:
+        print(
+            "Skipped (assignee excluded by board allowed_profiles): "
+            + ", ".join(res.skipped_disallowed)
+        )
     if res.skipped_per_profile_capped:
         for tid, who, current in res.skipped_per_profile_capped:
             print(
@@ -2661,7 +2764,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
         """
         try:
             with kb.connect_closing() as conn:
-                return kb.has_spawnable_ready(conn)
+                return kb.has_spawnable_ready(conn, board=kb.get_current_board())
         except Exception:
             return False
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1180,6 +1180,7 @@ _DELEGATED_CHILD_DENIED_BOARD_ACTIONS: frozenset[str] = frozenset({
     "use",
     "rename",
     "set-default-workdir",
+    "set-allowed-profiles",
 })
 
 
@@ -1299,15 +1300,19 @@ def _cmd_boards_create(args: argparse.Namespace) -> int:
         if allowed_profiles is not None
         else {}
     )
-    meta = kb.create_board(
-        normed,
-        name=args.name,
-        description=args.description,
-        icon=args.icon,
-        color=args.color,
-        default_workdir=args.default_workdir,
-        **policy_kwargs,
-    )
+    try:
+        meta = kb.create_board(
+            normed,
+            name=args.name,
+            description=args.description,
+            icon=args.icon,
+            color=args.color,
+            default_workdir=args.default_workdir,
+            **policy_kwargs,
+        )
+    except ValueError as exc:
+        print(f"kanban boards create: {exc}", file=sys.stderr)
+        return 2
     verb = "already exists" if already else "created"
     print(f"Board {meta['slug']!r} {verb}.")
     print(f"  Display name: {meta.get('name', '')}")
@@ -1629,19 +1634,23 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
     if not workers:
         print("kanban swarm: at least one --worker is required", file=sys.stderr)
         return 2
-    with kb.connect_closing() as conn:
-        created = ks.create_swarm(
-            conn,
-            goal=args.goal,
-            workers=workers,
-            verifier_assignee=args.verifier,
-            synthesizer_assignee=args.synthesizer,
-            tenant=args.tenant,
-            created_by=args.created_by or _profile_author(),
-            priority=args.priority,
-            idempotency_key=getattr(args, "idempotency_key", None),
-            board=kb.get_current_board(),
-        )
+    try:
+        with kb.connect_closing() as conn:
+            created = ks.create_swarm(
+                conn,
+                goal=args.goal,
+                workers=workers,
+                verifier_assignee=args.verifier,
+                synthesizer_assignee=args.synthesizer,
+                tenant=args.tenant,
+                created_by=args.created_by or _profile_author(),
+                priority=args.priority,
+                idempotency_key=getattr(args, "idempotency_key", None),
+                board=kb.get_current_board(),
+            )
+    except ValueError as exc:
+        print(f"kanban swarm: {exc}", file=sys.stderr)
+        return 2
     if getattr(args, "json", False):
         print(json.dumps(created.as_dict(), indent=2, ensure_ascii=False))
     else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -713,6 +713,11 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
                 # its directory — trust the filesystem.
                 raw["slug"] = slug
                 meta.update(raw)
+            else:
+                # A syntactically valid JSON scalar/list is still malformed
+                # board metadata. Do not let it erase a security policy by
+                # falling back to the unrestricted default.
+                meta["allowed_profiles"] = []
     except (OSError, json.JSONDecodeError):
         # Missing metadata is handled by the defaults above, but an existing
         # unreadable/malformed policy file must fail closed rather than erase
@@ -4182,10 +4187,15 @@ def claim_task(
             "SELECT assignee FROM tasks WHERE id = ? AND status = 'ready'",
             (task_id,),
         ).fetchone()
+        allowed_profiles = get_board_allowed_profiles(board)
         if (
             allowed_row is not None
-            and allowed_row["assignee"] is not None
-            and not is_profile_allowed(board, allowed_row["assignee"])
+            and allowed_profiles is not None
+            and (
+                allowed_row["assignee"] is None
+                or _canonical_assignee(allowed_row["assignee"])
+                not in set(allowed_profiles)
+            )
         ):
             _append_event(
                 conn,
@@ -4332,10 +4342,15 @@ def claim_review_task(
             "SELECT assignee FROM tasks WHERE id = ? AND status = 'review'",
             (task_id,),
         ).fetchone()
+        allowed_profiles = get_board_allowed_profiles(board)
         if (
             allowed_row is not None
-            and allowed_row["assignee"] is not None
-            and not is_profile_allowed(board, allowed_row["assignee"])
+            and allowed_profiles is not None
+            and (
+                allowed_row["assignee"] is None
+                or _canonical_assignee(allowed_row["assignee"])
+                not in set(allowed_profiles)
+            )
         ):
             _append_event(
                 conn,
@@ -4667,12 +4682,18 @@ def reassign_task(
     Returns True if the reassign landed. ``profile`` may be ``None`` to
     unassign entirely.
     """
+    canonical_profile = _canonical_assignee(profile)
+    # Validate before reclaiming so a rejected destination cannot terminate
+    # the current worker or mutate the task/run state.
+    require_profile_allowed(
+        board, canonical_profile, operation="task reassignment"
+    )
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
     # assign_task handles its own txn + the still-running guard.
     try:
-        return assign_task(conn, task_id, profile, board=board)
+        return assign_task(conn, task_id, canonical_profile, board=board)
     except RuntimeError:
         # Task is still running and reclaim_first was False; caller
         # needs to decide whether to retry with reclaim.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -639,12 +639,39 @@ def worker_logs_dir(board: Optional[str] = None) -> Path:
 def board_metadata_path(board: Optional[str] = None) -> Path:
     """Return the path to ``board.json`` for ``board``.
 
-    Stores display metadata (display name, description, icon, color,
-    created_at). The on-disk slug is the canonical identity; this file
-    is purely for presentation in the CLI / dashboard.
+    Stores display metadata plus board-scoped execution policy. The on-disk
+    slug is the canonical identity.
     """
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
     return board_dir(slug) / "board.json"
+
+
+_BOARD_METADATA_UNSET = object()
+
+
+def _normalize_allowed_profiles(value: Any) -> Optional[list[str]]:
+    """Normalize a board profile allowlist while preserving order.
+
+    ``None`` means unrestricted. An explicit empty list denies every profile.
+    Malformed values raise for writes; reads convert them to a fail-closed list.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple, set)):
+        raise ValueError("allowed_profiles must be a list of profile names or null")
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in value:
+        if not isinstance(raw, str):
+            raise ValueError("allowed_profiles entries must be profile names")
+        name = normalize_profile_name(raw)
+        validate_profile_name(name)
+        if name not in seen:
+            seen.add(name)
+            normalized.append(name)
+    return normalized
 
 
 def _default_board_display_name(slug: str) -> str:
@@ -673,6 +700,7 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "icon": "",
         "color": "",
         "default_workdir": None,
+        "allowed_profiles": None,
         "created_at": None,
         "archived": False,
     }
@@ -686,9 +714,53 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
                 raw["slug"] = slug
                 meta.update(raw)
     except (OSError, json.JSONDecodeError):
-        pass
+        # Missing metadata is handled by the defaults above, but an existing
+        # unreadable/malformed policy file must fail closed rather than erase
+        # an allowlist and reopen the board to every profile.
+        meta["allowed_profiles"] = []
+    try:
+        meta["allowed_profiles"] = _normalize_allowed_profiles(
+            meta.get("allowed_profiles")
+        )
+    except ValueError:
+        # A malformed security policy must not silently become unrestricted.
+        meta["allowed_profiles"] = []
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
+
+
+def get_board_allowed_profiles(board: Optional[str] = None) -> Optional[tuple[str, ...]]:
+    """Return the normalized allowlist, or ``None`` when unrestricted."""
+    effective_board = (
+        _normalize_board_slug(board) if board is not None else get_current_board()
+    )
+    value = read_board_metadata(effective_board).get("allowed_profiles")
+    if value is None:
+        return None
+    return tuple(value)
+
+
+def is_profile_allowed(board: Optional[str], profile: Optional[str]) -> bool:
+    """Return whether ``profile`` may own or execute work on ``board``."""
+    if profile is None:
+        return True
+    allowed = get_board_allowed_profiles(board)
+    if allowed is None:
+        return True
+    return _canonical_assignee(profile) in set(allowed)
+
+
+def require_profile_allowed(
+    board: Optional[str], profile: Optional[str], *, operation: str = "assign"
+) -> None:
+    """Raise when a configured board allowlist excludes ``profile``."""
+    if profile is None or is_profile_allowed(board, profile):
+        return
+    slug = _normalize_board_slug(board) or get_current_board()
+    raise ValueError(
+        f"profile {_canonical_assignee(profile)!r} is not allowed on board "
+        f"{slug!r} for {operation}"
+    )
 
 
 def write_board_metadata(
@@ -700,6 +772,7 @@ def write_board_metadata(
     color: Optional[str] = None,
     archived: Optional[bool] = None,
     default_workdir: Optional[str] = None,
+    allowed_profiles: Any = _BOARD_METADATA_UNSET,
 ) -> dict:
     """Create / update ``board.json`` for ``board``.
 
@@ -724,6 +797,8 @@ def write_board_metadata(
         meta["archived"] = bool(archived)
     if default_workdir is not None:
         meta["default_workdir"] = str(default_workdir) if default_workdir else None
+    if allowed_profiles is not _BOARD_METADATA_UNSET:
+        meta["allowed_profiles"] = _normalize_allowed_profiles(allowed_profiles)
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
@@ -744,6 +819,7 @@ def create_board(
     icon: Optional[str] = None,
     color: Optional[str] = None,
     default_workdir: Optional[str] = None,
+    allowed_profiles: Any = _BOARD_METADATA_UNSET,
 ) -> dict:
     """Create a new board directory + DB + metadata. Idempotent.
 
@@ -761,6 +837,7 @@ def create_board(
         icon=icon,
         color=color,
         default_workdir=default_workdir,
+        allowed_profiles=allowed_profiles,
     )
     # Touch the DB so list_boards() sees it immediately.
     init_db(board=normed)
@@ -2884,6 +2961,7 @@ def create_task(
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
+    require_profile_allowed(board, assignee, operation="task creation")
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -3323,13 +3401,20 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
-def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
+def assign_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    profile: Optional[str],
+    *,
+    board: Optional[str] = None,
+) -> bool:
     """Assign or reassign a task.  Returns True on success.
 
     Refuses to reassign a task that's currently running (claim_lock set).
     Reassign after the current run completes if needed.
     """
     profile = _canonical_assignee(profile)
+    require_profile_allowed(board, profile, operation="task assignment")
     with write_txn(conn):
         row = conn.execute(
             "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
@@ -4082,6 +4167,7 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    board: Optional[str] = None,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
@@ -4092,6 +4178,26 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        allowed_row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ? AND status = 'ready'",
+            (task_id,),
+        ).fetchone()
+        if (
+            allowed_row is not None
+            and allowed_row["assignee"] is not None
+            and not is_profile_allowed(board, allowed_row["assignee"])
+        ):
+            _append_event(
+                conn,
+                task_id,
+                "claim_rejected",
+                {
+                    "reason": "profile_not_allowed",
+                    "assignee": allowed_row["assignee"],
+                    "board": _normalize_board_slug(board) or get_current_board(),
+                },
+            )
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -4204,6 +4310,7 @@ def claim_review_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    board: Optional[str] = None,
 ) -> Optional[Task]:
     """Atomically transition ``review -> running``.
 
@@ -4221,6 +4328,27 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        allowed_row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ? AND status = 'review'",
+            (task_id,),
+        ).fetchone()
+        if (
+            allowed_row is not None
+            and allowed_row["assignee"] is not None
+            and not is_profile_allowed(board, allowed_row["assignee"])
+        ):
+            _append_event(
+                conn,
+                task_id,
+                "claim_rejected",
+                {
+                    "reason": "profile_not_allowed",
+                    "assignee": allowed_row["assignee"],
+                    "board": _normalize_board_slug(board) or get_current_board(),
+                    "source_status": "review",
+                },
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4526,6 +4654,7 @@ def reassign_task(
     *,
     reclaim_first: bool = False,
     reason: Optional[str] = None,
+    board: Optional[str] = None,
 ) -> bool:
     """Reassign a task, optionally reclaiming a stuck running worker first.
 
@@ -4543,7 +4672,7 @@ def reassign_task(
         reclaim_task(conn, task_id, reason=reason or "reassign")
     # assign_task handles its own txn + the still-running guard.
     try:
-        return assign_task(conn, task_id, profile)
+        return assign_task(conn, task_id, profile, board=board)
     except RuntimeError:
         # Task is still running and reclaim_first was False; caller
         # needs to decide whether to retry with reclaim.
@@ -5828,6 +5957,7 @@ def specify_triage_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     author: Optional[str] = None,
+    board: Optional[str] = None,
 ) -> bool:
     """Flesh out a triage task and promote it to ``todo``.
 
@@ -5848,6 +5978,7 @@ def specify_triage_task(
     if title is not None and not title.strip():
         raise ValueError("title cannot be blank")
     assignee = _canonical_assignee(assignee)
+    require_profile_allowed(board, assignee, operation="triage specification")
     with write_txn(conn):
         existing = conn.execute(
             "SELECT title, body, assignee FROM tasks WHERE id = ? AND status = 'triage'",
@@ -5919,6 +6050,7 @@ def decompose_triage_task(
     children: list[dict],
     author: Optional[str] = None,
     auto_promote: bool = True,
+    board: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fan a triage task out into child tasks and promote the root to ``todo``.
 
@@ -5950,6 +6082,7 @@ def decompose_triage_task(
         return None
     if root_assignee is not None:
         root_assignee = _canonical_assignee(root_assignee)
+    require_profile_allowed(board, root_assignee, operation="triage decomposition")
 
     # Pre-validate the children list shape outside the txn. Cheap checks
     # that don't need DB access. Bad input aborts before we touch the DB.
@@ -5959,6 +6092,11 @@ def decompose_triage_task(
         title = child.get("title")
         if not isinstance(title, str) or not title.strip():
             raise ValueError(f"child[{idx}].title is required")
+        require_profile_allowed(
+            board,
+            _canonical_assignee(child.get("assignee")),
+            operation=f"triage decomposition child[{idx}]",
+        )
         parents_idx = child.get("parents") or []
         if not isinstance(parents_idx, list):
             raise ValueError(f"child[{idx}].parents must be a list")
@@ -6668,6 +6806,10 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_disallowed: list[str] = field(default_factory=list)
+    """Ready task ids not dispatched because the board's ``allowed_profiles``
+    policy excludes their current assignee. The rows remain visible and ready
+    for an operator to reassign; they are never silently rewritten."""
     skipped_per_profile_capped: list[tuple[str, str, int]] = field(default_factory=list)
     """Tasks deferred this tick because their assignee is already at
     ``kanban.max_in_progress_per_profile`` (#21582). Each entry is
@@ -8002,7 +8144,9 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     return None
 
 
-def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
+def has_spawnable_ready(
+    conn: sqlite3.Connection, *, board: Optional[str] = None
+) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
 
@@ -8029,12 +8173,16 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
         # Can't introspect — assume spawnable, preserve legacy behavior.
         return True
     for row in rows:
+        if not is_profile_allowed(board, row["assignee"]):
+            continue
         if profile_exists(row["assignee"]):
             return True
     return False
 
 
-def has_spawnable_review(conn: sqlite3.Connection) -> bool:
+def has_spawnable_review(
+    conn: sqlite3.Connection, *, board: Optional[str] = None
+) -> bool:
     """Return True iff there is at least one review+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
 
@@ -8054,6 +8202,8 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     except Exception:
         return True
     for row in rows:
+        if not is_profile_allowed(board, row["assignee"]):
+            continue
         if profile_exists(row["assignee"]):
             return True
     return False
@@ -8176,6 +8326,8 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    _allowed_profiles = get_board_allowed_profiles(board)
+    _allowed_set = set(_allowed_profiles) if _allowed_profiles is not None else None
     result.reclaimed = release_stale_claims(conn)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
@@ -8259,6 +8411,12 @@ def _dispatch_once_locked(
     # rest of the loop can use ``if default_assignee:`` as a single check.
     # We also resolve profile_exists once here for the same reason.
     _default_assignee = (default_assignee or "").strip() or None
+    if (
+        _default_assignee is not None
+        and _allowed_set is not None
+        and _canonical_assignee(_default_assignee) not in _allowed_set
+    ):
+        _default_assignee = None
     _default_assignee_resolved = False
     if _default_assignee:
         try:
@@ -8318,6 +8476,12 @@ def _dispatch_once_locked(
             else:
                 result.skipped_unassigned.append(row["id"])
                 continue
+        if (
+            _allowed_set is not None
+            and _canonical_assignee(row_assignee) not in _allowed_set
+        ):
+            result.skipped_disallowed.append(row["id"])
+            continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
         # with "Profile 'X' does not exist" when the assignee names a
@@ -8386,7 +8550,9 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_task(
+            conn, row["id"], ttl_seconds=ttl_seconds, board=board
+        )
         if claimed is None:
             continue
         try:
@@ -8468,6 +8634,12 @@ def _dispatch_once_locked(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
+        if (
+            _allowed_set is not None
+            and _canonical_assignee(row["assignee"]) not in _allowed_set
+        ):
+            result.skipped_disallowed.append(row["id"])
+            continue
         try:
             from hermes_cli.profiles import profile_exists
         except Exception:
@@ -8478,7 +8650,9 @@ def _dispatch_once_locked(
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_review_task(
+            conn, row["id"], ttl_seconds=ttl_seconds, board=board
+        )
         if claimed is None:
             continue
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4307,7 +4307,7 @@ def claim_task(
     _fire_kanban_lifecycle_hook(
         "kanban_task_claimed",
         task_id,
-        board=get_current_board(),
+        board=_normalize_board_slug(board) or get_current_board(),
         assignee=claimed.assignee if claimed else None,
         run_id=run_id,
     )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import os
@@ -647,6 +648,156 @@ def board_metadata_path(board: Optional[str] = None) -> Path:
 
 
 _BOARD_METADATA_UNSET = object()
+_BOARD_METADATA_LOCK_TIMEOUT_SECONDS = 10.0
+_BOARD_METADATA_THREAD_LOCKS: dict[str, threading.RLock] = {}
+_BOARD_METADATA_THREAD_LOCKS_GUARD = threading.Lock()
+_BOARD_METADATA_LOCK_STATE = threading.local()
+
+
+def _board_metadata_lock_path(board: Optional[str] = None) -> Path:
+    """Return a stable lock path that survives board remove/recreate cycles."""
+    slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    return boards_root() / f".{slug}.metadata.lock"
+
+
+def _board_metadata_thread_lock(path: Path) -> threading.RLock:
+    try:
+        key = str(path.resolve(strict=False))
+    except OSError:
+        key = str(path)
+    with _BOARD_METADATA_THREAD_LOCKS_GUARD:
+        return _BOARD_METADATA_THREAD_LOCKS.setdefault(key, threading.RLock())
+
+
+@contextlib.contextmanager
+def _board_metadata_lock(
+    board: Optional[str] = None,
+    *,
+    timeout_seconds: float = _BOARD_METADATA_LOCK_TIMEOUT_SECONDS,
+):
+    """Serialize one board's metadata read-modify-write across processes.
+
+    The board profile allowlist is an execution-admission policy. If locking is
+    unavailable or contention exceeds the bounded timeout, metadata mutation
+    fails closed instead of risking a stale write that silently widens access.
+    """
+    lock_path = _board_metadata_lock_path(board)
+    try:
+        key = str(lock_path.resolve(strict=False))
+    except OSError:
+        key = str(lock_path)
+    held = getattr(_BOARD_METADATA_LOCK_STATE, "held", None)
+    if held is None:
+        held = {}
+        _BOARD_METADATA_LOCK_STATE.held = held
+    owner = held.get(key)
+    current_pid = os.getpid()
+    if owner is not None and owner[0] == current_pid:
+        held[key] = (current_pid, owner[1] + 1)
+        try:
+            yield
+        finally:
+            held[key] = (current_pid, held[key][1] - 1)
+        return
+    if owner is not None:
+        # ``threading.local`` state survives ``fork()``. A child must never
+        # inherit the parent's reentrancy exemption and skip the kernel lock.
+        held.pop(key, None)
+
+    deadline = time.monotonic() + max(0.1, float(timeout_seconds))
+    thread_lock = _board_metadata_thread_lock(lock_path)
+    if not thread_lock.acquire(timeout=max(0.1, deadline - time.monotonic())):
+        raise TimeoutError(
+            f"timed out waiting for board metadata lock: {lock_path}"
+        )
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as lock_file:
+            acquired = False
+            try:
+                while True:
+                    try:
+                        if os.name == "nt":
+                            import msvcrt
+
+                            if os.fstat(lock_file.fileno()).st_size == 0:
+                                lock_file.write(b"\0")
+                                lock_file.flush()
+                            lock_file.seek(0)
+                            msvcrt.locking(
+                                lock_file.fileno(), msvcrt.LK_NBLCK, 1
+                            )
+                        elif os.name == "posix":
+                            import fcntl
+
+                            fcntl.flock(
+                                lock_file.fileno(),
+                                fcntl.LOCK_EX | fcntl.LOCK_NB,
+                            )
+                        else:  # pragma: no cover - unsupported runtime
+                            raise RuntimeError(
+                                "cross-process board metadata locking is unavailable"
+                            )
+                        acquired = True
+                        break
+                    except OSError as exc:
+                        if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                            raise
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                f"timed out waiting for board metadata lock: {lock_path}"
+                            ) from exc
+                        time.sleep(0.05)
+
+                held[key] = (current_pid, 1)
+                try:
+                    yield
+                finally:
+                    held.pop(key, None)
+            finally:
+                if acquired:
+                    try:
+                        if os.name == "nt":
+                            import msvcrt
+
+                            lock_file.seek(0)
+                            msvcrt.locking(
+                                lock_file.fileno(), msvcrt.LK_UNLCK, 1
+                            )
+                        else:
+                            import fcntl
+
+                            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                    except OSError:
+                        pass
+    finally:
+        thread_lock.release()
+
+
+def _atomic_write_board_metadata(path: Path, meta: Mapping[str, Any]) -> None:
+    """Atomically replace board.json after fsyncing a same-directory temp file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(
+        f".{path.name}.tmp.{os.getpid()}.{threading.get_ident()}."
+        f"{secrets.token_hex(4)}"
+    )
+    fd: Optional[int] = None
+    try:
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            json.dump(meta, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if fd is not None:
+            os.close(fd)
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def _normalize_allowed_profiles(value: Any) -> Optional[list[str]]:
@@ -786,32 +937,38 @@ def write_board_metadata(
     """
     _assert_not_delegated_child_mutation()
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    meta = read_board_metadata(slug)
-    # Preserve existing DB-derived fields — they get re-computed each
-    # read but shouldn't be written into board.json.
-    meta.pop("db_path", None)
-    if name is not None:
-        meta["name"] = str(name).strip() or _default_board_display_name(slug)
-    if description is not None:
-        meta["description"] = str(description)
-    if icon is not None:
-        meta["icon"] = str(icon)
-    if color is not None:
-        meta["color"] = str(color)
-    if archived is not None:
-        meta["archived"] = bool(archived)
-    if default_workdir is not None:
-        meta["default_workdir"] = str(default_workdir) if default_workdir else None
-    if allowed_profiles is not _BOARD_METADATA_UNSET:
-        meta["allowed_profiles"] = _normalize_allowed_profiles(allowed_profiles)
-    if not meta.get("created_at"):
-        meta["created_at"] = int(time.time())
-    path = board_metadata_path(slug)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
+    existed_before_lock = slug == DEFAULT_BOARD or board_exists(slug)
+    with _board_metadata_lock(slug):
+        if existed_before_lock and not board_exists(slug):
+            # The board disappeared while this writer waited for the lock.
+            # Reject the stale update instead of silently recreating a board
+            # that another process just removed. Calls that began with no
+            # board still retain the historical implicit-create behaviour.
+            raise ValueError(f"board {slug!r} does not exist")
+        meta = read_board_metadata(slug)
+        # Preserve existing DB-derived fields — they get re-computed each
+        # read but shouldn't be written into board.json.
+        meta.pop("db_path", None)
+        if name is not None:
+            meta["name"] = str(name).strip() or _default_board_display_name(slug)
+        if description is not None:
+            meta["description"] = str(description)
+        if icon is not None:
+            meta["icon"] = str(icon)
+        if color is not None:
+            meta["color"] = str(color)
+        if archived is not None:
+            meta["archived"] = bool(archived)
+        if default_workdir is not None:
+            meta["default_workdir"] = (
+                str(default_workdir) if default_workdir else None
+            )
+        if allowed_profiles is not _BOARD_METADATA_UNSET:
+            meta["allowed_profiles"] = _normalize_allowed_profiles(allowed_profiles)
+        if not meta.get("created_at"):
+            meta["created_at"] = int(time.time())
+        path = board_metadata_path(slug)
+        _atomic_write_board_metadata(path, meta)
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
 
@@ -835,17 +992,20 @@ def create_board(
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
-    meta = write_board_metadata(
-        normed,
-        name=name,
-        description=description,
-        icon=icon,
-        color=color,
-        default_workdir=default_workdir,
-        allowed_profiles=allowed_profiles,
-    )
-    # Touch the DB so list_boards() sees it immediately.
-    init_db(board=normed)
+    with _board_metadata_lock(normed):
+        meta = write_board_metadata(
+            normed,
+            name=name,
+            description=description,
+            icon=icon,
+            color=color,
+            default_workdir=default_workdir,
+            allowed_profiles=allowed_profiles,
+        )
+        # Keep create atomic with remove: otherwise a remover could archive the
+        # metadata before init_db() and the trailing DB touch would resurrect a
+        # metadata-less board.
+        init_db(board=normed)
     return meta
 
 
@@ -910,36 +1070,39 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
         raise ValueError("board slug is required")
     if normed == DEFAULT_BOARD:
         raise ValueError("the 'default' board cannot be removed")
-    d = board_dir(normed)
-    if not d.exists():
-        raise ValueError(f"board {normed!r} does not exist")
+    with _board_metadata_lock(normed):
+        d = board_dir(normed)
+        if not d.exists():
+            raise ValueError(f"board {normed!r} does not exist")
 
-    # If the user removed the currently-active board, revert to default.
-    if get_current_board() == normed:
-        clear_current_board()
+        # If the user removed the currently-active board, revert to default.
+        if get_current_board() == normed:
+            clear_current_board()
 
-    # A concurrent connect(board=normed) after the rename/delete recreates
-    # an empty sqlite file via mkdir(exist_ok=True); the cache entry must be
-    # dropped first so the schema init pass re-runs on that fresh file.
-    _INITIALIZED_PATHS.discard(str((d / "kanban.db").resolve()))
+        # A concurrent connect(board=normed) after the rename/delete recreates
+        # an empty sqlite file via mkdir(exist_ok=True); the cache entry must be
+        # dropped first so the schema init pass re-runs on that fresh file.
+        _INITIALIZED_PATHS.discard(str((d / "kanban.db").resolve()))
 
-    if archive:
-        archive_root = boards_root() / "_archived"
-        archive_root.mkdir(parents=True, exist_ok=True)
-        ts = int(time.time())
-        target = archive_root / f"{normed}-{ts}"
-        # Avoid collision on rapid double-archives.
-        suffix = 1
-        while target.exists():
-            target = archive_root / f"{normed}-{ts}-{suffix}"
-            suffix += 1
-        d.rename(target)
-        return {"slug": normed, "action": "archived", "new_path": str(target)}
-    else:
-        import shutil
+        if archive:
+            archive_root = boards_root() / "_archived"
+            archive_root.mkdir(parents=True, exist_ok=True)
+            ts = int(time.time())
+            target = archive_root / f"{normed}-{ts}"
+            # Avoid collision on rapid double-archives.
+            suffix = 1
+            while target.exists():
+                target = archive_root / f"{normed}-{ts}-{suffix}"
+                suffix += 1
+            d.rename(target)
+            return {
+                "slug": normed,
+                "action": "archived",
+                "new_path": str(target),
+            }
+
         shutil.rmtree(d)
         return {"slug": normed, "action": "deleted", "new_path": ""}
-
 
 # ---------------------------------------------------------------------------
 # Data classes

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -290,12 +290,30 @@ def decompose_task(
             task_id, False, f"task is not in triage (status={task.status!r})"
         )
 
+    board = kb.get_current_board()
+    allowed_profiles = kb.get_board_allowed_profiles(board)
+    if allowed_profiles == ():
+        return DecomposeOutcome(task_id, False, "board profile allowlist is empty")
+
     cfg = _load_config()
     orchestrator = _resolve_orchestrator_profile(cfg)
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
     roster, valid_names = _build_roster()
+    if allowed_profiles is not None:
+        by_name = {entry["name"]: entry for entry in roster}
+        roster = [by_name[name] for name in allowed_profiles if name in by_name]
+        valid_names = {entry["name"] for entry in roster}
+    if not valid_names:
+        return DecomposeOutcome(
+            task_id, False, "no installed profiles satisfy the board profile allowlist"
+        )
+    fallback = roster[0]["name"]
+    if orchestrator not in valid_names:
+        orchestrator = fallback
+    if default_assignee not in valid_names:
+        default_assignee = fallback
 
     try:
         from agent.auxiliary_client import call_llm  # type: ignore
@@ -351,7 +369,7 @@ def decompose_task(
         title_val = new_title.strip() if isinstance(new_title, str) and new_title.strip() else None
         body_val = new_body if isinstance(new_body, str) and new_body.strip() else None
         assignee_val = None
-        if not task.assignee:
+        if not task.assignee or task.assignee not in valid_names:
             assignee_val = _normalize_assignee_choice(
                 parsed.get("assignee"),
                 default_assignee=default_assignee,
@@ -369,6 +387,7 @@ def decompose_task(
                 body=body_val,
                 assignee=assignee_val,
                 author=audit_author,
+                board=board,
             )
         if not ok:
             return DecomposeOutcome(
@@ -438,6 +457,7 @@ def decompose_task(
                 children=children,
                 author=audit_author,
                 auto_promote=auto_promote,
+                board=board,
             )
     except ValueError as exc:
         return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -90,6 +90,7 @@ def create_swarm(
     workspace_path: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
+    board: Optional[str] = None,
 ) -> SwarmCreated:
     """Create a durable Kanban swarm graph.
 
@@ -108,6 +109,20 @@ def create_swarm(
         _require_text(spec.profile, f"workers[{i}].profile")
         _require_text(spec.title, f"workers[{i}].title")
 
+    # Validate the complete topology before the first INSERT. Otherwise a
+    # disallowed verifier or late worker could leave a partial swarm behind.
+    kb.require_profile_allowed(board, created_by, operation="swarm root assignment")
+    for spec in worker_specs:
+        kb.require_profile_allowed(
+            board, spec.profile, operation="swarm worker assignment"
+        )
+    kb.require_profile_allowed(
+        board, verifier_assignee, operation="swarm verifier assignment"
+    )
+    kb.require_profile_allowed(
+        board, synthesizer_assignee, operation="swarm synthesizer assignment"
+    )
+
     root = kb.create_task(
         conn,
         title=root_title or f"Swarm: {goal.splitlines()[0][:80]}",
@@ -124,6 +139,7 @@ def create_swarm(
         idempotency_key=idempotency_key,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
+        board=board,
     )
 
     # If idempotency returned an existing non-archived root, do not duplicate the
@@ -169,6 +185,7 @@ def create_swarm(
             workspace_path=workspace_path,
             skills=spec.skills or None,
             max_runtime_seconds=spec.max_runtime_seconds,
+            board=board,
         )
         worker_ids.append(worker_id)
 
@@ -190,6 +207,7 @@ def create_swarm(
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
         skills=["requesting-code-review"],
+        board=board,
     )
 
     synthesizer_body = (
@@ -209,6 +227,7 @@ def create_swarm(
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
         skills=["humanizer"],
+        board=board,
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -636,6 +636,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             goal_max_turns=payload.goal_max_turns,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
+            board=board,
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
@@ -849,8 +850,10 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         if payload.assignee is not None:
             try:
                 ok = kanban_db.assign_task(
-                    conn, task_id, payload.assignee or None,
+                    conn, task_id, payload.assignee or None, board=board,
                 )
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
             except RuntimeError as e:
                 raise HTTPException(status_code=409, detail=str(e))
             if not ok:
@@ -1264,10 +1267,12 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             ok = kanban_db.reassign_task(
                                 conn, tid, payload.assignee or None,
                                 reclaim_first=True,
+                                board=board,
                             )
                         else:
                             ok = kanban_db.assign_task(
                                 conn, tid, payload.assignee or None,
+                                board=board,
                             )
                         if not ok:
                             entry.update(ok=False, error="assign refused")
@@ -1721,6 +1726,7 @@ def reassign_task_endpoint(
             payload.profile or None,
             reclaim_first=bool(payload.reclaim_first),
             reason=payload.reason,
+            board=board,
         )
         if not ok:
             raise HTTPException(
@@ -1731,6 +1737,8 @@ def reassign_task_endpoint(
                 ),
             )
         return {"ok": True, "task_id": task_id, "assignee": payload.profile or None}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     finally:
         conn.close()
 
@@ -2078,6 +2086,7 @@ class CreateBoardBody(BaseModel):
     icon: Optional[str] = None
     color: Optional[str] = None
     default_workdir: Optional[str] = None
+    allowed_profiles: Optional[list[str]] = None
     switch: bool = False
 
 
@@ -2089,6 +2098,7 @@ class RenameBoardBody(BaseModel):
     # Board-level default project directory for new tasks. ``None`` =
     # leave unchanged; empty string = clear; a path = validate + set.
     default_workdir: Optional[str] = None
+    allowed_profiles: Optional[list[str]] = None
 
 
 def _board_counts(slug: str) -> dict[str, int]:
@@ -2160,6 +2170,14 @@ def create_board_endpoint(payload: CreateBoardBody):
     if payload.default_workdir:
         default_workdir = _validate_workdir(payload.default_workdir)
     try:
+        payload_fields = getattr(
+            payload, "model_fields_set", getattr(payload, "__fields_set__", set())
+        )
+        policy_kwargs: dict[str, Any] = (
+            {"allowed_profiles": payload.allowed_profiles}
+            if "allowed_profiles" in payload_fields
+            else {}
+        )
         meta = kanban_db.create_board(
             payload.slug,
             name=payload.name,
@@ -2167,6 +2185,7 @@ def create_board_endpoint(payload: CreateBoardBody):
             icon=payload.icon,
             color=payload.color,
             default_workdir=default_workdir,
+            **policy_kwargs,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -2194,14 +2213,26 @@ def rename_board(slug: str, payload: RenameBoardBody):
     if payload.default_workdir is not None:
         raw = payload.default_workdir.strip()
         default_workdir = _validate_workdir(raw) if raw else ""
-    meta = kanban_db.write_board_metadata(
-        normed,
-        name=payload.name,
-        description=payload.description,
-        icon=payload.icon,
-        color=payload.color,
-        default_workdir=default_workdir,
+    payload_fields = getattr(
+        payload, "model_fields_set", getattr(payload, "__fields_set__", set())
     )
+    policy_kwargs: dict[str, Any] = (
+        {"allowed_profiles": payload.allowed_profiles}
+        if "allowed_profiles" in payload_fields
+        else {}
+    )
+    try:
+        meta = kanban_db.write_board_metadata(
+            normed,
+            name=payload.name,
+            description=payload.description,
+            icon=payload.icon,
+            color=payload.color,
+            default_workdir=default_workdir,
+            **policy_kwargs,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     meta["default_workspace_kind"] = _default_workspace_kind(meta)
     return {"board": meta}
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1221,6 +1221,14 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     entry.update(ok=False, error="not found")
                     results.append(entry)
                     continue
+                if payload.assignee is not None:
+                    # Validate policy before status/archive/priority writes so
+                    # a rejected destination cannot leave a partial mutation.
+                    kanban_db.require_profile_allowed(
+                        board,
+                        payload.assignee or None,
+                        operation="bulk task assignment",
+                    )
                 if payload.archive:
                     if not kanban_db.archive_task(conn, tid):
                         entry.update(ok=False, error="archive refused")

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -9,9 +9,13 @@ called every tick, reading the current config.
 
 from __future__ import annotations
 
+import os
+import threading
+
 import pytest
 
 from gateway.kanban_watchers import _resolve_auto_decompose_settings
+from hermes_cli import kanban_db as kb
 
 
 def test_enabled_by_default_when_key_absent():
@@ -81,3 +85,39 @@ def test_live_toggle_takes_effect_between_calls():
     # User edits config.yaml mid-run.
     state["kanban"]["auto_decompose"] = False
     assert _resolve_auto_decompose_settings(lambda: state)[0] is False
+
+
+def test_scoped_board_context_does_not_leak_between_threads(monkeypatch, tmp_path):
+    """A slow decomposer must not change concurrent requests' active board."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    kb._INITIALIZED_PATHS.clear()
+    kb.create_board("decomposed-board")
+    entered = threading.Barrier(2)
+    release = threading.Barrier(2)
+    observed: dict[str, str] = {}
+
+    def auto_decomposer_thread():
+        with kb.scoped_current_board("decomposed-board"):
+            observed["inside"] = kb.get_current_board()
+            entered.wait()
+            release.wait()
+        observed["after"] = kb.get_current_board()
+
+    thread = threading.Thread(target=auto_decomposer_thread)
+    thread.start()
+    entered.wait()
+    observed["parallel"] = kb.get_current_board()
+    observed["env"] = os.environ["HERMES_KANBAN_BOARD"]
+    release.wait()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert observed == {
+        "inside": "decomposed-board",
+        "parallel": "default",
+        "env": "default",
+        "after": "default",
+    }
+    kb._INITIALIZED_PATHS.clear()

--- a/tests/hermes_cli/test_kanban_board_metadata_lock.py
+++ b/tests/hermes_cli/test_kanban_board_metadata_lock.py
@@ -1,0 +1,302 @@
+"""Concurrency regressions for board.json policy updates."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    for key in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_DELEGATED_CHILD_CONTEXT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    kb._INITIALIZED_PATHS.clear()
+    kb._BOARD_METADATA_THREAD_LOCKS.clear()
+    kb.create_board("guarded")
+    return home
+
+
+def _wait_for(path: Path, *, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {path}")
+
+
+def test_concurrent_metadata_edits_preserve_tightened_allowlist(
+    kanban_home, monkeypatch
+):
+    """An unrelated stale rename must not reopen a concurrently frozen board."""
+    original_read = kb.read_board_metadata
+    rename_has_read = threading.Event()
+    release_rename = threading.Event()
+    policy_started = threading.Event()
+    policy_done = threading.Event()
+    errors: list[BaseException] = []
+
+    def gated_read(board=None):
+        meta = original_read(board)
+        if threading.current_thread().name == "metadata-rename":
+            rename_has_read.set()
+            if not release_rename.wait(timeout=5):
+                raise TimeoutError("test did not release rename writer")
+        return meta
+
+    monkeypatch.setattr(kb, "read_board_metadata", gated_read)
+
+    def rename_writer():
+        try:
+            kb.write_board_metadata("guarded", name="Renamed")
+        except BaseException as exc:  # surfaced below on the main test thread
+            errors.append(exc)
+
+    def policy_writer():
+        policy_started.set()
+        try:
+            kb.write_board_metadata("guarded", allowed_profiles=[])
+        except BaseException as exc:  # surfaced below on the main test thread
+            errors.append(exc)
+        finally:
+            policy_done.set()
+
+    rename = threading.Thread(target=rename_writer, name="metadata-rename")
+    policy = threading.Thread(target=policy_writer, name="metadata-policy")
+    rename.start()
+    _wait_for_event = rename_has_read.wait(timeout=5)
+    assert _wait_for_event, "rename writer never reached the controlled stale read"
+    policy.start()
+    assert policy_started.wait(timeout=5)
+    try:
+        time.sleep(0.1)
+        assert not policy_done.is_set(), (
+            "policy writer entered while the stale rename held the metadata lock"
+        )
+    finally:
+        release_rename.set()
+        rename.join(timeout=10)
+        policy.join(timeout=10)
+
+    assert not rename.is_alive()
+    assert not policy.is_alive()
+    assert errors == []
+    meta = original_read("guarded")
+    assert meta["name"] == "Renamed"
+    assert meta["allowed_profiles"] == []
+
+
+def test_metadata_lock_timeout_fails_closed(kanban_home):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def holder():
+        with kb._board_metadata_lock("guarded"):
+            entered.set()
+            release.wait(timeout=5)
+
+    thread = threading.Thread(target=holder)
+    thread.start()
+    assert entered.wait(timeout=5)
+    try:
+        with pytest.raises(TimeoutError, match="board metadata lock"):
+            with kb._board_metadata_lock("guarded", timeout_seconds=0.1):
+                raise AssertionError("contended lock unexpectedly acquired")
+    finally:
+        release.set()
+        thread.join(timeout=10)
+    assert not thread.is_alive()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires POSIX fork")
+def test_forked_child_does_not_inherit_reentrant_lock_exemption(kanban_home):
+    """A fork child must contend on the kernel lock, not skip it as reentrant."""
+    with kb._board_metadata_lock("guarded"):
+        child_pid = os.fork()
+        if child_pid == 0:  # pragma: no cover - assertions run in parent
+            try:
+                with kb._board_metadata_lock("guarded", timeout_seconds=0.2):
+                    os._exit(2)
+            except TimeoutError:
+                os._exit(0)
+            except BaseException:
+                os._exit(3)
+        waited_pid, status = os.waitpid(child_pid, 0)
+
+    assert waited_pid == child_pid
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+
+
+def test_remove_blocks_stale_writer_and_prevents_resurrection(
+    kanban_home, monkeypatch
+):
+    """A metadata edit queued behind deletion must fail, not recreate the board."""
+    remove_entered = threading.Event()
+    release_remove = threading.Event()
+    writer_started = threading.Event()
+    writer_done = threading.Event()
+    errors: list[BaseException] = []
+    original_rmtree = kb.shutil.rmtree
+
+    def gated_rmtree(path):
+        remove_entered.set()
+        if not release_remove.wait(timeout=5):
+            raise TimeoutError("test did not release board removal")
+        return original_rmtree(path)
+
+    monkeypatch.setattr(kb.shutil, "rmtree", gated_rmtree)
+
+    def remover():
+        try:
+            kb.remove_board("guarded", archive=False)
+        except BaseException as exc:
+            errors.append(exc)
+
+    def stale_writer():
+        writer_started.set()
+        try:
+            kb.write_board_metadata("guarded", name="Resurrected")
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            writer_done.set()
+
+    remove_thread = threading.Thread(target=remover)
+    writer_thread = threading.Thread(target=stale_writer)
+    remove_thread.start()
+    assert remove_entered.wait(timeout=5)
+    writer_thread.start()
+    assert writer_started.wait(timeout=5)
+    try:
+        time.sleep(0.1)
+        assert not writer_done.is_set(), "stale writer bypassed the removal lock"
+    finally:
+        release_remove.set()
+        remove_thread.join(timeout=10)
+        writer_thread.join(timeout=10)
+
+    assert not remove_thread.is_alive()
+    assert not writer_thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], ValueError)
+    assert "does not exist" in str(errors[0])
+    assert not kb.board_dir("guarded").exists()
+    assert not kb.board_exists("guarded")
+
+
+def test_write_metadata_preserves_implicit_named_board_creation(kanban_home):
+    meta = kb.write_board_metadata("implicit-alias", name="Implicit Alias")
+
+    assert meta["name"] == "Implicit Alias"
+    assert kb.board_exists("implicit-alias")
+    assert kb.read_board_metadata("implicit-alias")["name"] == "Implicit Alias"
+
+
+@pytest.mark.skipif(
+    os.name not in {"posix", "nt"},
+    reason="board metadata lock supports POSIX flock and Windows msvcrt",
+)
+def test_metadata_lock_excludes_another_process(kanban_home, tmp_path):
+    ready = tmp_path / "holder-ready"
+    release = tmp_path / "holder-release"
+    writer_started = tmp_path / "writer-started"
+    writer_done = tmp_path / "writer-done"
+    holder_script = tmp_path / "holder.py"
+    writer_script = tmp_path / "writer.py"
+
+    holder_script.write_text(
+        textwrap.dedent(
+            f"""
+            import time
+            from pathlib import Path
+            from hermes_cli import kanban_db as kb
+
+            ready = Path({str(ready)!r})
+            release = Path({str(release)!r})
+            with kb._board_metadata_lock("guarded"):
+                ready.write_text("1", encoding="utf-8")
+                deadline = time.monotonic() + 15
+                while not release.exists():
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("parent did not release metadata lock")
+                    time.sleep(0.01)
+            """
+        ),
+        encoding="utf-8",
+    )
+    writer_script.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            from hermes_cli import kanban_db as kb
+
+            Path({str(writer_started)!r}).write_text("1", encoding="utf-8")
+            kb.write_board_metadata("guarded", allowed_profiles=[])
+            Path({str(writer_done)!r}).write_text("1", encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(kanban_home)
+    env["HERMES_KANBAN_HOME"] = str(kanban_home)
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+    env.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+
+    holder = subprocess.Popen(
+        [sys.executable, str(holder_script)],
+        cwd=_REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    writer = None
+    try:
+        _wait_for(ready)
+        writer = subprocess.Popen(
+            [sys.executable, str(writer_script)],
+            cwd=_REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        _wait_for(writer_started)
+        time.sleep(0.1)
+        assert not writer_done.exists(), (
+            "separate process entered the board metadata critical section"
+        )
+    finally:
+        release.write_text("1", encoding="utf-8")
+
+    holder_out, holder_err = holder.communicate(timeout=15)
+    assert holder.returncode == 0, holder_out + holder_err
+    assert writer is not None
+    writer_out, writer_err = writer.communicate(timeout=15)
+    assert writer.returncode == 0, writer_out + writer_err
+    assert writer_done.exists()
+    assert kb.read_board_metadata("guarded")["allowed_profiles"] == []

--- a/tests/hermes_cli/test_kanban_board_profile_allowlist.py
+++ b/tests/hermes_cli/test_kanban_board_profile_allowlist.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    yield home
+    kb._INITIALIZED_PATHS.clear()
+
+
+def _profiles(names: list[str]):
+    return [
+        SimpleNamespace(
+            name=name,
+            is_default=name == "default",
+            description=f"description for {name}",
+            description_auto=False,
+            model="model",
+            provider="provider",
+            skill_count=0,
+        )
+        for name in names
+    ]
+
+
+def _aux_response(payload: dict):
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps(payload)
+    client = MagicMock()
+    client.chat.completions.create.return_value = response
+    return client
+
+
+def test_board_allowed_profiles_round_trip_and_normalize(kanban_home):
+    kb.create_board("guarded")
+
+    meta = kb.write_board_metadata(
+        "guarded",
+        allowed_profiles=[" Alex ", "kitt", "ALEX"],
+    )
+
+    assert meta["allowed_profiles"] == ["alex", "kitt"]
+    assert kb.get_board_allowed_profiles("guarded") == ("alex", "kitt")
+    assert kb.is_profile_allowed("guarded", "Alex") is True
+    assert kb.is_profile_allowed("guarded", "goggins") is False
+    assert kb.get_board_allowed_profiles("default") is None
+
+
+def test_implicit_policy_lookup_uses_current_board(kanban_home, monkeypatch):
+    kb.create_board("guarded", allowed_profiles=["alex"])
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "guarded")
+
+    assert kb.get_board_allowed_profiles() == ("alex",)
+    assert kb.is_profile_allowed(None, "alex") is True
+    assert kb.is_profile_allowed(None, "goggins") is False
+
+
+def test_malformed_existing_board_metadata_fails_closed(kanban_home):
+    kb.create_board("guarded", allowed_profiles=["alex"])
+    kb.board_metadata_path("guarded").write_text("{broken-json", encoding="utf-8")
+
+    assert kb.get_board_allowed_profiles("guarded") == ()
+    assert kb.is_profile_allowed("guarded", "alex") is False
+    assert kb.is_profile_allowed("guarded", "goggins") is False
+
+
+def test_empty_allowlist_denies_every_profile_and_none_restores_unrestricted(kanban_home):
+    kb.create_board("guarded", allowed_profiles=[])
+    assert kb.get_board_allowed_profiles("guarded") == ()
+    assert kb.is_profile_allowed("guarded", "alex") is False
+
+    kb.write_board_metadata("guarded", allowed_profiles=None)
+    assert kb.get_board_allowed_profiles("guarded") is None
+    assert kb.is_profile_allowed("guarded", "goggins") is True
+
+
+def test_create_and_reassign_reject_disallowed_profiles(kanban_home):
+    kb.create_board("guarded", allowed_profiles=["alex", "kitt"])
+    with kb.connect(board="guarded") as conn:
+        allowed_id = kb.create_task(
+            conn,
+            title="allowed",
+            assignee="alex",
+            board="guarded",
+        )
+        with pytest.raises(ValueError, match="not allowed on board 'guarded'"):
+            kb.create_task(
+                conn,
+                title="disallowed",
+                assignee="goggins",
+                board="guarded",
+            )
+        with pytest.raises(ValueError, match="not allowed on board 'guarded'"):
+            kb.reassign_task(conn, allowed_id, "chef", board="guarded")
+        assert kb.get_task(conn, allowed_id).assignee == "alex"
+
+
+def test_dispatch_skips_preexisting_disallowed_assignment(kanban_home):
+    kb.create_board("guarded")
+    with kb.connect(board="guarded") as conn:
+        allowed_id = kb.create_task(
+            conn, title="allowed", assignee="default", board="guarded"
+        )
+        disallowed_id = kb.create_task(
+            conn, title="stale", assignee="goggins", board="guarded"
+        )
+
+    kb.write_board_metadata("guarded", allowed_profiles=["default"])
+    spawned: list[str] = []
+
+    def spawn(task, workspace, board=None):
+        spawned.append(task.id)
+        return 4242
+
+    with kb.connect(board="guarded") as conn:
+        result = kb.dispatch_once(conn, spawn_fn=spawn, board="guarded")
+        allowed = kb.get_task(conn, allowed_id)
+        disallowed = kb.get_task(conn, disallowed_id)
+
+    assert spawned == [allowed_id]
+    assert result.skipped_disallowed == [disallowed_id]
+    assert allowed.status == "running"
+    assert disallowed.status == "ready"
+
+
+def test_direct_claim_rejects_preexisting_disallowed_assignment(kanban_home):
+    kb.create_board("guarded")
+    with kb.connect(board="guarded") as conn:
+        task_id = kb.create_task(
+            conn, title="stale", assignee="goggins", board="guarded"
+        )
+    kb.write_board_metadata("guarded", allowed_profiles=["alex"])
+
+    with kb.connect(board="guarded") as conn:
+        claimed = kb.claim_task(conn, task_id, board="guarded")
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+
+    assert claimed is None
+    assert task.status == "ready"
+    assert any(
+        event.kind == "claim_rejected"
+        and event.payload
+        and event.payload.get("reason") == "profile_not_allowed"
+        for event in events
+    )
+
+
+def test_decomposer_filters_roster_and_uses_allowed_fallbacks(kanban_home, monkeypatch):
+    kb.create_board("guarded", allowed_profiles=["alex", "kitt"])
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "guarded")
+    with kb.connect(board="guarded") as conn:
+        task_id = kb.create_task(conn, title="rough", triage=True, board="guarded")
+
+    payload = {
+        "fanout": True,
+        "rationale": "split",
+        "tasks": [
+            {"title": "ordinary", "body": "build", "assignee": "goggins", "parents": []},
+            {"title": "security", "body": "audit", "assignee": "kitt", "parents": []},
+        ],
+    }
+    client = _aux_response(payload)
+    with patch("hermes_cli.profiles.list_profiles", return_value=_profiles(["alex", "kitt", "goggins", "chef"])), \
+         patch("hermes_cli.profiles.profile_exists", return_value=True), \
+         patch("hermes_cli.profiles.get_active_profile_name", return_value="goggins"), \
+         patch("hermes_cli.kanban_decompose._load_config", return_value={"kanban": {}}), \
+         patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(client, "test-model")), \
+         patch("agent.auxiliary_client.get_auxiliary_extra_body", return_value={}):
+        outcome = decomp.decompose_task(task_id, author="test")
+
+    assert outcome.ok, outcome.reason
+    with kb.connect(board="guarded") as conn:
+        root = kb.get_task(conn, task_id)
+        children = [kb.get_task(conn, child_id) for child_id in outcome.child_ids]
+
+    assert root.assignee == "alex"
+    assert [child.assignee for child in children] == ["alex", "kitt"]
+    prompt = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert "alex" in prompt and "kitt" in prompt
+    assert "goggins" not in prompt and "chef" not in prompt
+
+
+def test_decomposer_does_not_call_llm_when_allowlist_is_empty(kanban_home, monkeypatch):
+    kb.create_board("frozen", allowed_profiles=[])
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "frozen")
+    with kb.connect(board="frozen") as conn:
+        task_id = kb.create_task(conn, title="rough", triage=True, board="frozen")
+
+    with patch("agent.auxiliary_client.get_text_auxiliary_client") as get_client:
+        outcome = decomp.decompose_task(task_id, author="test")
+
+    assert outcome.ok is False
+    assert "allowlist is empty" in outcome.reason
+    get_client.assert_not_called()

--- a/tests/hermes_cli/test_kanban_board_profile_allowlist.py
+++ b/tests/hermes_cli/test_kanban_board_profile_allowlist.py
@@ -80,6 +80,17 @@ def test_malformed_existing_board_metadata_fails_closed(kanban_home):
     assert kb.is_profile_allowed("guarded", "goggins") is False
 
 
+@pytest.mark.parametrize("payload", [[], None, "bad", 42, True])
+def test_non_object_board_metadata_fails_closed(kanban_home, payload):
+    kb.create_board("guarded", allowed_profiles=["alex"])
+    kb.board_metadata_path("guarded").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    assert kb.get_board_allowed_profiles("guarded") == ()
+    assert kb.is_profile_allowed("guarded", "alex") is False
+
+
 def test_empty_allowlist_denies_every_profile_and_none_restores_unrestricted(kanban_home):
     kb.create_board("guarded", allowed_profiles=[])
     assert kb.get_board_allowed_profiles("guarded") == ()
@@ -160,6 +171,66 @@ def test_direct_claim_rejects_preexisting_disallowed_assignment(kanban_home):
         and event.payload.get("reason") == "profile_not_allowed"
         for event in events
     )
+
+
+def test_empty_allowlist_rejects_unassigned_ready_and_review_claims(kanban_home):
+    kb.create_board("frozen", allowed_profiles=[])
+    with kb.connect(board="frozen") as conn:
+        ready_id = kb.create_task(conn, title="ready", board="frozen")
+        review_id = kb.create_task(conn, title="review", board="frozen")
+        conn.execute(
+            "UPDATE tasks SET status = 'review' WHERE id = ?",
+            (review_id,),
+        )
+        conn.commit()
+
+        assert kb.claim_task(conn, ready_id, board="frozen") is None
+        assert kb.claim_review_task(conn, review_id, board="frozen") is None
+        ready = kb.get_task(conn, ready_id)
+        review = kb.get_task(conn, review_id)
+        assert ready is not None and ready.status == "ready"
+        assert review is not None and review.status == "review"
+
+
+def test_rejected_reassign_reclaim_preserves_running_task_and_run(kanban_home):
+    kb.create_board("guarded", allowed_profiles=["alex"])
+    with kb.connect(board="guarded") as conn:
+        task_id = kb.create_task(
+            conn, title="running", assignee="alex", board="guarded"
+        )
+        claimed = kb.claim_task(
+            conn, task_id, claimer="claim-1", board="guarded"
+        )
+        assert claimed is not None
+        before = kb.get_task(conn, task_id)
+        assert before is not None
+        runs_before = kb.list_runs(conn, task_id)
+
+        with pytest.raises(ValueError, match="not allowed on board 'guarded'"):
+            kb.reassign_task(
+                conn,
+                task_id,
+                "goggins",
+                reclaim_first=True,
+                board="guarded",
+            )
+
+        after = kb.get_task(conn, task_id)
+        assert after is not None
+        runs_after = kb.list_runs(conn, task_id)
+
+    assert (
+        after.status,
+        after.assignee,
+        after.claim_lock,
+        after.current_run_id,
+    ) == (
+        before.status,
+        before.assignee,
+        before.claim_lock,
+        before.current_run_id,
+    )
+    assert runs_after == runs_before
 
 
 def test_decomposer_filters_roster_and_uses_allowed_fallbacks(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_board_profile_allowlist.py
+++ b/tests/hermes_cli/test_kanban_board_profile_allowlist.py
@@ -42,9 +42,7 @@ def _aux_response(payload: dict):
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = json.dumps(payload)
-    client = MagicMock()
-    client.chat.completions.create.return_value = response
-    return client
+    return response
 
 
 def test_board_allowed_profiles_round_trip_and_normalize(kanban_home):
@@ -247,13 +245,12 @@ def test_decomposer_filters_roster_and_uses_allowed_fallbacks(kanban_home, monke
             {"title": "security", "body": "audit", "assignee": "kitt", "parents": []},
         ],
     }
-    client = _aux_response(payload)
+    call_llm = MagicMock(return_value=_aux_response(payload))
     with patch("hermes_cli.profiles.list_profiles", return_value=_profiles(["alex", "kitt", "goggins", "chef"])), \
          patch("hermes_cli.profiles.profile_exists", return_value=True), \
          patch("hermes_cli.profiles.get_active_profile_name", return_value="goggins"), \
          patch("hermes_cli.kanban_decompose._load_config", return_value={"kanban": {}}), \
-         patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(client, "test-model")), \
-         patch("agent.auxiliary_client.get_auxiliary_extra_body", return_value={}):
+         patch("agent.auxiliary_client.call_llm", call_llm):
         outcome = decomp.decompose_task(task_id, author="test")
 
     assert outcome.ok, outcome.reason
@@ -263,7 +260,7 @@ def test_decomposer_filters_roster_and_uses_allowed_fallbacks(kanban_home, monke
 
     assert root.assignee == "alex"
     assert [child.assignee for child in children] == ["alex", "kitt"]
-    prompt = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    prompt = call_llm.call_args.kwargs["messages"][1]["content"]
     assert "alex" in prompt and "kitt" in prompt
     assert "goggins" not in prompt and "chef" not in prompt
 
@@ -274,9 +271,9 @@ def test_decomposer_does_not_call_llm_when_allowlist_is_empty(kanban_home, monke
     with kb.connect(board="frozen") as conn:
         task_id = kb.create_task(conn, title="rough", triage=True, board="frozen")
 
-    with patch("agent.auxiliary_client.get_text_auxiliary_client") as get_client:
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
         outcome = decomp.decompose_task(task_id, author="test")
 
     assert outcome.ok is False
     assert "allowlist is empty" in outcome.reason
-    get_client.assert_not_called()
+    call_llm.assert_not_called()

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -557,3 +557,83 @@ class TestCLI:
         res = _cli(["boards", "list", "--json"], env_extra=env)
         slugs = [b["slug"] for b in json.loads(res.stdout)]
         assert "rmme" not in slugs
+
+    def test_board_profile_allowlist_cli_round_trip(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        created = _cli(
+            [
+                "boards", "create", "guarded",
+                "--allowed-profile", "Alex",
+                "--allowed-profile", "kitt",
+            ],
+            env_extra=env,
+        )
+        assert created.returncode == 0, created.stderr
+
+        listed = _cli(["boards", "list", "--json"], env_extra=env)
+        guarded = next(b for b in json.loads(listed.stdout) if b["slug"] == "guarded")
+        assert guarded["allowed_profiles"] == ["alex", "kitt"]
+
+        denied = _cli(
+            ["--board", "guarded", "create", "wrong", "--assignee", "goggins"],
+            env_extra=env,
+        )
+        assert "not allowed on board 'guarded'" in denied.stderr
+
+        allowed = _cli(
+            ["--board", "guarded", "create", "right", "--assignee", "alex"],
+            env_extra=env,
+        )
+        assert "Created" in allowed.stdout
+
+    def test_set_allowed_profiles_can_freeze_and_restore_unrestricted(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "guarded"], env_extra=env).returncode == 0
+
+        frozen = _cli(
+            ["boards", "set-allowed-profiles", "guarded"], env_extra=env
+        )
+        assert "execution is frozen" in frozen.stdout
+        denied = _cli(
+            ["--board", "guarded", "create", "wrong", "--assignee", "alex"],
+            env_extra=env,
+        )
+        assert "not allowed" in denied.stderr
+
+        restored = _cli(
+            ["boards", "set-allowed-profiles", "guarded", "--unrestricted"],
+            env_extra=env,
+        )
+        assert "unrestricted" in restored.stdout
+        accepted = _cli(
+            ["--board", "guarded", "create", "works", "--assignee", "goggins"],
+            env_extra=env,
+        )
+        assert "Created" in accepted.stdout
+
+    def test_cli_dispatch_enforces_named_board_profile_allowlist(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        for profile in ("alex", "goggins"):
+            (tmp_path / "profiles" / profile).mkdir(parents=True, exist_ok=True)
+        assert _cli(["boards", "create", "guarded"], env_extra=env).returncode == 0
+        assert "Created" in _cli(
+            ["--board", "guarded", "create", "legacy", "--assignee", "goggins"],
+            env_extra=env,
+        ).stdout
+        assert _cli(
+            ["boards", "set-allowed-profiles", "guarded", "alex"],
+            env_extra=env,
+        ).returncode == 0
+        assert "Created" in _cli(
+            ["--board", "guarded", "create", "allowed", "--assignee", "alex"],
+            env_extra=env,
+        ).stdout
+
+        dispatched = _cli(
+            ["--board", "guarded", "dispatch", "--dry-run", "--json"],
+            env_extra=env,
+        )
+        assert dispatched.returncode == 0, dispatched.stderr
+        data = json.loads(dispatched.stdout)
+        assert [entry["assignee"] for entry in data["spawned"]] == ["alex"]
+        assert len(data["skipped_disallowed"]) == 1

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -637,3 +637,72 @@ class TestCLI:
         data = json.loads(dispatched.stdout)
         assert [entry["assignee"] for entry in data["spawned"]] == ["alex"]
         assert len(data["skipped_disallowed"]) == 1
+
+    def test_boards_create_invalid_allowed_profile_is_usage_error(self, tmp_path):
+        env = {
+            "HERMES_HOME": str(tmp_path),
+            "HERMES_DELEGATED_CHILD_CONTEXT": "",
+        }
+
+        result = _cli(
+            ["boards", "create", "guarded", "--allowed-profile", "bad/name"],
+            env_extra=env,
+        )
+
+        assert result.returncode == 2
+        assert "kanban boards create: Invalid profile name" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_swarm_disallowed_profile_is_usage_error(self, tmp_path):
+        env = {
+            "HERMES_HOME": str(tmp_path),
+            "HERMES_DELEGATED_CHILD_CONTEXT": "",
+            "HERMES_PROFILE_NAME": "alex",
+        }
+        assert _cli(
+            ["boards", "create", "guarded", "--allowed-profile", "alex"],
+            env_extra=env,
+        ).returncode == 0
+
+        result = _cli(
+            [
+                "--board", "guarded", "swarm", "policy proof",
+                "--worker", "goggins:worker",
+                "--verifier", "alex",
+                "--synthesizer", "alex",
+            ],
+            env_extra=env,
+        )
+
+        assert result.returncode == 2
+        assert "kanban swarm: profile 'goggins' is not allowed" in result.stderr
+        assert "Traceback" not in result.stderr
+        listed = _cli(["--board", "guarded", "list", "--json"], env_extra=env)
+        assert json.loads(listed.stdout) == []
+
+    def test_delegated_child_fast_fails_allowed_profile_mutation(self, tmp_path):
+        normal_env = {
+            "HERMES_HOME": str(tmp_path),
+            "HERMES_DELEGATED_CHILD_CONTEXT": "",
+        }
+        assert _cli(
+            ["boards", "create", "guarded", "--allowed-profile", "alex"],
+            env_extra=normal_env,
+        ).returncode == 0
+
+        child_env = {
+            "HERMES_HOME": str(tmp_path),
+            "HERMES_DELEGATED_CHILD_CONTEXT": "1",
+        }
+        result = _cli(
+            ["boards", "set-allowed-profiles", "guarded", "goggins"],
+            env_extra=child_env,
+        )
+
+        assert result.returncode == 1
+        assert "delegate_task child contexts cannot mutate Kanban" in result.stderr
+        assert "Traceback" not in result.stderr
+        metadata = json.loads(
+            (tmp_path / "kanban" / "boards" / "guarded" / "board.json").read_text()
+        )
+        assert metadata["allowed_profiles"] == ["alex"]

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -70,6 +70,28 @@ def test_claim_fires_hook(kanban_home, captured_hooks):
     assert kw["run_id"] is not None
 
 
+def test_claim_explicit_board_fires_hook_with_named_board(
+    kanban_home, captured_hooks
+):
+    kb.create_board("guarded", allowed_profiles=["worker"])
+    conn = kb.connect(board="guarded")
+    try:
+        tid = kb.create_task(
+            conn,
+            title="named-board task",
+            assignee="worker",
+            board="guarded",
+        )
+        claimed = kb.claim_task(conn, tid, board="guarded")
+        assert claimed is not None
+    finally:
+        conn.close()
+
+    fired = [e for e in captured_hooks if e[0] == "kanban_task_claimed"]
+    assert len(fired) == 1
+    assert fired[0][1]["board"] == "guarded"
+
+
 def test_complete_fires_hook_with_summary(kanban_home, captured_hooks):
     conn = kb.connect()
     try:

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -1,4 +1,6 @@
 
+import pytest
+
 from hermes_cli import kanban_db as kb
 from hermes_cli.kanban_swarm import (
     SwarmWorkerSpec,
@@ -115,3 +117,33 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         assert kb.get_task(conn, created.synthesizer_id).status == "ready"
     finally:
         conn.close()
+
+
+def test_create_swarm_rejects_disallowed_worker_profile(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb._INITIALIZED_PATHS.clear()
+    kb.create_board("guarded", allowed_profiles=["alex"])
+    conn = kb.connect(board="guarded")
+    try:
+        with pytest.raises(ValueError, match="not allowed on board 'guarded'"):
+            create_swarm(
+                conn,
+                goal="Use only authorized workers.",
+                workers=[
+                    SwarmWorkerSpec(
+                        profile="goggins",
+                        title="Unauthorized worker",
+                        body="Must be rejected",
+                    )
+                ],
+                verifier_assignee="alex",
+                synthesizer_assignee="alex",
+                created_by="alex",
+                board="guarded",
+            )
+    finally:
+        assert kb.list_tasks(conn) == []
+        conn.close()
+        kb._INITIALIZED_PATHS.clear()

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2592,3 +2592,41 @@ def test_board_profile_allowlist_api_enforces_create_and_patch(client):
         json={"title": "works again", "assignee": "goggins"},
     )
     assert accepted.status_code == 200, accepted.text
+
+
+def test_bulk_disallowed_assignee_does_not_apply_status_first(client):
+    created = client.post(
+        "/api/plugins/kanban/boards",
+        json={"slug": "guarded", "allowed_profiles": ["alex"]},
+    )
+    assert created.status_code == 200, created.text
+    task = client.post(
+        "/api/plugins/kanban/tasks?board=guarded",
+        json={"title": "keep running safely", "assignee": "alex"},
+    ).json()["task"]
+
+    bulk = client.post(
+        "/api/plugins/kanban/tasks/bulk?board=guarded",
+        json={
+            "ids": [task["id"]],
+            "status": "blocked",
+            "assignee": "goggins",
+        },
+    )
+
+    assert bulk.status_code == 200
+    assert bulk.json()["results"] == [
+        {
+            "id": task["id"],
+            "ok": False,
+            "error": (
+                "profile 'goggins' is not allowed on board 'guarded' "
+                "for bulk task assignment"
+            ),
+        }
+    ]
+    unchanged = client.get(
+        f"/api/plugins/kanban/tasks/{task['id']}?board=guarded"
+    ).json()["task"]
+    assert unchanged["status"] == "ready"
+    assert unchanged["assignee"] == "alex"

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2545,3 +2545,50 @@ def test_dashboard_parent_notice_and_child_results_use_detail_links():
     assert "t.link_counts" not in detail
     assert "Child Results" in detail
     assert "props.data.child_results" in detail
+
+def test_board_profile_allowlist_api_enforces_create_and_patch(client):
+    created = client.post(
+        "/api/plugins/kanban/boards",
+        json={"slug": "guarded", "allowed_profiles": ["alex", "kitt"]},
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["board"]["allowed_profiles"] == ["alex", "kitt"]
+
+    denied = client.post(
+        "/api/plugins/kanban/tasks?board=guarded",
+        json={"title": "wrong", "assignee": "goggins"},
+    )
+    assert denied.status_code == 400
+    assert "not allowed on board 'guarded'" in denied.json()["detail"]
+
+    allowed = client.post(
+        "/api/plugins/kanban/tasks?board=guarded",
+        json={"title": "right", "assignee": "alex"},
+    )
+    assert allowed.status_code == 200, allowed.text
+
+    frozen = client.patch(
+        "/api/plugins/kanban/boards/guarded",
+        json={"allowed_profiles": []},
+    )
+    assert frozen.status_code == 200, frozen.text
+    assert frozen.json()["board"]["allowed_profiles"] == []
+
+    denied_after_freeze = client.post(
+        "/api/plugins/kanban/tasks?board=guarded",
+        json={"title": "still wrong", "assignee": "alex"},
+    )
+    assert denied_after_freeze.status_code == 400
+
+    unrestricted = client.patch(
+        "/api/plugins/kanban/boards/guarded",
+        json={"allowed_profiles": None},
+    )
+    assert unrestricted.status_code == 200, unrestricted.text
+    assert unrestricted.json()["board"]["allowed_profiles"] is None
+
+    accepted = client.post(
+        "/api/plugins/kanban/tasks?board=guarded",
+        json={"title": "works again", "assignee": "goggins"},
+    )
+    assert accepted.status_code == 200, accepted.text

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -2115,6 +2115,26 @@ def test_board_param_routes_create_to_alt_board(multi_board_env):
         assert kb.get_task(conn, new_tid) is None
 
 
+def test_board_param_create_enforces_target_board_allowlist(multi_board_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    kb.write_board_metadata("alt", allowed_profiles=["alex"])
+    out = json.loads(
+        kt._handle_create(
+            {
+                "title": "must-not-exist",
+                "assignee": "goggins",
+                "board": "alt",
+            }
+        )
+    )
+
+    assert "not allowed on board 'alt'" in out["error"]
+    with kb.connect(board="alt") as conn:
+        assert all(task.title != "must-not-exist" for task in kb.list_tasks(conn))
+
+
 def test_board_param_routes_list_to_alt_board(multi_board_env):
     """kanban_list filters by the board parameter, not env-active."""
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1236,6 +1236,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                board=board or kb.get_current_board(),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -94,12 +94,21 @@ Per-board isolation is absolute:
 # See what's on disk. Fresh installs show only "default".
 hermes kanban boards list
 
-# Create a new board.
+# Create a new board. Repeat --allowed-profile to opt into a strict
+# board-level profile allowlist; omit it for legacy unrestricted routing.
 hermes kanban boards create atm10-server \
     --name "ATM10 Server" \
     --description "Minecraft modded server ops" \
     --icon 🎮 \
+    --allowed-profile ops \
+    --allowed-profile security \
     --switch                   # optional: make it the active board
+
+# Change a board's execution allowlist. Supplying no profiles freezes execution;
+# --unrestricted removes the policy and restores legacy routing.
+hermes kanban boards set-allowed-profiles atm10-server ops security
+hermes kanban boards set-allowed-profiles atm10-server
+hermes kanban boards set-allowed-profiles atm10-server --unrestricted
 
 # Operate on a specific board without switching.
 hermes kanban --board atm10-server list
@@ -133,6 +142,27 @@ Slugs are validated: lowercase alphanumerics + hyphens + underscores, 1-64
 chars, must start with alphanumeric. Uppercase input is auto-downcased.
 Anything else (slashes, spaces, dots, `..`) is rejected at the CLI layer
 so path-traversal tricks can't name a board.
+
+### Board profile allowlists
+
+`allowed_profiles` is stored in the board's `board.json` and read live on every
+dispatch/decomposition pass:
+
+- Missing or `null` preserves the historical unrestricted behavior.
+- A non-empty list restricts task creation, assignment, triage decomposition,
+  ready/review claims, and dispatcher spawning to those normalized profile names.
+- An explicit empty list freezes profile execution for the board.
+- Existing tasks assigned to an excluded profile remain visible and keep their
+  status, but the dispatcher reports them under `skipped_disallowed` and will
+  not spawn or claim them. Reassign them to an allowed profile explicitly.
+- The gateway process that owns the machine-wide dispatcher may belong to any
+  profile. It can still service the board, but decomposition fallbacks and child
+  routing are constrained to the board allowlist, so gateway startup order does
+  not leak its profile into the board.
+
+This is an execution/routing boundary, not an authorization system for humans
+with filesystem or database access. An operator who can edit `board.json` or the
+SQLite database can also change the policy.
 
 ### Managing boards from the dashboard
 


### PR DESCRIPTION
1|## Summary
2|
3|Add an optional per-board `allowed_profiles` policy that limits which Hermes profiles may own or execute work on that Kanban board.
4|
5|- Persist the policy in each named board's `board.json` metadata.
6|- Preserve legacy behavior when the field is absent or `null`.
7|- Treat `[]` as an explicit freeze: no profile may be assigned or dispatched.
8|- Normalize and deduplicate profile names while rejecting malformed values.
9|- Fail closed when board metadata exists but is malformed or unreadable.
10|- Serialize `board.json` read-modify-write updates with a bounded board-scoped cross-process lock and atomic replace, so unrelated concurrent metadata edits cannot silently reopen a tightened policy.
11|
12|## Enforcement coverage
13|
14|The policy is enforced at the mutation and execution boundaries, not just in the UI:
15|
16|- CLI task creation, assignment, reassignment, claim, and dispatch
17|- gateway ready/review checks and dispatch loops
18|- auto-decomposition and triage specification
19|- swarm preflight before any task is inserted
20|- dashboard create/update/bulk/reassign/dispatch APIs
21|- structured `kanban_create` tool calls
22|- direct DB-layer create/assign/reassign/claim paths
23|
24|Disallowed existing work remains visible but is reported as `skipped_disallowed` rather than spawned. Named-board claim lifecycle events retain the explicit board context.
25|
26|## Board metadata semantics
27|
28|| `allowed_profiles` value | Behavior |
29|| --- | --- |
30|| field absent or `null` | unrestricted; backward compatible |
31|| `[]` | deny all profile assignment/execution |
32|| `["alex", "kitt"]` | only those normalized profiles are allowed |
33|| malformed/unreadable metadata | fail closed as deny-all |
34|
35|CLI management:
36|
37|```bash
38|hermes kanban boards create guarded --allowed-profile alex --allowed-profile kitt
39|hermes kanban boards set-allowed-profiles guarded --allowed-profile alex
40|hermes kanban boards set-allowed-profiles guarded        # deny all
41|hermes kanban boards set-allowed-profiles guarded --unrestricted
42|```
43|
44|## Validation
45|
46|Executed against current upstream `main`:
47|
48|- Kanban CLI/gateway/dashboard/tool/delegated-isolation surface: **1,096 passed, 0 failed** across 42 files
49|- Command-level regressions prove invalid board-profile input and disallowed swarms return scoped usage errors without tracebacks, while delegated children fast-fail the new policy mutator without changing metadata
50|- Deterministic lost-update, bounded-timeout, cross-process, fork-inheritance, remove/resurrection, and implicit-create compatibility regressions: **6 passed, 0 failed**
51|- Ruff: clean
52|- Python bytecode compilation: clean
53|- `git diff --check`: clean
54|- secret/local-path diff scan: clean
55|- standalone temp-home CLI proof: allowed assignment passed; disallowed assignment rejected; deny-all rejected; unrestricted restore passed; malformed metadata failed closed; dry-run dispatch spawned only allowed work
56|
57|## Compatibility
58|
59|No migration is required. Existing boards without `allowed_profiles` remain unrestricted.
60|