### PR TITLE
fix(gateway): suppress responses interrupted during startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2746,6 +2746,59 @@ def _preserve_queued_followup_history_offset(
     return merged
 
 
+async def _retract_interrupted_stream_preview(
+    stream_consumer: Any,
+    stream_task: Any,
+) -> None:
+    """Stop stale streaming and retract any preview from an interrupted turn.
+
+    The agent result can be marked ``interrupted`` only after the provider
+    stream has already emitted text.  Cancel the consumer first so it cannot
+    race another edit onto the platform, then ask it to delete any preview it
+    delivered.  Retraction is best-effort for adapters without message-delete
+    support; the replacement turn must still continue.
+    """
+    if stream_consumer is None:
+        return
+
+    if stream_task is not None and not stream_task.done():
+        stream_task.cancel()
+    if stream_task is not None:
+        try:
+            await asyncio.wait_for(stream_task, timeout=5.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            stream_task.cancel()
+        except Exception as exc:
+            logger.debug("Interrupted stream shutdown failed: %s", exc)
+
+    retract = getattr(stream_consumer, "discard_interrupted_preview", None)
+    if callable(retract):
+        try:
+            await retract()
+        except Exception as exc:
+            logger.debug("Interrupted stream preview retraction failed: %s", exc)
+
+
+def _superseded_agent_run_result(
+    *,
+    messages: Optional[List[Dict[str, Any]]] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return a no-delivery result for a turn superseded during setup."""
+    return {
+        "final_response": "",
+        "messages": list(messages or []),
+        "api_calls": 0,
+        "completed": False,
+        "interrupted": True,
+        "interrupt_message": None,
+        "tools": [],
+        "history_offset": len(messages or []),
+        "session_id": session_id,
+        "superseded": True,
+    }
+
+
 async def _dispose_unused_adapter(adapter: "BasePlatformAdapter | None") -> None:
     """Best-effort dispose for an adapter that never made it onto ``self.adapters``.
 
@@ -5249,6 +5302,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return False
 
+    def _signal_busy_interrupt(
+        self,
+        session_key: str,
+        event: MessageEvent,
+        running_agent: Any,
+    ) -> None:
+        """Signal one interrupt across both gateway message guards.
+
+        A follow-up can arrive while ``_running_agents`` still contains the
+        pending sentinel, before an ``AIAgent`` exists.  Invalidate that run's
+        generation so setup cannot proceed into an obsolete API call.  Also set
+        the adapter guard event: the base adapter uses it to suppress stale
+        non-streaming delivery and the runner's monitor uses it as a backup
+        interrupt once agent construction completes.
+        """
+        if running_agent is _AGENT_PENDING_SENTINEL:
+            self._invalidate_session_run_generation(
+                session_key,
+                reason="busy_interrupt_during_agent_start",
+            )
+
+        adapter = self._adapter_for_source(event.source)
+        interrupt_event = (
+            getattr(adapter, "_active_sessions", {}).get(session_key)
+            if adapter
+            else None
+        )
+        if interrupt_event is not None:
+            try:
+                interrupt_event.set()
+            except Exception:
+                pass
+
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                running_agent.interrupt(event.text)
+            except Exception:
+                pass
+
     async def _session_has_compression_in_flight(self, session_key: str) -> bool:
         """Return True when a compression lock is held for this session's id.
 
@@ -5498,6 +5590,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "internal", False):
             return False
 
+        # Photo bursts/albums are merged by BasePlatformAdapter after this
+        # hook returns. They must never supersede or interrupt the active
+        # turn: Telegram can deliver one album as several near-simultaneous
+        # PHOTO events, including while the first turn still has only the
+        # pending-agent sentinel. Returning False preserves the adapter's
+        # native media queue/merge path and avoids losing the first image.
+        if event.message_type == MessageType.PHOTO:
+            return False
+
         running_agent = self._running_agents.get(session_key)
 
         effective_mode = self._busy_input_mode
@@ -5586,11 +5687,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit
         # at the next check point.
-        if effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
-            try:
-                running_agent.interrupt(event.text)
-            except Exception:
-                pass  # don't let interrupt failure block the ack
+        if effective_mode == "interrupt":
+            self._signal_busy_interrupt(session_key, event, running_agent)
 
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
@@ -9593,6 +9691,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
+            running_agent = self._running_agents.get(_quick_key)
+            if running_agent is _AGENT_PENDING_SENTINEL:
+                # The first turn is still in async setup. In interrupt mode,
+                # supersede it before it can enter the provider API; otherwise
+                # queue normally for the selected busy-input semantics.
+                self._queue_or_replace_pending_event(_quick_key, event)
+                if self._busy_input_mode == "interrupt":
+                    self._signal_busy_interrupt(_quick_key, event, running_agent)
+                return None
+
             _telegram_followup_grace = float(
                 os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
             )
@@ -9622,25 +9730,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                 return None
 
-            running_agent = self._running_agents.get(_quick_key)
-            if running_agent is _AGENT_PENDING_SENTINEL:
-                # Agent is being set up but not ready yet.
-                if event.get_command() == "stop":
-                    # Force-clean the sentinel so the session is unlocked.
-                    self._release_running_agent_state(_quick_key)
-                    logger.info("HARD STOP (pending) for session %s — sentinel cleared", _quick_key)
-                    return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
-                # Queue the message so it will be picked up after the
-                # agent starts.
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
-                return None
             if self._draining:
                 if self._queue_during_drain_enabled():
                     self._queue_or_replace_pending_event(_quick_key, event)
@@ -9704,7 +9793,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
-            running_agent.interrupt(event.text)
+            self._signal_busy_interrupt(_quick_key, event, running_agent)
             # NOTE: self._pending_messages was write-only (never consumed).
             # The actual interrupt message is delivered via adapter._pending_messages
             # which is read by _run_agent. Removed to prevent unbounded growth.
@@ -11735,6 +11824,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "message": message_text[:500],
             }
             await self.hooks.emit("agent:start", hook_ctx)
+
+            # A busy interrupt may have arrived while this turn was still in
+            # async setup and represented only by _AGENT_PENDING_SENTINEL.
+            # Do not let the superseded turn enter the provider API. The base
+            # adapter owns the queued replacement and will drain it once this
+            # handler returns.
+            if not self._is_session_run_current(_quick_key, run_generation):
+                logger.info(
+                    "Skipping superseded agent start for %s — generation %d is no longer current",
+                    _quick_key or "?",
+                    run_generation,
+                )
+                return None
 
             # Run the agent. Capture the session id that this run was launched
             # against so post-run compression publication can be identity-guarded
@@ -18231,6 +18333,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # `_resolve_turn_agent_config(message, …)`.
             nonlocal message
 
+            # A busy interrupt can invalidate the turn before the executor
+            # thread begins.  Stop before config/model setup and, critically,
+            # before any provider request.  Keep the pending event in the
+            # adapter; the outer active-session drain owns its next turn.
+            if not _run_still_current():
+                result = _superseded_agent_run_result(
+                    messages=history,
+                    session_id=session_id,
+                )
+                result_holder[0] = result
+                logger.info(
+                    "Skipping superseded agent setup for %s — generation %s is no longer current",
+                    session_key or "?",
+                    run_generation,
+                )
+                return result
+
             # session_key is propagated via contextvars in _set_session_env()
             # (_SESSION_KEY) and via set_current_session_key() (_approval_session_key)
             # below — both concurrency-safe and inherited by tool worker threads.
@@ -19118,6 +19237,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            _superseded_before_provider = False
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -19166,7 +19286,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
-                result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+                # Agent construction can take long enough for a follow-up to
+                # arrive while the runner still exposes the pending sentinel.
+                # Re-check immediately at the provider boundary so the
+                # obsolete prompt cannot consume a model request after the
+                # user has already replaced it.
+                if not _run_still_current():
+                    _superseded_before_provider = True
+                    result = _superseded_agent_run_result(
+                        messages=agent_history,
+                        session_id=session_id,
+                    )
+                    logger.info(
+                        "Skipping superseded provider call for %s — generation %s is no longer current",
+                        session_key or "?",
+                        run_generation,
+                    )
+                else:
+                    result = agent.run_conversation(
+                        _api_run_message,
+                        **_conversation_kwargs,
+                    )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
@@ -19183,6 +19323,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
                 _stream_consumer.finish()
+
+            if _superseded_before_provider:
+                return result
             
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
@@ -19895,6 +20038,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "failed": True,
                 }
 
+            # Generation invalidation means the adapter, not this stale run,
+            # owns the queued replacement.  Retract any preview emitted before
+            # invalidation and return without consuming _pending_messages;
+            # otherwise the recursive in-band drain would reuse the obsolete
+            # generation and could drop the user's replacement turn.
+            if not _run_still_current():
+                logger.info(
+                    "Leaving queued follow-up to adapter drain for superseded session %s generation %s",
+                    session_key or "?",
+                    run_generation,
+                )
+                await _retract_interrupted_stream_preview(
+                    stream_consumer_holder[0],
+                    stream_task,
+                )
+                return result_holder[0] or response
+
             # Track fallback model state: if the agent switched to a
             # fallback model during this run, persist it so /model shows
             # the actually-active model instead of the config default.
@@ -19933,6 +20093,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]
+            if result and result.get("interrupted"):
+                await _retract_interrupted_stream_preview(
+                    stream_consumer_holder[0],
+                    stream_task,
+                )
             adapter = self._adapter_for_source(source)
             
             # Get pending message from adapter.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1586,6 +1586,34 @@ class GatewayStreamConsumer:
             self._final_response_sent = True
         return True
 
+    async def _retract_visible_preview(self, reason: str) -> None:
+        """Best-effort delete all visible preview messages for this response."""
+        stale_ids = set(self._preview_message_ids)
+        if self._message_id and self._message_id != "__no_edit__":
+            stale_ids.add(self._message_id)
+        delete_fn = getattr(self.adapter, "delete_message", None)
+        if delete_fn is not None:
+            for stale_id in stale_ids:
+                if not stale_id or stale_id == "__no_edit__":
+                    continue
+                try:
+                    await delete_fn(self.chat_id, stale_id)
+                except Exception as e:
+                    logger.debug(
+                        "%s preview cleanup failed (%s): %s",
+                        reason, stale_id, e,
+                    )
+        self._preview_message_ids = set()
+        self._segment_preview_message_ids = set()
+        self._message_id = None
+        self._message_created_ts = None
+        self._accumulated = ""
+        self._last_sent_text = ""
+        self._already_sent = False
+        self._final_response_sent = False
+        self._final_content_delivered = False
+        logger.info("Retracted streamed %s (chat=%s)", reason, self.chat_id)
+
     async def _suppress_silence_marker(self) -> None:
         """Retract any streamed preview when the final reply is a silence marker.
 
@@ -1602,32 +1630,17 @@ class GatewayStreamConsumer:
         send happens either.  ``_already_sent`` is likewise cleared so the
         gateway's ``already_sent`` short-circuits do not fire.
         """
-        stale_ids = set(self._preview_message_ids)
-        if self._message_id and self._message_id != "__no_edit__":
-            stale_ids.add(self._message_id)
-        delete_fn = getattr(self.adapter, "delete_message", None)
-        if delete_fn is not None:
-            for stale_id in stale_ids:
-                if not stale_id or stale_id == "__no_edit__":
-                    continue
-                try:
-                    await delete_fn(self.chat_id, stale_id)
-                except Exception as e:
-                    logger.debug(
-                        "Silence-marker preview cleanup failed (%s): %s",
-                        stale_id, e,
-                    )
-        self._preview_message_ids = set()
-        self._message_id = None
-        self._accumulated = ""
-        self._last_sent_text = ""
-        self._already_sent = False
-        self._final_response_sent = False
-        self._final_content_delivered = False
-        logger.info(
-            "Suppressed streamed intentional-silence marker (chat=%s)",
-            self.chat_id,
-        )
+        await self._retract_visible_preview("intentional-silence marker")
+
+    async def discard_interrupted_preview(self) -> None:
+        """Retract stale streamed text after the turn is interrupted.
+
+        Telegram and other editable adapters may have displayed a partial
+        answer before the provider observes the interrupt. Removing those
+        previews prevents the obsolete answer from surviving beside the
+        replacement turn.
+        """
+        await self._retract_visible_preview("interrupted response")
 
     async def _send_or_edit(
         self, text: str, *, finalize: bool = False, is_turn_final: bool = True,

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -12,6 +12,7 @@ This test covers the two fallback paths that previously lacked
 1. ``agent_failed_early`` path — transient 429/timeout failures
 2. ``not new_messages`` path — edge case where ``history_offset`` exceeds
    the actual message count
+3. Superseded setup generations never enter the provider API
 """
 
 import sys
@@ -242,3 +243,17 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+
+
+@pytest.mark.asyncio
+async def test_superseded_setup_generation_skips_agent_start(monkeypatch, tmp_path):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._is_session_run_current = lambda _key, _generation: False
+    runner._run_agent = AsyncMock()
+
+    result = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert result is None
+    runner._run_agent.assert_not_awaited()

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -3,6 +3,7 @@
 Verifies that users get an immediate status response instead of total silence
 when the agent is working on a task. See PR fix for the @Lonely__MH report.
 """
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -61,6 +62,7 @@ def _make_runner():
     runner = object.__new__(GatewayRunner)
     runner._running_agents = {}
     runner._running_agents_ts = {}
+    runner._session_run_generation = {}
     runner._pending_messages = {}
     runner._busy_ack_ts = {}
     runner._draining = False
@@ -82,6 +84,7 @@ def _make_adapter(platform_val="telegram"):
     """Build a minimal adapter mock."""
     adapter = MagicMock()
     adapter._pending_messages = {}
+    adapter._active_sessions = {}
     adapter._send_with_retry = AsyncMock()
     adapter.config = MagicMock()
     adapter.config.extra = {}
@@ -193,6 +196,7 @@ class TestBusySessionAck:
         }
         runner._running_agents[sk] = agent
         runner._running_agents_ts[sk] = time.time() - 600  # 10 min ago
+        adapter._active_sessions[sk] = asyncio.Event()
         runner.adapters[event.source.platform] = adapter
 
         result = await runner._handle_active_session_busy_message(event, sk)
@@ -210,6 +214,7 @@ class TestBusySessionAck:
 
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")
+        assert adapter._active_sessions[sk].is_set()
 
     @pytest.mark.asyncio
     async def test_queue_mode_suppresses_interrupt_and_updates_ack(self):
@@ -661,8 +666,8 @@ class TestBusySessionAck:
         assert "restarting" in content
 
     @pytest.mark.asyncio
-    async def test_pending_sentinel_no_interrupt(self):
-        """When agent is PENDING_SENTINEL, don't call interrupt (it has no method)."""
+    async def test_pending_sentinel_supersedes_start_without_agent_interrupt(self):
+        """Interrupt during setup invalidates the obsolete turn before its API call."""
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()
@@ -672,11 +677,15 @@ class TestBusySessionAck:
 
         runner._running_agents[sk] = sentinel
         runner._running_agents_ts[sk] = time.time()
+        runner._session_run_generation[sk] = 1
+        adapter._active_sessions[sk] = asyncio.Event()
         runner.adapters[event.source.platform] = adapter
 
         result = await runner._handle_active_session_busy_message(event, sk)
         assert result is True
-        # Should still send ack
+        assert adapter._pending_messages[sk] is event
+        assert runner._session_run_generation[sk] == 2
+        assert adapter._active_sessions[sk].is_set()
         adapter._send_with_retry.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -14,6 +14,7 @@ Covers four fix paths:
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -375,6 +376,20 @@ class TestQueuedMessageAlreadyStreamed:
         )
 
         assert _already_streamed is False
+
+
+class TestInterruptedStreamRetraction:
+    @pytest.mark.asyncio
+    async def test_cancels_stream_before_retracting_stale_preview(self):
+        from gateway.run import _retract_interrupted_stream_preview
+
+        consumer = SimpleNamespace(discard_interrupted_preview=AsyncMock())
+        stream_task = asyncio.create_task(asyncio.sleep(60))
+
+        await _retract_interrupted_stream_preview(consumer, stream_task)
+
+        assert stream_task.cancelled()
+        consumer.discard_interrupted_preview.assert_awaited_once_with()
 
 
 # ===================================================================

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1329,6 +1329,80 @@ async def test_run_agent_drops_interim_commentary_after_generation_invalidation(
 
 
 @pytest.mark.asyncio
+async def test_run_agent_skips_provider_when_generation_changes_during_setup(
+    monkeypatch,
+    tmp_path,
+):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_progress": "off"}}),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="dm-setup-race",
+        chat_type="dm",
+        thread_id=None,
+    )
+    session_key = "agent:main:telegram:dm:dm-setup-race"
+    runner._session_run_generation[session_key] = 1
+    pending = MessageEvent(
+        text="replacement prompt",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    adapter._pending_messages[session_key] = pending
+    provider_calls = []
+
+    class InvalidatingSetupAgent:
+        def __init__(self, **kwargs):
+            self.tools = []
+            runner._invalidate_session_run_generation(
+                session_key,
+                reason="test_interrupt_during_setup",
+            )
+
+        def run_conversation(self, *args, **kwargs):
+            provider_calls.append((args, kwargs))
+            raise AssertionError("superseded turn must not enter provider call")
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = InvalidatingSetupAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    result = await runner._run_agent(
+        message="obsolete prompt",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-setup-race",
+        session_key=session_key,
+        run_generation=1,
+    )
+
+    assert result["superseded"] is True
+    assert result["api_calls"] == 0
+    assert provider_calls == []
+    assert adapter._pending_messages[session_key] is pending
+
+
+@pytest.mark.asyncio
 async def test_keep_typing_stops_immediately_when_interrupt_event_is_set():
     adapter = ProgressCaptureAdapter(platform=Platform.DISCORD)
     stop_event = asyncio.Event()

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -180,17 +180,20 @@ async def test_second_message_during_sentinel_queued_not_duplicate():
 
         # Verify sentinel is set
         assert runner._running_agents.get(session_key) is _AGENT_PENDING_SENTINEL
+        adapter = runner.adapters[Platform.TELEGRAM]
+        adapter._active_sessions[session_key] = asyncio.Event()
 
         # Second message should see "already running" and be queued
         result2 = await runner._handle_message(event2)
         assert result2 is None, "Second message should return None (queued)"
 
         # The second message should have been queued in adapter pending
-        adapter = runner.adapters[Platform.TELEGRAM]
         assert session_key in adapter._pending_messages, (
             "Second message should be queued as pending"
         )
         assert adapter._pending_messages[session_key] is event2
+        assert runner._session_run_generation[session_key] == 2
+        assert adapter._active_sessions[session_key].is_set()
 
         # Let first message complete
         barrier.set()

--- a/tests/gateway/test_stream_consumer_silence.py
+++ b/tests/gateway/test_stream_consumer_silence.py
@@ -237,3 +237,29 @@ class TestStreamedSilenceSuppression:
         delivered = "".join(_sent_and_edited(adapter))
         assert "the build is already green" in delivered
         assert consumer.final_content_delivered is True
+
+
+class TestInterruptedPreviewRetraction:
+    @pytest.mark.asyncio
+    async def test_interrupted_preview_is_deleted_and_delivery_flags_reset(self):
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_1", StreamConsumerConfig())
+        consumer._message_id = "preview_1"
+        consumer._preview_message_ids = {"preview_1"}
+        consumer._segment_preview_message_ids = {"preview_1"}
+        consumer._accumulated = "obsolete partial answer"
+        consumer._last_sent_text = "obsolete partial answer"
+        consumer._already_sent = True
+        consumer._final_response_sent = True
+        consumer._final_content_delivered = True
+
+        await consumer.discard_interrupted_preview()
+
+        adapter.delete_message.assert_awaited_once_with("chat_1", "preview_1")
+        assert consumer._message_id is None
+        assert consumer._preview_message_ids == set()
+        assert consumer._segment_preview_message_ids == set()
+        assert consumer._accumulated == ""
+        assert consumer.already_sent is False
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False

--- a/tests/gateway/test_telegram_photo_interrupts.py
+++ b/tests/gateway/test_telegram_photo_interrupts.py
@@ -1,11 +1,17 @@
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
 from gateway.session import SessionSource, build_session_key
-from gateway.run import GatewayRunner
+from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
 
 
 class _PendingAdapter:
@@ -13,14 +19,40 @@ class _PendingAdapter:
         self._pending_messages = {}
 
 
+class _RecordingAdapter(BasePlatformAdapter):
+    def __init__(self, config):
+        super().__init__(config, Platform.TELEGRAM)
+        self.sent = []
+
+    async def connect(self, *, is_reconnect=False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return SendResult(success=True, message_id=str(len(self.sent)))
+
+    async def get_chat_info(self, chat_id):
+        return {"name": chat_id, "type": "dm"}
+
+
 def _make_runner():
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
     runner.adapters = {Platform.TELEGRAM: _PendingAdapter()}
     runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
+    runner._busy_ack_ts = {}
     runner._voice_mode = {}
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    runner.session_store = None
     runner._is_user_authorized = lambda _source: True
     return runner
 
@@ -46,3 +78,107 @@ async def test_handle_message_does_not_priority_interrupt_photo_followup():
     assert result is None
     running_agent.interrupt.assert_not_called()
     assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pending_start", [True, False])
+async def test_base_adapter_busy_route_queues_photo_without_interrupt(pending_start):
+    runner = _make_runner()
+    config = PlatformConfig(enabled=True, token="***", typing_indicator=False)
+    adapter = _RecordingAdapter(config)
+    adapter.set_message_handler(AsyncMock(return_value=None))
+    adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="photo-busy-route",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+    interrupt_event = asyncio.Event()
+    adapter._active_sessions[session_key] = interrupt_event
+    runner._session_run_generation[session_key] = 1
+    running_agent = _AGENT_PENDING_SENTINEL if pending_start else MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    event = MessageEvent(
+        text="album caption",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/photo-b.jpg"],
+        media_types=["image/jpeg"],
+    )
+
+    await adapter.handle_message(event)
+
+    assert adapter._pending_messages[session_key] is event
+    assert runner._session_run_generation[session_key] == 1
+    assert interrupt_event.is_set() is False
+    assert adapter.sent == []
+    if not pending_start:
+        running_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_interrupt_replaces_startup_turn_exactly_once(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+    runner = _make_runner()
+    config = PlatformConfig(enabled=True, token="***", typing_indicator=False)
+    adapter = _RecordingAdapter(config)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="startup-interrupt-route",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+    obsolete_started = asyncio.Event()
+    release_obsolete = asyncio.Event()
+    handled = []
+
+    async def handler(event):
+        handled.append(event.text)
+        if event.text == "obsolete prompt":
+            runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+            runner._session_run_generation[session_key] = 1
+            obsolete_started.set()
+            await release_obsolete.wait()
+            runner._running_agents.pop(session_key, None)
+            return "obsolete answer"
+        return "replacement answer"
+
+    adapter.set_message_handler(handler)
+    first = MessageEvent(
+        text="obsolete prompt",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    replacement = MessageEvent(
+        text="replacement prompt",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    await adapter.handle_message(first)
+    await asyncio.wait_for(obsolete_started.wait(), timeout=2.0)
+    await adapter.handle_message(replacement)
+
+    assert adapter._pending_messages[session_key] is replacement
+    assert runner._session_run_generation[session_key] == 2
+    assert adapter._active_sessions[session_key].is_set()
+
+    release_obsolete.set()
+    for _ in range(200):
+        if adapter.sent == ["replacement answer"] and session_key not in adapter._active_sessions:
+            break
+        await asyncio.sleep(0.01)
+
+    assert handled == ["obsolete prompt", "replacement prompt"]
+    assert adapter.sent == ["replacement answer"]
+    assert session_key not in adapter._pending_messages
+    assert session_key not in adapter._active_sessions


### PR DESCRIPTION
## Problem

A Telegram follow-up can arrive while the first turn is still represented by the gateway's pending-agent sentinel. In `busy_input_mode: interrupt`, the original turn could then cross the provider boundary anyway, stream or deliver an obsolete response, and race the queued replacement. The operator could see the stale answer plus duplicate replacement replies.

## Fix

- Invalidate the obsolete run generation when an interrupt lands during agent startup.
- Re-check generation after `agent:start`, before executor setup, and immediately before the provider call.
- Leave the replacement event owned by the base adapter so it drains exactly once.
- Cancel stale stream consumption and retract any visible interrupted preview before the replacement runs.
- Preserve native PHOTO/album merging: media follow-ups queue without interrupting either the startup sentinel or a real agent.
- Preserve queue/steer behavior, command bypasses, internal events, and subagent/compression interrupt demotions.

## Changed files

- `gateway/run.py`: startup-interrupt signaling, generation gates, pending-event ownership, and stale-stream cleanup.
- `gateway/stream_consumer.py`: shared best-effort preview retraction for intentional silence and interrupted responses.
- Seven gateway test files: sentinel/provider race, adapter exact-once delivery, photo/album routing, pending ownership, and preview cleanup coverage.

## Validation

All tests were invoked through the repository's canonical `scripts/run_tests.sh` wrapper.

- Modified-file batch: 147 passed, 0 failed.
- Adjacent queue/media/interrupt batch: 108 passed, 0 failed.
- Independent QA: 258 passed across 17 files, 0 failed.
- Broader streaming batch: 192 passed; one unchanged Windows-only update-command assertion failed because it assumes a Unix `bash -c` argv shape. Neither that test nor the update-command path is changed by this PR.
- `ruff check` on all changed Python files: passed.
- `git diff --check`: passed.

## Protected systems

No live gateway configuration, credentials, session data, Kanban data, Telegram state, or service state is changed by this PR. The live deployment remains on its prior safe mode until a separately guarded backport and acceptance test.

## Remaining risk and rollback

Focused tests do not replace a live Telegram/provider acceptance run. Rollback is a single commit revert; live activation uses only this commit backported onto the installed baseline.

No equivalent open PR was found. Related open work covers queue acknowledgements, queue defaults, internal-event interruptions, desktop interruption, or per-platform busy modes rather than this startup sentinel/provider race.

Linear: [SV-198](https://linear.app/1xx/issue/SV-198/restore-donna-conversation-first-routing-and-native-telegram)