### PR TITLE
fix(email): interrupt active IMAP poll on shutdown

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -24,6 +24,7 @@ import re
 import smtplib
 import socket
 import ssl
+import threading
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -480,6 +481,9 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
+        self._imap_poll_lock = threading.Lock()
+        self._active_poll_imap: Optional[imaplib.IMAP4_SSL] = None
+        self._imap_poll_stop = threading.Event()
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
@@ -505,6 +509,50 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _register_poll_imap(self, imap: imaplib.IMAP4_SSL) -> bool:
+        """Expose the active polling connection so disconnect can interrupt it."""
+        with self._imap_poll_lock:
+            if self._imap_poll_stop.is_set():
+                return False
+            self._active_poll_imap = imap
+            return True
+
+    def _clear_poll_imap(self, imap: imaplib.IMAP4_SSL) -> None:
+        with self._imap_poll_lock:
+            if self._active_poll_imap is imap:
+                self._active_poll_imap = None
+
+    @staticmethod
+    def _close_poll_socket(imap: imaplib.IMAP4_SSL) -> None:
+        """Close an IMAP socket without waiting on its buffered reader lock."""
+        sock = getattr(imap, "sock", None)
+        if sock is None:
+            return
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    def _interrupt_poll_imap(self) -> None:
+        """Close the active poll socket so its executor thread can terminate."""
+        with self._imap_poll_lock:
+            imap = self._active_poll_imap
+            self._active_poll_imap = None
+        if imap is None:
+            return
+        try:
+            # IMAP4.shutdown() closes the buffered file before the socket; that
+            # close can wait on the executor thread's reader lock. Close the
+            # socket directly so the blocked read wakes without blocking the
+            # event-loop thread that is performing shutdown.
+            self._close_poll_socket(imap)
+        except Exception as e:
+            logger.debug("[Email] Failed to interrupt active IMAP poll: %s", e)
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -612,6 +660,7 @@ class EmailAdapter(BasePlatformAdapter):
             return False
 
         self._running = True
+        self._imap_poll_stop.clear()
         self._poll_task = asyncio.create_task(self._poll_loop())
         print(f"[Email] Connected as {self._address}")
         return True
@@ -619,6 +668,8 @@ class EmailAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop polling and disconnect."""
         self._running = False
+        self._imap_poll_stop.set()
+        self._interrupt_poll_imap()
         if self._poll_task:
             self._poll_task.cancel()
             try:
@@ -650,8 +701,13 @@ class EmailAdapter(BasePlatformAdapter):
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
+        if self._imap_poll_stop.is_set():
+            return results
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            if not self._register_poll_imap(imap):
+                self._close_poll_socket(imap)
+                return results
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
@@ -662,6 +718,8 @@ class EmailAdapter(BasePlatformAdapter):
                     return results
 
                 for uid in data[0].split():
+                    if self._imap_poll_stop.is_set():
+                        break
                     if uid in self._seen_uids:
                         continue
                     self._seen_uids.add(uid)
@@ -741,6 +799,7 @@ class EmailAdapter(BasePlatformAdapter):
                     imap.logout()
                 except Exception:
                     pass
+                self._clear_poll_imap(imap)
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -32,6 +32,7 @@ import socket
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
 import ssl
+import threading
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -648,6 +649,9 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
+        self._imap_poll_lock = threading.Lock()
+        self._active_poll_imap: Optional[imaplib.IMAP4_SSL] = None
+        self._imap_poll_stop = threading.Event()
 
         # Track the last IMAP fetch attempt so the poll loop can distinguish
         # "checked, nothing new" from "the check itself failed" (#80016).
@@ -697,6 +701,50 @@ class EmailAdapter(BasePlatformAdapter):
                 _close_imap(imap)
                 raise
         return imap
+
+    def _register_poll_imap(self, imap: imaplib.IMAP4) -> bool:
+        """Expose the active polling connection so disconnect can interrupt it."""
+        with self._imap_poll_lock:
+            if self._imap_poll_stop.is_set():
+                return False
+            self._active_poll_imap = imap
+            return True
+
+    def _clear_poll_imap(self, imap: imaplib.IMAP4) -> None:
+        with self._imap_poll_lock:
+            if self._active_poll_imap is imap:
+                self._active_poll_imap = None
+
+    @staticmethod
+    def _close_poll_socket(imap: imaplib.IMAP4_SSL) -> None:
+        """Close an IMAP socket without waiting on its buffered reader lock."""
+        sock = getattr(imap, "sock", None)
+        if sock is None:
+            return
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    def _interrupt_poll_imap(self) -> None:
+        """Close the active poll socket so its executor thread can terminate."""
+        with self._imap_poll_lock:
+            imap = self._active_poll_imap
+            self._active_poll_imap = None
+        if imap is None:
+            return
+        try:
+            # IMAP4.shutdown() closes the buffered file before the socket; that
+            # close can wait on the executor thread's reader lock. Close the
+            # socket directly so the blocked read wakes without blocking the
+            # event-loop thread that is performing shutdown.
+            self._close_poll_socket(imap)
+        except Exception as e:
+            logger.debug("[Email] Failed to interrupt active IMAP poll: %s", e)
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -867,6 +915,7 @@ class EmailAdapter(BasePlatformAdapter):
             return False
 
         self._running = True
+        self._imap_poll_stop.clear()
         self._poll_task = asyncio.create_task(self._poll_loop())
         print(f"[Email] Connected as {self._address}")
         # Plugin-registered native handlers (ctx.register_platform_handler).
@@ -876,6 +925,8 @@ class EmailAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop polling and disconnect."""
         self._running = False
