### PR TITLE
fix(desktop): keep clarify prompts out of tool overflow

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldBoundToolGroup } from './fallback'
+
+describe('shouldBoundToolGroup', () => {
+  it('bounds long runs of ordinary tool calls', () => {
+    expect(shouldBoundToolGroup(3, false)).toBe(true)
+  })
+
+  it('never bounds a run containing clarify', () => {
+    expect(shouldBoundToolGroup(3, true)).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -611,6 +611,10 @@ function ToolEntry({ part }: ToolEntryProps) {
 // auto-scrolling window; fewer than this stays a plain inline stack.
 const TOOL_GROUP_SCROLL_THRESHOLD = 3
 
+export function shouldBoundToolGroup(childCount: number, containsClarify: boolean) {
+  return childCount >= TOOL_GROUP_SCROLL_THRESHOLD && !containsClarify
+}
+
 // Pin-to-bottom + top-fade for the bounded tool window. Pins the newest row on
 // growth (a call lands or a row expands) unless the user scrolled up, and fades
 // the top edge once anything sits above it. Mirrors ThinkingDisclosure's live
@@ -678,13 +682,21 @@ function useToolWindow(enabled: boolean) {
  */
 export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex: number }>> = ({
   children,
+  endIndex,
   startIndex
 }) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRunning = useAuiState(selectMessageRunning)
+
+  const containsClarify = useAuiState(s =>
+    s.message.parts
+      .slice(Math.max(0, startIndex), endIndex + 1)
+      .some(part => part.type === 'tool-call' && part.toolName === 'clarify')
+  )
+
   const enterRef = useEnterAnimation(messageRunning, `tool-group:${messageId}:${startIndex}`)
 
-  const bounded = Children.count(children) >= TOOL_GROUP_SCROLL_THRESHOLD
+  const bounded = shouldBoundToolGroup(Children.count(children), containsClarify)
   const { contentRef, faded, onScroll, scrollRef } = useToolWindow(bounded)
 
   return (


### PR DESCRIPTION
## Summary
- treat `clarify` as a hard boundary for bounded adjacent tool-call runs
- keep clarify and multi-choice forms fully visible while preserving overflow behavior for ordinary tool runs
- cover both bounded ordinary runs and clarify opt-out behavior

## Test plan
- [x] `npx vitest run --project ui src/components/assistant-ui/tool/fallback.test.ts src/components/assistant-ui/clarify-tool.test.tsx`
- [x] `npx eslint src/components/assistant-ui/tool/fallback.tsx src/components/assistant-ui/tool/fallback.test.ts`
- [x] `npm run typecheck`