### PR TITLE
fix(skills): remove developer-specific repo paths

### DIFF
--- a/skills/software-development/node-inspect-debugger/SKILL.md
+++ b/skills/software-development/node-inspect-debugger/SKILL.md
@@ -183,7 +183,7 @@ The TUI is built Ink + tsx. Two common scenarios:
 `ui-tui/package.json` has `npm run dev` (tsx --watch). Add `--inspect-brk` by running tsx directly:
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd "$(git rev-parse --show-toplevel)/ui-tui"
 npm run build    # produce dist/ once so transpile isn't needed on first load
 node --inspect-brk dist/entry.js
 # In another terminal:
@@ -227,7 +227,7 @@ Those are Python, not Node — use the `python-debugpy` skill for them. Only Nod
 ## Running Vitest Tests Under the Debugger
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd "$(git rev-parse --show-toplevel)/ui-tui"
 # Run a single test file paused on entry
 node --inspect-brk ./node_modules/vitest/vitest.mjs run --no-file-parallelism src/app/foo.test.tsx
 ```

--- a/skills/software-development/node-inspect-debugger/SKILL.md
+++ b/skills/software-development/node-inspect-debugger/SKILL.md
@@ -183,7 +183,11 @@ The TUI is built Ink + tsx. Two common scenarios:
 `ui-tui/package.json` has `npm run dev` (tsx --watch). Add `--inspect-brk` by running tsx directly:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/ui-tui"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: run this command from inside the Hermes Agent checkout." >&2
+  exit 1
+}
+cd "$repo_root/ui-tui"
 npm run build    # produce dist/ once so transpile isn't needed on first load
 node --inspect-brk dist/entry.js
 # In another terminal:
@@ -227,7 +231,11 @@ Those are Python, not Node — use the `python-debugpy` skill for them. Only Nod
 ## Running Vitest Tests Under the Debugger
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/ui-tui"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: run this command from inside the Hermes Agent checkout." >&2
+  exit 1
+}
+cd "$repo_root/ui-tui"
 # Run a single test file paused on entry
 node --inspect-brk ./node_modules/vitest/vitest.mjs run --no-file-parallelism src/app/foo.test.tsx
 ```

--- a/skills/software-development/python-debugpy/SKILL.md
+++ b/skills/software-development/python-debugpy/SKILL.md
@@ -149,7 +149,10 @@ For long-lived processes: Hermes gateway, tui_gateway, a daemon, a process that'
 ### Setup
 
 ```bash
-repo_root="$(git rev-parse --show-toplevel)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: run this command from inside the Hermes Agent checkout." >&2
+  exit 1
+}
 source "$repo_root/.venv/bin/activate"
 pip install debugpy
 ```

--- a/skills/software-development/python-debugpy/SKILL.md
+++ b/skills/software-development/python-debugpy/SKILL.md
@@ -149,7 +149,8 @@ For long-lived processes: Hermes gateway, tui_gateway, a daemon, a process that'
 ### Setup
 
 ```bash
-source /home/bb/hermes-agent/.venv/bin/activate
+repo_root="$(git rev-parse --show-toplevel)"
+source "$repo_root/.venv/bin/activate"
 pip install debugpy
 ```
 
