### PR TITLE
feat(cron): add routed progress heartbeats

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1036,6 +1036,33 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _normalize_progress(progress: Any) -> Optional[Dict[str, Any]]:
+    """Normalize optional per-job cron progress overrides."""
+    if progress is None:
+        return None
+    if isinstance(progress, bool):
+        return {"enabled": progress}
+    if isinstance(progress, str):
+        value = progress.strip()
+        return {"enabled": value} if value else None
+    if not isinstance(progress, dict):
+        raise ValueError("Cron progress override must be a bool, string, or object")
+
+    allowed = {
+        "enabled",
+        "initial_delay_seconds",
+        "interval_seconds",
+        "edit_in_place",
+        "state_path",
+    }
+    normalized = {
+        key: value
+        for key, value in progress.items()
+        if key in allowed and value is not None
+    }
+    return normalized or None
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1054,6 +1081,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    progress: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1098,6 +1126,9 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        progress: Optional per-job progress-heartbeat override. A bool/string
+                controls ``enabled``; an object may override timing, editing,
+                and the displayed state path. None inherits ``cron.progress``.
 
     Returns:
         The created job dict
@@ -1130,6 +1161,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_progress = _normalize_progress(progress)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1225,6 +1257,8 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    if normalized_progress is not None:
+        job["progress"] = normalized_progress
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -1314,6 +1348,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "progress" in updates:
+                updates["progress"] = _normalize_progress(updates["progress"])
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import concurrent.futures
 import contextvars
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -1402,6 +1403,67 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _resolve_live_cron_route(
+    job: dict,
+    *,
+    platform: Any,
+    runtime_adapter: Any,
+    chat_id: Any,
+    thread_id: Any,
+    loop: Any,
+) -> tuple[Any, dict, Optional[dict]]:
+    """Build the router target/metadata for one live cron delivery.
+
+    Telegram positive-chat numeric topic IDs are ambiguous: they can be a
+    forum-style ``message_thread_id`` or a channel Direct-Messages topic. Keep
+    that probe and metadata policy in one place so final responses and progress
+    updates cannot route the same cron target into different lanes.
+    """
+    from gateway.config import Platform
+    from gateway.delivery import (
+        DeliveryTarget,
+        _looks_like_int,
+        looks_like_telegram_private_chat_id,
+    )
+
+    is_ambiguous_telegram_topic = (
+        platform == Platform.TELEGRAM
+        and thread_id is not None
+        and looks_like_telegram_private_chat_id(str(chat_id))
+        and _looks_like_int(str(thread_id))
+    )
+    route_via_dm_topic = is_ambiguous_telegram_topic and _is_channel_dm_topic(
+        runtime_adapter,
+        chat_id,
+        loop,
+        str(job.get("id") or "?"),
+    )
+
+    if route_via_dm_topic:
+        route_thread_id = None
+        route_metadata = {
+            "direct_messages_topic_id": str(thread_id),
+            "job_id": job["id"],
+        }
+        media_metadata: Optional[dict] = {
+            "direct_messages_topic_id": str(thread_id),
+        }
+    else:
+        route_thread_id = str(thread_id) if thread_id is not None else None
+        route_metadata = {"job_id": job["id"]}
+        if route_thread_id:
+            route_metadata["thread_id"] = route_thread_id
+        media_metadata = {"thread_id": thread_id} if thread_id else None
+
+    route_target = DeliveryTarget(
+        platform=platform,
+        chat_id=str(chat_id),
+        thread_id=route_thread_id,
+        is_explicit=True,
+    )
+    return route_target, route_metadata, media_metadata
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1635,47 +1697,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # anchorless cron send bypasses the DeliveryRouter's private-chat
             # reply-anchor requirement. Compute the routed metadata ONCE so both
             # the text send (via DeliveryRouter) and the media send agree.
-            from gateway.delivery import (
-                DeliveryRouter,
-                DeliveryTarget,
-                _looks_like_int,
-                looks_like_telegram_private_chat_id,
-            )
+            from gateway.delivery import DeliveryRouter
 
-            is_ambiguous_telegram_topic = (
-                platform == Platform.TELEGRAM
-                and thread_id is not None
-                and looks_like_telegram_private_chat_id(str(chat_id))
-                and _looks_like_int(str(thread_id))
+            route_target, route_metadata, media_metadata = _resolve_live_cron_route(
+                job,
+                platform=platform,
+                runtime_adapter=runtime_adapter,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                loop=loop,
             )
-            route_via_dm_topic = is_ambiguous_telegram_topic and _is_channel_dm_topic(
-                runtime_adapter, chat_id, loop, job["id"],
-            )
-            if route_via_dm_topic:
-                # Genuine Bot API channel Direct-Messages topic (#22773 mode 2):
-                # routed via direct_messages_topic_id, no bare thread_id.
-                route_thread_id = None
-                route_metadata = {
-                    "direct_messages_topic_id": str(thread_id),
-                    "job_id": job["id"],
-                }
-                # Media metadata mirrors the text routing so attachments land in
-                # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
-            else:
-                # Forum-style topic (private chat / supergroup) or non-topic
-                # target: route via message_thread_id (#52060).  Put thread_id in
-                # *route_metadata* (not just the DeliveryTarget) deliberately —
-                # the DeliveryRouter's private-chat topic detection
-                # (gateway/delivery.py) demands a reply anchor when thread_id is
-                # absent from metadata; cron deliveries have no inbound reply
-                # anchor, so the metadata key bypasses that check and lets the
-                # adapter route via a plain message_thread_id.
-                route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
-                if route_thread_id:
-                    route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"thread_id": thread_id} if thread_id else None
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
@@ -1691,13 +1722,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
-                    route_target = DeliveryTarget(
-                        platform=platform,
-                        chat_id=str(chat_id),
-                        thread_id=route_thread_id,
-                        is_explicit=True,
-                    )
+                    router = DeliveryRouter(config, adapters or {})
                     # Pass thread routing via the target (not a bare metadata
                     # "thread_id"): the router only applies its Telegram DM-topic
                     # detection when "thread_id"/"message_thread_id" are absent
