### PR TITLE
feat(telegram): support Bot API 10.2 ephemeral replies and inline media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -72,6 +72,11 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         scope_id = getattr(source, "scope_id", None)
         if scope_id:
             metadata["slack_team_id"] = str(scope_id)
+    # Platform adapters may attach short-lived outbound constraints without
+    # changing session identity. Preserve them across background delivery.
+    delivery_metadata = getattr(source, "delivery_metadata", None)
+    if isinstance(delivery_metadata, dict):
+        metadata.update(delivery_metadata)
     if not metadata:
         return None
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
@@ -4887,7 +4892,10 @@ class BasePlatformAdapter(ABC):
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
         typing_task: Optional[asyncio.Task] = None
-        if getattr(self.config, "typing_indicator", True):
+        if (
+            getattr(self.config, "typing_indicator", True)
+            and not (event.metadata or {}).get("suppress_typing")
+        ):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
             try:
                 _keep_typing_sig = inspect.signature(self._keep_typing)
@@ -5055,6 +5063,32 @@ class BasePlatformAdapter(ABC):
                             os.remove(_tts_path)
                         except OSError:
                             pass
+
+                # Adapter rich-media hook. Only explicit MEDIA: files
+                # participate; bare local paths and image URLs retain their
+                # established attachment behavior. ``None`` means unsupported
+                # and falls through. Any SendResult owns the attempt, including
+                # uncertain transient failures, so we do not duplicate-send.
+                if (
+                    media_files
+                    and text_content
+                    and not force_document_attachments
+                    and not _tts_caption_delivered
+                ):
+                    rich_media_impl = getattr(type(self), "send_rich_media", None)
+                    if callable(rich_media_impl):
+                        rich_media_result = await rich_media_impl(
+                            self,
+                            event.source.chat_id,
+                            text_content,
+                            media_files,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_final_thread_metadata,
+                        )
+                        if rich_media_result is not None:
+                            _record_delivery(rich_media_result)
+                            text_content = ""
+                            media_files = []
 
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12296,7 +12296,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
                         await self._deliver_media_from_response(
-                            response, event, _media_adapter,
+                            response,
+                            event,
+                            _media_adapter,
+                            stream_message_id=agent_result.get("stream_message_id"),
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
@@ -13351,6 +13354,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         response: str,
         event: MessageEvent,
         adapter,
+        stream_message_id: Optional[str] = None,
     ) -> None:
         """Extract MEDIA: tags and local file paths from a response and deliver them.
 
@@ -13384,6 +13388,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
             _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+
+            # If streaming already created the final text message, adapters may
+            # upgrade it in place with embedded media. ``None`` means unsupported
+            # and falls through to conventional attachments. Any SendResult owns
+            # the request to avoid duplicates after uncertain network failures.
+            if stream_message_id and media_files and not force_document_attachments:
+                rich_editor = getattr(adapter, "edit_rich_media", None)
+                if callable(rich_editor):
+                    rich_result = await rich_editor(
+                        event.source.chat_id,
+                        stream_message_id,
+                        cleaned,
+                        media_files,
+                        metadata=_thread_meta,
+                    )
+                    if rich_result is not None:
+                        if not rich_result.success:
+                            logger.warning(
+                                "[%s] Inline-media finalization failed: %s",
+                                adapter.name,
+                                rich_result.error,
+                            )
+                        return
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -14506,7 +14533,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if team_id:
                 metadata = dict(metadata or {})
                 metadata["slack_team_id"] = str(team_id)
+        delivery_metadata = getattr(source, "delivery_metadata", None)
+        if isinstance(delivery_metadata, dict):
+            metadata = dict(metadata or {})
+            metadata.update(delivery_metadata)
         return metadata
+
+    @staticmethod
+    def _streaming_allowed_for_source(source, enabled: bool) -> bool:
+        """Honor adapter-provided delivery constraints for activity previews."""
+        delivery_metadata = getattr(source, "delivery_metadata", None)
+        if isinstance(delivery_metadata, dict) and delivery_metadata.get(
+            "suppress_streaming"
+        ):
+            return False
+        return bool(enabled)
 
     def _thread_metadata_for_target(
         self,
@@ -16990,6 +17031,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        _streaming_enabled = self._streaming_allowed_for_source(
+            source, _streaming_enabled
+        )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 
@@ -17048,7 +17092,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Send typing indicator
         _adapter = self._adapter_for_source(source)
-        if _adapter:
+        if _adapter and self._streaming_allowed_for_source(source, True):
             try:
                 await _adapter.send_typing(source.chat_id, metadata=_thread_metadata)
             except Exception:
@@ -17990,8 +18034,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if await _roll_progress_overflow_if_needed():
                         _last_edit_ts = time.monotonic()
                         await asyncio.sleep(0.3)
-                        if _run_still_current():
-                            await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
+                        if (
+                            _run_still_current()
+                            and self._streaming_allowed_for_source(source, True)
+                        ):
+                            await adapter.send_typing(
+                                source.chat_id, metadata=_progress_metadata
+                            )
                         continue
 
                     # Throttle edits: batch rapid tool updates into fewer
@@ -18076,8 +18125,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     # Restore typing indicator
                     await asyncio.sleep(0.3)
-                    if _run_still_current():
-                        await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
+                    if (
+                        _run_still_current()
+                        and self._streaming_allowed_for_source(source, True)
+                    ):
+                        await adapter.send_typing(
+                            source.chat_id, metadata=_progress_metadata
+                        )
 
                 except queue.Empty:
                     await asyncio.sleep(0.3)
@@ -18314,8 +18368,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _plat_streaming is None
                 else bool(_plat_streaming)
             )
+            _streaming_enabled = self._streaming_allowed_for_source(
+                source, _streaming_enabled
+            )
             _want_stream_deltas = _streaming_enabled
-            _want_interim_messages = interim_assistant_messages_enabled
+            _want_interim_messages = (
+                interim_assistant_messages_enabled
+                and self._streaming_allowed_for_source(source, True)
+            )
             _want_interim_consumer = _want_interim_messages
             if _want_stream_deltas or _want_interim_consumer:
                 try:
@@ -20184,7 +20244,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # the follow-up turn runs.  The outer _process_message_background
                 # typing task is still alive but may be stale.
                 _followup_adapter = self._adapter_for_source(source)
-                if _followup_adapter:
+                if _followup_adapter and self._streaming_allowed_for_source(
+                    source, True
+                ):
                     try:
                         await _followup_adapter.send_typing(
                             source.chat_id,
@@ -20330,6 +20392,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _content_delivered,
                 )
                 response["already_sent"] = True
+                if _sc is not None and _sc.message_id:
+                    response["stream_message_id"] = str(_sc.message_id)
             elif not _is_empty_sentinel and _transformed and _sc is not None:
                 # Plugin hooks transformed the response after streaming — edit the
                 # existing streamed message instead of sending a duplicate.
@@ -20343,6 +20407,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             finalize=True,
                         )
                         response["already_sent"] = True
+                        response["stream_message_id"] = str(_sc_msg_id)
                         logger.info(
                             "Edited streamed message %s for session %s to include plugin-transformed content.",
                             _sc_msg_id, session_key or "?",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -17,7 +17,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -202,6 +202,17 @@ class SessionSource:
     # deliberately excluded from ``to_dict``/``from_dict`` so a peer can never
     # forge it across the wire or have it restored from persistence.
     delivered_via_upstream_relay: bool = False
+
+    # Per-message outbound constraints supplied by a platform adapter (for
+    # example Telegram ephemeral recipient targeting). This is intentionally
+    # wire-invisible: to_dict()/from_dict() must never persist or restore it,
+    # because stale or remote data must not be able to forge private routing.
+    # Keep this at the end to preserve the existing positional constructor.
+    delivery_metadata: Optional[Dict[str, Any]] = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
     def __post_init__(self) -> None:
         # D-Q2.5 dual-field reconciliation: `scope_id` is canonical, `guild_id`

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -17,6 +17,7 @@ import os
 import html as _html
 import re
 import threading
+import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
@@ -592,6 +593,22 @@ class TelegramAdapter(BasePlatformAdapter):
         # as plain text, which is worse than degraded table/task-list rendering
         # for command snippets and mobile handoffs.
         self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
+        self._rich_inline_media_enabled: bool = self._coerce_bool_extra(
+            "rich_inline_media", False
+        )
+        # Bot API 10.2 ephemeral commands are opt-in and group-scoped. Keep the
+        # allowlist explicit: commands with interactive edit/stream flows need
+        # dedicated ephemeral callback support before they can be private.
+        _ephemeral_commands = self.config.extra.get("ephemeral_group_commands", [])
+        if isinstance(_ephemeral_commands, str):
+            _ephemeral_commands = _ephemeral_commands.split(",")
+        if not isinstance(_ephemeral_commands, (list, tuple, set)):
+            _ephemeral_commands = []
+        self._ephemeral_group_commands: Set[str] = {
+            str(command).strip().lstrip("/").lower()
+            for command in _ephemeral_commands
+            if str(command).strip()
+        }
         # Rich draft previews use a separate opt-in. Telegram macOS / Desktop
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
@@ -775,11 +792,20 @@ class TelegramAdapter(BasePlatformAdapter):
         (disable_notification=True) unless the caller explicitly requests a
         notification by setting ``metadata["notify"] = True``.
         """
