### PR TITLE
feat(compresr): query-specific context + tool-output compression

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9670,6 +9670,58 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 print("  ❌ Timed out talking to the Codex backend — try again shortly.")
                 return
         print(f"  {result.message}")
+    def _compresr_usage_lines(self):
+        """Compresr ROI lines for /usage; empty when the integration is inactive.
+
+        Reads compaction-engine counters off the live ``context_compressor`` and
+        per-turn counters off the registered ``transform_tool_result`` hook
+        instance. Fully defensive — /usage must never break if a plugin's shape
+        changes or the plugins aren't loaded.
+        """
+        rows = []  # (label, calls, tokens_in, tokens_saved, errors)
+        try:
+            eng = getattr(self.agent, "context_compressor", None)
+            calls = getattr(eng, "compresr_calls", 0) or 0
+            if calls:
+                rows.append((
+                    "compaction", calls,
+                    getattr(eng, "compresr_tokens_in", 0) or 0,
+                    getattr(eng, "compresr_tokens_saved", 0) or 0,
+                    getattr(eng, "compresr_errors", 0) or 0,
+                ))
+        except Exception:
+            pass
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            for cb in get_plugin_manager()._hooks.get("transform_tool_result", []):
+                inst = getattr(cb, "__self__", None)
+                st = inst.get_status() if hasattr(inst, "get_status") else None
+                if st and st.get("plugin") == "tool_output_compresr" and st.get("calls"):
+                    rows.append((
+                        "tool output", st["calls"],
+                        st.get("tokens_in", 0) or 0,
+                        st.get("tokens_saved", 0) or 0,
+                        st.get("errors", 0) or 0,
+                    ))
+        except Exception:
+            pass
+        if not rows:
+            return []
+
+        def _pct(saved, total):
+            return f" (~{round(100 * saved / total)}% of {total:,})" if total else ""
+
+        lines, tot_saved, tot_in = [], 0, 0
+        for label, calls, tokens_in, saved, errs in rows:
+            tot_saved += saved
+            tot_in += tokens_in
+            suffix = f" · {errs} err" if errs else ""
+            lines.append(
+                f"  Compresr ({label}): {calls} calls · "
+                f"{saved:,} tok saved{_pct(saved, tokens_in)}{suffix}")
+        if len(rows) > 1:
+            lines.append(f"  Compresr total saved:  {tot_saved:,} tokens{_pct(tot_saved, tot_in)}")
+        return lines
 
     def _show_usage(self):
         """Rate limits + session token usage (when a live agent exists) + Nous credits.
@@ -9733,6 +9785,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
+        for _line in self._compresr_usage_lines():
+            print(_line)
 
         # Account limits -- fetched off-thread with a hard timeout so slow
         # provider APIs don't hang the prompt.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1500,6 +1500,28 @@ DEFAULT_CONFIG = {
         "auto_subscribe_on_create": True,
     },
 
+    # Compresr context and tool-output compression plugin settings. Secrets
+    # stay in ~/.hermes/.env (COMPRESR_API_KEY); this block is non-secret
+    # behavior only.
+    "compresr": {
+        "base_url": "https://api.compresr.ai/api",
+        "model": "latte_v2",
+        "target_ratio": "",
+        "timeout": 60,
+        "coarse": False,
+        "disable_placeholders": False,
+        "tool_output_enabled": True,
+        "tool_output_model": "toc_latte_v2",
+        "tool_output_min_tokens": 1500,
+        "tool_output_timeout": 30,
+        # Best-effort cap for Hermes-managed compresr originals written by
+        # the per-turn tool-output plugin. 0 disables pruning.
+        "tool_output_max_cache_mb": 256,
+        # Nx compression target for per-turn tool-output compression (2.0 = ~2x).
+        # 0 lets the API choose.
+        "tool_output_target_ratio": 2.0,
+    },
+
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
@@ -3801,6 +3823,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "COMPRESR_API_KEY": {
+        "description": "Compresr API key for context and tool-output compression",
+        "prompt": "Compresr API key",
+        "url": "https://compresr.ai/dashboard/tokens",
+        "tools": ["context_engine", "tool_output_compresr"],
+        "password": True,
+        "category": "tool",
+    },
     "FIRECRAWL_API_URL": {
         "description": "Firecrawl API URL for self-hosted instances (optional)",
         "prompt": "Firecrawl API URL (leave empty for cloud)",
@@ -5268,7 +5298,7 @@ _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
-    "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
+    "auxiliary", "moa", "custom_providers", "context", "compresr", "memory", "gateway",
     "sessions", "streaming", "updates", "mcp_servers",
 }
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2694,6 +2694,105 @@ def _run_portal_one_shot(config: dict) -> None:
     print_info("  Run `hermes` to start chatting.")
 
 
+def _setup_context_compression(config: dict):
+    """Context compression engine — Default (built-in) or Compresr (YC W26).
+
+    A single choice. Picking Compresr turns on both in-repo plugins together:
+      * compaction-time   — context.engine: compresr replaces the built-in
+        abstractive summarizer with Compresr's query-specific compression.
+      * per-turn          — the tool_output_compresr plugin compresses large
+        tool outputs as they arrive, leaving a recoverable reference under
+        cache/compresr/tool-output the agent can Read/Grep back (a lossy
+        summary with the full original recoverable on demand).
+
+    If the Compresr API is unreachable, compaction preserves the current
+    transcript instead of dropping turns with a placeholder summary; per-turn
+    tool-output compression leaves the original tool output unchanged.
+    """
+    print()
+    print_header("Context Compression — Compresr (optional)")
+
+    ctx = config.get("context", {}) or {}
+    current_engine = ctx.get("engine", "compressor")
+    compresr_block = config.get("compresr", {}) or {}
+    tool_output_on = bool(compresr_block.get("tool_output_enabled"))
+
+    currently_on = current_engine == "compresr" or tool_output_on
+    if currently_on:
+        print_info(f"Current: Compresr (engine={current_engine})")
+
+    choices = [
+        "Default — Hermes's built-in compressor",
+        "Compresr — query-specific compression (compaction + tool-output)",
+    ]
+    idx = prompt_choice("Compression engine:", choices, 1 if currently_on else 0)
+    if idx == 0:
+        config.setdefault("context", {})["engine"] = "compressor"
+        config.setdefault("compresr", {})["tool_output_enabled"] = False
+        _set_plugin_enabled(config, "tool_output_compresr", False)
+        print_info("Using the built-in compressor.")
+        if get_env_value("COMPRESR_API_KEY"):
+            print_info(
+                "To fully remove Compresr: delete COMPRESR_API_KEY from ~/.hermes/.env "
+                "and rm -rf ~/.hermes/cache/compresr/ to clear cached tool outputs."
+            )
+        return
+
+    print_warning(
+        "Compresr is a third-party API. When enabled, Hermes sends "
+        "conversation text for compaction and large tool outputs for "
+        "per-turn compression, including file contents and command output "
+        "the agent has read or run."
+    )
+
+    # Compresr needs an API key.
+    existing = get_env_value("COMPRESR_API_KEY")
+    if not existing:
+        print()
+        print_info("Get a key at https://compresr.ai/dashboard/tokens")
+        api_key = prompt("Compresr API key (cmp_...)", password=True)
+        if not api_key:
+            print_warning("No API key provided. Leaving the built-in compressor in place.")
+            return
+        if not api_key.startswith("cmp_"):
+            print_error("Invalid format: Compresr API keys start with 'cmp_'.")
+            return
+        save_env_value("COMPRESR_API_KEY", api_key)
+        print_success("Compresr API key saved")
+
+    config.setdefault("context", {})["engine"] = "compresr"
+    config.setdefault("compresr", {})["tool_output_enabled"] = True
+    # The per-turn plugin is a *standalone* plugin: it only loads if its name is
+    # in plugins.enabled. Setting tool_output_enabled alone is not enough — the
+    # hook would never register. Enable the plugin so the hook actually fires.
+    _set_plugin_enabled(config, "tool_output_compresr", True)
+    print_success(
+        "Compresr enabled (compaction-time + per-turn tool-output compression)"
+    )
+
+
+SETUP_SECTIONS.append(
+    ("compression", "Context Compression", _setup_context_compression)
+)
+
+
+def _set_plugin_enabled(config: dict, name: str, enabled: bool):
+    """Add/remove a plugin name in the ``plugins.enabled`` list in config.yaml.
+
+    Standalone plugins (like ``tool_output_compresr``) only load when listed
+    here; the loader accepts the bare manifest name.
+    """
+    plugins = config.setdefault("plugins", {})
+    lst = plugins.get("enabled")
+    if not isinstance(lst, list):
+        lst = [] if lst is None else list(lst)
+    if enabled and name not in lst:
+        lst.append(name)
+    elif not enabled and name in lst:
+        lst = [p for p in lst if p != name]
+    plugins["enabled"] = lst
+
+
 def run_setup_wizard(args):
     """Run the interactive setup wizard.
 
@@ -2919,6 +3018,10 @@ def run_setup_wizard(args):
     # Section 5: Tools
     if not (migration_ran and _skip_configured_section(config, "tools", "Tools")):
         setup_tools(config, first_install=not is_existing)
+
+    # Section 6: Context Compression (Compresr) — optional, opt-in
+    if not (migration_ran and _skip_configured_section(config, "compresr", "Context Compression")):
+        _setup_context_compression(config)
 
     # Save and show summary
     save_config(config)

--- a/hermes_cli/subcommands/setup.py
+++ b/hermes_cli/subcommands/setup.py
@@ -18,12 +18,12 @@ def build_setup_parser(subparsers, *, cmd_setup: Callable) -> None:
         "setup",
         help="Interactive setup wizard",
         description="Configure Hermes Agent with an interactive wizard. "
-        "Run a specific section: hermes setup model|tts|terminal|gateway|tools|agent",
+        "Run a specific section: hermes setup model|tts|terminal|gateway|tools|agent|compression",
     )
     setup_parser.add_argument(
         "section",
         nargs="?",
-        choices=["model", "tts", "terminal", "gateway", "tools", "agent"],
+        choices=["model", "tts", "terminal", "gateway", "tools", "agent", "compression"],
         default=None,
         help="Run a specific setup section instead of the full wizard",
     )

--- a/plugins/compresr_common.py
+++ b/plugins/compresr_common.py
@@ -1,0 +1,131 @@
+"""Shared helpers for the two Compresr plugins (``context_engine/compresr`` and
+``tool_output_compresr``).
+
+Kept in one module so the security-sensitive base-URL / host validation and the
+secret sanitization can't drift between the plugins. stdlib-only.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import re
+import socket
+from typing import Any
+
+logger = logging.getLogger("plugins.compresr")
+
+# Cap on any single API response we read into memory.
+MAX_RESPONSE_BYTES = 32 * 1024 * 1024
+
+_SECRET_CTL_RE = re.compile(r"[\r\n\x00]")
+# Numeric-shorthand IPv4 (decimal or hex, e.g. 2852039166 / 0xa9fea9fe) that
+# getaddrinfo would resolve to a real address — refused outright.
+_NUMERIC_ONLY_HOST_RE = re.compile(r"\A(?:0x[0-9a-fA-F]+|[0-9]+)\Z")
+
+_BLOCKED_METADATA_HOST_NAMES = frozenset({
+    "metadata.google.internal", "metadata.goog", "metadata",
+})
+# Link-local (incl. cloud metadata), private, CGNAT, and IPv6 local ranges.
+_BLOCKED_NETWORKS = tuple(
+    ipaddress.ip_network(n) for n in (
+        "169.254.0.0/16", "fd00::/8", "fe80::/10",
+        "100.100.100.200/32", "168.63.129.16/32",
+        "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10",
+    )
+)
+_LOCALHOST_NAMES = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def read_with_cap(resp: Any, cap: int) -> bytes:
+    """Bounded read tolerant of mocks whose ``read()`` takes no size arg."""
+    try:
+        raw = resp.read(cap + 1)
+    except TypeError:
+        raw = resp.read()
+    if isinstance(raw, str):
+        raw = raw.encode("utf-8")
+    if len(raw) > cap:
+        raise RuntimeError(f"response exceeded {cap} bytes")
+    return raw
+
+
+def sanitize_secret(raw: str, label: str) -> str:
+    """Strip whitespace and reject CR/LF/NUL (urllib would raise with the raw key
+    in the message). Returns ``""`` on rejection, never the value."""
+    if not raw:
+        return ""
+    stripped = raw.strip()
+    if _SECRET_CTL_RE.search(stripped):
+        logger.error("compresr: %s contained CR/LF/NUL and was rejected", label)
+        return ""
+    return stripped
+
+
+def _resolve_host_ips(host: str) -> tuple:
+    if not host:
+        return ()
+    ips: list = []
+    try:
+        ip = ipaddress.ip_address(host)
+        mapped = getattr(ip, "ipv4_mapped", None)
+        ips.append(mapped if mapped is not None else ip)
+        return tuple(ips)
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, socket.herror, UnicodeError, OSError):
+        return ()
+    for _, _, _, _, sockaddr in infos:
+        try:
+            ip = ipaddress.ip_address(sockaddr[0].split("%", 1)[0])
+        except ValueError:
+            continue
+        mapped = getattr(ip, "ipv4_mapped", None)
+        ips.append(mapped if mapped is not None else ip)
+    return tuple(ips)
+
+
+def _is_blocked_host(host: str) -> bool:
+    h = (host or "").rstrip(".").lower()
+    if h in _BLOCKED_METADATA_HOST_NAMES:
+        return True
+    return any(ip in net for ip in _resolve_host_ips(h) for net in _BLOCKED_NETWORKS)
+
+
+def _safe_url_repr(parsed) -> str:
+    if parsed is None:
+        return "?"
+    try:
+        return f"{parsed.scheme or '?'}://{parsed.hostname or '?'}"
+    except Exception:
+        return "?"
+
+
+def secure_base_url(url: str, default: str) -> str:
+    """Reject non-HTTPS (except localhost), numeric-shorthand IPv4 literals,
+    cloud-metadata hosts, and hosts resolving to a private/link-local net.
+    Logs only scheme://host — the raw URL may carry userinfo credentials.
+    """
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        parsed = None
+    host = (parsed.hostname or "").lower() if parsed else ""
+    safe = _safe_url_repr(parsed)
+
+    if parsed and host and _NUMERIC_ONLY_HOST_RE.match(host):
+        logger.warning("compresr: refusing numeric-shorthand IPv4 host %s; using %s", safe, default)
+        return default
+    if parsed and parsed.scheme in ("http", "https") and host in _LOCALHOST_NAMES:
+        return url
+    if parsed and _is_blocked_host(host):
+        logger.warning("compresr: refusing base_url %s (metadata/private host); using %s", safe, default)
+        return default
+    if parsed and parsed.scheme == "https":
+        return url
+    logger.warning("compresr: ignoring insecure base_url %s (must be https); using %s", safe, default)
+    return default

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -179,10 +179,14 @@ def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
             mod.register(collector)
             if collector.engine:
                 return collector.engine
+            # register() ran cleanly but registered no engine: the plugin
+            # declined (e.g. missing credentials). Respect that and let the
+            # caller fall back rather than resurrecting it via the scan below.
+            return None
         except Exception as e:
             logger.debug("register() failed for %s: %s", name, e)
 
-    # Fallback: find a ContextEngine subclass and instantiate it
+    # Fallback for modules with no register() entry point.
     from agent.context_engine import ContextEngine
     for attr_name in dir(mod):
         attr = getattr(mod, attr_name, None)

--- a/plugins/context_engine/compresr/README.md
+++ b/plugins/context_engine/compresr/README.md
@@ -1,0 +1,76 @@
+# context_engine/compresr
+
+**Compaction-time context compression** for Hermes, powered by
+[Compresr](https://compresr.ai) (YC W26).
+
+A drop-in replacement for the built-in `compressor` context engine. Instead of
+asking an auxiliary LLM to write an abstractive summary of the middle of the
+conversation when the context-window threshold is crossed, this engine sends
+those turns to Compresr's query-specific compression API (`latte_v1`/`latte_v2`),
+which scores spans against the current goal and keeps only the answer-bearing
+ones — in sub-second time rather than a multi-second LLM summarization.
+
+## Design
+
+It subclasses `ContextCompressor` and overrides **only** the "compress the
+middle window" step (`_generate_summary`) plus `update_model` (to recompute
+token budgets once the real model is known). Everything else — old-tool-result
+pruning, head/tail protection, boundary alignment, tool_call/tool_result
+sanitization, historical-media stripping, anti-thrashing accounting — is
+inherited verbatim. So an A/B against the built-in engine is a clean comparison
+of the *core compaction strategy* only.
+
+The query handed to Compresr is Hermes's own derived focus topic
+(`_derive_auto_focus_topic`), so compression is goal-aware. Because Compresr is
+an external service, this engine defaults to preserving the current transcript
+when summary generation fails instead of dropping middle turns with a
+deterministic placeholder handoff. A short cooldown avoids hammering a failing
+endpoint. During a sustained Compresr outage, long conversations may stop
+compacting until the API recovers or the user starts a fresh session; this is a
+deliberate fail-open tradeoff to avoid losing context.
+
+## Data sent to Compresr
+
+When enabled, Hermes sends the middle conversation window selected for
+compaction to the configured Compresr API endpoint. Do not enable this engine
+unless that third-party processing is acceptable for your deployment.
+
+## Activation
+
+```yaml
+# ~/.hermes/config.yaml
+context:
+  engine: compresr
+```
+```bash
+# ~/.hermes/.env
+COMPRESR_API_KEY=cmp_...
+```
+Or run `hermes setup` and choose a Compresr option under **Context Compression**.
+
+## Configuration
+
+| env / `compresr:` key | default | meaning |
+|---|---|---|
+| `COMPRESR_API_KEY` | — | **required** `cmp_…` key, read from `.env` only |
+| `COMPRESR_BASE_URL` / `base_url` | `https://api.compresr.ai/api` | API base |
+| `COMPRESR_MODEL` / `model` | `latte_v2` | `latte_v1` \| `latte_v2` |
+| `COMPRESR_TARGET_RATIO` / `target_ratio` | — | override (Compresr Nx / removal semantics) |
+| `COMPRESR_TIMEOUT` / `timeout` | `60` | request timeout (s) |
+
+`target_compression_ratio` semantics: a value in (0, 1] is a *removal* fraction
+(0.8 → remove ~80%); a value > 1 is an Nx target (5 → ~1/5). When unset, Hermes's
+keep-fraction `f` is mapped to the Nx factor `1/f` (0.2 keep → 5×).
+
+## Relationship to `tool_output_compresr`
+
+This handles compaction-time compression of the conversation. Its per-turn
+complement, [`tool_output_compresr`](../../tool_output_compresr), compresses
+large *tool outputs* as they arrive. They compose; enable either or both.
+
+## Tests
+
+`tests/test_compresr_context_engine.py` — contract test pinning the
+`_generate_summary` override signature and the success → prefixed-body /
+error → `None` fallback round-trip, so an upstream refactor of the parent's
+private seam fails loudly in CI rather than silently degrading.

--- a/plugins/context_engine/compresr/__init__.py
+++ b/plugins/context_engine/compresr/__init__.py
@@ -1,0 +1,384 @@
+"""Compresr (YC W26) context engine for Hermes.
+
+A drop-in replacement for the built-in ``compressor``. Instead of an auxiliary
+LLM writing an abstractive summary of the mid-conversation turns, this engine
+sends them to Compresr's query-specific API (``latte_v1``/``latte_v2``), which
+scores spans against the current goal and keeps the answer-bearing ones.
+
+It subclasses :class:`ContextCompressor` and overrides only ``_generate_summary``
+(and ``update_model`` for signature parity); all surrounding machinery — pruning,
+head/tail protection, pair sanitization, anti-thrashing accounting — is inherited.
+
+Activate with ``context.engine: compresr`` and ``COMPRESR_API_KEY`` in ``.env``.
+See ``README.md`` for the full config/env reference and ratio semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+from agent.context_compressor import ContextCompressor
+from hermes_constants import get_hermes_home
+from plugins.compresr_common import (
+    MAX_RESPONSE_BYTES as _MAX_RESPONSE_BYTES,
+    read_with_cap as _read_with_cap,
+    sanitize_secret as _sanitize_secret,
+    secure_base_url as _secure_base_url,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.compresr.ai/api"
+_DEFAULT_MODEL = "latte_v2"
+_DEFAULT_TIMEOUT = 60
+_FAILURE_COOLDOWN_SECONDS = 30.0
+_PLACEHOLDER_CONTEXT_LEN = 200_000
+_MIN_KEEP_FRACTION = 0.01
+_MAX_KEEP_FRACTION = 0.95
+_DEFAULT_KEEP_FRACTION = 0.2
+_MAX_NX = 200.0
+_SOURCE_TAG = "integration:hermes"
+_FALLBACK_QUERY = (
+    "Preserve the key facts, decisions, file paths, commands, results, and open "
+    "tasks needed to continue this work."
+)
+
+
+def _as_int(v: Any, default: int = 0) -> int:
+    """Tolerant int coercion — never crash on 'N/A' server stats or a typo'd
+    numeric config/env value; fall back to *default* instead of raising in
+    ``__init__`` and silently disabling the engine."""
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(v: Any, default: Optional[float]) -> Optional[float]:
+    """Tolerant float coercion (see :func:`_as_int`)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _read_config_block(key: str = "compresr") -> Dict[str, Any]:
+    """Best-effort read of a top-level *key* block from config.yaml.
+
+    Environment variables take precedence; this only fills gaps. Never raises.
+    """
+    cfg_path = get_hermes_home() / "config.yaml"
+    if not cfg_path.exists():
+        return {}
+    try:
+        import yaml
+
+        with open(cfg_path, encoding="utf-8-sig") as f:
+            data = yaml.safe_load(f) or {}
+        block = data.get(key, {})
+        return block if isinstance(block, dict) else {}
+    except Exception as e:  # pragma: no cover - config is optional
+        logger.debug("compresr: could not read config block %r: %s", key, e)
+        return {}
+
+
+class CompresrContextEngine(ContextCompressor):
+    """Context engine that compacts via Compresr's query-specific API."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        cfg = _read_config_block()
+
+        def _opt(env_key: str, cfg_key: str, default: Any) -> Any:
+            val = os.environ.get(env_key)
+            if val is not None and val != "":
+                return val
+            if cfg_key in cfg and cfg[cfg_key] not in (None, ""):
+                return cfg[cfg_key]
+            return default
+
+        self.compresr_api_key = _sanitize_secret(
+            os.environ.get("COMPRESR_API_KEY", ""), "COMPRESR_API_KEY"
+        )
+        self.compresr_base_url = _secure_base_url(
+            str(_opt("COMPRESR_BASE_URL", "base_url", _DEFAULT_BASE_URL)).rstrip("/"),
+            _DEFAULT_BASE_URL,
+        )
+        self.compresr_model = str(_opt("COMPRESR_MODEL", "model", _DEFAULT_MODEL))
+        self.compresr_timeout = max(
+            1, _as_int(_opt("COMPRESR_TIMEOUT", "timeout", _DEFAULT_TIMEOUT), _DEFAULT_TIMEOUT)
+        )
+        self.compresr_coarse = str(_opt("COMPRESR_COARSE", "coarse", "")).lower() in (
+            "1", "true", "yes",
+        )
+        self.compresr_disable_placeholders = str(
+            _opt("COMPRESR_DISABLE_PLACEHOLDERS", "disable_placeholders", "")
+        ).lower() in ("1", "true", "yes")
+        self.compresr_ratio_override: Optional[float] = _as_float(
+            _opt("COMPRESR_TARGET_RATIO", "target_ratio", ""), None
+        )
+
+        self.compresr_calls = 0
+        self.compresr_errors = 0
+        self.compresr_tokens_in = 0
+        self.compresr_tokens_saved = 0
+        self.compresr_last_duration_ms = 0
+
+        # Forward the user's compression.* geometry (threshold / head-tail /
+        # keep-ratio) so compresr honors the same tuning as the built-in engine.
+        # Only fills gaps — an explicit caller kwarg still wins.
+        comp_cfg = _read_config_block("compression")
+        if "threshold" in comp_cfg:
+            _thr = _as_float(comp_cfg.get("threshold"), None)
+            if _thr is not None:
+                kwargs.setdefault("threshold_percent", _thr)
+        if "protect_first_n" in comp_cfg:
+            kwargs.setdefault("protect_first_n", _as_int(comp_cfg.get("protect_first_n"), 3))
+        if "protect_last_n" in comp_cfg:
+            kwargs.setdefault("protect_last_n", _as_int(comp_cfg.get("protect_last_n"), 20))
+        if "target_ratio" in comp_cfg:
+            _ratio = _as_float(comp_cfg.get("target_ratio"), None)
+            if _ratio is not None:
+                kwargs.setdefault("summary_target_ratio", _ratio)
+
+        # Construct the parent with a placeholder model + explicit context length
+        # so __init__ never makes a network/model-metadata lookup. agent_init
+        # always calls update_model() right after, which sets the real values.
+        kwargs.setdefault("model", "compresr-placeholder")
+        kwargs.setdefault("config_context_length", _PLACEHOLDER_CONTEXT_LEN)
+        # Compresr is an external service. If it is unavailable, preserve the
+        # current transcript instead of inserting a deterministic placeholder
+        # handoff and dropping the middle window.
+        kwargs.setdefault("abort_on_summary_failure", True)
+        super().__init__(**kwargs)
+
+        if not self.compresr_api_key:
+            logger.warning(
+                "compresr: COMPRESR_API_KEY is not set — compaction will fail and "
+                "compression will be aborted without dropping context. Set it in "
+                "~/.hermes/.env."
+            )
+
+    # -- Identity ----------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "compresr"
+
+    def is_available(self) -> bool:
+        """Used by discover_context_engines() for the availability check."""
+        return bool(self.compresr_api_key)
+
+    # -- Token budgets must be recomputed when the real model arrives ------
+
+    def update_model(
+        self,
+        model: str,
+        context_length: int,
+        base_url: str = "",
+        api_key: Any = "",
+        provider: str = "",
+        api_mode: str = "",
+        max_tokens: int | None = None,
+    ) -> None:
+        # Pure pass-through: the parent already computes all token budgets. This
+        # override exists only to stay signature-compatible as the parent evolves
+        # (re-flooring context_length here regressed small-context compaction).
+        super().update_model(
+            model, context_length, base_url, api_key, provider, api_mode, max_tokens
+        )
+
+    # -- Ratio mapping -----------------------------------------------------
+
+    def _target_compression_ratio(self) -> float:
+        """Resolve the Compresr ``target_compression_ratio`` to send.
+
+        Explicit override wins. Otherwise map Hermes's keep-fraction
+        ``summary_target_ratio`` (e.g. 0.2 = keep ~20%) to a Compresr Nx factor
+        (1/0.2 = 5x). Clamp to Compresr's documented [.., 200] range.
+        """
+        if self.compresr_ratio_override is not None:
+            return self.compresr_ratio_override
+        keep = self.summary_target_ratio or _DEFAULT_KEEP_FRACTION
+        keep = min(max(keep, _MIN_KEEP_FRACTION), _MAX_KEEP_FRACTION)
+        return round(min(1.0 / keep, _MAX_NX), 3)
+
+    # -- The one override that matters: compress the middle via Compresr ---
+
+    def _generate_summary(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        focus_topic: Optional[str] = None,
+    ) -> Optional[str]:
+        """Compress the middle window with Compresr instead of an LLM summary.
+
+        Returns the compressed text (with the standard summary prefix so
+        iterative re-compaction recognizes it), or None on failure — which lets
+        the inherited ``compress()`` fall back to its deterministic handoff.
+        """
+        now = time.monotonic()
+        if now < self._summary_failure_cooldown_until:
+            logger.debug("compresr: in failure cooldown, skipping")
+            return None
+
+        context = self._serialize_for_summary(turns_to_summarize)
+        if not context.strip():
+            return None
+
+        query = (focus_topic or "").strip() or _FALLBACK_QUERY
+
+        # Preserve continuity: fold the prior handoff summary into the context so
+        # Compresr can carry forward still-relevant facts across compactions.
+        if self._previous_summary:
+            context = (
+                "[PRIOR CONTEXT SUMMARY]\n"
+                + self._previous_summary
+                + "\n\n[NEW CONVERSATION TURNS]\n"
+                + context
+            )
+
+        try:
+            compressed, stats = self._call_compresr(context, query)
+        except Exception as e:
+            self.compresr_errors += 1
+            self._last_summary_error = f"compresr: {e}"
+            # Mirror the base's failure behavior via the parent API so the
+            # back-off persists to the session DB and survives across processes
+            # (resume / gateway restart), not just in-memory for this process.
+            self._record_compression_failure_cooldown(
+                _FAILURE_COOLDOWN_SECONDS, self._last_summary_error
+            )
+            logger.warning("compresr: compression failed (%s) — falling back", e)
+            return None
+
+        if not compressed or not compressed.strip():
+            self.compresr_errors += 1
+            self._last_summary_error = "compresr: empty compressed_context"
+            # Back off like the exception path (persisted), so a persistently-empty
+            # endpoint isn't re-hit on every compaction across processes.
+            self._record_compression_failure_cooldown(
+                _FAILURE_COOLDOWN_SECONDS, self._last_summary_error
+            )
+            return None
+
+        self.compresr_calls += 1
+        self.compresr_tokens_in += _as_int(stats.get("original_tokens"))
+        self.compresr_tokens_saved += _as_int(stats.get("tokens_saved"))
+        self.compresr_last_duration_ms = _as_int(stats.get("duration_ms"))
+        # Clear the failure back-off on success via the parent helper so the
+        # persisted session-DB row is cleared too (else it reloads on resume).
+        self._clear_compression_failure_cooldown()
+        logger.info(
+            "compresr: %s %s tokens -> %s tokens (saved %s, %sms server)",
+            self.compresr_model,
+            stats.get("original_tokens", "?"),
+            stats.get("compressed_tokens", "?"),
+            stats.get("tokens_saved", "?"),
+            stats.get("duration_ms", "?"),
+        )
+
+        body = self._strip_summary_prefix(compressed)
+        self._previous_summary = body
+        return self._with_summary_prefix(body)
+
+    # -- Compresr API call -------------------------------------------------
+
+    def _call_compresr(self, context: str, query: str) -> tuple[str, Dict[str, Any]]:
+        """POST to /compress/question-specific/ and return (text, stats).
+
+        Raises on transport/HTTP/parse errors so the caller can fall back.
+        """
+        if not self.compresr_api_key:
+            raise RuntimeError("COMPRESR_API_KEY not set")
+
+        payload: Dict[str, Any] = {
+            "context": context,
+            "query": query,
+            "compression_model_name": self.compresr_model,
+            "target_compression_ratio": self._target_compression_ratio(),
+            "source": _SOURCE_TAG,
+        }
+        if self.compresr_model == "latte_v1":
+            payload["coarse"] = self.compresr_coarse
+        if self.compresr_disable_placeholders:
+            payload["disable_placeholders"] = True
+
+        url = f"{self.compresr_base_url}/compress/question-specific/"
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-API-Key": self.compresr_api_key,
+                "User-Agent": "hermes-compresr-engine/0.1",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.compresr_timeout) as resp:
+                raw = _read_with_cap(resp, _MAX_RESPONSE_BYTES).decode("utf-8")
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                detail = _read_with_cap(e, 4096).decode("utf-8")[:300]
+            except Exception:
+                pass
+            raise RuntimeError(f"HTTP {e.code}: {detail or e.reason}") from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"connection error: {e.reason}") from e
+        except ValueError:
+            # urllib raises ValueError containing the raw API key when a header
+            # value has CTL chars — swallow the chain so it never reaches logs.
+            raise RuntimeError(
+                "invalid request headers (check COMPRESR_API_KEY for stray whitespace/CRLF)"
+            ) from None
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"non-JSON response ({e}); body prefix: {raw[:200]!r}") from e
+        if not parsed.get("success", False):
+            raise RuntimeError(
+                f"API error: {parsed.get('message') or parsed.get('error')}"
+            )
+        d = parsed.get("data") or {}
+        compressed = d.get("compressed_context", "")
+        return compressed, d
+
+    # -- Status (extends base with Compresr counters) ---------------------
+
+    def get_status(self) -> Dict[str, Any]:
+        status = super().get_status()
+        status.update(
+            {
+                "engine": "compresr",
+                "compresr_model": self.compresr_model,
+                "compresr_calls": self.compresr_calls,
+                "compresr_errors": self.compresr_errors,
+                "compresr_tokens_in": self.compresr_tokens_in,
+                "compresr_tokens_saved": self.compresr_tokens_saved,
+                "compresr_last_duration_ms": self.compresr_last_duration_ms,
+            }
+        )
+        return status
+
+
+def register(ctx: Any) -> None:
+    """Plugin entry point — called by the context-engine loader."""
+    engine = CompresrContextEngine()
+    # Refuse to register when unavailable so the loader falls back to the
+    # built-in compressor instead of ending sessions in a provider-side
+    # context-limit error under abort_on_summary_failure=True.
+    if not engine.is_available():
+        logger.error(
+            "compresr: refusing to register — engine is not available "
+            "(COMPRESR_API_KEY missing). Falling back to built-in compressor."
+        )
+        return
+    ctx.register_context_engine(engine)

