### PR TITLE
fix(gateway): stop systemd retries on fatal config

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -32,6 +32,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 from gateway.status import terminate_pid
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+    GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     parse_restart_drain_timeout,
 )
@@ -2761,6 +2762,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -2795,6 +2797,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -14,6 +14,7 @@ import hermes_cli.gateway as gateway_cli
 from gateway import status
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+    GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
 )
 
@@ -435,6 +436,7 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
@@ -546,6 +548,7 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.

--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -139,6 +139,29 @@ WantedBy=default.target
 
 
 class TestSystemdUnitIsCurrent:
+    def test_unit_without_fatal_config_restart_policy_is_not_current(
+        self, tmp_path, monkeypatch,
+    ):
+        from hermes_cli import gateway as gw
+
+        expected = """[Service]
+Restart=always
+RestartForceExitStatus=75
+RestartPreventExitStatus=78
+"""
+        installed = expected.replace("RestartPreventExitStatus=78\n", "")
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: expected,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is False
+
     def test_unit_without_optional_directives_is_current(self, tmp_path, monkeypatch):
         """Installed unit missing RestartMaxDelaySec/RestartSteps should be
         considered current when the generated unit includes them."""


### PR DESCRIPTION
## Summary

- render `RestartPreventExitStatus=78` in both user and system gateway units
- preserve exit 75 as the explicit forced-restart path
- mark installed units without the fatal-config policy as stale so normal service refresh rewrites them

## Problem

The gateway already exits with `EX_CONFIG` (78) for non-retryable startup conflicts such as a Telegram token collision. The generated systemd units use `Restart=always`, however, and did not exempt exit 78, so systemd immediately restarted the same invalid configuration forever.

On current main, a generated user unit contained `Restart=always` and `RestartForceExitStatus=75` but no `RestartPreventExitStatus=78`.

This change stops that loop without weakening planned restarts: exit 75 remains force-restarted, while exit 78 remains stopped for operator intervention.

## Scope

This addresses the repository-level service policy reported in #64422. It does not change the private `tester` profile or its Telegram credentials; that profile still needs a distinct token or Telegram disabled before it can run.

The maintained user and system render paths were audited and both are covered. The container s6 path already translates exit 78 to its permanent-failure status.

## Tests

- `2 passed` for the user/system unit rendering regressions
- `12 passed` in `tests/hermes_cli/test_systemd_optional_directives.py`
- `96 passed` across startup-failure, process-exit, restart-loop, and stale-unit suites
- `184 passed, 4 failed` in the full gateway service suite; the same four macOS user-systemd fixture failures reproduce on untouched current main
- Ruff, Windows-footgun diff scan, `uv lock --check`, `git diff --check`, and gitleaks passed

Addresses #64422


## Infographic

![systemd-fatal-config](https://v3b.fal.media/files/b/0aa27537/tPQJSZ7vUS45jRAl1TAYG_HKWSlGti.png)