+        kwargs: Dict[str, Any] = {}
+        if self._is_ephemeral_delivery(metadata):
+            private_kwargs = self._ephemeral_send_api_kwargs(metadata)
+            if private_kwargs is None:
+                raise ValueError(
+                    "Ephemeral delivery refused: receiver_user_id is missing"
+                )
+            kwargs["api_kwargs"] = private_kwargs
         if getattr(self, "_notifications_mode", "important") != "important":
-            return {}
+            return kwargs
         if (metadata or {}).get("notify"):
-            return {}
-        return {"disable_notification": True}
+            return kwargs
+        kwargs["disable_notification"] = True
+        return kwargs
 
     def _is_callback_user_authorized(
         self,
@@ -1026,6 +1052,8 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         reply_to_mode: Optional[str] = None,
     ) -> Optional[int]:
+        if metadata and metadata.get("telegram_ephemeral_required"):
+            return None
         if reply_to:
             return int(reply_to)
         if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
@@ -1378,6 +1406,178 @@ class TelegramAdapter(BasePlatformAdapter):
         return {"disable_web_page_preview": True}
 
     # ------------------------------------------------------------------
+    # Bot API 10.2 Ephemeral Messages
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _telegram_api_field(obj: Any, field: str, default: Any = None) -> Any:
+        """Read a field modeled by PTB or preserved in ``api_kwargs``.
+
+        python-telegram-bot 22.6 predates Bot API 10.2, but preserves unknown
+        response fields in ``TelegramObject.api_kwargs``. This helper naturally
+        prefers future typed fields when PTB adds them.
+        """
+        value = getattr(obj, field, None)
+        if value is not None:
+            return value
+        api_kwargs = getattr(obj, "api_kwargs", None)
+        if isinstance(api_kwargs, dict):
+            return api_kwargs.get(field, default)
+        return default
+
+    def _ephemeral_metadata_for_message(self, message: Any) -> Dict[str, Any]:
+        """Return private-delivery metadata for an opted-in group command."""
+        chat = getattr(message, "chat", None)
+        chat_type = str(getattr(chat, "type", "") or "").split(".")[-1].lower()
+        if chat_type not in {"group", "supergroup"}:
+            return {}
+        text = str(getattr(message, "text", "") or "").strip()
+        if not text.startswith("/"):
+            return {}
+        command = text.split(maxsplit=1)[0][1:].split("@", 1)[0].lower()
+        if command not in getattr(self, "_ephemeral_group_commands", set()):
+            return {}
+        user = getattr(message, "from_user", None)
+        receiver_user_id = getattr(user, "id", None)
+        if receiver_user_id is None:
+            return {}
+        metadata: Dict[str, Any] = {
+            "telegram_ephemeral_required": True,
+            "telegram_ephemeral_receiver_user_id": int(receiver_user_id),
+            "telegram_ephemeral_received_at_monotonic": time.monotonic(),
+            "suppress_streaming": True,
+            "suppress_typing": True,
+        }
+        ephemeral_message_id = self._telegram_api_field(message, "ephemeral_message_id")
+        if ephemeral_message_id is not None:
+            metadata["telegram_ephemeral_message_id"] = str(ephemeral_message_id)
+        return metadata
+
+    def _make_menu_bot_commands(
+        self,
+        menu_commands: List[tuple],
+        *,
+        group_scope: bool,
+    ) -> List[Any]:
+        """Build BotCommand objects with Bot API 10.2 private flags."""
+        from telegram import BotCommand
+
+        private_names = getattr(self, "_ephemeral_group_commands", set())
+        commands: List[Any] = []
+        for name, description in menu_commands:
+            if group_scope and str(name).lower() in private_names:
+                commands.append(
+                    BotCommand(name, description, api_kwargs={"is_ephemeral": True})
+                )
+            else:
+                commands.append(BotCommand(name, description))
+        return commands
+
+    @staticmethod
+    def _is_ephemeral_delivery(metadata: Optional[Dict[str, Any]]) -> bool:
+        return bool(metadata and metadata.get("telegram_ephemeral_required"))
+
+    def _ephemeral_send_api_kwargs(
+        self, metadata: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Build Bot API 10.2 private-target fields, or ``None`` if invalid."""
+        if not self._is_ephemeral_delivery(metadata):
+            return {}
+        receiver_user_id = (metadata or {}).get("telegram_ephemeral_receiver_user_id")
+        if receiver_user_id is None:
+            return None
+        try:
+            receiver_user_id = int(receiver_user_id)
+        except (TypeError, ValueError):
+            return None
+        kwargs: Dict[str, Any] = {"receiver_user_id": receiver_user_id}
+        received_at = (metadata or {}).get("telegram_ephemeral_received_at_monotonic")
+        within_reply_window = True
+        if received_at is not None:
+            try:
+                within_reply_window = (time.monotonic() - float(received_at)) < 14.0
+            except (TypeError, ValueError):
+                within_reply_window = False
+        ephemeral_message_id = (metadata or {}).get("telegram_ephemeral_message_id")
+        if ephemeral_message_id and within_reply_window:
+            kwargs["reply_parameters"] = {
+                "ephemeral_message_id": str(ephemeral_message_id)
+            }
+        return kwargs
+
+    async def _send_ephemeral_text(
+        self,
+        chat_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        """Send private group text and never fall back to a public message."""
+        private_kwargs = self._ephemeral_send_api_kwargs(metadata)
+        if private_kwargs is None:
+            return SendResult(
+                success=False,
+                error="Ephemeral delivery refused: receiver_user_id is missing",
+                retryable=False,
+            )
+
+        formatted = self.format_message(content)
+        chunks = self.truncate_message(
+            formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
+        )
+        if len(chunks) > 1:
+            chunks = [
+                _separate_chunk_indicator_from_fence(
+                    re.sub(r" \((\d+)/(\d+)\)$", r" \\(\1/\2\\)", chunk)
+                )
+                for chunk in chunks
+            ]
+
+        try:
+            for index, chunk in enumerate(chunks):
+                if index:
+                    await asyncio.sleep(
+                        getattr(self, "_text_batch_split_delay_seconds", 0.0)
+                    )
+                notification_kwargs = self._notification_kwargs(metadata)
+                notification_kwargs.pop("api_kwargs", None)
+                payload: Dict[str, Any] = {
+                    "chat_id": normalize_telegram_chat_id(chat_id),
+                    "text": chunk,
+                    "parse_mode": "MarkdownV2",
+                    **private_kwargs,
+                    **notification_kwargs,
+                }
+                if getattr(self, "_disable_link_previews", False):
+                    payload["link_preview_options"] = {"is_disabled": True}
+                try:
+                    await self._bot.do_api_request("sendMessage", api_kwargs=payload)
+                except Exception as markdown_exc:
+                    if not any(
+                        marker in str(markdown_exc).lower()
+                        for marker in ("parse", "markdown", "entity")
+                    ):
+                        raise
+                    plain_payload = dict(payload)
+                    plain_payload["text"] = _strip_mdv2(chunk)
+                    plain_payload.pop("parse_mode", None)
+                    await self._bot.do_api_request(
+                        "sendMessage", api_kwargs=plain_payload
+                    )
+        except Exception as exc:
+            # Privacy invariant: never retry through send_message() without the
+            # Bot API 10.2 target fields. Failed private delivery beats a leak.
+            safe_error = _redact_telegram_error_text(exc)
+            logger.warning(
+                "[%s] Ephemeral send failed closed (no public fallback): %s",
+                self.name, safe_error,
+            )
+            return SendResult(
+                success=False,
+                error=f"Ephemeral delivery failed: {safe_error}",
+                retryable=False,
+            )
+        return SendResult(success=True, message_id=None)
+
+    # ------------------------------------------------------------------
     # Bot API 10.1 Rich Messages (sendRichMessage)
     #
     # Final / new-message replies opportunistically use sendRichMessage with
@@ -1562,6 +1762,201 @@ class TelegramAdapter(BasePlatformAdapter):
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload
+
+    @staticmethod
+    def _rich_inline_media_type(path: str, is_voice: bool) -> Optional[tuple[str, str]]:
+        """Return ``(InputMedia.type, tg:// scheme)`` for supported local media."""
+        ext = os.path.splitext(path)[1].lower()
+        if ext in {".jpg", ".jpeg", ".png", ".webp"}:
+            return "photo", "photo"
+        if ext == ".gif":
+            return "animation", "video"
+        if ext == ".mp4":
+            return "video", "video"
+        if ext in {".mp3", ".m4a"}:
+            return "audio", "audio"
+        if is_voice and ext in {".ogg", ".opus"}:
+            return "voice_note", "audio"
+        return None
+
+    def _build_rich_inline_media_payload(
+        self,
+        content: str,
+        media_files: List[tuple],
+        stack: Any,
+    ) -> Optional[tuple[Dict[str, Any], Dict[str, Any]]]:
+        """Build InputRichMessage.media plus multipart InputFile parameters."""
+        # Defensive bound: cap simultaneously opened files and multipart parts.
+        if not media_files or len(media_files) > 50:
+            return None
+        from telegram import InputFile
+
+        media_entries: List[Dict[str, Any]] = []
+        markdown_blocks: List[str] = []
+        uploads: Dict[str, Any] = {}
+        for index, item in enumerate(media_files):
+            try:
+                path, is_voice = item
+            except (TypeError, ValueError):
+                return None
+            path = str(path)
+            media_type = self._rich_inline_media_type(path, bool(is_voice))
+            if media_type is None or not os.path.isfile(path):
+                return None
+            input_type, scheme = media_type
+            file_obj = stack.enter_context(open(path, "rb"))
+            input_file = InputFile(
+                file_obj,
+                filename=os.path.basename(path),
+                attach=True,
+            )
+            media_id = f"media_{index}"
+            media_entries.append(
+                {
+                    "id": media_id,
+                    "media": {
+                        "type": input_type,
+                        "media": input_file.attach_uri,
+                    },
+                }
+            )
+            markdown_blocks.append(f"![](tg://{scheme}?id={media_id})")
+            # PTB 22.6 cannot recursively discover InputFile inside the new
+            # InputRichMessage.media object. Supplying each InputFile as a
+            # top-level multipart value makes PTB add the attachment part; the
+            # Bot API ignores the extra scalar field and resolves attach://.
+            uploads[input_file.attach_name] = input_file
+
+        rich_message = self._rich_message_payload(content)
+        rich_message["markdown"] = (
+            rich_message["markdown"].rstrip()
+            + "\n\n"
+            + "\n\n".join(markdown_blocks)
+        )
+        rich_message["media"] = media_entries
+        return rich_message, uploads
+
+    async def _rich_media_request(
+        self,
+        endpoint: str,
+        payload: Dict[str, Any],
+        content: str,
+    ) -> Optional[SendResult]:
+        """Execute rich-media send/edit with the existing no-duplicate contract."""
+        try:
+            raw = await self._bot.do_api_request(endpoint, api_kwargs=payload)
+        except Exception as exc:
+            if self._is_rich_fallback_error(exc):
+                if self._is_rich_capability_error(exc):
+                    self._rich_send_disabled = True
+                logger.debug(
+                    "[%s] %s inline-media rejected (%s) — using separate attachments",
+                    self.name, endpoint, exc,
+                )
+                return None
+            safe_error = _redact_telegram_error_text(exc)
+            logger.warning(
+                "[%s] %s inline-media transient failure (no duplicate fallback): %s",
+                self.name, endpoint, safe_error,
+            )
+            return SendResult(success=False, error=safe_error, retryable=True)
+
+        message_id = None
+        if isinstance(raw, dict):
+            message_id = raw.get("message_id")
+            if message_id is None:
+                message_id = (raw.get("result") or {}).get("message_id")
+        else:
+            message_id = getattr(raw, "message_id", None)
+        if message_id is not None:
+            try:
+                from gateway import rich_sent_store
+                rich_sent_store.record(str(payload.get("chat_id")), str(message_id), content)
+            except Exception:
+                pass
+        return SendResult(
+            success=True,
+            message_id=str(message_id) if message_id is not None else None,
+        )
+
+    async def send_rich_media(
+        self,
+        chat_id: str,
+        content: str,
+        media_files: List[tuple],
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[SendResult]:
+        """Send one Bot API 10.2 rich report with embedded local media."""
+        if self._is_ephemeral_delivery(metadata):
+            # The generic caller retains both text and files when this returns
+            # None, then routes them through targetable ephemeral send methods.
+            return None
+        if (
+            not getattr(self, "_rich_inline_media_enabled", False)
+            or not getattr(self, "_rich_messages_enabled", False)
+            or getattr(self, "_rich_send_disabled", False)
+            or not self._bot_supports_rich()
+        ):
+            return None
+        from contextlib import ExitStack
+
+        routing = self._compute_single_send_routing(
+            chat_id, reply_to, metadata, self._metadata_thread_id(metadata)
+        )
+        if routing is None:
+            return None
+        reply_to_id, thread_kwargs = routing
+        with ExitStack() as stack:
+            built = self._build_rich_inline_media_payload(content, media_files, stack)
+            if built is None:
+                return None
+            rich_message, uploads = built
+            payload: Dict[str, Any] = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "rich_message": rich_message,
+                **uploads,
+            }
+            payload.update({k: v for k, v in thread_kwargs.items() if v is not None})
+            payload.update(self._notification_kwargs(metadata))
+            if reply_to_id is not None:
+                payload["reply_parameters"] = {"message_id": reply_to_id}
+            return await self._rich_media_request("sendRichMessage", payload, content)
+
+    async def edit_rich_media(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        media_files: List[tuple],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[SendResult]:
+        """Upgrade a streamed text preview to rich text with embedded media."""
+        if self._is_ephemeral_delivery(metadata):
+            # Ephemeral delivery disables streaming, so no public preview is
+            # eligible for an in-place rich edit.
+            return None
+        if (
+            not getattr(self, "_rich_inline_media_enabled", False)
+            or not getattr(self, "_rich_messages_enabled", False)
+            or getattr(self, "_rich_send_disabled", False)
+            or not self._bot_supports_rich()
+        ):
+            return None
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            built = self._build_rich_inline_media_payload(content, media_files, stack)
+            if built is None:
+                return None
+            rich_message, uploads = built
+            payload: Dict[str, Any] = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "message_id": int(message_id),
+                "rich_message": rich_message,
+                **uploads,
+            }
+            return await self._rich_media_request("editMessageText", payload, content)
 
     def _is_rich_capability_error(self, exc: Exception) -> bool:
         """True ⇒ the rich endpoint itself is unavailable (old PTB/server).
@@ -3146,7 +3541,6 @@ class TelegramAdapter(BasePlatformAdapter):
             # gateway command there automatically adds it to the Telegram menu.
             try:
                 from telegram import (
-                    BotCommand,
                     BotCommandScopeAllPrivateChats,
                     BotCommandScopeAllGroupChats,
                     BotCommandScopeDefault,
@@ -3161,15 +3555,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 # platforms.telegram.extra.command_menu.
                 max_commands = telegram_menu_max_commands()
                 menu_commands, hidden_count = telegram_menu_commands(max_commands=max_commands)
-                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                default_commands = self._make_menu_bot_commands(
+                    menu_commands, group_scope=False
+                )
+                group_commands = self._make_menu_bot_commands(
+                    menu_commands, group_scope=True
+                )
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
                 # through to AllGroupChats or Default).
-                for scope_cls in (BotCommandScopeDefault, BotCommandScopeAllPrivateChats, BotCommandScopeAllGroupChats):
+                for scope_cls, commands in (
+                    (BotCommandScopeDefault, default_commands),
+                    (BotCommandScopeAllPrivateChats, default_commands),
+                    (BotCommandScopeAllGroupChats, group_commands),
+                ):
                     scope_name = getattr(scope_cls, "__name__", str(scope_cls))
                     try:
-                        await self._bot.set_my_commands(bot_commands, scope=scope_cls())
-                        logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
+                        await self._bot.set_my_commands(commands, scope=scope_cls())
+                        logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(commands))
                     except Exception as scope_err:
                         logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
                 # Forum topics don't inherit AllGroupChats — Telegram resolves
@@ -3853,6 +4256,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        # Ephemeral privacy is a hard routing contract, not a preference. Keep
+        # this before rich/legacy sends so no exception can drop into a public
+        # group message.
+        if self._is_ephemeral_delivery(metadata):
+            return await self._send_ephemeral_text(chat_id, content, metadata)
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
@@ -6219,6 +6628,31 @@ class TelegramAdapter(BasePlatformAdapter):
         if not images:
             return
 
+        # sendMediaGroup has no Bot API 10.2 receiver_user_id parameter. For
+        # private group replies, send each image through sendPhoto instead;
+        # falling back to a public album would violate the privacy contract.
+        if self._is_ephemeral_delivery(metadata):
+            from urllib.parse import unquote as _unquote
+
+            for image_url, alt_text in images:
+                if human_delay > 0:
+                    await asyncio.sleep(human_delay)
+                if image_url.startswith("file://"):
+                    await self.send_image_file(
+                        chat_id=chat_id,
+                        image_path=_unquote(image_url[7:]),
+                        caption=alt_text,
+                        metadata=metadata,
+                    )
+                else:
+                    await self.send_image(
+                        chat_id=chat_id,
+                        image_url=image_url,
+                        caption=alt_text,
+                        metadata=metadata,
+                    )
+            return
+
         try:
             from telegram import InputMediaPhoto
         except Exception as exc:  # pragma: no cover - missing SDK
@@ -7758,10 +8192,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id = int(chat.id)
                 if chat_id in self._forum_command_registered:
                     return
-                from telegram import BotCommand, BotCommandScopeChat
+                from telegram import BotCommandScopeChat
                 from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
                 menu_commands, _ = telegram_menu_commands(max_commands=telegram_menu_max_commands())
-                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                bot_commands = self._make_menu_bot_commands(
+                    menu_commands, group_scope=True
+                )
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)
                 logger.info("[%s] Lazy-registered %d commands for forum chat %s", self.name, len(bot_commands), chat_id)
@@ -8708,6 +9144,10 @@ class TelegramAdapter(BasePlatformAdapter):
             message_id=str(message.message_id),
             is_bot=bool(getattr(user, "is_bot", False)) if user else False,
         )
+        ephemeral_metadata = self._ephemeral_metadata_for_message(message)
+        # Delivery metadata is deliberately separate from SessionSource's
+        # identity fields and is forwarded by the generic gateway send paths.
+        source.delivery_metadata = ephemeral_metadata
         
         # Extract reply context if this message is a reply.
         # Prefer Telegram's native partial quote (message.quote, TextQuote)
@@ -8765,6 +9205,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            metadata=ephemeral_metadata,
             timestamp=message.date,
         )
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1491,7 +1491,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return None
         kwargs: Dict[str, Any] = {"receiver_user_id": receiver_user_id}
         received_at = (metadata or {}).get("telegram_ephemeral_received_at_monotonic")
-        within_reply_window = True
+        # The ephemeral reply anchor is only valid for Telegram's short reply
+        # window. Missing/corrupt timing metadata must not resurrect it.
+        within_reply_window = False
         if received_at is not None:
             try:
                 within_reply_window = (time.monotonic() - float(received_at)) < 14.0
@@ -1531,6 +1533,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 for chunk in chunks
             ]
 
+        thread_kwargs = self._thread_kwargs_for_send(
+            chat_id,
+            self._metadata_thread_id(metadata),
+            metadata,
+            reply_to_message_id=None,
+            reply_to_mode=self._reply_to_mode,
+        )
+        thread_kwargs = {
+            key: value for key, value in thread_kwargs.items() if value is not None
+        }
+
         try:
             for index, chunk in enumerate(chunks):
                 if index:
@@ -1544,6 +1557,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "text": chunk,
                     "parse_mode": "MarkdownV2",
                     **private_kwargs,
+                    **thread_kwargs,
                     **notification_kwargs,
                 }
                 if getattr(self, "_disable_link_previews", False):
@@ -1833,6 +1847,8 @@ class TelegramAdapter(BasePlatformAdapter):
             + "\n\n"
             + "\n\n".join(markdown_blocks)
         )
+        if not self._content_fits_rich_limits(rich_message["markdown"]):
+            return None
         rich_message["media"] = media_entries
         return rich_message, uploads
 
@@ -1919,6 +1935,8 @@ class TelegramAdapter(BasePlatformAdapter):
             }
             payload.update({k: v for k, v in thread_kwargs.items() if v is not None})
             payload.update(self._notification_kwargs(metadata))
+            if getattr(self, "_disable_link_previews", False):
+                payload["link_preview_options"] = {"is_disabled": True}
             if reply_to_id is not None:
                 payload["reply_parameters"] = {"message_id": reply_to_id}
             return await self._rich_media_request("sendRichMessage", payload, content)
@@ -1956,6 +1974,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 "rich_message": rich_message,
                 **uploads,
             }
+            if getattr(self, "_disable_link_previews", False):
+                payload["link_preview_options"] = {"is_disabled": True}
             return await self._rich_media_request("editMessageText", payload, content)
 
     def _is_rich_capability_error(self, exc: Exception) -> bool:

--- a/tests/gateway/test_telegram_ephemeral_messages.py
+++ b/tests/gateway/test_telegram_ephemeral_messages.py
@@ -1,0 +1,340 @@
+"""Telegram Bot API 10.2 ephemeral group interaction tests.
+
+These tests define the fail-closed contract before the adapter implements it:
+configured group commands are registered/ingested as ephemeral, private replies
+use raw Bot API 10.2 fields, and no public legacy send occurs on failure.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType, _thread_metadata_for_source
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from telegram.error import BadRequest
+
+
+def _adapter(extra=None):
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={"ephemeral_group_commands": ["status", "help"], **(extra or {})},
+    )
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(
+        return_value={"message_id": 0, "ephemeral_message_id": "out-eph-1"}
+    )
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=999))
+    bot.send_chat_action = AsyncMock()
+    bot.set_my_commands = AsyncMock()
+    adapter._bot = bot
+    return adapter
+
+
+def _message(*, text="/status", chat_type="supergroup", api_kwargs=None):
+    return SimpleNamespace(
+        text=text,
+        message_id=0,
+        api_kwargs=api_kwargs or {"ephemeral_message_id": "in-eph-1"},
+        from_user=SimpleNamespace(id=42),
+        chat=SimpleNamespace(id=-100123, type=chat_type),
+    )
+
+
+def _ephemeral_source():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="group",
+        user_id="42",
+    )
+    source.delivery_metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+        "suppress_streaming": True,
+        "suppress_typing": True,
+    }
+    return source
+
+
+def test_configured_group_command_extracts_ephemeral_delivery_metadata():
+    adapter = _adapter()
+
+    metadata = adapter._ephemeral_metadata_for_message(_message())
+
+    assert metadata["telegram_ephemeral_required"] is True
+    assert metadata["telegram_ephemeral_receiver_user_id"] == 42
+    assert metadata["telegram_ephemeral_message_id"] == "in-eph-1"
+    assert metadata["suppress_streaming"] is True
+    assert metadata["suppress_typing"] is True
+    assert time.monotonic() - metadata["telegram_ephemeral_received_at_monotonic"] < 1
+
+
+def test_build_message_event_preserves_private_delivery_context():
+    adapter = _adapter()
+    message = _message()
+    message.from_user.full_name = "Alice"
+    message.chat.title = "Test group"
+    message.chat.is_forum = False
+    message.caption = None
+    message.message_thread_id = None
+    message.is_topic_message = False
+    message.reply_to_message = None
+    message.date = None
+
+    event = adapter._build_message_event(message, MessageType.TEXT)
+
+    assert event.metadata["telegram_ephemeral_required"] is True
+    assert event.source.delivery_metadata["telegram_ephemeral_receiver_user_id"] == 42
+    assert event.source.delivery_metadata["telegram_ephemeral_message_id"] == "in-eph-1"
+
+
+@pytest.mark.asyncio
+async def test_background_ephemeral_command_never_starts_typing_indicator():
+    adapter = _adapter()
+    message = _message()
+    message.from_user.full_name = "Alice"
+    message.chat.title = "Test group"
+    message.chat.is_forum = False
+    message.caption = None
+    message.message_thread_id = None
+    message.is_topic_message = False
+    message.reply_to_message = None
+    message.date = None
+    event = adapter._build_message_event(message, MessageType.TEXT)
+
+    async def handler(_event):
+        return "private status"
+
+    adapter.set_message_handler(handler)
+    adapter._send_with_retry = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id=None)
+    )
+    keep_typing = AsyncMock()
+
+    with patch.object(adapter, "_keep_typing", new=keep_typing):
+        await adapter._process_message_background(event, "telegram:group:-100123")
+
+    keep_typing.assert_not_awaited()
+    metadata = adapter._send_with_retry.await_args.kwargs["metadata"]
+    assert metadata["telegram_ephemeral_receiver_user_id"] == 42
+
+
+def test_unconfigured_or_private_commands_are_not_marked_ephemeral():
+    adapter = _adapter()
+
+    assert adapter._ephemeral_metadata_for_message(_message(text="/new")) == {}
+    assert adapter._ephemeral_metadata_for_message(_message(chat_type="private")) == {}
+
+
+def test_ephemeral_source_metadata_reaches_base_and_runner_send_paths():
+    source = _ephemeral_source()
+
+    base_metadata = _thread_metadata_for_source(source)
+    runner = object.__new__(GatewayRunner)
+    runner_metadata = runner._thread_metadata_for_source(source)
+
+    for metadata in (base_metadata, runner_metadata):
+        assert metadata["telegram_ephemeral_required"] is True
+        assert metadata["telegram_ephemeral_receiver_user_id"] == 42
+        assert metadata["telegram_ephemeral_message_id"] == "in-eph-1"
+
+
+def test_ephemeral_source_disables_streaming_to_avoid_public_preview():
+    runner = object.__new__(GatewayRunner)
+
+    assert runner._streaming_allowed_for_source(_ephemeral_source(), True) is False
+    assert runner._streaming_allowed_for_source(_ephemeral_source(), False) is False
+    assert (
+        runner._streaming_allowed_for_source(
+            SessionSource(platform=Platform.TELEGRAM, chat_id="1"), True
+        )
+        is True
+    )
+
+
+def test_group_command_objects_mark_only_configured_commands_ephemeral():
+    adapter = _adapter()
+
+    with patch("telegram.BotCommand") as command_cls:
+        command_cls.side_effect = lambda name, description, api_kwargs=None: (
+            SimpleNamespace(
+                command=name,
+                description=description,
+                api_kwargs=api_kwargs or {},
+            )
+        )
+        commands = adapter._make_menu_bot_commands(
+            [("status", "Show status"), ("new", "New session")],
+            group_scope=True,
+        )
+
+    assert commands[0].api_kwargs["is_ephemeral"] is True
+    assert "is_ephemeral" not in commands[1].api_kwargs
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_text_reply_uses_botapi_10_2_fields_and_not_public_send():
+    adapter = _adapter()
+    metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+        "notify": True,
+    }
+
+    result = await adapter.send("-100123", "**Private status**", metadata=metadata)
+
+    assert result.success is True
+    assert result.message_id is None
+    adapter._bot.send_message.assert_not_called()
+    adapter._bot.do_api_request.assert_awaited_once()
+    call = adapter._bot.do_api_request.call_args
+    assert call.args[0] == "sendMessage"
+    payload = call.kwargs["api_kwargs"]
+    assert payload["chat_id"] == -100123
+    assert payload["receiver_user_id"] == 42
+    assert payload["reply_parameters"] == {"ephemeral_message_id": "in-eph-1"}
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload.get("disable_notification", False) is False
+
+
+def test_expired_reply_window_drops_anchor_but_keeps_admin_private_target():
+    adapter = _adapter()
+    kwargs = adapter._ephemeral_send_api_kwargs({
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+        "telegram_ephemeral_received_at_monotonic": time.monotonic() - 16,
+    })
+
+    assert kwargs == {"receiver_user_id": 42}
+    assert (
+        adapter._ephemeral_send_api_kwargs({
+            "telegram_ephemeral_required": True,
+            "telegram_ephemeral_receiver_user_id": "not-a-user-id",
+        })
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_markdown_fallback_remains_private():
+    adapter = _adapter()
+    adapter._bot.do_api_request = AsyncMock(
+        side_effect=[BadRequest("can't parse entities"), {"message_id": 0}]
+    )
+    metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+    }
+
+    result = await adapter.send("-100123", "broken _ markdown", metadata=metadata)
+
+    assert result.success is True
+    assert adapter._bot.do_api_request.await_count == 2
+    retry_payload = adapter._bot.do_api_request.await_args_list[1].kwargs["api_kwargs"]
+    assert retry_payload["receiver_user_id"] == 42
+    assert retry_payload["reply_parameters"] == {"ephemeral_message_id": "in-eph-1"}
+    assert "parse_mode" not in retry_payload
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_text_failure_is_fail_closed_without_public_fallback():
+    adapter = _adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=BadRequest("not eligible"))
+    metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+    }
+
+    result = await adapter.send("-100123", "secret", metadata=metadata)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert "ephemeral" in (result.error or "").lower()
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_image_uses_private_api_kwargs(tmp_path):
+    adapter = _adapter()
+    adapter._bot.send_photo = AsyncMock(
+        return_value=SimpleNamespace(
+            message_id=0, api_kwargs={"ephemeral_message_id": "out-eph-img"}
+        )
+    )
+    image = tmp_path / "chart.png"
+    image.write_bytes(b"not-a-real-png-but-send-is-mocked")
+    metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+    }
+
+    result = await adapter.send_image_file("-100123", str(image), metadata=metadata)
+
+    assert result.success is True
+    kwargs = adapter._bot.send_photo.call_args.kwargs
+    assert kwargs["api_kwargs"]["receiver_user_id"] == 42
+    assert kwargs["api_kwargs"]["reply_parameters"] == {
+        "ephemeral_message_id": "in-eph-1"
+    }
+    assert kwargs["reply_to_message_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_media_without_receiver_fails_closed(tmp_path):
+    adapter = _adapter()
+    adapter._bot.send_photo = AsyncMock()
+    adapter._bot.send_document = AsyncMock()
+    image = tmp_path / "chart.png"
+    image.write_bytes(b"png")
+
+    result = await adapter.send_image_file(
+        "-100123",
+        str(image),
+        metadata={"telegram_ephemeral_required": True},
+    )
+
+    assert result.success is False
+    adapter._bot.send_photo.assert_not_called()
+    adapter._bot.send_document.assert_not_called()
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_image_batch_avoids_public_send_media_group(tmp_path):
+    adapter = _adapter()
+    adapter.send_image_file = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter._bot.send_media_group = AsyncMock()
+    p1 = tmp_path / "one.png"
+    p2 = tmp_path / "two.png"
+    p1.write_bytes(b"1")
+    p2.write_bytes(b"2")
+    metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+    }
+
+    await adapter.send_multiple_images(
+        "-100123",
+        [(f"file://{p1}", "one"), (f"file://{p2}", "two")],
+        metadata=metadata,
+    )
+
+    adapter._bot.send_media_group.assert_not_called()
+    assert adapter.send_image_file.await_count == 2
+    for call in adapter.send_image_file.await_args_list:
+        assert call.kwargs["metadata"] is metadata