--- a/plugins/context_engine/compresr/plugin.yaml
+++ b/plugins/context_engine/compresr/plugin.yaml
@@ -1,0 +1,10 @@
+name: compresr
+description: >-
+  Compresr (YC W26) query-specific context engine. Replaces Hermes's default
+  abstractive summarization of mid-conversation turns with Compresr's
+  query-specific span extraction (latte_v1/latte_v2) via https://api.compresr.ai.
+  Reuses the built-in compressor's head/tail protection and tool-pair
+  sanitization, so only the core compaction strategy differs.
+version: "0.1.0"
+author: "Compresr (YC W26)"
+homepage: https://compresr.ai

--- a/plugins/tool_output_compresr/README.md
+++ b/plugins/tool_output_compresr/README.md
@@ -1,0 +1,115 @@
+# tool_output_compresr
+
+Per-turn **tool-output compression** for Hermes, powered by [Compresr](https://compresr.ai) (YC W26).
+
+Large tool outputs — a 5k-line `read_file`, a verbose `grep`, a noisy
+`execute_code`/test run — are the real driver of context-window bloat. This
+plugin compresses them **as they arrive** (on the `transform_tool_result` hook),
+*before* they ever enter the context, using Compresr's query-specific
+tool-output API with the **tool's own intent** as the query.
+
+It is a **lossy summary with a recoverable source**. The API's compressed text is
+passed through **unchanged** (its own `[N tokens removed]` markers included), and
+a footer points the agent at the full verbatim original:
+
+```
+…compressed tool output from the API, verbatim…
+
+[compresr:recover] Tool output compressed 8120→2310 tokens (~72% saved). The full
+verbatim original is cached at /root/.hermes/cache/compresr/tool-output/a3f9c1 —
+if you need exact details that were summarized away, recover them with
+read_file("…") or search_files.
+```
+
+The original is cached verbatim under `~/.hermes/cache/compresr/tool-output/<id>`
+on the host (PR #6 *cache-authority*). When the active backend can prove an
+agent-visible path, the footer points at that mounted or synced location instead;
+if the path cannot be guaranteed, the plugin **fails open** and leaves the
+original output untouched — never a pointer the agent can't read.
+
+## How it works — one path
+
+```
+1. Below the threshold (min_tokens)? → return None, original output unchanged.
+2. Above it → call the Compresr tool-output API (toc_latte_v2, coarse) with the
+   tool's intent as the query.
+3. Did it meaningfully shorten the output? If not → return None (unchanged).
+4. Otherwise: cache the verbatim original (cache-authority) and return
+   <API compressed text, unchanged> + a recovery footer.
+```
+
+It **fails open**: an API error — or an output that isn't meaningfully shorter —
+returns `None` (original output unchanged), with a short cooldown so a failing
+endpoint isn't hammered.
+
+Recovery is deliberately simple: the agent `read_file`s (or `search_files`) the
+cached original named in the footer. There is no line-level anchoring to trust —
+the whole original is one `read_file` away.
+
+## Data sent to Compresr
+
+When enabled, this plugin sends large tool outputs to the configured Compresr
+API endpoint before those outputs enter the conversation context. Those outputs
+can include file contents, command output, logs, and other data returned by
+Hermes tools. Do not enable per-turn tool-output compression unless that
+third-party processing is acceptable for your deployment.
+
+## Relationship to `context_engine/compresr`
+
+This is the **per-turn** complement to the **compaction-time**
+[`context_engine/compresr`](../context_engine/compresr) engine. They compose:
+this plugin is a pre-filter that shrinks each tool output once, so compaction has
+far less residual to summarize. Enable either or both.
+
+## Activation
+
+Enable the plugin — run `hermes setup` and choose **Compresr**, or add
+`tool_output_compresr` to `plugins.enabled` — and provide a key:
+
+```yaml
+# ~/.hermes/config.yaml
+compresr:
+  tool_output_enabled: true   # master switch — on by default
+```
+```bash
+# ~/.hermes/.env
+COMPRESR_API_KEY=cmp_...
+```
+
+Once the plugin is loaded and a key is present, tool-output compression is **on
+by default** (`tool_output_enabled` defaults to `true`). Set it to `false` to
+keep the plugin loaded but leave tool-output compression off. The plugin stays
+fully inert until it is listed in `plugins.enabled`, so nothing is sent to
+Compresr until you opt in.
+
+## Configuration
+
+| env / `compresr:` key | default | meaning |
+|---|---|---|
+| `COMPRESR_API_KEY` | — | **required** `cmp_…` key, read from `.env` only |
+| `COMPRESR_BASE_URL` / `base_url` | `https://api.compresr.ai/api` | API base |
+| `COMPRESR_TOOL_OUTPUT_ENABLED` / `tool_output_enabled` | `true` | master switch |
+| `COMPRESR_TOOL_OUTPUT_MODEL` / `tool_output_model` | `toc_latte_v2` | model (tool-output endpoint only accepts `toc_*` models) |
+| `COMPRESR_TOOL_OUTPUT_MIN_TOKENS` / `tool_output_min_tokens` | `1500` | skip smaller outputs |
+| `COMPRESR_TOOL_OUTPUT_TIMEOUT` / `tool_output_timeout` | `30` | request timeout (s) |
+| `COMPRESR_TOOL_OUTPUT_MAX_CACHE_MB` / `tool_output_max_cache_mb` | `256` | best-effort Hermes cache cap; `0` disables pruning |
+| `COMPRESR_TOOL_OUTPUT_TARGET_RATIO` / `tool_output_target_ratio` | `2.0` | Nx compression target; `0` lets the API decide |
+
+`base_url` must be `https://` (an `http://` value other than localhost is
+rejected and the default is used) so a stray config change can't send the API
+key or tool output in cleartext.
+
+The cache cap is a disk-usage guard, not a retention guarantee. Old cached
+originals can be pruned after enough later compressed outputs are written into
+the profile's shared Hermes cache, so a very old resumed session may contain a
+recovery reference whose backing cache file has since been evicted. Set
+`tool_output_max_cache_mb: 0` if preserving historical recovery references
+across long-lived resumed sessions matters more than bounding profile cache
+growth.
+
+## Tests
+
+`tests/test_tool_output_compresr.py` — the footer/pointer contract, hook gating
+(small output, already-compressed, JSON-envelope folding) and fail-open (API
+error, cache-write failure, not-shorter), cache-authority path translation
+(local/docker/ssh-sync/singularity), size-based retention, and config.

--- a/plugins/tool_output_compresr/__init__.py
+++ b/plugins/tool_output_compresr/__init__.py
@@ -1,0 +1,453 @@
+"""Compresr tool-output compression plugin for Hermes.
+
+Compresses large tool outputs (verbose grep/read_file/execute_code dumps) as
+they arrive, on the ``transform_tool_result`` hook, using Compresr's
+query-specific tool-output API. The compressed text is passed through unchanged
+and a footer points the agent at the full verbatim original in Hermes's managed
+cache, recoverable with a plain ``read_file``/``search_files``. Fail-open.
+
+Per-turn complement to ``plugins/context_engine/compresr`` (compaction time):
+this pre-filter shrinks each output once so compaction has less to summarize.
+
+Requires ``COMPRESR_API_KEY`` in ``.env``; the plugin stays inert until listed
+in ``plugins.enabled``. See ``README.md`` for the full config/env reference.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+from plugins.compresr_common import (
+    sanitize_secret as _sanitize_secret,
+    secure_base_url as _secure_base_url,
+)
+
+from . import cache
+from .client import CompresrToolOutputClient, DEFAULT_TOOL_OUTPUT_MODEL
+from .compress import FOOTER_MARKER, compress_tool_output, count_tokens
+
+try:
+    from agent.redact import redact_sensitive_text as _redact
+except Exception:
+    def _redact(s: str) -> str:  # type: ignore[misc]
+        return s
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.compresr.ai/api"
+_DEFAULT_MIN_TOKENS = 1500
+_DEFAULT_TIMEOUT = 30
+_DEFAULT_MAX_CACHE_MB = 256
+_DEFAULT_TARGET_RATIO = 2.0
+_COOLDOWN_SECONDS = 30.0                # back-off after an API error before retrying
+_MAX_QUERY_CHARS = 600                  # cap on the derived query sent to the API
+_CACHE_ID_LEN = 32                      # hex chars of the content hash used as cache id (128 bits)
+_OK_STATUSES = ("", "ok", "success")    # statuses we compress; others pass through
+_FALLBACK_QUERY = (
+    "Preserve the facts, paths, identifiers, errors, and results in this tool "
+    "output that are needed to continue the task."
+)
+# Args we mine, in priority order, to reconstruct the tool's intent as a query.
+_QUERY_ARG_KEYS = ("query", "pattern", "command", "q", "search", "regex", "url")
+_PATH_ARG_KEYS = ("file_path", "path", "file", "filename", "directory")
+
+
+# Full path segment every recovery target carries (host + container-translated).
+# Matching the whole segment avoids misreading an incidental mention as a recovery
+# read. Kept in sync with cache._CACHE_SUBDIR.
+_CACHE_PATH_MARKER = "cache/compresr/tool-output"
+
+# Tool → key holding the plain-text payload inside a JSON envelope. Unwrapping
+# compresses the real content (not JSON syntax) and caches readable text.
+_UNWRAPPABLE_JSON_TOOLS: Dict[str, str] = {
+    "read_file": "content",
+    "terminal": "output",
+    "execute_code": "output",
+    "search_files": "matches_text",
+}
+
+# Tools whose unwrapped payload is already line-numbered ("N|code"). We cache a
+# de-numbered copy so a recovery read_file re-adds exactly one clean gutter.
+_NUMBERED_JSON_TOOLS = {"read_file"}
+_LINE_GUTTER_RE = re.compile(r"^\d+\|")
+
+
+def _max_recoverable_line_length() -> int:
+    """The per-line cap the recovery read_file/search_files apply. Any cached
+    line longer than this is silently clamped on recovery (with no offset to
+    reach the tail), so an output containing one can't be recovered byte-exact.
+    """
+    try:
+        from tools.tool_output_limits import get_max_line_length
+
+        return int(get_max_line_length())
+    except Exception:
+        return 2000
+
+
+def _has_unrecoverable_long_line(text: str) -> bool:
+    limit = _max_recoverable_line_length()
+    return any(len(ln) > limit for ln in text.split("\n"))
+
+
+def _strip_line_gutter(text: str) -> str:
+    return "\n".join(_LINE_GUTTER_RE.sub("", ln) for ln in text.split("\n"))
+
+
+def _is_fully_guttered(text: str) -> bool:
+    """True only if every non-blank line carries an ``N|`` gutter, so stripping
+    can't mangle a payload that merely happens to contain a ``|``."""
+    lines = [ln for ln in text.split("\n") if ln.strip()]
+    return bool(lines) and all(_LINE_GUTTER_RE.match(ln) for ln in lines)
+
+
+def _try_unwrap_json_tool_result(
+    tool_name: str, result: str
+) -> Tuple[Optional[str], Optional[Callable[[str], str]]]:
+    key = _UNWRAPPABLE_JSON_TOOLS.get(tool_name)
+    if key is None:
+        return None, None
+    if not result.lstrip().startswith("{"):
+        return None, None
+    try:
+        parsed = json.loads(result)
+    except (json.JSONDecodeError, ValueError):
+        return None, None
+    if not isinstance(parsed, dict):
+        return None, None
+    inner = parsed.get(key)
+    if not isinstance(inner, str) or not inner.strip():
+        return None, None
+
+    def splice(new_inner: str) -> str:
+        out = dict(parsed)
+        out[key] = new_inner
+        return json.dumps(out, ensure_ascii=False)
+
+    return inner, splice
+
+
+def _read_config_block() -> Dict[str, Any]:
+    """Best-effort read of the ``compresr:`` block from config.yaml. Never raises."""
+    cfg_path = get_hermes_home() / "config.yaml"
+    if not cfg_path.exists():
+        return {}
+    try:
+        import yaml
+
+        with open(cfg_path, encoding="utf-8-sig") as f:
+            data = yaml.safe_load(f) or {}
+        block = data.get("compresr", {})
+        return block if isinstance(block, dict) else {}
+    except Exception as e:  # pragma: no cover - config is optional
+        logger.debug("tool_output_compresr: could not read config block: %s", e)
+        return {}
+
+
+def _as_bool(v: Any) -> bool:
+    return str(v).lower() in ("1", "true", "yes", "on")
+
+
+def _as_int(v: Any, default: int) -> int:
+    """Tolerant int coercion — a malformed config/env value (e.g. a typo'd
+    ``COMPRESR_TOOL_OUTPUT_TIMEOUT``) falls back to *default* instead of raising
+    in ``__init__`` and silently disabling the whole plugin."""
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        logger.warning("tool_output_compresr: invalid numeric value %r, using %s", v, default)
+        return default
+
+
+def _as_float(v: Any, default: float) -> float:
+    """Tolerant float coercion (see :func:`_as_int`)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        logger.warning("tool_output_compresr: invalid numeric value %r, using %s", v, default)
+        return default
+
+
+class ToolOutputCompressor:
+    """Holds config + clients and implements the transform hook."""
+
+    def __init__(self) -> None:
+        cfg = _read_config_block()
+
+        def _opt(env_key: str, cfg_key: str, default: Any) -> Any:
+            val = os.environ.get(env_key)
+            if val is not None and val != "":
+                return val
+            if cfg_key in cfg and cfg[cfg_key] not in (None, ""):
+                return cfg[cfg_key]
+            return default
+
+        self.api_key = _sanitize_secret(
+            os.environ.get("COMPRESR_API_KEY", ""), "COMPRESR_API_KEY"
+        )
+        self.base_url = _secure_base_url(
+            str(_opt("COMPRESR_BASE_URL", "base_url", _DEFAULT_BASE_URL)).rstrip("/"),
+            _DEFAULT_BASE_URL,
+        )
+        self.enabled = _as_bool(
+            _opt("COMPRESR_TOOL_OUTPUT_ENABLED", "tool_output_enabled", "")
+        )
+        self.model = str(
+            _opt("COMPRESR_TOOL_OUTPUT_MODEL", "tool_output_model", DEFAULT_TOOL_OUTPUT_MODEL)
+        )
+        self.min_tokens = _as_int(
+            _opt("COMPRESR_TOOL_OUTPUT_MIN_TOKENS", "tool_output_min_tokens", _DEFAULT_MIN_TOKENS),
+            _DEFAULT_MIN_TOKENS,
+        )
+        self.timeout = max(
+            1,
+            _as_int(
+                _opt("COMPRESR_TOOL_OUTPUT_TIMEOUT", "tool_output_timeout", _DEFAULT_TIMEOUT),
+                _DEFAULT_TIMEOUT,
+            ),
+        )
+        self.max_cache_mb = _as_int(
+            _opt(
+                "COMPRESR_TOOL_OUTPUT_MAX_CACHE_MB",
+                "tool_output_max_cache_mb",
+                _DEFAULT_MAX_CACHE_MB,
+            ),
+            _DEFAULT_MAX_CACHE_MB,
+        )
+        self.target_ratio = _as_float(
+            _opt(
+                "COMPRESR_TOOL_OUTPUT_TARGET_RATIO",
+                "tool_output_target_ratio",
+                _DEFAULT_TARGET_RATIO,
+            ),
+            _DEFAULT_TARGET_RATIO,
+        )
+
+        self._client = CompresrToolOutputClient(
+            api_key=self.api_key, base_url=self.base_url, model=self.model, timeout=self.timeout
+        )
+        # Cumulative stats for /usage and benchmarking.
+        self.calls = 0
+        self.errors = 0
+        self.tokens_in = 0       # original tokens across compressed outputs
+        self.tokens_saved = 0
+        self.recoveries = 0
+        self._cooldown_until = 0.0
+
+    # -- helpers -----------------------------------------------------------
+
+    @property
+    def active(self) -> bool:
+        return self.enabled and bool(self.api_key)
+
+    @staticmethod
+    def _derive_query(tool_name: str, args: Any) -> str:
+        """Reconstruct the tool's intent as a Compresr query.
+
+        For search-class tools (grep/web_search) the args ARE an excellent query;
+        for read/exec tools they are a weaker but still useful proxy.
+        """
+        if isinstance(args, dict):
+            for k in _QUERY_ARG_KEYS:
+                v = args.get(k)
+                if isinstance(v, str) and v.strip():
+                    return f"{tool_name}: {v.strip()}"[:_MAX_QUERY_CHARS]
+            for k in _PATH_ARG_KEYS:
+                v = args.get(k)
+                if isinstance(v, str) and v.strip():
+                    return f"Relevant content of {v.strip()} for the current task"[:_MAX_QUERY_CHARS]
+        if tool_name:
+            return f"Relevant output of the {tool_name} call for the current task"
+        return _FALLBACK_QUERY
+
+    @staticmethod
+    def _is_recovery_read(args: Any) -> bool:
+        """True if *args* points at a file under our compresr cache.
+
+        A recovery ``read_file`` (or ``search_files``) targeting a cached
+        original must NOT be re-compressed: the cached file is the verbatim
+        source and is >= min_tokens but carries no FOOTER_MARKER, so without
+        this guard the hook re-fires and returns a lossy summary instead of the
+        exact original the agent asked to recover.
+
+        Backend-agnostic: the cache path always contains the segment
+        ``cache/compresr/tool-output`` — true for the host path AND the
+        container-translated ``/root/.hermes/...`` path. We first check for that
+        full segment (which remote/translated paths still carry), then fall back
+        to a resolved comparison against the real cache root.
+        """
+        if not isinstance(args, dict):
+            return False
+        try:
+            cache_root = str(cache.get_cache_root().resolve())
+        except Exception:
+            cache_root = ""
+        for v in args.values():
+            if not isinstance(v, str) or not v:
+                continue
+            if _CACHE_PATH_MARKER in v:
+                return True
+            if cache_root:
+                try:
+                    if str(Path(v).resolve()).startswith(cache_root):
+                        return True
+                except (OSError, ValueError):
+                    pass
+        return False
+
+    @staticmethod
+    def _cache_id(content: str) -> str:
+        # Hash the CONTENT (not the tool_call_id) so two different outputs can
+        # never collide onto one cache file; identical outputs safely dedupe.
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()[:_CACHE_ID_LEN]
+
+    # -- the hook ----------------------------------------------------------
+
+    def on_transform_tool_result(
+        self,
+        tool_name: str = "",
+        args: Any = None,
+        result: Any = None,
+        task_id: str = "",
+        tool_call_id: str = "",
+        status: str = "",
+        **_: Any,
+    ) -> Optional[str]:
+        """Return a compressed replacement string, or None to leave unchanged.
+
+        Fail-open: any error, cooldown, small output, or error-status result
+        returns None so the model sees the original.
+        """
+        if not self.active or not isinstance(result, str):
+            return None
+        if status and status not in _OK_STATUSES:
+            return None  # don't mangle error results
+        if FOOTER_MARKER in result:
+            return None  # already compressed by us — idempotent
+        if self._is_recovery_read(args):
+            # The agent is recovering a cached original via read_file/search_files;
+            # return it verbatim rather than re-compressing it into a lossy summary.
+            self.recoveries += 1
+            return None
+        if count_tokens(result) < self.min_tokens:
+            return None  # too small to be worth a round-trip
+        now = time.monotonic()
+        if now < self._cooldown_until:
+            return None
+
+        # Redact secrets in tool args (curl -H 'Authorization: Bearer ...' etc)
+        # before the query string leaves the process to a third-party API.
+        query = _redact(self._derive_query(tool_name, args))
+
+        inner_text, splice = _try_unwrap_json_tool_result(tool_name, result)
+        compress_target = inner_text if inner_text is not None else result
+        if inner_text is not None and count_tokens(inner_text) < self.min_tokens:
+            return None
+
+        cache_content = compress_target
+        if (
+            inner_text is not None
+            and tool_name in _NUMBERED_JSON_TOOLS
+            and _is_fully_guttered(inner_text)
+        ):
+            cache_content = _strip_line_gutter(inner_text)
+
+        if _has_unrecoverable_long_line(cache_content):
+            return None
+
+        # Redact outbound + cached content. The cache is a durable secret-bearing
+        # artefact on disk; content-address AFTER redaction so identical
+        # redacted content dedupes.
+        compress_target = _redact(compress_target)
+        cache_content = _redact(cache_content)
+
+        cache_id = self._cache_id(compress_target)
+        try:
+            out, info = compress_tool_output(
+                query=query,
+                content=compress_target,
+                cache_content=cache_content,
+                tool_name=tool_name,
+                cache_id=cache_id,
+                client=self._client,
+                task_id=task_id,
+                max_cache_mb=self.max_cache_mb,
+                target_ratio=self.target_ratio,
+            )
+        except Exception as e:  # compress is already fail-open, but be defensive
+            self.errors += 1
+            self._cooldown_until = time.monotonic() + _COOLDOWN_SECONDS
+            logger.warning("tool_output_compresr: hook error (%s)", e)
+            return None
+
+        if info.get("error"):
+            # Genuine failures (API/transport error, empty output, cache-write
+            # failure) arm the anti-hammer cooldown. A benign "no net win" uses
+            # skipped_reason instead, so it can't suppress all later outputs.
+            self.errors += 1
+            self._cooldown_until = time.monotonic() + _COOLDOWN_SECONDS
+        if not info.get("called_api"):
+            return None  # API failed → leave the original output unchanged
+        if not info.get("shortened"):
+            # The API didn't produce a meaningfully shorter output (or the cache
+            # write / backend-visibility check failed) — leave the original
+            # unchanged rather than spend context on a footer for no gain.
+            return None
+        saved = max(0, info.get("base_tokens", 0) - info.get("out_tokens", 0))
+        self.calls += 1
+        self.tokens_in += info.get("base_tokens", 0)
+        self.tokens_saved += saved
+        logger.info(
+            "tool_output_compresr: %s %d→%d tokens (saved %d, unwrapped=%s, cache=%s)",
+            tool_name,
+            info.get("base_tokens", 0),
+            info.get("out_tokens", 0),
+            saved,
+            splice is not None,
+            info.get("cache_path", "?"),
+        )
+        if splice is not None:
+            # Fold the footer into the JSON envelope's inner text so the result
+            # stays valid JSON for the tool that produced it.
+            return splice(out)
+        return out
+
+    def get_status(self) -> Dict[str, Any]:
+        return {
+            "plugin": "tool_output_compresr",
+            "active": self.active,
+            "model": self.model,
+            "min_tokens": self.min_tokens,
+            "max_cache_mb": self.max_cache_mb,
+            "calls": self.calls,
+            "errors": self.errors,
+            "tokens_in": self.tokens_in,
+            "tokens_saved": self.tokens_saved,
+            "recoveries": self.recoveries,
+        }
+
+
+def register(ctx: Any) -> None:
+    """Plugin entry point — called by the Hermes plugin loader."""
+    try:
+        cache.ensure_cache_root()
+    except Exception as e:
+        logger.warning("tool_output_compresr: could not initialize cache root: %s", e)
+    compressor = ToolOutputCompressor()
+    ctx.register_hook("transform_tool_result", compressor.on_transform_tool_result)
+    if not compressor.api_key:
+        logger.info(
+            "tool_output_compresr: loaded but COMPRESR_API_KEY is unset — inactive."
+        )
+    elif not compressor.enabled:
+        logger.info(
+            "tool_output_compresr: loaded but disabled — set compresr.tool_output_enabled: true."
+        )

--- a/plugins/tool_output_compresr/cache.py
+++ b/plugins/tool_output_compresr/cache.py
@@ -1,0 +1,292 @@
+"""Persist original tool outputs so recovery references resolve.
+
+The canonical cache lives under ``HERMES_HOME/cache/compresr/tool-output``. We
+write originals there on the host, then translate the path to an agent-visible
+location only when the active backend can prove one — otherwise callers fail open
+rather than emit a recovery reference the agent can't read.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_CACHE_SUBDIR = Path("cache") / "compresr" / "tool-output"
+_CONTAINER_HERMES_HOME = "/root/.hermes"  # HERMES_HOME inside Docker/Modal backends
+_DIR_MODE = 0o700
+_FILE_MODE = 0o600
+_MB = 1024 * 1024
+
+# Serialize write+prune across threads: subagents share one cache dir, so a
+# concurrent prune must never race a sibling that just handed out a footer path.
+_STORE_LOCK = threading.Lock()
+
+# Pin recently-written entries against size-based eviction for this long, so a
+# footer path just returned to the model survives a parallel prune.
+_PRUNE_PIN_SECONDS = 300.0
+
+
+def get_cache_root() -> Path:
+    """Return the host-side cache root for compressed tool outputs."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / _CACHE_SUBDIR
+
+
+def ensure_cache_root() -> Path:
+    """Create the cache root with restrictive permissions if needed."""
+    root = get_cache_root()
+    root.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
+    try:
+        os.chmod(root, _DIR_MODE)
+    except OSError:
+        pass
+    return root
+
+
+def cache_file_path(cache_id: str) -> Path:
+    """Host-side file path for *cache_id* — the single source of truth, used by
+    :func:`store_original`."""
+    return get_cache_root() / cache_id
+
+
+def _get_active_env(task_id: str):
+    try:
+        from tools.terminal_tool import get_active_env as _get
+
+        return _get(task_id)
+    except Exception:
+        return None
+
+
+def _container_file_visible(active_env, container_path: str, host_path: Path) -> bool:
+    """Prove the *running* container can actually read *container_path*.
+
+    Docker bind-mounts are fixed at ``docker run`` time and the default
+    cross-process reuse path attaches to an existing container by label without
+    re-mounting — so a container created before our cache dir existed (or by a
+    process where the plugin was inactive) may lack the mount even though
+    ``map_cache_path_to_container`` "proved" it in principle. We exec a cheap
+    read-only byte count in the container and require it to match the host file
+    size; anything else (no exec primitive, non-zero rc, size mismatch, error)
+    means the path is not readable there → caller fails open.
+    """
+    execute = getattr(active_env, "execute", None)
+    if not callable(execute):
+        return False
+    try:
+        expected = host_path.stat().st_size
+    except OSError:
+        return False
+    try:
+        res = execute(f"wc -c < {shlex.quote(str(container_path))}")
+    except Exception as e:  # pragma: no cover - probe is best effort
+        logger.debug("tool_output_compresr: container visibility probe failed: %s", e)
+        return False
+    if not isinstance(res, dict) or res.get("returncode", 1) != 0:
+        return False
+    match = re.search(r"\d+", str(res.get("output", "")))
+    return bool(match) and int(match.group()) == expected
+
+
+def _agent_visible_cache_path(cache_path: Path, task_id: str) -> Optional[str]:
+    """Translate *cache_path* to the path the active backend can read.
+
+    Local backends read the host path directly; non-local backends need a
+    concrete mounted/synced path. Return ``None`` (→ caller fails open) if we
+    can't establish one.
+    """
+    active_env = _get_active_env(task_id)
+    probe_container = False
+
+    if active_env is not None:
+        env_name = active_env.__class__.__name__
+        if env_name == "LocalEnvironment":
+            try:
+                return str(cache_path.resolve())
+            except OSError:
+                return str(cache_path)
+        if env_name == "SingularityEnvironment" or "singularity" in env_name.lower():
+            return None
+
+        remote_home = getattr(active_env, "_remote_home", None)
+        if isinstance(remote_home, str) and remote_home.strip():
+            container_base = f"{remote_home.rstrip('/')}/.hermes"
+        elif env_name in {"DockerEnvironment", "ModalEnvironment"}:
+            container_base = _CONTAINER_HERMES_HOME
+            # Docker relies purely on a bind-mount fixed at container creation
+            # (no per-write sync), so a reused container can lack the mount.
+            # Probe the live container before trusting the translated path.
+            probe_container = env_name == "DockerEnvironment"
+        else:
+            return None
+    else:
+        backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower() or "local"
+        if backend == "local":
+            try:
+                return str(cache_path.resolve())
+            except OSError:
+                return str(cache_path)
+        if backend in {"docker", "modal"}:
+            container_base = _CONTAINER_HERMES_HOME
+        else:
+            return None
+
+    try:
+        from tools.credential_files import map_cache_path_to_container
+
+        translated = map_cache_path_to_container(str(cache_path), container_base=container_base)
+    except Exception as e:  # pragma: no cover - translation is best effort
+        logger.debug("tool_output_compresr: cache path mapping failed: %s", e)
+        return None
+
+    if translated and probe_container and not _container_file_visible(
+        active_env, translated, cache_path
+    ):
+        logger.warning(
+            "tool_output_compresr: container cannot read cache path %s — failing open",
+            translated,
+        )
+        return None
+    return translated
+
+
+def _force_sync_visible_cache(cache_path: Path, task_id: str) -> bool:
+    """Best-effort force sync for backends that stage files into a remote FS."""
+    active_env = _get_active_env(task_id)
+    if active_env is None:
+        return True
+
+    env_name = active_env.__class__.__name__
+    if env_name == "LocalEnvironment":
+        return True
+    if env_name == "SingularityEnvironment" or "singularity" in env_name.lower():
+        return True
+
+    sync_manager = None
+    for attr in ("_sync_manager", "sync_manager", "_file_sync_manager"):
+        candidate = getattr(active_env, attr, None)
+        if candidate is not None and callable(getattr(candidate, "sync", None)):
+            sync_manager = candidate
+            break
+    if sync_manager is None:
+        return True
+
+    # raise_on_error surfaces transport failures that sync() would otherwise
+    # swallow (leaving a dangling footer); fall back for managers without it.
+    try:
+        try:
+            sync_manager.sync(force=True, raise_on_error=True)
+        except TypeError:
+            sync_manager.sync(force=True)
+        return True
+    except Exception as e:
+        # Don't unlink cache_path: it is content-addressed, so a sibling may
+        # already hold this path. Leave it for the pruner to reclaim.
+        logger.warning("tool_output_compresr: force sync failed for %s: %s", cache_path, e)
+        return False
+
+
+def _prune_cache_dir(cache_dir: str, max_bytes: int, keep_path: str) -> None:
+    """Best-effort size-based prune of the host-side cache root."""
+    if max_bytes <= 0:
+        return
+    root = Path(cache_dir)
+    keep = Path(keep_path)
+    now = time.time()
+    try:
+        entries = []
+        total = 0
+        for path in root.iterdir():
+            if not path.is_file():
+                continue
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            size = int(stat.st_size)
+            total += size
+            entries.append((float(stat.st_mtime), path, size))
+        if total <= max_bytes:
+            return
+        for mtime, path, size in sorted(entries):
+            try:
+                if path.resolve() == keep.resolve():
+                    continue
+                if now - mtime < _PRUNE_PIN_SECONDS:  # pin recent footer targets
+                    continue
+                path.unlink()
+                total -= size
+            except OSError:
+                continue
+            if total <= max_bytes:
+                break
+    except Exception as e:  # pragma: no cover - pruning must never break recovery
+        logger.debug("tool_output_compresr: cache prune failed for %s: %s", cache_dir, e)
+
+
+def store_original(
+    cache_id: str,
+    content: str,
+    task_id: str = "default",
+    max_cache_mb: int = 256,
+) -> Optional[str]:
+    """Persist ``content`` under ``cache_id`` on the host cache root.
+
+    Returns an agent-visible path when one can be proven, else ``None`` (caller
+    must fail open).
+    """
+    root = ensure_cache_root()
+    cache_path = cache_file_path(cache_id)
+    # Atomic write via O_NOFOLLOW + os.replace: a symlink attack on the cache
+    # dir can't redirect writes, and a concurrent sibling opening cache_path
+    # sees either the full old or full new bytes — never a partial write.
+    tmp_path = cache_path.with_name(f".{cache_path.name}.{os.getpid()}.tmp")
+    try:
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+            _FILE_MODE,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        try:
+            os.chmod(tmp_path, _FILE_MODE)
+        except OSError:
+            pass
+        os.replace(str(tmp_path), str(cache_path))
+    except Exception as e:
+        logger.warning("tool_output_compresr: cache write failed for %s: %s", cache_path, e)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+
+    sync_ok = _force_sync_visible_cache(cache_path, task_id)
+    visible_path = _agent_visible_cache_path(cache_path, task_id) if sync_ok else None
+
+    # Run the pruner unconditionally so a Singularity / non-visible backend
+    # can't grow the cache without bound. Don't unlink on visibility failure
+    # — a concurrent sibling with identical content may already hold this path.
+    try:
+        with _STORE_LOCK:
+            _prune_cache_dir(str(root), max(0, int(max_cache_mb)) * _MB, str(cache_path))
+    except Exception as e:  # pragma: no cover
+        logger.debug("tool_output_compresr: cache prune failed: %s", e)
+
+    if visible_path is None:
+        logger.warning(
+            "tool_output_compresr: cache path not visible to the active backend: %s",
+            cache_path,
+        )
+        return None
+    return visible_path

--- a/plugins/tool_output_compresr/client.py
+++ b/plugins/tool_output_compresr/client.py
@@ -1,0 +1,109 @@
+"""Thin client for Compresr's tool-output compression endpoint.
+
+``POST /compress/tool-output/`` with the tool output, the query (tool intent),
+and the tool name. ``disable_placeholders`` stays FALSE so the API keeps its own
+inline drop markers (``[N tokens removed]``), passed through verbatim alongside
+the recovery pointer. stdlib-only (urllib) to keep the plugin import-light.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Tuple
+
+from plugins.compresr_common import (
+    MAX_RESPONSE_BYTES as _MAX_RESPONSE_BYTES,
+    read_with_cap as _read_with_cap,
+    sanitize_secret as _sanitize_secret,
+)
+
+DEFAULT_TOOL_OUTPUT_MODEL = "toc_latte_v2"
+
+_ERR_DETAIL_MAXLEN = 300
+
+
+class CompresrToolOutputClient:
+    DEFAULT_SOURCE = "integration:hermes"
+    USER_AGENT = "hermes-tool-output/0.1"
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.compresr.ai/api",
+        model: str = DEFAULT_TOOL_OUTPUT_MODEL,
+        timeout: int = 30,
+        source: str = DEFAULT_SOURCE,
+    ) -> None:
+        self.api_key = _sanitize_secret(api_key, "COMPRESR_API_KEY")
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.timeout = timeout
+        self.source = source
+
+    def compress(
+        self,
+        tool_output: str,
+        query: str,
+        tool_name: str,
+        target_ratio: float = 0.0,
+        coarse: bool = True,
+        disable_placeholders: bool = False,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Return ``(compressed_output, data)``. Raises on transport/HTTP/API error."""
+        if not self.api_key:
+            raise RuntimeError("COMPRESR_API_KEY not set")
+        if not tool_output:
+            raise RuntimeError("tool_output is required")
+
+        payload: Dict[str, Any] = {
+            "tool_output": tool_output,
+            "query": query,
+            "tool_name": tool_name or "unknown",
+            "compression_model_name": self.model,
+            "source": self.source,
+            "disable_placeholders": disable_placeholders,
+            "coarse": coarse,
+        }
+        if target_ratio and target_ratio > 0:
+            payload["target_compression_ratio"] = target_ratio
+
+        req = urllib.request.Request(
+            f"{self.base_url}/compress/tool-output/",
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-API-Key": self.api_key,
+                "User-Agent": self.USER_AGENT,
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = _read_with_cap(resp, _MAX_RESPONSE_BYTES).decode("utf-8")
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                detail = _read_with_cap(e, 4096).decode("utf-8")[:_ERR_DETAIL_MAXLEN]
+            except Exception:
+                pass
+            raise RuntimeError(f"HTTP {e.code}: {detail or e.reason}") from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"connection error: {e.reason}") from e
+        except ValueError:
+            raise RuntimeError(
+                "invalid request headers (check COMPRESR_API_KEY for stray whitespace/CRLF)"
+            ) from None
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"non-JSON response ({e}); body prefix: {raw[:200]!r}") from e
+        if not parsed.get("success", False):
+            raise RuntimeError(f"API error: {parsed.get('message') or parsed.get('error')}")
+        d = parsed.get("data") or {}
+        compressed = d.get("compressed_output", "")
+        if not compressed:
+            raise RuntimeError("API returned empty compressed_output")
+        return compressed, d

--- a/plugins/tool_output_compresr/compress.py
+++ b/plugins/tool_output_compresr/compress.py
@@ -1,0 +1,129 @@
+"""Tool-output compression: compress, cache the original, point back.
+
+Call the Compresr API, persist the verbatim original to Hermes's managed cache,
+and return the API's compressed text unchanged plus a footer pointing the agent
+at the full original (recoverable via ``read_file``/``search_files``). Fail-open:
+any API error, or an output that isn't meaningfully shorter once the footer is
+added, returns the original content unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from . import cache
+from .client import CompresrToolOutputClient
+
+logger = logging.getLogger(__name__)
+
+# Marks our own footer so the hook never re-compresses an output it produced.
+FOOTER_MARKER = "[compresr:recover]"
+
+# Conservative footer token budget (path embedded twice: in prose + read_file hint).
+# The exact net-size check below catches any long remote-home path that exceeds it.
+FOOTER_TOKEN_BUDGET = 90
+
+# Rough chars-per-token used for dependency-free gating estimates.
+_CHARS_PER_TOKEN = 4
+
+
+def count_tokens(s: str) -> int:
+    """Cheap, dependency-free token estimate for gating."""
+    return (len(s) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN
+
+
+def _footer(path: str, base_tok: int, out_tok: int) -> str:
+    saved = max(0, base_tok - out_tok)
+    pct = int(round(100 * saved / base_tok)) if base_tok else 0
+    return (
+        f"\n\n{FOOTER_MARKER} Tool output compressed {base_tok}→{out_tok} tokens "
+        f"(~{pct}% saved). The full verbatim original is cached at {path} — "
+        f"if you need exact details that were summarized away, recover them with "
+        f'read_file("{path}") or search_files.'
+    )
+
+
+def compress_tool_output(
+    query: str,
+    content: str,
+    tool_name: str,
+    cache_id: str,
+    client: CompresrToolOutputClient,
+    task_id: str = "default",
+    max_cache_mb: int = 256,
+    target_ratio: float = 2.0,
+    cache_content: Optional[str] = None,
+) -> Tuple[str, Dict[str, Any]]:
+    """Compress via Compresr, store the original, append a recovery footer.
+
+    Returns ``(output_text, info)`` and never raises: on any failure it returns
+    the original ``content`` with ``info["shortened"]`` False.
+
+    ``cache_content`` is what gets persisted for recovery (defaults to
+    ``content``); it may differ, e.g. a de-numbered copy of already-line-numbered
+    read_file output. The API call and size gate always use ``content``.
+    """
+    if cache_content is None:
+        cache_content = content
+    base_tok = count_tokens(content)
+    info: Dict[str, Any] = {
+        "called_api": False,
+        "base_tokens": base_tok,
+        "out_tokens": base_tok,
+        "shortened": False,
+    }
+
+    try:
+        compressed, stats = client.compress(
+            tool_output=content, query=query, tool_name=tool_name,
+            coarse=True, target_ratio=target_ratio,
+        )
+    except Exception as e:  # fail-open to the original tool output
+        logger.warning("tool_output_compresr: API failed (%s) — leaving original", e)
+        info["error"] = str(e)
+        return content, info
+
+    info["called_api"] = True
+    info["api_stats"] = stats
+
+    # A whitespace-only body is truthy at the client layer but would replace the
+    # output with near-nothing — treat as failure and fail open.
+    if not compressed or not compressed.strip():
+        info["error"] = "empty compressed output"
+        return content, info
+
+    # Cheap pre-filter before paying for the cache write / remote sync.
+    body_tok = count_tokens(compressed)
+    if body_tok + FOOTER_TOKEN_BUDGET >= base_tok:
+        # Benign "no net win", NOT a failure — leave info["error"] unset so the
+        # caller doesn't back off / count it as an error.
+        info["skipped_reason"] = "not smaller"
+        return content, info
+
+    # store_original returns an agent-visible path, or None if the active backend
+    # can't prove one — fail open rather than point at an unreadable file.
+    cache_path = cache.store_original(cache_id, cache_content, task_id, max_cache_mb=max_cache_mb)
+    if cache_path is None:
+        info["error"] = "cache write failed"
+        return content, info
+
+    # Report the honest post-footer size so the footer never understates cost.
+    reported_out_tok = body_tok + FOOTER_TOKEN_BUDGET
+    out = compressed + _footer(cache_path, base_tok, reported_out_tok)
+    # Exact gate on the REAL returned size: a long remote-home cache path can push
+    # the footer past FOOTER_TOKEN_BUDGET, so fail open if it isn't a net win.
+    out_tok = count_tokens(out)
+    if out_tok >= base_tok:
+        # Don't delete the cache entry — cache_id is content-addressed, so a
+        # sibling may already hold this path; the pruner reclaims it if unused.
+        # Benign "no net win" (not a failure): leave info["error"] unset.
+        info["skipped_reason"] = "not smaller after footer"
+        return content, info
+    info.update({
+        "shortened": True,
+        "out_tokens": out_tok,
+        "saved": max(0, base_tok - out_tok),
+        "cache_path": cache_path,
+    })
+    return out, info

--- a/plugins/tool_output_compresr/plugin.yaml
+++ b/plugins/tool_output_compresr/plugin.yaml
@@ -1,0 +1,17 @@
+name: tool_output_compresr
+version: "0.1.0"
+description: >-
+  Compresr (YC W26) per-turn tool-output compression. Compresses large tool
+  outputs (verbose grep/read_file/execute_code dumps) on the
+  transform_tool_result hook — before they bloat the context window — using
+  Compresr's query-specific tool-output API (toc_latte_v2), with the tool's
+  intent as the query. The compressed text is passed through unchanged and a
+  footer points the agent at the full verbatim original under Hermes's managed
+  cache (cache/compresr/tool-output/<id>), recoverable with a plain
+  read_file/search_files. Lossy-summary + recoverable-source, fail-open, and
+  enabled by default when the plugin is loaded. Complements the compaction-time
+  context_engine/compresr plugin.
+author: "Compresr (YC W26)"
+homepage: https://compresr.ai
+hooks:
+  - transform_tool_result

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,11 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
+    "kamel@compresr.ai": "Compresr (YC W26) — charafkamel",
+    "oussama@compresr.ai": "Compresr (YC W26) — Ousso11",
+    "jakub.wolniewicz@gmail.com": "frizikk",
+    "markvlcek@gmail.com": "MarkVLK",
+    "agent@agents-Mac-mini.local": "teknium1",
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)
@@ -207,6 +212,8 @@ AUTHOR_MAP = {
     "rebel@rebels-Mac-Studio-2.local": "rebel0789",  # PR #47308 salvage (redact browser_type typed text across display surfaces; #47197)
     "267614622+agt-user@users.noreply.github.com": "agt-user",  # PR #48496 salvage (telegram CLOSE-WAIT polling heartbeat, #48495)
     "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #52272 salvage (route reasoning-model thinking-timeouts to timeout not context_overflow + reasoning-specific guidance; #52271)
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",
+    "gigakun@agentmail.to": "gigakun3030",
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
     "nikshepsvn@gmail.com": "nikshepsvn",  # PR #27426 salvage (two-layer guard against hallucinated acp_command crashing the gateway on hosts with no ACP CLI)
     "65363919+coygeek@users.noreply.github.com": "coygeek",  # PR #37735 salvage (redact provider error text at api-server HTTP boundary; #37733)

--- a/tests/hermes_cli/test_setup_openclaw_migration.py
+++ b/tests/hermes_cli/test_setup_openclaw_migration.py
@@ -260,6 +260,7 @@ class TestSetupWizardOpenclawIntegration:
             patch.object(setup_mod, "setup_agent_settings"),
             patch.object(setup_mod, "setup_gateway"),
             patch.object(setup_mod, "setup_tools"),
+            patch.object(setup_mod, "_setup_context_compression"),
             patch.object(setup_mod, "save_config"),
             patch.object(setup_mod, "_print_setup_summary"),
         ):
@@ -291,6 +292,7 @@ class TestSetupWizardOpenclawIntegration:
             patch.object(setup_mod, "setup_agent_settings"),
             patch.object(setup_mod, "setup_gateway"),
             patch.object(setup_mod, "setup_tools"),
+            patch.object(setup_mod, "_setup_context_compression"),
             patch.object(setup_mod, "save_config"),
             patch.object(setup_mod, "_print_setup_summary"),
         ):
@@ -323,6 +325,7 @@ class TestSetupWizardOpenclawIntegration:
             patch.object(setup_mod, "setup_agent_settings"),
             patch.object(setup_mod, "setup_gateway"),
             patch.object(setup_mod, "setup_tools"),
+            patch.object(setup_mod, "_setup_context_compression"),
             patch.object(setup_mod, "save_config"),
             patch.object(setup_mod, "_print_setup_summary"),
         ):
