### PR TITLE
feat(dashboard): clarify manual Telegram bot setup

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4140,14 +4140,14 @@ OPTIONAL_ENV_VARS = {
 
     # ── Messaging platforms ──
     "TELEGRAM_BOT_TOKEN": {
-        "description": "Telegram bot token from @BotFather",
+        "description": "Complete Telegram bot token created by @BotFather (numeric bot ID followed by a colon and secret)",
         "prompt": "Telegram bot token",
         "url": "https://t.me/BotFather",
         "password": True,
         "category": "messaging",
     },
     "TELEGRAM_ALLOWED_USERS": {
-        "description": "Comma-separated Telegram user IDs allowed to use the bot (get ID from @userinfobot)",
+        "description": "Optional comma-separated numeric Telegram user IDs allowed immediately; leave blank to approve new users through DM pairing",
         "prompt": "Allowed Telegram user IDs (comma-separated)",
         "url": "https://t.me/userinfobot",
         "password": False,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3360,14 +3360,33 @@ def _gateway_display_command(profile: Optional[str], verb: str) -> str:
     return " ".join(["hermes", *_gateway_subcommand(profile, verb)])
 
 
-# Slack member IDs (users U..., Enterprise Grid W...). Kept in sync with the
-# frontend SLACK_MEMBER_ID_RE in web/src/pages/ChannelsPage.tsx.
+# Kept in sync with the corresponding frontend validation in ChannelsPage.tsx.
+_TELEGRAM_BOT_TOKEN_RE = re.compile(r"\d+:[A-Za-z0-9_-]{30,}")
+_TELEGRAM_USER_ID_RE = re.compile(r"\d+")
 _SLACK_MEMBER_ID_RE = re.compile(r"[UW][A-Z0-9]{2,}")
 
 
 def _validate_messaging_env_value(platform_id: str, key: str, value: str) -> None:
     """Reject platform credentials that are clearly in the wrong field."""
-    if platform_id != "slack" or not value:
+    if not value:
+        return
+
+    if platform_id == "telegram":
+        if key == "TELEGRAM_BOT_TOKEN" and not _TELEGRAM_BOT_TOKEN_RE.fullmatch(value):
+            raise HTTPException(
+                status_code=400,
+                detail="Telegram bot token must be the complete token from @BotFather, such as 123456789:ABC…",
+            )
+        if key == "TELEGRAM_ALLOWED_USERS":
+            user_ids = [part.strip() for part in value.split(",") if part.strip()]
+            if any(not _TELEGRAM_USER_ID_RE.fullmatch(user_id) for user_id in user_ids):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Telegram allowed users must be comma-separated numeric user IDs.",
+                )
+        return
+
+    if platform_id != "slack":
         return
 
     if key == "SLACK_BOT_TOKEN" and not value.startswith("xoxb-"):
@@ -7684,9 +7703,6 @@ async def cancel_whatsapp_onboarding(pairing_id: str):
 
 _TELEGRAM_ONBOARDING_DEFAULT_URL = "https://setup.hermes-agent.nousresearch.com"
 _TELEGRAM_ONBOARDING_USER_AGENT = f"HermesDashboard/{__version__}"
-_TELEGRAM_USER_ID_RE = re.compile(r"^\d+$")
-
-
 @dataclass
 class _TelegramOnboardingPairing:
     poll_token: str

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2659,7 +2659,12 @@ class TestWebServerEndpoints:
         telegram = next(platform for platform in platforms if platform["id"] == "telegram")
         assert telegram["name"] == "Telegram"
         assert telegram["enabled"] is False
-        assert any(field["key"] == "TELEGRAM_BOT_TOKEN" and field["required"] for field in telegram["env_vars"])
+        fields = {field["key"]: field for field in telegram["env_vars"]}
+        assert fields["TELEGRAM_BOT_TOKEN"]["required"] is True
+        assert fields["TELEGRAM_BOT_TOKEN"]["url"] == "https://t.me/BotFather"
+        assert "Complete Telegram bot token" in fields["TELEGRAM_BOT_TOKEN"]["description"]
+        assert fields["TELEGRAM_ALLOWED_USERS"]["url"] == "https://t.me/userinfobot"
+        assert "DM pairing" in fields["TELEGRAM_ALLOWED_USERS"]["description"]
 
     def test_slack_messaging_platform_exposes_user_allowlist(self):
         resp = self.client.get("/api/messaging/platforms")
@@ -2771,17 +2776,35 @@ class TestWebServerEndpoints:
             "/api/messaging/platforms/telegram",
             json={
                 "enabled": False,
-                "env": {"TELEGRAM_BOT_TOKEN": "1234567890abcdef"},
+                "env": {"TELEGRAM_BOT_TOKEN": "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ_1234"},
             },
         )
 
         assert resp.status_code == 200