--- a/tests/gateway/test_telegram_ephemeral_messages.py
+++ b/tests/gateway/test_telegram_ephemeral_messages.py
@@ -64,6 +64,43 @@ def _ephemeral_source():
     return source
 
 
+def test_ephemeral_delivery_metadata_is_explicit_but_wire_invisible():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="group",
+        user_id="42",
+    )
+
+    assert source.delivery_metadata is None
+    source.delivery_metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+    }
+    equivalent_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="group",
+        user_id="42",
+    )
+
+    assert source == equivalent_source
+    assert "telegram_ephemeral" not in repr(source)
+
+    serialized = source.to_dict()
+    assert "delivery_metadata" not in serialized
+
+    restored = SessionSource.from_dict({
+        **serialized,
+        # Persisted or remote data cannot forge transient private routing.
+        "delivery_metadata": {
+            "telegram_ephemeral_required": True,
+            "telegram_ephemeral_receiver_user_id": 999,
+        },
+    })
+    assert restored.delivery_metadata is None
+
+
 def test_configured_group_command_extracts_ephemeral_delivery_metadata():
     adapter = _adapter()
 
@@ -187,6 +224,7 @@ async def test_ephemeral_text_reply_uses_botapi_10_2_fields_and_not_public_send(
         "telegram_ephemeral_required": True,
         "telegram_ephemeral_receiver_user_id": 42,
         "telegram_ephemeral_message_id": "in-eph-1",
+        "telegram_ephemeral_received_at_monotonic": time.monotonic(),
         "notify": True,
     }
 
