### PR TITLE
feat(kanban): add Ship Crew governance controls

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2743,6 +2743,15 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Ship's Crew optimization controls. S00 defines these defaults;
+        # later slices must opt in one capability at a time.
+        "ship_crew": {
+            "enforce_contracts": False,
+            "compact_worker_context": False,
+            "enforce_route_policy": False,
+            "enforce_output_budgets": False,
+            "quota_domain_scheduling": False,
+        },
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -77,6 +77,13 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "complexity_tier": t.complexity_tier,
+        "route_id": t.route_id,
+        "reasoning_effort": t.reasoning_effort,
+        "executor": t.executor,
+        "executor_mode": t.executor_mode,
+        "quota_domain": t.quota_domain,
+        "routing_metadata": t.routing_metadata,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
@@ -360,6 +367,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           metavar="N", dest="goal_max_turns",
                           help="Turn budget for --goal workers (default 20). "
                                "Ignored without --goal.")
+    p_create.add_argument("--complexity-tier", choices=("T0", "T1", "T2", "T3", "T4"), default=None,
+                          help="Task routing complexity tier")
+    p_create.add_argument("--route-id", default=None,
+                          help="Allowlisted route id; dispatch fails closed if it is not calibrated")
+    p_create.add_argument("--reasoning-effort", default=None,
+                          help="Immutable route reasoning-effort value")
+    p_create.add_argument("--executor", default=None,
+                          help="Allowlisted executor identity")
+    p_create.add_argument("--executor-mode", default=None,
+                          help="Allowlisted executor mode/protocol")
+    p_create.add_argument("--quota-domain", default=None,
+                          help="Normalized shared provider quota domain")
+    p_create.add_argument("--routing-metadata", default=None,
+                          help="Routing/governance metadata as a JSON object")
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -690,6 +711,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_stats.add_argument("--json", action="store_true")
 
+    # --- Ship's Crew baseline metrics ---
+    p_metrics = sub.add_parser(
+        "metrics",
+        help="Read-only Ship's Crew baseline metrics for before/after comparison",
+    )
+    p_metrics.add_argument(
+        "--json", action="store_true", default=False,
+        help="Emit the structured diagnostics snapshot (recommended)",
+    )
+
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
@@ -963,6 +994,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "daemon":   _cmd_daemon,
             "watch":    _cmd_watch,
             "stats":    _cmd_stats,
+            "metrics":  _cmd_metrics,
             "log":      _cmd_log,
             "runs":     _cmd_runs,
             "heartbeat": _cmd_heartbeat,