@@ -246,7 +247,7 @@ This is fine for one-off automation but painful as an interactive UX.
   "connect": { "host": "127.0.0.1", "port": 5678 },
   "justMyCode": false,
   "pathMappings": [
-    { "localRoot": "${workspaceFolder}", "remoteRoot": "/home/bb/hermes-agent" }
+    { "localRoot": "${workspaceFolder}", "remoteRoot": "<remote-hermes-agent-root>" }
   ]
 }
 ```

--- a/tests/skills/test_bundled_skill_paths.py
+++ b/tests/skills/test_bundled_skill_paths.py
@@ -1,0 +1,31 @@
+"""Regression tests for developer-specific paths in shipped skill docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEVELOPER_ROOT = "/home/bb/hermes-agent"
+SEARCH_ROOTS = (
+    REPO_ROOT / "skills",
+    REPO_ROOT / "website" / "docs" / "user-guide" / "skills",
+    REPO_ROOT
+    / "website"
+    / "i18n"
+    / "zh-Hans"
+    / "docusaurus-plugin-content-docs"
+    / "current"
+    / "user-guide"
+    / "skills",
+)
+
+
+def test_shipped_skill_docs_do_not_expose_developer_checkout() -> None:
+    offenders = [
+        path.relative_to(REPO_ROOT)
+        for root in SEARCH_ROOTS
+        for path in root.rglob("*.md")
+        if DEVELOPER_ROOT in path.read_text(encoding="utf-8")
+    ]
+
+    assert not offenders, f"developer checkout leaked into: {offenders}"

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
@@ -201,7 +201,7 @@ The TUI is built Ink + tsx. Two common scenarios:
 `ui-tui/package.json` has `npm run dev` (tsx --watch). Add `--inspect-brk` by running tsx directly:
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd "$(git rev-parse --show-toplevel)/ui-tui"
 npm run build    # produce dist/ once so transpile isn't needed on first load
 node --inspect-brk dist/entry.js
 # In another terminal:
@@ -245,7 +245,7 @@ Those are Python, not Node — use the `python-debugpy` skill for them. Only Nod
 ## Running Vitest Tests Under the Debugger
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd "$(git rev-parse --show-toplevel)/ui-tui"
 # Run a single test file paused on entry
 node --inspect-brk ./node_modules/vitest/vitest.mjs run --no-file-parallelism src/app/foo.test.tsx
 ```

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
@@ -201,7 +201,11 @@ The TUI is built Ink + tsx. Two common scenarios:
 `ui-tui/package.json` has `npm run dev` (tsx --watch). Add `--inspect-brk` by running tsx directly:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/ui-tui"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: run this command from inside the Hermes Agent checkout." >&2
+  exit 1
+}
+cd "$repo_root/ui-tui"
 npm run build    # produce dist/ once so transpile isn't needed on first load
 node --inspect-brk dist/entry.js
 # In another terminal:
@@ -245,7 +249,11 @@ Those are Python, not Node — use the `python-debugpy` skill for them. Only Nod
 ## Running Vitest Tests Under the Debugger
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/ui-tui"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: run this command from inside the Hermes Agent checkout." >&2
+  exit 1
+}
+cd "$repo_root/ui-tui"
 # Run a single test file paused on entry
 node --inspect-brk ./node_modules/vitest/vitest.mjs run --no-file-parallelism src/app/foo.test.tsx
 ```

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
@@ -169,7 +169,8 @@ For long-lived processes: Hermes gateway, tui_gateway, a daemon, a process that'
 ### Setup
 
 ```bash
-source /home/bb/hermes-agent/.venv/bin/activate
+repo_root="$(git rev-parse --show-toplevel)"
+source "$repo_root/.venv/bin/activate"
 pip install debugpy
 ```
 
@@ -266,7 +267,7 @@ This is fine for one-off automation but painful as an interactive UX.
   "connect": { "host": "127.0.0.1", "port": 5678 },
   "justMyCode": false,
   "pathMappings": [
-    { "localRoot": "${workspaceFolder}", "remoteRoot": "/home/bb/hermes-agent" }
+    { "localRoot": "${workspaceFolder}", "remoteRoot": "<remote-hermes-agent-root>" }
   ]
 }
 ```

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
@@ -169,7 +169,10 @@ For long-lived processes: Hermes gateway, tui_gateway, a daemon, a process that'
 ### Setup
 
 ```bash
-repo_root="$(git rev-parse --show-toplevel)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: run this command from inside the Hermes Agent checkout." >&2
+  exit 1
+}
 source "$repo_root/.venv/bin/activate"
 pip install debugpy
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
@@ -36,13 +36,13 @@ description: "在仓库中编写 SKILL.md"
 SKILL.md 可以存放在两个位置：
 
 1. **用户本地：** `~/.hermes/skills/<maybe-category>/<name>/SKILL.md` — 个人使用，不共享。通过 `skill_manage(action='create')` 创建。
-2. **仓库内（本 skill 讨论此情况）：** `/home/bb/hermes-agent/skills/<category>/<name>/SKILL.md` — 已提交，随包一起发布。使用 `write_file` + `git add`。`skill_manage(action='create')` **不**针对此目录树。
+2. **仓库内（本 skill 讨论此情况）：** `<repo-root>/skills/<category>/<name>/SKILL.md` — 已提交，随包一起发布。使用 `write_file` + `git add`。`skill_manage(action='create')` **不**针对此目录树。
 
 ## 使用时机
 
 - 用户要求你"在此分支 / 仓库 / 提交中"添加一个 skill
 - 你正在提交一个应随 hermes-agent 一起发布的可复用工作流
-- 你正在编辑 `/home/bb/hermes-agent/skills/` 下的现有 skill（小改动用 `patch`，重写用 `write_file`；`skill_manage` 对仓库内 skill 的 `patch` 仍有效，但 `create` 无效）
+- 你正在编辑 `<repo-root>/skills/` 下的现有 skill（小改动用 `patch`，重写用 `write_file`；`skill_manage` 对仓库内 skill 的 `patch` 仍有效，但 `create` 无效）
 
 ## 必需的 Frontmatter
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
@@ -201,7 +201,7 @@ TUI 基于 Ink + tsx 构建。两种常见场景：
 `ui-tui/package.json` 有 `npm run dev`（tsx --watch）。直接运行 tsx 并添加 `--inspect-brk`：
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd "$(git rev-parse --show-toplevel)/ui-tui"
 npm run build    # produce dist/ once so transpile isn't needed on first load
 node --inspect-brk dist/entry.js
 # In another terminal:
@@ -245,7 +245,7 @@ node inspect ws://127.0.0.1:9229/<uuid>
 ## 在调试器下运行 Vitest 测试
 
 ```bash