@@ -1973,6 +1998,436 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     return None
 
 
+_DEFAULT_CRON_PROGRESS_INITIAL_DELAY = 90.0
+_DEFAULT_CRON_PROGRESS_INTERVAL = 120.0
+_CRON_PROGRESS_AUTO_SKILL_MARKERS = frozenset({
+    "github-ci-repair",
+    "github-code-review",
+    "github-operations",
+    "github-pr-workflow",
+    "requesting-code-review",
+    "systematic-debugging",
+    "test-driven-development",
+    "webapp-playwright-testing",
+})
+_CRON_PROGRESS_AUTO_TEXT_MARKERS = frozenset({
+    "cron-ready",
+    "implement",
+    "implementation",
+    "long-running",
+    "code change",
+    "pull request",
+    "github pr",
+    "focused checks",
+    "pytest",
+    "git diff",
+    "git status",
+})
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Coerce common config bool spellings without raising."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on", "enabled"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", "disabled"}:
+        return False
+    return default
+
+
+def _positive_float(value: Any, default: float, *, minimum: float = 0.0) -> float:
+    """Parse a finite timing value and fall back safely."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(parsed) or parsed < minimum:
+        return default
+    return parsed
+
+
+def _job_progress_override(job: dict) -> dict:
+    raw = job.get("progress")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _cron_progress_auto_enabled(job: dict) -> bool:
+    """Enable auto progress only for likely-long agent jobs."""
+    if job.get("no_agent"):
+        return False
+    if str(job.get("workdir") or "").strip():
+        return True
+
+    skills = {str(skill).strip().lower() for skill in (job.get("skills") or [])}
+    legacy_skill = str(job.get("skill") or "").strip().lower()
+    if legacy_skill:
+        skills.add(legacy_skill)
+    if skills & _CRON_PROGRESS_AUTO_SKILL_MARKERS:
+        return True
+
+    haystack = "\n".join(
+        str(part or "").lower()
+        for part in (
+            job.get("name"),
+            job.get("prompt"),
+            " ".join(str(skill) for skill in (job.get("skills") or [])),
+        )
+    )
+    return any(marker in haystack for marker in _CRON_PROGRESS_AUTO_TEXT_MARKERS)
+
+
+def _resolve_cron_progress_enabled(value: Any, job: dict) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = str(value if value is not None else "auto").strip().lower() or "auto"
+    if text in {"1", "true", "yes", "y", "on", "enabled", "all", "always"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", "disabled", "never"}:
+        return False
+    return _cron_progress_auto_enabled(job)
+
+
+def _extract_cron_progress_state_path(job: dict, workdir: Optional[str] = None) -> str:
+    """Find a concise state/plan reference for development-job updates."""
+    override = _job_progress_override(job).get("state_path")
+    if override:
+        return str(override)
+
+    prompt = str(job.get("prompt") or "")
+    match = re.search(
+        r"(?P<path>(?:[\w./~:-]+)?(?:state|progress|handoff)\.json)",
+        prompt,
+    )
+    if match:
+        return match.group("path")
+    match = re.search(
+        r"(?P<path>(?:[\w./~:-]+)?\.hermes/plans/[\w./~:-]+\.md)",
+        prompt,
+    )
+    if match:
+        return match.group("path")
+    return str(workdir or job.get("workdir") or "")
+
+
+def _resolve_cron_progress_config(job: dict, cfg: Any) -> dict:
+    """Resolve ``cron.progress`` plus the per-job override."""
+    job_progress = _job_progress_override(job)
+    cron_cfg = (cfg or {}).get("cron", {}) if isinstance(cfg, dict) else {}
+    raw_cfg = cron_cfg.get("progress", {}) if isinstance(cron_cfg, dict) else {}
+    if isinstance(raw_cfg, bool):
+        progress_cfg: dict = {"enabled": raw_cfg}
+    elif isinstance(raw_cfg, dict):
+        progress_cfg = dict(raw_cfg)
+    else:
+        progress_cfg = {}
+
+    enabled_value = job_progress.get(
+        "enabled",
+        progress_cfg.get("enabled", "auto"),
+    )
+    if isinstance(job.get("progress"), bool):
+        enabled_value = job["progress"]
+
+    return {
+        "enabled": _resolve_cron_progress_enabled(enabled_value, job),
+        "initial_delay_seconds": _positive_float(
+            job_progress.get(
+                "initial_delay_seconds",
+                progress_cfg.get("initial_delay_seconds"),
+            ),
+            _DEFAULT_CRON_PROGRESS_INITIAL_DELAY,
+        ),
+        "interval_seconds": _positive_float(
+            job_progress.get(
+                "interval_seconds",
+                progress_cfg.get("interval_seconds"),
+            ),
+            _DEFAULT_CRON_PROGRESS_INTERVAL,
+            minimum=1.0,
+        ),
+        "edit_in_place": _coerce_bool(
+            job_progress.get(
+                "edit_in_place",
+                progress_cfg.get("edit_in_place"),
+            ),
+            True,
+        ),
+        "state_path": str(job_progress.get("state_path") or ""),
+    }
+
+
+def _format_cron_progress_message(
+    job: dict,
+    activity: dict,
+    *,
+    elapsed_seconds: float,
+    state_path: str = "",
+) -> str:
+    """Render a compact owner-facing progress update."""
+    job_name = str(job.get("name") or job.get("id") or "cron job")
+    elapsed_mins = max(0, int(elapsed_seconds // 60))
+    api_call_count = activity.get("api_call_count", 0)
+    max_iterations = activity.get("max_iterations", 0)
+    action = activity.get("current_tool") or activity.get("last_activity_desc") or "working"
+    idle = activity.get("seconds_since_activity")
+
+    lines = [f"⏳ {job_name}", f"{elapsed_mins} min elapsed"]
+    if max_iterations:
+        lines[1] += f" — iteration {api_call_count}/{max_iterations}"
+    if action:
+        action_text = str(action)
+        if idle is not None:
+            action_text += f" ({float(idle):.0f}s since last activity)"
+        lines.append(f"Activity: {action_text}")
+    if state_path:
+        lines.append(f"State: {state_path}")
+    return "\n".join(lines)
+
+
+def _target_progress_key(target: dict) -> str:
+    return (
+        f"{target.get('platform', '').lower()}:"
+        f"{target.get('chat_id')}:{target.get('thread_id') or ''}"
+    )
+
+
+def _result_success(result: Any) -> bool:
+    if isinstance(result, dict):
+        return result.get("success") is True
+    return _confirm_adapter_delivery(result)
+
+
+def _result_message_id(result: Any) -> Optional[str]:
+    value = result.get("message_id") if isinstance(result, dict) else getattr(result, "message_id", None)
+    return str(value) if value else None
+
+
+def _deliver_cron_progress_update(
+    job: dict,
+    content: str,
+    progress_state: dict,
+    *,
+    adapters=None,
+    loop=None,
+    edit_in_place: bool = True,
+) -> Optional[str]:
+    """Best-effort progress delivery using the final-delivery route contract."""
+    targets = _resolve_delivery_targets(job)
+    if not targets:
+        return None
+
+    try:
+        from gateway.config import Platform, load_gateway_config
+        from tools.send_message_tool import _send_to_platform
+
+        config = load_gateway_config()
+    except Exception as exc:
+        return f"failed to load delivery config for cron progress: {exc}"
+
+    message_ids = progress_state.setdefault("message_ids", {})
+    delivery_errors: list[str] = []
+
+    for target in targets:
+        platform_name = str(target["platform"]).lower()
+        chat_id = target["chat_id"]
+        thread_id = target.get("thread_id")
+        key = _target_progress_key(target)
+
+        try:
+            platform = Platform(platform_name)
+        except (ValueError, KeyError):
+            delivery_errors.append(f"unknown platform '{platform_name}'")
+            continue
+
+        pconfig = config.platforms.get(platform)
+        if not pconfig or not pconfig.enabled:
+            delivery_errors.append(f"platform '{platform_name}' not configured/enabled")
+            continue
+
+        runtime_adapter = (adapters or {}).get(platform)
+        delivered = False
+        live_router_available = (
+            runtime_adapter is not None
+            and loop is not None
+            and getattr(loop, "is_running", lambda: False)()
+        )
+        if live_router_available and runtime_adapter is not None:
+            try:
+                from agent.async_utils import safe_schedule_threadsafe
+                from gateway.delivery import DeliveryRouter
+
+                message_id = message_ids.get(key)
+                if edit_in_place and message_id and hasattr(runtime_adapter, "edit_message"):
+                    edit_future = safe_schedule_threadsafe(
+                        runtime_adapter.edit_message(chat_id, message_id, content),
+                        loop,
+                    )
+                    if edit_future is not None:
+                        try:
+                            delivered = _result_success(edit_future.result(timeout=15))
+                        except TimeoutError:
+                            edit_future.cancel()
+                            logger.debug(
+                                "Job '%s': cron progress edit timed out",
+                                job.get("id", "?"),
+                            )
+
+                if not delivered:
+                    route_target, route_metadata, _ = _resolve_live_cron_route(
+                        job,
+                        platform=platform,
+                        runtime_adapter=runtime_adapter,
+                        chat_id=chat_id,
+                        thread_id=thread_id,
+                        loop=loop,
+                    )
+                    router = DeliveryRouter(config, adapters or {})
+                    send_future = safe_schedule_threadsafe(
+                        router._deliver_to_platform(
+                            route_target,
+                            content,
+                            route_metadata,
+                        ),
+                        loop,
+                    )
+                    if send_future is not None:
+                        try:
+                            send_result = send_future.result(timeout=15)
+                        except TimeoutError:
+                            # Avoid a duplicate fallback when the coroutine is
+                            # already executing on the gateway loop.
+                            delivered = not send_future.cancel()
+                        else:
+                            delivered = _result_success(send_result)
+                            new_message_id = _result_message_id(send_result)
+                            if delivered and new_message_id:
+                                message_ids[key] = new_message_id
+            except Exception as exc:
+                logger.debug(
+                    "Job '%s': live cron progress delivery to %s:%s failed: %s",
+                    job.get("id", "?"),
+                    platform_name,
+                    chat_id,
+                    exc,
+                )
+
+        if delivered:
+            continue
+        if live_router_available:
+            delivery_errors.append(
+                f"live routed progress delivery to {platform_name}:{chat_id} failed"
+            )
+            continue
+
+        # Without a live gateway adapter there is no router probe. Match the
+        # existing final-delivery standalone fallback and preserve thread_id.
+        try:
+            result: Any
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                content,
+                thread_id=thread_id,
+            )
+            try:
+                result = asyncio.run(coro)
+            except RuntimeError:
+                coro.close()
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            content,
+                            thread_id=thread_id,
+                        ),
+                    )
+                    result = future.result(timeout=15)
+            if isinstance(result, dict) and result.get("error"):
+                delivery_errors.append(f"progress delivery error: {result['error']}")
+            else:
+                new_message_id = _result_message_id(result)
+                if new_message_id:
+                    message_ids[key] = new_message_id
+        except Exception as exc:
+            delivery_errors.append(
+                f"progress delivery to {platform_name}:{chat_id} failed: {exc}"
+            )
+
+    return "; ".join(delivery_errors) if delivery_errors else None
+
+
+def _maybe_send_cron_progress(
+    job: dict,
+    agent: Any,
+    progress_cfg: dict,
+    progress_state: dict,
+    *,
+    adapters=None,
+    loop=None,
+    workdir: Optional[str] = None,
+    activity_override: Optional[dict] = None,
+) -> None:
+    """Send one rate-limited progress update without affecting the cron run."""
+    if not progress_cfg.get("enabled"):
+        return
+    now = time.monotonic()
+    started_at = float(progress_state.setdefault("started_at", now))
+    last_sent_at = float(progress_state.get("last_sent_at") or 0.0)
+    elapsed = now - started_at
+    if elapsed < float(progress_cfg["initial_delay_seconds"]):
+        return
+    if last_sent_at and now - last_sent_at < float(progress_cfg["interval_seconds"]):
+        return
+
+    activity = activity_override or {}
+    if not activity and hasattr(agent, "get_activity_summary"):
+        try:
+            activity = agent.get_activity_summary() or {}
+        except Exception:
+            activity = {}
+    state_path = str(progress_cfg.get("state_path") or "") or _extract_cron_progress_state_path(
+        job,
+        workdir,
+    )
+    message = _format_cron_progress_message(
+        job,
+        activity,
+        elapsed_seconds=elapsed,
+        state_path=state_path,
+    )
+    # Throttle failed routes too: progress must never become a retry storm.
+    progress_state["last_sent_at"] = now
+    try:
+        error = _deliver_cron_progress_update(
+            job,
+            message,
+            progress_state,
+            adapters=adapters,
+            loop=loop,
+            edit_in_place=bool(progress_cfg.get("edit_in_place", True)),
+        )
+        if error:
+            logger.debug(
+                "Job '%s': cron progress delivery issue: %s",
+                job.get("id", "?"),
+                error,
+            )
+    except Exception:
+        logger.debug(
+            "Job '%s': cron progress update failed",
+            job.get("id", "?"),
+            exc_info=True,
+        )
+
+
 _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
@@ -2199,6 +2654,51 @@ def _run_job_script_with_claim_heartbeat(
         # Event.wait() wakes immediately.  Keep completion bounded if the
         # heartbeat is already waiting on another process's jobs-file lock.
         heartbeat_thread.join(timeout=1.0)
+
+
+def _run_job_script_with_progress(
+    job: dict,
+    script_path: str,
+    progress_cfg: dict,
+    progress_state: dict,
+    *,
+    adapters=None,
+    loop=None,
+    workdir: Optional[str] = None,
+) -> tuple[bool, str]:
+    """Run a script while preserving claim and human progress heartbeats."""
+    if not progress_cfg.get("enabled"):
+        return _run_job_script_with_claim_heartbeat(job, script_path)
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    script_context = contextvars.copy_context()
+    future = pool.submit(
+        script_context.run,
+        _run_job_script_with_claim_heartbeat,
+        job,
+        script_path,
+    )
+    try:
+        while True:
+            done, _ = concurrent.futures.wait({future}, timeout=5.0)
+            if done:
+                return future.result()
+            _maybe_send_cron_progress(
+                job,
+                None,
+                progress_cfg,
+                progress_state,
+                adapters=adapters,
+                loop=loop,
+                workdir=workdir,
+                activity_override={
+                    "last_activity_desc": f"running script: {script_path}",
+                    "current_tool": "script",
+                    "seconds_since_activity": 0.0,
+                },
+            )
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
 
 
 def _parse_wake_gate(script_output: str) -> bool:
@@ -2549,7 +3049,11 @@ def _guard_job_credential_exfil(job: dict) -> None:
 
 
 def run_job(
-    job: dict, *, defer_agent_teardown: Optional[list] = None
+    job: dict,
+    *,
+    defer_agent_teardown: Optional[list] = None,
+    adapters=None,
+    loop=None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -2563,6 +3067,10 @@ def run_job(
     torn-down async client (defense-in-depth alongside the interpreter-shutdown
     guard). When ``None`` (the default) teardown happens inline as before, so
     every existing caller is unchanged.
+
+    ``adapters`` and ``loop`` carry the live gateway delivery context used for
+    in-run progress updates. They remain keyword-only so adding visibility does
+    not change the historical positional call contract.
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -2608,7 +3116,28 @@ def run_job(
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
+            try:
+                _script_progress_source = load_config() or {}
+            except Exception:
+                _script_progress_source = {}
+            _script_progress_cfg = _resolve_cron_progress_config(
+                job,
+                _script_progress_source,
+            )
+            _script_progress_state = {
+                "started_at": time.monotonic(),
+                "last_sent_at": 0.0,
+                "message_ids": {},
+            }
+            ok, output = _run_job_script_with_progress(
+                job,
+                script_path,
+                _script_progress_cfg,
+                _script_progress_state,
+                adapters=adapters,
+                loop=loop,
+                workdir=_job_workdir,
+            )
         finally:
             if _prior_cwd is not None:
                 try:
@@ -2712,7 +3241,6 @@ def run_job(
                 )
         if _session_db_timeout is None:
             try:
-                from hermes_cli.config import load_config
                 _cfg = load_config() or {}
                 _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
                 _configured = _cron_cfg.get("session_db_timeout_seconds")
@@ -2755,7 +3283,27 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
+        try:
+            _script_progress_source = load_config() or {}
+        except Exception:
+            _script_progress_source = {}
+        _script_progress_cfg = _resolve_cron_progress_config(
+            job,
+            _script_progress_source,
+        )
+        _script_progress_state = {
+            "started_at": time.monotonic(),
+            "last_sent_at": 0.0,
+            "message_ids": {},
+        }
+        prerun_script = _run_job_script_with_progress(
+            job,
+            script_path,
+            _script_progress_cfg,
+            _script_progress_state,
+            adapters=adapters,
+            loop=loop,
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
@@ -3222,6 +3770,12 @@ def run_job(
         else:
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        _progress_cfg = _resolve_cron_progress_config(job, _cfg)
+        _progress_state = {
+            "started_at": time.monotonic(),
+            "last_sent_at": 0.0,
+            "message_ids": {},
+        }
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
         # the claim TTL is a dead-owner detector, but without a heartbeat a
@@ -3265,8 +3819,9 @@ def run_job(
         try:
             if _cron_inactivity_limit is None:
                 # Unlimited — no inactivity watchdog, but a one-shot still
-                # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot:
+                # needs its run_claim heartbeat and progress-enabled jobs still
+                # need visibility, so poll instead of blocking.
+                if _is_oneshot or _progress_cfg.get("enabled"):
                     result = None
                     while True:
                         done, _ = concurrent.futures.wait(
@@ -3276,6 +3831,15 @@ def run_job(
                             result = _cron_future.result()
                             break
                         _heartbeat_run_claim_if_due()
+                        _maybe_send_cron_progress(
+                            job,
+                            agent,
+                            _progress_cfg,
+                            _progress_state,
+                            adapters=adapters,
+                            loop=loop,
+                            workdir=_job_workdir,
+                        )
                 else:
                     result = _cron_future.result()
             else:
@@ -3288,6 +3852,15 @@ def run_job(
                         result = _cron_future.result()
                         break
                     _heartbeat_run_claim_if_due()
+                    _maybe_send_cron_progress(
+                        job,
+                        agent,
+                        _progress_cfg,
+                        _progress_state,
+                        adapters=adapters,
+                        loop=loop,
+                        workdir=_job_workdir,
+                    )
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
@@ -3573,8 +4146,16 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
+            _run_job_kwargs: dict[str, Any] = {
+                "defer_agent_teardown": _deferred_agents,
+            }
+            if adapters is not None:
+                _run_job_kwargs["adapters"] = adapters
+            if loop is not None:
+                _run_job_kwargs["loop"] = loop
             success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
+                job,
+                **_run_job_kwargs,
             )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3281,6 +3281,7 @@ def run_job(
     # the whole agent run. We pass the result into _build_job_prompt so
     # the script is only executed once.
     prerun_script = None
+    _progress_state = None
     script_path = job.get("script")
     if script_path:
         try:
@@ -3291,7 +3292,7 @@ def run_job(
             job,
             _script_progress_source,
         )
-        _script_progress_state = {
+        _progress_state = {
             "started_at": time.monotonic(),
             "last_sent_at": 0.0,
             "message_ids": {},
@@ -3300,7 +3301,7 @@ def run_job(
             job,
             script_path,
             _script_progress_cfg,
-            _script_progress_state,
+            _progress_state,
             adapters=adapters,
             loop=loop,
         )
@@ -3771,11 +3772,12 @@ def run_job(
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _progress_cfg = _resolve_cron_progress_config(job, _cfg)
-        _progress_state = {
-            "started_at": time.monotonic(),
-            "last_sent_at": 0.0,
-            "message_ids": {},
-        }
+        if _progress_state is None:
+            _progress_state = {
+                "started_at": time.monotonic(),
+                "last_sent_at": 0.0,
+                "message_ids": {},
+            }
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
         # the claim TTL is a dead-owner detector, but without a heartbeat a

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2728,6 +2728,15 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Human-readable progress updates for long-running cron jobs.
+        # "auto" enables likely-long agent jobs; true enables every run,
+        # including no_agent scripts. Per-job ``progress`` overrides these.
+        "progress": {
+            "enabled": "auto",
+            "initial_delay_seconds": 90,
+            "interval_seconds": 120,
+            "edit_in_place": True,
+        },
         # Timeout (seconds) for SessionDB() init inside cron jobs.
         # SessionDB opens/migrates state.db synchronously and has no timeout
         # of its own against a wedged sqlite3.connect. An unbounded hang here

--- a/tests/cron/test_cron_progress.py
+++ b/tests/cron/test_cron_progress.py
@@ -1,0 +1,497 @@
+"""Regression tests for configurable cron progress updates."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+
+class FakeProgressAgent:
+    def get_activity_summary(self):
+        return {
+            "last_activity_desc": "running focused tests",
+            "seconds_since_activity": 3.0,
+            "current_tool": "terminal",
+            "api_call_count": 4,
+            "max_iterations": 90,
+        }
+
+
+def test_auto_progress_policy_targets_likely_long_agent_jobs():
+    from cron.scheduler import _cron_progress_auto_enabled
+
+    assert _cron_progress_auto_enabled(
+        {"name": "repo worker", "workdir": "/repo", "no_agent": False}
+    )
+    assert _cron_progress_auto_enabled(
+        {"skills": ["github-ci-repair"], "no_agent": False}
+    )
+    assert not _cron_progress_auto_enabled(
+        {"name": "daily report", "no_agent": False}
+    )
+    assert not _cron_progress_auto_enabled(
+        {
+            "name": "implementation watchdog",
+            "no_agent": True,
+            "script": "watch.py",
+        }
+    )
+
+
+def test_progress_config_uses_global_and_per_job_values():
+    from cron.scheduler import _resolve_cron_progress_config
+
+    global_cfg = {
+        "cron": {
+            "progress": {
+                "enabled": True,
+                "initial_delay_seconds": 30,
+                "interval_seconds": 45,
+                "edit_in_place": False,
+            }
+        }
+    }
+    job = {
+        "name": "worker",
+        "progress": {
+            "enabled": False,
+            "initial_delay_seconds": 5,
+            "interval_seconds": 7,
+            "edit_in_place": True,
+            "state_path": "state.json",
+        },
+    }
+
+    resolved = _resolve_cron_progress_config(job, global_cfg)
+
+    assert resolved == {
+        "enabled": False,
+        "initial_delay_seconds": 5.0,
+        "interval_seconds": 7.0,
+        "edit_in_place": True,
+        "state_path": "state.json",
+    }
+
+
+def test_progress_config_rejects_non_finite_timing_values():
+    from cron.scheduler import _resolve_cron_progress_config
+
+    resolved = _resolve_cron_progress_config(
+        {
+            "progress": {
+                "enabled": True,
+                "initial_delay_seconds": float("nan"),
+                "interval_seconds": float("inf"),
+            }
+        },
+        {},
+    )
+
+    assert resolved["initial_delay_seconds"] == 90.0
+    assert resolved["interval_seconds"] == 120.0
+
+
+def test_default_config_exposes_cron_progress_settings():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cron_config = cast(dict[str, Any], DEFAULT_CONFIG["cron"])
+    assert cron_config["progress"] == {
+        "enabled": "auto",
+        "initial_delay_seconds": 90,
+        "interval_seconds": 120,
+        "edit_in_place": True,
+    }
+
+
+def test_job_progress_override_is_normalized_and_persisted(tmp_path):
+    from cron.jobs import create_job, get_job, update_job, use_cron_store
+
+    with use_cron_store(tmp_path):
+        job = create_job(
+            prompt="",
+            schedule="every 5m",
+            deliver="local",
+            script="watch.py",
+            no_agent=True,
+            progress={
+                "enabled": "all",
+                "interval_seconds": 10,
+                "state_path": "state.json",
+                "ignored": "drop me",
+            },
+        )
+        stored = get_job(job["id"])
+        assert stored is not None
+        assert stored["progress"] == {
+            "enabled": "all",
+            "interval_seconds": 10,
+            "state_path": "state.json",
+        }
+
+        updated = update_job(job["id"], {"progress": "off"})
+        assert updated is not None
+        assert updated["progress"] == {"enabled": "off"}
+
+        cleared = update_job(job["id"], {"progress": {}})
+        assert cleared is not None
+        assert cleared.get("progress") is None
+
+
+def test_cronjob_schema_exposes_progress_override():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    parameters = cast(dict[str, Any], CRONJOB_SCHEMA["parameters"])
+    progress = parameters["properties"]["progress"]
+    assert {entry["type"] for entry in progress["anyOf"][:2]} == {
+        "boolean",
+        "string",
+    }
+    assert set(progress["anyOf"][2]["properties"]) == {
+        "enabled",
+        "initial_delay_seconds",
+        "interval_seconds",
+        "edit_in_place",
+        "state_path",
+    }
+
+
+def test_cronjob_tool_create_update_and_clear_progress(tmp_path, monkeypatch):
+    from cron.jobs import use_cron_store
+    from tools.cronjob_tools import cronjob
+
+    home = tmp_path / ".hermes"
+    (home / "scripts").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with use_cron_store(home):
+        created = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 5m",
+                deliver="local",
+                script="watch.py",
+                no_agent=True,
+                progress={"enabled": True, "initial_delay_seconds": 1},
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["progress"] == {
+            "enabled": True,
+            "initial_delay_seconds": 1,
+        }
+
+        job_id = created["job_id"]
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, progress="off")
+        )
+        assert updated["job"]["progress"] == {"enabled": "off"}
+
+        cleared = json.loads(
+            cronjob(action="update", job_id=job_id, progress={})
+        )
+        assert "progress" not in cleared["job"]
+
+
+def test_progress_message_is_compact_and_includes_state_reference():
+    from cron.scheduler import _format_cron_progress_message
+
+    message = _format_cron_progress_message(
+        {"id": "abc123", "name": "repo worker"},
+        FakeProgressAgent().get_activity_summary(),
+        elapsed_seconds=367,
+        state_path=".hermes/plans/dev/state.json",
+    )
+
+    assert message.splitlines() == [
+        "⏳ repo worker",
+        "6 min elapsed — iteration 4/90",
+        "Activity: terminal (3s since last activity)",
+        "State: .hermes/plans/dev/state.json",
+    ]
+
+
+def test_maybe_send_progress_is_rate_limited(monkeypatch):
+    import cron.scheduler as scheduler
+
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_cron_progress_update",
+        lambda job, content, progress_state, **kwargs: sent.append(content),
+    )
+    monkeypatch.setattr(scheduler.time, "monotonic", lambda: 125.0)
+
+    cfg = {
+        "enabled": True,
+        "initial_delay_seconds": 10.0,
+        "interval_seconds": 60.0,
+        "edit_in_place": True,
+        "state_path": "",
+    }
+    state = {"started_at": 100.0, "last_sent_at": 0.0, "message_ids": {}}
+    job = {
+        "id": "job1",
+        "name": "repo worker",
+        "workdir": "/repo",
+        "prompt": "Use .hermes/plans/dev/state.json",
+    }
+
+    scheduler._maybe_send_cron_progress(
+        job,
+        FakeProgressAgent(),
+        cfg,
+        state,
+        workdir="/repo",
+    )
+    scheduler._maybe_send_cron_progress(
+        job,
+        FakeProgressAgent(),
+        cfg,
+        state,
+        workdir="/repo",
+    )
+
+    assert len(sent) == 1
+    assert state["last_sent_at"] == 125.0
+
+
+def test_live_route_helper_distinguishes_forum_and_direct_message_topics(monkeypatch):
+    import cron.scheduler as scheduler
+    from gateway.config import Platform
+
+    job = {"id": "job1"}
+    adapter = object()
+    loop = object()
+
+    monkeypatch.setattr(scheduler, "_is_channel_dm_topic", lambda *args: False)
+    forum_target, forum_metadata, forum_media = scheduler._resolve_live_cron_route(
+        job,
+        platform=Platform.TELEGRAM,
+        runtime_adapter=adapter,
+        chat_id="123",
+        thread_id="42",
+        loop=loop,
+    )
+    assert forum_target.thread_id == "42"
+    assert forum_metadata == {"job_id": "job1", "thread_id": "42"}
+    assert forum_media == {"thread_id": "42"}
+
+    monkeypatch.setattr(scheduler, "_is_channel_dm_topic", lambda *args: True)
+    dm_target, dm_metadata, dm_media = scheduler._resolve_live_cron_route(
+        job,
+        platform=Platform.TELEGRAM,
+        runtime_adapter=adapter,
+        chat_id="123",
+        thread_id="42",
+        loop=loop,
+    )
+    assert dm_target.thread_id is None
+    assert dm_metadata == {
+        "job_id": "job1",
+        "direct_messages_topic_id": "42",
+    }
+    assert dm_media == {"direct_messages_topic_id": "42"}
+
+
+def test_progress_initial_send_uses_router_topic_metadata(monkeypatch):
+    import agent.async_utils as async_utils
+    import cron.scheduler as scheduler
+    import gateway.config as gateway_config
+    import gateway.delivery as delivery
+
+    platform = gateway_config.Platform.TELEGRAM
+    routed = []
+
+    class FakeLoop:
+        def is_running(self):
+            return True
+
+    class FakeAdapter:
+        async def send(self, *args, **kwargs):
+            raise AssertionError("progress must send through DeliveryRouter")
+
+    async def fake_deliver(self, target, content, metadata):
+        routed.append((target, content, metadata))
+        return SimpleNamespace(success=True, message_id="msg-1")
+
+    def fake_safe_schedule(coro, loop):
+        result = asyncio.run(coro)
+        return SimpleNamespace(result=lambda timeout=None: result, cancel=lambda: True)
+
+    config = SimpleNamespace(
+        platforms={platform: SimpleNamespace(enabled=True)},
+        filter_silence_narration=True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_delivery_targets",
+        lambda job: [
+            {"platform": "telegram", "chat_id": "123", "thread_id": "42"}
+        ],
+    )
+    monkeypatch.setattr(scheduler, "_is_channel_dm_topic", lambda *args: True)
+    monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: config)
+    monkeypatch.setattr(delivery.DeliveryRouter, "_deliver_to_platform", fake_deliver)
+    monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", fake_safe_schedule)
+
+    state = {"message_ids": {}}
+    error = scheduler._deliver_cron_progress_update(
+        {"id": "job1", "name": "worker"},
+        "working",
+        state,
+        adapters={platform: FakeAdapter()},
+        loop=FakeLoop(),
+    )
+
+    assert error is None
+    target, content, metadata = routed[0]
+    assert content == "working"
+    assert target.thread_id is None
+    assert metadata == {
+        "job_id": "job1",
+        "direct_messages_topic_id": "42",
+    }
+    assert state["message_ids"]["telegram:123:42"] == "msg-1"
+
+
+@pytest.mark.parametrize(
+    ("future_mode", "expect_error"),
+    (("failure", True), ("ambiguous_timeout", False)),
+)
+def test_live_router_failure_never_falls_back_to_raw_send(
+    monkeypatch,
+    future_mode,
+    expect_error,
+):
+    import agent.async_utils as async_utils
+    import cron.scheduler as scheduler
+    import gateway.config as gateway_config
+    import tools.send_message_tool as send_message_tool
+
+    platform = gateway_config.Platform.TELEGRAM
+    raw_sends = []
+
+    class FakeLoop:
+        def is_running(self):
+            return True
+
+    class FakeAdapter:
+        pass
+
+    class FakeFuture:
+        def result(self, timeout=None):
+            if future_mode == "ambiguous_timeout":
+                raise TimeoutError
+            return SimpleNamespace(success=False)
+
+        def cancel(self):
+            return future_mode != "ambiguous_timeout"
+
+    def fake_safe_schedule(coro, loop):
+        coro.close()
+        return FakeFuture()
+
+    async def must_not_raw_send(*args, **kwargs):
+        raw_sends.append((args, kwargs))
+        raise AssertionError("live router failures must not fall back to raw send")
+
+    config = SimpleNamespace(
+        platforms={platform: SimpleNamespace(enabled=True)},
+        filter_silence_narration=True,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_delivery_targets",
+        lambda job: [
+            {"platform": "telegram", "chat_id": "123", "thread_id": "42"}
+        ],
+    )
+    monkeypatch.setattr(scheduler, "_is_channel_dm_topic", lambda *args: True)
+    monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: config)
+    monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", fake_safe_schedule)
+    monkeypatch.setattr(send_message_tool, "_send_to_platform", must_not_raw_send)
+
+    error = scheduler._deliver_cron_progress_update(
+        {"id": "job1"},
+        "working",
+        {"message_ids": {}},
+        adapters={platform: FakeAdapter()},
+        loop=FakeLoop(),
+    )
+
+    assert bool(error) is expect_error
+    assert raw_sends == []
+
+
+def test_progress_existing_message_edits_without_resending(monkeypatch):
+    import agent.async_utils as async_utils
+    import cron.scheduler as scheduler
+    import gateway.config as gateway_config
+
+    platform = gateway_config.Platform.TELEGRAM
+
+    class FakeLoop:
+        def is_running(self):
+            return True
+
+    class FakeAdapter:
+        def __init__(self):
+            self.edits = []
+
+        async def edit_message(self, chat_id, message_id, text):
+            self.edits.append((chat_id, message_id, text))
+            return SimpleNamespace(success=True)
+
+    def fake_safe_schedule(coro, loop):
+        result = asyncio.run(coro)
+        return SimpleNamespace(result=lambda timeout=None: result, cancel=lambda: True)
+
+    config = SimpleNamespace(platforms={platform: SimpleNamespace(enabled=True)})
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_delivery_targets",
+        lambda job: [
+            {"platform": "telegram", "chat_id": "123", "thread_id": "42"}
+        ],
+    )
+    monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: config)
+    monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", fake_safe_schedule)
+
+    adapter = FakeAdapter()
+    state = {"message_ids": {"telegram:123:42": "msg-1"}}
+    error = scheduler._deliver_cron_progress_update(
+        {"id": "job1"},
+        "still working",
+        state,
+        adapters={platform: adapter},
+        loop=FakeLoop(),
+    )
+
+    assert error is None
+    assert adapter.edits == [("123", "msg-1", "still working")]
+
+
+def test_progress_script_wrapper_preserves_claim_heartbeat_path(monkeypatch):
+    import cron.scheduler as scheduler
+
+    calls = []
+    monkeypatch.setattr(
+        scheduler,
+        "_run_job_script_with_claim_heartbeat",
+        lambda job, script_path: calls.append((job["id"], script_path))
+        or (True, "done"),
+    )
+
+    result = scheduler._run_job_script_with_progress(
+        {"id": "job1"},
+        "watch.py",
+        {"enabled": True},
+        {"started_at": 0.0, "last_sent_at": 0.0, "message_ids": {}},
+    )
+
+    assert result == (True, "done")
+    assert calls == [("job1", "watch.py")]