+        self._imap_poll_stop.set()
+        self._interrupt_poll_imap()
         if self._poll_task:
             self._poll_task.cancel()
             try:
@@ -926,9 +977,14 @@ class EmailAdapter(BasePlatformAdapter):
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
+        if self._imap_poll_stop.is_set():
+            return results
         imap: Optional[imaplib.IMAP4] = None
         try:
             imap = self._connect_imap()
+            if not self._register_poll_imap(imap):
+                self._close_poll_socket(imap)
+                return results
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
@@ -939,6 +995,8 @@ class EmailAdapter(BasePlatformAdapter):
                     return results
 
                 for uid in data[0].split():
+                    if self._imap_poll_stop.is_set():
+                        break
                     if uid in self._seen_uids:
                         continue
 
@@ -991,8 +1049,10 @@ class EmailAdapter(BasePlatformAdapter):
                     if parsed is not None:
                         results.append(parsed)
             finally:
+                self._clear_poll_imap(imap)
                 # _close_imap guarantees the socket dies even when logout()
-                # raises IMAP4.abort on a broken connection (#79889).
+                # raises IMAP4.abort on a broken connection (#79889). Also
+                # tolerates logout after the socket was interrupted mid-poll.
                 _close_imap(imap)
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)

--- a/tests/gateway/test_email_imap_shutdown.py
+++ b/tests/gateway/test_email_imap_shutdown.py
@@ -1,0 +1,171 @@
+"""Regression tests for interruptible Email IMAP polling shutdown."""
+
+import asyncio
+import os
+import threading
+from unittest.mock import patch
+
+from gateway.config import PlatformConfig
+from plugins.platforms.email.adapter import EmailAdapter
+
+
+_EMAIL_ENV = {
+    "EMAIL_ADDRESS": "hermes@test.com",
+    "EMAIL_PASSWORD": "secret",
+    "EMAIL_IMAP_HOST": "imap.test.com",
+    "EMAIL_SMTP_HOST": "smtp.test.com",
+}
+
+_SAMPLE_RAW = (
+    b"From: sender@test.com\n"
+    b"To: hermes@test.com\n"
+    b"Subject: shutdown test\n"
+    b"Message-ID: <shutdown@test.com>\n"
+    b"\n"
+    b"hello\n"
+)
+
+
+def _make_adapter() -> EmailAdapter:
+    with patch.dict(os.environ, _EMAIL_ENV):
+        return EmailAdapter(PlatformConfig(enabled=True))
+
+
+async def _wait_for_event(event: threading.Event, timeout: float = 1.0) -> None:
+    async def _wait() -> None:
+        while not event.is_set():
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_wait(), timeout)
+
+
+class _BlockingIMAP:
+    def __init__(self):
+        self.sock = self
+        self.search_started = threading.Event()
+        self.released = threading.Event()
+        self.worker_finished = threading.Event()
+        self.shutdown_called = threading.Event()
+
+    def login(self, *_args):
+        return "OK", []
+
+    def select(self, *_args):
+        return "OK", []
+
+    def response(self, *_args):
+        return None
+
+    def uid(self, command, *_args):
+        assert command == "search"
+        self.search_started.set()
+        self.released.wait(timeout=5)
+        return "OK", [b""]
+
+    def shutdown(self, _how):
+        self.shutdown_called.set()
+        self.released.set()
+
+    def close(self):
+        pass
+
+    def logout(self):
+        self.worker_finished.set()
+
+
+def test_disconnect_interrupts_blocked_executor_poll():
+    adapter = _make_adapter()
+    imap = _BlockingIMAP()
+
+    async def _scenario() -> None:
+        adapter._running = True
+        adapter._poll_task = asyncio.create_task(adapter._check_inbox())
+        await _wait_for_event(imap.search_started)
+        await asyncio.wait_for(adapter.disconnect(), timeout=1)
+        await _wait_for_event(imap.worker_finished)
+
+    with patch(
+        "plugins.platforms.email.adapter.imaplib.IMAP4_SSL",
+        return_value=imap,
+    ), patch("plugins.platforms.email.adapter._send_imap_id"):
+        asyncio.run(_scenario())
+
+    assert imap.shutdown_called.is_set()
+    assert adapter._active_poll_imap is None
+    assert adapter._poll_task is None
+
+
+class _BatchIMAP:
+    def __init__(self, adapter: EmailAdapter):
+        self.adapter = adapter
+        self.fetched = []
+
+    def login(self, *_args):
+        return "OK", []
+
+    def select(self, *_args):
+        return "OK", []
+
+    def response(self, *_args):
+        return None
+
+    def uid(self, command, *args):
+        if command == "search":
+            return "OK", [b"1 2 3"]
+        if command == "fetch":
+            self.fetched.append(args[0])
+            self.adapter._imap_poll_stop.set()
+            return "OK", [(b"1 (RFC822)", _SAMPLE_RAW)]
+        raise AssertionError(f"unexpected IMAP command: {command}")
+
+    def logout(self):
+        return "BYE", []
+
+
+def test_poll_batch_stops_after_shutdown_begins():
+    adapter = _make_adapter()
+    adapter._running = True
+    imap = _BatchIMAP(adapter)
+
+    with patch(
+        "plugins.platforms.email.adapter.imaplib.IMAP4_SSL",
+        return_value=imap,
+    ), patch("plugins.platforms.email.adapter._send_imap_id"):
+        adapter._fetch_new_messages()
+
+    assert imap.fetched == [b"1"]
+    assert adapter._active_poll_imap is None
+
+
+class _FailingIMAP:
+    def login(self, *_args):
+        raise RuntimeError("login failed")
+
+    def logout(self):
+        return "BYE", []
+
+
+def test_poll_connection_clears_after_exception():
+    adapter = _make_adapter()
+    adapter._running = True
+    imap = _FailingIMAP()
+
+    with patch(
+        "plugins.platforms.email.adapter.imaplib.IMAP4_SSL",
+        return_value=imap,
+    ):
+        assert adapter._fetch_new_messages() == []
+
+    assert adapter._active_poll_imap is None
+
+
+def test_stopped_poll_does_not_open_new_connection():
+    adapter = _make_adapter()
+    adapter._imap_poll_stop.set()
+
+    with patch(
+        "plugins.platforms.email.adapter.imaplib.IMAP4_SSL",
+    ) as imap_constructor:
+        assert adapter._fetch_new_messages() == []
+
+    imap_constructor.assert_not_called()