-cd /home/bb/hermes-agent/ui-tui
+cd "$(git rev-parse --show-toplevel)/ui-tui"
 # Run a single test file paused on entry
 node --inspect-brk ./node_modules/vitest/vitest.mjs run --no-file-parallelism src/app/foo.test.tsx
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger.md
@@ -201,7 +201,11 @@ TUI 基于 Ink + tsx 构建。两种常见场景：
 `ui-tui/package.json` 有 `npm run dev`（tsx --watch）。直接运行 tsx 并添加 `--inspect-brk`：
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/ui-tui"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "错误：请从 Hermes Agent 检出目录中运行此命令。" >&2
+  exit 1
+}
+cd "$repo_root/ui-tui"
 npm run build    # produce dist/ once so transpile isn't needed on first load
 node --inspect-brk dist/entry.js
 # In another terminal:
@@ -245,7 +249,11 @@ node inspect ws://127.0.0.1:9229/<uuid>
 ## 在调试器下运行 Vitest 测试
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/ui-tui"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "错误：请从 Hermes Agent 检出目录中运行此命令。" >&2
+  exit 1
+}
+cd "$repo_root/ui-tui"
 # Run a single test file paused on entry
 node --inspect-brk ./node_modules/vitest/vitest.mjs run --no-file-parallelism src/app/foo.test.tsx
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
@@ -167,7 +167,8 @@ sys.excepthook = excepthook
 ### 安装
 
 ```bash
-source /home/bb/hermes-agent/.venv/bin/activate
+repo_root="$(git rev-parse --show-toplevel)"
+source "$repo_root/.venv/bin/activate"
 pip install debugpy
 ```
 
@@ -264,7 +265,7 @@ send({"type": "request", "command": "configurationDone"})
   "connect": { "host": "127.0.0.1", "port": 5678 },
   "justMyCode": false,
   "pathMappings": [
-    { "localRoot": "${workspaceFolder}", "remoteRoot": "/home/bb/hermes-agent" }
+    { "localRoot": "${workspaceFolder}", "remoteRoot": "<remote-hermes-agent-root>" }
   ]
 }
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/software-development/software-development-python-debugpy.md
@@ -167,7 +167,10 @@ sys.excepthook = excepthook
 ### 安装
 
 ```bash
-repo_root="$(git rev-parse --show-toplevel)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "错误：请从 Hermes Agent 检出目录中运行此命令。" >&2
+  exit 1
+}
 source "$repo_root/.venv/bin/activate"
 pip install debugpy
 ```


### PR DESCRIPTION
## Summary

- replace `/home/bb/hermes-agent` in the Python and Node debugger recipes with checkout-relative commands or an explicit remote-root placeholder
- remove the same developer checkout path from the in-repo skill-authoring guidance found during the audit
- sync the English generated pages and Simplified Chinese translations
- add a regression test that scans shipped skill documentation for the leaked checkout root

## Root cause

The examples were authored against one contributor's local checkout and that absolute path was copied into bundled skills and generated documentation. Other users could copy commands that point to a nonexistent directory, while the path also exposed contributor-specific environment details.

## Validation

- `scripts/run_tests.sh tests/skills/test_bundled_skill_paths.py tests/website/test_generate_skill_docs.py` (8 passed)
- `python -m ruff check tests/skills/test_bundled_skill_paths.py`
- verified the `node-inspect-debugger` and `python-debugpy` generated pages match their current source render
- `git diff --cached --check`