@@ -204,6 +242,25 @@ async def test_ephemeral_text_reply_uses_botapi_10_2_fields_and_not_public_send(
     assert payload["reply_parameters"] == {"ephemeral_message_id": "in-eph-1"}
     assert payload["parse_mode"] == "MarkdownV2"
     assert payload.get("disable_notification", False) is False
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_text_preserves_forum_thread_target():
+    adapter = _adapter()
+    metadata = {
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+        "telegram_ephemeral_received_at_monotonic": time.monotonic(),
+        "message_thread_id": 7,
+    }
+
+    result = await adapter.send("-100123", "private status", metadata=metadata)
+
+    assert result.success is True
+    payload = adapter._bot.do_api_request.call_args.kwargs["api_kwargs"]
+    assert payload["message_thread_id"] == 7
+    adapter._bot.send_message.assert_not_called()
 
 
 def test_expired_reply_window_drops_anchor_but_keeps_admin_private_target():
@@ -225,6 +282,18 @@ def test_expired_reply_window_drops_anchor_but_keeps_admin_private_target():
     )
 
 
+def test_missing_receipt_timestamp_drops_ephemeral_reply_anchor():
+    adapter = _adapter()
+
+    kwargs = adapter._ephemeral_send_api_kwargs({
+        "telegram_ephemeral_required": True,
+        "telegram_ephemeral_receiver_user_id": 42,
+        "telegram_ephemeral_message_id": "in-eph-1",
+    })
+
+    assert kwargs == {"receiver_user_id": 42}
+
+
 @pytest.mark.asyncio
 async def test_ephemeral_markdown_fallback_remains_private():
     adapter = _adapter()
