### PR TITLE
fix(gateway): expose stable machine identity in health

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1525,8 +1525,33 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
+        import socket as _socket
+
+        hostname = ""
+        try:
+            hostname = _socket.gethostname()
+        except Exception:
+            pass
+
+        local_ip = ""
+        try:
+            # Ask the kernel which local interface would carry normal traffic.
+            # UDP connect does not send a packet, so no external service is
+            # contacted by this health check.
+            with _socket.socket(_socket.AF_INET, _socket.SOCK_DGRAM) as sock:
+                sock.connect(("8.8.8.8", 80))
+                local_ip = sock.getsockname()[0]
+        except Exception:
+            pass
+
         return web.json_response(
-            {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
+            {
+                "status": "ok",
+                "platform": "hermes-agent",
+                "version": _hermes_version(),
+                "hostname": hostname,
+                "local_ip": local_ip,
+            }
         )
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -725,6 +725,18 @@ class TestHealthEndpoint:
             assert data["version"] != ""
 
     @pytest.mark.asyncio
+    async def test_health_reports_machine_identity(self, adapter):
+        """Direct clients need stable identity to keep multiple gateways distinct."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+            data = await resp.json()
+            assert isinstance(data["hostname"], str)
+            assert data["hostname"]
+            assert isinstance(data["local_ip"], str)
+
+    @pytest.mark.asyncio
     async def test_v1_health_alias_returns_ok(self, adapter):
         """GET /v1/health should return the same response as /health."""
         app = _create_app(adapter)


### PR DESCRIPTION
Summary:
- Return gateway hostname and local interface IP from /health and /v1/health.
- Let direct clients keep multiple gateways distinct instead of merging unnamed routes.
- Preserve health availability if identity lookup fails.

Reproduction: two reachable gateways returned the same anonymous health shape. A mobile direct client counted both routes but could not assign the unnamed route a stable machine identity, causing the wrong machine name to be combined with the active transport.

Verification:
- Focused gateway health tests: 13 passed.
- Live MacBook Pro health: hostname Igors-MacBook-Pro.local, local_ip 192.168.68.70.
- Physical Android UI after gateway restart: Igors-MacBook-Pro - USB.