### PR TITLE
fix(memory): reject missing action at runtime with clear error message

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -997,6 +997,14 @@ def memory_tool(
         return json.dumps(result, ensure_ascii=False)
 
     # --- Single-op path ---------------------------------------------------
+    if not action:
+        return tool_error(
+            "action is required when operations is not provided. "
+            "Use 'add', 'replace', or 'remove' for single-op, "
+            "or the 'operations' array for batch writes.",
+            success=False,
+        )
+
     # Validate required params BEFORE the gate so an invalid write is rejected
     # immediately instead of being staged and only failing at approve time.
     if action == "add" and not content:


### PR DESCRIPTION
Fixes #64291

## Problem

The `memory` tool's schema has `action` only in `parameters.required: ["target"]` — `action` is deliberately omitted from the top-level required list because it is correctly omitted in the batch shape (which uses `operations` instead). However, when a malformed call provides neither `action` nor `operations`, it passes schema validation and falls through to `memory_tool()` where the dispatch chain produces a confusing `Unknown action 'None'. Use: add, replace, remove` error.

Adding `action` to the schema-level `required` array is not possible because it would break valid batch-mode calls, and conditional schemas (`oneOf`, `if/then`) are rejected by strict backends (Codex).

## Fix

Add an explicit runtime guard after the batch-path return and before the single-op dispatch: when `action` is falsy (None or empty string) and we've fallen through the batch path, return a clear error telling the caller that either `action` (single-op) or `operations` (batch) is required.

This catches:
- Missing `action` key (`args.get("action", "")` → `""`)
- `action: null` in JSON (`args.get("action", "")` → `None`)
while valid calls (truthy `action`, or non-empty `operations`) pass through unchanged.