@@ -664,6 +667,7 @@ class TestSetupWizardSkipsConfiguredSections:
             patch.object(setup_mod, "setup_agent_settings") as mock_agent,
             patch.object(setup_mod, "setup_gateway") as mock_gateway,
             patch.object(setup_mod, "setup_tools") as mock_tools,
+            patch.object(setup_mod, "_setup_context_compression"),
             patch.object(setup_mod, "save_config"),
             patch.object(setup_mod, "_print_setup_summary"),
         ):

--- a/tests/hermes_cli/test_setup_reconfigure.py
+++ b/tests/hermes_cli/test_setup_reconfigure.py
@@ -114,6 +114,7 @@ class TestExistingInstallDefault:
                 agent="hermes_cli.setup.setup_agent_settings",
                 gateway="hermes_cli.setup.setup_gateway",
                 tools="hermes_cli.setup.setup_tools",
+                compresr="hermes_cli.setup._setup_context_compression",
             )
             from hermes_cli.setup import run_setup_wizard
             run_setup_wizard(args)
@@ -143,6 +144,7 @@ class TestExistingInstallDefault:
                 agent="hermes_cli.setup.setup_agent_settings",
                 gateway="hermes_cli.setup.setup_gateway",
                 tools="hermes_cli.setup.setup_tools",