--- a/tests/cron/test_cron_progress.py
+++ b/tests/cron/test_cron_progress.py
@@ -495,3 +495,121 @@ def test_progress_script_wrapper_preserves_claim_heartbeat_path(monkeypatch):
 
     assert result == (True, "done")
     assert calls == [("job1", "watch.py")]
+
+
+def test_run_job_reuses_script_progress_state_for_agent_heartbeat(
+    tmp_path, monkeypatch
+):
+    import sys
+
+    import cron.scheduler as scheduler
+    import hermes_state
+    from hermes_cli import env_loader, runtime_provider
+    from tools import mcp_tool
+
+    observed = {}
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            pass
+
+        def run_conversation(self, *_args, **_kwargs):
+            return {
+                "completed": True,
+                "final_response": "done",
+                "messages": [],
+            }
+
+        def get_activity_summary(self):
+            return {"seconds_since_activity": 0.0}
+
+        def close(self):
+            pass
+
+    fake_run_agent = type(sys)("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(
+        scheduler,
+        "_build_job_prompt",
+        lambda job, prerun_script=None: "run the agent",
+    )
+    monkeypatch.setattr(scheduler, "_resolve_origin", lambda job: None)
+    monkeypatch.setattr(scheduler, "_resolve_delivery_target", lambda job: None)
+    monkeypatch.setattr(
+        scheduler, "_resolve_cron_enabled_toolsets", lambda job, cfg: None
+    )
+    monkeypatch.setattr(scheduler, "_teardown_cron_agent", lambda *_args: None)
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: None)
+    monkeypatch.setattr(env_loader, "reset_secret_source_cache", lambda: None)
+    monkeypatch.setattr(env_loader, "load_hermes_dotenv", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "test",
+            "api_key": "test",
+            "base_url": "http://test.local",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", lambda: [])
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "60")
+
+    def fake_script_progress(job, script_path, cfg, state, **_kwargs):
+        observed["script_state"] = state
+        state["last_sent_at"] = 120.0
+        state["message_ids"]["telegram:123:42"] = "script-progress-message"
+        return True, '{"wakeAgent": true}'
+
+    monkeypatch.setattr(
+        scheduler, "_run_job_script_with_progress", fake_script_progress
+    )
+
+    real_wait = scheduler.concurrent.futures.wait
+    wait_calls = 0
+
+    def fake_wait(futures, timeout):
+        nonlocal wait_calls
+        wait_calls += 1
+        if wait_calls == 1:
+            return set(), set(futures)
+        return real_wait(futures, timeout=timeout)
+
+    monkeypatch.setattr(scheduler.concurrent.futures, "wait", fake_wait)
+
+    def fake_agent_progress(job, agent, cfg, state, **_kwargs):
+        observed["agent_state"] = state
+        observed["edit_in_place"] = cfg["edit_in_place"]
+
+    monkeypatch.setattr(
+        scheduler, "_maybe_send_cron_progress", fake_agent_progress
+    )
+
+    success, _output, response, error = scheduler.run_job(
+        {
+            "id": "job1",
+            "name": "script then agent",
+            "script": "watch.py",
+            "model": "test-model",
+            "schedule_display": "manual",
+            "progress": {
+                "enabled": True,
+                "initial_delay_seconds": 1,
+                "interval_seconds": 1,
+                "edit_in_place": True,
+            },
+        }
+    )
+
+    assert success is True, error
+    assert response == "done"
+    assert observed["agent_state"] is observed["script_state"]
+    assert observed["agent_state"]["last_sent_at"] == 120.0
+    assert observed["agent_state"]["message_ids"] == {
+        "telegram:123:42": "script-progress-message"
+    }
+    assert observed["edit_in_place"] is True

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -205,6 +205,43 @@ def test_run_one_job_delivers_before_agent_teardown(monkeypatch):
     assert order == ["run_job", "deliver", "agent.close", "cleanup_stale"], order
 
 
