### PR TITLE
fix(telegram): attach polling instrumentation without an instance attribute

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1970,12 +1970,31 @@ class TelegramAdapter(BasePlatformAdapter):
         self._send_path_degraded = False
 
     def _instrument_polling_request(self, request):
-        """Wrap one dedicated PTB getUpdates request with progress tracking."""
-        do_request = request.do_request
+        """Wrap one dedicated PTB getUpdates request with progress tracking.
 
-        async def _do_request(*args, **kwargs):
+        The wrapper is attached by rebinding ``request.__class__`` to a subclass
+        that overrides ``do_request``, rather than by assigning the attribute on
+        the instance. ``HTTPXRequest`` declares ``__slots__`` (python-telegram-bot
+        >= 22), so ``request.do_request = ...`` raises
+
+            AttributeError: 'HTTPXRequest' object attribute 'do_request' is read-only
+
+        and aborts Telegram startup. A subclass with empty ``__slots__`` has the
+        same instance layout, so ``__class__`` assignment is legal and adds no
+        per-instance attribute.
+
+        The wrapper cannot simply be skipped when it fails to attach: the polling
+        progress verifier consumes what ``_record_polling_progress`` records, so a
+        no-op wrapper makes healthy polling look stalled and drops the adapter into
+        a reconnect loop.
+        """
+        adapter = self
+        base = type(request)
+        base_do_request = base.do_request
+
+        async def _do_request(request, *args, **kwargs):
             generation = _POLLING_GENERATION_CONTEXT.get()
-            result = await do_request(*args, **kwargs)
+            result = await base_do_request(request, *args, **kwargs)
             status_code, payload = result
             if generation is not None and 200 <= status_code < 300:
                 try:
@@ -1993,10 +2012,15 @@ class TelegramAdapter(BasePlatformAdapter):
                         and envelope.get("ok") is True
                         and "result" in envelope
                     ):
-                        self._record_polling_progress(generation)
+                        adapter._record_polling_progress(generation)
             return result
 
-        request.do_request = _do_request
+        instrumented = type(
+            f"_Instrumented{base.__name__}",
+            (base,),
+            {"__slots__": (), "do_request": _do_request},
+        )
+        request.__class__ = instrumented
         return request
 
     async def _start_polling_once(

--- a/tests/test_telegram_polling_progress_ptb.py
+++ b/tests/test_telegram_polling_progress_ptb.py
@@ -291,3 +291,49 @@ async def test_real_ptb_stop_cleanup_cannot_heal_recovery_generation():
             await app.updater.stop()
         await _cancel_task(adapter._polling_progress_verifier_task)
         await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_instrument_polling_request_attaches_to_real_httpxrequest(monkeypatch):
+    """Instrumentation must attach to the real PTB request class.
+
+    Regression for the Telegram startup failure
+
+        AttributeError: 'HTTPXRequest' object attribute 'do_request' is read-only
+
+    ``HTTPXRequest`` declares ``__slots__`` (python-telegram-bot >= 22), so the
+    instrumentation cannot be attached by assigning ``request.do_request``. The
+    other doubles in this suite subclass ``BaseRequest`` without ``__slots__``,
+    so they acquire a ``__dict__`` and accept the assignment — which is why the
+    suite did not catch this. Use the production class here.
+
+    Attaching is not enough: progress must still be recorded. A wrapper that
+    silently fails to attach would make healthy polling look stalled to the
+    progress verifier and send the adapter into a reconnect loop.
+    """
+    from telegram.request import HTTPXRequest
+
+    async def _no_network(self, *args, **kwargs):
+        return (200, b'{"ok":true,"result":[]}')
+
+    monkeypatch.setattr(HTTPXRequest, "do_request", _no_network)
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    generation, progress = adapter._begin_polling_generation()
+
+    request = HTTPXRequest()
+    instrumented = adapter._instrument_polling_request(request)
+
+    assert instrumented is request
+
+    generation_context = tg_adapter._POLLING_GENERATION_CONTEXT
+    token = generation_context.set(generation)
+    try:
+        result = await instrumented.do_request(
+            "https://api.telegram.org/bottest-token/getUpdates", "POST"
+        )
+    finally:
+        generation_context.reset(token)
+
+    assert result == (200, b'{"ok":true,"result":[]}')
+    assert progress.is_set(), "instrumentation attached but recorded no polling progress"


### PR DESCRIPTION
## Problem

Telegram cannot connect at all on v0.18.2. The adapter aborts on startup with:

```
AttributeError: 'HTTPXRequest' object attribute 'do_request' is read-only
```

Reported in #64566 and #64482.

## Root cause

`_instrument_polling_request()` attaches its progress-tracking wrapper by assigning the attribute on the instance:

```python
request.do_request = _do_request
```

`HTTPXRequest` declares `__slots__` (python-telegram-bot >= 22), so the instance has no `__dict__` and the assignment raises `AttributeError`.

## Fix

Attach the wrapper by rebinding `request.__class__` to a subclass that overrides `do_request`. A subclass with empty `__slots__` has the same instance layout, so `__class__` assignment is legal and creates no per-instance attribute. The instrumentation itself is unchanged.

## Why the wrapper must not simply be skipped

The obvious fix — wrapping the assignment in `try/except AttributeError` and moving on — is wrong, and I tried it first. The polling-progress verifier *consumes* what `_record_polling_progress()` records. With a no-op wrapper, healthy polling looks stalled and the adapter drops into a reconnect loop:

```
Telegram polling degraded (polling progress verifier: general path healthy but getUpdates stalled)
Error: getUpdates made no progress before verifier deadline
```

So the wrapper has to actually attach, not merely fail quietly.

## Testing

Added a regression test against the real `HTTPXRequest`:

- Against unmodified `main` it fails with the exact production error (`AttributeError ... is read-only` at `adapter.py:1999`).
- With this change it passes, and asserts progress is still recorded — so a future no-op regression is caught too.
- `tests/test_telegram_polling_progress_ptb.py` goes from 7 passing to 8 passing when run on its own.

The existing request doubles subclass `BaseRequest` **without** `__slots__`, so they acquire a `__dict__` and happily accept the assignment. That is why the suite never caught this — the doubles do not model the constraint that production hits.

Verified against a live bot: the gateway now connects, holds the `getUpdates` long-poll, and replies to messages.

### Pre-existing issue noticed, unrelated to this change

Every test in `tests/test_telegram_polling_progress_ptb.py` fails when the file runs *after* `tests/gateway/test_telegram_*.py` in the same pytest session — **this also happens on unmodified `main`** (baseline: 7 failed / 68 passed; with this change: 8 failed / 68 passed, the extra failure being the new test succumbing to the same ordering issue). Run on its own the file is green. Flagging it as a separate test-isolation problem so it isn't mistaken for a regression from this PR.

Fixes #64566
Fixes #64482

🤖 Generated with [Claude Code](https://claude.com/claude-code)