@@ -1325,6 +1357,16 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    routing_metadata = None
+    raw_routing_metadata = getattr(args, "routing_metadata", None)
+    if raw_routing_metadata:
+        try:
+            routing_metadata = json.loads(raw_routing_metadata)
+            if not isinstance(routing_metadata, dict):
+                raise ValueError("must be a JSON object")
+        except (ValueError, json.JSONDecodeError) as exc:
+            print(f"kanban: --routing-metadata: {exc}", file=sys.stderr)
+            return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1346,6 +1388,13 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_retries=max_retries,
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
+            complexity_tier=getattr(args, "complexity_tier", None),
+            route_id=getattr(args, "route_id", None),
+            reasoning_effort=getattr(args, "reasoning_effort", None),
+            executor=getattr(args, "executor", None),
+            executor_mode=getattr(args, "executor_mode", None),
+            quota_domain=getattr(args, "quota_domain", None),
+            routing_metadata=routing_metadata,
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
@@ -2409,6 +2458,27 @@ def _cmd_watch(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         print("\n(stopped)")
         return 0
+
+
+def _cmd_metrics(args: argparse.Namespace) -> int:
+    """Emit the read-only Ship's Crew baseline metrics snapshot."""
+    from hermes_cli import kanban_metrics as km
+
+    with kb.connect_closing() as conn:
+        snapshot = km.aggregate_connection(conn, board=kb.get_current_board())
+    # JSON is the stable comparison surface. Keep a compact human fallback so
+    # the command remains useful when invoked without --json.
+    if getattr(args, "json", False):
+        print(json.dumps(snapshot, indent=2, ensure_ascii=False, sort_keys=True))
+    else:
+        print(
+            f"Ship's Crew metrics: {snapshot['tasks']['total']} tasks, "
+            f"{snapshot['runs']['total']} runs, "
+            f"{snapshot['runs']['retries']} retries, "
+            f"{snapshot['protocol_violations']} protocol violations"
+        )
+        print("Use `hermes kanban metrics --json` for the comparison snapshot.")
+    return 0
 
 
 def _cmd_stats(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -122,7 +122,7 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient", "contract_rejected"}
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -908,6 +908,15 @@ class Task:
     # set the env var. Lets clients render a per-session board without
     # relying on tenant + time-window heuristics.
     session_id: Optional[str] = None
+    # Nullable Ship's Crew task routing metadata. Legacy rows remain profile-
+    # routed when these fields are absent.
+    complexity_tier: Optional[str] = None
+    route_id: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    executor: Optional[str] = None
+    executor_mode: Optional[str] = None
+    quota_domain: Optional[str] = None
+    routing_metadata: Optional[dict] = None
     # Typed block reason (one of VALID_BLOCK_KINDS) or None for legacy/un-typed
     # blocks. Set by ``block_task``; preserved across unblock so a re-block for
     # the same kind is recognisable as an unblock↔re-block loop.
@@ -990,6 +999,17 @@ class Task:
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
+            ),
+            complexity_tier=(row["complexity_tier"] if "complexity_tier" in keys else None),
+            route_id=(row["route_id"] if "route_id" in keys else None),
+            reasoning_effort=(row["reasoning_effort"] if "reasoning_effort" in keys else None),
+            executor=(row["executor"] if "executor" in keys else None),
+            executor_mode=(row["executor_mode"] if "executor_mode" in keys else None),
+            quota_domain=(row["quota_domain"] if "quota_domain" in keys else None),
+            routing_metadata=(
+                json.loads(row["routing_metadata"])
+                if "routing_metadata" in keys and row["routing_metadata"]
+                else None
             ),
             block_kind=(
                 row["block_kind"] if "block_kind" in keys and row["block_kind"] else None
@@ -1142,6 +1162,15 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- to the worker, overriding the profile's default model. NULL = use
     -- the profile default.
     model_override       TEXT,
+    -- Nullable task-scoped route selection. NULL preserves legacy profile
+    -- defaults and is intentionally additive for old boards.
+    complexity_tier      TEXT,
+    route_id             TEXT,
+    reasoning_effort     TEXT,
+    executor             TEXT,
+    executor_mode        TEXT,
+    quota_domain         TEXT,
+    routing_metadata     TEXT,
     -- Per-task override for the consecutive-failure circuit breaker.
     -- The value is the failure count at which the breaker trips — e.g.
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
@@ -1971,6 +2000,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "session_id", "session_id TEXT"
         )
 
+    for column, definition in (
+        ("complexity_tier", "complexity_tier TEXT"),
+        ("route_id", "route_id TEXT"),
+        ("reasoning_effort", "reasoning_effort TEXT"),
+        ("executor", "executor TEXT"),
+        ("executor_mode", "executor_mode TEXT"),
+        ("quota_domain", "quota_domain TEXT"),
+        ("routing_metadata", "routing_metadata TEXT"),
+    ):
+        if column not in cols:
+            _add_column_if_missing(conn, "tasks", column, definition)
+
     if "block_kind" not in cols:
         # Typed block reason (VALID_BLOCK_KINDS) or NULL for legacy/un-typed
         # blocks. Existing blocked rows get NULL, which is treated as a
@@ -2404,6 +2445,13 @@ def create_task(
     max_retries: Optional[int] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
+    complexity_tier: Optional[str] = None,
+    route_id: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    executor: Optional[str] = None,
+    executor_mode: Optional[str] = None,
+    quota_domain: Optional[str] = None,
+    routing_metadata: Optional[dict] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
@@ -2636,8 +2684,15 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        complexity_tier, route_id, reasoning_effort, executor,
+                        executor_mode, quota_domain, routing_metadata
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, ?,
+                        ?, ?, ?, ?, ?, ?, ?,
+                        ?, ?, ?, ?, ?, ?, ?,
+                        ?, ?, ?, ?, ?, ?
+                    )
                     """,
                     (
                         task_id,
@@ -2660,6 +2715,13 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        complexity_tier,
+                        route_id,
+                        reasoning_effort,
+                        executor,
+                        executor_mode,
+                        quota_domain,
+                        json.dumps(routing_metadata, ensure_ascii=False, sort_keys=True) if routing_metadata is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -2679,6 +2741,12 @@ def create_task(
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
+                        "complexity_tier": complexity_tier,
+                        "route_id": route_id,
+                        "reasoning_effort": reasoning_effort,
+                        "executor": executor,
+                        "executor_mode": executor_mode,
+                        "quota_domain": quota_domain,
                     },
                 )
             return task_id
@@ -2706,6 +2774,58 @@ def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> l
 def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
     row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
     return Task.from_row(row) if row else None
+
+
+def update_task_routing(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    complexity_tier: Optional[str] = None,
+    route_id: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    executor: Optional[str] = None,
+    executor_mode: Optional[str] = None,
+    quota_domain: Optional[str] = None,
+    routing_metadata: Optional[dict] = None,
+) -> bool:
+    """Atomically set nullable routing fields before a task is claimed."""
+    if complexity_tier is not None and complexity_tier not in {"T0", "T1", "T2", "T3", "T4"}:
+        raise ValueError(f"invalid complexity_tier {complexity_tier!r}")
+    if routing_metadata is not None and not isinstance(routing_metadata, dict):
+        raise ValueError("routing_metadata must be a JSON object")
+    with write_txn(conn):
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (task_id,)).fetchone()
+        if row is None or row["status"] in {"running", "done", "archived"}:
+            return False
+        conn.execute(
+            """UPDATE tasks SET complexity_tier=?, route_id=?, reasoning_effort=?,
+               executor=?, executor_mode=?, quota_domain=?, routing_metadata=?
+               WHERE id=?""",
+            (
+                complexity_tier,
+                route_id,
+                reasoning_effort,
+                executor,
+                executor_mode,
+                quota_domain,
+                json.dumps(routing_metadata, ensure_ascii=False, sort_keys=True) if routing_metadata is not None else None,
+                task_id,
+            ),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "routing_updated",
+            {
+                "complexity_tier": complexity_tier,
+                "route_id": route_id,
+                "reasoning_effort": reasoning_effort,
+                "executor": executor,
+                "executor_mode": executor_mode,
+                "quota_domain": quota_domain,
+            },
+        )
+    return True
 
 
 # Canonical sort-order mappings for ``hermes kanban list --sort``.
@@ -5946,6 +6066,10 @@ class DispatchResult:
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    quarantined: list[str] = field(default_factory=list)
+    """Task ids held because pre-dispatch contract validation failed."""
+    quota_deferred: list[tuple[str, str]] = field(default_factory=list)
+    """Task/domain pairs deferred while a shared quota circuit is open."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -7603,6 +7727,48 @@ def _dispatch_once_locked(
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
             continue
+        # Contract/routing validation happens before claim and before any
+        # workspace or subprocess side effect. It is opt-in for legacy boards,
+        # but automatically applies to tasks that carry route metadata.
+        _policy_task = None
+        try:
+            from hermes_cli.ship_crew_dispatch import (
+                should_validate_dispatch,
+                validate_task_for_dispatch,
+                quarantine_task,
+            )
+            _policy_task = get_task(conn, row["id"])
+            _require_contracts = os.environ.get(
+                "HERMES_SHIP_CREW_ENFORCE_DISPATCH_VALIDATION", "0"
+            ).strip().lower() in {"1", "true", "yes", "on"}
+            if _policy_task and should_validate_dispatch(
+                _policy_task, require_contracts=_require_contracts
+            ):
+                _validation = validate_task_for_dispatch(
+                    _policy_task, require_contracts=_require_contracts
+                )
+                if not _validation.valid:
+                    quarantine_task(conn, row["id"], _validation)
+                    result.quarantined.append(row["id"])
+                    continue
+        except ImportError:
+            # Keep core Kanban dispatch usable in minimal installations.
+            _log.debug("ship-crew dispatch policy unavailable", exc_info=True)
+        if _policy_task and _policy_task.quota_domain:
+            try:
+                from hermes_cli.ship_crew_quota import quota_available
+                if not quota_available(conn, _policy_task.quota_domain):
+                    result.quota_deferred.append((row["id"], _policy_task.quota_domain))
+                    with write_txn(conn):
+                        _append_event(
+                            conn,
+                            row["id"],
+                            "quota_deferred",
+                            {"quota_domain": _policy_task.quota_domain},
+                        )
+                    continue
+            except ImportError:
+                _log.debug("ship-crew quota policy unavailable", exc_info=True)
         # Per-profile concurrency cap (#21582): even if there's global
         # headroom, refuse to spawn for an assignee that's already at
         # its in-flight cap. Prevents one profile's local model / API

--- a/hermes_cli/kanban_metrics.py
+++ b/hermes_cli/kanban_metrics.py
@@ -1,0 +1,238 @@
+"""Read-only Ship's Crew baseline metrics for a Kanban board.
+
+The aggregator intentionally derives a snapshot from existing board rows. It
+never inserts events, updates tasks, or infers absent routing/context fields.
+Unknown values are grouped under the explicit ``unknown`` bucket.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+import json
+from typing import Any, Iterable, Mapping
+
+
+_FAILURE_OUTCOMES = frozenset({"blocked", "crashed", "failed", "gave_up", "spawn_failed", "timed_out"})
+_RATE_LIMIT_TERMS = ("rate_limit", "rate-limited", "ratelimit")
+_QUOTA_TERMS = ("quota", "budget_exhausted", "capacity_exhausted")
+_PROTOCOL_TERMS = ("protocol_violation", "protocol_error", "invalid_protocol")
+
+
+def _row(row: Any, name: str, default: Any = None) -> Any:
+    if row is None:
+        return default
+    try:
+        keys = row.keys()
+        if name in keys:
+            return row[name]
+    except Exception:
+        pass
+    if isinstance(row, Mapping):
+        return row.get(name, default)
+    return getattr(row, name, default)
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _unknown(value: Any) -> str:
+    value = str(value or "").strip()
+    return value or "unknown"
+
+
+def _inc(counter: Counter[str], value: Any) -> None:
+    counter[_unknown(value)] += 1
+
+
+def _metadata(run: Any, task: Any, event: Any = None) -> dict[str, Any]:
+    """Merge only explicitly stored metadata; later sources win."""
+    merged: dict[str, Any] = {}
+    merged.update(_json_object(_row(task, "metadata")))
+    merged.update(_json_object(_row(run, "metadata")))
+    merged.update(_json_object(_row(event, "payload")))
+    return merged
+
+
+def _field(run: Any, task: Any, metadata: Mapping[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in metadata and metadata[name] not in (None, ""):
+            return metadata[name]
+        value = _row(run, name)
+        if value not in (None, ""):
+            return value
+        value = _row(task, name)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _event_matches(kind: Any, terms: tuple[str, ...]) -> bool:
+    text = str(kind or "").casefold()
+    return any(term in text for term in terms)
+
+
+def _sum_numeric(values: Iterable[Any]) -> int:
+    total = 0
+    for value in values:
+        try:
+            total += max(0, int(value or 0))
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def aggregate_metrics(tasks: Iterable[Any], runs: Iterable[Any], comments: Iterable[Any], events: Iterable[Any], *, board: str = "default") -> dict[str, Any]:
+    """Return a JSON-serializable, read-only baseline snapshot."""
+    task_rows = list(tasks)
+    run_rows = list(runs)
+    comment_rows = list(comments)
+    event_rows = list(events)
+
+    tasks_by_profile: Counter[str] = Counter()
+    tasks_by_status: Counter[str] = Counter()
+    runs_by_profile: Counter[str] = Counter()
+    runs_by_outcome: Counter[str] = Counter()
+    models: Counter[str] = Counter()
+    efforts: Counter[str] = Counter()
+    quota_domains: Counter[str] = Counter()
+    output_classes: Counter[str] = Counter()
+    task_runs: Counter[str] = Counter()
+    task_goal_mode: set[str] = set()
+    run_goal_mode = 0
+    retries = 0
+
+    tasks_by_id = {}
+    for task in task_rows:
+        task_id = str(_row(task, "id", ""))
+        tasks_by_id[task_id] = task
+        _inc(tasks_by_profile, _row(task, "assignee"))
+        _inc(tasks_by_status, _row(task, "status"))
+        if bool(_row(task, "goal_mode", 0)):
+            task_goal_mode.add(task_id)
+
+    runs_by_task: defaultdict[str, int] = defaultdict(int)
+    body_bytes = _sum_numeric(len(str(_row(t, "body", "") or "").encode("utf-8")) for t in task_rows)
+    parent_summary_bytes = 0
+    assembled_context_bytes = 0
+    output_bytes = 0
+    inline_output_bytes = 0
+    for run in run_rows:
+        task_id = str(_row(run, "task_id", ""))
+        task = tasks_by_id.get(task_id)
+        runs_by_task[task_id] += 1
+        _inc(runs_by_profile, _row(run, "profile"))
+        outcome = _row(run, "outcome") or _row(run, "status")
+        _inc(runs_by_outcome, outcome)
+        metadata = _metadata(run, task)
+        model = _field(run, task, metadata, "model", "model_name", "route_model", "model_override")
+        effort = _field(run, task, metadata, "reasoning_effort", "effort")
+        quota = _field(run, task, metadata, "quota_domain", "quota")
+        _inc(models, model)
+        _inc(efforts, effort)
+        _inc(quota_domains, quota)
+        output_class = _field(run, task, metadata, "output_class", "output_classification")
+        _inc(output_classes, output_class)
+        if bool(_field(run, task, metadata, "goal_mode")):
+            run_goal_mode += 1
+        parent_summary_bytes += _sum_numeric((metadata.get("parent_summary_bytes"), metadata.get("parent_result_bytes")))
+        assembled_context_bytes += _sum_numeric((metadata.get("assembled_context_bytes"), metadata.get("context_bytes")))
+        output_bytes += _sum_numeric((metadata.get("output_bytes"), metadata.get("result_bytes")))
+        inline_output_bytes += _sum_numeric((metadata.get("inline_output_bytes"),))
+
+    retries = sum(max(0, count - 1) for count in runs_by_task.values())
+    comment_bytes = _sum_numeric(len(str(_row(c, "body", "") or "").encode("utf-8")) for c in comment_rows)
+
+    protocol_violations = 0
+    rate_limit_events = 0
+    quota_block_events = 0
+    for event in event_rows:
+        kind = _row(event, "kind")
+        if _event_matches(kind, _PROTOCOL_TERMS):
+            protocol_violations += 1
+        if _event_matches(kind, _RATE_LIMIT_TERMS):
+            rate_limit_events += 1
+        if _event_matches(kind, _QUOTA_TERMS):
+            quota_block_events += 1
+
+    queue_waits: list[int] = []
+    durations: list[int] = []
+    for run in run_rows:
+        task = tasks_by_id.get(str(_row(run, "task_id", "")))
+        started = _row(run, "started_at")
+        created = _row(task, "created_at")
+        ended = _row(run, "ended_at")
+        if started is not None and created is not None:
+            queue_waits.append(max(0, int(started) - int(created)))
+        if started is not None and ended is not None:
+            durations.append(max(0, int(ended) - int(started)))
+
+    def timing(values: list[int]) -> dict[str, Any]:
+        return {
+            "count": len(values),
+            "total_seconds": sum(values),
+            "max_seconds": max(values) if values else 0,
+            "unknown": len(run_rows) - len(values),
+        }
+
+    return {
+        "schema_version": "ship-crew/diagnostics/v1",
+        "board": board,
+        "read_only": True,
+        "tasks": {
+            "total": len(task_rows),
+            "by_profile": dict(sorted(tasks_by_profile.items())),
+            "by_status": dict(sorted(tasks_by_status.items())),
+        },
+        "runs": {
+            "total": len(run_rows),
+            "by_profile": dict(sorted(runs_by_profile.items())),
+            "by_outcome": dict(sorted(runs_by_outcome.items())),
+            "retries": retries,
+            "failure_outcomes": sum(runs_by_outcome.get(outcome, 0) for outcome in _FAILURE_OUTCOMES),
+            "goal_mode_runs": run_goal_mode,
+            "goal_mode_tasks": len(task_goal_mode),
+        },
+        "protocol_violations": protocol_violations,
+        "context_bytes": {
+            "task_body": body_bytes,
+            "parent_summary": parent_summary_bytes,
+            "comments": comment_bytes,
+            "assembled_context": assembled_context_bytes,
+        },
+        "output": {
+            "by_class": dict(sorted(output_classes.items())),
+            "total_bytes": output_bytes,
+            "inline_bytes": inline_output_bytes,
+        },
+        "routing": {
+            "model": dict(sorted(models.items())),
+            "reasoning_effort": dict(sorted(efforts.items())),
+            "quota_domain": dict(sorted(quota_domains.items())),
+        },
+        "events": {
+            "rate_limit": rate_limit_events,
+            "quota_block": quota_block_events,
+        },
+        "timing": {
+            "queue_to_start": timing(queue_waits),
+            "run_duration": timing(durations),
+        },
+    }
+
+
+def aggregate_connection(conn: Any, *, board: str = "default") -> dict[str, Any]:
+    """Aggregate existing rows without opening a write transaction."""
+    tasks = conn.execute("SELECT * FROM tasks ORDER BY id").fetchall()
+    runs = conn.execute("SELECT * FROM task_runs ORDER BY id").fetchall()
+    comments = conn.execute("SELECT * FROM task_comments ORDER BY id").fetchall()
+    events = conn.execute("SELECT * FROM task_events ORDER BY id").fetchall()
+    return aggregate_metrics(tasks, runs, comments, events, board=board)

--- a/hermes_cli/ship_crew_contracts.py
+++ b/hermes_cli/ship_crew_contracts.py
@@ -1,0 +1,252 @@
+"""Versioned Ship's Crew handoff contracts and strict validation.
+
+Contracts are deliberately data-only: validation is deterministic and does not
+invoke a model.  The runtime keeps payloads separate from their envelope so a
+receipt can identify an immutable, hashed artifact without copying the artifact
+into every downstream task.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import jsonschema
+
+
+SCHEMA_VERSION = "crew-handoff/v1"
+CONTRACT_TYPES = frozenset(
+    {
+        "navigator-evidence/v1",
+        "engineer-delivery/v1",
+        "pirate-review/v1",
+        "captain-disposition/v1",
+        "crew-block/v1",
+        "completion-metadata/v1",
+    }
+)
+
+_ROLE_PAIRS = {
+    "navigator-evidence/v1": {("navigator", "captain"), ("navigator", "engineer")},
+    "engineer-delivery/v1": {("engineer", "pirate"), ("engineer", "captain")},
+    "pirate-review/v1": {("pirate", "captain")},
+    "captain-disposition/v1": {("captain", "user"), ("captain", "engineer")},
+    "crew-block/v1": {
+        ("navigator", "captain"),
+        ("engineer", "captain"),
+        ("pirate", "captain"),
+        ("captain", "user"),
+    },
+}
+
+
+class ContractValidationError(ValueError):
+    """Raised when an envelope or payload is not safe to persist/dispatch."""
+
+    def __init__(self, issues: list[str]):
+        self.issues = tuple(issues)
+        super().__init__("; ".join(issues))
+
+
+@dataclass(frozen=True)
+class ContractIssue:
+    path: str
+    message: str
+
+
+_COMMON_ENVELOPE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "schema_version",
+        "mission_id",
+        "task_id",
+        "producer",
+        "consumer",
+        "contract_type",
+        "governance_class",
+        "governance_version",
+        "idempotency_key",
+        "data_class",
+        "authority",
+        "payload_ref",
+        "payload_sha256",
+    ],
+    "properties": {
+        "schema_version": {"const": SCHEMA_VERSION},
+        "mission_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "task_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "source_task_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "producer": {"type": "string", "enum": ["navigator", "engineer", "pirate", "captain", "user"]},
+        "consumer": {"type": "string", "enum": ["navigator", "engineer", "pirate", "captain", "user"]},
+        "contract_type": {"type": "string", "enum": sorted(CONTRACT_TYPES)},
+        "governance_class": {"type": "string", "enum": ["lite", "standard", "constitutional"]},
+        "governance_version": {"type": "string", "minLength": 1, "maxLength": 32},
+        "idempotency_key": {"type": "string", "minLength": 1, "maxLength": 256},
+        "data_class": {"type": "string", "enum": ["ordinary", "sensitive"]},
+        "authority": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["write_scope", "external_effect"],
+            "properties": {
+                "write_scope": {"type": "string", "enum": ["read-only", "worktree", "scoped-internal", "broad"]},
+                "external_effect": {"type": "boolean"},
+            },
+        },
+        "payload_ref": {"type": "string", "pattern": r"^/[^\x00]*$"},
+        "payload_sha256": {"type": "string", "pattern": r"^[0-9a-f]{64}$"},
+        "supersedes": {"type": "string", "minLength": 1, "maxLength": 256},
+    },
+}
+
+_PAYLOAD_SCHEMAS: dict[str, dict[str, Any]] = {
+    "navigator-evidence/v1": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["evidence", "findings"],
+        "properties": {
+            "evidence": {"type": "array", "items": {"type": "object", "additionalProperties": False, "required": ["id", "kind", "ref"], "properties": {"id": {"type": "string", "minLength": 1}, "kind": {"type": "string", "minLength": 1}, "ref": {"type": "string", "pattern": r"^/[^\x00]*$"}, "sha256": {"type": "string", "pattern": r"^[0-9a-f]{64}$"}}}},
+            "findings": {"type": "array", "items": {"type": "object", "additionalProperties": False, "required": ["id", "severity", "summary"], "properties": {"id": {"type": "string", "minLength": 1}, "severity": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]}, "summary": {"type": "string", "minLength": 1, "maxLength": 2000}}}},
+        },
+    },
+    "engineer-delivery/v1": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["status", "changed_paths", "verification"],
+        "properties": {
+            "status": {"type": "string", "enum": ["completed", "partial", "blocked"]},
+            "changed_paths": {"type": "array", "items": {"type": "string", "pattern": r"^/[^\x00]*$"}},
+            "verification": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": False, "required": ["id", "status"], "properties": {"id": {"type": "string", "minLength": 1}, "status": {"type": "string", "enum": ["passed", "failed", "skipped", "manual", "environment-blocked"]}, "ref": {"type": "string", "pattern": r"^/[^\x00]*$"}}}},
+        },
+    },
+    "pirate-review/v1": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["decision", "findings", "required_action"],
+        "properties": {
+            "decision": {"type": "string", "enum": ["approve", "reject", "request-changes", "block"]},
+            "findings": {"type": "array", "items": {"type": "object", "additionalProperties": False, "required": ["id", "severity", "summary"], "properties": {"id": {"type": "string", "minLength": 1}, "severity": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]}, "summary": {"type": "string", "minLength": 1, "maxLength": 2000}}}},
+            "required_action": {"type": "string", "minLength": 1},
+        },
+    },
+    "captain-disposition/v1": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["decision", "rationale", "sail_required"],
+        "properties": {
+            "decision": {"type": "string", "enum": ["sail", "amend", "reconvene", "approve", "reject", "block"]},
+            "rationale": {"type": "string", "minLength": 1, "maxLength": 4000},
+            "sail_required": {"type": "boolean"},
+        },
+    },
+    "crew-block/v1": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["kind", "retryable", "required_action", "required_evidence"],
+        "properties": {
+            "kind": {"type": "string", "enum": ["dependency", "needs_input", "capability", "transient", "contract", "quota"]},
+            "retryable": {"type": "boolean"},
+            "blocked_until": {"type": ["integer", "null"], "minimum": 0},
+            "quota_domain": {"type": ["string", "null"], "minLength": 1},
+            "required_action": {"type": "string", "minLength": 1, "maxLength": 2000},
+            "required_evidence": {"type": "array", "items": {"type": "string", "pattern": r"^/[^\x00]*$"}},
+        },
+    },
+    "completion-metadata/v1": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["status", "output_class", "summary", "evidence_refs"],
+        "properties": {
+            "status": {"type": "string", "enum": ["completed", "blocked", "failed"]},
+            "output_class": {"type": "string", "enum": ["O0", "O1", "O2", "O3+"]},
+            "summary": {"type": "string", "minLength": 1, "maxLength": 4000},
+            "evidence_refs": {"type": "array", "items": {"type": "string", "pattern": r"^/[^\x00]*$"}},
+            "artifact_ref": {"type": ["string", "null"], "pattern": r"^/[^\x00]*$"},
+        },
+    },
+}
+
+
+def schema_for(contract_type: str) -> dict[str, Any]:
+    if contract_type not in _PAYLOAD_SCHEMAS:
+        raise ContractValidationError([f"contract_type: unsupported contract {contract_type!r}"])
+    return _PAYLOAD_SCHEMAS[contract_type]
+
+
+def _errors(instance: Any, schema: Mapping[str, Any]) -> list[str]:
+    validator = jsonschema.Draft202012Validator(schema)
+    result: list[str] = []
+    for error in sorted(validator.iter_errors(instance), key=lambda item: list(item.absolute_path)):
+        path = ".".join(str(part) for part in error.absolute_path) or "$"
+        result.append(f"{path}: {error.message}")
+    return result
+
+
+def canonical_sha256(payload: Any) -> str:
+    """Hash canonical JSON without persisting or logging the payload."""
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def validate_envelope(envelope: Mapping[str, Any]) -> None:
+    issues = _errors(dict(envelope), _COMMON_ENVELOPE_SCHEMA)
+    contract_type = envelope.get("contract_type") if isinstance(envelope, Mapping) else None
+    if not issues and contract_type in _ROLE_PAIRS:
+        pair = (envelope.get("producer"), envelope.get("consumer"))
+        if pair not in _ROLE_PAIRS[contract_type]:
+            issues.append(f"producer/consumer: role pair {pair!r} is not allowed for {contract_type}")
+    if issues:
+        raise ContractValidationError(issues)
+
+
+def validate_payload(contract_type: str, payload: Mapping[str, Any]) -> None:
+    issues = _errors(dict(payload), schema_for(contract_type))
+    if issues:
+        raise ContractValidationError(issues)
+
+
+def validate_contract(envelope: Mapping[str, Any], payload: Mapping[str, Any] | None = None) -> None:
+    """Validate an envelope and, when supplied, its separately stored payload."""
+    validate_envelope(envelope)
+    if payload is not None:
+        contract_type = str(envelope["contract_type"])
+        validate_payload(contract_type, payload)
+        actual = canonical_sha256(payload)
+        if actual != envelope["payload_sha256"]:
+            raise ContractValidationError([f"payload_sha256: expected {envelope['payload_sha256']}, observed {actual}"])
+
+
+def validate_completion_metadata(metadata: Mapping[str, Any]) -> None:
+    validate_payload("completion-metadata/v1", metadata)
+
+
+def contract_metadata(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the safe, JSON-serializable task/run metadata projection."""
+    validate_envelope(envelope)
+    return {
+        "schema_version": envelope["schema_version"],
+        "contract_type": envelope["contract_type"],
+        "mission_id": envelope["mission_id"],
+        "source_task_id": envelope.get("source_task_id"),
+        "governance_class": envelope["governance_class"],
+        "idempotency_key": envelope["idempotency_key"],
+        "data_class": envelope["data_class"],
+        "authority": dict(envelope["authority"]),
+        "payload_ref": envelope["payload_ref"],
+        "payload_sha256": envelope["payload_sha256"],
+    }
+
+
+def load_json_contract(path: str | Path) -> dict[str, Any]:
+    """Load strict UTF-8 JSON for a contract fixture without accepting NaN."""
+    try:
+        raw = Path(path).read_text(encoding="utf-8")
+        value = json.loads(raw, parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)))
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ContractValidationError([f"fixture: invalid strict JSON ({exc})"]) from exc
+    if not isinstance(value, dict):
+        raise ContractValidationError(["fixture: top-level value must be an object"])
+    return value

--- a/hermes_cli/ship_crew_dispatch.py
+++ b/hermes_cli/ship_crew_dispatch.py
@@ -1,0 +1,117 @@
+"""Pre-dispatch validation and quarantine for routed Ship's Crew tasks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.ship_crew_routes import RouteRegistry, RouteRequest, RoutePolicyError, select_route
+
+
+@dataclass(frozen=True)
+class DispatchValidation:
+    valid: bool
+    issues: tuple[str, ...] = ()
+
+
+def _metadata(task: kb.Task) -> dict[str, Any]:
+    value = task.routing_metadata
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return {"_invalid_json": True}
+        return parsed if isinstance(parsed, dict) else {"_invalid_json": True}
+    return {}
+
+
+def validate_task_for_dispatch(
+    task: kb.Task,
+    *,
+    registry: Optional[RouteRegistry] = None,
+    require_contracts: bool = False,
+) -> DispatchValidation:
+    """Validate immutable routing and governance metadata without spawning.
+
+    Legacy profile-routed tasks are allowed unless ``require_contracts`` is
+    requested. Once any route field is set, all fields needed to reproduce the
+    route are mandatory and cannot silently fall back to a profile default.
+    """
+    issues: list[str] = []
+    meta = _metadata(task)
+    if meta.get("_invalid_json"):
+        issues.append("routing_metadata_not_json_object")
+
+    routed = any(
+        getattr(task, name, None)
+        for name in ("route_id", "executor", "executor_mode", "quota_domain", "complexity_tier")
+    )
+    governed = bool(meta.get("contract_version") or meta.get("governance_class"))
+    if require_contracts and not governed:
+        issues.append("contract_version_missing")
+    if routed or governed:
+        for name in ("complexity_tier", "route_id", "reasoning_effort", "executor", "executor_mode", "quota_domain"):
+            if not getattr(task, name, None):
+                issues.append(f"routing_{name}_missing")
+        if governed and not meta.get("contract_version"):
+            issues.append("contract_version_missing")
+        if governed and meta.get("governance_class") not in {"lite", "standard", "constitutional"}:
+            issues.append("governance_class_invalid")
+
+    if registry is not None and task.route_id:
+        request = RouteRequest(
+            profile=task.assignee or "",
+            complexity_tier=task.complexity_tier or "",
+            governance_class=str(meta.get("governance_class", "standard")),
+            write_scope=str(meta.get("write_scope", "none")),
+            output_class=str(meta.get("output_class", "text")),
+            required_capability=meta.get("required_capability"),
+        )
+        try:
+            selected = select_route(request, registry)
+        except RoutePolicyError as exc:
+            issues.append(str(exc))
+        else:
+            if selected.route_id != task.route_id:
+                issues.append("route_selection_mismatch")
+
+    return DispatchValidation(not issues, tuple(issues))
+
+
+def quarantine_task(
+    conn,
+    task_id: str,
+    validation: DispatchValidation,
+    *,
+    actor: str = "dispatcher",
+) -> bool:
+    """Move a malformed task to a non-spawnable quarantine state."""
+    if validation.valid:
+        return False
+    with kb.write_txn(conn):
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (task_id,)).fetchone()
+        if row is None or row["status"] in {"done", "archived"}:
+            return False
+        conn.execute(
+            "UPDATE tasks SET status='blocked', block_kind='contract_rejected', claim_lock=NULL, claim_expires=NULL WHERE id=?",
+            (task_id,),
+        )
+        kb._append_event(
+            conn,
+            task_id,
+            "contract_rejected",
+            {"actor": actor, "issues": list(validation.issues)},
+        )
+    return True
+
+
+def should_validate_dispatch(task: kb.Task, *, require_contracts: bool = False) -> bool:
+    """Return whether a dispatcher should apply the contract gate."""
+    return require_contracts or any(
+        getattr(task, name, None)
+        for name in ("route_id", "executor", "executor_mode", "quota_domain", "complexity_tier")
+    ) or bool(_metadata(task).get("contract_version"))