+                compresr="hermes_cli.setup._setup_context_compression",
             )
             from hermes_cli.setup import run_setup_wizard
             run_setup_wizard(args)

--- a/tests/test_compresr_context_engine.py
+++ b/tests/test_compresr_context_engine.py
@@ -1,0 +1,317 @@
+"""Contract test for the context_engine/compresr compaction engine.
+
+The engine couples to the parent ``ContextCompressor``'s PRIVATE seam
+(``_generate_summary`` + summary-prefix helpers). This test pins that contract
+so an upstream refactor fails loudly in CI instead of silently degrading the
+plugin to a no-op:
+
+  * the override's signature matches the parent's,
+  * a successful API call returns the prefixed compressed body,
+  * an API failure returns None and trips the error counter + cooldown,
+  * the external engine defaults to aborting failed compactions so context is
+    preserved instead of replaced by a deterministic placeholder.
+"""
+
+import inspect
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from agent.context_compressor import ContextCompressor  # noqa: E402
+from plugins.context_engine.compresr import CompresrContextEngine  # noqa: E402
+
+TURNS = [
+    {"role": "user", "content": "Refactor the auth module and fix the login bug."},
+    {"role": "assistant", "content": "Edited auth.py; tests pass. Token TTL set to 3600."},
+]
+
+
+def _engine():
+    e = CompresrContextEngine()
+    e.compresr_api_key = "cmp_test"  # avoid the unset-key warning path
+    return e
+
+
+def test_override_signature_matches_parent():
+    parent = inspect.signature(ContextCompressor._generate_summary).parameters
+    child = inspect.signature(CompresrContextEngine._generate_summary).parameters
+    assert list(parent) == list(child), (
+        "parent _generate_summary signature changed — update the override"
+    )
+
+
+def test_update_model_signature_matches_parent():
+    """The update_model override must stay signature-compatible with the parent
+    so a caller passing e.g. max_tokens never hits a TypeError or a silently
+    dropped argument. Pins the parameter list against the authoritative parent."""
+    parent = inspect.signature(ContextCompressor.update_model).parameters
+    child = inspect.signature(CompresrContextEngine.update_model).parameters
+    assert list(parent) == list(child), (
+        "parent update_model signature changed — update the override"
+    )
+
+
+def test_update_model_forwards_max_tokens_to_parent():
+    """max_tokens must be forwarded, not dropped."""
+    e = _engine()
+    seen = {}
+
+    def _spy(self, model, context_length, base_url="", api_key="", provider="",
+             api_mode="", max_tokens=None):
+        seen["max_tokens"] = max_tokens
+
+    orig = ContextCompressor.update_model
+    try:
+        ContextCompressor.update_model = _spy  # type: ignore[method-assign]
+        e.update_model("m", 128000, max_tokens=4096)
+    finally:
+        ContextCompressor.update_model = orig  # type: ignore[method-assign]
+    assert seen["max_tokens"] == 4096
+
+
+def test_call_compresr_builds_request_and_parses_compressed_context(monkeypatch):
+    """Pin the HTTP contract of the question-specific client: payload shape,
+    X-API-Key header, and the response envelope key ``compressed_context``
+    (which DIFFERS from the tool-output endpoint's ``compressed_output`` — a
+    real drift footgun if the two are ever conflated)."""
+    import io
+    import urllib.error
+    import urllib.request
+
+    captured = {}
+
+    class _Resp:
+        def __init__(self, body):
+            self._b = body.encode("utf-8")
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=None):
+        captured["req"] = req
+        return _Resp(json.dumps({"success": True, "data": {
+            "compressed_context": "KEPT summary", "tokens_saved": 12,
+        }}))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    e = _engine()
+    e.compresr_model = "latte_v2"
+    text, stats = e._call_compresr("some context", "the query")
+
+    assert text == "KEPT summary"
+    assert stats["tokens_saved"] == 12
+    req = captured["req"]
+    assert req.full_url.endswith("/compress/question-specific/")
+    assert req.get_header("X-api-key") == "cmp_test"
+    payload = json.loads(req.data)
+    assert payload["context"] == "some context"
+    assert payload["query"] == "the query"
+    assert payload["compression_model_name"] == "latte_v2"
+    assert "target_compression_ratio" in payload
+    assert payload["source"] == "integration:hermes"
+
+    # success:false → RuntimeError so the caller can fall back.
+    def _fail(req, timeout=None):
+        return _Resp(json.dumps({"success": False, "message": "nope"}))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fail)
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError):
+        e._call_compresr("c", "q")
+
+    # HTTPError → RuntimeError carrying the status + server detail.
+    def _http_err(req, timeout=None):
+        raise urllib.error.HTTPError(
+            "u", 422, "Unprocessable", None, io.BytesIO(b'{"detail":"bad"}')
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", _http_err)
+    with _pytest.raises(RuntimeError) as ei:
+        e._call_compresr("c", "q")
+    assert "422" in str(ei.value)
+
+
+def test_success_returns_prefixed_body():
+    e = _engine()
+    e._call_compresr = lambda context, query: ("KEPT: login bug, TTL 3600", {"tokens_saved": 42})
+    out = e._generate_summary(TURNS, focus_topic="login bug")
+    assert out is not None
+    # Carries the standard summary prefix so iterative re-compaction recognizes it.
+    assert out == e._with_summary_prefix(e._strip_summary_prefix(out))
+    assert "login bug" in out
+    assert e.compresr_calls == 1
+    assert e._previous_summary  # continuity state updated
+
+
+def test_failure_falls_back_to_none():
+    e = _engine()
+
+    def _boom(context, query):
+        raise RuntimeError("HTTP 500")
+
+    e._call_compresr = _boom
+    out = e._generate_summary(TURNS, focus_topic="anything")
+    assert out is None  # → inherited compress() uses its deterministic handoff
+    assert e.compresr_errors == 1
+    assert e._summary_failure_cooldown_until > 0  # cooldown tripped
+    assert e.abort_on_summary_failure is True
+
+
+def test_empty_compression_is_treated_as_failure():
+    e = _engine()
+    e._call_compresr = lambda context, query: ("", {})
+    assert e._generate_summary(TURNS, focus_topic="x") is None
+    assert e.compresr_errors == 1
+
+
+def test_failure_cooldown_persists_to_session_db():
+    """Fix #4: the failure cooldown must go through the parent's
+    _record_compression_failure_cooldown so it persists to the session DB and
+    survives across processes — not just an in-memory field assignment."""
+    e = _engine()
+
+    class _FakeDB:
+        def __init__(self):
+            self.calls = []
+
+        def record_compression_failure_cooldown(self, session_id, cooldown_until, error):
+            self.calls.append((session_id, cooldown_until, error))
+
+    db = _FakeDB()
+    e._session_db = db
+    e._session_id = "sess-1"
+
+    def _boom(context, query):
+        raise RuntimeError("HTTP 500")
+
+    e._call_compresr = _boom
+    assert e._generate_summary(TURNS, focus_topic="x") is None
+    assert e._summary_failure_cooldown_until > 0        # in-memory still set
+    assert len(db.calls) == 1                            # AND persisted
+    assert db.calls[0][0] == "sess-1"
+    assert "HTTP 500" in (db.calls[0][2] or "")
+
+
+def test_ratio_mapping_keep_to_nx():
+    e = _engine()
+    e.summary_target_ratio = 0.2  # keep ~20%
+    assert e._target_compression_ratio() == 5.0  # → 5x
+    e.compresr_ratio_override = 0.8
+    assert e._target_compression_ratio() == 0.8  # explicit override wins
+
+
+def test_api_key_is_env_only(monkeypatch, tmp_path):
+    monkeypatch.delenv("COMPRESR_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "compresr:\n  api_key: cmp_from_config\n  model: latte_v1\n",
+        encoding="utf-8",
+    )
+
+    e = CompresrContextEngine()
+    assert e.compresr_api_key == ""
+    assert e.compresr_model == "latte_v1"
+    assert not e.is_available()
+
+
+def _parent_reference(context_length):
+    """Build a bare parent ContextCompressor and drive its update_model so we
+    can compare the child's derived budgets against the authoritative parent."""
+    parent = ContextCompressor(model="parent-placeholder", config_context_length=200_000)
+    parent.update_model("m", context_length)
+    return parent
+
+
+def test_update_model_threshold_matches_parent_and_can_fire_small_ctx():
+    """update_model must not re-floor threshold_tokens above the window.
+
+    For ctx <= 64K the parent's small-context carve-out keeps the trigger below
+    the window; re-flooring to MINIMUM_CONTEXT_LENGTH regressed #14690 (threshold
+    >= window → compaction never fires → provider 400)."""
+    e = _engine()
+    e.update_model("m", 64000)
+    parent = _parent_reference(64000)
+    assert e.threshold_tokens == parent.threshold_tokens
+    # The whole point: compaction can still fire before the window fills.
+    assert e.threshold_tokens < 64000
+    # Derived budgets stay in parity with the parent too.
+    assert e.tail_token_budget == parent.tail_token_budget
+    assert e.max_summary_tokens == parent.max_summary_tokens
+
+
+def test_update_model_parity_for_large_contexts():
+    for ctx in (100000, 128000):
+        e = _engine()
+        e.update_model("m", ctx)
+        parent = _parent_reference(ctx)
+        assert e.threshold_tokens == parent.threshold_tokens
+        assert e.threshold_tokens < ctx
+        assert e.tail_token_budget == parent.tail_token_budget
+        assert e.max_summary_tokens == parent.max_summary_tokens
+
+
+def test_secure_base_url_rejects_cloud_metadata_ip():
+    # Regression: a misconfigured base_url pointing at IMDS would leak the
+    # API key to the metadata endpoint. Reject cloud-metadata hosts.
+    from plugins.context_engine.compresr import _secure_base_url
+
+    default = "https://api.compresr.ai"
+    assert _secure_base_url("https://169.254.169.254/latest/", default) == default
+    assert _secure_base_url("https://metadata.google.internal/", default) == default
+    assert _secure_base_url("https://100.100.100.200/", default) == default
+
+
+def test_secure_base_url_allows_valid_https():
+    from plugins.context_engine.compresr import _secure_base_url
+
+    default = "https://api.compresr.ai"
+    assert _secure_base_url("https://compresr.internal", default) == "https://compresr.internal"
+    assert _secure_base_url("http://localhost:8000", default) == "http://localhost:8000"
+
+
+def test_url_error_routed_through_runtime_error(monkeypatch):
+    # Regression: urllib.error.URLError (DNS failure, connect refused,
+    # socket.timeout) is NOT a subclass of HTTPError; it slipped past the
+    # except HTTPError and surfaced as an opaque exception. Must be caught.
+    import urllib.error
+    import urllib.request as ureq
+
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test")
+    e = CompresrContextEngine()
+
+    def _boom(*_a, **_kw):
+        raise urllib.error.URLError("Name or service not known")
+
+    monkeypatch.setattr(ureq, "urlopen", _boom)
+    with pytest.raises(RuntimeError, match="connection error"):
+        e._call_compresr("q", "ctx")
+
+
+def test_compresr_config_metadata_registered():
+    from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS, validate_config_structure
+
+    compresr = DEFAULT_CONFIG["compresr"]
+    assert compresr["tool_output_enabled"] is True
+    assert compresr["tool_output_max_cache_mb"] == 256
+
+    env_info = OPTIONAL_ENV_VARS["COMPRESR_API_KEY"]
+    assert env_info["password"] is True
+    assert env_info["tools"] == ["context_engine", "tool_output_compresr"]
+    assert validate_config_structure({"compresr": {"tool_output_enabled": True}}) == []
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_compresr_extra_coverage.py
+++ b/tests/test_compresr_extra_coverage.py
@@ -1,0 +1,698 @@
+"""Extra unit coverage for the Compresr integration (audit gap-fill).
+
+These tests target branches the existing suite leaves uncovered:
+
+  * JSON-unwrap edge cases (`_try_unwrap_json_tool_result`) — non-brace prefix,
+    malformed JSON, non-dict top level, missing/blank inner key.
+  * De-numbering helpers (`_strip_line_gutter`, `_is_fully_guttered`) edge cases.
+  * The recovery-read guard (`_is_recovery_read`) — non-dict args, resolved
+    host-path match, exception fallback.
+  * Config/env precedence in `_opt` (env wins over config.yaml block).
+  * Query derivation (`_derive_query`) path/tool-name/fallback branches.
+  * Hook gating: error-status results, monotonic cooldown, unwrapped-inner too
+    small, and the cooldown that trips on an API error (`info["error"]`).
+  * compress.py exact-gate cleanup and target_ratio plumbing.
+  * cache.py: LocalEnvironment host-path + no-op sync, no-active-env docker path,
+    write failure, and prune stat/total edge cases.
+  * context_engine: cooldown skip, empty-context skip, prior-summary fold,
+    ratio clamping bounds, latte_v1 coarse payload, disable_placeholders,
+    missing-key raise, and get_status extension.
+
+The Compresr HTTP client is always mocked — no network calls.
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest  # noqa: E402
+
+import plugins.tool_output_compresr as toc  # noqa: E402
+from plugins.tool_output_compresr import ToolOutputCompressor, cache  # noqa: E402
+from plugins.tool_output_compresr.compress import compress_tool_output  # noqa: E402
+from plugins.context_engine.compresr import CompresrContextEngine  # noqa: E402
+
+# Reuse the big fixture shape from the primary test module.
+ORIGINAL = "\n".join(
+    f"line{i} {w}"
+    for i, w in enumerate(["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"] * 40)
+)
+COMPRESSED = "line0 alpha\nline1 bravo\n[4 lines removed]"
+
+
+class _FakeClient:
+    def __init__(self, out=COMPRESSED, stats=None, boom=False):
+        self.out, self.stats, self.boom = out, stats or {}, boom
+        self.seen = {}
+
+    def compress(self, **kw):
+        self.seen = kw
+        if self.boom:
+            raise RuntimeError("HTTP 500")
+        return self.out, self.stats
+
+
+def _fake_env(name, **attrs):
+    env = type(name, (), {})()
+    for k, v in attrs.items():
+        setattr(env, k, v)
+    return env
+
+
+def _active(min_tokens=5):
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", min_tokens
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# _try_unwrap_json_tool_result — every early-return branch
+# --------------------------------------------------------------------------- #
+def test_unwrap_unknown_tool_returns_none():
+    assert toc._try_unwrap_json_tool_result("web_search", "{...}") == (None, None)
+
+
+def test_unwrap_non_brace_prefix_returns_none():
+    # read_file IS unwrappable, but a non-JSON payload must not be parsed.
+    assert toc._try_unwrap_json_tool_result("read_file", "just plain text") == (None, None)
+
+
+def test_unwrap_malformed_json_returns_none():
+    assert toc._try_unwrap_json_tool_result("read_file", '{"content": ') == (None, None)
+
+
+def test_unwrap_non_dict_top_level_returns_none():
+    assert toc._try_unwrap_json_tool_result("read_file", "[1,2,3]") == (None, None)
+
+
+def test_unwrap_missing_or_blank_inner_returns_none():
+    assert toc._try_unwrap_json_tool_result("read_file", '{"path": "/x"}') == (None, None)
+    assert toc._try_unwrap_json_tool_result("read_file", '{"content": "   "}') == (None, None)
+    assert toc._try_unwrap_json_tool_result("read_file", '{"content": 5}') == (None, None)
+
+
+def test_unwrap_success_and_splice_roundtrip():
+    inner, splice = toc._try_unwrap_json_tool_result(
+        "terminal", json.dumps({"output": "hello", "rc": 0})
+    )
+    assert inner == "hello"
+    spliced = json.loads(splice("BYE"))
+    assert spliced == {"output": "BYE", "rc": 0}
+
+
+# --------------------------------------------------------------------------- #
+# de-numbering helpers — extra edges
+# --------------------------------------------------------------------------- #
+def test_is_fully_guttered_empty_and_blank_lines():
+    assert toc._is_fully_guttered("") is False          # no non-blank lines
+    assert toc._is_fully_guttered("   \n\t") is False
+    # blank interior lines are ignored, gutters on the rest still qualify
+    assert toc._is_fully_guttered("1|a\n\n2|b") is True
+    # one un-guttered non-blank line disqualifies the whole payload
+    assert toc._is_fully_guttered("1|a\nplain\n2|b") is False
+
+
+def test_strip_line_gutter_multidigit_and_no_gutter():
+    assert toc._strip_line_gutter("123|x\n4567|y") == "x\ny"
+    assert toc._strip_line_gutter("no gutter here") == "no gutter here"
+
+
+# --------------------------------------------------------------------------- #
+# _is_recovery_read — non-dict, resolved-path match, cache_root exception
+# --------------------------------------------------------------------------- #
+def test_recovery_read_non_dict_args():
+    assert ToolOutputCompressor._is_recovery_read(None) is False
+    assert ToolOutputCompressor._is_recovery_read("string") is False
+    assert ToolOutputCompressor._is_recovery_read({"file_path": 5}) is False
+    assert ToolOutputCompressor._is_recovery_read({"file_path": ""}) is False
+
+
+def test_recovery_read_resolved_host_path_match(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    root = cache.ensure_cache_root()
+    target = root / "abc"
+    target.write_text("x", encoding="utf-8")
+    # No "cache/compresr" substring shortcut here would be exercised on a fully
+    # resolved absolute path that starts with the resolved cache root.
+    assert ToolOutputCompressor._is_recovery_read({"file_path": str(target)}) is True
+
+
+def test_recovery_read_cache_root_exception_falls_back(monkeypatch):
+    # If get_cache_root().resolve() blows up, the substring shortcut must still
+    # catch a container-translated path.
+    monkeypatch.setattr(cache, "get_cache_root", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert ToolOutputCompressor._is_recovery_read(
+        {"file_path": "/root/.hermes/cache/compresr/tool-output/x"}
+    ) is True
+    # And a non-cache path returns False even with the broken cache_root.
+    assert ToolOutputCompressor._is_recovery_read({"file_path": "/etc/passwd"}) is False
+
+
+def test_recovery_read_resolve_oserror_is_swallowed(monkeypatch, tmp_path):
+    """If Path(v).resolve() raises OSError/ValueError for a candidate value, the
+    guard must swallow it and keep checking (not crash the hook)."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    real_resolve = cache.Path.resolve
+
+    def _maybe_boom(self, *a, **k):
+        if "boomtarget" in str(self):
+            raise OSError("bad path")
+        return real_resolve(self, *a, **k)
+
+    monkeypatch.setattr(cache.Path, "resolve", _maybe_boom)
+    # value has no cache/compresr substring, so it reaches the resolve() try/except.
+    assert ToolOutputCompressor._is_recovery_read({"file_path": "/some/boomtarget/x"}) is False
+
+
+# --------------------------------------------------------------------------- #
+# register() — plugin entry point wires the hook and stays quiet when inactive
+# --------------------------------------------------------------------------- #
+def test_register_wires_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("COMPRESR_API_KEY", raising=False)
+    hooks = {}
+
+    class _Ctx:
+        def register_hook(self, name, fn):
+            hooks[name] = fn
+
+    toc.register(_Ctx())
+    assert "transform_tool_result" in hooks
+    assert callable(hooks["transform_tool_result"])
+
+
+def test_register_survives_cache_init_failure(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cache, "ensure_cache_root", lambda: (_ for _ in ()).throw(OSError("no perms")))
+    hooks = {}
+
+    class _Ctx:
+        def register_hook(self, name, fn):
+            hooks[name] = fn
+
+    toc.register(_Ctx())  # must not raise despite ensure_cache_root blowing up
+    assert "transform_tool_result" in hooks
+
+
+# --------------------------------------------------------------------------- #
+# _derive_query — path/tool-name/fallback branches
+# --------------------------------------------------------------------------- #
+def test_derive_query_branches():
+    d = ToolOutputCompressor._derive_query
+    assert d("grep", {"pattern": "foo"}) == "grep: foo"
+    assert d("read_file", {"file_path": "/a/b.py"}).startswith("Relevant content of /a/b.py")
+    assert d("read_file", {}) == "Relevant output of the read_file call for the current task"
+    assert "Preserve the facts" in d("", None)  # empty tool + no args → fallback query
+    # non-str arg values are skipped, falls through to tool-name form
+    assert d("grep", {"pattern": 123}) == "Relevant output of the grep call for the current task"
+
+
+def test_derive_query_truncates_to_600():
+    long = "x" * 5000
+    out = ToolOutputCompressor._derive_query("grep", {"query": long})
+    assert len(out) == 600
+
+
+# --------------------------------------------------------------------------- #
+# _opt config/env precedence
+# --------------------------------------------------------------------------- #
+def test_opt_env_wins_over_config(monkeypatch, tmp_path):
+    hermes_home = tmp_path
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(
+        "compresr:\n"
+        "  tool_output_model: model_from_cfg\n"
+        "  tool_output_min_tokens: 111\n"
+        "  base_url: https://cfg.example/api/\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("COMPRESR_TOOL_OUTPUT_MODEL", "model_from_env")
+    monkeypatch.delenv("COMPRESR_TOOL_OUTPUT_MIN_TOKENS", raising=False)
+    c = ToolOutputCompressor()
+    assert c.model == "model_from_env"     # env wins
+    assert c.min_tokens == 111             # config fills the gap
+    assert c.base_url == "https://cfg.example/api"  # trailing slash stripped
+
+
+def test_opt_defaults_when_absent(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))  # no config.yaml
+    for k in ("COMPRESR_TOOL_OUTPUT_MODEL", "COMPRESR_TOOL_OUTPUT_MIN_TOKENS",
+              "COMPRESR_TOOL_OUTPUT_TARGET_RATIO", "COMPRESR_TOOL_OUTPUT_MAX_CACHE_MB"):
+        monkeypatch.delenv(k, raising=False)
+    c = ToolOutputCompressor()
+    assert c.min_tokens == 1500
+    assert c.max_cache_mb == 256
+    assert c.target_ratio == 2.0
+
+
+# --------------------------------------------------------------------------- #
+# hook gating branches
+# --------------------------------------------------------------------------- #
+def test_hook_inactive_when_no_key():
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key = True, ""
+    assert c.active is False
+    assert c.on_transform_tool_result(tool_name="grep", args={}, result=ORIGINAL) is None
+
+
+def test_hook_non_string_result_is_ignored():
+    c = _active()
+    assert c.on_transform_tool_result(tool_name="grep", args={}, result={"a": 1}) is None
+    assert c.on_transform_tool_result(tool_name="grep", args={}, result=None) is None
+
+
+def test_hook_skips_error_status(monkeypatch):
+    c = _active()
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: "/root/.hermes/cache/compresr/tool-output/x")
+    out = c.on_transform_tool_result(
+        tool_name="grep", args={"pattern": "x"}, result=ORIGINAL, status="error",
+    )
+    assert out is None  # error-status results are never mangled
+
+
+def test_hook_respects_cooldown(monkeypatch):
+    c = _active()
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: "/root/.hermes/cache/compresr/tool-output/x")
+    c._cooldown_until = time.monotonic() + 100.0  # in cooldown
+    out = c.on_transform_tool_result(tool_name="grep", args={"pattern": "x"}, result=ORIGINAL)
+    assert out is None
+
+
+def test_hook_api_error_trips_cooldown(monkeypatch):
+    """An API error inside compress_tool_output must bump errors + set a 30s
+    cooldown so a failing endpoint isn't re-hit every turn."""
+    c = _active()
+
+    def _boom(**kw):
+        raise RuntimeError("HTTP 500")
+
+    monkeypatch.setattr(c._client, "compress", _boom)
+    before = time.monotonic()
+    out = c.on_transform_tool_result(tool_name="grep", args={"pattern": "x"}, result=ORIGINAL)
+    assert out is None
+    assert c.errors == 1
+    assert c._cooldown_until >= before + 29.0
+
+
+def test_hook_successful_but_not_shorter_does_not_cooldown(monkeypatch):
+    """Fix #2: a SUCCESSFUL API call whose output simply isn't a net win reports
+    skipped_reason (NOT error), so it must NOT arm the 30s cooldown or bump the
+    error counter — otherwise one incompressible output silently blocks
+    compression of every later tool output for 30s."""
+    c = _active()
+
+    def _not_shorter(**kw):
+        return ORIGINAL, {
+            "called_api": True,
+            "shortened": False,
+            "skipped_reason": "not smaller after footer",
+            "base_tokens": 500,
+            "out_tokens": 500,
+        }
+
+    monkeypatch.setattr(toc, "compress_tool_output", _not_shorter)
+    out = c.on_transform_tool_result(tool_name="grep", args={"pattern": "x"}, result=ORIGINAL)
+    assert out is None
+    assert c.errors == 0            # benign no-win — no error bump
+    assert c._cooldown_until == 0.0  # cooldown NOT armed
+
+
+def test_hook_cache_write_failure_does_cooldown(monkeypatch):
+    """Fix #2 (refined): a GENUINE failure after a successful API call —
+    store_original returning None (e.g. a reused Docker container that lost its
+    cache mount, per Fix #1) — must still arm the cooldown and count as an error
+    so the plugin doesn't make an un-throttled paid API call on every subsequent
+    output and doesn't hide the infra failure from /usage."""
+    c = _active()
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: None)  # cache write fails
+    before = time.monotonic()
+    out = c.on_transform_tool_result(tool_name="grep", args={"pattern": "x"}, result=ORIGINAL)
+    assert out is None                          # fail open
+    assert c.errors == 1                         # counted as a real error
+    assert c._cooldown_until >= before + 29.0    # cooldown armed
+
+
+def test_hook_long_line_fails_open_without_calling_api(monkeypatch):
+    """Fix #3: a tool output whose cached original would contain a line longer
+    than the recovery per-line cap (get_max_line_length, default 2000) can't be
+    recovered byte-exact, so the hook fails open and never calls the API."""
+    c = _active(min_tokens=10)
+    long_line = "x" * 3000  # exceeds the 2000-char recovery clamp
+    payload = "short head line\n" + long_line + "\nshort tail line"
+    result = json.dumps({"output": payload})  # terminal-style envelope
+
+    called = {"n": 0}
+
+    def _spy(**kw):
+        called["n"] += 1
+        return COMPRESSED, {}
+
+    monkeypatch.setattr(c._client, "compress", _spy)
+    out = c.on_transform_tool_result(
+        tool_name="terminal", args={"command": "cat big"}, result=result
+    )
+    assert out is None
+    assert called["n"] == 0  # never hit the API — failed open before compressing
+
+
+def test_hook_unwrapped_inner_below_min_tokens_skips(monkeypatch):
+    """A JSON envelope whose *inner* payload is below min_tokens (even though the
+    whole envelope exceeds it) must skip — the inner text is what gets compressed."""
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key = True, "cmp_test"
+    # min_tokens between inner size and envelope size.
+    small_inner = "tiny content"
+    result = json.dumps({"content": small_inner, "padding": "P" * 4000})
+    c.min_tokens = (len(small_inner) + 3) // 4 + 5  # just above inner token count
+    called = {"n": 0}
+
+    def _spy(**kw):
+        called["n"] += 1
+        return COMPRESSED, {}
+
+    monkeypatch.setattr(c._client, "compress", _spy)
+    out = c.on_transform_tool_result(tool_name="read_file", args={"file_path": "/x"}, result=result)
+    assert out is None
+    assert called["n"] == 0  # never hit the API
+
+
+def test_hook_defensive_except_on_store_raises(monkeypatch):
+    """compress_tool_output is fail-open, but the hook wraps it in try/except as a
+    belt-and-suspenders guard. Force a raise from within to hit that path."""
+    c = _active()
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+
+    def _raise(*a, **k):
+        raise RuntimeError("unexpected cache explosion")
+
+    monkeypatch.setattr(cache, "store_original", _raise)
+    before = time.monotonic()
+    out = c.on_transform_tool_result(tool_name="grep", args={"pattern": "x"}, result=ORIGINAL)
+    assert out is None
+    assert c.errors == 1
+    assert c._cooldown_until >= before + 29.0
+
+
+def test_hook_target_ratio_is_plumbed_to_client(monkeypatch):
+    c = _active()
+    c.target_ratio = 3.5
+    fake = _FakeClient(out=COMPRESSED)
+    c._client = fake
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: "/root/.hermes/cache/compresr/tool-output/x")
+    c.on_transform_tool_result(tool_name="grep", args={"pattern": "x"}, result=ORIGINAL)
+    assert fake.seen.get("target_ratio") == 3.5
+    assert fake.seen.get("coarse") is True
+
+
+# --------------------------------------------------------------------------- #
+# compress.py — target_ratio plumbing
+# --------------------------------------------------------------------------- #
+def test_compress_forwards_target_ratio(monkeypatch):
+    monkeypatch.setattr(cache, "store_original", lambda cid, content, task_id="default", **_: "/p/" + cid)
+    fake = _FakeClient(out=COMPRESSED)
+    compress_tool_output(
+        query="q", content=ORIGINAL, tool_name="grep", cache_id="c",
+        client=fake, task_id="t", target_ratio=7.0,
+    )
+    assert fake.seen.get("target_ratio") == 7.0
+
+
+# --------------------------------------------------------------------------- #
+# cache.py — LocalEnvironment + no-active-env docker + write failure + prune
+# --------------------------------------------------------------------------- #
+def test_store_original_local_env_returns_resolved_host_path(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: _fake_env("LocalEnvironment"))
+    path = cache.store_original("local1", ORIGINAL, task_id="t", max_cache_mb=0)
+    assert path == str((hermes_home / "cache" / "compresr" / "tool-output" / "local1").resolve())
+
+
+def test_store_original_no_env_docker_backend(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: None)
+    path = cache.store_original("dk", ORIGINAL, task_id="t", max_cache_mb=0)
+    assert path == "/root/.hermes/cache/compresr/tool-output/dk"
+
+
+def test_store_original_no_env_unknown_backend_fails_open(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "daytona")  # not local/docker/modal
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: None)
+    path = cache.store_original("dt", ORIGINAL, task_id="t", max_cache_mb=0)
+    assert path is None
+    # Content-addressed: the host file is retained (not unlinked) when visibility
+    # can't be proven, so a concurrent sibling's recovery pointer can't dangle;
+    # the size-based pruner reclaims it later.
+    assert (hermes_home / "cache" / "compresr" / "tool-output" / "dt").exists()
+
+
+def test_store_original_write_failure_returns_none(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: None)
+
+    real_open = cache.os.open
+
+    def _boom_open(path, *a, **k):
+        if "compresr" in str(path):
+            raise OSError("disk full")
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr(cache.os, "open", _boom_open)
+    assert cache.store_original("wf", ORIGINAL, task_id="t") is None
+
+
+def test_prune_total_under_budget_is_noop(tmp_path):
+    from plugins.tool_output_compresr.cache import _prune_cache_dir
+
+    a = tmp_path / "a"
+    a.write_text("x" * 5, encoding="utf-8")
+    _prune_cache_dir(str(tmp_path), 1000, str(tmp_path / "keep"))
+    assert a.exists()  # under budget → nothing removed
+
+
+def test_prune_ignores_subdirectories(tmp_path):
+    """Only files count toward the budget; a subdir under the cache root must be
+    skipped by the ``is_file()`` filter and never unlinked."""
+    from plugins.tool_output_compresr.cache import _prune_cache_dir
+
+    subdir = tmp_path / "adir"
+    subdir.mkdir()
+    old = tmp_path / "old"
+    current = tmp_path / "current"
+    old.write_text("x" * 100, encoding="utf-8")
+    current.write_text("z" * 10, encoding="utf-8")
+    os.utime(old, (1, 1))
+
+    _prune_cache_dir(str(tmp_path), 1, str(current))
+    assert not old.exists()
+    assert current.exists()
+    assert subdir.is_dir()  # directory untouched
+
+
+# --------------------------------------------------------------------------- #
+# context_engine — cooldown, empty context, prior-summary fold, ratio bounds,
+# latte_v1 coarse, disable_placeholders, missing key, get_status
+# --------------------------------------------------------------------------- #
+def _engine():
+    e = CompresrContextEngine()
+    e.compresr_api_key = "cmp_test"
+    return e
+
+
+TURNS = [
+    {"role": "user", "content": "Fix the login bug in auth.py."},
+    {"role": "assistant", "content": "Edited auth.py; token TTL 3600."},
+]
+
+
+def test_engine_cooldown_skips_generate(monkeypatch):
+    e = _engine()
+    e._summary_failure_cooldown_until = time.monotonic() + 100.0
+    called = {"n": 0}
+    e._call_compresr = lambda c, q: (called.__setitem__("n", called["n"] + 1), ("x", {}))[1]
+    assert e._generate_summary(TURNS, focus_topic="x") is None
+    assert called["n"] == 0
+
+
+def test_engine_empty_context_skips(monkeypatch):
+    e = _engine()
+    monkeypatch.setattr(e, "_serialize_for_summary", lambda turns: "   \n\t")
+    called = {"n": 0}
+    e._call_compresr = lambda c, q: called.__setitem__("n", called["n"] + 1)
+    assert e._generate_summary(TURNS) is None
+    assert called["n"] == 0
+
+
+def test_engine_folds_prior_summary_into_context():
+    e = _engine()
+    e._previous_summary = "EARLIER FACTS"
+    seen = {}
+
+    def _spy(context, query):
+        seen["context"] = context
+        return "KEPT body", {"tokens_saved": 5}
+
+    e._call_compresr = _spy
+    out = e._generate_summary(TURNS, focus_topic="topic")
+    assert out is not None
+    assert "[PRIOR CONTEXT SUMMARY]" in seen["context"]
+    assert "EARLIER FACTS" in seen["context"]
+    assert "[NEW CONVERSATION TURNS]" in seen["context"]
+
+
+def test_engine_ratio_clamps_bounds():
+    e = _engine()
+    e.compresr_ratio_override = None
+    # keep=0 is falsy so `keep or 0.2` substitutes the 0.2 default → 5x.
+    e.summary_target_ratio = 0.0
+    assert e._target_compression_ratio() == 5.0
+    # A tiny but truthy keep clamps to the 0.01 floor → 100x (well under the 200 cap).
+    e.summary_target_ratio = 0.001
+    assert e._target_compression_ratio() == 100.0
+    # keep near 1 clamps to the 0.95 ceiling → ~1.053x
+    e.summary_target_ratio = 0.99
+    assert e._target_compression_ratio() == round(1.0 / 0.95, 3)
+
+
+def test_engine_latte_v1_sends_coarse(monkeypatch):
+    e = _engine()
+    e.compresr_model = "latte_v1"
+    e.compresr_coarse = True
+    e.compresr_disable_placeholders = True
+    captured = {}
+
+    class _Resp:
+        def __init__(self, body):
+            self._b = body.encode()
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    import urllib.request
+    def _fake(req, timeout=None):
+        captured["payload"] = json.loads(req.data)
+        return _Resp(json.dumps({"success": True, "data": {"compressed_context": "x"}}))
+    monkeypatch.setattr(urllib.request, "urlopen", _fake)
+
+    e._call_compresr("ctx", "q")
+    assert captured["payload"]["coarse"] is True
+    assert captured["payload"]["disable_placeholders"] is True
+
+
+def test_engine_missing_key_raises_in_call():
+    e = CompresrContextEngine()
+    e.compresr_api_key = ""
+    with pytest.raises(RuntimeError):
+        e._call_compresr("ctx", "q")
+
+
+def test_engine_http_error_body_read_failure_still_raises(monkeypatch):
+    import urllib.error
+    import urllib.request
+
+    class _BadReadErr(urllib.error.HTTPError):
+        def read(self):
+            raise RuntimeError("cannot read body")
+
+    def _raise(req, timeout=None):
+        raise _BadReadErr("u", 500, "Server Error", None, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raise)
+    e = _engine()
+    with pytest.raises(RuntimeError) as ei:
+        e._call_compresr("ctx", "q")
+    assert "500" in str(ei.value)
+
+
+def test_engine_get_status_extends_parent():
+    e = _engine()
+    e.compresr_calls = 3
+    e.compresr_tokens_saved = 99
+    st = e.get_status()
+    assert st["engine"] == "compresr"
+    assert st["compresr_calls"] == 3
+    assert st["compresr_tokens_saved"] == 99
+    assert "compresr_last_duration_ms" in st
+
+
+# --------------------------------------------------------------------------- #
+# base_url must be https (except localhost) — no silent cleartext downgrade of
+# the API key / egress via a stray config or env value.
+# --------------------------------------------------------------------------- #
+def test_secure_base_url_rejects_plaintext_remote():
+    from plugins.tool_output_compresr import _secure_base_url as _sec_toc
+    from plugins.context_engine.compresr import _secure_base_url as _sec_ce
+
+    default = "https://api.compresr.ai/api"
+    for _sec in (_sec_toc, _sec_ce):
+        assert _sec("https://api.compresr.ai/api", default) == "https://api.compresr.ai/api"
+        assert _sec("http://evil.example.com/api", default) == default  # remote http rejected
+        assert _sec("http://localhost:8000/api", default) == "http://localhost:8000/api"
+        assert _sec("http://127.0.0.1:8000", default) == "http://127.0.0.1:8000"
+        assert _sec("not a url", default) == default  # garbage → default
+
+
+def test_tool_output_compressor_ignores_insecure_base_url(monkeypatch):
+    monkeypatch.setenv("COMPRESR_BASE_URL", "http://evil.example.com/api")
+    assert ToolOutputCompressor().base_url == "https://api.compresr.ai/api"
+
+
+def test_context_engine_ignores_insecure_base_url(monkeypatch):
+    monkeypatch.setenv("COMPRESR_BASE_URL", "http://evil.example.com/api")
+    assert CompresrContextEngine().compresr_base_url == "https://api.compresr.ai/api"
+
+
+# --------------------------------------------------------------------------- #
+# context.engine: compresr forwards the user's compression.* geometry instead
+# of silently using ContextCompressor's hardcoded defaults.
+# --------------------------------------------------------------------------- #
+def test_context_engine_forwards_compression_config(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        "compression:\n"
+        "  protect_first_n: 5\n"
+        "  protect_last_n: 40\n"
+        "  target_ratio: 0.10\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    eng = CompresrContextEngine()
+    assert eng.protect_first_n == 5
+    assert eng.protect_last_n == 40
+    assert eng.summary_target_ratio == 0.10
+
+
+def test_context_engine_uses_parent_defaults_without_compression_config(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    eng = CompresrContextEngine()
+    assert eng.protect_last_n == 20      # ContextCompressor default, unchanged
+    assert eng.summary_target_ratio == 0.20
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_compresr_fixes.py
+++ b/tests/test_compresr_fixes.py
@@ -1,0 +1,457 @@
+"""Regression tests for three fixes to the Compresr integration.
+
+Each test pins a specific bug so it cannot silently reappear:
+
+* **F1** — the exact post-footer size gate used to ``unlink`` the content-addressed
+  cache file when it failed. Because the cache key is a hash of the *content*, a
+  concurrent (or prior) compression of identical content could already have handed
+  that path to the model as a recovery pointer; deleting it dangled the pointer and
+  broke the recover-verbatim guarantee. The gate must now fail open WITHOUT deleting.
+* **F2** — ``_is_recovery_read`` matched a bare ``"cache/compresr"`` substring in any
+  arg, so an ordinary grep/read that merely mentioned it (e.g. working on this repo)
+  was misread as a recovery and skipped compression. It must now match the full
+  ``cache/compresr/tool-output`` segment, while genuine recovery paths still skip.
+* **F3** — plugin ``__init__`` coerced numeric config/env with bare ``int()``/
+  ``float()``; a typo like ``COMPRESR_TIMEOUT=abc`` raised, which the loader swallowed
+  into a silent whole-feature disable. Bad values must now fall back to defaults.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest  # noqa: E402
+
+import plugins.tool_output_compresr as toc  # noqa: E402
+from plugins.tool_output_compresr import ToolOutputCompressor, cache, compress  # noqa: E402
+from plugins.tool_output_compresr.compress import compress_tool_output  # noqa: E402
+from plugins.context_engine.compresr import CompresrContextEngine  # noqa: E402
+
+# ~240 tokens — comfortably above the min_tokens gates used below.
+ORIGINAL = "\n".join(f"line{i} payload" for i in range(400))
+COMPRESSED = "line0 payload\n[many lines removed]"
+
+# An agent-visible path long enough that the real footer (which embeds the path
+# twice) costs more than the nominal FOOTER_TOKEN_BUDGET, so the exact gate can
+# actually fire. store_original returns this; the host file that must survive is
+# whatever cache_file_path resolves to — in reality these differ (agent-visible
+# vs host path), which is exactly the long-remote-home case F1 rode on.
+_LONG_VISIBLE_PATH = "/root/.hermes/cache/compresr/tool-output/" + ("a" * 560)
+
+
+class _FakeClient:
+    def __init__(self, out=COMPRESSED):
+        self.out = out
+
+    def compress(self, **kw):
+        return self.out, {}
+
+
+# --------------------------------------------------------------------------- #
+# F1 — the gate-fail path must not delete a content-addressed cache file
+# --------------------------------------------------------------------------- #
+def test_f1_gate_fail_does_not_delete_cache_file(tmp_path, monkeypatch):
+    real_file = tmp_path / "host-cache-file"
+    real_file.write_text("VERBATIM ORIGINAL")
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: _LONG_VISIBLE_PATH)
+    monkeypatch.setattr(cache, "cache_file_path", lambda cid: real_file)
+
+    base = "x" * 4000  # ~1000 tokens
+    body = "x" * 3400  # passes the cheap pre-filter, fails the exact gate via the long path
+    out, info = compress_tool_output(
+        query="q", content=base, tool_name="grep", cache_id="c",
+        client=_FakeClient(out=body), task_id="t",
+    )
+    assert out == base                                   # failed open
+    assert info["skipped_reason"] == "not smaller after footer"  # benign, not an error
+    assert real_file.exists()                            # F1: NOT deleted
+    assert real_file.read_text() == "VERBATIM ORIGINAL"  # verbatim original intact
+
+
+def test_f1_second_call_does_not_dangle_first_calls_pointer(tmp_path, monkeypatch):
+    """The original failure: two compressions of identical content share one
+    content-addressed cache file. Call A wins and returns a footer pointing at it;
+    call B over the same content fails the exact gate. B must not delete A's file."""
+    real_file = tmp_path / "host-cache-file"
+
+    def _store(cid, content, task_id="default", **_):
+        real_file.write_text(content)   # host write, as the real store_original does
+        return _LONG_VISIBLE_PATH        # agent-visible path handed to the model
+
+    monkeypatch.setattr(cache, "store_original", _store)
+    monkeypatch.setattr(cache, "cache_file_path", lambda cid: real_file)
+
+    base = "x" * 4000
+    # A: small body → net win → returns a footer that names the shared cache file.
+    out_a, info_a = compress_tool_output(
+        query="q", content=base, tool_name="grep", cache_id="shared",
+        client=_FakeClient(out="y" * 2000), task_id="t",
+    )
+    assert info_a["shortened"] is True
+    assert info_a["cache_path"] in out_a
+    assert real_file.exists()
+
+    # B: larger body over identical content → fails the exact gate.
+    out_b, info_b = compress_tool_output(
+        query="q", content=base, tool_name="grep", cache_id="shared",
+        client=_FakeClient(out="z" * 3400), task_id="t",
+    )
+    assert out_b == base
+    assert info_b["skipped_reason"] == "not smaller after footer"
+
+    # F1: A's recovery pointer still resolves to the verbatim original.
+    assert real_file.exists()
+    assert real_file.read_text() == base
+
+
+# --------------------------------------------------------------------------- #
+# F2 — recovery guard matches the full segment, not a bare substring
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("args", [
+    {"pattern": "cache/compresr"},                       # grepping for the string
+    {"query": "find TODOs under cache/compresr"},        # query mentioning it
+    {"file_path": "/work/src/cache/compresr_notes.md"},  # a file whose path contains it
+])
+def test_f2_ordinary_call_mentioning_substring_is_still_compressed(tmp_path, monkeypatch, args):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: f"{tmp_path}/cache/compresr/tool-output/{cid}",
+    )
+    before = c.recoveries
+    out = c.on_transform_tool_result(tool_name="search_files", args=args, result=ORIGINAL)
+    assert out is not None and compress.FOOTER_MARKER in out  # compressed, not skipped
+    assert c.recoveries == before                            # recoveries stat not inflated
+
+
+def test_f2_genuine_recovery_path_still_skips(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    called = {"n": 0}
+
+    def _spy(**kw):
+        called["n"] += 1
+        return COMPRESSED, {}
+
+    monkeypatch.setattr(c._client, "compress", _spy)
+    before = c.recoveries
+    # A container-translated recovery path carries the full cache/compresr/tool-output segment.
+    out = c.on_transform_tool_result(
+        tool_name="read_file",
+        args={"file_path": "/root/.hermes/cache/compresr/tool-output/deadbeef"},
+        result=ORIGINAL,
+    )
+    assert out is None                    # verbatim passthrough
+    assert c.recoveries == before + 1     # correctly counted as a recovery
+    assert called["n"] == 0               # never hit the API
+
+
+# --------------------------------------------------------------------------- #
+# F3 — malformed numeric config/env falls back to defaults instead of raising
+# --------------------------------------------------------------------------- #
+_TOOL_OUTPUT_DEFAULTS = {
+    "COMPRESR_TOOL_OUTPUT_MIN_TOKENS": ("min_tokens", toc._DEFAULT_MIN_TOKENS),
+    "COMPRESR_TOOL_OUTPUT_TIMEOUT": ("timeout", toc._DEFAULT_TIMEOUT),
+    "COMPRESR_TOOL_OUTPUT_MAX_CACHE_MB": ("max_cache_mb", toc._DEFAULT_MAX_CACHE_MB),
+    "COMPRESR_TOOL_OUTPUT_TARGET_RATIO": ("target_ratio", toc._DEFAULT_TARGET_RATIO),
+}
+
+
+@pytest.mark.parametrize("var", list(_TOOL_OUTPUT_DEFAULTS))
+def test_f3_bad_tool_output_numeric_env_falls_back(monkeypatch, var):
+    attr, default = _TOOL_OUTPUT_DEFAULTS[var]
+    monkeypatch.setenv(var, "not-a-number")
+    c = ToolOutputCompressor()  # must not raise
+    assert getattr(c, attr) == default
+
+
+def test_f3_bad_context_engine_timeout_falls_back(monkeypatch):
+    monkeypatch.setenv("COMPRESR_TIMEOUT", "abc")
+    eng = CompresrContextEngine()  # must not raise
+    assert eng.compresr_timeout == 60
+
+
+def test_f3_bad_context_engine_ratio_override_becomes_none(monkeypatch):
+    monkeypatch.setenv("COMPRESR_TARGET_RATIO", "abc")
+    eng = CompresrContextEngine()  # must not raise
+    assert eng.compresr_ratio_override is None
+
+
+def test_f3_register_still_succeeds_with_bad_env(monkeypatch):
+    """The end goal of F3: a typo'd tunable must not silently disable the feature.
+    Both plugins must still register their hook / engine."""
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    monkeypatch.setenv("COMPRESR_TIMEOUT", "abc")
+    monkeypatch.setenv("COMPRESR_TOOL_OUTPUT_TIMEOUT", "abc")
+    hooks, engines = [], []
+    ctx = type("Ctx", (), {
+        "register_hook": lambda self, name, cb: hooks.append(name),
+        "register_context_engine": lambda self, e: engines.append(e),
+    })()
+
+    import plugins.context_engine.compresr as ce
+
+    toc.register(ctx)                                 # must not raise
+    ce.register(ctx)                                  # must not raise
+
+    assert "transform_tool_result" in hooks
+    assert len(engines) == 1
+
+
+# F4 — CR/LF/NUL in COMPRESR_API_KEY: sanitize on read + swallow ValueError.
+def test_f4_crlf_in_api_key_is_rejected_context_engine(monkeypatch, caplog):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_secret\r\ninjected")
+    eng = CompresrContextEngine()
+    assert eng.compresr_api_key == ""
+    assert eng.is_available() is False
+    assert "cmp_secret" not in caplog.text
+
+
+def test_f4_crlf_in_api_key_is_rejected_tool_output(monkeypatch, caplog):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_secret\r\ninjected")
+    monkeypatch.setenv("COMPRESR_TOOL_OUTPUT_ENABLED", "1")
+    comp = ToolOutputCompressor()
+    assert comp.api_key == ""
+    assert comp.active is False
+    assert "cmp_secret" not in caplog.text
+
+
+# F5 — metadata / private-net blocklist covers IPv6-mapped, decimal/hex shorthand,
+# full 169.254/16, RFC1918, CGNAT, fd00::/8, trailing-dot FQDN. Log-safe URL.
+@pytest.mark.parametrize("bad_url", [
+    "https://169.254.169.254/",
+    "https://169.254.170.2/",
+    "https://169.254.169.253/",
+    "https://[::ffff:169.254.169.254]/",
+    "https://2852039166/",
+    "https://0xa9fea9fe/",
+    "https://10.0.0.1/",
+    "https://192.168.1.1/",
+    "https://100.64.0.1/",
+    "https://[fd00:ec2::254]/",
+    "https://metadata.google.internal/",
+    "https://metadata.google.internal./",
+])
+def test_f5_context_engine_rejects_all_metadata_and_private_hosts(monkeypatch, bad_url):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    monkeypatch.setenv("COMPRESR_BASE_URL", bad_url)
+    eng = CompresrContextEngine()
+    assert eng.compresr_base_url == "https://api.compresr.ai/api", (
+        f"base_url {bad_url!r} was not rejected — became {eng.compresr_base_url!r}"
+    )
+
+
+@pytest.mark.parametrize("bad_url", [
+    "https://169.254.169.254/",
+    "https://[::ffff:169.254.169.254]/",
+    "https://2852039166/",
+    "https://10.0.0.1/",
+])
+def test_f5_tool_output_plugin_rejects_all_metadata_and_private_hosts(monkeypatch, bad_url):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    monkeypatch.setenv("COMPRESR_TOOL_OUTPUT_ENABLED", "1")
+    monkeypatch.setenv("COMPRESR_BASE_URL", bad_url)
+    comp = ToolOutputCompressor()
+    assert comp.base_url == "https://api.compresr.ai/api", (
+        f"base_url {bad_url!r} was not rejected — became {comp.base_url!r}"
+    )
+
+
+def test_f5_localhost_and_valid_https_still_pass(monkeypatch):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    monkeypatch.setenv("COMPRESR_BASE_URL", "http://localhost:8000/api")
+    eng = CompresrContextEngine()
+    assert eng.compresr_base_url == "http://localhost:8000/api"
+
+    monkeypatch.setenv("COMPRESR_BASE_URL", "https://api.compresr.ai/api")
+    eng = CompresrContextEngine()
+    assert eng.compresr_base_url == "https://api.compresr.ai/api"
+
+
+def test_f5_rejected_url_log_never_contains_userinfo(monkeypatch, caplog):
+    import logging
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    monkeypatch.setenv(
+        "COMPRESR_BASE_URL", "https://user:cmp_secret_in_url@169.254.169.254/"
+    )
+    eng = CompresrContextEngine()
+    assert eng.compresr_base_url == "https://api.compresr.ai/api"
+    assert "cmp_secret_in_url" not in caplog.text
+    assert "user:cmp_secret_in_url" not in caplog.text
+
+
+# F6 — register() refuses when is_available()==False.
+def test_f6_register_refuses_when_api_key_missing(monkeypatch):
+    monkeypatch.delenv("COMPRESR_API_KEY", raising=False)
+    engines = []
+    ctx = type("Ctx", (), {
+        "register_context_engine": lambda self, e: engines.append(e),
+    })()
+    import plugins.context_engine.compresr as ce
+    ce.register(ctx)
+    assert engines == []
+
+
+def test_f6_register_succeeds_when_api_key_present(monkeypatch):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    engines = []
+    ctx = type("Ctx", (), {
+        "register_context_engine": lambda self, e: engines.append(e),
+    })()
+    import plugins.context_engine.compresr as ce
+    ce.register(ctx)
+    assert len(engines) == 1
+    assert engines[0].is_available() is True
+
+
+def test_f6_loader_does_not_resurrect_declined_engine(monkeypatch):
+    """The real load path must honor register()'s decline, not fall through to
+    the subclass scan (which would instantiate CompresrContextEngine anyway)."""
+    from plugins.context_engine import load_context_engine
+
+    monkeypatch.delenv("COMPRESR_API_KEY", raising=False)
+    assert load_context_engine("compresr") is None
+
+
+def test_f6_loader_returns_engine_when_available(monkeypatch):
+    from plugins.context_engine import load_context_engine
+
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    engine = load_context_engine("compresr")
+    assert engine is not None
+    assert engine.is_available() is True
+
+
+# F7 — redact tool args (query) + outbound + cached content.
+def test_f7_tool_output_redacts_query_and_content(monkeypatch, tmp_path):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    monkeypatch.setenv("COMPRESR_TOOL_OUTPUT_ENABLED", "1")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("COMPRESR_TOOL_OUTPUT_MIN_TOKENS", "1")
+
+    comp = ToolOutputCompressor()
+    seen = {}
+
+    def fake_compress(query, content, tool_name, cache_id, client, task_id,
+                      max_cache_mb, target_ratio, cache_content=None):
+        seen["query"] = query
+        seen["content"] = content
+        seen["cache_content"] = cache_content
+        return "compressed body\n\n[compresr:recover] ...", {
+            "called_api": True, "shortened": True, "cache_path": "/tmp/x",
+            "base_tokens": 1000, "out_tokens": 100, "saved": 900,
+        }
+
+    monkeypatch.setattr(
+        "plugins.tool_output_compresr.compress_tool_output", fake_compress
+    )
+
+    secret_args = {"command": "curl -H 'Authorization: Bearer sk-live-SECRETVALUE' https://api.example.com"}
+    # Short lines only, to avoid _has_unrecoverable_long_line's fail-open gate.
+    secret_output = (
+        "AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE\n"
+        + "\n".join(f"line {i} of output body xxxxxxxxxxxx" for i in range(500))
+    )
+
+    comp.on_transform_tool_result(
+        tool_name="terminal", args=secret_args, result=secret_output, status="ok",
+    )
+
+    from agent.redact import redact_sensitive_text
+    assert seen["query"] == redact_sensitive_text(f"terminal: {secret_args['command']}"[:600])
+    assert seen["content"] == redact_sensitive_text(secret_output)
+
+
+# F8 — success clears prior failure back-off state.
+class _FakeSessionDB:
+    """Minimal session-DB double exposing the cooldown persist/clear hooks."""
+
+    def __init__(self):
+        self.rows = {}
+
+    def record_compression_failure_cooldown(self, session_id, cooldown_until, error):
+        self.rows[session_id] = (cooldown_until, error)
+
+    def clear_compression_failure_cooldown(self, session_id):
+        self.rows.pop(session_id, None)
+
+
+def test_f8_success_clears_prior_failure_cooldown(monkeypatch):
+    monkeypatch.setenv("COMPRESR_API_KEY", "cmp_test_key")
+    eng = CompresrContextEngine()
+
+    # Bind a session DB and record a REAL prior failure so the persisted row
+    # exists (in-memory-only assertions were the false positive this exercises).
+    db = _FakeSessionDB()
+    eng._session_db = db
+    eng._session_id = "sess-1"
+    eng._record_compression_failure_cooldown(3600.0, "compresr: prior transient error")
+    assert "sess-1" in db.rows
+    # Simulate the in-memory cooldown having elapsed (or a fresh process where
+    # only the persisted DB row was reloaded) so _generate_summary may run.
+    eng._summary_failure_cooldown_until = 1e-9
+
+    monkeypatch.setattr(
+        eng, "_call_compresr",
+        lambda ctx, q: ("compressed body", {"original_tokens": 1000, "tokens_saved": 800}),
+    )
+    monkeypatch.setattr(eng, "_serialize_for_summary", lambda turns: "some turns")
+    out = eng._generate_summary([{"role": "user", "content": "x"}], focus_topic="topic")
+    assert out is not None
+    assert eng._summary_failure_cooldown_until == 0.0
+    assert eng._last_summary_error is None
+    # The persisted session-DB row must be cleared too, not just the in-memory
+    # fields — otherwise the cooldown reloads on resume and suppresses the engine.
+    assert "sess-1" not in db.rows
+
+
+# F9 — atomic cache write via O_NOFOLLOW + os.replace; concurrent-write safe.
+def test_f9_store_original_uses_atomic_replace(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: None)
+
+    replaced = []
+    real_replace = cache.os.replace
+
+    def _spy_replace(src, dst):
+        replaced.append((str(src), str(dst)))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(cache.os, "replace", _spy_replace)
+    content = "atomic body\n" * 200
+    cache.store_original("atomic1", content, task_id="t", max_cache_mb=0)
+
+    assert len(replaced) == 1
+    src, dst = replaced[0]
+    assert ".atomic1." in os.path.basename(src) and src.endswith(".tmp")
+    assert dst.endswith("/atomic1")
+
+    final_path = tmp_path / "cache" / "compresr" / "tool-output" / "atomic1"
+    assert final_path.read_text() == content
+
+
+def test_f9_concurrent_writes_never_produce_partial_content(monkeypatch, tmp_path):
+    import threading
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: None)
+
+    content_a = "AAAA" * 5000
+    content_b = "BBBB" * 5000
+
+    def writer(cid, content, n):
+        for _ in range(n):
+            cache.store_original(cid, content, task_id="t", max_cache_mb=0)
+
+    ta = threading.Thread(target=writer, args=("cw", content_a, 30))
+    tb = threading.Thread(target=writer, args=("cw", content_b, 30))
+    ta.start(); tb.start(); ta.join(); tb.join()
+
+    final = (tmp_path / "cache" / "compresr" / "tool-output" / "cw").read_text()
+    assert final == content_a or final == content_b
+    assert len(final) == len(content_a)

--- a/tests/test_tool_output_compresr.py
+++ b/tests/test_tool_output_compresr.py
@@ -1,0 +1,801 @@
+"""Tests for the tool_output_compresr plugin.
+
+The plugin compresses large tool outputs via the Compresr API, caches the
+verbatim original under Hermes's managed cache (PR #6 cache-authority: host write
++ per-backend agent-visible path), and passes the API's compressed text through
+UNCHANGED with a footer pointing the agent at the original (recoverable with
+``read_file``/``search_files``). These cover the footer/pointer contract, the
+transform hook's gating and fail-open behavior, the cache-authority path
+translation, and size-based retention.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import json  # noqa: E402
+
+from plugins.tool_output_compresr import ToolOutputCompressor  # noqa: E402
+from plugins.tool_output_compresr import cache, compress  # noqa: E402
+
+# Large enough that a small compressed body is a genuine win even after the
+# recovery footer's token budget (~90) is added back — the size gate now
+# accounts for the footer, so a marginal fixture would (correctly) fail open.
+ORIGINAL = "\n".join(
+    [f"line{i} {word}" for i, word in enumerate(
+        ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"] * 40
+    )]
+)
+
+# A short stand-in for the API's compressed output. Keeps a couple of lines and
+# an inline drop marker, which the plugin now passes through verbatim.
+COMPRESSED = "line0 alpha\nline1 bravo\n[4 lines removed]"
+
+CACHE_ROOT = "/root/.hermes/cache/compresr/tool-output"
+
+
+def _cache_path(cache_id: str) -> str:
+    return f"{CACHE_ROOT}/{cache_id}"
+
+
+def _fake_env(name: str, **attrs):
+    env = type(name, (), {})()
+    for key, value in attrs.items():
+        setattr(env, key, value)
+    return env
+
+
+class _FakeSyncManager:
+    def __init__(self, boom: Exception | None = None):
+        self.calls = []
+        self.boom = boom
+
+    def sync(self, force=False):
+        self.calls.append(force)
+        if self.boom is not None:
+            raise self.boom
+
+
+# --------------------------------------------------------------------------- #
+# compress_tool_output: footer contract + fail-open
+# --------------------------------------------------------------------------- #
+class _FakeClient:
+    def __init__(self, out=COMPRESSED, stats=None, boom=False):
+        self.out, self.stats, self.boom = out, stats or {}, boom
+
+    def compress(self, **kw):
+        if self.boom:
+            raise RuntimeError("HTTP 500")
+        return self.out, self.stats
+
+
+def test_compress_appends_footer_with_cache_pointer(monkeypatch):
+    monkeypatch.setattr(cache, "store_original", lambda cid, content, task_id="default", **_: _cache_path(cid))
+    out, info = compress.compress_tool_output(
+        query="q", content=ORIGINAL, tool_name="grep",
+        cache_id="abc", client=_FakeClient(), task_id="t",
+    )
+    assert info["shortened"] is True
+    assert out.startswith(COMPRESSED)                 # API output verbatim
+    assert "[4 lines removed]" in out                 # marker preserved, not rewritten
+    assert compress.FOOTER_MARKER in out
+    assert info["cache_path"] in out                  # pointer names the cache path
+    assert "read_file" in out and "search_files" in out
+
+
+def test_compress_failopen_on_api_error():
+    out, info = compress.compress_tool_output(
+        query="q", content=ORIGINAL, tool_name="grep", cache_id="c",
+        client=_FakeClient(boom=True), task_id="t",
+    )
+    assert out == ORIGINAL
+    assert info["called_api"] is False and info["shortened"] is False
+
+
+def test_compress_failopen_when_not_shorter():
+    out, info = compress.compress_tool_output(
+        query="q", content=ORIGINAL, tool_name="grep", cache_id="c",
+        client=_FakeClient(out=ORIGINAL + "\nplus more padding text here"),
+        task_id="t",
+    )
+    assert out == ORIGINAL
+    assert info["called_api"] is True and info["shortened"] is False
+
+
+def test_compress_failopen_on_cache_write_failure(monkeypatch):
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: None)
+    out, info = compress.compress_tool_output(
+        query="q", content=ORIGINAL, tool_name="grep", cache_id="c",
+        client=_FakeClient(), task_id="t",
+    )
+    assert out == ORIGINAL
+    assert info["shortened"] is False and info["error"] == "cache write failed"
+
+
+# --------------------------------------------------------------------------- #
+# transform_tool_result hook
+# --------------------------------------------------------------------------- #
+def test_hook_skips_small_output():
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key = True, "cmp_test"
+    assert c.on_transform_tool_result(tool_name="grep", args={}, result="tiny") is None
+
+
+def test_hook_compresses_large_output(monkeypatch):
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    stored = {}
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: stored.update({cid: content}) or _cache_path(cid),
+    )
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    out = c.on_transform_tool_result(
+        tool_name="grep", args={"pattern": "line"}, result=ORIGINAL, tool_call_id="tc1"
+    )
+    assert out is not None
+    assert compress.FOOTER_MARKER in out
+    assert out.startswith(COMPRESSED)                 # API markers preserved
+    assert CACHE_ROOT in out                          # pointer present
+    assert ".compresr/cache" not in out               # not the old workspace path
+    assert c._cache_id(ORIGINAL) in stored
+
+
+def test_hook_folds_footer_into_json_envelope(monkeypatch):
+    """For unwrappable JSON tools, the footer must land inside the inner payload
+    so the returned result stays valid JSON."""
+    result = json.dumps({"content": ORIGINAL, "path": "/x"})
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: _cache_path(cid),
+    )
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 1
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    out = c.on_transform_tool_result(
+        tool_name="read_file", args={"file_path": "/x"}, result=result,
+        task_id="t", tool_call_id="tc2",
+    )
+    assert out is not None
+    parsed = json.loads(out)                           # still valid JSON
+    assert compress.FOOTER_MARKER in parsed["content"]
+    assert parsed["path"] == "/x"                       # sibling fields preserved
+
+
+def test_hook_skips_already_compressed(monkeypatch):
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 1
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    already = "some output\n" + compress.FOOTER_MARKER + " ... cached at /x"
+    assert c.on_transform_tool_result(tool_name="grep", args={}, result=already) is None
+
+
+def test_hook_failopen_on_api_error(monkeypatch):
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+
+    def _boom(**kw):
+        raise RuntimeError("HTTP 500")
+
+    monkeypatch.setattr(c._client, "compress", _boom)
+    out = c.on_transform_tool_result(
+        tool_name="grep", args={"pattern": "x"}, result=ORIGINAL, tool_call_id="tc3"
+    )
+    assert out is None
+
+
+def test_hook_failopen_on_cache_write_failure(monkeypatch):
+    """If persisting the original fails, the pointer would dangle — the hook must
+    fail open to the original output rather than emit it."""
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: None)
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    out = c.on_transform_tool_result(
+        tool_name="grep", args={"pattern": "x"}, result=ORIGINAL, tool_call_id="tc4"
+    )
+    assert out is None
+
+
+def test_hook_failopen_when_not_shorter(monkeypatch):
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: _cache_path("c"))
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (ORIGINAL + "\nlonger now", {}))
+    out = c.on_transform_tool_result(
+        tool_name="grep", args={"pattern": "x"}, result=ORIGINAL, tool_call_id="tc5"
+    )
+    assert out is None
+
+
+# --------------------------------------------------------------------------- #
+# Cache-authority (PR #6): host write + per-backend agent-visible path
+# --------------------------------------------------------------------------- #
+def _docker_env(byte_count=None, returncode=0):
+    """A fake DockerEnvironment whose `execute` simulates the in-container
+    visibility probe. byte_count None → echo the real host size back (mount
+    present); otherwise return the given count / returncode (mount absent)."""
+    def _execute(cmd, cwd="", **kw):
+        out = "" if byte_count is None else str(byte_count)
+        return {"returncode": returncode, "output": out}
+    env = _fake_env("DockerEnvironment", execute=_execute)
+    env._byte_count = byte_count
+    return env
+
+
+def test_store_original_writes_host_cache_and_returns_visible_path(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # Docker mount is present: the probe reads back the real host byte size.
+    real_bytes = len(ORIGINAL.encode("utf-8"))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: _docker_env(byte_count=real_bytes))
+
+    path = cache.store_original("abc123", ORIGINAL, task_id="task-cache", max_cache_mb=0)
+
+    assert path == f"{CACHE_ROOT}/abc123"
+    host_file = hermes_home / "cache" / "compresr" / "tool-output" / "abc123"
+    assert host_file.read_text(encoding="utf-8") == ORIGINAL
+
+
+def test_store_original_docker_mount_missing_fails_open(monkeypatch, tmp_path):
+    """Fix #1: a reused Docker container that never bind-mounted the cache dir
+    (the probe can't read the file) must fail open, not hand out a dangling
+    recovery pointer. The host file is retained for the pruner."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        cache, "_get_active_env", lambda task_id: _docker_env(byte_count=0, returncode=1)
+    )
+    assert cache.store_original("missing-mount", ORIGINAL, task_id="t", max_cache_mb=0) is None
+    assert (hermes_home / "cache" / "compresr" / "tool-output" / "missing-mount").exists()
+
+
+def test_store_original_docker_size_mismatch_fails_open(monkeypatch, tmp_path):
+    """Fix #1: probe returns a different byte count (a stale/other file shadows
+    the mount point) → treat as not visible and fail open."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        cache, "_get_active_env", lambda task_id: _docker_env(byte_count=999999)
+    )
+    assert cache.store_original("stale-shadow", ORIGINAL, task_id="t", max_cache_mb=0) is None
+
+
+def test_store_original_docker_no_exec_primitive_fails_open(monkeypatch, tmp_path):
+    """Fix #1: a Docker env we can't probe (no callable execute) can't prove
+    visibility → fail open."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: _fake_env("DockerEnvironment"))
+    assert cache.store_original("no-exec", ORIGINAL, task_id="t", max_cache_mb=0) is None
+
+
+def test_store_original_fails_open_when_visibility_unknown(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: _fake_env("SingularityEnvironment"))
+
+    assert cache.store_original("no-visible-path", ORIGINAL, task_id="task-cache", max_cache_mb=0) is None
+    # Content-addressed: the host file is retained (not unlinked) on the
+    # fail-open path so a concurrent sibling's recovery pointer can't dangle;
+    # the size-based pruner reclaims it later.
+    assert (hermes_home / "cache" / "compresr" / "tool-output" / "no-visible-path").exists()
+
+
+def test_store_original_with_no_active_env_uses_host_path(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: None)
+
+    path = cache.store_original("host-path", ORIGINAL, task_id="task-cache", max_cache_mb=0)
+
+    assert path == str(hermes_home / "cache" / "compresr" / "tool-output" / "host-path")
+    assert (hermes_home / "cache" / "compresr" / "tool-output" / "host-path").exists()
+
+
+def test_store_original_force_syncs_remote_cache_before_return(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    sync_manager = _FakeSyncManager()
+    env = _fake_env("SSHEnvironment", _remote_home="/home/agent", _sync_manager=sync_manager)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: env)
+
+    path = cache.store_original("synced", ORIGINAL, task_id="task-sync", max_cache_mb=0)
+
+    assert sync_manager.calls == [True]
+    assert path == "/home/agent/.hermes/cache/compresr/tool-output/synced"
+    assert (hermes_home / "cache" / "compresr" / "tool-output" / "synced").exists()
+
+
+def test_store_original_force_sync_failure_retains_host_file(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    sync_manager = _FakeSyncManager(boom=RuntimeError("sync failed"))
+    env = _fake_env("SSHEnvironment", _remote_home="/home/agent", _sync_manager=sync_manager)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: env)
+
+    assert cache.store_original("sync-fail", ORIGINAL, task_id="task-sync", max_cache_mb=0) is None
+    assert sync_manager.calls == [True]
+    # Content-addressed: retained, not unlinked — a sibling compression of
+    # identical content may already hold a recovery pointer to this exact file.
+    assert (hermes_home / "cache" / "compresr" / "tool-output" / "sync-fail").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Retention (size-based prune)
+# --------------------------------------------------------------------------- #
+def test_cache_prune_evicts_oldest_over_budget(tmp_path):
+    from plugins.tool_output_compresr.cache import _prune_cache_dir
+
+    old = tmp_path / "old"
+    newer = tmp_path / "newer"
+    current = tmp_path / "current"
+    old.write_text("x" * 10, encoding="utf-8")
+    newer.write_text("y" * 10, encoding="utf-8")
+    current.write_text("z" * 10, encoding="utf-8")
+    os.utime(old, (1, 1))
+    os.utime(newer, (2, 2))
+    os.utime(current, (3, 3))
+
+    _prune_cache_dir(str(tmp_path), 20, str(current))
+
+    assert not old.exists()
+    assert newer.exists()
+    assert current.exists()
+    assert sum(path.stat().st_size for path in tmp_path.iterdir() if path.is_file()) <= 20
+
+
+def test_cache_prune_disabled_leaves_files(tmp_path):
+    from plugins.tool_output_compresr.cache import _prune_cache_dir
+
+    old = tmp_path / "old"
+    current = tmp_path / "current"
+    old.write_text("x" * 10, encoding="utf-8")
+    current.write_text("z" * 10, encoding="utf-8")
+
+    _prune_cache_dir(str(tmp_path), 0, str(current))
+
+    assert old.exists()
+    assert current.exists()
+
+
+def test_cache_prune_host_root(tmp_path):
+    from plugins.tool_output_compresr.cache import _prune_cache_dir
+
+    old = tmp_path / "old"
+    current = tmp_path / "current"
+    old.write_text("x" * 10, encoding="utf-8")
+    current.write_text("z" * 10, encoding="utf-8")
+    # Age the eviction candidate past the recovery pin window so size-based
+    # prune reclaims it (recent entries are pinned; see pin-recent).
+    os.utime(old, (1, 1))
+
+    _prune_cache_dir(str(tmp_path), 1, str(current))
+
+    assert not old.exists()
+    assert current.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+def test_tool_output_api_key_is_env_only(monkeypatch, tmp_path):
+    monkeypatch.delenv("COMPRESR_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "compresr:\n"
+        "  api_key: cmp_from_config\n"
+        "  tool_output_enabled: true\n"
+        "  tool_output_min_tokens: 7\n"
+        "  tool_output_max_cache_mb: 3\n",
+        encoding="utf-8",
+    )
+
+    c = ToolOutputCompressor()
+    assert c.api_key == ""            # secrets are env-only
+    assert c.enabled is True
+    assert c.min_tokens == 7
+    assert c.max_cache_mb == 3
+    assert not c.active               # no key → inactive
+
+
+# --------------------------------------------------------------------------- #
+# H1: recovery reads of a cached original must not be re-compressed
+# --------------------------------------------------------------------------- #
+def test_hook_skips_recovery_read_of_cached_original(monkeypatch):
+    """A read_file targeting a compresr cache file returns the verbatim original
+    (None from the hook) instead of being re-compressed into a lossy summary."""
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    # If the guard fails, this would fire and mangle the recovery.
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: _cache_path("x"))
+
+    # Container-translated path (backend-agnostic substring match).
+    out = c.on_transform_tool_result(
+        tool_name="read_file",
+        args={"file_path": f"{CACHE_ROOT}/deadbeef"},
+        result=ORIGINAL,
+        tool_call_id="rec1",
+    )
+    assert out is None
+    assert c.recoveries == 1
+    assert c.get_status()["recoveries"] == 1
+
+
+def test_hook_recovery_guard_matches_host_cache_root(monkeypatch, tmp_path):
+    """The guard also matches a resolved host cache path under get_cache_root()."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    host_path = str(cache.get_cache_root() / "abc123")
+    out = c.on_transform_tool_result(
+        tool_name="read_file", args={"file_path": host_path}, result=ORIGINAL,
+    )
+    assert out is None
+    assert c.recoveries == 1
+
+
+# --------------------------------------------------------------------------- #
+# H2: search_files unwraps its real dense shape ("matches_text")
+# --------------------------------------------------------------------------- #
+def test_hook_unwraps_search_files_matches_text(monkeypatch):
+    """search_files emits {"total_count":N,"matches_text":"..."} (never a
+    top-level "content"). The plugin must unwrap matches_text, keep the result
+    valid JSON, and fold the footer into matches_text."""
+    matches = "\n".join(f"file{i}.py\n  {i}: match line {i}" for i in range(60))
+    result = json.dumps({"total_count": 60, "matches_text": matches})
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: _cache_path(cid),
+    )
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 1
+    monkeypatch.setattr(c._client, "compress", lambda **kw: (COMPRESSED, {}))
+    out = c.on_transform_tool_result(
+        tool_name="search_files", args={"pattern": "match"}, result=result,
+        tool_call_id="sf1",
+    )
+    assert out is not None
+    parsed = json.loads(out)                            # still valid JSON
+    assert parsed["total_count"] == 60                  # sibling field preserved
+    assert compress.FOOTER_MARKER in parsed["matches_text"]
+    assert parsed["matches_text"].startswith(COMPRESSED)
+    assert "content" not in parsed
+
+
+# --------------------------------------------------------------------------- #
+# H3: a real FileSyncManager whose upload raises fails open (host file retained)
+# --------------------------------------------------------------------------- #
+def test_store_original_real_sync_upload_failure_fails_open(monkeypatch, tmp_path):
+    from tools.environments.file_sync import FileSyncManager
+
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def _boom_upload(host_path, remote_path):
+        raise RuntimeError("transport down")
+
+    # A real manager: sync() catches the transport error internally, so without
+    # raise_on_error the failure would be swallowed and store_original would hand
+    # back a remote path for a file that was never uploaded.
+    sm = FileSyncManager(
+        get_files_fn=lambda: [(str(hermes_home / "x"), "/root/.hermes/x")],
+        upload_fn=_boom_upload,
+        delete_fn=lambda paths: None,
+    )
+    # Force the initial file to look new so sync attempts an upload.
+    (hermes_home).mkdir(parents=True, exist_ok=True)
+    (hermes_home / "x").write_text("seed", encoding="utf-8")
+
+    env = _fake_env("SSHEnvironment", _remote_home="/home/agent", _sync_manager=sm)
+    monkeypatch.setattr(cache, "_get_active_env", lambda task_id: env)
+
+    assert cache.store_original("sync-boom", ORIGINAL, task_id="t", max_cache_mb=0) is None
+    # Fail open (returns None) but retain the content-addressed host file so a
+    # concurrent sibling's recovery pointer can't dangle; pruner reclaims later.
+    assert (hermes_home / "cache" / "compresr" / "tool-output" / "sync-boom").exists()
+
+
+# --------------------------------------------------------------------------- #
+# M1: a marginally-shorter compression must not come back net-larger + footer
+# --------------------------------------------------------------------------- #
+def test_compress_failopen_on_marginal_shrink(monkeypatch):
+    """The size gate now accounts for the ~90-token footer, so a body only a few
+    tokens smaller than the original fails open (no net growth, no cache write)."""
+    stored = {}
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: stored.update({cid: content}) or _cache_path(cid),
+    )
+    base = "x" * 1000                                   # ~250 tokens
+    marginal = "x" * 990                                # ~2.5 tokens shorter — below footer budget
+    out, info = compress.compress_tool_output(
+        query="q", content=base, tool_name="grep", cache_id="marg",
+        client=_FakeClient(out=marginal), task_id="t",
+    )
+    assert out == base
+    assert info["shortened"] is False
+    assert "marg" not in stored                         # cache NOT written on failure
+
+
+# --------------------------------------------------------------------------- #
+# M2: whitespace-only compressed output is treated as a failure (fail open)
+# --------------------------------------------------------------------------- #
+def test_compress_failopen_on_whitespace_only_output(monkeypatch):
+    stored = {}
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: stored.update({cid: content}) or _cache_path(cid),
+    )
+    out, info = compress.compress_tool_output(
+        query="q", content=ORIGINAL, tool_name="grep", cache_id="ws",
+        client=_FakeClient(out="  \n  \t "), task_id="t",
+    )
+    assert out == ORIGINAL
+    assert info["shortened"] is False
+    assert info["error"] == "empty compressed output"
+    assert "ws" not in stored
+
+
+def test_hook_failopen_on_whitespace_only_output(monkeypatch):
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 5
+    monkeypatch.setattr(cache, "store_original", lambda *a, **k: _cache_path("c"))
+    monkeypatch.setattr(c._client, "compress", lambda **kw: ("   \n  ", {}))
+    out = c.on_transform_tool_result(
+        tool_name="grep", args={"pattern": "x"}, result=ORIGINAL, tool_call_id="ws1"
+    )
+    assert out is None
+
+
+# --------------------------------------------------------------------------- #
+# M4: recently-written cache entries are pinned against size-based prune
+# --------------------------------------------------------------------------- #
+def test_prune_pins_recently_written_entries(tmp_path):
+    from plugins.tool_output_compresr.cache import _prune_cache_dir
+
+    old = tmp_path / "old"
+    fresh = tmp_path / "fresh"
+    current = tmp_path / "current"
+    for p in (old, fresh, current):
+        p.write_text("x" * 10, encoding="utf-8")
+    # Only `old` is aged past the pin window; `fresh` is a footer path a sibling
+    # just handed to the model and must survive even though the dir is over budget.
+    os.utime(old, (1, 1))
+
+    _prune_cache_dir(str(tmp_path), 1, str(current))
+
+    assert not old.exists()      # aged → evictable
+    assert fresh.exists()        # recent → pinned, survives prune
+    assert current.exists()      # explicit keep
+
+
+import plugins.tool_output_compresr as toc  # noqa: E402
+
+
+def test_gutter_helpers():
+    assert toc._is_fully_guttered("1|def f():\n2|    return 1")
+    assert not toc._is_fully_guttered("plain text\nno gutter")
+    # a line that merely contains a pipe must not be mistaken for a gutter
+    assert not toc._is_fully_guttered("a | b table")
+    assert toc._strip_line_gutter("3|def f():\n4|    return 1") == "def f():\n    return 1"
+    assert toc._strip_line_gutter("a | b") == "a | b"  # untouched
+
+
+def test_read_file_output_cached_denumbered(monkeypatch):
+    """read_file content arrives line-numbered (N|code); the cache must store a
+    DE-numbered copy so a recovery read_file re-adds exactly one gutter, not two."""
+    body = "\n".join("%d|line %d content here" % (i, i) for i in range(1, 60))
+    result = json.dumps({"content": body, "path": "/x"})
+    stored = {}
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: stored.update({"content": content})
+        or "/hermes/cache/compresr/tool-output/" + cid,
+    )
+    c = ToolOutputCompressor()
+    c.enabled, c.api_key, c.min_tokens = True, "cmp_test", 1
+    monkeypatch.setattr(c._client, "compress", lambda **kw: ("line 1 content here\n[56 lines removed]", {}))
+    out = c.on_transform_tool_result(
+        tool_name="read_file", args={"file_path": "/x"}, result=result,
+        task_id="t", tool_call_id="tc-num",
+    )
+    assert out is not None
+    # what was cached is the DE-numbered content (no "N|" gutters)
+    cached = stored["content"]
+    assert cached.startswith("line 1 content here")
+    assert "1|line 1" not in cached
+    assert cached == "\n".join("line %d content here" % i for i in range(1, 60))
+
+
+# --------------------------------------------------------------------------- #
+# C: the size gate is EXACT — a long cache path whose footer exceeds the nominal
+# FOOTER_TOKEN_BUDGET must not sneak a net-larger output past the gate.
+# --------------------------------------------------------------------------- #
+def test_compress_failopen_when_long_cache_path_makes_output_net_larger(monkeypatch):
+    """A body a bit under the nominal budget passes the cheap pre-filter, but a
+    very long remote cache path makes the real footer cost far more than
+    FOOTER_TOKEN_BUDGET. The exact post-footer gate must catch it and fail open."""
+    long_path = "/root/.hermes/cache/compresr/tool-output/" + ("a" * 560)
+    monkeypatch.setattr(
+        cache, "store_original",
+        lambda cid, content, task_id="default", **_: long_path,
+    )
+    base = "x" * 4000            # ~1000 tokens
+    body = "x" * 3400            # ~850 tokens: 850 + 90 (budget) < 1000 → passes pre-filter
+    out, info = compress.compress_tool_output(
+        query="q", content=base, tool_name="grep", cache_id="longpath",
+        client=_FakeClient(out=body), task_id="t",
+    )
+    assert out == base                                   # failed open, original returned
+    assert info["shortened"] is False
+    # A benign "no net win" is NOT a failure — no error key (so the hook doesn't
+    # back off / count it); it is recorded as a skipped_reason instead.
+    assert "error" not in info
+    assert info["skipped_reason"] == "not smaller after footer"
+
+
+# --------------------------------------------------------------------------- #
+# D: HTTP contract of the tool-output client (payload shape, headers, envelope).
+# Kept unmocked at the urllib layer so envelope-key drift (compressed_output vs
+# the engine's compressed_context) fails loudly.
+# --------------------------------------------------------------------------- #
+class _FakeResp:
+    def __init__(self, body):
+        self._b = body.encode("utf-8")
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_tool_output_client_builds_request_and_parses_compressed_output(monkeypatch):
+    from plugins.tool_output_compresr.client import CompresrToolOutputClient
+
+    captured = {}
+
+    def _fake_urlopen(req, timeout=None):
+        captured["req"] = req
+        return _FakeResp(json.dumps({"success": True, "data": {
+            "compressed_output": "SHORT\n[3 lines removed]", "tokens_saved": 7,
+        }}))
+
+    import urllib.request
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    client = CompresrToolOutputClient(api_key="cmp_secret", model="toc_latte_v2")
+    text, data = client.compress(
+        tool_output="a huge dump", query="grep: foo", tool_name="grep",
+        target_ratio=2.0,
+    )
+
+    assert text == "SHORT\n[3 lines removed]"
+    assert data["tokens_saved"] == 7
+    req = captured["req"]
+    assert req.full_url.endswith("/compress/tool-output/")
+    assert req.get_header("X-api-key") == "cmp_secret"
+    assert req.get_header("User-agent") == CompresrToolOutputClient.USER_AGENT
+    assert req.get_header("Content-type") == "application/json"
+    payload = json.loads(req.data)
+    assert payload["tool_output"] == "a huge dump"
+    assert payload["query"] == "grep: foo"
+    assert payload["tool_name"] == "grep"
+    assert payload["compression_model_name"] == "toc_latte_v2"
+    assert payload["source"] == "integration:hermes"
+    assert payload["coarse"] is True
+    assert payload["disable_placeholders"] is False
+    assert payload["target_compression_ratio"] == 2.0
+
+
+def test_tool_output_client_raises_on_api_failure_and_empty(monkeypatch):
+    import pytest as _pytest
+    import urllib.request
+    from plugins.tool_output_compresr.client import CompresrToolOutputClient
+
+    client = CompresrToolOutputClient(api_key="cmp_secret")
+
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda req, timeout=None: _FakeResp(json.dumps(
+                            {"success": False, "message": "bad source"})))
+    with _pytest.raises(RuntimeError):
+        client.compress(tool_output="x", query="q", tool_name="grep")
+
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda req, timeout=None: _FakeResp(json.dumps(
+                            {"success": True, "data": {"compressed_output": ""}})))
+    with _pytest.raises(RuntimeError):
+        client.compress(tool_output="x", query="q", tool_name="grep")
+
+
+def test_tool_output_client_raises_on_http_error_with_detail(monkeypatch):
+    import io
+    import pytest as _pytest
+    import urllib.error
+    import urllib.request
+    from plugins.tool_output_compresr.client import CompresrToolOutputClient
+
+    def _http_err(req, timeout=None):
+        raise urllib.error.HTTPError(
+            "u", 422, "Unprocessable", None, io.BytesIO(b'{"detail":"bad source"}')
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", _http_err)
+    client = CompresrToolOutputClient(api_key="cmp_secret")
+    with _pytest.raises(RuntimeError) as ei:
+        client.compress(tool_output="x", query="q", tool_name="grep")
+    assert "422" in str(ei.value)
+
+
+def test_tool_output_client_requires_key_and_output():
+    import pytest as _pytest
+    from plugins.tool_output_compresr.client import CompresrToolOutputClient
+
+    with _pytest.raises(RuntimeError):
+        CompresrToolOutputClient(api_key="").compress(
+            tool_output="x", query="q", tool_name="grep")
+    with _pytest.raises(RuntimeError):
+        CompresrToolOutputClient(api_key="k").compress(
+            tool_output="", query="q", tool_name="grep")
+
+
+def test_secure_base_url_rejects_cloud_metadata_ip():
+    from plugins.tool_output_compresr import _secure_base_url
+
+    default = "https://api.compresr.ai"
+    assert _secure_base_url("https://169.254.169.254/", default) == default
+    assert _secure_base_url("https://metadata.google.internal/", default) == default
+
+
+def test_client_url_error_routed_through_runtime_error(monkeypatch):
+    # Regression: urllib.error.URLError (DNS failure, connect refused,
+    # socket.timeout) is not a subclass of HTTPError; must be caught explicitly
+    # so callers get a fail-open-worthy RuntimeError instead of a raw URLError.
+    import urllib.error
+    import urllib.request as ureq
+    from plugins.tool_output_compresr.client import CompresrToolOutputClient
+
+    def _boom(*_a, **_kw):
+        raise urllib.error.URLError("Name or service not known")
+
+    monkeypatch.setattr(ureq, "urlopen", _boom)
+    with pytest.raises(RuntimeError, match="connection error"):
+        CompresrToolOutputClient(api_key="cmp_test").compress(
+            tool_output="hello", query="q", tool_name="grep"
+        )
+
+
+def test_client_json_decode_error_routed_through_runtime_error(monkeypatch):
+    import urllib.request as ureq
+    from plugins.tool_output_compresr.client import CompresrToolOutputClient
+
+    class _Resp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *_a):
+            return False
+        def read(self):
+            return b"<html>gateway error</html>"
+
+    monkeypatch.setattr(ureq, "urlopen", lambda *a, **kw: _Resp())
+    with pytest.raises(RuntimeError, match="non-JSON response"):
+        CompresrToolOutputClient(api_key="cmp_test").compress(
+            tool_output="hello", query="q", tool_name="grep"
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -435,6 +435,19 @@ class TestCacheDirectoryMounts:
 
         assert get_cache_directory_mounts() == []
 
+    def test_tool_output_compresr_cache_dir_is_mounted(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        cache_dir = hermes_home / "cache" / "compresr" / "tool-output"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "abc123").write_text("payload", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mounts = get_cache_directory_mounts()
+        assert any(m["host_path"] == str(cache_dir) for m in mounts)
+        assert "/root/.hermes/cache/compresr/tool-output" in {
+            m["container_path"] for m in mounts
+        }
+
 
 class TestMapCachePathToContainer:
     """Tests for map_cache_path_to_container() — the backend-agnostic mapper."""
@@ -476,6 +489,18 @@ class TestMapCachePathToContainer:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert map_cache_path_to_container(str(hermes_home / "cache" / "images" / "x.png")) is None
+
+    def test_maps_tool_output_cache_path(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        cache_file = hermes_home / "cache" / "compresr" / "tool-output" / "x.txt"
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text("payload", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert (
+            map_cache_path_to_container(str(cache_file))
+            == "/root/.hermes/cache/compresr/tool-output/x.txt"
+        )
 
 
 class TestIterCacheFiles:
@@ -530,3 +555,16 @@ class TestIterCacheFiles:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert iter_cache_files() == []
+
+    def test_tool_output_cache_files_are_enumerated(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        cache_dir = hermes_home / "cache" / "compresr" / "tool-output"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "x.txt").write_text("payload", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        entries = iter_cache_files()
+        assert any(
+            entry["container_path"] == "/root/.hermes/cache/compresr/tool-output/x.txt"
+            for entry in entries
+        )

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -343,7 +343,9 @@ def iter_skills_files(
 
 # The cache subdirectories that should be mirrored into remote backends.
 # Each tuple is (new_subpath, old_name) matching hermes_constants.get_hermes_dir().
-_CACHE_DIRS: list[tuple[str, str]] = [
+# When old_name is None, the path has no legacy fallback and always resolves to
+# the new layout under get_hermes_home().
+_CACHE_DIRS: list[tuple[str, str | None]] = [
     ("cache/documents", "document_cache"),
     ("cache/images", "image_cache"),
     ("cache/audio", "audio_cache"),
@@ -351,7 +353,16 @@ _CACHE_DIRS: list[tuple[str, str]] = [
     ("cache/screenshots", "browser_screenshots"),
     ("cache/web", "web_cache"),
     ("cache/delegation", "delegation_cache"),
+    ("cache/compresr/tool-output", None),
 ]
+
+
+def _resolve_cache_dir(new_subpath: str, old_name: str | None) -> Path:
+    from hermes_constants import get_hermes_dir, get_hermes_home
+
+    if old_name is None:
+        return get_hermes_home() / new_subpath
+    return get_hermes_dir(new_subpath, old_name)
 
 
 def get_cache_directory_mounts(
@@ -363,14 +374,16 @@ def get_cache_directory_mounts(
     ``container_path`` keys.  The host path is resolved via
     ``get_hermes_dir()`` for backward compatibility with old directory layouts.
     """
