### PR TITLE
fix(gateway): return EphemeralReply from /background ack to block double file upload

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3302,7 +3302,7 @@ class GatewaySlashCommandsMixin:
             )
         return f"```diff\n{diff}{note}\n```"
 
-    async def _handle_background_command(self, event: MessageEvent) -> str:
+    async def _handle_background_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /background <prompt> — run a prompt in a separate background session.
 
         Spawns a new AIAgent in a background thread with its own session.
@@ -3337,7 +3337,14 @@ class GatewaySlashCommandsMixin:
         _task.add_done_callback(self._background_tasks.discard)
 
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-        return t("gateway.background.started", preview=preview, task_id=task_id)
+        # EphemeralReply so extract_local_files() (run on every non-ephemeral
+        # response) skips this ack — otherwise a bare path echoed from the
+        # prompt gets uploaded from the ack itself, and the background task's
+        # own intentional delivery of the same file uploads it again (#64661).
+        # ttl_seconds=0 keeps prior behavior (no auto-delete of the ack).
+        return EphemeralReply(
+            t("gateway.background.started", preview=preview, task_id=task_id), ttl_seconds=0
+        )
 
     def _save_gateway_config_key(self, key_path: str, value) -> bool:
         """Save a dot-separated key to config.yaml (shared by /reasoning, /fast

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -9,8 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, EphemeralReply, MessageEvent, SendResult
 from gateway.session import SessionSource
 
 
@@ -80,6 +80,99 @@ class TestHandleBackgroundCommand:
         event = _make_event(text="/background   ")
         result = await runner._handle_background_command(event)
         assert "Usage:" in result
+
+    @pytest.mark.asyncio
+    async def test_ack_is_ephemeral_so_it_is_never_scanned_for_attachments(self):
+        """The ack must not be scanned by extract_local_files() at all.
+
+        Regression for #64661: the ack text embeds a truncated echo of the
+        user's prompt. If that prompt contains a bare existing file path,
+        extract_local_files() (run by _process_message_background on every
+        *non-ephemeral* response, per gateway/platforms/base.py) would upload
+        it from the ack — and the background task's own intentional delivery
+        of the same file then uploads it a second time. Returning an
+        EphemeralReply (the same mechanism /stop, /restart, /reset and /yolo
+        already use for status notices) makes _process_message_background
+        skip extraction for this reply entirely, regardless of what the
+        echoed preview contains.
+        """
+        runner = _make_runner()
+        prompt = "use /tmp/bg.png and return it as an image"
+        with patch("gateway.run.asyncio.create_task", side_effect=lambda c, **kw: (c.close(), MagicMock())[1]):
+            event = _make_event(text=f"/background {prompt}")
+            result = await runner._handle_background_command(event)
+
+        assert isinstance(result, EphemeralReply)
+        assert result.ttl_seconds == 0  # no auto-delete — prior behavior preserved
+
+        # Sanity: the path really would be picked up if this weren't skipped
+        # via the is_ephemeral_response guard (confirms the test is not
+        # trivially passing because the path can never match).
+        with patch("os.path.isfile", return_value=True):
+            local_files, _ = BasePlatformAdapter.extract_local_files(str(result))
+        assert local_files == ["/tmp/bg.png"]
+
+    @pytest.mark.asyncio
+    async def test_background_ack_and_completion_deliver_file_exactly_once(self, tmp_path):
+        """Full adapter-pipeline regression for #64661.
+
+        Runs the ack and the background task's completion notice through the
+        real `_process_message_background` pipeline (not just the standalone
+        extractor, per the maintainer review on this PR) with a real existing
+        file, and asserts the required delivery invariant directly: the
+        acknowledgement never triggers an attachment, and the completion
+        notice triggers the file's *only* upload.
+        """
+        result_path = tmp_path / "bg_result.txt"
+        result_path.write_text("background task output", encoding="utf-8")
+
+        class _Adapter(BasePlatformAdapter):
+            async def connect(self, *, is_reconnect: bool = False):
+                pass
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, chat_id, content="", **kwargs):
+                return SendResult(success=True, message_id="m-1")
+
+            async def get_chat_info(self, chat_id):
+                return {}
+
+        adapter = _Adapter(PlatformConfig(enabled=True, token="t"), Platform.TELEGRAM)
+        adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="sent-1"))
+        adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc-1"))
+
+        session_key = "agent:main:telegram:private:67890"
+        ack_event = _make_event(text=f"/background summarize {result_path}")
+        completion_event = _make_event(text="/background")  # source only; text is the prior command
+
+        # Step 1 — the ack, exactly as _handle_background_command returns it:
+        # an EphemeralReply whose truncated echo can contain the same path.
+        async def _ack_handler(evt):
+            return EphemeralReply(f"⏳ Running in background... (prompt: summarize {result_path})", ttl_seconds=0)
+
+        adapter.set_message_handler(_ack_handler)
+        with patch("gateway.platforms.base.asyncio.sleep", AsyncMock()), \
+             patch.object(adapter, "_keep_typing", new=AsyncMock()):
+            await adapter._process_message_background(ack_event, session_key)
+
+        adapter.send_document.assert_not_awaited()
+
+        # Step 2 — the background task's own completion delivery: a plain
+        # response naming the same file, exactly as _run_background_task
+        # sends it once the task finishes.
+        async def _completion_handler(evt):
+            return f"Done! Output saved to {result_path}"
+
+        adapter.set_message_handler(_completion_handler)
+        with patch("gateway.platforms.base.asyncio.sleep", AsyncMock()), \
+             patch.object(adapter, "_keep_typing", new=AsyncMock()):
+            await adapter._process_message_background(completion_event, session_key)
+
+        adapter.send_document.assert_awaited_once()
+        assert adapter.send_document.call_args.kwargs["file_path"] == str(result_path)
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`/background <prompt>` (and its `/btw` alias) immediately replies with an acknowledgement that
echoes a truncated copy of the user's prompt (`preview = prompt[:60] + "..."`). That
acknowledgement is a plain string, so `_process_message_background()` treats it like any other
agent response and runs `extract_local_files()` on it — which uploads any bare, existing local
file path it finds. If the prompt itself contains such a path, the ack uploads it immediately;
then, when the background task finishes and intentionally returns that same file, it gets
uploaded a second time.

The root cause is that the ack has no way to tell `_process_message_background()` "this is a
status notice, don't scan me for attachments." The codebase already has exactly that mechanism —
`EphemeralReply`, used by `/stop`, `/restart`, `/reset`, and `/yolo` in this same file for the
same purpose (`isinstance(response, EphemeralReply)` gates the `extract_local_files()` call).
`_handle_background_command` was just returning a plain `str` instead of reusing it. The fix
returns `EphemeralReply(..., ttl_seconds=0)` — `ttl_seconds=0` explicitly disables the wrapper's
optional auto-delete behavior, so the only change is that this reply is no longer scanned for
local files; everything else about the ack (content, visibility) is unchanged.

### How it works

```mermaid
flowchart TD
    A["/background &lt;prompt with bare path&gt;"] --> B["_handle_background_command builds ack\n(echoes truncated prompt)"]
    B --> C{"ack return type"}
    C -->|"before: plain str"| D["_process_message_background scans ack\nextract_local_files() finds the path\n→ uploads it (1st upload)"]
    D --> E["background task finishes,\nintentionally returns the same file\n→ uploads it again (2nd upload, duplicate)"]
    C -->|"after: EphemeralReply(ttl_seconds=0)"| F["is_ephemeral_response = True\n→ extract_local_files() skipped for the ack"]
    F --> G["background task finishes,\nintentionally returns the file\n→ uploads it once (correct)"]
```

## Related Issue

Fixes #64661

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: `_handle_background_command` now returns `EphemeralReply(t(...), ttl_seconds=0)` instead of a plain `str`; return type annotation updated to `Union[str, EphemeralReply]` to match the four sibling handlers (`_handle_reset_command`, `_handle_stop_command`, `_handle_restart_command`, `_handle_yolo_command`) that already use this pattern.
- `tests/gateway/test_background_command.py`: new regression test asserting the ack is an `EphemeralReply` with `ttl_seconds == 0`, plus a sanity check (against the raw string, with `os.path.isfile` mocked true) confirming the embedded path really would be extracted if the ephemeral guard weren't in place — so the test can't pass trivially.

## Step-by-step

1. Read `extract_local_files()`'s caller in `gateway/platforms/base.py::_process_message_background`: it only runs when `not isinstance(response, EphemeralReply)`.
2. Confirmed `/background`'s ack was the only status-notice-style handler in `gateway/slash_commands.py` still returning a plain `str` — `/stop`, `/restart`, `/reset`, `/yolo` all already return `EphemeralReply` for this exact reason.
3. Changed `_handle_background_command`'s return to `EphemeralReply(t("gateway.background.started", preview=preview, task_id=task_id), ttl_seconds=0)`, keeping the preview/task_id content identical — only the wrapper type changes, so no auto-delete side effect (ttl 0 = disabled) and no visible text change.
4. Test strategy: added a test asserting `isinstance(result, EphemeralReply)` and `ttl_seconds == 0`. Verified it fails against the pre-fix code (returns a plain `str`) and passes after. Also independently confirmed, on an earlier iteration of this fix (backtick-wrapping the preview, before switching to `EphemeralReply`), that the underlying leak is real: `extract_local_files()` on the ack text picks up `/tmp/bg.png` from a prompt like `"use /tmp/bg.png and return it as an image"` unless the reply is ephemeral.

## Acceptance Criteria

- [x] Given a `/background <prompt>` where `<prompt>` contains a bare existing local file path, when the ack is generated, then the ack is an `EphemeralReply` and is never passed to `extract_local_files()` by `_process_message_background`.
- [x] Adjacent behavior is unchanged: ack still contains the emoji, "Background task started", truncated preview, and task ID (all existing tests for these still pass); `ttl_seconds=0` means no auto-delete behavior change.
- [x] Test suite passes locally with the new test included.

## How to Test

1. On `main`: call `/background use /tmp/bg.png and return it as an image` where `/tmp/bg.png` exists — the immediate ack, once processed by `_process_message_background`, has its bare path extracted and uploaded (visible via `extract_local_files()` returning a non-empty list for the ack text).
2. Check out this branch.
3. Same call — the ack is now an `EphemeralReply`, so `_process_message_background` skips `extract_local_files()` entirely for it; only the background task's own intentional file delivery uploads the image, once.

## Tests Performed

| Check | Command | Result |
|---|---|---|
| New + existing background-command tests | `python -m pytest tests/gateway/test_background_command.py -q` | ✅ `22 passed, 1 skipped in 3.36s` (skip is pre-existing, missing optional `prompt_toolkit` dep, unrelated to this change) |
| Related extraction tests | `python -m pytest tests/gateway/test_extract_local_files.py tests/gateway/test_background_command.py -q` | ✅ `70 passed, 1 skipped in 4.64s` |
| Windows footguns | `python scripts/check-windows-footguns.py gateway/slash_commands.py tests/gateway/test_background_command.py` | ✅ `No Windows footguns found (2 file(s) scanned).` |
| Lint | `python -m ruff check gateway/slash_commands.py tests/gateway/test_background_command.py` | ✅ `All checks passed!` |
| Fail-before/pass-after | New test run against pre-fix code (plain `str` return) | ❌ fails: `assert False == isinstance('🔄 Background task started...', EphemeralReply)`; passes after the fix |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updated — N/A (no user-facing docs describe this internal dispatch detail)
- [x] `cli-config.yaml.example` updated if config keys changed — N/A (no config keys changed)
- [x] `CONTRIBUTING.md`/`AGENTS.md` updated if architecture/workflow changed — N/A
- [x] Cross-platform impact considered (Windows, macOS) — the leaked-path mechanism (`extract_local_files`) and the fix (`EphemeralReply`) are both platform-agnostic; issue was reported via QQBot/Windows but the code path is shared by every platform adapter
- [x] Tool descriptions/schemas updated if tool behavior changed — N/A (no tool schema affected, gateway slash-command only)

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_background_command.py -q
......................s                                                  [100%]
22 passed, 1 skipped in 3.36s
```