@@ -235,6 +304,7 @@ async def test_ephemeral_markdown_fallback_remains_private():
         "telegram_ephemeral_required": True,
         "telegram_ephemeral_receiver_user_id": 42,
         "telegram_ephemeral_message_id": "in-eph-1",
+        "telegram_ephemeral_received_at_monotonic": time.monotonic(),
     }
 
     result = await adapter.send("-100123", "broken _ markdown", metadata=metadata)
@@ -280,6 +350,7 @@ async def test_ephemeral_image_uses_private_api_kwargs(tmp_path):
         "telegram_ephemeral_required": True,
         "telegram_ephemeral_receiver_user_id": 42,
         "telegram_ephemeral_message_id": "in-eph-1",
+        "telegram_ephemeral_received_at_monotonic": time.monotonic(),
     }
 
     result = await adapter.send_image_file("-100123", str(image), metadata=metadata)

--- a/tests/gateway/test_telegram_rich_inline_media.py
+++ b/tests/gateway/test_telegram_rich_inline_media.py
@@ -1,0 +1,255 @@
+"""Telegram Bot API 10.2 inline media inside rich-message reports."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+RICH_REPORT = "## Report\n\n| Metric | Value |\n|---|---|\n| risk | low |"
+
+
+def _adapter(extra=None):
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={
+            "rich_messages": True,
+            "rich_inline_media": True,
+            **(extra or {}),
+        },
+    )
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value={"message_id": 321})
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+    return adapter
+
+
+class _FakeInputFile:
+    counter = 0
+
+    def __init__(self, file_obj, *, filename=None, attach=False):
+        type(self).counter += 1
+        self.file_obj = file_obj
+        self.filename = filename
+        self.attach_name = f"attach_{type(self).counter}"
+        self.attach_uri = f"attach://{self.attach_name}" if attach else None
+
+
+@pytest.mark.asyncio
+async def test_new_rich_report_embeds_local_photo_in_single_send(tmp_path):
+    adapter = _adapter()
+    photo = tmp_path / "chart.png"
+    photo.write_bytes(b"png")
+
+    with patch("telegram.InputFile", _FakeInputFile):
+        result = await adapter.send_rich_media(
+            "12345",
+            RICH_REPORT,
+            [(str(photo), False)],
+            metadata={"notify": True},
+        )
+
+    assert result is not None and result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    call = adapter._bot.do_api_request.call_args
+    assert call.args[0] == "sendRichMessage"
+    payload = call.kwargs["api_kwargs"]
+    rich = payload["rich_message"]
+    assert "![](tg://photo?id=media_0)" in rich["markdown"]
+    assert rich["media"][0]["id"] == "media_0"
+    attach_uri = rich["media"][0]["media"]["media"]
+    assert attach_uri.startswith("attach://")
+    uploads = [value for value in payload.values() if isinstance(value, _FakeInputFile)]
+    assert len(uploads) == 1
+    assert uploads[0].attach_uri == attach_uri
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_streamed_report_can_be_edited_to_add_inline_media(tmp_path):
+    adapter = _adapter()
+    video = tmp_path / "proof.mp4"
+    video.write_bytes(b"mp4")
+
+    with patch("telegram.InputFile", _FakeInputFile):
+        result = await adapter.edit_rich_media(
+            "12345",
+            "777",
+            RICH_REPORT,
+            [(str(video), False)],
+            metadata={"notify": True},
+        )
+
+    assert result is not None and result.success is True
+    call = adapter._bot.do_api_request.call_args
+    assert call.args[0] == "editMessageText"
+    payload = call.kwargs["api_kwargs"]
+    assert payload["message_id"] == 777
+    assert "![](tg://video?id=media_0)" in payload["rich_message"]["markdown"]
+
+
+@pytest.mark.asyncio
+async def test_rich_inline_media_opt_out_or_unsupported_file_falls_back(tmp_path):
+    photo = tmp_path / "chart.png"
+    photo.write_bytes(b"png")
+    document = tmp_path / "report.pdf"
+    document.write_bytes(b"pdf")
+
+    disabled = _adapter(extra={"rich_inline_media": False})
+    assert (
+        await disabled.send_rich_media("12345", RICH_REPORT, [(str(photo), False)])
+        is None
+    )
+    disabled._bot.do_api_request.assert_not_called()
+
+    enabled = _adapter()
+    assert (
+        await enabled.send_rich_media("12345", RICH_REPORT, [(str(document), False)])
+        is None
+    )
+    enabled._bot.do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rich_inline_media_transient_failure_does_not_duplicate_send(tmp_path):
+    class TimedOut(Exception):
+        pass
+
+    photo = tmp_path / "chart.png"
+    photo.write_bytes(b"png")
+    adapter = _adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=TimedOut("network timeout"))
+
+    with patch("telegram.InputFile", _FakeInputFile):
+        result = await adapter.send_rich_media(
+            "12345", RICH_REPORT, [(str(photo), False)]
+        )
+
+    assert result is not None
+    assert result.success is False
+    assert result.retryable is True
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_delivery_upgrades_existing_message_instead_of_resending_media(
+    tmp_path,
+):
+    chart = tmp_path / "chart.png"
+    chart.write_bytes(b"png")
+    adapter = MagicMock()
+    adapter.name = "Telegram"
+    adapter.extract_media.return_value = (
+        [(str(chart), False)],
+        RICH_REPORT,
+    )
+    adapter.extract_images.return_value = ([], RICH_REPORT)
+    adapter.extract_local_files.return_value = ([], RICH_REPORT)
+    adapter.edit_rich_media = AsyncMock(
+        return_value=SendResult(success=True, message_id="777")
+    )
+    adapter.send_multiple_images = AsyncMock()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="show report",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    runner = object.__new__(GatewayRunner)
+
+    await runner._deliver_media_from_response(
+        f"{RICH_REPORT}\nMEDIA:{chart}",
+        event,
+        adapter,
+        stream_message_id="777",
+    )
+
+    adapter.edit_rich_media.assert_awaited_once_with(
+        "12345",
+        "777",
+        RICH_REPORT,
+        [(str(chart), False)],
+        metadata=None,
+    )
+    adapter.send_multiple_images.assert_not_called()
+
+
+class _RecordingRichMediaAdapter(TelegramAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={"rich_messages": True, "rich_inline_media": True},
+            )
+        )
+        self.rich_media_calls = []
+
+    async def send_rich_media(
+        self,
+        chat_id,
+        content,
+        media_files,
+        reply_to=None,
+        metadata=None,
+    ):
+        self.rich_media_calls.append((
+            chat_id,
+            content,
+            media_files,
+            reply_to,
+            metadata,
+        ))
+        return SendResult(success=True, message_id="321")
+
+
+@pytest.mark.asyncio
+async def test_background_delivery_combines_text_and_media_without_duplicates(tmp_path):
+    chart = tmp_path / "chart.png"
+    chart.write_bytes(b"png")
+    adapter = _RecordingRichMediaAdapter()
+    adapter._send_with_retry = AsyncMock()
+    adapter.send_multiple_images = AsyncMock()
+
+    async def handler(_event):
+        return f"{RICH_REPORT}\nMEDIA:{chart}"
+
+    adapter.set_message_handler(handler)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="group",
+    )
+    event = MessageEvent(
+        text="show report",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="12",
+    )
+
+    with patch.object(adapter, "_keep_typing", new=AsyncMock()):
+        await adapter._process_message_background(event, "telegram:group:12345")
+
+    assert len(adapter.rich_media_calls) == 1
+    chat_id, content, media_files, reply_to, metadata = adapter.rich_media_calls[0]
+    assert chat_id == "12345"
+    assert content == RICH_REPORT
+    assert media_files == [(str(chart), False)]
+    assert reply_to == "12"
+    assert metadata["notify"] is True
+    adapter._send_with_retry.assert_not_awaited()
+    adapter.send_multiple_images.assert_not_awaited()

--- a/tests/gateway/test_telegram_rich_inline_media.py
+++ b/tests/gateway/test_telegram_rich_inline_media.py
@@ -76,6 +76,24 @@ async def test_new_rich_report_embeds_local_photo_in_single_send(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_rich_inline_media_honors_disabled_link_previews(tmp_path):
+    adapter = _adapter(extra={"disable_link_previews": True})
+    photo = tmp_path / "chart.png"
+    photo.write_bytes(b"png")
+
+    with patch("telegram.InputFile", _FakeInputFile):
+        result = await adapter.send_rich_media(
+            "12345",
+            f"{RICH_REPORT}\n\nhttps://example.com/report",
+            [(str(photo), False)],
+        )
+
+    assert result is not None and result.success is True
+    payload = adapter._bot.do_api_request.call_args.kwargs["api_kwargs"]
+    assert payload["link_preview_options"] == {"is_disabled": True}
+
+
+@pytest.mark.asyncio
 async def test_streamed_report_can_be_edited_to_add_inline_media(tmp_path):
     adapter = _adapter()
     video = tmp_path / "proof.mp4"
@@ -99,6 +117,25 @@ async def test_streamed_report_can_be_edited_to_add_inline_media(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_rich_inline_media_edit_honors_disabled_link_previews(tmp_path):
+    adapter = _adapter(extra={"disable_link_previews": True})
+    video = tmp_path / "proof.mp4"
+    video.write_bytes(b"mp4")
+
+    with patch("telegram.InputFile", _FakeInputFile):
+        result = await adapter.edit_rich_media(
+            "12345",
+            "777",
+            f"{RICH_REPORT}\n\nhttps://example.com/report",
+            [(str(video), False)],
+        )
+
+    assert result is not None and result.success is True
+    payload = adapter._bot.do_api_request.call_args.kwargs["api_kwargs"]
+    assert payload["link_preview_options"] == {"is_disabled": True}
+
+
+@pytest.mark.asyncio
 async def test_rich_inline_media_opt_out_or_unsupported_file_falls_back(tmp_path):
     photo = tmp_path / "chart.png"
     photo.write_bytes(b"png")
@@ -118,6 +155,24 @@ async def test_rich_inline_media_opt_out_or_unsupported_file_falls_back(tmp_path
         is None
     )
     enabled._bot.do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_media_references_cannot_push_rich_message_past_text_limit(tmp_path):
+    adapter = _adapter()
+    photo = tmp_path / "chart.png"
+    photo.write_bytes(b"png")
+    content_at_limit = "x" * adapter.RICH_MESSAGE_MAX_CHARS
+
+    with patch("telegram.InputFile", _FakeInputFile):
+        result = await adapter.send_rich_media(
+            "12345",
+            content_at_limit,
+            [(str(photo), False)],
+        )
+
+    assert result is None
+    adapter._bot.do_api_request.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -104,6 +104,38 @@ platforms:
 
 Telegram allows up to 100 BotCommands, but large command payloads can fail. Hermes defaults to 60 for reliability and clamps configured values to `1..100`; use `/commands` for the full command list.
 
+### Bot API 10.2: private group commands and inline rich media
+
+Telegram Bot API 10.2 adds ephemeral group commands and media embedded inside
+rich messages. Both are opt-in:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      rich_messages: true
+      rich_inline_media: true
+      # A YAML list or comma-separated string is accepted.
+      ephemeral_group_commands: status,help,commands,usage
+```
+
+- **Ephemeral group commands** are registered with `is_ephemeral=true` only in
+  Telegram's group scopes. Their replies target the invoking user with
+  `receiver_user_id` and, when Telegram supplies it, reply to the inbound
+  `ephemeral_message_id`. Private chats and unlisted commands remain durable.
+- Hermes disables typing, streaming, and interim previews for these commands.
+  If Telegram rejects private delivery, Hermes does not resend the content
+  publicly. Within Telegram's 15-second reply window Hermes anchors the reply
+  to the inbound ephemeral message; afterward it attempts an administrator-only
+  private send without the expired anchor.
+- Keep interactive commands that edit inline keyboards out of the list unless
+  their callback flow supports ephemeral edits.
+- **Rich inline media** upgrades a final rich report containing local `MEDIA:`
+  image/video/audio files into one `sendRichMessage` or `editMessageText`
+  payload. Unsupported file types, `[[as_document]]`, and permanent capability
+  errors fall back to normal separate attachments.
+- Ephemeral messages are transient. Do not use them for durable audit records.
+
 ## Step 3: Privacy Mode (Critical for Groups)
 
 Telegram bots have a **privacy mode** that is **enabled by default**. This is the single most common source of confusion when using bots in groups.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -125,9 +125,9 @@ platforms:
   `ephemeral_message_id`. Private chats and unlisted commands remain durable.
 - Hermes disables typing, streaming, and interim previews for these commands.
   If Telegram rejects private delivery, Hermes does not resend the content
-  publicly. Within Telegram's 15-second reply window Hermes anchors the reply
-  to the inbound ephemeral message; afterward it attempts an administrator-only
-  private send without the expired anchor.
+  publicly. Telegram allows the inbound ephemeral reply anchor for 15 seconds;
+  Hermes uses a 14-second local guard for transport headroom, then attempts an
+  administrator-only private send without the expired anchor.
 - Keep interactive commands that edit inline keyboards out of the list unless
   their callback flow supports ephemeral edits.
 - **Rich inline media** upgrades a final rich report containing local `MEDIA:`


### PR DESCRIPTION
## Summary

- add opt-in Telegram Bot API 10.2 ephemeral group commands and user-targeted replies
- carry private delivery constraints through background and streamed gateway paths without changing session identity
- keep transient recipient routing explicit but wire-invisible: it is excluded from serialization, relay restoration, repr output, and equality
- fail closed: private replies never fall back to a public group message, typing preview, or stream preview
- add opt-in local image/video/audio media inside `sendRichMessage` and streamed `editMessageText` rich reports
- preserve existing rich-text and separate-attachment fallbacks for unsupported media and permanent capability errors
- preserve `disable_link_previews` behavior for rich-media sends and in-place rich-media edits
- preserve forum-topic targeting for private ephemeral text replies
- drop ephemeral reply anchors when receipt timing metadata is missing or corrupt
- reject inline-media rich payloads when appended media references would exceed Telegram's 32,768-character limit

## Configuration

```yaml
platforms:
  telegram:
    extra:
      rich_messages: true
      rich_inline_media: true
      ephemeral_group_commands: status,help,commands,usage
```

Interactive commands that edit inline keyboards should remain outside the ephemeral list until their callback flow supports ephemeral edits.

## Safety and compatibility

- uses `api_kwargs` / raw Bot API requests as a narrow compatibility shim for python-telegram-bot 22.6
- honors Telegram's 15-second ephemeral reply window with a 14-second client-side guard, then attempts receiver-only delivery for administrator bots
- avoids `sendMediaGroup` for ephemeral output because that endpoint has no `receiver_user_id`; images are sent privately one at a time instead
- suppresses duplicate media fallback after uncertain transport failures
- keeps short-lived recipient metadata out of persisted/session/relay wire formats and dataclass repr/equality
- keeps ordinary Telegram commands, messages, rich text, threads, and media delivery unchanged unless the new options are enabled

## Verification

- canonical per-file runner across ephemeral, inline-media, rich-message, and forum-command suites — **103 passed**
- session serialization/equality plus Telegram thread fallback suites — **158 passed**
- broad Telegram differential:
  - feature branch: **1,204 passed, 8 failed, 1 skipped**
  - clean current `origin/main`: **1,178 passed, 8 failed, 1 skipped**
  - exact same eight pre-existing order-dependent mock failures; the feature branch adds **26 passing tests**
  - all eight broad-suite failures pass when selected directly
- Ruff on all changed Python files — passed
- Python compilation and `git diff --check` — passed
- Semgrep Python rules on all changed Python files — passed
- live Bot API probe on Linux: rich-media send and existing-message rich-media edit both succeeded; probe messages were deleted
- live group-command scope round trip: 60 commands registered, 4 returned with `is_ephemeral=true`

No new dependencies.

Developed with AI assistance from **Cronus**.