### PR DESCRIPTION
Fixes #64638

## Summary

- Interrupts an active synchronous IMAP poll when the Email adapter disconnects.
- Prevents `asyncio.run()` from waiting for a blocked default-executor worker until systemd's `TimeoutStopSec` expires.
- Stops long UID batches promptly once gateway shutdown begins.

## Root cause

Cancelling the Future returned by `run_in_executor()` does not stop the underlying synchronous IMAP worker. The adapter could therefore report a successful disconnect while an IMAP socket remained blocked, leaving `asyncio.run()` inside default-executor shutdown.

## Implementation

- Tracks the active polling IMAP connection under a thread lock.
- Sets a thread-safe stop event before cancelling the asyncio poll task.
- Shuts down and closes the raw socket to wake blocked IMAP reads without waiting on `imaplib`'s buffered-reader lock.
- Closes the constructor/register race and checks the stop event between UIDs.
- Clears active connection state in `finally` and tolerates logout after socket interruption.

The fix is independent of the Email `BODY.PEEK[]` work and is based directly on current `main`.

## Tests

```text
scripts/run_tests.sh \
  tests/gateway/test_email.py \
  tests/gateway/test_email_robustness.py \
  tests/gateway/test_email_imap_shutdown.py -q

# 101 passed
```

New executor-backed regressions cover:

- Disconnect releasing a blocked IMAP worker.
- Shutdown stopping a long UID batch.
- Active connection cleanup after exceptions.
- No new IMAP connection after shutdown begins.

The dogfood deployment documented in #64638 reduced the observed restart from a 90-second forced kill to a 3.95-second clean restart.