--- a/hermes_cli/ship_crew_evidence.py
+++ b/hermes_cli/ship_crew_evidence.py
@@ -1,0 +1,76 @@
+"""Deterministic evidence records and safe artifact persistence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+_SECRET_KEY = re.compile(r"(token|secret|password|api[_-]?key|credential|authorization)", re.I)
+
+
+def _safe(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(k): "[REDACTED]" if _SECRET_KEY.search(str(k)) else _safe(v)
+            for k, v in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_safe(v) for v in value]
+    return value
+
+
+def canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(_safe(value), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def evidence_sha256(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def build_evidence(
+    *,
+    task_id: str,
+    contract_version: str,
+    outcome: str,
+    role: str,
+    inputs: Mapping[str, Any],
+    outputs: Mapping[str, Any],
+    provenance: Mapping[str, Any],
+) -> dict[str, Any]:
+    body = {
+        "contract_version": contract_version,
+        "task_id": task_id,
+        "outcome": outcome,
+        "role": role,
+        "inputs": dict(inputs),
+        "outputs": dict(outputs),
+        "provenance": dict(provenance),
+    }
+    safe_body = _safe(body)
+    safe_body["evidence_sha256"] = evidence_sha256(safe_body)
+    return safe_body
+
+
+def write_evidence_artifact(root: str | Path, record: Mapping[str, Any], filename: str) -> Path:
+    name = Path(filename).name
+    if not name or name != filename or name in {".", ".."}:
+        raise ValueError("filename must be a simple artifact filename")
+    destination = Path(root).resolve() / name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = canonical_json(record) + "\n"
+    fd, temp_name = tempfile.mkstemp(prefix=f".{name}.", dir=str(destination.parent), text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, destination)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+    return destination

--- a/hermes_cli/ship_crew_execution.py
+++ b/hermes_cli/ship_crew_execution.py
@@ -1,0 +1,95 @@
+"""Deterministic per-task context/output and execution guardrails."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class ExecutionBudget:
+    complexity_tier: str
+    max_context_chars: int
+    max_output_chars: int
+    max_retries: int
+    max_review_attempts: int
+    goal_max_turns: int
+
+
+_DEFAULTS: dict[str, ExecutionBudget] = {
+    "T0": ExecutionBudget("T0", 6_000, 2_000, 0, 1, 1),
+    "T1": ExecutionBudget("T1", 12_000, 4_000, 1, 1, 3),
+    "T2": ExecutionBudget("T2", 20_000, 8_000, 2, 2, 8),
+    "T3": ExecutionBudget("T3", 32_000, 12_000, 2, 2, 12),
+    "T4": ExecutionBudget("T4", 48_000, 16_000, 3, 3, 20),
+}
+
+
+class BudgetExceededError(ValueError):
+    """Raised when an output cannot be accepted under its declared budget."""
+
+
+def resolve_execution_budget(
+    complexity_tier: str = "T1", overrides: Optional[Mapping[str, Any]] = None
+) -> ExecutionBudget:
+    tier = str(complexity_tier).upper()
+    if tier not in _DEFAULTS:
+        raise ValueError(f"unknown complexity tier {complexity_tier!r}")
+    base = _DEFAULTS[tier]
+    values = {name: getattr(base, name) for name in base.__dataclass_fields__}
+    for name in (
+        "max_context_chars",
+        "max_output_chars",
+        "max_retries",
+        "max_review_attempts",
+        "goal_max_turns",
+    ):
+        if overrides and name in overrides and overrides[name] is not None:
+            value = int(overrides[name])
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative")
+            values[name] = value
+    # A zero retry/review budget is valid; a zero output/context budget is not.
+    if values["max_context_chars"] <= 0 or values["max_output_chars"] <= 0:
+        raise ValueError("context/output budgets must be positive")
+    return ExecutionBudget(**values)
+
+
+def compact_context(text: str, max_chars: int) -> str:
+    """Keep a deterministic head/tail window with an explicit omission marker."""
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    text = str(text)
+    if len(text) <= max_chars:
+        return text
+    marker = f"\n… [context compacted: {len(text) - max_chars} chars omitted] …\n"
+    if len(marker) >= max_chars:
+        return marker[:max_chars]
+    remaining = max_chars - len(marker)
+    head = (remaining + 1) // 2
+    tail = remaining // 2
+    return text[:head] + marker + text[-tail:] if tail else text[:head] + marker
+
+
+def accept_output(text: str, budget: ExecutionBudget) -> str:
+    """Return output if it fits; callers must retry or quarantine on overflow."""
+    output = str(text)
+    if len(output) > budget.max_output_chars:
+        raise BudgetExceededError(
+            f"output exceeds {budget.max_output_chars} chars for {budget.complexity_tier}"
+        )
+    return output
+
+
+def retry_allowed(failure_count: int, budget: ExecutionBudget) -> bool:
+    """Use a strict bound: N means N total failures are tolerated."""
+    return int(failure_count) < budget.max_retries
+
+
+def review_allowed(review_attempts: int, budget: ExecutionBudget) -> bool:
+    """Never auto-approve after the independent review attempt budget."""
+    return int(review_attempts) < budget.max_review_attempts
+
+
+def goal_turn_allowed(turn: int, budget: ExecutionBudget) -> bool:
+    return 0 <= int(turn) < budget.goal_max_turns

