### PR TITLE
fix(desktop): worktree from origin/main should not set up upstream tracking

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -271,9 +271,10 @@ test('addWorktree: base origin/main does not set up upstream tracking', async ()
   const git = (...args) => execFileSync('git', args, { cwd: cloneDir }).toString().trim()
 
   try {
-    // Seed the remote with a commit on main.
+    // Seed the remote with a commit on main. Inline identity so it works
+    // on CI runners with no global git config.
     execFileSync('git', ['init', '-b', 'main', remoteDir])
-    execFileSync('git', ['-C', remoteDir, 'commit', '--allow-empty', '-m', 'root'])
+    execFileSync('git', ['-C', remoteDir, '-c', 'user.email=hermes@localhost', '-c', 'user.name=Hermes', 'commit', '--allow-empty', '-m', 'root'])
 
     // Clone so origin/main exists as a remote-tracking ref.
     execFileSync('git', ['clone', remoteDir, cloneDir])

--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -262,3 +262,39 @@ test('addWorktree: base param branches off a specified local branch', async () =
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('addWorktree: base origin/main does not set up upstream tracking', async () => {
+  // Two repos: a bare "remote" and a clone, so origin/main resolves as a
+  // remote-tracking ref — the condition that triggers auto-tracking.
+  const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-remote-'))
+  const cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-clone-'))
+  const git = (...args) => execFileSync('git', args, { cwd: cloneDir }).toString().trim()
+
+  try {
+    // Seed the remote with a commit on main.
+    execFileSync('git', ['init', '-b', 'main', remoteDir])
+    execFileSync('git', ['-C', remoteDir, 'commit', '--allow-empty', '-m', 'root'])
+
+    // Clone so origin/main exists as a remote-tracking ref.
+    execFileSync('git', ['clone', remoteDir, cloneDir])
+
+    const result = await addWorktree(cloneDir, { base: 'origin/main', branch: 'feature-branch', name: 'feature-branch' }, 'git')
+
+    assert.equal(result.branch, 'feature-branch')
+
+    // The new branch must NOT have an upstream — like `git checkout origin/main
+    // && git checkout -b feature-branch`, not `git worktree add -b … origin/main`.
+    let hasUpstream = true
+
+    try {
+      execFileSync('git', ['-C', result.path, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'])
+    } catch {
+      hasUpstream = false
+    }
+
+    assert.equal(hasUpstream, false)
+  } finally {
+    fs.rmSync(remoteDir, { recursive: true, force: true })
+    fs.rmSync(cloneDir, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -265,8 +265,15 @@ async function addWorktree(repoPath, options, gitBin) {
       } catch {
         // The fetch isn't mandatory, but it would be nice to do if possible.
         // If it's not possible, just use the local ref of the remote branch.
-        // If it doesn't exist locally, we'll get an error anyways 
+        // If it doesn't exist locally, we'll get an error
       }
+
+      // When branching off a remote-tracking ref, git auto-sets up tracking
+      // (e.g. `new-branch` → tracks `origin/main`). The user almost certainly
+      // wants a standalone local branch — like `git checkout origin/main &&
+      // git checkout -b new-branch` — not a branch silently wired to the
+      // remote's upstream. `--no-track` prevents that.
+      args.push('--no-track')
     }
 
     args.push(base)


### PR DESCRIPTION
## What does this PR do?

When the desktop app's "new worktree" button branches off a remote-tracking ref like `origin/main`, `git worktree add -b <branch> <dir> origin/main` automatically sets up upstream tracking — so the new branch ends up tracking `origin/main`, showing as `branch:origin/main` in branch listings.

The user expects a standalone local branch based on the remote's commit — like `git checkout origin/main && git checkout -b branch` — not one silently wired to the remote's upstream. This adds `--no-track` to the `git worktree add` args when the base is an `origin/` ref. Local branch bases are unaffected (they never triggered tracking).

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/git-worktree-ops.ts` — add `--no-track` flag when `opts.base` starts with `origin/` (the only case that triggers auto-tracking)
- `apps/desktop/electron/git-worktree-ops.test.ts` — new test `addWorktree: base origin/main does not set up upstream tracking` that creates a real remote + clone, runs `addWorktree` with `base: 'origin/main'`, and asserts no upstream is configured

## How to Test

1. In the desktop app, open a repo that has a remote (e.g. clone of hermes-agent)
2. Click "new worktree", select `origin/main` as the base branch
3. After creation, check `git -C <worktree-path> rev-parse --abbrev-ref --symbolic-full-name '@{u}'` — should fail with "no upstream configured"
4. Run the test: `cd apps/desktop && npx vitest run electron/git-worktree-ops.test.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux 7.1.0)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed
