### PR TITLE
fix(email): interrupt active IMAP poll on shutdown

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -24,6 +24,7 @@ import re
 import smtplib
 import socket
 import ssl
+import threading
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -480,6 +481,9 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
+        self._poll_stop_event = threading.Event()
+        self._active_imap_lock = threading.Lock()
+        self._active_imap: Optional[Any] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
@@ -548,6 +552,45 @@ class EmailAdapter(BasePlatformAdapter):
             # Retry with IPv4 only.
             return _connect(ipv4_only=True)
 
+    def _set_active_imap(self, imap: Any) -> None:
+        """Remember the IMAP connection currently owned by the poll worker."""
+        with self._active_imap_lock:
+            self._active_imap = imap
+
+    def _clear_active_imap(self, imap: Any) -> None:
+        """Clear the active IMAP handle without racing a newer poll."""
+        with self._active_imap_lock:
+            if self._active_imap is imap:
+                self._active_imap = None
+
+    def _interrupt_active_imap(self) -> None:
+        """Wake a blocking IMAP poll by closing its socket from the loop thread."""
+        with self._active_imap_lock:
+            imap = self._active_imap
+        if imap is None:
+            return
+
+        raw_sock = None
+        for attr in ("sock", "_sock"):
+            raw_sock = getattr(imap, attr, None)
+            if raw_sock is not None:
+                break
+        if raw_sock is None:
+            return
+
+        try:
+            raw_sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        except Exception as exc:
+            logger.debug("[Email] Error shutting down active IMAP socket: %s", exc)
+        try:
+            raw_sock.close()
+        except OSError:
+            pass
+        except Exception as exc:
+            logger.debug("[Email] Error closing active IMAP socket: %s", exc)
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         # Validate up front so a missing host surfaces as an actionable config
@@ -611,6 +654,7 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] SMTP connection failed: %s", e)
             return False
 
+        self._poll_stop_event.clear()
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
         print(f"[Email] Connected as {self._address}")