--- a/hermes_cli/ship_crew_notifications.py
+++ b/hermes_cli/ship_crew_notifications.py
@@ -1,0 +1,49 @@
+"""Role-aware, deduplicated Ship's Crew notification policy."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class NotificationPolicy:
+    terminal_events: frozenset[str] = frozenset({"completed", "blocked", "contract_rejected", "review_requested"})
+    roles: frozenset[str] = frozenset({"captain", "navigator", "engineer", "pirate"})
+    max_chars: int = 1_500
+    dedupe_window_seconds: int = 3_600
+    suppress_without_evidence: bool = True
+
+
+def notification_key(*, task_id: str, event_kind: str, event_id: int | str) -> str:
+    raw = f"{task_id}|{event_kind}|{event_id}".encode()
+    return hashlib.sha256(raw).hexdigest()[:24]
+
+
+def should_notify(event: Mapping[str, Any], policy: NotificationPolicy = NotificationPolicy()) -> bool:
+    kind = str(event.get("kind", ""))
+    role = str(event.get("role", ""))
+    if kind not in policy.terminal_events or role not in policy.roles:
+        return False
+    if policy.suppress_without_evidence and kind in {"completed", "review_requested"}:
+        evidence = event.get("evidence_sha256") or event.get("evidence_ref")
+        if not evidence:
+            return False
+    return True
+
+
+def render_notification(event: Mapping[str, Any], policy: NotificationPolicy = NotificationPolicy()) -> str:
+    if not should_notify(event, policy):
+        return ""
+    body = {
+        "task_id": event.get("task_id"),
+        "event": event.get("kind"),
+        "role": event.get("role"),
+        "outcome": event.get("outcome"),
+        "evidence": event.get("evidence_sha256") or event.get("evidence_ref"),
+        "summary": event.get("summary", ""),
+    }
+    text = json.dumps(body, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return text if len(text) <= policy.max_chars else text[: policy.max_chars] + "…"

--- a/hermes_cli/ship_crew_planning.py
+++ b/hermes_cli/ship_crew_planning.py
@@ -1,0 +1,349 @@
+"""Deterministic Ship's Crew risk classification and graph compilation.
+
+This module owns the model-free part of Quest planning. It validates structured
+risk inputs, chooses the smallest lawful governance graph, and can persist that
+graph atomically to a Kanban board. Ambiguous or malformed inputs fail closed;
+no model or provider is consulted.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from hermes_cli import kanban_db as kb
+
+
+RISK_DIMENSIONS = (
+    "blast_radius",
+    "reversibility",
+    "authority",
+    "data_security",
+    "uncertainty",
+    "operational_cost",
+)
+GOVERNANCE_RANK = {"lite": 0, "standard": 1, "constitutional": 2}
+HARD_TRIGGERS = frozenset(
+    {
+        "credential-access",
+        "security-policy-change",
+        "external-publication",
+        "external-side-effect",
+        "irreversible-write",
+        "spending-commitment",
+        "sensitive-data",
+        "broad-filesystem-scope",
+        "broad-network-scope",
+    }
+)
+RULE_VERSION = "ship-crew-risk/v1"
+
+
+class GraphCompilationError(ValueError):
+    """Raised before or during graph persistence; failed compiles leave no rows."""
+
+
+@dataclass(frozen=True)
+class RiskClassification:
+    governance_class: str
+    score: int
+    hard_triggers: tuple[str, ...]
+    reviewer: str | None
+    rationale_codes: tuple[str, ...]
+    rule_version: str = RULE_VERSION
+
+
+@dataclass(frozen=True)
+class GraphNode:
+    key: str
+    title: str
+    role: str
+    contract_type: str
+    parent_keys: tuple[str, ...] = ()
+    user_gate: bool = False
+
+
+@dataclass(frozen=True)
+class CompiledGraph:
+    quest_id: str
+    capsule_sha256: str
+    classification: RiskClassification
+    graph_template: str
+    nodes: tuple[GraphNode, ...]
+    task_ids: Mapping[str, str] | None = None
+
+
+_GRAPH_TEMPLATES: dict[str, tuple[GraphNode, ...]] = {
+    "lite": (
+        GraphNode("owner", "Quest owner", "captain", "captain-disposition/v1"),
+        GraphNode("verification", "Deterministic verification", "engineer", "engineer-delivery/v1", ("owner",)),
+        GraphNode("closeout", "Mission closeout", "captain", "captain-disposition/v1", ("verification",)),
+    ),
+    "standard": (
+        GraphNode("proposal", "Scoped proposal", "engineer", "engineer-delivery/v1"),
+        GraphNode("review", "Independent risk review", "pirate", "pirate-review/v1", ("proposal",)),
+        GraphNode("decision", "Captain decision", "captain", "captain-disposition/v1", ("review",)),
+        GraphNode("execution", "Substantive execution", "engineer", "engineer-delivery/v1", ("decision",)),
+        GraphNode("verification", "Deterministic verification", "engineer", "engineer-delivery/v1", ("execution",)),
+        GraphNode("closeout", "Mission closeout", "captain", "captain-disposition/v1", ("verification",)),
+    ),
+    "constitutional": (
+        GraphNode("council", "Full Council review", "navigator", "navigator-evidence/v1"),
+        GraphNode("pirate_review", "Independent Pirate review", "pirate", "pirate-review/v1", ("council",)),
+        GraphNode("decision", "Captain decision", "captain", "captain-disposition/v1", ("pirate_review",)),
+        GraphNode("user_sail", "User sail gate", "user", "captain-disposition/v1", ("decision",), True),
+        GraphNode("execution", "Substantive execution", "engineer", "engineer-delivery/v1", ("user_sail",)),
+        GraphNode("verification", "Deterministic verification", "engineer", "engineer-delivery/v1", ("execution",)),
+        GraphNode("closeout", "Mission closeout", "captain", "captain-disposition/v1", ("verification",)),
+    ),
+}
+
+_REVIEWER_BY_RISK = {
+    "blast_radius": "pirate",
+    "reversibility": "engineer",
+    "authority": "navigator",
+    "data_security": "pirate",
+    "uncertainty": "navigator",
+    "operational_cost": "engineer",
+}
+
+
+def _canonical_json(value: Any) -> bytes:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise GraphCompilationError(f"capsule is not canonical JSON: {exc}") from exc
+
+
+def capsule_sha256(capsule: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(capsule)).hexdigest()
+
+
+def validate_quest_capsule(capsule: Mapping[str, Any]) -> None:
+    if not isinstance(capsule, Mapping):
+        raise GraphCompilationError("Quest Capsule must be an object")
+    required = {"schema_version", "quest_id", "risk_inputs", "scope", "acceptance_evidence"}
+    missing = sorted(required - set(capsule))
+    if missing:
+        raise GraphCompilationError(f"capsule missing required fields: {', '.join(missing)}")
+    if capsule["schema_version"] != "quest-capsule/v1":
+        raise GraphCompilationError("capsule schema_version must be quest-capsule/v1")
+    quest_id = capsule["quest_id"]
+    if not isinstance(quest_id, str) or not quest_id.startswith("Q-") or not quest_id[2:]:
+        raise GraphCompilationError("capsule quest_id must be a non-empty Q-* identifier")
+    inputs = capsule["risk_inputs"]
+    if not isinstance(inputs, Mapping):
+        raise GraphCompilationError("risk_inputs must be an object")
+    unknown = sorted(set(inputs) - set(RISK_DIMENSIONS) - {"hard_triggers"})
+    if unknown:
+        raise GraphCompilationError(f"risk_inputs has unknown fields: {', '.join(unknown)}")
+    for name in RISK_DIMENSIONS:
+        value = inputs.get(name)
+        if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 3:
+            raise GraphCompilationError(f"risk_inputs.{name} must be an integer from 0 through 3")
+    triggers = inputs.get("hard_triggers")
+    if not isinstance(triggers, list) or len(set(triggers)) != len(triggers):
+        raise GraphCompilationError("risk_inputs.hard_triggers must be a unique array")
+    unknown_triggers = sorted(set(triggers) - HARD_TRIGGERS)
+    if unknown_triggers:
+        raise GraphCompilationError(f"unknown hard trigger(s): {', '.join(unknown_triggers)}")
+    scope = capsule["scope"]
+    if not isinstance(scope, Mapping):
+        raise GraphCompilationError("scope must be an object")
+    if not isinstance(scope.get("external_effect"), bool):
+        raise GraphCompilationError("scope.external_effect must be boolean")
+    if scope.get("write_scope") not in {"read-only", "scoped-internal", "broad"}:
+        raise GraphCompilationError("scope.write_scope is invalid")
+    if scope.get("data_class") not in {"ordinary", "sensitive"}:
+        raise GraphCompilationError("scope.data_class is invalid")
+    if (scope["external_effect"] or scope["write_scope"] == "broad" or scope["data_class"] == "sensitive") and not triggers:
+        raise GraphCompilationError("scope risk must be represented by an explicit hard trigger")
+    evidence = capsule["acceptance_evidence"]
+    if not isinstance(evidence, list) or not evidence or any(not isinstance(item, str) or not item.strip() for item in evidence):
+        raise GraphCompilationError("acceptance_evidence must be a non-empty list of strings")
+
+
+def classify_risk(capsule: Mapping[str, Any]) -> RiskClassification:
+    validate_quest_capsule(capsule)
+    inputs = capsule["risk_inputs"]
+    triggers = tuple(sorted(inputs["hard_triggers"]))
+    score = sum(int(inputs[name]) for name in RISK_DIMENSIONS)
+    rationale: list[str] = []
+    if triggers:
+        governance = "constitutional"
+        rationale.append("hard-trigger")
+    elif score >= 10:
+        governance = "constitutional"
+        rationale.append("score-critical")
+    elif score >= 5 or capsule["scope"]["write_scope"] == "scoped-internal":
+        governance = "standard"
+        rationale.append("score-standard" if score >= 5 else "scoped-write")
+    else:
+        governance = "lite"
+        rationale.append("score-lite")
+    reviewer = None
+    if governance == "standard":
+        # RISK_DIMENSIONS order is the deterministic tie-break order.
+        dominant = max(RISK_DIMENSIONS, key=lambda name: (int(inputs[name]), -RISK_DIMENSIONS.index(name)))
+        reviewer = _REVIEWER_BY_RISK[dominant]
+        rationale.append(f"reviewer-{dominant}")
+    if governance == "constitutional":
+        rationale.append("full-council")
+    return RiskClassification(governance, score, triggers, reviewer, tuple(rationale))
+
+
+def graph_for_classification(classification: RiskClassification) -> tuple[GraphNode, ...]:
+    try:
+        return _GRAPH_TEMPLATES[classification.governance_class]
+    except KeyError as exc:
+        raise GraphCompilationError(f"unknown governance class {classification.governance_class!r}") from exc
+
+
+def compile_graph_plan(capsule: Mapping[str, Any], *, captain_classification: str | None = None) -> CompiledGraph:
+    classification = classify_risk(capsule)
+    selected = captain_classification or classification.governance_class
+    if selected not in GOVERNANCE_RANK:
+        raise GraphCompilationError(f"unknown governance class {selected!r}")
+    if GOVERNANCE_RANK[selected] < GOVERNANCE_RANK[classification.governance_class]:
+        raise GraphCompilationError("Captain cannot lower the deterministic risk classification")
+    if selected != classification.governance_class:
+        classification = RiskClassification(selected, classification.score, classification.hard_triggers, classification.reviewer, classification.rationale_codes + ("captain-promoted",))
+    return CompiledGraph(
+        quest_id=str(capsule["quest_id"]),
+        capsule_sha256=capsule_sha256(capsule),
+        classification=classification,
+        graph_template=f"{selected}-v1",
+        nodes=graph_for_classification(classification),
+    )
+
+
+def _node_idempotency(prefix: str, node: GraphNode) -> str:
+    return f"ship-crew:{prefix}:{node.key}"
+
+
+def _existing_graph_rows(conn: sqlite3.Connection, keys: list[str]) -> dict[str, str]:
+    if not keys:
+        return {}
+    placeholders = ",".join("?" for _ in keys)
+    rows = conn.execute(
+        f"SELECT id, idempotency_key FROM tasks WHERE idempotency_key IN ({placeholders}) AND status != 'archived'",
+        keys,
+    ).fetchall()
+    return {str(row["idempotency_key"]): str(row["id"]) for row in rows}
+
+
+def compile_graph(
+    conn: sqlite3.Connection,
+    capsule: Mapping[str, Any],
+    *,
+    captain_classification: str | None = None,
+    created_by: str = "captain",
+) -> CompiledGraph:
+    """Compile and persist one graph atomically, or return its existing graph."""
+    plan = compile_graph_plan(capsule, captain_classification=captain_classification)
+    prefix = f"{plan.quest_id}:{plan.capsule_sha256[:16]}:{plan.graph_template}"
+    keys = [_node_idempotency(prefix, node) for node in plan.nodes]
+    existing = _existing_graph_rows(conn, keys)
+    if existing:
+        if len(existing) != len(keys):
+            raise GraphCompilationError("partial graph exists for idempotency prefix; refusing to duplicate or repair silently")
+        return CompiledGraph(plan.quest_id, plan.capsule_sha256, plan.classification, plan.graph_template, plan.nodes, {node.key: existing[_node_idempotency(prefix, node)] for node in plan.nodes})
+
+    task_ids: dict[str, str] = {}
+    with kb.write_txn(conn):
+        # Re-check under the write lock so two compilers cannot both create the graph.
+        if _existing_graph_rows(conn, keys):
+            raise GraphCompilationError("graph appeared concurrently; retry the idempotent compile")
+        now = int(__import__("time").time())
+        for index, node in enumerate(plan.nodes):
+            task_id = kb._new_task_id()
+            parent_ids = [task_ids[parent] for parent in node.parent_keys]
+            if node.user_gate:
+                status = "blocked"
+                block_kind = "needs_input"
+            elif parent_ids:
+                status = "todo"
+                block_kind = None
+            else:
+                status = "ready"
+                block_kind = None
+            task_ids[node.key] = task_id
+            body = json.dumps(
+                {
+                    "schema_version": "crew-task/v1",
+                    "mission_id": plan.quest_id,
+                    "graph_template": plan.graph_template,
+                    "node_key": node.key,
+                    "contract_type": node.contract_type,
+                    "governance_class": plan.classification.governance_class,
+                    "rule_version": RULE_VERSION,
+                },
+                sort_keys=True,
+            )
+            conn.execute(
+                """INSERT INTO tasks (
+                    id, title, body, assignee, status, block_kind, priority,
+                    created_by, created_at, workspace_kind, workspace_path,
+                    branch_name, project_id, tenant, idempotency_key,
+                    max_runtime_seconds, skills, max_retries, goal_mode,
+                    goal_max_turns, session_id
+                ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, 'scratch', NULL, NULL, NULL, ?, ?, NULL, NULL, NULL, 0, NULL, NULL)""",
+                (
+                    task_id,
+                    f"{plan.quest_id} — {node.title}",
+                    body,
+                    node.role,
+                    status,
+                    block_kind,
+                    created_by,
+                    now,
+                    plan.quest_id,
+                    _node_idempotency(prefix, node),
+                ),
+            )
+            for parent_id in parent_ids:
+                conn.execute("INSERT INTO task_links (parent_id, child_id) VALUES (?, ?)", (parent_id, task_id))
+            kb._append_event(
+                conn,
+                task_id,
+                "created",
+                {
+                    "source": "ship-crew-graph-compiler",
+                    "mission_id": plan.quest_id,
+                    "graph_template": plan.graph_template,
+                    "node_key": node.key,
+                    "parents": parent_ids,
+                    "contract_type": node.contract_type,
+                    "user_gate": node.user_gate,
+                    "classification": {
+                        "governance_class": plan.classification.governance_class,
+                        "score": plan.classification.score,
+                        "hard_triggers": list(plan.classification.hard_triggers),
+                        "reviewer": plan.classification.reviewer,
+                        "rationale_codes": list(plan.classification.rationale_codes),
+                        "rule_version": RULE_VERSION,
+                    },
+                },
+            )
+            if node.user_gate:
+                kb._append_event(conn, task_id, "blocked", {"kind": "needs_input", "reason": "await user sail"})
+    return CompiledGraph(plan.quest_id, plan.capsule_sha256, plan.classification, plan.graph_template, plan.nodes, task_ids)
+
+
+def sail_before_execution(conn: sqlite3.Connection, graph: CompiledGraph) -> bool:
+    """Return whether every execution node is downstream of a satisfied gate."""
+    if not graph.task_ids:
+        return True
+    execution_id = graph.task_ids.get("execution")
+    if not execution_id:
+        return True
+    rows = conn.execute(
+        "SELECT parent_id FROM task_links WHERE child_id=? ORDER BY parent_id", (execution_id,)
+    ).fetchall()
+    parent_ids = {row["parent_id"] for row in rows}
+    gate_id = graph.task_ids.get("user_sail")
+    if gate_id:
+        return gate_id in parent_ids and conn.execute("SELECT status FROM tasks WHERE id=?", (gate_id,)).fetchone()["status"] == "blocked"
+    return True

