### PR TITLE
fix(gateway): shut down memory provider on soft cache eviction (#64278)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16613,6 +16613,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._cleanup_agent_resources(agent)
         except Exception:
             pass
+        # Shut down the memory provider to release threads, executors, and
+        # HTTP connections. A fresh AIAgent built on session resume creates
+        # its own MemoryManager and provider, so the old one must not be
+        # left alive leaking resources (#64278).
+        try:
+            if hasattr(agent, "shutdown_memory_provider"):
+                _msgs = getattr(agent, "_session_messages", None)
+                if isinstance(_msgs, list):
+                    agent.shutdown_memory_provider(_msgs)
+                else:
+                    agent.shutdown_memory_provider()
+        except Exception:
+            pass
         # Free conversation history memory — can be tens of MB with tool
         # outputs (file reads, terminal output, search results) on heavy
         # 100+-tool-call sessions. release_clients() deliberately preserves


### PR DESCRIPTION
Fixes #64278

## Problem

The gateway's soft agent-cache eviction path (_release_evicted_agent_soft)
calls release_clients() which deliberately preserves the memory provider
("has its own lifecycle; keeps running"). When the session later becomes active
again, a fresh AIAgent is built with a brand-new MemoryManager and provider.
The old provider's resources — executor thread pool, writer threads, HTTP
connections — are never cleaned up, causing a slow resource leak over time.

## Fix

Add a shutdown_memory_provider() call in _release_evicted_agent_soft,
mirroring the pattern already used in _cleanup_agent_resources (the hard
cleanup path for session boundaries). This ensures:

1. The background sync executor is drained and its thread pool shut down
2. Each provider's shutdown() method is called (releasing HTTP clients, file
   handles, and provider-specific state)

The agent's terminal sandbox, browser daemon, and background processes are
still preserved (they are torn down only by close(), which is NOT called).
On session resume, the new AIAgent creates a fresh, clean memory provider.

## Testing

- All 93 tests in tests/gateway/test_agent_cache.py,
  tests/gateway/test_shutdown_cache_cleanup.py, and
  tests/gateway/test_shutdown_memory_provider_messages.py pass.
- 843 of 844 gateway tests pass (the one failure is a pre-existing flaky
  ordering issue in test_channel_directory.py).