-        assert load_env()["TELEGRAM_BOT_TOKEN"] == "1234567890abcdef"
+        assert load_env()["TELEGRAM_BOT_TOKEN"] == "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ_1234"
         assert load_config()["platforms"]["telegram"]["enabled"] is False
 
         status = self.client.get("/api/messaging/platforms").json()["platforms"]
         telegram = next(platform for platform in status if platform["id"] == "telegram")
         assert telegram["enabled"] is False
+
+    def test_update_messaging_platform_rejects_invalid_telegram_bot_token(self):
+        resp = self.client.put(
+            "/api/messaging/platforms/telegram",
+            json={"env": {"TELEGRAM_BOT_TOKEN": "not-a-botfather-token"}},
+        )
+
+        assert resp.status_code == 400
+        assert "@BotFather" in resp.json()["detail"]
+
+    def test_update_messaging_platform_rejects_invalid_telegram_allowed_users(self):
+        resp = self.client.put(
+            "/api/messaging/platforms/telegram",
+            json={"env": {"TELEGRAM_ALLOWED_USERS": "123456,@username"}},
+        )
+
+        assert resp.status_code == 400
+        assert "numeric user IDs" in resp.json()["detail"]
 
     def test_update_messaging_platform_saves_slack_allowed_users(self):
         from hermes_cli.config import load_env

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -11,6 +11,10 @@ import pytest
 import yaml
 
 
+_VALID_WORKER_BOT_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ_1234"
+_VALID_BODY_BOT_TOKEN = "987654321:ZYXWVUTSRQPONMLKJIHGFEDCBA_4321"
+
+
 @pytest.fixture
 def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
     """Isolated default home + one named profile, each with its own .env."""
@@ -142,7 +146,7 @@ class TestProfileScopedMessagingWrites:
             params={"profile": "worker_alpha"},
             json={
                 "enabled": True,
-                "env": {"TELEGRAM_BOT_TOKEN": "worker-token"},
+                "env": {"TELEGRAM_BOT_TOKEN": _VALID_WORKER_BOT_TOKEN},
             },
         )
         assert resp.status_code == 200
@@ -150,13 +154,13 @@ class TestProfileScopedMessagingWrites:
         worker_env = (
             isolated_profiles["worker_alpha"] / ".env"
         ).read_text(encoding="utf-8")
-        assert "TELEGRAM_BOT_TOKEN=worker-token" in worker_env
+        assert f"TELEGRAM_BOT_TOKEN={_VALID_WORKER_BOT_TOKEN}" in worker_env
 
         # The dashboard's own .env must stay untouched — this was the bug.
         root_env = (isolated_profiles["default"] / ".env").read_text(
             encoding="utf-8"
         )
-        assert "worker-token" not in root_env
+        assert _VALID_WORKER_BOT_TOKEN not in root_env
         assert "TELEGRAM_BOT_TOKEN=root-token" in root_env
 
         # Enablement lands in the target profile's config.yaml.
@@ -173,7 +177,7 @@ class TestProfileScopedMessagingWrites:
         resp = client.put(
             "/api/messaging/platforms/telegram",
             json={
-                "env": {"TELEGRAM_BOT_TOKEN": "body-token"},
+                "env": {"TELEGRAM_BOT_TOKEN": _VALID_BODY_BOT_TOKEN},
                 "profile": "worker_alpha",
             },
         )
@@ -181,7 +185,7 @@ class TestProfileScopedMessagingWrites:
         worker_env = (
             isolated_profiles["worker_alpha"] / ".env"
         ).read_text(encoding="utf-8")