--- a/hermes_cli/ship_crew_quota.py
+++ b/hermes_cli/ship_crew_quota.py
@@ -1,0 +1,202 @@
+"""Installation-wide persistent provider-quota circuit breaker.
+
+The quota state is deliberately separate from each Kanban board so two boards
+using the same normalized provider/model domain cannot stampede an exhausted
+provider. The caller's board connection remains an API compatibility parameter;
+state authority is the Hermes-home ``ship-crew-quota.db`` file.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+
+@dataclass(frozen=True)
+class QuotaState:
+    domain: str
+    failure_count: int
+    open_until: int
+    last_error: Optional[str]
+
+    @property
+    def open(self) -> bool:
+        return self.open_until > int(time.time())
+
+
+def quota_db_path() -> Path:
+    from hermes_cli.kanban_db import kanban_home
+
+    return kanban_home() / "ship-crew-quota.db"
+
+
+@contextmanager
+def _quota_connection() -> Iterator[sqlite3.Connection]:
+    path = quota_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), timeout=30.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=30000")
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        ensure_quota_schema(conn)
+        yield conn
+    finally:
+        conn.close()
+
+
+def ensure_quota_schema(conn=None) -> None:
+    """Create the shared quota tables; ``conn`` is accepted for API parity."""
+    target = conn
+    if target is None:
+        with _quota_connection() as owned:
+            ensure_quota_schema(owned)
+        return
+    target.executescript(
+        """CREATE TABLE IF NOT EXISTS ship_crew_quota_domains (
+            domain TEXT PRIMARY KEY,
+            failure_count INTEGER NOT NULL DEFAULT 0,
+            open_until INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS ship_crew_quota_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            domain TEXT NOT NULL,
+            event TEXT NOT NULL,
+            actor TEXT,
+            detail TEXT,
+            created_at INTEGER NOT NULL
+        );"""
+    )
+    target.commit()
+
+
+def _row_state(row: Optional[sqlite3.Row], domain: str) -> QuotaState:
+    if row is None:
+        return QuotaState(domain, 0, 0, None)
+    return QuotaState(row["domain"], int(row["failure_count"]), int(row["open_until"]), row["last_error"])
+
+
+def quota_state(conn, domain: str) -> QuotaState:
+    del conn  # shared authority is intentionally independent of board selection
+    domain = str(domain)
+    with _quota_connection() as qconn:
+        row = qconn.execute(
+            "SELECT domain, failure_count, open_until, last_error FROM ship_crew_quota_domains WHERE domain=?",
+            (domain,),
+        ).fetchone()
+        return _row_state(row, domain)
+
+
+def quota_available(conn, domain: Optional[str], *, now: Optional[int] = None) -> bool:
+    del conn
+    if not domain:
+        return True
+    now = int(time.time()) if now is None else int(now)
+    with _quota_connection() as qconn:
+        row = qconn.execute(
+            "SELECT open_until FROM ship_crew_quota_domains WHERE domain=?", (str(domain),)
+        ).fetchone()
+        return row is None or int(row["open_until"]) <= now
+
+
+def record_quota_failure(
+    conn,
+    domain: str,
+    *,
+    retry_after_seconds: int = 60,
+    threshold: int = 3,
+    error: str = "quota",
+    now: Optional[int] = None,
+) -> QuotaState:
+    del conn
+    domain = str(domain).strip()
+    if not domain:
+        raise ValueError("quota domain is required")
+    if threshold < 1 or retry_after_seconds < 0:
+        raise ValueError("threshold must be positive and retry delay non-negative")
+    now = int(time.time()) if now is None else int(now)
+    with _quota_connection() as qconn:
+        qconn.execute("BEGIN IMMEDIATE")
+        try:
+            row = qconn.execute(
+                "SELECT failure_count FROM ship_crew_quota_domains WHERE domain=?", (domain,)
+            ).fetchone()
+            failures = (int(row["failure_count"]) if row else 0) + 1
+            open_until = now + int(retry_after_seconds) if failures >= threshold else 0
+            qconn.execute(
+                """INSERT INTO ship_crew_quota_domains(domain, failure_count, open_until, last_error, updated_at)
+                   VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT(domain) DO UPDATE SET failure_count=excluded.failure_count,
+                     open_until=excluded.open_until, last_error=excluded.last_error,
+                     updated_at=excluded.updated_at""",
+                (domain, failures, open_until, str(error)[:500], now),
+            )
+            qconn.execute(
+                "INSERT INTO ship_crew_quota_events(domain, event, actor, detail, created_at) VALUES (?, 'failure', NULL, ?, ?)",
+                (domain, str(error)[:500], now),
+            )
+            qconn.commit()
+        except Exception:
+            qconn.rollback()
+            raise
+    return quota_state(None, domain)
+
+
+def record_quota_success(conn, domain: str, *, now: Optional[int] = None) -> QuotaState:
+    del conn
+    now = int(time.time()) if now is None else int(now)
+    domain = str(domain)
+    with _quota_connection() as qconn:
+        qconn.execute("BEGIN IMMEDIATE")
+        try:
+            qconn.execute(
+                """INSERT INTO ship_crew_quota_domains(domain, failure_count, open_until, last_error, updated_at)
+                   VALUES (?, 0, 0, NULL, ?)
+                   ON CONFLICT(domain) DO UPDATE SET failure_count=0, open_until=0,
+                     last_error=NULL, updated_at=excluded.updated_at""",
+                (domain, now),
+            )
+            qconn.execute(
+                "INSERT INTO ship_crew_quota_events(domain, event, actor, detail, created_at) VALUES (?, 'success', NULL, NULL, ?)",
+                (domain, now),
+            )
+            qconn.commit()
+        except Exception:
+            qconn.rollback()
+            raise
+    return quota_state(None, domain)
+
+
+def reset_quota(conn, domain: str, *, actor: str, now: Optional[int] = None) -> QuotaState:
+    """Audited manual reset for an operator-authorized quota circuit."""
+    del conn
+    actor = str(actor).strip()
+    if not actor:
+        raise ValueError("actor is required for manual quota reset")
+    now = int(time.time()) if now is None else int(now)
+    domain = str(domain)
+    with _quota_connection() as qconn:
+        qconn.execute("BEGIN IMMEDIATE")
+        try:
+            qconn.execute(
+                """INSERT INTO ship_crew_quota_domains(domain, failure_count, open_until, last_error, updated_at)
+                   VALUES (?, 0, 0, NULL, ?)
+                   ON CONFLICT(domain) DO UPDATE SET failure_count=0, open_until=0,
+                     last_error=NULL, updated_at=excluded.updated_at""",
+                (domain, now),
+            )
+            qconn.execute(
+                "INSERT INTO ship_crew_quota_events(domain, event, actor, detail, created_at) VALUES (?, 'manual_reset', ?, 'operator reset', ?)",
+                (domain, actor, now),
+            )
+            qconn.commit()
+        except Exception:
+            qconn.rollback()
+            raise
+    return quota_state(None, domain)

--- a/hermes_cli/ship_crew_routes.py
+++ b/hermes_cli/ship_crew_routes.py
@@ -1,0 +1,270 @@
+"""Fail-closed allowlisted route registry for Ship's Crew workers.
+
+The static registry is only a catalog. A route becomes selectable after its
+exact executor/model/mode has a non-secret runtime calibration receipt. This
+keeps stale inventories and free-text model choices out of dispatch.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+TIERS = frozenset({"T0", "T1", "T2", "T3", "T4"})
+OUTPUT_CLASSES = frozenset({"O0", "O1", "O2", "O3+"})
+PROFILES = frozenset({"captain", "engineer", "navigator", "pirate"})
+GOVERNANCE_RANK = {"lite": 0, "standard": 1, "constitutional": 2}
+EXCLUDED_MODEL_TERMS = ("codex gpt-5.6", "gpt-5.6", "sol")
+
+
+class RoutePolicyError(ValueError):
+    """A route or capability request cannot be safely satisfied."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+@dataclass(frozen=True)
+class CalibrationReceipt:
+    route_id: str
+    executor: str
+    model: str
+    mode: str
+    authenticated: bool
+    protocol_valid: bool
+    acceptance_fixture: bool
+    receipt_ref: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "CalibrationReceipt":
+        required = ("route_id", "executor", "model", "mode", "authenticated", "protocol_valid", "acceptance_fixture", "receipt_ref")
+        missing = [name for name in required if name not in value]
+        if missing:
+            raise RoutePolicyError("calibration_missing", f"missing fields: {', '.join(missing)}")
+        if not all(isinstance(value[name], bool) for name in ("authenticated", "protocol_valid", "acceptance_fixture")):
+            raise RoutePolicyError("calibration_shape", "calibration booleans must be explicit")
+        ref = str(value["receipt_ref"])
+        if not ref.startswith("/"):
+            raise RoutePolicyError("calibration_ref", "calibration receipt reference must be absolute")
+        return cls(
+            route_id=str(value["route_id"]),
+            executor=str(value["executor"]),
+            model=str(value["model"]),
+            mode=str(value["mode"]),
+            authenticated=value["authenticated"],
+            protocol_valid=value["protocol_valid"],
+            acceptance_fixture=value["acceptance_fixture"],
+            receipt_ref=ref,
+        )
+
+    def matches(self, route: "RouteRecord") -> bool:
+        return (
+            self.route_id == route.route_id
+            and self.executor == route.executor
+            and self.model == route.model
+            and self.mode == route.mode
+            and self.authenticated
+            and self.protocol_valid
+            and self.acceptance_fixture
+        )
+
+
+@dataclass(frozen=True)
+class RouteRecord:
+    route_id: str
+    provider: str
+    model: str
+    executor: str
+    mode: str
+    reasoning_effort: str | None
+    quota_domain: str
+    write_scope: str
+    profiles: tuple[str, ...]
+    complexity_tiers: tuple[str, ...]
+    output_classes: tuple[str, ...]
+    fallback_routes: tuple[str, ...]
+    calibration: CalibrationReceipt | None = None
+
+    @property
+    def calibrated(self) -> bool:
+        return self.calibration is not None and self.calibration.matches(self)
+
+    @property
+    def excluded(self) -> bool:
+        text = f"{self.provider} {self.model}".casefold()
+        return any(term in text for term in EXCLUDED_MODEL_TERMS)
+
+    @classmethod
+    def from_mapping(cls, route_id: str, value: Mapping[str, Any]) -> "RouteRecord":
+        required = ("provider", "model", "executor", "mode", "quota_domain", "write_scope", "profiles", "complexity_tiers", "output_classes", "fallback_routes")
+        missing = [name for name in required if name not in value]
+        if missing:
+            raise RoutePolicyError("route_missing", f"{route_id}: missing fields: {', '.join(missing)}")
+        profiles = tuple(str(item) for item in value["profiles"])
+        tiers = tuple(str(item) for item in value["complexity_tiers"])
+        outputs = tuple(str(item) for item in value["output_classes"])
+        if not set(profiles) <= PROFILES:
+            raise RoutePolicyError("route_profile", f"{route_id}: unknown profile")
+        if not set(tiers) <= TIERS:
+            raise RoutePolicyError("route_tier", f"{route_id}: unknown complexity tier")
+        if not set(outputs) <= OUTPUT_CLASSES:
+            raise RoutePolicyError("route_output", f"{route_id}: unknown output class")
+        if value["write_scope"] not in {"read-only", "worktree", "scoped-internal", "broad"}:
+            raise RoutePolicyError("route_scope", f"{route_id}: invalid write scope")
+        calibration = value.get("calibration")
+        return cls(
+            route_id=str(route_id),
+            provider=str(value["provider"]),
+            model=str(value["model"]),
+            executor=str(value["executor"]),
+            mode=str(value["mode"]),
+            reasoning_effort=(str(value["reasoning_effort"]) if value.get("reasoning_effort") is not None else None),
+            quota_domain=str(value["quota_domain"]),
+            write_scope=str(value["write_scope"]),
+            profiles=profiles,
+            complexity_tiers=tiers,
+            output_classes=outputs,
+            fallback_routes=tuple(str(item) for item in value["fallback_routes"]),
+            calibration=CalibrationReceipt.from_mapping(calibration) if calibration is not None else None,
+        )
+
+
+class RouteRegistry:
+    def __init__(self, routes: Mapping[str, RouteRecord], *, schema_version: str = "crew-route-registry/v1"):
+        if schema_version != "crew-route-registry/v1":
+            raise RoutePolicyError("registry_version", "unsupported registry version")
+        self.schema_version = schema_version
+        self.routes = dict(routes)
+        if set(self.routes) != {route.route_id for route in self.routes.values()}:
+            raise RoutePolicyError("route_id", "route map key must match route_id")
+        for route in self.routes.values():
+            if route.excluded:
+                # Exclusions are valid catalog entries but never selectable.
+                continue
+            for fallback in route.fallback_routes:
+                if fallback not in self.routes:
+                    raise RoutePolicyError("fallback_unknown", f"{route.route_id}: unknown fallback {fallback}")
+        self._check_fallback_cycles()
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "RouteRegistry":
+        if value.get("schema_version") != "crew-route-registry/v1":
+            raise RoutePolicyError("registry_version", "schema_version must be crew-route-registry/v1")
+        raw_routes = value.get("routes")
+        if not isinstance(raw_routes, Mapping) or not raw_routes:
+            raise RoutePolicyError("routes", "routes must be a non-empty object")
+        return cls({str(route_id): RouteRecord.from_mapping(str(route_id), raw) for route_id, raw in raw_routes.items()})
+
+    def _check_fallback_cycles(self) -> None:
+        def visit(route_id: str, stack: tuple[str, ...]) -> None:
+            if route_id in stack:
+                cycle = " -> ".join((*stack, route_id))
+                raise RoutePolicyError("fallback_cycle", cycle)
+            route = self.routes[route_id]
+            for fallback in route.fallback_routes:
+                visit(fallback, (*stack, route_id))
+
+        for route_id in self.routes:
+            visit(route_id, ())
+
+    def get(self, route_id: str) -> RouteRecord:
+        try:
+            return self.routes[route_id]
+        except KeyError as exc:
+            raise RoutePolicyError("unknown_route", route_id) from exc
+
+    def active_routes(self) -> tuple[RouteRecord, ...]:
+        return tuple(route for route in self.routes.values() if route.calibrated and not route.excluded)
+
+
+@dataclass(frozen=True)
+class RouteRequest:
+    profile: str
+    complexity_tier: str
+    output_class: str
+    write_scope: str
+    governance_class: str
+    quota_domains_available: frozenset[str] = frozenset()
+    requested_route_id: str | None = None
+    required_executor: str | None = None
+
+
+@dataclass(frozen=True)
+class RouteSelection:
+    requested_route_id: str | None
+    effective_route_id: str | None
+    executor: str | None
+    model: str | None
+    mode: str | None
+    reasoning_effort: str | None
+    quota_domain: str | None
+    rationale: tuple[str, ...]
+
+
+def _scope_allows(route_scope: str, requested_scope: str) -> bool:
+    if requested_scope == "read-only":
+        return True
+    if requested_scope == "worktree":
+        return route_scope in {"worktree", "scoped-internal", "broad"}
+    if requested_scope == "scoped-internal":
+        return route_scope in {"scoped-internal", "broad"}
+    return route_scope == "broad"
+
+
+def select_route(request: RouteRequest, registry: RouteRegistry) -> RouteSelection:
+    if request.complexity_tier not in TIERS:
+        raise RoutePolicyError("tier", request.complexity_tier)
+    if request.output_class not in OUTPUT_CLASSES:
+        raise RoutePolicyError("output_class", request.output_class)
+    if request.governance_class not in GOVERNANCE_RANK:
+        raise RoutePolicyError("governance", request.governance_class)
+    if request.complexity_tier == "T0":
+        return RouteSelection(request.requested_route_id, None, None, None, None, None, None, ("deterministic-t0",))
+    if request.profile not in PROFILES:
+        raise RoutePolicyError("profile", request.profile)
+    if request.requested_route_id:
+        candidate_ids = (request.requested_route_id,)
+    else:
+        candidate_ids = tuple(registry.routes)
+    rejected: list[str] = []
+    for route_id in candidate_ids:
+        route = registry.get(route_id)
+        if route.excluded:
+            rejected.append(f"{route_id}:excluded")
+            continue
+        if not route.calibrated:
+            rejected.append(f"{route_id}:uncalibrated")
+            continue
+        if request.profile not in route.profiles:
+            rejected.append(f"{route_id}:profile")
+            continue
+        if request.complexity_tier not in route.complexity_tiers:
+            rejected.append(f"{route_id}:tier")
+            continue
+        if request.output_class not in route.output_classes:
+            rejected.append(f"{route_id}:output")
+            continue
+        if not _scope_allows(route.write_scope, request.write_scope):
+            rejected.append(f"{route_id}:scope")
+            continue
+        if request.profile in {"navigator", "pirate"} and route.write_scope not in {"read-only"}:
+            rejected.append(f"{route_id}:profile-write-scope")
+            continue
+        if request.required_executor and route.executor != request.required_executor:
+            rejected.append(f"{route_id}:executor")
+            continue
+        if request.quota_domains_available and route.quota_domain not in request.quota_domains_available:
+            rejected.append(f"{route_id}:quota")
+            continue
+        return RouteSelection(
+            request.requested_route_id,
+            route.route_id,
+            route.executor,
+            route.model,
+            route.mode,
+            route.reasoning_effort,
+            route.quota_domain,
+            ("allowlisted", "calibrated", f"tier-{request.complexity_tier}"),
+        )
+    raise RoutePolicyError("no_route", "; ".join(rejected) or "no candidate route")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -91,6 +91,21 @@ def test_run_slash_create_and_list(kanban_home):
     assert "alice" in out
 
 
+def test_run_slash_create_preserves_routing_metadata(kanban_home):
+    out = kc.run_slash(
+        "create 'routed feature' --assignee captain --complexity-tier T2 "
+        "--route-id local-safe --reasoning-effort medium --executor local "
+        "--executor-mode structured --quota-domain local:model "
+        "--routing-metadata '{\"contract_version\":\"1.0\",\"governance_class\":\"standard\"}' --json"
+    )
+    task = json.loads(out)
+    assert task["complexity_tier"] == "T2"
+    assert task["route_id"] == "local-safe"
+    assert task["executor_mode"] == "structured"
+    assert task["quota_domain"] == "local:model"
+    assert task["routing_metadata"]["contract_version"] == "1.0"
+
+
 def test_run_slash_create_worktree_path_and_branch(kanban_home, tmp_path):
     target = tmp_path / ".worktrees" / "t6-wire"
     target_arg = target.as_posix()

--- a/tests/hermes_cli/test_kanban_metrics.py
+++ b/tests/hermes_cli/test_kanban_metrics.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_metrics as km
+from hermes_cli import kanban as kc
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+def test_ship_crew_flags_default_disabled_and_explicitly_enableable():
+    flags = DEFAULT_CONFIG["kanban"]["ship_crew"]
+    assert flags == {
+        "enforce_contracts": False,
+        "compact_worker_context": False,
+        "enforce_route_policy": False,
+        "enforce_output_budgets": False,
+        "quota_domain_scheduling": False,
+    }
+    enabled = {**flags, "compact_worker_context": True}
+    assert enabled["compact_worker_context"] is True
+    assert flags["compact_worker_context"] is False
+
+
+def test_empty_board_metrics_are_read_only(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb.init_db()
+    db_path = home / "kanban.db"
+    before_mtime = db_path.stat().st_mtime_ns
+    with kb.connect_closing() as conn:
+        before = conn.execute("SELECT name, sql FROM sqlite_master ORDER BY name").fetchall()
+        before_counts = {
+            table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in ("tasks", "task_runs", "task_comments", "task_events")
+        }
+        snapshot = km.aggregate_connection(conn)
+        after = conn.execute("SELECT name, sql FROM sqlite_master ORDER BY name").fetchall()
+        after_counts = {
+            table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in ("tasks", "task_runs", "task_comments", "task_events")
+        }
+    assert snapshot["read_only"] is True
+    assert snapshot["tasks"]["total"] == 0
+    assert snapshot["runs"]["total"] == 0
+    assert snapshot["protocol_violations"] == 0
+    assert [(r["name"], r["sql"]) for r in before] == [(r["name"], r["sql"]) for r in after]
+    assert before_counts == after_counts
+    assert db_path.stat().st_mtime_ns == before_mtime
+
+
+def test_metrics_cover_retries_context_routing_and_events():
+    tasks = [
+        {"id": "t1", "assignee": "engineer", "status": "done", "created_at": 100,
+         "body": "hello", "goal_mode": 1},
+        {"id": "t2", "assignee": "pirate", "status": "blocked", "created_at": 100,
+         "body": "world", "goal_mode": 0},
+    ]
+    runs = [
+        {"id": 1, "task_id": "t1", "profile": "engineer", "started_at": 110,
+         "ended_at": 120, "outcome": "completed", "metadata": json.dumps({
+             "model": "gemini-flash", "reasoning_effort": "medium",
+             "quota_domain": "agy", "goal_mode": True, "parent_summary_bytes": 7,
+             "assembled_context_bytes": 33, "output_class": "inline",
+             "inline_output_bytes": 12,
+         })},
+        {"id": 2, "task_id": "t1", "profile": "engineer", "started_at": 130,
+         "ended_at": 140, "outcome": "timed_out", "metadata": "{}"},
+        {"id": 3, "task_id": "t2", "profile": "pirate", "started_at": 120,
+         "ended_at": 125, "outcome": "blocked", "metadata": json.dumps({
+             "output_class": "artifact", "output_bytes": 20,
+         })},
+    ]
+    comments = [{"body": "a comment"}]
+    events = [
+        {"kind": "protocol_violation", "payload": "{}"},
+        {"kind": "quota_blocked", "payload": "{}"},
+        {"kind": "rate_limit_requeued", "payload": "{}"},
+    ]
+    snapshot = km.aggregate_metrics(tasks, runs, comments, events, board="fixture")
+    assert snapshot["board"] == "fixture"
+    assert snapshot["tasks"]["by_profile"] == {"engineer": 1, "pirate": 1}
+    assert snapshot["runs"]["retries"] == 1
+    assert snapshot["runs"]["failure_outcomes"] == 2
+    assert snapshot["runs"]["goal_mode_runs"] == 2
+    assert snapshot["runs"]["goal_mode_tasks"] == 1
+    assert snapshot["protocol_violations"] == 1
+    assert snapshot["events"] == {"rate_limit": 1, "quota_block": 1}
+    assert snapshot["routing"]["quota_domain"] == {"agy": 1, "unknown": 2}
+    assert snapshot["context_bytes"]["task_body"] == 10
+    assert snapshot["context_bytes"]["comments"] == 9
+    assert snapshot["timing"]["queue_to_start"]["count"] == 3
+
+
+def test_metrics_command_emits_json(tmp_path, monkeypatch, capsys):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb.init_db()
+    output = kc.run_slash("metrics --json")
+    payload = json.loads(output)
+    assert payload["schema_version"] == "ship-crew/diagnostics/v1"
+    assert payload["read_only"] is True

--- a/tests/hermes_cli/test_ship_crew_controls.py
+++ b/tests/hermes_cli/test_ship_crew_controls.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.ship_crew_evidence import (
+    build_evidence,
+    evidence_sha256,
+    write_evidence_artifact,
+)
+from hermes_cli.ship_crew_execution import (
+    BudgetExceededError,
+    compact_context,
+    accept_output,
+    resolve_execution_budget,
+    retry_allowed,
+    review_allowed,
+)
+from hermes_cli.ship_crew_notifications import (
+    NotificationPolicy,
+    notification_key,
+    render_notification,
+)
+from hermes_cli.ship_crew_quota import (
+    quota_available,
+    quota_db_path,
+    quota_state,
+    record_quota_failure,
+    record_quota_success,
+    reset_quota,
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_budgets_compact_and_bound_execution():
+    budget = resolve_execution_budget("T2", {"max_output_chars": 10, "max_retries": 2})
+    compacted = compact_context("0123456789" * 10, 40)
+    assert len(compacted) <= 40
+    assert "compacted" in compacted
+    assert retry_allowed(0, budget)
+    assert not retry_allowed(2, budget)
+    assert review_allowed(0, budget)
+    assert not review_allowed(2, resolve_execution_budget("T2", {"max_review_attempts": 2}))
+    with pytest.raises(BudgetExceededError):
+        accept_output("01234567890", budget)
+
+
+def test_quota_circuit_is_shared_and_resets(kanban_home):
+    with kb.connect_closing() as conn:
+        assert quota_available(conn, "provider:model")
+        assert quota_db_path().name == "ship-crew-quota.db"
+        state = record_quota_failure(
+            conn, "provider:model", threshold=2, retry_after_seconds=60, now=100
+        )
+        assert not state.open
+        state = record_quota_failure(
+            conn, "provider:model", threshold=2, retry_after_seconds=60, now=100
+        )
+        assert state.open_until == 160
+        assert not quota_available(conn, "provider:model", now=120)
+        assert quota_available(conn, "provider:model", now=160)
+        reset = record_quota_success(conn, "provider:model", now=161)
+        assert reset.failure_count == 0
+        assert quota_state(conn, "provider:model").open_until == 0
+        record_quota_failure(conn, "provider:model", threshold=1, retry_after_seconds=60, now=200)
+        manual = reset_quota(conn, "provider:model", actor="captain", now=201)
+        assert manual.failure_count == 0
+        with sqlite3.connect(quota_db_path()) as quota_conn:
+            assert quota_conn.execute(
+                "SELECT COUNT(*) FROM ship_crew_quota_events WHERE event='manual_reset'"
+            ).fetchone()[0] == 1
+
+
+def test_evidence_is_canonical_redacted_and_atomic(tmp_path):
+    record = build_evidence(
+        task_id="t1",
+        contract_version="1.0",
+        outcome="completed",
+        role="engineer",
+        inputs={"prompt": "safe", "api_key": "do-not-write"},
+        outputs={"summary": "done"},
+        provenance={"executor": "local"},
+    )
+    assert record["inputs"]["api_key"] == "[REDACTED]"
+    assert record["evidence_sha256"] == evidence_sha256({k: v for k, v in record.items() if k != "evidence_sha256"})
+    path = write_evidence_artifact(tmp_path, record, "t1.json")
+    assert path.read_text(encoding="utf-8").endswith("\n")
+    assert "do-not-write" not in path.read_text(encoding="utf-8")
+
+
+def test_notifications_are_role_aware_and_deduplicable():
+    event = {
+        "task_id": "t1",
+        "kind": "completed",
+        "role": "engineer",
+        "outcome": "completed",
+        "evidence_sha256": "a" * 64,
+        "summary": "ok",
+    }
+    rendered = render_notification(event)
+    assert rendered and "t1" in rendered
+    assert render_notification({**event, "role": "worker"}) == ""
+    assert notification_key(task_id="t1", event_kind="completed", event_id=3) == notification_key(task_id="t1", event_kind="completed", event_id=3)
+    assert render_notification(event, NotificationPolicy(max_chars=10)).endswith("…")

--- a/tests/hermes_cli/test_ship_crew_dispatch.py
+++ b/tests/hermes_cli/test_ship_crew_dispatch.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.ship_crew_dispatch import (
+    quarantine_task,
+    validate_task_for_dispatch,
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_task_routing_round_trips_and_rejects_running(kanban_home):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="route me",
+            assignee="engineer",
+            complexity_tier="T2",
+            route_id="local-t2",
+            reasoning_effort="medium",
+            executor="hermes-native",
+            executor_mode="medium",
+            quota_domain="local",
+            routing_metadata={"contract_version": "1.0", "governance_class": "standard"},
+        )
+        task = kb.get_task(conn, task_id)
+        assert task and task.route_id == "local-t2"
+        assert validate_task_for_dispatch(task).valid
+        assert kb.claim_task(conn, task_id) is not None
+        assert not kb.update_task_routing(conn, task_id, route_id="changed")
+
+
+def test_invalid_route_is_quarantined_before_dispatch(kanban_home):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="bad route", assignee="engineer", route_id="r")
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        validation = validate_task_for_dispatch(task)
+        assert not validation.valid
+        assert quarantine_task(conn, task_id, validation)
+        quarantined = kb.get_task(conn, task_id)
+        assert quarantined and quarantined.status == "blocked"
+        assert quarantined.block_kind == "contract_rejected"

--- a/tests/hermes_cli/test_ship_crew_planning.py
+++ b/tests/hermes_cli/test_ship_crew_planning.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.ship_crew_contracts import (
+    ContractValidationError,
+    canonical_sha256,
+    contract_metadata,
+    validate_completion_metadata,
+    validate_contract,
+)
+from hermes_cli.ship_crew_planning import (
+    GraphCompilationError,
+    classify_risk,
+    compile_graph,
+    compile_graph_plan,
+    sail_before_execution,
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb.init_db()
+    return home
+
+
+def _envelope(contract_type: str, producer: str, consumer: str, payload: dict) -> dict:
+    return {
+        "schema_version": "crew-handoff/v1",
+        "mission_id": "Q-S01-TEST",
+        "task_id": "t_child",
+        "source_task_id": "t_parent",
+        "producer": producer,
+        "consumer": consumer,
+        "contract_type": contract_type,
+        "governance_class": "standard",
+        "governance_version": "0.5.1",
+        "idempotency_key": f"Q-S01-TEST:{producer}:r1",
+        "data_class": "ordinary",
+        "authority": {"write_scope": "worktree", "external_effect": False},
+        "payload_ref": "/tmp/ship-crew-payload.json",
+        "payload_sha256": canonical_sha256(payload),
+    }
+
+
+def test_each_role_contract_accepts_positive_payload():
+    fixtures = [
+        ("navigator-evidence/v1", "navigator", "captain", {"evidence": [], "findings": []}),
+        ("engineer-delivery/v1", "engineer", "pirate", {"status": "completed", "changed_paths": [], "verification": [{"id": "V1", "status": "passed"}]}),
+        ("pirate-review/v1", "pirate", "captain", {"decision": "approve", "findings": [], "required_action": "none"}),
+        ("captain-disposition/v1", "captain", "user", {"decision": "sail", "rationale": "bounded", "sail_required": True}),
+        ("crew-block/v1", "engineer", "captain", {"kind": "quota", "retryable": True, "blocked_until": 123, "quota_domain": "provider-a", "required_action": "wait", "required_evidence": []}),
+    ]
+    for contract_type, producer, consumer, payload in fixtures:
+        envelope = _envelope(contract_type, producer, consumer, payload)
+        validate_contract(envelope, payload)
+        assert contract_metadata(envelope)["contract_type"] == contract_type
+
+
+def test_contract_rejects_unknown_safety_fields_role_pairs_and_bad_digest():
+    payload = {"decision": "approve", "findings": [], "required_action": "none"}
+    envelope = _envelope("pirate-review/v1", "pirate", "captain", payload)
+    envelope["unsafe"] = True
+    with pytest.raises(ContractValidationError):
+        validate_contract(envelope, payload)
+
+    wrong_role = _envelope("pirate-review/v1", "engineer", "captain", payload)
+    with pytest.raises(ContractValidationError, match="role pair"):
+        validate_contract(wrong_role, payload)
+
+    wrong_digest = _envelope("pirate-review/v1", "pirate", "captain", payload)
+    wrong_digest["payload_sha256"] = hashlib.sha256(b"wrong").hexdigest()
+    with pytest.raises(ContractValidationError, match="payload_sha256"):
+        validate_contract(wrong_digest, payload)
+
+
+def test_completion_metadata_output_class_contract():
+    validate_completion_metadata({"status": "completed", "output_class": "O1", "summary": "done", "evidence_refs": []})
+    with pytest.raises(ContractValidationError):
+        validate_completion_metadata({"status": "completed", "output_class": "O1", "summary": "done", "evidence_refs": [], "extra": True})
+
+
+def _capsule(**overrides):
+    capsule = {
+        "schema_version": "quest-capsule/v1",
+        "quest_id": "Q-S02-TEST",
+        "user_intent": "implement bounded work",
+        "objective": "produce verified result",
+        "risk_inputs": {
+            "blast_radius": 1,
+            "reversibility": 1,
+            "authority": 1,
+            "data_security": 0,
+            "uncertainty": 1,
+            "operational_cost": 0,
+            "hard_triggers": [],
+        },
+        "scope": {"external_effect": False, "write_scope": "read-only", "data_class": "ordinary"},
+        "acceptance_evidence": ["pytest"],
+    }
+    for key, value in overrides.items():
+        capsule[key] = value
+    return capsule
+
+
+def test_risk_boundaries_and_deterministic_reviewer():
+    lite = classify_risk(_capsule())
+    assert lite.governance_class == "lite"
+
+    standard_capsule = _capsule()
+    standard_capsule["risk_inputs"]["data_security"] = 2
+    standard_capsule["risk_inputs"]["blast_radius"] = 2
+    standard = classify_risk(standard_capsule)
+    assert standard.governance_class == "standard"
+    assert standard.reviewer == "pirate"
+
+    constitutional_capsule = _capsule()
+    constitutional_capsule["risk_inputs"]["hard_triggers"] = ["external-side-effect"]
+    constitutional = classify_risk(constitutional_capsule)
+    assert constitutional.governance_class == "constitutional"
+    assert constitutional.reviewer is None
+
+
+def test_graph_plan_cannot_lower_hard_trigger_class():
+    capsule = _capsule()
+    capsule["risk_inputs"]["hard_triggers"] = ["irreversible-write"]
+    with pytest.raises(GraphCompilationError, match="lower"):
+        compile_graph_plan(capsule, captain_classification="standard")
+
+
+def test_graph_compile_is_atomic_idempotent_and_sail_gated(kanban_home: Path):
+    capsule = _capsule()
+    capsule["risk_inputs"]["hard_triggers"] = ["external-side-effect"]
+    with kb.connect_closing() as conn:
+        graph = compile_graph(conn, capsule)
+        assert graph.task_ids is not None
+        assert len(graph.task_ids) == 7
+        assert sail_before_execution(conn, graph) is True
+        assert conn.execute("SELECT COUNT(*) AS n FROM tasks").fetchone()["n"] == 7
+        execution = kb.get_task(conn, graph.task_ids["execution"])
+        gate = kb.get_task(conn, graph.task_ids["user_sail"])
+        assert execution is not None and execution.status == "todo"
+        assert gate is not None and gate.status == "blocked" and gate.block_kind == "needs_input"
+
+        again = compile_graph(conn, capsule)
+        assert again.task_ids == graph.task_ids
+        assert conn.execute("SELECT COUNT(*) AS n FROM tasks").fetchone()["n"] == 7
+
+
+def test_partial_idempotency_refuses_silent_repair(kanban_home: Path):
+    capsule = _capsule()
+    with kb.connect_closing() as conn:
+        plan = compile_graph_plan(capsule)
+        key = f"ship-crew:{plan.quest_id}:{plan.capsule_sha256[:16]}:{plan.graph_template}:{plan.nodes[0].key}"
+        kb.create_task(conn, title="partial", idempotency_key=key)
+        with pytest.raises(GraphCompilationError, match="partial graph"):
+            compile_graph(conn, capsule)

--- a/tests/hermes_cli/test_ship_crew_routes.py
+++ b/tests/hermes_cli/test_ship_crew_routes.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.ship_crew_routes import (
+    RoutePolicyError,
+    RouteRegistry,
+    RouteRequest,
+    select_route,
+)
+
+
+def _registry(calibrated: bool = True):
+    route = {
+        "provider": "configured-provider",
+        "model": "approved-model",
+        "executor": "hermes-native",
+        "mode": "medium",
+        "reasoning_effort": "medium",
+        "quota_domain": "provider-a",
+        "write_scope": "read-only",
+        "profiles": ["captain", "navigator", "pirate"],
+        "complexity_tiers": ["T1", "T2"],
+        "output_classes": ["O0", "O1", "O2"],
+        "fallback_routes": [],
+    }
+    if calibrated:
+        route["calibration"] = {
+            "route_id": "readonly-medium",
+            "executor": "hermes-native",
+            "model": "approved-model",
+            "mode": "medium",
+            "authenticated": True,
+            "protocol_valid": True,
+            "acceptance_fixture": True,
+            "receipt_ref": "/tmp/calibration.json",
+        }
+    return RouteRegistry.from_mapping({"schema_version": "crew-route-registry/v1", "routes": {"readonly-medium": route}})
+
+
+def test_t0_is_deterministic_and_uncalibrated_routes_are_inactive():
+    registry = _registry(calibrated=False)
+    selection = select_route(RouteRequest("navigator", "T0", "O0", "read-only", "lite"), registry)
+    assert selection.effective_route_id is None
+    with pytest.raises(RoutePolicyError, match="no_route"):
+        select_route(RouteRequest("navigator", "T1", "O0", "read-only", "lite"), registry)
+
+
+def test_exact_calibrated_route_selects_and_persists_mode_semantics():
+    selection = select_route(RouteRequest("navigator", "T1", "O1", "read-only", "standard"), _registry())
+    assert selection.effective_route_id == "readonly-medium"
+    assert selection.executor == "hermes-native"
+    assert selection.mode == "medium"
+    assert selection.reasoning_effort == "medium"
+
+
+def test_profile_write_scope_and_excluded_codex_fail_closed():
+    registry = _registry()
+    write_route = dict(registry.routes["readonly-medium"].__dict__)
+    write_route["write_scope"] = "worktree"
+    write_route.pop("calibration")
+    write_route["calibration"] = {
+        "route_id": "readonly-medium", "executor": "hermes-native", "model": "approved-model", "mode": "medium",
+        "authenticated": True, "protocol_valid": True, "acceptance_fixture": True, "receipt_ref": "/tmp/calibration.json",
+    }
+    registry = RouteRegistry.from_mapping({"schema_version": "crew-route-registry/v1", "routes": {"readonly-medium": write_route}})
+    with pytest.raises(RoutePolicyError, match="no_route"):
+        select_route(RouteRequest("pirate", "T1", "O1", "worktree", "standard"), registry)
+
+    excluded = dict(write_route)
+    excluded["model"] = "Codex GPT-5.6"
+    excluded["calibration"] = {**excluded["calibration"], "model": "Codex GPT-5.6"}
+    with pytest.raises(RoutePolicyError, match="no_route"):
+        select_route(RouteRequest("captain", "T1", "O1", "read-only", "lite"), RouteRegistry.from_mapping({"schema_version": "crew-route-registry/v1", "routes": {"readonly-medium": excluded}}))
+
+
+def test_fallback_cycles_and_unknown_routes_reject():
+    raw = {
+        "schema_version": "crew-route-registry/v1",
+        "routes": {
+            "a": {"provider": "p", "model": "m", "executor": "e", "mode": "x", "quota_domain": "q", "write_scope": "read-only", "profiles": ["captain"], "complexity_tiers": ["T1"], "output_classes": ["O0"], "fallback_routes": ["b"]},
+            "b": {"provider": "p", "model": "m2", "executor": "e", "mode": "x", "quota_domain": "q", "write_scope": "read-only", "profiles": ["captain"], "complexity_tiers": ["T1"], "output_classes": ["O0"], "fallback_routes": ["a"]},
+        },
+    }
+    with pytest.raises(RoutePolicyError, match="fallback_cycle"):
+        RouteRegistry.from_mapping(raw)
+
+    raw["routes"]["b"]["fallback_routes"] = ["missing"]
+    with pytest.raises(RoutePolicyError, match="fallback_unknown"):
+        RouteRegistry.from_mapping(raw)

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -205,7 +205,24 @@ hermes kanban watch
 # 5. See the board (you)
 hermes kanban list
 hermes kanban stats
+hermes kanban metrics --json
 ```
+
+`metrics --json` is a local, read-only Ship's Crew baseline snapshot. It is intended for before/after comparisons and does not send telemetry or mutate the board. It reports task/run counts, profiles, outcomes, retries, protocol-violation events, goal-mode use, explicitly recorded context/output byte counts, route/model/effort/quota-domain fields, rate-limit/quota events, and queue/run timing. Missing optional fields are placed in an explicit `unknown` bucket rather than inferred.
+
+The optimization feature gates are disabled by default under `kanban.ship_crew`:
+
+```yaml
+kanban:
+  ship_crew:
+    enforce_contracts: false
+    compact_worker_context: false
+    enforce_route_policy: false
+    enforce_output_budgets: false
+    quota_domain_scheduling: false
+```
+
+S00 only defines these rollback-safe defaults and the snapshot surface. Later optimization slices must enable and consume each capability independently.
 
 When the dispatcher picks up `t_abcd` and spawns the `researcher` profile, the very first thing that worker's model does is call `kanban_show()` to read its task. It doesn't run `hermes kanban show t_abcd`.
 
@@ -675,6 +692,7 @@ hermes kanban dispatch [--dry-run] [--max N]           # one-shot pass
 hermes kanban daemon --force                           # DEPRECATED — standalone dispatcher (use `hermes gateway start` instead)
         [--failure-limit N] [--pidfile PATH] [-v]
 hermes kanban stats [--json]                           # per-status + per-assignee counts
+hermes kanban metrics [--json]                         # read-only Ship's Crew baseline snapshot
 hermes kanban log <id> [--tail BYTES]                  # worker log from ~/.hermes/kanban/logs/
 hermes kanban notify-subscribe <id>                    # gateway bridge hook (used by /kanban in the gateway)
         --platform <name> --chat-id <id> [--thread-id <id>] [--user-id <id>]


### PR DESCRIPTION
## Summary
- add deterministic Ship Crew contracts, risk/graph planning, calibrated route selection, and pre-dispatch quarantine
- add task-scoped routing metadata through Kanban database and CLI paths
- add execution budgets, retry/goal/review guardrails, shared installation-wide quota circuit breaker, evidence redaction, and role-aware notifications

## Validation
- targeted Kanban/Ship Crew integration suite — 525 passed
- focused regression subset — 289 passed
- clean PR-base targeted suite after rebasing — 295 passed
- CP008 smoke rehearsal — PASS
- CLI/gateway parity smoke — PASS
- compileall and `git diff --check` — PASS

## Known limitations
- broad `tests/hermes_cli` run: 3,323 passed, 5 skipped, 10 unrelated baseline failures in session-store, dashboard-auth, environment-key-auth, and GUI subprocess tests
- Ruff unavailable in the configured environment

## Safety and rollout
- contracts and planning are deterministic/model-free
- routes fail closed without calibration/authentication/protocol evidence
- quota state is installation-wide under the resolved Hermes home with SQLite WAL and locking
- no production rollout, credentials, or write-capable external AGY route activation is included
