### PR TITLE
fix(desktop): normalize Windows workspace identity 🩷

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -166,6 +166,69 @@ describe('mergeRepoWorktreeGroups (visual enhancer)', () => {
     expect(merged[0].sessions).toHaveLength(1)
   })
 
+  it('deduplicates Windows worktree paths across separator and case variants', () => {
+    const repo = {
+      id: String.raw`D:\IvoDimitrov-Universe`,
+      path: String.raw`D:\IvoDimitrov-Universe`,
+      groups: [
+        lane({
+          id: String.raw`D:\IvoDimitrov-Universe-wt-feature`,
+          label: 'IvoDimitrov-Universe-wt-feature',
+          isMain: false,
+          path: String.raw`D:\IvoDimitrov-Universe-wt-feature`,
+          sessions: [makeSession(String.raw`D:\IvoDimitrov-Universe-wt-feature`)]
+        })
+      ]
+    }
+    const discovered: HermesGitWorktree[] = [
+      {
+        branch: 'feature',
+        detached: false,
+        isMain: false,
+        locked: false,
+        path: 'd:/ivodimitrov-universe-wt-feature/'
+      }
+    ]
+
+    const merged = mergeRepoWorktreeGroups(repo, discovered)
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].sessions).toHaveLength(1)
+    expect(merged[0].path).toBe(String.raw`D:\IvoDimitrov-Universe-wt-feature`)
+  })
+
+  it('keeps one home lane when the Windows main checkout uses mixed separators', () => {
+    const repo = {
+      id: String.raw`D:\IvoDimitrov-Universe`,
+      path: String.raw`D:\IvoDimitrov-Universe`,
+      groups: [
+        lane({
+          id: String.raw`D:\IvoDimitrov-Universe::branch::master`,
+          label: 'master',
+          isMain: true,
+          path: String.raw`D:\IvoDimitrov-Universe`,
+          sessions: [makeSession(String.raw`D:\IvoDimitrov-Universe`)]
+        })
+      ]
+    }
+    const discovered: HermesGitWorktree[] = [
+      {
+        branch: 'master',
+        detached: false,
+        isMain: true,
+        locked: false,
+        path: 'D:/IvoDimitrov-Universe'
+      }
+    ]
+
+    const merged = mergeRepoWorktreeGroups(repo, discovered)
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].isHome).toBe(true)
+    expect(merged[0].path).toBe(repo.path)
+    expect(merged[0].sessions).toHaveLength(1)
+  })
+
   it('is a no-op when git worktree list is unavailable (remote backend)', () => {
     const groups = [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -198,7 +198,7 @@ export function mergeRepoWorktreeGroups(
     const branch = worktree.branch?.trim()
 
     if (wtPath && branch && !worktree.detached) {
-      liveBranchByPath.set(wtPath, branch)
+      liveBranchByPath.set(pathKey(wtPath), branch)
       livePathByBranch.set(branch.toLowerCase(), worktree.path.trim())
     }
   }
@@ -224,7 +224,7 @@ export function mergeRepoWorktreeGroups(
       return group
     }
 
-    const branchForPath = liveBranchByPath.get(normalizePath(group.path))
+    const branchForPath = liveBranchByPath.get(pathKey(group.path))
 
     if (branchForPath) {
       return branchForPath !== group.label ? { ...group, label: branchForPath } : group
@@ -232,7 +232,7 @@ export function mergeRepoWorktreeGroups(
 
     const livePath = livePathByBranch.get(normalize(group.label))
 
-    if (livePath && normalizePath(livePath) !== normalizePath(group.path)) {
+    if (livePath && pathKey(livePath) !== pathKey(group.path)) {
       return { ...group, id: livePath, path: livePath }
     }
 
@@ -275,7 +275,7 @@ export function mergeRepoWorktreeGroups(
   const merged: SidebarSessionGroup[] = []
 
   for (const group of reconciled) {
-    const key = !group.isMain && group.path ? normalizePath(group.path) : ''
+    const key = !group.isMain && group.path ? pathKey(group.path) : ''
     const existing = key ? byPath.get(key) : undefined
 
     if (existing) {
@@ -295,7 +295,7 @@ export function mergeRepoWorktreeGroups(
   }
 
   const seenIds = new Set(merged.map(group => group.id))
-  const seenPaths = new Set(merged.map(group => group.path).filter((path): path is string => Boolean(path)))
+  const seenPaths = new Set(merged.map(group => pathKey(group.path)).filter(Boolean))
   // Dedupe by branch label too: a branch shows once even if it's checked out in
   // a linked worktree AND already has a session lane.
   const seenLabels = new Set(merged.map(group => group.label.toLowerCase()))
@@ -327,7 +327,7 @@ export function mergeRepoWorktreeGroups(
     const id = worktree.isMain ? branchLaneId(repo.id, label) : wtPath
 
     const alreadySeen =
-      seenIds.has(id) || seenLabels.has(label.toLowerCase()) || (!worktree.isMain && seenPaths.has(wtPath))
+      seenIds.has(id) || seenLabels.has(label.toLowerCase()) || (!worktree.isMain && seenPaths.has(pathKey(wtPath)))
 
     if (alreadySeen) {
       continue
@@ -335,7 +335,7 @@ export function mergeRepoWorktreeGroups(
 
     merged.push({ id, isMain: worktree.isMain, label, path: wtPath, sessions: [] })
     seenIds.add(id)
-    seenPaths.add(wtPath)
+    seenPaths.add(pathKey(wtPath))
     seenLabels.add(label.toLowerCase())
   }
 

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -235,6 +235,22 @@ def test_equivalent_windows_cwds_collapse_into_one_auto_project():
     assert len(project["repos"][0]["groups"][0]["sessions"]) == 3
 
 
+def test_windows_main_checkout_uses_path_identity_not_display_spelling():
+    cwd = r"D:\IvoDimitrov-Universe"
+    resolve = _resolver({cwd: (cwd, "D:/IvoDimitrov-Universe")})
+
+    tree = pt.build_tree([], [_session(cwd, branch="master")], [], resolve, hydrate=True)
+    project = tree["projects"][0]
+    repo = project["repos"][0]
+
+    assert repo["id"] == cwd
+    assert repo["path"] == cwd
+    assert len(repo["groups"]) == 1
+    assert repo["groups"][0]["isMain"] is True
+    assert repo["groups"][0]["id"] == f"{cwd}::branch::master"
+    assert repo["groups"][0]["path"] == cwd
+
+
 def test_windows_path_identity_preserves_explicit_project_priority():
     explicit = _project("p_notes", "Notes", ["C:/Work/Notes"])
     session = _session("c:\\work\\notes\\")

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -230,7 +230,7 @@ def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: st
     if info and info.get("repo_root") and info.get("worktree_root"):
         repo_root = info["repo_root"]
         worktree_root = info["worktree_root"]
-        is_main = worktree_root == repo_root or bool(info.get("is_main"))
+        is_main = _path_key(worktree_root) == _path_key(repo_root) or bool(info.get("is_main"))
 
         if is_main:
             # Unrecorded branch folds into the one trunk lane, so a repo never


### PR DESCRIPTION
## Summary
- classify the main checkout with the existing Windows-aware comparison key instead of raw path spelling
- use the same canonical comparison key throughout Desktop worktree reconciliation and deduplication while preserving original display paths
- cover the reported `D:\\...` vs `D:/...` main-checkout flow and linked-worktree case/separator variants

## Tests
- `python -m pytest -q tests/tui_gateway/test_project_tree.py` (27 passed)
- `npm exec -- vitest run src/app/chat/sidebar/projects/workspace-groups.test.ts` from `apps/desktop` (41 passed)
- `npm run typecheck` from `apps/desktop`
- `ruff check tui_gateway/project_tree.py tests/tui_gateway/test_project_tree.py`
- `npm exec -- prettier --check src/app/chat/sidebar/projects/workspace-groups.ts src/app/chat/sidebar/projects/workspace-groups.test.ts`
- `git diff --check`

Closes #64629