### PR TITLE
fix: null tool-call arguments no longer crash the conversation turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4495,7 +4495,9 @@ def run_conversation(
                 
                 if agent.verbose_logging:
                     for tc in assistant_message.tool_calls:
-                        logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
+                        raw_args = tc.function.arguments
+                        args_preview = raw_args[:200] if isinstance(raw_args, str) else repr(raw_args)[:200]
+                        logging.debug("Tool call: %s with args: %s...", tc.function.name, args_preview)
                 
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -155,10 +155,11 @@ def _plan_tool_batch_segments(tool_calls) -> List[tuple]:
         try:
             function_args = json.loads(tool_call.function.arguments)
         except Exception:
+            _raw = tool_call.function.arguments
             logging.debug(
                 "Could not parse args for %s — treating as sequential barrier; raw=%s",
                 tool_name,
-                tool_call.function.arguments[:200],
+                _raw[:200] if isinstance(_raw, str) else repr(_raw)[:200],
             )
             _add_sequential(tool_call)
             continue

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2443,19 +2443,23 @@ class TestExecuteToolCalls:
         assert "valid json object" in messages[0]["content"].lower()
         assert "tool was not executed" in messages[0]["content"].lower()
 
-    def test_none_args_defaults_empty(self, agent):
+    def test_none_args_rejected_without_dispatch(self, agent):
+        """None arguments must not crash the dispatch path. Current contract:
+        malformed (non-string, non-JSON-object) args are rejected without
+        executing the tool — same as invalid JSON strings. The mainline
+        run_conversation path normalizes None to "{}" BEFORE dispatch (see
+        test_tool_call_none_args_verbose_logging_does_not_crash), so this
+        direct-dispatch path only needs to degrade gracefully, not coerce."""
         tc = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
         with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
             agent._execute_tool_calls(mock_msg, messages, "task-1")
-
-        args, kwargs = mock_hfc.call_args
-        assert args[:3] == ("web_search", {}, "task-1")
-        assert set(kwargs.get("enabled_tools", [])) == agent.valid_tool_names
+            mock_hfc.assert_not_called()
         assert len(messages) == 1
         assert messages[0]["role"] == "tool"
         assert messages[0]["tool_call_id"] == "c1"
+        assert "tool was not executed" in messages[0]["content"].lower()
 
     def test_result_truncation_over_100k(self, agent, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
@@ -2721,8 +2725,10 @@ class TestConcurrentToolExecution:
                 mock_seq.assert_called_once()
                 mock_con.assert_not_called()
 
-    def test_none_args_batch_forces_sequential(self, agent):
-        """Non-string tool arguments should not crash parallelism gating."""
+    def test_none_args_batch_does_not_crash_parallelism_gating(self, agent):
+        """Non-string tool arguments must not crash the segment planner —
+        the None-args call becomes a sequential barrier and the batch
+        dispatches without raising."""
         tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
         tc2 = _mock_tool_call(name="web_search", arguments=None, call_id="c2")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
@@ -2745,9 +2751,12 @@ class TestConcurrentToolExecution:
                 mock_seq.assert_called_once()
                 mock_con.assert_not_called()
 
-    def test_dict_args_batch_allows_concurrent(self, agent):
-        """Pre-parsed dict arguments should not force sequential — the gate
-        accepts them as-is, like the executors do."""
+    def test_dict_args_batch_forces_sequential_without_crash(self, agent):
+        """Pre-parsed dict arguments (non-string) must not crash the planner.
+        Current contract: the mainline loop normalizes dict args to JSON
+        strings BEFORE dispatch, so raw dicts reaching the gate are treated
+        as barriers (defensive sequential), consistent with the executors
+        rejecting non-string args rather than repairing them."""
         tc1 = _mock_tool_call(name="web_search", arguments={"q": "alpha"}, call_id="c1")
         tc2 = _mock_tool_call(name="web_search", arguments={"q": "beta"}, call_id="c2")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
@@ -2755,8 +2764,8 @@ class TestConcurrentToolExecution:
         with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
             with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
                 agent._execute_tool_calls(mock_msg, messages, "task-1")
-                mock_con.assert_called_once()
-                mock_seq.assert_not_called()
+                mock_seq.assert_called_once()
+                mock_con.assert_not_called()
 
     def test_concurrent_executes_all_tools(self, agent):
         """Concurrent path should execute all tools and append results in order."""
@@ -2787,8 +2796,11 @@ class TestConcurrentToolExecution:
         assert "beta" in messages[1]["content"]
         assert "gamma" in messages[2]["content"]
 
-    def test_concurrent_none_args_defaults_empty(self, agent):
-        """Concurrent executor should treat arguments=None as an empty object."""
+    def test_concurrent_none_args_rejected_without_crash(self, agent):
+        """Concurrent executor must not crash on arguments=None. Current
+        contract (_parse_tool_arguments): non-object args are rejected with
+        a structured error result and the tool is not executed; the valid
+        sibling still runs. One result per call, in order."""
         tc1 = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
         tc2 = _mock_tool_call(name="web_search", arguments='{"q":"ok"}', call_id="c2")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
@@ -2802,8 +2814,10 @@ class TestConcurrentToolExecution:
         with patch("run_agent.handle_function_call", side_effect=fake_handle):
             agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
 
-        assert sorted(seen_args) == [("c1", {}), ("c2", {"q": "ok"})]
+        # Only the valid call executed; the None-args call was rejected.
+        assert seen_args == [("c2", {"q": "ok"})]
         assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
+        assert "tool was not executed" in messages[0]["content"].lower()
 
     def test_concurrent_preserves_order_despite_timing(self, agent):
         """Even if tools finish in different order, messages should be in original order."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2443,6 +2443,20 @@ class TestExecuteToolCalls:
         assert "valid json object" in messages[0]["content"].lower()
         assert "tool was not executed" in messages[0]["content"].lower()
 
+    def test_none_args_defaults_empty(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        args, kwargs = mock_hfc.call_args
+        assert args[:3] == ("web_search", {}, "task-1")
+        assert set(kwargs.get("enabled_tools", [])) == agent.valid_tool_names
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+        assert messages[0]["tool_call_id"] == "c1"
+
     def test_result_truncation_over_100k(self, agent, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         (tmp_path / ".hermes").mkdir()
@@ -2707,6 +2721,18 @@ class TestConcurrentToolExecution:
                 mock_seq.assert_called_once()
                 mock_con.assert_not_called()
 
+    def test_none_args_batch_forces_sequential(self, agent):
+        """Non-string tool arguments should not crash parallelism gating."""
+        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments=None, call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_seq.assert_called_once()
+                mock_con.assert_not_called()
+
     def test_non_dict_args_forces_sequential(self, agent):
         """Tool arguments that parse to a non-dict type should fall back to sequential."""
         tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
@@ -2718,6 +2744,19 @@ class TestConcurrentToolExecution:
                 agent._execute_tool_calls(mock_msg, messages, "task-1")
                 mock_seq.assert_called_once()
                 mock_con.assert_not_called()
+
+    def test_dict_args_batch_allows_concurrent(self, agent):
+        """Pre-parsed dict arguments should not force sequential — the gate
+        accepts them as-is, like the executors do."""
+        tc1 = _mock_tool_call(name="web_search", arguments={"q": "alpha"}, call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments={"q": "beta"}, call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_con.assert_called_once()
+                mock_seq.assert_not_called()
 
     def test_concurrent_executes_all_tools(self, agent):
         """Concurrent path should execute all tools and append results in order."""
@@ -2747,6 +2786,24 @@ class TestConcurrentToolExecution:
         assert "alpha" in messages[0]["content"]
         assert "beta" in messages[1]["content"]
         assert "gamma" in messages[2]["content"]
+
+    def test_concurrent_none_args_defaults_empty(self, agent):
+        """Concurrent executor should treat arguments=None as an empty object."""
+        tc1 = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"ok"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        seen_args = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            seen_args.append((kwargs["tool_call_id"], args))
+            return "ok"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert sorted(seen_args) == [("c1", {}), ("c2", {"q": "ok"})]
+        assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
 
     def test_concurrent_preserves_order_despite_timing(self, agent):
         """Even if tools finish in different order, messages should be in original order."""
@@ -4120,6 +4177,25 @@ class TestRunConversation:
         assert result["api_calls"] == 2
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
+
+    def test_tool_call_none_args_verbose_logging_does_not_crash(self, agent):
+        self._setup_agent(agent)
+        agent.verbose_logging = True
+        tc = _mock_tool_call(name="web_search", arguments=None, call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done searching"
+        assert mock_handle_function_call.call_args.args[:2] == ("web_search", {})
 
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

A provider returning `tool_call.function.arguments: null` no longer crashes the entire conversation turn. Salvages @michaelHMK's #50896 (fixes #50892) onto current main, adapted to the post-#64460 segment planner.

Root cause: the verbose-logging tool-call preview in `agent/conversation_loop.py` slices `arguments[:200]` BEFORE the argument-normalization step that coerces `None` to `"{}"`. With verbose logging on and a non-streaming provider emitting null args, that raised an uncaught `TypeError: 'NoneType' object is not subscriptable` and aborted the turn with no recovery.

## Changes

- `agent/conversation_loop.py` (@michaelHMK, cherry-picked): guard the verbose-log slice with an isinstance check; non-string args preview via `repr()`.
- `agent/tool_dispatch_helpers.py` (follow-up): the same latent slice existed in the segment planner's except-path debug log (inherited from the old gate when #64460 rewrote it) — a None-args call in a multi-call batch would raise from inside the exception handler. Same guard applied.
- `tests/run_agent/test_run_agent.py`: @michaelHMK's 5 regression tests, reworked to pin current contracts — the original PR also coerced null args to `{}` in both executors, but those hunks are now redundant/contrary: `_parse_tool_arguments` already rejects non-object args with a structured error result ("we do not repair bad model outputs"). Tests now assert: None args rejected without dispatch, valid siblings still execute, planner treats None-args calls as barriers without raising, mainline verbose-logging turn completes.

## Validation

| | Result |
|---|---|
| Crash repro on pre-fix code | `TypeError: 'NoneType' object is not subscriptable` (planner, confirmed) |
| Live E2E (real AIAgent, temp HERMES_HOME, verbose logging, null-args tool call) | turn completes, tool dispatched with `{}` |
| test_run_agent.py + segmentation + malformed-args suites | 462/462 pass |
| ruff + windows-footgun checkers | clean |

Duplicate #52033 (@lin-hongkuan) fixes the same issue, filed 2 days later — will be closed with credit.

## Infographic

![null-tool-args-crash-fix](https://v3b.fal.media/files/b/0aa24460/nL4tyXfnstPp_zvD25tCW_HiaIKdSd.png)
