### PR TITLE
fix(cli): sanitize terminal escapes when replaying stored history (port of openai/codex#31494)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -530,6 +530,7 @@ class CLIAgentSetupMixin:
         an indicator for earlier hidden messages.
         """
         from cli import CLI_CONFIG, _record_output_history_entry, _strip_reasoning_tags, _suspend_output_history
+        from tools.ansi_strip import sanitize_display_text as _sanitize_display_text
         if not self.conversation_history:
             return
 
@@ -570,13 +571,18 @@ class CLIAgentSetupMixin:
                         elif isinstance(part, dict) and part.get("type") == "image_url":
                             parts.append("[image]")
                     text = " ".join(parts)
+                # Stored history is untrusted for display: strip escape
+                # sequences/control chars so replaying a message can't
+                # clear the screen, retitle the window, or restyle the
+                # recap panel (see tools/ansi_strip.sanitize_display_text).
+                text = _sanitize_display_text(text)
                 if len(text) > MAX_USER_LEN:
                     text = text[:MAX_USER_LEN] + "..."
                 entries.append(("user", text))
 
             elif role == "assistant":
                 text = "" if content is None else str(content)
-                text = _strip_reasoning_tags(text)
+                text = _sanitize_display_text(_strip_reasoning_tags(text))
                 parts = []
                 full_parts = []  # un-truncated version
                 if text:

--- a/hermes_cli/session_recap.py
+++ b/hermes_cli/session_recap.py
@@ -23,6 +23,8 @@ import os
 from collections import Counter
 from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
 
+from tools.ansi_strip import sanitize_display_text
+
 # How many recent user/assistant turns we consider "recent activity".
 _RECENT_TURN_WINDOW = 20
 
@@ -229,6 +231,10 @@ def _summarise_tool_activity(
 
 
 def _truncate(text: str, limit: int) -> str:
+    # Stored history is untrusted for display — remove escape sequences and
+    # control chars so a recap line can't clear the screen / retitle the
+    # window when echoed to a terminal (openai/codex#31494 bug class).
+    text = sanitize_display_text(text)
     text = " ".join(text.split())  # collapse newlines for a compact one-liner
     if len(text) <= limit:
         return text

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -728,3 +728,47 @@ class TestResumeDisplayConfig:
 
         display = config.get("display", {})
         assert display.get("resume_display") == "full"
+
+
+class TestResumeDisplaySanitization:
+    """Stored history replayed by /resume must not carry raw terminal
+    escapes or control chars (openai/codex#31494 bug class)."""
+
+    def _capture_display(self, cli_obj):
+        buf = StringIO()
+        cli_obj.console.file = buf
+        cli_obj._display_resumed_history()
+        return buf.getvalue()
+
+    def test_escape_sequences_stripped_from_user_and_assistant(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "hi \x1b[2J\x1b]0;pwned\x07 there"},
+            {"role": "assistant", "content": "ok \x9b31m fine\x07"},
+        ]
+        output = self._capture_display(cli)
+        # Rich adds its own SGR styling escapes when force_terminal is on;
+        # what must NOT survive are the injected non-SGR sequences.
+        assert "\x1b[2J" not in output
+        assert "\x1b]0;pwned" not in output
+        assert "\x9b" not in output
+        assert "\x07" not in output
+        assert "hi" in output and "there" in output
+        assert "fine" in output
+
+    def test_multimodal_text_part_sanitized(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look \x1b[3J\x1b[H at this"},
+                    {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                ],
+            },
+            {"role": "assistant", "content": "sure"},
+        ]
+        output = self._capture_display(cli)
+        assert "\x1b[3J" not in output
+        assert "\x1b[H" not in output
+        assert "[image]" in output

--- a/tests/hermes_cli/test_session_recap.py
+++ b/tests/hermes_cli/test_session_recap.py
@@ -177,3 +177,17 @@ def test_ignores_non_mapping_entries_gracefully():
     # Should not raise.
     out = build_recap(msgs)
     assert "Session recap" in out
+
+
+def test_escape_sequences_sanitized_in_previews():
+    """Recap previews must not carry raw terminal escapes (codex#31494 class)."""
+    msgs = [
+        _user("please \x1b[2J\x1b]0;pwned\x07 do the thing"),
+        _assistant("done \x9b31m with it\x07"),
+    ]
+    out = build_recap(msgs)
+    assert "\x1b" not in out
+    assert "\x9b" not in out
+    assert "\x07" not in out
+    assert "do the thing" in out
+    assert "with it" in out

--- a/tests/tools/test_ansi_strip.py
+++ b/tests/tools/test_ansi_strip.py
@@ -5,7 +5,7 @@ ANSI codes leaking into the model's context via terminal/execute_code output.
 It must strip ALL terminal escape sequences while preserving legitimate text.
 """
 
-from tools.ansi_strip import strip_ansi
+from tools.ansi_strip import sanitize_display_text, strip_ansi
 
 
 class TestStripAnsiBasicSGR:
@@ -166,3 +166,46 @@ class TestStripAnsiPassthrough:
         """Array indexing must not be confused with CSI."""
         code = "arr[0] = arr[31]"
         assert strip_ansi(code) == code
+
+
+class TestSanitizeDisplayText:
+    """sanitize_display_text — escape sequences AND bare control chars.
+
+    Port of the openai/codex#31494 bug class: stored/untrusted text
+    replayed into a terminal UI (e.g. the /resume recap) must not be able
+    to clear the screen, retitle the window, or corrupt adjacent output.
+    """
+
+    def test_csi_removed(self):
+        assert sanitize_display_text("a\x1b[2Jb") == "ab"
+
+    def test_osc_title_removed(self):
+        assert sanitize_display_text("x\x1b]0;pwned\x07y") == "xy"
+
+    def test_c1_csi_removed(self):
+        assert sanitize_display_text("a\x9b31mb") == "ab"
+
+    def test_bare_controls_removed(self):
+        assert sanitize_display_text("a\x00b\x08c\x07d\x7fe") == "abcde"
+
+    def test_newline_and_tab_preserved(self):
+        assert sanitize_display_text("line1\nline2\tend") == "line1\nline2\tend"
+
+    def test_crlf_normalized_to_newline(self):
+        assert sanitize_display_text("one\r\ntwo\rthree") == "one\ntwo\nthree"
+
+    def test_clean_text_fast_path_identity(self):
+        s = "plain text with unicode 🎉 and [brackets]"
+        assert sanitize_display_text(s) is s
+
+    def test_empty(self):
+        assert sanitize_display_text("") == ""
+
+    def test_codex_31494_fixture(self):
+        """The exact input shape from openai/codex#31494's test."""
+        raw = "_count_r\x1b[13;2:3uows\tindent\n\x00two\x7f"
+        assert sanitize_display_text(raw) == "_count_rows\tindent\ntwo"
+
+    def test_mixed_escape_and_controls(self):
+        raw = "hello \x1b[2J\x1b]0;pwned\x07 world \x9b31m red\x07"
+        assert sanitize_display_text(raw) == "hello  world  red"

--- a/tools/ansi_strip.py
+++ b/tools/ansi_strip.py
@@ -31,6 +31,17 @@ _ANSI_ESCAPE_RE = re.compile(
 # Fast-path check — skip full regex when no escape-like bytes are present.
 _HAS_ESCAPE = re.compile(r"[\x1b\x80-\x9f]")
 
+# C0 control characters (minus tab/newline/carriage-return, handled
+# separately) plus DEL. These survive strip_ansi() — it only removes
+# well-formed escape *sequences* — but are still dangerous or garbled
+# when echoed back to a terminal (BEL rings, backspace/DEL overwrite,
+# NUL truncates in some terminals).
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+# Fast-path check for sanitize_display_text — any C0 control (except
+# tab/newline), CR, DEL, ESC, or C1 byte triggers the slow path.
+_HAS_CONTROL = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
 
 def strip_ansi(text: str) -> str:
     """Remove ANSI escape sequences from text.
@@ -42,3 +53,27 @@ def strip_ansi(text: str) -> str:
     if not text or not _HAS_ESCAPE.search(text):
         return text
     return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def sanitize_display_text(text: str) -> str:
+    """Sanitize stored/untrusted text before echoing it to a terminal.
+
+    Removes ANSI/ECMA-48 escape sequences AND bare control characters,
+    preserving only newlines and tabs (carriage returns are normalized
+    to newlines so ``\\r``-overwrite spoofing can't hide content).
+
+    Use this when re-rendering conversation history or other persisted
+    text in a terminal UI (e.g. the ``/resume`` recap): a message that
+    arrived with embedded escapes — pasted content, gateway-origin
+    text, or model output echoing injected tool results — must not be
+    able to clear the screen, retitle the window, move the cursor, or
+    restyle adjacent UI when replayed. Rich's ``Text()`` does NOT
+    neutralize raw escape bytes, so sanitization has to happen before
+    display. Mirrors openai/codex#31494 (``sanitize_user_text``).
+    """
+    if not text or not _HAS_CONTROL.search(text):
+        return text
+    text = strip_ansi(text)
+    if "\r" in text:
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return _CONTROL_CHARS_RE.sub("", text)


### PR DESCRIPTION
## Summary

Replaying stored conversation history to a terminal can no longer inject raw escape sequences — the `/resume` recap panel and `build_recap` (`/status` on CLI + every gateway platform) now sanitize CSI/OSC/C1 sequences and bare control characters before rendering.

Port of the bug class fixed in [openai/codex#31494](https://github.com/openai/codex/pull/31494) (`sanitize_user_text` in their TUI history cells). Hermes had the same shape: history text is untrusted for display (pasted content, gateway-origin messages, model output echoing injected tool results), and both recap paths wrote it to the terminal verbatim. An embedded `ESC[2J` cleared the screen, `ESC]0;…BEL` retitled the window, C1 `0x9B` restyled the recap panel, and `\r`-overwrite could hide content. Proven live against current main: Rich's `Text()` passes raw escape bytes straight through (`force_terminal` render kept `\x1b[2J`, `\x1b]0;pwned`, and `\x9b` intact).

## Changes

- `tools/ansi_strip.py`: new `sanitize_display_text()` — reuses the existing ECMA-48 `strip_ansi()` (rather than transcribing Codex's Rust char-walk), then removes bare C0 controls + DEL, preserving `\n`/`\t` and normalizing `\r`/`\r\n` to `\n`. Fast-path identity for clean text.
- `hermes_cli/cli_agent_setup_mixin.py`: `_display_resumed_history()` sanitizes user and assistant text (including multimodal text parts) before building the Rich recap panel.
- `hermes_cli/session_recap.py`: `build_recap()` sanitizes preview lines at the `_truncate()` choke point — covers `/status` recaps on CLI and all gateway platforms.
- Tests: 10 new `sanitize_display_text` cases (including the exact codex#31494 fixture string), plus leak assertions for `build_recap` and `_display_resumed_history`.

## Adaptation notes

- Codex sanitizes at composer paste-time AND display-time; hermes deliberately sanitizes **display only**. What the model sees (conversation history sent to the API) is untouched — mutating stored history would break prompt-cache integrity and alter what the agent actually received.
- Bare control chars (BEL, BS, NUL, DEL) are removed in addition to escape sequences, matching Codex's `is_control()` filter; the existing `strip_ansi()` alone only removes well-formed sequences.

## Validation

| Check | Result |
|---|---|
| `tests/tools/test_ansi_strip.py` + `tests/hermes_cli/test_session_recap.py` | 54 passed |
| `tests/cli/test_resume_display.py` | 42 passed |
| Sibling `-k "recap or resume"` across `tests/cli` + `tests/hermes_cli` | 94 passed |
| E2E (real `HermesCLI`, Rich `force_terminal` console, injected CSI/OSC/C1/C0) | no bytes leaked, content preserved |

## Infographic

![sanitize-replayed-history](https://v3b.fal.media/files/b/0aa248d6/Em7dP5G4nt1I2IPmjZtCz_yGvh6Byh.png)