-        assert "TELEGRAM_BOT_TOKEN=body-token" in worker_env
+        assert f"TELEGRAM_BOT_TOKEN={_VALID_BODY_BOT_TOKEN}" in worker_env
 
     def test_scoped_read_after_scoped_write_round_trips(
         self, client, isolated_profiles
@@ -189,7 +193,10 @@ class TestProfileScopedMessagingWrites:
         client.put(
             "/api/messaging/platforms/telegram",
             params={"profile": "worker_alpha"},
-            json={"enabled": True, "env": {"TELEGRAM_BOT_TOKEN": "worker-token"}},
+            json={
+                "enabled": True,
+                "env": {"TELEGRAM_BOT_TOKEN": _VALID_WORKER_BOT_TOKEN},
+            },
         )
         resp = client.get(
             "/api/messaging/platforms", params={"profile": "worker_alpha"}
@@ -205,7 +212,7 @@ class TestProfileScopedMessagingWrites:
         client.put(
             "/api/messaging/platforms/telegram",
             params={"profile": "worker_alpha"},
-            json={"env": {"TELEGRAM_BOT_TOKEN": "worker-token"}},
+            json={"env": {"TELEGRAM_BOT_TOKEN": _VALID_WORKER_BOT_TOKEN}},
         )
         resp = client.put(
             "/api/messaging/platforms/telegram",
@@ -216,7 +223,7 @@ class TestProfileScopedMessagingWrites:
         worker_env = (
             isolated_profiles["worker_alpha"] / ".env"
         ).read_text(encoding="utf-8")
-        assert "worker-token" not in worker_env
+        assert _VALID_WORKER_BOT_TOKEN not in worker_env
         root_env = (isolated_profiles["default"] / ".env").read_text(
             encoding="utf-8"
         )

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
+  Bot,
   Check,
   CheckCircle2,
   ExternalLink,
@@ -57,6 +58,7 @@ function stateBadge(state: string) {
 }
 
 const TELEGRAM_USER_ID_RE = /^\d+$/;
+const TELEGRAM_BOT_TOKEN_RE = /^\d+:[A-Za-z0-9_-]{30,}$/;
 const SLACK_MEMBER_ID_RE = /^[UW][A-Z0-9]{2,}$/;
 const SLACK_TOKEN_PREFIXES: Record<string, string> = {
   SLACK_BOT_TOKEN: "xoxb-",
@@ -66,6 +68,21 @@ const SLACK_TOKEN_PREFIXES: Record<string, string> = {
 function validateMessagingEnvField(field: MessagingPlatformEnvVar, value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
+
+  if (field.key === "TELEGRAM_BOT_TOKEN" && !TELEGRAM_BOT_TOKEN_RE.test(trimmed)) {
+    return "Paste the complete token from @BotFather (for example, 123456789:ABC…).";
+  }
+
+  if (field.key === "TELEGRAM_ALLOWED_USERS") {
+    const invalid = trimmed
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .find((part) => !TELEGRAM_USER_ID_RE.test(part));
+    if (invalid) {
+      return `${invalid} is not a numeric Telegram user ID.`;
+    }
+  }
 
   const expectedPrefix = SLACK_TOKEN_PREFIXES[field.key];
   if (expectedPrefix && !trimmed.startsWith(expectedPrefix)) {
@@ -367,7 +384,9 @@ export default function ChannelsPage() {
                 id="channel-config-title"
                 className="font-mondwest text-display text-base tracking-wider"
               >
-                Configure {editing.name}
+                {editing.id === "telegram"
+                  ? "Use your own Telegram bot"
+                  : `Configure ${editing.name}`}
               </h2>
               {editing.docs_url && (
                 <a
@@ -376,12 +395,56 @@ export default function ChannelsPage() {
                   rel="noopener noreferrer"
                   className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
                 >
-                  Setup guide <ExternalLink className="h-3 w-3" />
+                  {editing.id === "telegram" ? "BotFather guide" : "Setup guide"}
+                  <ExternalLink className="h-3 w-3" />
                 </a>
               )}
             </header>
 
             <div className="grid gap-4 overflow-y-auto overscroll-contain p-4 sm:p-5">
+              {editing.id === "telegram" && (
+                <div className="grid gap-3 text-sm text-muted-foreground">
+                  <p>
+                    Connect a bot you already own, or create one in Telegram before
+                    filling in this form.
+                  </p>
+                  <ol className="grid list-decimal gap-1.5 pl-5">
+                    <li>
+                      Open <span className="text-foreground">@BotFather</span>, send
+                      <code className="mx-1 font-courier text-xs">/newbot</code>, and
+                      follow its prompts.
+                    </li>
+                    <li>Copy the complete bot token BotFather gives you.</li>
+                    <li>
+                      Message <span className="text-foreground">@userinfobot</span> to
+                      find your numeric Telegram user ID, then add it below for
+                      immediate access.
+                    </li>
+                  </ol>
+                  <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs">
+                    <a
+                      href="https://t.me/BotFather"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-primary hover:underline"
+                    >
+                      Open @BotFather <ExternalLink className="h-3 w-3" />
+                    </a>
+                    <a
+                      href="https://t.me/userinfobot"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-primary hover:underline"
+                    >
+                      Find my user ID <ExternalLink className="h-3 w-3" />
+                    </a>
+                  </div>
+                  <p className="text-xs">
+                    You can leave allowed users blank. Hermes will then send new DM
+                    users a code that you approve from the Pairing page.
+                  </p>
+                </div>
+              )}
               <p className="text-xs text-muted-foreground">
                 {editing.description}
               </p>
@@ -534,18 +597,21 @@ export default function ChannelsPage() {
                     >
                       Test
                     </Button>
-                    <Button
-                      size="sm"
-                      className="uppercase"
-                      onClick={() => openConfig(platform)}
-                      prefix={<Settings2 className="h-4 w-4" />}
-                    >
-                      Configure
-                    </Button>
+                    {platform.id !== "telegram" && (
+                      <Button
+                        size="sm"
+                        className="uppercase"
+                        onClick={() => openConfig(platform)}
+                        prefix={<Settings2 className="h-4 w-4" />}
+                      >
+                        Configure
+                      </Button>
+                    )}
                   </div>
                 </div>
                 {platform.id === "telegram" && (
                   <TelegramOnboardingPanel
+                    onManualSetup={() => openConfig(platform)}
                     onChanged={load}
                     onRestartNeeded={() => setRestartNeeded(true)}
                     platform={platform}
@@ -979,12 +1045,14 @@ function WhatsAppOnboardingPanel({
 }
 
 function TelegramOnboardingPanel({
+  onManualSetup,
   onChanged,
   onRestartNeeded,
   platform,
   setRestartNeeded,
   showToast,
 }: {
+  onManualSetup: () => void;
   onChanged: () => Promise<void>;
   onRestartNeeded: () => void;
   platform: MessagingPlatform;
@@ -1192,22 +1260,74 @@ function TelegramOnboardingPanel({
 
   return (
     <div className="rounded-sm border border-border bg-background/35 p-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          size="sm"
-          className="uppercase"
-          onClick={() => void start()}
-          disabled={phase === "starting" || phase === "waiting" || phase === "applying"}
-          prefix={phase === "starting" ? <Spinner /> : <QrCode className="h-4 w-4" />}
-        >
-          {phase === "starting" ? "Starting…" : "Set up with QR"}
-        </Button>
-        {platform.configured && (
-          <span className="text-xs text-muted-foreground">
-            Existing Telegram credentials are configured.
-          </span>
-        )}
+      <div className="grid gap-1">
+        <span className="font-mondwest text-sm text-foreground">
+          Choose how to connect your Telegram bot
+        </span>
+        <span className="text-xs text-muted-foreground">
+          Both options connect a bot you control and save its credentials only to
+          this Hermes installation.
+        </span>
       </div>
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2 sm:divide-x sm:divide-border">
+        <div className="grid content-start gap-3 sm:pr-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium uppercase text-foreground">
+              Quick setup
+            </span>
+            <Badge tone="success">recommended</Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Scan a QR code and confirm in Telegram. Hermes creates the bot and
+            detects your Telegram user ID automatically.
+          </p>
+          <Button
+            size="sm"
+            className="w-fit uppercase"
+            onClick={() => void start()}
+            disabled={phase !== "idle"}
+            prefix={phase === "starting" ? <Spinner /> : <QrCode className="h-4 w-4" />}
+          >
+            {phase === "starting" ? "Starting…" : "Create with QR"}
+          </Button>
+        </div>
+
+        <div className="grid content-start gap-3 border-t border-border pt-4 sm:border-t-0 sm:pl-4 sm:pt-0">
+          <span className="text-xs font-medium uppercase text-foreground">
+            Use your own bot
+          </span>
+          <p className="text-xs text-muted-foreground">
+            Create a bot with @BotFather, or connect one you already have, by
+            entering its token and choosing who can use it.
+          </p>
+          <Button
+            size="sm"
+            outlined
+            className="w-fit uppercase"
+            onClick={onManualSetup}
+            disabled={phase !== "idle"}
+            prefix={<Bot className="h-4 w-4" />}
+          >
+            Manual setup
+          </Button>
+        </div>
+      </div>
+
+      {platform.configured && (
+        <div className="mt-4 border-t border-border pt-3 text-xs text-muted-foreground">
+          Telegram credentials are already configured. A new QR setup or bot token
+          will replace the current bot when you save.
+        </div>
+      )}
+
+      {phase !== "idle" && (
+        <div className="mt-4 border-t border-border pt-4">
+          <span className="text-xs text-muted-foreground">
+            Finish or cancel the current QR setup before switching methods.
+          </span>
+        </div>
+      )}
 
       {error && (
         <div className="mt-3 border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">


### PR DESCRIPTION
## What does this PR do?

Makes the two Telegram onboarding paths explicit in the dashboard Channels page:

- **Quick setup** keeps the managed QR flow as the recommended path.
- **Use your own bot** opens a guided manual setup flow for bots created with `@BotFather`.

The manual flow now explains how to create a bot, where to obtain the complete token and numeric user ID, and how leaving the allowlist blank falls back to dashboard pairing approval. It also validates Telegram credentials in both the browser and API so malformed tokens or usernames cannot be silently written as configuration.

This keeps the centralized bot manager convenient without implying it is the only supported setup method.

## Related Issue

[NS-594: Add wording and clearer options for manual Telegram bot config](https://linear.app/nousresearch/issue/NS-594/add-wording-and-clearer-options-for-manual-telegram-bot-config)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added clear Quick setup and Use your own bot choices to the Telegram channel card.
- Added BotFather and user-ID instructions, direct links, and DM pairing guidance to the manual form.
- Added client-side validation for Telegram bot-token shape and numeric allowlists.
- Added matching API validation so non-dashboard callers receive the same protection.
- Updated Telegram field metadata and added backend coverage for descriptions and invalid values.

## How to Test

1. Open Dashboard → Channels and confirm Telegram offers separate Quick setup and Manual setup controls.
2. Open Manual setup and verify the BotFather, `/newbot`, user-ID, and Pairing guidance on desktop and mobile widths.
3. Enter an invalid bot token or non-numeric allowed user ID and confirm the form rejects it before saving.
4. Enter a valid-looking token such as `123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ_1234` and numeric comma-separated user IDs to exercise the accepted API shape in an isolated Hermes home.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, desktop and mobile browser viewports

Focused validation run:

- `pytest -q tests/hermes_cli/test_web_server.py -k 'telegram_onboarding or messaging_platform'` (20 passed)
- `npm --workspace web run typecheck`
- `npm --workspace web run build`
- `npm --workspace web run test -- --run src/lib/api.test.ts`
- `ruff check hermes_cli/web_server.py hermes_cli/config.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`config.py` field metadata supplies the dashboard guidance)
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change uses existing dashboard controls and platform-neutral validation
- [x] Tool description/schema updates are N/A

## Screenshots / Logs

Manually verified the Telegram choice panel and manual setup dialog at desktop and 390 × 844 mobile viewports. The dialog remains scrollable within the viewport and displays field-level errors for malformed tokens and allowlists.


## Infographic

![telegram-manual-setup](https://v3b.fal.media/files/b/0aa273de/R_x2ylGp1ml0e8gVPwehm_ae0RlpJ3.png)