+def test_run_one_job_threads_progress_context_without_dropping_teardown(monkeypatch):
+    """Live adapter context is keyword-only and always accompanies the holder."""
+    adapters = object()
+    loop = object()
+    observed = {}
+
+    def fake_run_job(
+        job,
+        *,
+        defer_agent_teardown=None,
+        adapters=None,
+        loop=None,
+    ):
+        observed.update(
+            holder=defer_agent_teardown,
+            adapters=adapters,
+            loop=loop,
+        )
+        return (True, "out", "final response", None)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *args, **kwargs: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *args, **kwargs: None)
+
+    ok = s.run_one_job(
+        {"id": "j-progress", "name": "t"},
+        adapters=adapters,
+        loop=loop,
+    )
+
+    assert ok is True
+    assert isinstance(observed["holder"], list)
+    assert observed["adapters"] is adapters
+    assert observed["loop"] is loop
+
+
 def test_run_one_job_tears_down_deferred_agent_when_delivery_raises(monkeypatch):
     """Even if _deliver_result raises, the deferred agent is still torn down
     (no fd/client leak — #10200). Teardown lives in a finally around delivery.

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("progress"):
+        result["progress"] = job["progress"]
     return result
 
 
@@ -677,6 +679,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    progress: Optional[Union[bool, str, Dict[str, Any]]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +753,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                progress=progress,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -923,6 +927,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if progress is not None:
+                updates["progress"] = progress
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1085,6 +1091,23 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "progress": {
+                "description": "Optional progress-heartbeat override. A bool/string controls enabled; an object may set enabled, initial_delay_seconds, interval_seconds, edit_in_place, and state_path. Omit to inherit cron.progress; pass false/off to disable for this job.",
+                "anyOf": [
+                    {"type": "boolean"},
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "enabled": {"type": ["boolean", "string"]},
+                            "initial_delay_seconds": {"type": "number"},
+                            "interval_seconds": {"type": "number"},
+                            "edit_in_place": {"type": "boolean"},
+                            "state_path": {"type": "string"},
+                        },
+                    },
+                ],
+            },
         },
         "required": ["action"]
     }
@@ -1140,6 +1163,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
+        progress=args.get("progress"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary
- add configurable progress heartbeats under `cron.progress` with per-job overrides
- preserve deferred agent teardown until after final delivery
- route live heartbeat sends through `DeliveryRouter` with the same Telegram forum/direct-message-topic metadata as final cron delivery
- keep raw standalone fallback only when no live router exists, preventing duplicate or misrouted retries
- remove the original PR's behavioral environment overrides

## Supersedes
Replaces #49165 on current `main` after its branch became conflicting and over 1,000 commits stale. This port addresses review `#pullrequestreview-4698403579` without rewriting the old branch history.

## Verification
- `python3 -m pytest tests/cron/test_cron_progress.py tests/cron/test_run_one_job.py -q` — 26 passed
- `python3 -m pytest tests/cron -q` — 709 passed
- `python3 -m pytest tests/gateway/test_telegram_thread_fallback.py -q` — 50 passed
- focused `ruff check` — passed
- `git diff --check` — passed
- no `HERMES_CRON_PROGRESS_*` references
- Codex `gpt-5.6-terra` focused audit — blocker fixed; re-audit approved
- Claude OAuth `claude-fable-5` final review — approved; API not used

## Safety notes
Progress uses the configured cron targets and existing gateway routing. Failed live-router sends never fall back to a second raw send. Heartbeat failures are throttled and do not fail the cron run. No production deployment is included.
