### PR TITLE
fix: reset request_overrides on model switch to prevent stale provider params

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,6 +19,7 @@ preserved.
 
 from __future__ import annotations
 
+import copy as _copy
 import logging
 import os
 import re
@@ -354,7 +355,11 @@ def _record_codex_gpt55_autoraise_notice(autoraise: Dict[str, Any]) -> None:
 def _normalized_custom_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
-    return value.strip().rstrip("/")
+    # Keep this canonicalization aligned with
+    # runtime_provider._normalize_base_url_for_match(): provider endpoints are
+    # matched case-insensitively and ignore a trailing slash.  This helper is
+    # used only for URL matching, never opaque provider identifiers.
+    return value.strip().rstrip("/").lower()
 
 
 def _custom_provider_model_matches(agent_model: str, entry: Dict[str, Any]) -> bool:
@@ -2684,6 +2689,9 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "request_overrides": _copy.deepcopy(
+            getattr(agent, "request_overrides", {}) or {}
+        ),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1295,6 +1295,7 @@ def try_recover_primary_transport(
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        agent.request_overrides = copy.deepcopy(rt.get("request_overrides", {}))
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1468,6 +1469,7 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
+        agent.request_overrides = copy.deepcopy(rt.get("request_overrides", {}))
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).
@@ -2094,6 +2096,72 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
+def _rebuild_request_overrides_for_runtime(
+    agent,
+    *,
+    previous_provider: str,
+    previous_base_url: str,
+    previous_model: str,
+) -> bool:
+    """Rebuild provider-owned overrides after crossing a runtime boundary."""
+    from hermes_cli.runtime_provider import _normalize_base_url_for_match
+
+    previous_provider = str(previous_provider or "").strip().lower()
+    current_provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    previous_base_url = _normalize_base_url_for_match(previous_base_url)
+    current_base_url = _normalize_base_url_for_match(
+        getattr(agent, "base_url", "")
+    )
+    previous_model = str(previous_model or "").strip().lower()
+    current_model = str(getattr(agent, "model", "") or "").strip().lower()
+    if (
+        previous_provider == current_provider
+        and previous_base_url == current_base_url
+        and previous_model == current_model
+    ):
+        return False
+
+    # There is no provenance on the live dict that can distinguish
+    # provider-owned values from route-local ones.  At a provider/endpoint
+    # boundary, start empty and apply only the target provider's config.
+    agent.request_overrides = {}
+    custom_providers = getattr(agent, "_custom_providers", [])
+    try:
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            load_config_readonly,
+        )
+
+        custom_providers = get_compatible_custom_providers(load_config_readonly())
+    except Exception:
+        logger.debug(
+            "custom-provider request override resolution skipped on runtime switch",
+            exc_info=True,
+        )
+    try:
+        from agent.agent_init import _merge_custom_provider_extra_body
+
+        _merge_custom_provider_extra_body(agent, custom_providers)
+    except Exception:
+        logger.debug(
+            "custom-provider request override rebuild failed on runtime switch",
+            exc_info=True,
+        )
+    if getattr(agent, "service_tier", None):
+        try:
+            from hermes_cli.models import resolve_fast_mode_overrides
+
+            fast_overrides = resolve_fast_mode_overrides(agent.model)
+            if fast_overrides:
+                agent.request_overrides.update(fast_overrides)
+        except Exception:
+            logger.debug(
+                "fast-mode request override rebuild failed on runtime switch",
+                exc_info=True,
+            )
+    return True
+
+
 def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
     """Switch the model/provider in-place for a live agent.
 
@@ -2132,6 +2200,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    old_base_url = agent.base_url
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client
@@ -2162,9 +2231,15 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_config_context_length",
         )
     }
-    # _client_kwargs is a dict — snapshot a shallow copy so mutating the
-    # live dict doesn't poison the rollback target.
+    # _client_kwargs and request_overrides are dicts. Overrides may contain
+    # nested provider payloads, so keep a deep rollback snapshot.
     _snapshot["_client_kwargs"] = dict(getattr(agent, "_client_kwargs", {}) or {})
+    _old_request_overrides = getattr(agent, "request_overrides", _MISSING)
+    _snapshot["request_overrides"] = (
+        copy.deepcopy(_old_request_overrides)
+        if isinstance(_old_request_overrides, dict)
+        else _old_request_overrides
+    )
     # Snapshot the credential pool reference so a failed client rebuild can
     # restore the original pool (issue #52727: pool reload is part of this
     # switch and must be reversible on rollback).
@@ -2218,6 +2293,14 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 "refusing to keep the previous provider's endpoint"
             )
         agent.api_mode = api_mode
+
+        _rebuild_request_overrides_for_runtime(
+            agent,
+            previous_provider=old_provider,
+            previous_base_url=old_base_url,
+            previous_model=old_model,
+        )
+
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
@@ -2468,6 +2551,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "request_overrides": copy.deepcopy(
+            getattr(agent, "request_overrides", {}) or {}
+        ),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -16,6 +16,7 @@ sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 from __future__ import annotations
 
 import contextvars
+import copy
 import json
 import logging
 import math
@@ -1690,6 +1691,199 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
     return None
 
 
+_FALLBACK_RUNTIME_MISSING = object()
+
+
+def _snapshot_fallback_candidate_runtime(agent) -> dict[str, Any]:
+    """Capture every mutable runtime field a fallback candidate may replace."""
+
+    def _value(name: str, *, deep: bool = False):
+        value = getattr(agent, name, _FALLBACK_RUNTIME_MISSING)
+        if value is _FALLBACK_RUNTIME_MISSING:
+            return value
+        return copy.deepcopy(value) if deep else value
+
+    snapshot = {
+        name: _value(name)
+        for name in (
+            "model",
+            "provider",
+            "base_url",
+            "api_mode",
+            "api_key",
+            "client",
+            "_anthropic_client",
+            "_anthropic_api_key",
+            "_anthropic_base_url",
+            "_is_anthropic_oauth",
+            "_credential_pool",
+            "_fallback_activated",
+            "_config_context_length",
+            "_use_prompt_caching",
+            "_use_native_cache_layout",
+            "_cached_system_prompt",
+            "_pending_fallback_notice",
+        )
+    }
+    for name in ("_client_kwargs", "request_overrides", "reasoning_config"):
+        snapshot[name] = _value(name, deep=True)
+
+    transport_cache = _value("_transport_cache")
+    snapshot["_transport_cache"] = (
+        dict(transport_cache)
+        if transport_cache is not _FALLBACK_RUNTIME_MISSING
+        else transport_cache
+    )
+
+    compressor = getattr(agent, "context_compressor", _FALLBACK_RUNTIME_MISSING)
+    snapshot["context_compressor"] = compressor
+    if compressor is not _FALLBACK_RUNTIME_MISSING and compressor is not None:
+        snapshot["compressor_fields"] = {
+            name: getattr(compressor, name, _FALLBACK_RUNTIME_MISSING)
+            for name in (
+                "model",
+                "context_length",
+                "base_url",
+                "api_key",
+                "provider",
+                "api_mode",
+                "threshold_tokens",
+            )
+        }
+    else:
+        snapshot["compressor_fields"] = {}
+    return snapshot
+
+
+def _restore_fallback_candidate_runtime(agent, snapshot: dict[str, Any]) -> None:
+    """Rollback a failed candidate without rewinding chain progress."""
+
+    def _restore_attr(name: str, *, deep: bool = False) -> None:
+        value = snapshot[name]
+        if value is _FALLBACK_RUNTIME_MISSING:
+            try:
+                delattr(agent, name)
+            except AttributeError:
+                pass
+            return
+        setattr(agent, name, copy.deepcopy(value) if deep else value)
+
+    for name in ("model", "provider", "base_url", "api_mode", "api_key"):
+        _restore_attr(name)
+    for name in (
+        "client",
+        "_anthropic_client",
+        "_anthropic_api_key",
+        "_anthropic_base_url",
+        "_is_anthropic_oauth",
+    ):
+        _restore_attr(name)
+    for name in ("_client_kwargs", "request_overrides", "reasoning_config"):
+        _restore_attr(name, deep=True)
+    _restore_attr("_transport_cache")
+    for name in (
+        "_credential_pool",
+        "_fallback_activated",
+        "_config_context_length",
+        "_use_prompt_caching",
+        "_use_native_cache_layout",
+        "_cached_system_prompt",
+        "_pending_fallback_notice",
+    ):
+        _restore_attr(name)
+
+    compressor = snapshot["context_compressor"]
+    if compressor is _FALLBACK_RUNTIME_MISSING:
+        try:
+            delattr(agent, "context_compressor")
+        except AttributeError:
+            pass
+        return
+    agent.context_compressor = compressor
+    if compressor is None:
+        return
+
+    fields = snapshot["compressor_fields"]
+    update_model = getattr(compressor, "update_model", None)
+    required = ("model", "context_length", "base_url", "api_key", "provider")
+    if callable(update_model) and all(
+        fields.get(name, _FALLBACK_RUNTIME_MISSING) is not _FALLBACK_RUNTIME_MISSING
+        for name in required
+    ):
+        try:
+            update_model(
+                model=fields["model"],
+                context_length=fields["context_length"],
+                base_url=fields["base_url"],
+                api_key=fields["api_key"],
+                provider=fields["provider"],
+                api_mode=(
+                    ""
+                    if fields.get("api_mode", _FALLBACK_RUNTIME_MISSING)
+                    is _FALLBACK_RUNTIME_MISSING
+                    else fields["api_mode"]
+                ),
+            )
+        except Exception:
+            logger.debug(
+                "Fallback rollback could not rebind context compressor",
+                exc_info=True,
+            )
+    # Preserve exact observable state even for lightweight/plugin compressors
+    # whose update_model is partial or failed.
+    for name, value in fields.items():
+        try:
+            if value is _FALLBACK_RUNTIME_MISSING:
+                delattr(compressor, name)
+            else:
+                setattr(compressor, name, value)
+        except (AttributeError, TypeError):
+            pass
+
+
+def _close_rejected_fallback_clients(
+    agent,
+    snapshot: dict[str, Any],
+    *,
+    resolved_client: Any,
+    active_client: Any,
+    active_anthropic_client: Any,
+) -> None:
+    """Best-effort close clients created by a candidate that was rolled back."""
+    retained = {
+        id(value)
+        for value in (snapshot["client"], snapshot["_anthropic_client"])
+        if value is not _FALLBACK_RUNTIME_MISSING and value is not None
+    }
+    seen: set[int] = set()
+    for client, is_anthropic in (
+        (resolved_client, False),
+        (active_client, False),
+        (active_anthropic_client, True),
+    ):
+        if client is None or id(client) in retained or id(client) in seen:
+            continue
+        seen.add(id(client))
+        try:
+            if not is_anthropic and callable(
+                getattr(agent, "_close_openai_client", None)
+            ):
+                agent._close_openai_client(
+                    client,
+                    reason="fallback_activation_rollback",
+                    shared=True,
+                )
+            else:
+                close = getattr(client, "close", None)
+                if callable(close):
+                    close()
+        except Exception:
+            logger.debug(
+                "Fallback rollback could not close rejected candidate client",
+                exc_info=True,
+            )
+
+
 
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
@@ -1783,6 +1977,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # Use centralized router for client construction.
     # raw_codex=True because the main agent needs direct responses.stream()
     # access for Codex providers.
+    _entry_runtime = _snapshot_fallback_candidate_runtime(agent)
+    fb_client = None
     try:
         from agent.auxiliary_client import resolve_provider_client
         # Pass base_url and api_key from fallback config so custom
@@ -1869,6 +2065,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         old_model = agent.model
         old_provider = agent.provider
+        old_base_url = agent.base_url
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -1879,6 +2076,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.requested_provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
+        from agent.agent_runtime_helpers import (
+            _rebuild_request_overrides_for_runtime,
+        )
+
+        _rebuild_request_overrides_for_runtime(
+            agent,
+            previous_provider=old_provider,
+            previous_base_url=old_base_url,
+            previous_model=old_model,
+        )
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
@@ -2062,6 +2269,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _reset_stale_streak(agent)
         return True
     except Exception as e:
+        _rejected_client = getattr(agent, "client", None)
+        _rejected_anthropic_client = getattr(agent, "_anthropic_client", None)
+        _restore_fallback_candidate_runtime(agent, _entry_runtime)
+        _close_rejected_fallback_clients(
+            agent,
+            _entry_runtime,
+            resolved_client=fb_client,
+            active_client=_rejected_client,
+            active_anthropic_client=_rejected_anthropic_client,
+        )
         if fb_provider == "nous":
             unavailable.add(fb_key)
         logger.error("Failed to activate fallback %s: %s", fb_model, e)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1015,7 +1015,6 @@ def test_preflight_codex_api_kwargs_rejects_function_call_output_without_call_id
 
 
 
-
 def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
     agent = _build_agent(monkeypatch)
     responses = [_codex_tool_call_response(), _codex_message_response("done")]

--- a/tests/run_agent/test_switch_model_request_overrides.py
+++ b/tests/run_agent/test_switch_model_request_overrides.py
@@ -1,0 +1,987 @@
+"""Regression tests for provider-derived overrides across runtime switches."""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+_ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+_ZAI_ALT_BASE_URL = "https://alt.z.ai/api/coding/paas/v4"
+_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex/responses"
+_STALE_OVERRIDES = {"extra_body": {"thinking": {"type": "enabled"}}}
+
+
+def _make_zai_agent() -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "glm-5.2"
+    agent.provider = "custom:zai-coding-plan"
+    agent.base_url = _ZAI_BASE_URL
+    agent.api_key = "zai-key"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="OriginalZaiClient")
+    agent._client_kwargs = {"api_key": "zai-key", "base_url": _ZAI_BASE_URL}
+    agent.request_overrides = {"extra_body": {"thinking": {"type": "enabled"}}}
+    agent._custom_providers = [
+        {
+            "provider_key": "zai-coding-plan",
+            "name": "Z.AI Coding Plan",
+            "base_url": _ZAI_BASE_URL,
+            "model": "glm-5.2",
+            "extra_body": {"thinking": {"type": "enabled"}},
+        }
+    ]
+    agent.context_compressor = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._anthropic_client = None
+    agent._is_anthropic_oauth = False
+    agent._cached_system_prompt = "cached"
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._config_context_length = None
+    agent._credential_pool = None
+    return agent
+
+
+def _make_fallback_agent(chain: list[dict]) -> AIAgent:
+    """Build the smallest real fallback runtime needed by the activator."""
+    from agent.chat_completion_helpers import try_activate_fallback
+
+    agent = _make_zai_agent()
+    primary_overrides = copy.deepcopy(agent.request_overrides)
+    agent._primary_runtime = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": agent.api_key,
+        "client_kwargs": dict(agent._client_kwargs),
+        "request_overrides": copy.deepcopy(primary_overrides),
+        "use_prompt_caching": False,
+        "use_native_cache_layout": False,
+        "compressor_model": agent.model,
+        "compressor_base_url": agent.base_url,
+        "compressor_api_key": agent.api_key,
+        "compressor_provider": agent.provider,
+        "compressor_context_length": 131072,
+        "compressor_api_mode": agent.api_mode,
+        "compressor_threshold_tokens": 100000,
+    }
+    agent._fallback_chain = list(chain)
+    agent._fallback_index = 0
+    agent._fallback_activated = False
+    agent._unavailable_fallback_keys = set()
+    agent._rate_limited_until = 0
+    agent._transport_cache = {}
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent.log_prefix = ""
+    agent.reasoning_config = None
+    agent._consecutive_stale_streams = 0
+    agent._is_azure_openai_url = lambda _url: False
+    agent._is_direct_openai_url = lambda _url: False
+    agent._provider_model_requires_responses_api = lambda *_args, **_kwargs: False
+    agent._anthropic_prompt_cache_policy = lambda **_kwargs: (False, False)
+    agent._ensure_lmstudio_runtime_loaded = lambda: None
+    agent._buffer_status = MagicMock()
+    agent._replace_primary_openai_client = MagicMock()
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+    agent._close_openai_client = MagicMock()
+    agent._try_activate_fallback = (
+        lambda reason=None: try_activate_fallback(agent, reason)
+    )
+    return agent
+
+
+def _fallback_client(base_url: str, api_key: str = "fallback-key") -> SimpleNamespace:
+    return SimpleNamespace(
+        api_key=api_key,
+        base_url=base_url,
+        _custom_headers={},
+    )
+
+
+class _StatefulCompressor:
+    def __init__(self, agent: AIAgent, *, fail_model: str | None = None):
+        self.model = agent.model
+        self.context_length = 131072
+        self.base_url = agent.base_url
+        self.api_key = agent.api_key
+        self.provider = agent.provider
+        self.api_mode = agent.api_mode
+        self.threshold_tokens = 100000
+        self.fail_model = fail_model
+
+    def update_model(
+        self,
+        *,
+        model,
+        context_length,
+        base_url,
+        api_key,
+        provider,
+        api_mode,
+    ):
+        self.model = model
+        self.context_length = context_length
+        self.base_url = base_url
+        self.api_key = api_key
+        self.provider = provider
+        self.api_mode = api_mode
+        self.threshold_tokens = context_length // 2
+        if model == self.fail_model:
+            raise RuntimeError(f"compressor rejected {model}")
+
+
+def _fallback_patches(*, clients, custom_providers=None, fallback_pool=None):
+    return (
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=list(clients),
+        ),
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, _provider: model,
+        ),
+        patch("agent.credential_pool.load_pool", return_value=fallback_pool),
+        patch(
+            "agent.chat_completion_helpers.get_provider_request_timeout",
+            return_value=None,
+        ),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=list(custom_providers or []),
+        ),
+    )
+
+
+def test_switch_to_openai_codex_clears_custom_provider_extra_body():
+    agent = _make_zai_agent()
+    new_client = MagicMock(name="CodexClient")
+    agent._create_openai_client = lambda *_args, **_kwargs: new_client
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="gpt-5.6-luna",
+            new_provider="openai-codex",
+            api_key="codex-key",
+            base_url=_CODEX_BASE_URL,
+            api_mode="codex_responses",
+        )
+
+    assert agent.request_overrides == {}
+    assert agent._primary_runtime["request_overrides"] == {}
+    assert agent.client is new_client
+
+
+def test_switch_endpoint_rebuilds_extra_body_from_new_custom_provider_config():
+    agent = _make_zai_agent()
+    new_provider_config = {
+        "provider_key": "zai-coding-plan",
+        "name": "Z.AI Coding Plan",
+        "base_url": _ZAI_ALT_BASE_URL,
+        "model": "glm-5.3",
+        "extra_body": {"enable_thinking": False},
+    }
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=[new_provider_config],
+        ),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="glm-5.3",
+            new_provider="custom:zai-coding-plan",
+            api_key="new-zai-key",
+            base_url=_ZAI_ALT_BASE_URL,
+            api_mode="chat_completions",
+        )
+
+    assert agent.request_overrides == {"extra_body": {"enable_thinking": False}}
+    assert agent._primary_runtime["request_overrides"] == {
+        "extra_body": {"enable_thinking": False}
+    }
+    agent.request_overrides["extra_body"]["enable_thinking"] = True
+    assert agent._primary_runtime["request_overrides"] == {
+        "extra_body": {"enable_thinking": False}
+    }
+
+
+def test_switch_same_endpoint_rebuilds_extra_body_for_new_model():
+    agent = _make_zai_agent()
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+    configs = [
+        {
+            "provider_key": "zai-coding-plan",
+            "base_url": _ZAI_BASE_URL,
+            "model": "glm-5.2",
+            "extra_body": {"candidate": "a"},
+        },
+        {
+            "provider_key": "zai-coding-plan",
+            "base_url": _ZAI_BASE_URL,
+            "model": "glm-5.3",
+            "extra_body": {"candidate": "b"},
+        },
+    ]
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=configs,
+        ),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="glm-5.3",
+            new_provider="custom:zai-coding-plan",
+            api_key="new-zai-key",
+            base_url=_ZAI_BASE_URL,
+            api_mode="chat_completions",
+        )
+
+    assert agent.request_overrides == {"extra_body": {"candidate": "b"}}
+
+
+def test_switch_model_rebuild_matches_target_config_with_url_case_and_slash():
+    agent = _make_zai_agent()
+    upper_runtime_url = "HTTPS://API.Z.AI/api/coding/paas/v4/"
+    agent.base_url = upper_runtime_url
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+    configs = [
+        {
+            "provider_key": "zai-coding-plan",
+            "base_url": _ZAI_BASE_URL,
+            "model": "glm-5.3",
+            "extra_body": {"candidate": "b"},
+        }
+    ]
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=configs,
+        ),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="glm-5.3",
+            new_provider="custom:zai-coding-plan",
+            api_key="new-zai-key",
+            base_url=upper_runtime_url,
+            api_mode="chat_completions",
+        )
+
+    assert agent.request_overrides == {"extra_body": {"candidate": "b"}}
+
+
+def test_switch_same_endpoint_clears_old_model_extra_body_when_target_has_none():
+    agent = _make_zai_agent()
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+    target_without_overrides = {
+        "provider_key": "zai-coding-plan",
+        "base_url": _ZAI_BASE_URL,
+        "model": "glm-5.3",
+    }
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=[target_without_overrides],
+        ),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="glm-5.3",
+            new_provider="custom:zai-coding-plan",
+            api_key="new-zai-key",
+            base_url=_ZAI_BASE_URL,
+            api_mode="chat_completions",
+        )
+
+    assert agent.request_overrides == {}
+
+
+def test_failed_switch_restores_original_request_overrides():
+    agent = _make_zai_agent()
+    overrides_seen_during_rebuild = []
+
+    def fail_client_rebuild(*_args, **_kwargs):
+        overrides_seen_during_rebuild.append(dict(agent.request_overrides))
+        raise RuntimeError("simulated client build failure")
+
+    agent._create_openai_client = fail_client_rebuild
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+        pytest.raises(RuntimeError, match="simulated client build failure"),
+    ):
+        agent.switch_model(
+            new_model="gpt-5.6-luna",
+            new_provider="openai-codex",
+            api_key="codex-key",
+            base_url=_CODEX_BASE_URL,
+            api_mode="codex_responses",
+        )
+
+    assert overrides_seen_during_rebuild == [{}]
+    assert agent.request_overrides == _STALE_OVERRIDES
+
+
+def test_tui_one_turn_switch_isolates_then_restores_request_overrides():
+    """A temporary provider must not leak overrides in either direction."""
+    from tui_gateway import server
+
+    agent = _make_zai_agent()
+    original_overrides = {
+        "extra_body": {
+            "thinking": {"type": "enabled"},
+            "route_local_marker": "keep-after-restore",
+        }
+    }
+    agent.request_overrides = original_overrides
+    agent._fallback_chain = [
+        {
+            "provider": "custom:backup",
+            "model": "backup-model",
+            "nested": {"owner": "primary"},
+        }
+    ]
+    agent._fallback_model = copy.deepcopy(agent._fallback_chain[0])
+    agent._fallback_index = 3
+    agent._consecutive_stale_streams = 7
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+    restore_snapshot = server._snapshot_agent_model_runtime(agent)
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers", return_value=[]
+        ),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="gpt-5.6-luna",
+            new_provider="openai-codex",
+            api_key="codex-key",
+            base_url=_CODEX_BASE_URL,
+            api_mode="codex_responses",
+        )
+
+        # The temporary request must not carry the original provider's body.
+        assert agent.request_overrides == {}
+
+        server._restore_agent_model_runtime(agent, restore_snapshot)
+
+    assert agent.provider == "custom:zai-coding-plan"
+    assert agent.base_url == _ZAI_BASE_URL
+    assert agent.request_overrides == original_overrides
+    assert agent._fallback_chain == [
+        {
+            "provider": "custom:backup",
+            "model": "backup-model",
+            "nested": {"owner": "primary"},
+        }
+    ]
+    assert agent._fallback_model == agent._fallback_chain[0]
+    assert agent._fallback_model is not agent._fallback_chain[0]
+    assert agent._fallback_index == 3
+    assert agent._consecutive_stale_streams == 7
+
+
+def test_fallback_success_rebuilds_overrides_for_target_runtime():
+    agent = _make_fallback_agent(
+        [{"provider": "openai-codex", "model": "gpt-5.6-luna"}]
+    )
+    patches = _fallback_patches(
+        clients=[
+            (
+                _fallback_client(_CODEX_BASE_URL, "codex-key"),
+                "gpt-5.6-luna",
+            )
+        ]
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        assert agent._try_activate_fallback() is True
+
+    assert agent.provider == "openai-codex"
+    assert agent.request_overrides == {}
+
+
+def test_fallback_exact_runtime_and_canonical_endpoint_keeps_nested_overrides():
+    from agent.agent_runtime_helpers import _rebuild_request_overrides_for_runtime
+
+    agent = _make_zai_agent()
+    agent.base_url = "HTTPS://API.Z.AI/api/coding/paas/v4/"
+    agent.request_overrides["route_local"] = {"nested": {"owner": "same-runtime"}}
+    original = copy.deepcopy(agent.request_overrides)
+    original_identity = agent.request_overrides
+
+    changed = _rebuild_request_overrides_for_runtime(
+        agent,
+        previous_provider="CUSTOM:ZAI-CODING-PLAN",
+        previous_base_url=f"{_ZAI_BASE_URL}/",
+        previous_model="GLM-5.2",
+    )
+
+    assert changed is False
+    assert agent.request_overrides == original
+    assert agent.request_overrides is original_identity
+
+
+def test_runtime_override_rebuild_recomputes_fast_mode_for_target_model():
+    from agent.agent_runtime_helpers import _rebuild_request_overrides_for_runtime
+
+    agent = _make_zai_agent()
+    agent.model = "claude-opus-4-6"
+    agent.provider = "anthropic"
+    agent.base_url = "https://api.anthropic.com"
+    agent.service_tier = "priority"
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers", return_value=[]
+        ),
+    ):
+        changed = _rebuild_request_overrides_for_runtime(
+            agent,
+            previous_provider="custom:zai-coding-plan",
+            previous_base_url=_ZAI_BASE_URL,
+            previous_model="glm-5.2",
+        )
+
+    assert changed is True
+    assert agent.request_overrides == {"speed": "fast"}
+
+
+def test_fallback_chain_rebuilds_overrides_for_the_candidate_that_succeeds():
+    target_base_url = "https://target.example/v1"
+    target_config = {
+        "provider_key": "target",
+        "name": "Target",
+        "base_url": target_base_url,
+        "model": "target-model",
+        "extra_body": {"target_flag": True},
+    }
+    agent = _make_fallback_agent(
+        [
+            {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+            {
+                "provider": "custom:target",
+                "model": "target-model",
+                "base_url": target_base_url,
+            },
+        ]
+    )
+    prompt_cache_calls = 0
+
+    def fail_first_candidate(**_kwargs):
+        nonlocal prompt_cache_calls
+        prompt_cache_calls += 1
+        if prompt_cache_calls == 1:
+            raise RuntimeError("first candidate failed after runtime swap")
+        return False, False
+
+    agent._anthropic_prompt_cache_policy = fail_first_candidate
+    patches = _fallback_patches(
+        clients=[
+            (_fallback_client(_CODEX_BASE_URL), "gpt-5.6-luna"),
+            (_fallback_client(target_base_url), "target-model"),
+        ],
+        custom_providers=[target_config],
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        assert agent._try_activate_fallback() is True
+
+    assert agent.provider == "custom:target"
+    assert agent.request_overrides == {"extra_body": {"target_flag": True}}
+
+
+def test_failed_candidate_does_not_confuse_same_endpoint_successor_ownership():
+    target_base_url = "https://target.example/v1"
+    target_configs = [
+        {
+            "provider_key": "target",
+            "base_url": target_base_url,
+            "model": "candidate-a",
+            "extra_body": {"candidate": "a"},
+        },
+        {
+            "provider_key": "target",
+            "base_url": target_base_url,
+            "model": "candidate-b",
+            "extra_body": {"candidate": "b"},
+        },
+    ]
+    agent = _make_fallback_agent(
+        [
+            {
+                "provider": "custom:target",
+                "model": "candidate-a",
+                "base_url": target_base_url,
+            },
+            {
+                "provider": "custom:target",
+                "model": "candidate-b",
+                "base_url": target_base_url,
+            },
+        ]
+    )
+    prompt_cache_calls = 0
+
+    def fail_first_candidate(**_kwargs):
+        nonlocal prompt_cache_calls
+        prompt_cache_calls += 1
+        if prompt_cache_calls == 1:
+            raise RuntimeError("candidate-a failed after runtime swap")
+        return False, False
+
+    agent._anthropic_prompt_cache_policy = fail_first_candidate
+    patches = _fallback_patches(
+        clients=[
+            (_fallback_client(target_base_url), "candidate-a"),
+            (_fallback_client(target_base_url), "candidate-b"),
+        ],
+        custom_providers=target_configs,
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        assert agent._try_activate_fallback() is True
+
+    assert agent.model == "candidate-b"
+    assert agent.request_overrides == {"extra_body": {"candidate": "b"}}
+
+
+def test_successful_fallback_rebuilds_overrides_for_same_endpoint_next_model():
+    target_base_url = "https://target.example/v1"
+    target_configs = [
+        {
+            "provider_key": "target",
+            "base_url": target_base_url,
+            "model": "candidate-a",
+            "extra_body": {"candidate": "a"},
+        },
+        {
+            "provider_key": "target",
+            "base_url": target_base_url,
+            "model": "candidate-b",
+            "extra_body": {"candidate": "b"},
+        },
+    ]
+    agent = _make_fallback_agent(
+        [
+            {
+                "provider": "custom:target",
+                "model": "candidate-a",
+                "base_url": target_base_url,
+            },
+            {
+                "provider": "custom:target",
+                "model": "candidate-b",
+                "base_url": target_base_url,
+            },
+        ]
+    )
+    patches = _fallback_patches(
+        clients=[
+            (_fallback_client(target_base_url), "candidate-a"),
+            (_fallback_client(target_base_url), "candidate-b"),
+        ],
+        custom_providers=target_configs,
+    )
+
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+    ):
+        assert agent._try_activate_fallback() is True
+        assert agent.request_overrides == {"extra_body": {"candidate": "a"}}
+        assert agent._try_activate_fallback() is True
+
+    assert agent.model == "candidate-b"
+    assert agent.request_overrides == {"extra_body": {"candidate": "b"}}
+
+
+def test_failed_candidate_transaction_does_not_pollute_successor_runtime():
+    a_base_url = "https://candidate-a.example/v1"
+    b_base_url = "https://candidate-b.example/v1"
+    configs = [
+        {
+            "provider_key": "candidate-a",
+            "base_url": a_base_url,
+            "model": "model-a",
+            "extra_body": {"candidate": "a"},
+        },
+        {
+            "provider_key": "candidate-b",
+            "base_url": b_base_url,
+            "model": "model-b",
+            "extra_body": {"candidate": "b"},
+        },
+    ]
+    agent = _make_fallback_agent(
+        [
+            {
+                "provider": "custom:candidate-a",
+                "model": "model-a",
+                "base_url": a_base_url,
+            },
+            {
+                "provider": "custom:candidate-b",
+                "model": "model-b",
+                "base_url": b_base_url,
+            },
+        ]
+    )
+    agent.context_compressor = _StatefulCompressor(agent, fail_model="model-a")
+    candidate_a = _fallback_client(a_base_url, "key-a")
+    candidate_b = _fallback_client(b_base_url, "key-b")
+    cache_policies = [(True, False), (False, True)]
+    agent._anthropic_prompt_cache_policy = lambda **_kwargs: cache_policies.pop(0)
+    agent._cached_system_prompt = (
+        "Stable prefix\n"
+        f"Model: {agent.model}\n"
+        f"Provider: {agent.provider}\n"
+    )
+    patches = _fallback_patches(
+        clients=[
+            (candidate_a, "model-a"),
+            (candidate_b, "model-b"),
+        ],
+        custom_providers=configs,
+    )
+
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patch("agent.model_metadata.get_model_context_length", return_value=65536),
+    ):
+        assert agent._try_activate_fallback() is True
+
+    assert agent.model == "model-b"
+    assert agent.provider == "custom:candidate-b"
+    assert agent.base_url == b_base_url
+    assert agent.api_key == "key-b"
+    assert agent.client is candidate_b
+    assert agent._client_kwargs["api_key"] == "key-b"
+    assert agent._client_kwargs["base_url"] == b_base_url
+    assert agent.request_overrides == {"extra_body": {"candidate": "b"}}
+    assert agent._credential_pool is None
+    assert agent._transport_cache == {}
+    assert agent._use_prompt_caching is False
+    assert agent._use_native_cache_layout is True
+    assert agent._cached_system_prompt.endswith(
+        "Model: model-b\nProvider: custom:candidate-b\n"
+    )
+    assert agent._fallback_activated is True
+    assert agent.context_compressor.model == "model-b"
+    assert agent.context_compressor.provider == "custom:candidate-b"
+    assert agent.context_compressor.base_url == b_base_url
+    assert agent.context_compressor.api_key == "key-b"
+    assert agent.context_compressor.context_length == 65536
+    agent._close_openai_client.assert_any_call(
+        candidate_a,
+        reason="fallback_activation_rollback",
+        shared=True,
+    )
+
+
+def test_failed_fallback_candidate_restores_entry_overrides_before_exhaustion():
+    agent = _make_fallback_agent(
+        [{"provider": "openai-codex", "model": "gpt-5.6-luna"}]
+    )
+    original = copy.deepcopy(agent.request_overrides)
+
+    def mutate_then_fail(**_kwargs):
+        agent.request_overrides = {"extra_body": {"candidate_only": True}}
+        raise RuntimeError("candidate activation failed")
+
+    agent._anthropic_prompt_cache_policy = mutate_then_fail
+    patches = _fallback_patches(
+        clients=[(_fallback_client(_CODEX_BASE_URL), "gpt-5.6-luna")]
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        assert agent._try_activate_fallback() is False
+
+    assert agent.request_overrides == original
+
+
+def test_terminal_fallback_failure_restores_atomic_entry_runtime():
+    target_base_url = "https://target.example/v1"
+    target_config = {
+        "provider_key": "target",
+        "base_url": target_base_url,
+        "model": "candidate-a",
+        "extra_body": {"candidate": "a"},
+    }
+    agent = _make_fallback_agent(
+        [
+            {
+                "provider": "custom:target",
+                "model": "candidate-a",
+                "base_url": target_base_url,
+            }
+        ]
+    )
+    primary_client = agent.client
+    primary_pool = MagicMock()
+    primary_pool.provider = agent.provider
+    agent._credential_pool = primary_pool
+    agent._client_kwargs["default_headers"] = {
+        "X-Primary": {"nested": "keep"}
+    }
+    agent._transport_cache = {"primary": object()}
+    primary_transport_cache = dict(agent._transport_cache)
+    agent._config_context_length = 77777
+    agent._cached_system_prompt = (
+        "Stable prefix\n"
+        f"Model: {agent.model}\n"
+        f"Provider: {agent.provider}\n"
+    )
+    primary_prompt = agent._cached_system_prompt
+    primary_runtime = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": agent.api_key,
+        "client": primary_client,
+        "client_kwargs": copy.deepcopy(agent._client_kwargs),
+        "request_overrides": copy.deepcopy(agent.request_overrides),
+        "credential_pool": primary_pool,
+        "transport_cache": primary_transport_cache,
+        "config_context_length": agent._config_context_length,
+        "use_prompt_caching": agent._use_prompt_caching,
+        "use_native_cache_layout": agent._use_native_cache_layout,
+        "cached_system_prompt": primary_prompt,
+        "fallback_activated": agent._fallback_activated,
+    }
+    agent._anthropic_prompt_cache_policy = lambda **_kwargs: (True, True)
+    agent._buffer_status = MagicMock(
+        side_effect=RuntimeError("candidate failed after prompt rewrite")
+    )
+    patches = _fallback_patches(
+        clients=[(_fallback_client(target_base_url), "candidate-a")],
+        custom_providers=[target_config],
+        fallback_pool=None,
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        assert agent._try_activate_fallback() is False
+
+    assert agent.model == primary_runtime["model"]
+    assert agent.provider == primary_runtime["provider"]
+    assert agent.base_url == primary_runtime["base_url"]
+    assert agent.api_mode == primary_runtime["api_mode"]
+    assert agent.api_key == primary_runtime["api_key"]
+    assert agent.client is primary_runtime["client"]
+    assert agent._client_kwargs == primary_runtime["client_kwargs"]
+    assert agent.request_overrides == primary_runtime["request_overrides"]
+    assert agent._credential_pool is primary_runtime["credential_pool"]
+    assert agent._transport_cache == primary_runtime["transport_cache"]
+    assert agent._config_context_length == primary_runtime["config_context_length"]
+    assert agent._use_prompt_caching is primary_runtime["use_prompt_caching"]
+    assert agent._use_native_cache_layout is primary_runtime["use_native_cache_layout"]
+    assert agent._cached_system_prompt == primary_runtime["cached_system_prompt"]
+    assert agent._fallback_activated is primary_runtime["fallback_activated"]
+    agent._client_kwargs["default_headers"]["X-Primary"]["nested"] = "mutated"
+    agent.request_overrides["extra_body"]["thinking"]["type"] = "mutated"
+    assert primary_runtime["client_kwargs"]["default_headers"] == {
+        "X-Primary": {"nested": "keep"}
+    }
+    assert primary_runtime["request_overrides"] == {
+        "extra_body": {"thinking": {"type": "enabled"}}
+    }
+
+
+def test_failed_candidate_after_successful_fallback_restores_that_fallback():
+    x_base_url = "https://fallback-x.example/v1"
+    y_base_url = "https://fallback-y.example/v1"
+    configs = [
+        {
+            "provider_key": "fallback-x",
+            "base_url": x_base_url,
+            "model": "model-x",
+            "extra_body": {"candidate": "x"},
+        },
+        {
+            "provider_key": "fallback-y",
+            "base_url": y_base_url,
+            "model": "model-y",
+            "extra_body": {"candidate": "y"},
+        },
+    ]
+    agent = _make_fallback_agent(
+        [
+            {
+                "provider": "custom:fallback-x",
+                "model": "model-x",
+                "base_url": x_base_url,
+            },
+            {
+                "provider": "custom:fallback-y",
+                "model": "model-y",
+                "base_url": y_base_url,
+            },
+        ]
+    )
+    candidate_x = _fallback_client(x_base_url, "key-x")
+    candidate_y = _fallback_client(y_base_url, "key-y")
+    agent._cached_system_prompt = (
+        "Stable prefix\n"
+        f"Model: {agent.model}\n"
+        f"Provider: {agent.provider}\n"
+    )
+    agent._buffer_status = MagicMock(
+        side_effect=[None, RuntimeError("fallback-y failed late")]
+    )
+    patches = _fallback_patches(
+        clients=[
+            (candidate_x, "model-x"),
+            (candidate_y, "model-y"),
+        ],
+        custom_providers=configs,
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        assert agent._try_activate_fallback() is True
+        fallback_x_runtime = {
+            "model": agent.model,
+            "provider": agent.provider,
+            "base_url": agent.base_url,
+            "api_mode": agent.api_mode,
+            "api_key": agent.api_key,
+            "client": agent.client,
+            "client_kwargs": copy.deepcopy(agent._client_kwargs),
+            "request_overrides": copy.deepcopy(agent.request_overrides),
+            "cached_system_prompt": agent._cached_system_prompt,
+            "pending_notice": agent._pending_fallback_notice,
+            "fallback_activated": agent._fallback_activated,
+        }
+        assert agent._try_activate_fallback() is False
+
+    assert agent.model == fallback_x_runtime["model"]
+    assert agent.provider == fallback_x_runtime["provider"]
+    assert agent.base_url == fallback_x_runtime["base_url"]
+    assert agent.api_mode == fallback_x_runtime["api_mode"]
+    assert agent.api_key == fallback_x_runtime["api_key"]
+    assert agent.client is fallback_x_runtime["client"]
+    assert agent._client_kwargs == fallback_x_runtime["client_kwargs"]
+    assert agent.request_overrides == fallback_x_runtime["request_overrides"]
+    assert agent._cached_system_prompt == fallback_x_runtime["cached_system_prompt"]
+    assert agent._pending_fallback_notice == fallback_x_runtime["pending_notice"]
+    assert agent._fallback_activated is fallback_x_runtime["fallback_activated"]
+    agent._close_openai_client.assert_any_call(
+        candidate_y,
+        reason="fallback_activation_rollback",
+        shared=True,
+    )
+
+
+def test_restore_primary_runtime_deep_copies_primary_request_overrides():
+    agent = _make_fallback_agent(
+        [{"provider": "openai-codex", "model": "gpt-5.6-luna"}]
+    )
+    primary_snapshot = copy.deepcopy(agent._primary_runtime["request_overrides"])
+    agent.context_compressor = MagicMock()
+    patches = _fallback_patches(
+        clients=[(_fallback_client(_CODEX_BASE_URL), "gpt-5.6-luna")]
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        assert agent._try_activate_fallback() is True
+    assert agent.request_overrides == {}
+
+    assert agent._restore_primary_runtime() is True
+    assert agent.request_overrides == primary_snapshot
+    agent.request_overrides["extra_body"]["mutated_after_restore"] = True
+    assert agent._primary_runtime["request_overrides"] == primary_snapshot
+
+
+def test_initial_primary_runtime_deep_copies_request_overrides():
+    original = {"extra_body": {"thinking": {"type": "enabled"}}}
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=_ZAI_BASE_URL,
+            provider="custom:zai-coding-plan",
+            model="glm-5.2",
+            request_overrides=original,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._primary_runtime["request_overrides"] == original
+    original["extra_body"]["thinking"]["type"] = "mutated"
+    assert agent._primary_runtime["request_overrides"] == {
+        "extra_body": {"thinking": {"type": "enabled"}}
+    }
+
+
+def test_primary_transport_recovery_restores_request_overrides_from_snapshot():
+    from agent.agent_runtime_helpers import try_recover_primary_transport
+
+    agent = _make_fallback_agent([])
+    primary_snapshot = copy.deepcopy(agent._primary_runtime["request_overrides"])
+    agent.request_overrides = {"extra_body": {"candidate_only": True}}
+    agent._fallback_activated = False
+    agent._is_openrouter_url = lambda: False
+    agent._vprint = MagicMock()
+
+    class ReadTimeout(Exception):
+        pass
+
+    with patch("agent.agent_runtime_helpers.time.sleep", return_value=None):
+        assert try_recover_primary_transport(
+            agent,
+            ReadTimeout(),
+            retry_count=0,
+            max_retries=1,
+        ) is True
+
+    assert agent.request_overrides == primary_snapshot
+    agent.request_overrides["extra_body"]["after_recovery"] = True
+    assert agent._primary_runtime["request_overrides"] == primary_snapshot

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,5 @@
+import copy
+import errno
 import json
 import os
 import subprocess
@@ -6826,6 +6828,436 @@ def test_config_set_model_once_keeps_env_and_records_restore(monkeypatch):
         assert session["one_turn_model_restore"]["model"] == "old/model"
         assert os.environ["HERMES_INFERENCE_PROVIDER"] == "openrouter"
         assert os.environ["HERMES_MODEL"] == "old/model"
+    finally:
+        server._sessions.clear()
+
+
+@pytest.mark.parametrize(
+    ("failure_point", "failure"),
+    [
+        ("_restart_slash_worker", RuntimeError("restart failed")),
+        ("_persist_live_session_runtime", RuntimeError("runtime persist failed")),
+        (
+            "_persist_live_session_system_prompt",
+            RuntimeError("prompt persist failed"),
+        ),
+        ("_emit", OSError(errno.ENOSPC, "event pipe is full")),
+    ],
+)
+def test_config_set_model_once_side_effect_failure_restores_atomically(
+    monkeypatch,
+    failure_point,
+    failure,
+):
+    old_client = object()
+    new_client = object()
+    old_pool = object()
+    new_pool = object()
+
+    class SessionDB:
+        def __init__(self):
+            self.model_config = {
+                "model": "old/model",
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            }
+            self.model = "old/model"
+            self.billing_route = {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "billing_mode": "chat_completions",
+            }
+            self.system_prompt = "Model: old/model\nProvider: openrouter"
+
+        def get_session(self, _session_id):
+            return {"model_config": copy.deepcopy(self.model_config)}
+
+        def update_session_meta(self, _session_id, model_config_json, model=None):
+            self.model_config = json.loads(model_config_json)
+            if model is not None:
+                self.model = model
+
+        def update_session_billing_route(
+            self,
+            _session_id,
+            *,
+            provider,
+            base_url,
+            billing_mode=None,
+        ):
+            self.billing_route = {
+                "provider": provider,
+                "base_url": base_url,
+                "billing_mode": billing_mode,
+            }
+            self.system_prompt = None
+
+        def update_system_prompt(self, _session_id, system_prompt):
+            self.system_prompt = system_prompt
+
+    class Agent:
+        def __init__(self, db):
+            self.model = "old/model"
+            self.provider = "openrouter"
+            self.base_url = "https://openrouter.ai/api/v1"
+            self.api_key = "sk-old"
+            self.api_mode = "chat_completions"
+            self.client = old_client
+            self._client_kwargs = {
+                "api_key": "sk-old",
+                "nested": {"owner": "old"},
+            }
+            self.request_overrides = {
+                "extra_body": {"thinking": {"type": "old"}}
+            }
+            self._primary_runtime = {
+                "model": self.model,
+                "provider": self.provider,
+                "request_overrides": copy.deepcopy(self.request_overrides),
+            }
+            self._transport_cache = {"old": object()}
+            self._credential_pool = old_pool
+            self._fallback_activated = False
+            self._config_context_length = 131072
+            self._use_prompt_caching = False
+            self._use_native_cache_layout = False
+            self.reasoning_config = {"enabled": True, "nested": {"owner": "old"}}
+            self._cached_system_prompt = "Model: old/model\nProvider: openrouter"
+            self._pending_fallback_notice = "old notice"
+            self._fallback_chain = [
+                {
+                    "provider": "custom:backup",
+                    "model": "backup/model",
+                    "nested": {"owner": "old"},
+                }
+            ]
+            self._fallback_model = copy.deepcopy(self._fallback_chain[0])
+            self._fallback_index = 2
+            self._consecutive_stale_streams = 7
+            self.context_compressor = None
+            self.closed_clients = []
+            self._session_db = db
+            self.session_id = "session-key"
+
+        def switch_model(self, **kwargs):
+            self.model = kwargs["new_model"]
+            self.provider = kwargs["new_provider"]
+            self.api_key = kwargs["api_key"]
+            self.base_url = kwargs["base_url"]
+            self.api_mode = kwargs["api_mode"]
+            self.client = new_client
+            self._client_kwargs = {
+                "api_key": kwargs["api_key"],
+                "nested": {"owner": "new"},
+            }
+            self.request_overrides = {
+                "extra_body": {"thinking": {"type": "new"}}
+            }
+            self._primary_runtime = {
+                "model": self.model,
+                "provider": self.provider,
+                "request_overrides": copy.deepcopy(self.request_overrides),
+            }
+            self._transport_cache = {"new": object()}
+            self._credential_pool = new_pool
+            self._use_prompt_caching = True
+            self._use_native_cache_layout = True
+            self.reasoning_config = {
+                "enabled": True,
+                "nested": {"owner": "new"},
+            }
+            self._cached_system_prompt = "Model: new/model\nProvider: anthropic"
+            self._pending_fallback_notice = "new notice"
+            self._fallback_chain = []
+            self._fallback_model = None
+            self._fallback_index = 0
+            self._consecutive_stale_streams = 0
+            self._session_db.update_session_billing_route(
+                self.session_id,
+                provider=self.provider,
+                base_url=self.base_url,
+                billing_mode=self.api_mode,
+            )
+
+        def _close_openai_client(self, client, **_kwargs):
+            self.closed_clients.append(client)
+
+        def _build_system_prompt(self, _context=None):
+            return f"Model: {self.model}\nProvider: {self.provider}"
+
+    result = types.SimpleNamespace(
+        success=True,
+        new_model="new/model",
+        target_provider="anthropic",
+        api_key="sk-new",
+        base_url="https://api.anthropic.com",
+        api_mode="anthropic_messages",
+        warning_message="",
+    )
+    db = SessionDB()
+    agent = Agent(db)
+    session = _session(agent=agent)
+    session["history"] = [{"role": "user", "content": "before switch"}]
+    initial_history = copy.deepcopy(session["history"])
+    initial_history_version = session.get("history_version", 0)
+    initial_override = copy.deepcopy(session.get("model_override"))
+    server._sessions["sid"] = session
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **_kwargs: result)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_k: None)
+
+    def append_marker(target_session, **_kwargs):
+        target_session["history"].append(
+            {"role": "user", "content": "temporary model marker"}
+        )
+        target_session["history_version"] = (
+            int(target_session.get("history_version", 0)) + 1
+        )
+
+    monkeypatch.setattr(server, "_append_model_switch_marker", append_marker)
+
+    def fail(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(server, failure_point, fail)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": "sid",
+                    "key": "model",
+                    "value": "new/model --provider anthropic --once",
+                },
+            }
+        )
+
+        assert "error" in resp
+        assert agent.model == "old/model"
+        assert agent.provider == "openrouter"
+        assert agent.base_url == "https://openrouter.ai/api/v1"
+        assert agent.api_key == "sk-old"
+        assert agent.api_mode == "chat_completions"
+        assert agent.client is old_client
+        assert agent._client_kwargs == {
+            "api_key": "sk-old",
+            "nested": {"owner": "old"},
+        }
+        assert agent.request_overrides == {
+            "extra_body": {"thinking": {"type": "old"}}
+        }
+        assert agent._credential_pool is old_pool
+        assert agent.reasoning_config == {
+            "enabled": True,
+            "nested": {"owner": "old"},
+        }
+        assert agent._cached_system_prompt == "Model: old/model\nProvider: openrouter"
+        assert agent._pending_fallback_notice == "old notice"
+        assert db.model == "old/model"
+        assert db.model_config["model"] == "old/model"
+        assert db.model_config["provider"] == "openrouter"
+        assert db.model_config["base_url"] == "https://openrouter.ai/api/v1"
+        assert db.model_config["api_mode"] == "chat_completions"
+        assert db.billing_route == {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "billing_mode": "chat_completions",
+        }
+        assert agent._fallback_chain == [
+            {
+                "provider": "custom:backup",
+                "model": "backup/model",
+                "nested": {"owner": "old"},
+            }
+        ]
+        assert agent._fallback_model == agent._fallback_chain[0]
+        assert agent._fallback_model is not agent._fallback_chain[0]
+        assert agent._fallback_index == 2
+        assert agent._consecutive_stale_streams == 7
+        assert new_client in agent.closed_clients
+        assert "one_turn_model_restore" not in session
+        assert session.get("model_override") == initial_override
+        assert session["history"] == initial_history
+        assert session.get("history_version", 0) == initial_history_version
+
+        agent.request_overrides["extra_body"]["thinking"]["type"] = "mutated"
+        assert agent._primary_runtime["request_overrides"] == {
+            "extra_body": {"thinking": {"type": "old"}}
+        }
+    finally:
+        server._sessions.clear()
+
+
+@pytest.mark.parametrize(
+    "failure_point",
+    [
+        "_restart_slash_worker",
+        "_persist_live_session_runtime",
+        "_persist_live_session_billing_route",
+        "_persist_live_session_system_prompt",
+    ],
+)
+def test_model_once_successful_turn_restore_repairs_are_independent(
+    monkeypatch,
+    failure_point,
+):
+    class SessionDB:
+        def __init__(self):
+            self.model_config = {
+                "model": "temp/model",
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_mode": "anthropic_messages",
+            }
+            self.model = "temp/model"
+            self.billing_route = {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "billing_mode": "anthropic_messages",
+            }
+            self.system_prompt = "Model: temp/model\nProvider: anthropic"
+
+        def get_session(self, _session_id):
+            return {"model_config": copy.deepcopy(self.model_config)}
+
+        def update_session_meta(self, _session_id, model_config_json, model=None):
+            self.model_config = json.loads(model_config_json)
+            if model is not None:
+                self.model = model
+
+        def update_session_billing_route(
+            self,
+            _session_id,
+            *,
+            provider,
+            base_url,
+            billing_mode=None,
+        ):
+            self.billing_route = {
+                "provider": provider,
+                "base_url": base_url,
+                "billing_mode": billing_mode,
+            }
+            self.system_prompt = None
+
+        def update_system_prompt(self, _session_id, system_prompt):
+            self.system_prompt = system_prompt
+
+    class Agent:
+        def __init__(self, db):
+            self.model = "old/model"
+            self.provider = "openrouter"
+            self.base_url = "https://openrouter.ai/api/v1"
+            self.api_key = "sk-old"
+            self.api_mode = "chat_completions"
+            self.client = object()
+            self._client_kwargs = {"nested": {"owner": "old"}}
+            self.request_overrides = {"nested": {"owner": "old"}}
+            self._primary_runtime = {
+                "model": self.model,
+                "provider": self.provider,
+                "request_overrides": copy.deepcopy(self.request_overrides),
+            }
+            self._transport_cache = {}
+            self._credential_pool = None
+            self._fallback_activated = False
+            self._config_context_length = None
+            self._use_prompt_caching = False
+            self._use_native_cache_layout = False
+            self.reasoning_config = None
+            self._cached_system_prompt = "Model: old/model\nProvider: openrouter"
+            self._pending_fallback_notice = None
+            self._fallback_chain = [{"provider": "custom:backup"}]
+            self._fallback_model = {"provider": "custom:backup"}
+            self._fallback_index = 2
+            self._consecutive_stale_streams = 7
+            self.context_compressor = None
+            self._session_db = db
+            self.session_id = "session-key"
+
+        def _build_system_prompt(self, _context=None):
+            return f"Model: {self.model}\nProvider: {self.provider}"
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+        ):
+            return {
+                "final_response": "done",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "done"},
+                ],
+            }
+
+    db = SessionDB()
+    agent = Agent(db)
+    restore = server._snapshot_agent_model_runtime(agent)
+    agent.model = "temp/model"
+    agent.provider = "anthropic"
+    agent.base_url = "https://api.anthropic.com"
+    agent.api_key = "sk-temp"
+    agent.api_mode = "anthropic_messages"
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._fallback_index = 0
+    agent._consecutive_stale_streams = 0
+    session = _session(agent=agent, one_turn_model_restore=restore)
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda *_a, **_k: None)
+
+    def fail_repair(*_args, **_kwargs):
+        raise RuntimeError(f"{failure_point} failed")
+
+    monkeypatch.setattr(server, failure_point, fail_repair)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "turn",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            }
+        )
+
+        assert "result" in response
+        assert agent.model == "old/model"
+        assert agent.provider == "openrouter"
+        assert agent._fallback_chain == [{"provider": "custom:backup"}]
+        assert agent._fallback_index == 2
+        assert agent._consecutive_stale_streams == 7
+        if failure_point == "_persist_live_session_runtime":
+            assert db.model == "temp/model"
+            assert db.model_config["provider"] == "anthropic"
+        else:
+            assert db.model == "old/model"
+            assert db.model_config["provider"] == "openrouter"
+        if failure_point == "_persist_live_session_billing_route":
+            assert db.billing_route == {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "billing_mode": "anthropic_messages",
+            }
+        else:
+            assert db.billing_route == {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "billing_mode": "chat_completions",
+            }
+        if failure_point == "_persist_live_session_system_prompt":
+            assert db.system_prompt is None
+        else:
+            assert db.system_prompt == "Model: old/model\nProvider: openrouter"
     finally:
         server._sessions.clear()
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3533,6 +3533,29 @@ def _persist_live_session_runtime(session: dict | None) -> None:
         logger.debug("failed to persist live session runtime", exc_info=True)
 
 
+def _persist_live_session_billing_route(session: dict | None) -> None:
+    """Persist the billing route for the agent currently bound to a session."""
+    if not session:
+        return
+    agent = session.get("agent")
+    session_key = str(session.get("session_key") or "").strip()
+    if agent is None or not session_key:
+        return
+
+    db = getattr(agent, "_session_db", None) or _get_db()
+    if db is None or not hasattr(db, "update_session_billing_route"):
+        return
+    try:
+        db.update_session_billing_route(
+            session_key,
+            provider=str(getattr(agent, "provider", "") or ""),
+            base_url=str(getattr(agent, "base_url", "") or ""),
+            billing_mode=str(getattr(agent, "api_mode", "") or "") or None,
+        )
+    except Exception:
+        logger.debug("failed to persist live session billing route", exc_info=True)
+
+
 def _persist_live_session_system_prompt(session: dict | None) -> None:
     """Refresh the stored system prompt after a live runtime identity change."""
     if not session:
@@ -3999,7 +4022,7 @@ def _persist_model_switch(result) -> None:
 
 def _snapshot_agent_model_runtime(agent) -> dict:
     """Capture the current agent model runtime for a one-turn restore."""
-    return {
+    snapshot = {
         "model": getattr(agent, "model", ""),
         "provider": getattr(agent, "provider", ""),
         "api_key": getattr(agent, "api_key", ""),
@@ -4007,19 +4030,75 @@ def _snapshot_agent_model_runtime(agent) -> dict:
         "api_mode": getattr(agent, "api_mode", ""),
         "primary_runtime": copy.deepcopy(getattr(agent, "_primary_runtime", None)),
     }
+    if hasattr(agent, "request_overrides"):
+        snapshot["request_overrides"] = copy.deepcopy(agent.request_overrides)
+    snapshot["one_turn_fallback_state"] = {
+        name: copy.deepcopy(getattr(agent, name))
+        for name in (
+            "_fallback_chain",
+            "_fallback_model",
+            "_fallback_index",
+            "_consecutive_stale_streams",
+        )
+        if hasattr(agent, name)
+    }
+    try:
+        from agent.chat_completion_helpers import (
+            _snapshot_fallback_candidate_runtime,
+        )
+
+        snapshot["atomic_runtime"] = _snapshot_fallback_candidate_runtime(agent)
+    except Exception:
+        logger.debug("TUI one-turn atomic runtime snapshot failed", exc_info=True)
+    return snapshot
 
 
 def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
     """Restore an agent model runtime captured before a one-turn override."""
     if not snapshot or agent is None:
         return
+
+    def _restore_request_overrides() -> None:
+        if "request_overrides" in snapshot:
+            agent.request_overrides = copy.deepcopy(snapshot["request_overrides"])
+
+    def _restore_one_turn_fallback_state() -> None:
+        for name, value in snapshot.get("one_turn_fallback_state", {}).items():
+            setattr(agent, name, copy.deepcopy(value))
+
     primary = snapshot.get("primary_runtime")
+    atomic_runtime = snapshot.get("atomic_runtime")
+    if atomic_runtime:
+        try:
+            from agent.chat_completion_helpers import (
+                _close_rejected_fallback_clients,
+                _restore_fallback_candidate_runtime,
+            )
+
+            rejected_client = getattr(agent, "client", None)
+            rejected_anthropic_client = getattr(agent, "_anthropic_client", None)
+            if "primary_runtime" in snapshot:
+                agent._primary_runtime = copy.deepcopy(primary)
+            _restore_fallback_candidate_runtime(agent, atomic_runtime)
+            _close_rejected_fallback_clients(
+                agent,
+                atomic_runtime,
+                resolved_client=None,
+                active_client=rejected_client,
+                active_anthropic_client=rejected_anthropic_client,
+            )
+            _restore_one_turn_fallback_state()
+            return
+        except Exception:
+            logger.debug("TUI one-turn atomic runtime restore failed", exc_info=True)
     if primary and hasattr(agent, "_restore_primary_runtime"):
         try:
             agent._primary_runtime = copy.deepcopy(primary)
             agent._fallback_activated = True
             agent._rate_limited_until = 0
             if agent._restore_primary_runtime():
+                _restore_request_overrides()
+                _restore_one_turn_fallback_state()
                 return
         except Exception:
             logger.debug("TUI one-turn model restore via primary runtime failed", exc_info=True)
@@ -4031,6 +4110,8 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
             base_url=snapshot.get("base_url", ""),
             api_mode=snapshot.get("api_mode", ""),
         )
+        _restore_request_overrides()
+        _restore_one_turn_fallback_state()
 
 
 def _apply_model_switch(
@@ -4204,17 +4285,70 @@ def _apply_model_switch(
                 f"Model switch to {result.new_model} failed ({exc}); "
                 f"staying on {getattr(agent, 'model', current_model)}."
             ) from exc
-        _restart_slash_worker(sid, session)
-        _persist_live_session_runtime(session)
-        _persist_live_session_system_prompt(session)
-        _append_model_switch_marker(
-            session, model=result.new_model, provider=result.target_provider
-        )
-        _emit("session.info", sid, _session_info(agent, session))
         if one_turn:
+            # Install the rollback token immediately after the runtime commit.
+            # Every later hook can fail (worker restart, persistence, stdio
+            # event delivery), and a temporary runtime must never survive such
+            # a partial command.
             session["one_turn_model_restore"] = restore_snapshot
         else:
             session.pop("one_turn_model_restore", None)
+
+        if one_turn:
+            history_len = len(session.get("history", []))
+            history_version = int(session.get("history_version", 0))
+            try:
+                _restart_slash_worker(sid, session)
+                _persist_live_session_runtime(session)
+                _persist_live_session_system_prompt(session)
+                # Event delivery can raise (for example ENOSPC on a saturated
+                # pipe). Emit before appending the durable history marker so a
+                # delivery failure cannot leave a marker for a rolled-back swap.
+                _emit("session.info", sid, _session_info(agent, session))
+                _append_model_switch_marker(
+                    session,
+                    model=result.new_model,
+                    provider=result.target_provider,
+                )
+            except Exception:
+                try:
+                    _restore_agent_model_runtime(agent, restore_snapshot)
+                finally:
+                    session.pop("one_turn_model_restore", None)
+                    lock = session.get("history_lock")
+                    if lock is not None:
+                        with lock:
+                            del session.setdefault("history", [])[history_len:]
+                            session["history_version"] = history_version
+                    else:
+                        del session.setdefault("history", [])[history_len:]
+                        session["history_version"] = history_version
+
+                # Earlier hooks may already have persisted the temporary
+                # runtime. Repair those durable/session-adjacent surfaces on a
+                # best-effort basis after the in-memory rollback.
+                for repair in (
+                    lambda: _persist_live_session_runtime(session),
+                    lambda: _persist_live_session_billing_route(session),
+                    lambda: _persist_live_session_system_prompt(session),
+                    lambda: _restart_slash_worker(sid, session),
+                ):
+                    try:
+                        repair()
+                    except Exception:
+                        logger.debug(
+                            "TUI one-turn rollback repair hook failed",
+                            exc_info=True,
+                        )
+                raise
+        else:
+            _restart_slash_worker(sid, session)
+            _persist_live_session_runtime(session)
+            _persist_live_session_system_prompt(session)
+            _append_model_switch_marker(
+                session, model=result.new_model, provider=result.target_provider
+            )
+            _emit("session.info", sid, _session_info(agent, session))
 
     # Record the switch as a PER-SESSION override so a later rebuild of THIS
     # session (e.g. /new via _reset_session_agent, or resume) re-derives the
@@ -9543,11 +9677,36 @@ def _run_prompt_submit(
             if one_turn_restore:
                 try:
                     _restore_agent_model_runtime(agent, one_turn_restore)
-                    _restart_slash_worker(sid, session)
-                    _persist_live_session_runtime(session)
-                    _persist_live_session_system_prompt(session)
                 except Exception:
-                    logger.debug("TUI one-turn model restore failed", exc_info=True)
+                    logger.debug(
+                        "TUI one-turn in-memory model restore failed",
+                        exc_info=True,
+                    )
+                # Each session-adjacent repair is independent. A dead slash
+                # worker or one unavailable DB surface must not leave the
+                # remaining metadata pinned to the temporary route. Billing
+                # precedes the prompt because updating the route invalidates
+                # the stored prompt snapshot.
+                for repair_name, repair in (
+                    ("runtime", lambda: _persist_live_session_runtime(session)),
+                    (
+                        "billing route",
+                        lambda: _persist_live_session_billing_route(session),
+                    ),
+                    (
+                        "system prompt",
+                        lambda: _persist_live_session_system_prompt(session),
+                    ),
+                    ("slash worker", lambda: _restart_slash_worker(sid, session)),
+                ):
+                    try:
+                        repair()
+                    except Exception:
+                        logger.debug(
+                            "TUI one-turn %s repair failed",
+                            repair_name,
+                            exc_info=True,
+                        )
             try:
                 if approval_token is not None:
                     reset_current_session_key(approval_token)


### PR DESCRIPTION
## Problem

When switching models in-place (e.g. GLM-5.2 → GPT-5.6 via `/model`), stale `request_overrides` from the old provider leak into the new provider's API request. Specifically, `extra_body.thinking` from a GLM/Kimi custom provider config persists and gets merged into the wire JSON by the OpenAI SDK, causing:

```
HTTP 400: {"detail":"Unsupported parameter: thinking"}
```

## Root Cause

`switch_model()` in `agent/agent_runtime_helpers.py` updates model/provider/base_url but does NOT clear or rebuild `request_overrides`. The dict was populated at agent init time from the custom provider's `extra_body` config (`agent/agent_init.py:257-273`) and persists across model switches.

The codex transport blindly applies overrides via `kwargs.update(request_overrides)` (`agent/transports/codex.py:303-305`), and the preflight in `agent/codex_responses_adapter.py:973-984` passes `extra_body` through verbatim without validating nested keys.

Introduced in `ba9964ff0` (`fix(custom): pass custom provider extra body`).

## Fix (two layers)

### Layer 1: Rebuild request_overrides on provider change

`switch_model()` now:
1. Snapshots `request_overrides` for rollback (alongside model/provider/base_url)
2. When the provider or endpoint changes, rebuilds `request_overrides` from the new provider's live config
3. Restores the snapshot on rollback if the switch fails

### Layer 2: Defense-in-depth preflight stripping

`_preflight_codex_api_kwargs()` now strips known foreign-provider keys from `extra_body`:
- `thinking` (Kimi/GLM)
- `enable_thinking`
- `chat_template_kwargs`

Valid fields like `prompt_cache_key` are preserved.

## Testing

- Switch/custom-provider suites: **36 passed**
- Codex preflight tests: **8 passed**
- Broader Codex transport/Responses/profile suites: **191 passed**
- Ruff + `git diff --check`: passed

```bash
PYTHONPATH=. pytest tests/run_agent/test_switch_model_request_overrides.py tests/run_agent/test_run_agent_codex_responses.py -x -q
# 44 passed
```