-    from hermes_constants import get_hermes_dir
-
     mounts: List[Dict[str, str]] = []
+    seen_container_paths: set[str] = set()
     for new_subpath, old_name in _CACHE_DIRS:
-        host_dir = get_hermes_dir(new_subpath, old_name)
+        host_dir = _resolve_cache_dir(new_subpath, old_name)
         if host_dir.is_dir():
             # Always map to the *new* container layout regardless of host layout.
             container_path = f"{container_base.rstrip('/')}/{new_subpath}"
+            if container_path in seen_container_paths:
+                continue
+            seen_container_paths.add(container_path)
             mounts.append({
                 "host_path": str(host_dir),
                 "container_path": container_path,
@@ -455,11 +468,9 @@ def iter_cache_files(
     Used by Modal to upload files individually and resync before each command.
     Skips symlinks.  The container paths use the new ``cache/<subdir>`` layout.
     """
-    from hermes_constants import get_hermes_dir
-
     result: List[Dict[str, str]] = []
     for new_subpath, old_name in _CACHE_DIRS:
-        host_dir = get_hermes_dir(new_subpath, old_name)
+        host_dir = _resolve_cache_dir(new_subpath, old_name)
         if not host_dir.is_dir():
             continue
         container_root = f"{container_base.rstrip('/')}/{new_subpath}"

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -159,7 +159,7 @@ class FileSyncManager:
         self._last_sync_time: float = 0.0  # monotonic; 0 ensures first sync runs
         self._sync_interval = sync_interval
 
-    def sync(self, *, force: bool = False) -> None:
+    def sync(self, *, force: bool = False, raise_on_error: bool = False) -> None:
         """Run a sync cycle: upload changed files, delete removed files.
 
         Rate-limited to once per ``sync_interval`` unless *force* is True
@@ -167,6 +167,12 @@ class FileSyncManager:
 
         Transactional: state only committed if ALL operations succeed.
         On failure, state rolls back so the next cycle retries everything.
+
+        By default a transport failure is logged and swallowed (best-effort
+        background sync). Pass ``raise_on_error=True`` when a caller must know
+        the sync actually landed (e.g. a cache write that hands the model a
+        recovery path pointing at the just-uploaded file); the transport error
+        is then re-raised after rollback instead of being swallowed.
         """
         if not force and not os.environ.get(_FORCE_SYNC_ENV):
             now = time.monotonic()
@@ -234,6 +240,8 @@ class FileSyncManager:
             self._pushed_hashes = prev_hashes
             self._last_sync_time = time.monotonic()
             logger.warning("file_sync: sync failed, rolled back state: %s", exc)
+            if raise_on_error:
+                raise
 
     # ------------------------------------------------------------------
     # Sync-back: pull remote changes to host on teardown


### PR DESCRIPTION
Adds two plugins that cut the token and latency costof context management using query-specific compression via the Compresr (YC W26) API. Both require an API key and are opt-in (external hosted service); both fail open, so with them disabled or on any error nothing changes.

## Plugins

- **`context_engine/compresr`**:  drop-in `ContextEngine` that compacts mid-conversation turns via the Compresr API instead of an auxiliary-LLM summary. Overrides only `_generate_summary` (+ `update_model` for parity); all pruning, head/tail protection, and pair sanitization are inherited. Falls back to the built-in compressor on failure.
- **`tool_output_compresr`**: `transform_tool_result` hook that compresses large tool outputs as they arrive, appending a footer that points at the full verbatim original in Hermes's managed cache (recoverable via `read_file`/`search_files`).

## Safety

Off by default; fail-open everywhere (host tool calls never break); SSRF-hardened base-URL validation + secret redaction, shared in one module so they can't drift. Optional `/usage` stats, setup-wizard section, and config wiring are all no-ops when disabled.

## Tests

Unit + contract + regression for both plugins, plus live end-to-end against the real API with byte-exact `read_file` recovery.

## Enable

```yaml
context: { engine: compresr }
compresr: { tool_output_enabled: true }
plugins: { enabled: [tool_output_compresr] }
```

```bash
# ~/.hermes/.env
COMPRESR_API_KEY=cmp_...
```