@@ -619,6 +663,8 @@ class EmailAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop polling and disconnect."""
         self._running = False
+        self._poll_stop_event.set()
+        self._interrupt_active_imap()
         if self._poll_task:
             self._poll_task.cancel()
             try:
@@ -626,6 +672,7 @@ class EmailAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             self._poll_task = None
+        self._interrupt_active_imap()
         logger.info("[Email] Disconnected.")
 
     async def _poll_loop(self) -> None:
@@ -650,18 +697,31 @@ class EmailAdapter(BasePlatformAdapter):
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
+        if self._poll_stop_event.is_set():
+            return results
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            self._set_active_imap(imap)
             try:
+                if self._poll_stop_event.is_set():
+                    return results
                 imap.login(self._address, self._password)
+                if self._poll_stop_event.is_set():
+                    return results
                 _send_imap_id(imap)
+                if self._poll_stop_event.is_set():
+                    return results
                 imap.select("INBOX")
+                if self._poll_stop_event.is_set():
+                    return results
 
                 status, data = imap.uid("search", None, "UNSEEN")
-                if status != "OK" or not data or not data[0]:
+                if self._poll_stop_event.is_set() or status != "OK" or not data or not data[0]:
                     return results
 
                 for uid in data[0].split():
+                    if self._poll_stop_event.is_set():
+                        break
                     if uid in self._seen_uids:
                         continue
                     self._seen_uids.add(uid)
@@ -670,6 +730,8 @@ class EmailAdapter(BasePlatformAdapter):
                         self._trim_seen_uids()
 
                     status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    if self._poll_stop_event.is_set():
+                        break
                     if status != "OK":
                         continue
 
@@ -741,6 +803,8 @@ class EmailAdapter(BasePlatformAdapter):
                     imap.logout()
                 except Exception:
                     pass
+                finally:
+                    self._clear_active_imap(imap)
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -552,24 +552,9 @@ class EmailAdapter(BasePlatformAdapter):
             # Retry with IPv4 only.
             return _connect(ipv4_only=True)
 
-    def _set_active_imap(self, imap: Any) -> None:
-        """Remember the IMAP connection currently owned by the poll worker."""
-        with self._active_imap_lock:
-            self._active_imap = imap
-
-    def _clear_active_imap(self, imap: Any) -> None:
-        """Clear the active IMAP handle without racing a newer poll."""
-        with self._active_imap_lock:
-            if self._active_imap is imap:
-                self._active_imap = None
-
-    def _interrupt_active_imap(self) -> None:
-        """Wake a blocking IMAP poll by closing its socket from the loop thread."""
-        with self._active_imap_lock:
-            imap = self._active_imap
-        if imap is None:
-            return
-
+    @staticmethod
+    def _close_imap_socket(imap: Any) -> None:
+        """Close an IMAP socket directly to wake a blocking worker."""
         raw_sock = None
         for attr in ("sock", "_sock"):
             raw_sock = getattr(imap, attr, None)
@@ -590,6 +575,34 @@ class EmailAdapter(BasePlatformAdapter):
             pass
         except Exception as exc:
             logger.debug("[Email] Error closing active IMAP socket: %s", exc)
+
+    def _register_active_imap(self, imap: Any) -> bool:
+        """Publish the active poll connection unless shutdown already began."""
+        should_close = False
+        with self._active_imap_lock:
+            if self._poll_stop_event.is_set():
+                should_close = True
+            else:
+                self._active_imap = imap
+
+        if should_close:
+            self._close_imap_socket(imap)
+            return False
+        return True
+
+    def _clear_active_imap(self, imap: Any) -> None:
+        """Clear the active IMAP handle without racing a newer poll."""
+        with self._active_imap_lock:
+            if self._active_imap is imap:
+                self._active_imap = None
+
+    def _interrupt_active_imap(self) -> None:
+        """Wake a blocking IMAP poll by closing its socket from the loop thread."""
+        with self._active_imap_lock:
+            imap = self._active_imap
+        if imap is None:
+            return
+        self._close_imap_socket(imap)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
@@ -701,7 +714,8 @@ class EmailAdapter(BasePlatformAdapter):
             return results
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            self._set_active_imap(imap)
+            if not self._register_active_imap(imap):
+                return results
             try:
                 if self._poll_stop_event.is_set():
                     return results

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1197,6 +1197,200 @@ class TestPollLoop(unittest.TestCase):
         self.assertEqual(dispatched[0]["subject"], "Inbox Test")
 
 
+class TestImapPollingShutdown(unittest.TestCase):
+    """Regression coverage for executor-backed IMAP polling shutdown."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_POLL_INTERVAL": "1",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    async def _wait_until(self, predicate, *, timeout=1.0):
+        import asyncio
+        import time
+
+        deadline = time.monotonic() + timeout
+        while not predicate():
+            if time.monotonic() >= deadline:
+                raise AssertionError("condition was not met before timeout")
+            await asyncio.sleep(0.01)
+
+    def test_disconnect_interrupts_blocked_imap_poll_worker(self):
+        """disconnect() must wake the synchronous IMAP worker, not just cancel the task."""
+        import asyncio
+        import threading
+
+        adapter = self._make_adapter()
+        search_entered = threading.Event()
+        released = threading.Event()
+        worker_finished = threading.Event()
+
+        class FakeSocket:
+            def __init__(self):
+                self.shutdown_called = False
+                self.close_called = False
+
+            def shutdown(self, _how):
+                self.shutdown_called = True
+                released.set()
+
+            def close(self):
+                self.close_called = True
+                released.set()
+
+        class BlockingImap:
+            def __init__(self):
+                self.sock = FakeSocket()
+
+            def login(self, *_args):
+                return "OK", []
+
+            def select(self, *_args):
+                return "OK", []
+
+            def xatom(self, *_args):
+                return "OK", []
+
+            def uid(self, command, *_args):
+                if command == "search":
+                    search_entered.set()
+                    released.wait()
+                    worker_finished.set()
+                    raise OSError("IMAP socket interrupted")
+                return "NO", []
+
+            def logout(self):
+                return "OK", []
+
+            def force_release(self):
+                released.set()
+
+        fake_imap = BlockingImap()
+
+        async def exercise():
+            adapter._running = True
+            with patch("imaplib.IMAP4_SSL", return_value=fake_imap):
+                adapter._poll_task = asyncio.create_task(adapter._poll_loop())
+                await self._wait_until(search_entered.is_set)
+                try:
+                    await adapter.disconnect()
+                    await self._wait_until(worker_finished.is_set, timeout=0.5)
+                finally:
+                    fake_imap.force_release()
+                    await self._wait_until(worker_finished.is_set, timeout=0.5)
+
+        asyncio.run(exercise())
+
+        self.assertTrue(fake_imap.sock.shutdown_called)
+        self.assertTrue(fake_imap.sock.close_called)
+
+    def test_fetch_does_not_open_new_connection_after_disconnect(self):
+        """Once shutdown starts, stale executor work must not start a new IMAP session."""
+        import asyncio
+
+        adapter = self._make_adapter()
+
+        async def exercise_disconnect():
+            adapter._running = True
+            await adapter.disconnect()
+
+        asyncio.run(exercise_disconnect())
+
+        with patch("imaplib.IMAP4_SSL") as mock_imap:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        mock_imap.assert_not_called()
+
+    def test_fetch_stops_between_uids_when_disconnect_requested(self):
+        """A long UID batch should stop after shutdown begins."""
+        import asyncio
+        import threading
+
+        adapter = self._make_adapter()
+        first_fetch_entered = threading.Event()
+        release_fetch = threading.Event()
+        fetched_uids = []
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+        raw_email["Authentication-Results"] = (
+            "mx.test.com; dmarc=pass header.from=test.com"
+        )
+
+        class FakeSocket:
+            def shutdown(self, _how):
+                release_fetch.set()
+
+            def close(self):
+                release_fetch.set()
+
+        class BatchImap:
+            sock = FakeSocket()
+
+            def login(self, *_args):
+                return "OK", []
+
+            def select(self, *_args):
+                return "OK", []
+
+            def xatom(self, *_args):
+                return "OK", []
+
+            def uid(self, command, *args):
+                if command == "search":
+                    return "OK", [b"1 2 3"]
+                if command == "fetch":
+                    uid = args[0]
+                    fetched_uids.append(uid)
+                    if len(fetched_uids) == 1:
+                        first_fetch_entered.set()
+                        release_fetch.wait()
+                    return "OK", [(b"RFC822", raw_email.as_bytes())]
+                return "NO", []
+
+            def logout(self):
+                return "OK", []
+
+        fake_imap = BatchImap()
+
+        async def exercise():
+            loop = asyncio.get_running_loop()
+            with patch("imaplib.IMAP4_SSL", return_value=fake_imap):
+                fetch_task = loop.run_in_executor(None, adapter._fetch_new_messages)
+                await self._wait_until(first_fetch_entered.is_set)
+                try:
+                    await adapter.disconnect()
+                finally:
+                    release_fetch.set()
+                return await asyncio.wait_for(fetch_task, timeout=1.0)
+
+        asyncio.run(exercise())
+
+        self.assertEqual(fetched_uids, [b"1"])
+
+    def test_active_imap_reference_clears_after_fetch_exception(self):
+        """Failed polling attempts must not leave a stale active connection handle."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.uid.side_effect = RuntimeError("search failed")
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertIsNone(adapter._active_imap)
+
+
 class TestSendEmailStandalone(unittest.TestCase):
     """Test the standalone _send_email function in send_message_tool."""
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1309,6 +1309,49 @@ class TestImapPollingShutdown(unittest.TestCase):
         self.assertEqual(results, [])
         mock_imap.assert_not_called()
 
+    def test_fetch_closes_connection_when_shutdown_races_after_constructor(self):
+        """If shutdown wins after IMAP construction, the returned socket must be closed."""
+        adapter = self._make_adapter()
+
+        class FakeSocket:
+            def __init__(self):
+                self.shutdown_called = False
+                self.close_called = False
+
+            def shutdown(self, _how):
+                self.shutdown_called = True
+
+            def close(self):
+                self.close_called = True
+
+        class RaceImap:
+            def __init__(self):
+                self.sock = FakeSocket()
+                self.login_called = False
+
+            def login(self, *_args):
+                self.login_called = True
+                raise AssertionError("stopped poll should not log in")
+
+            def logout(self):
+                return "OK", []
+
+        fake_imap = RaceImap()
+
+        def construct_imap(*_args, **_kwargs):
+            adapter._poll_stop_event.set()
+            adapter._interrupt_active_imap()
+            return fake_imap
+
+        with patch("imaplib.IMAP4_SSL", side_effect=construct_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertFalse(fake_imap.login_called)
+        self.assertTrue(fake_imap.sock.shutdown_called)
+        self.assertTrue(fake_imap.sock.close_called)
+        self.assertIsNone(adapter._active_imap)
+
     def test_fetch_stops_between_uids_when_disconnect_requested(self):
         """A long UID batch should stop after shutdown begins."""
         import asyncio


### PR DESCRIPTION
## Summary

Fixes #64638.

Email gateway shutdown now interrupts an active executor-backed IMAP poll instead of only cancelling the asyncio polling task. This prevents `asyncio.run()` from waiting on a blocked default-executor worker after gateway teardown has otherwise completed.

## Root Cause

`EmailAdapter.disconnect()` cancelled `_poll_task`, but `_check_inbox()` runs `_fetch_new_messages()` through `run_in_executor(None, ...)`. Cancelling the asyncio Future does not stop the underlying synchronous IMAP worker thread, so a blocked `login`, `search`, or `fetch` could keep the process alive until systemd `TimeoutStopSec` escalated to `SIGKILL`.

## Changes

- Track the active polling IMAP connection under a thread lock.
- Add a thread-safe poll stop event.
- On `disconnect()`, set the stop event and close the active IMAP socket with `shutdown(SHUT_RDWR)` followed by `close()`.
- Check the stop event before opening a new IMAP connection and between blocking IMAP operations / UID fetches.
- Keep IMAP logout tolerant of already-interrupted sockets.
- Clear the active IMAP reference after fetch cleanup.

## Tests

Added regression coverage for:

- `disconnect()` waking a blocked executor IMAP worker.
- No new IMAP connection opening after shutdown begins.
- Long UID batches stopping once disconnect starts.
- Active IMAP state clearing after fetch exceptions.

Validation:

```text
scripts/run_tests.sh tests/gateway/test_email.py tests/gateway/test_email_robustness.py
101 tests passed, 0 failed
```

Also verified:

```text
git diff --check
```

## Residual Risk

An `IMAP4_SSL` constructor already inside DNS/TCP/TLS setup still cannot be interrupted before the connection object exists. That path remains bounded by the existing constructor timeout.