### PR TITLE
fix(gateway): return EphemeralReply from /undo ack to block file-path leak

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2370,7 +2370,7 @@ class GatewaySlashCommandsMixin:
         idx = len(mgr.state.subgoals) if mgr.state else 0
         return f"✓ Added subgoal {idx}: {text}"
 
-    async def _handle_undo_command(self, event: MessageEvent) -> str:
+    async def _handle_undo_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /undo [N] — back up N user turns (default 1), soft-deleting
         the truncated rows on disk and echoing the backed-up message text so
         the user can copy/edit and resend.
@@ -2390,7 +2390,12 @@ class GatewaySlashCommandsMixin:
             try:
                 n = int(raw_args.split()[0])
             except (ValueError, IndexError):
-                return t("gateway.undo.invalid_count", arg=raw_args.split()[0])
+                # EphemeralReply for the same reason as the success path below:
+                # this echoes the user's own just-typed argument, which can
+                # itself be a bare existing local path.
+                return EphemeralReply(
+                    t("gateway.undo.invalid_count", arg=raw_args.split()[0]), ttl_seconds=0
+                )
             if n < 1:
                 n = 1
 
@@ -2412,11 +2417,19 @@ class GatewaySlashCommandsMixin:
 
         target_text = result["target_text"]
         preview = target_text[:200] + "..." if len(target_text) > 200 else target_text
-        return t(
-            "gateway.undo.removed",
-            turns=result["turns_undone"],
-            count=result["rewound_count"],
-            preview=preview,
+        # EphemeralReply (ttl_seconds=0, no auto-delete) so extract_local_files()
+        # never scans this reply: target_text is the removed turn's raw text,
+        # not agent-authored, so it can contain a bare existing local path —
+        # same leak class as #64661 (uploads the path from the ack itself,
+        # duplicating anything the agent later sends for real).
+        return EphemeralReply(
+            t(
+                "gateway.undo.removed",
+                turns=result["turns_undone"],
+                count=result["rewound_count"],
+                preview=preview,
+            ),
+            ttl_seconds=0,
         )
 
     async def _handle_set_home_command(self, event: MessageEvent) -> str:

--- a/tests/gateway/test_undo_command.py
+++ b/tests/gateway/test_undo_command.py
@@ -1,0 +1,125 @@
+"""Tests for /undo gateway slash command.
+
+Tests the _handle_undo_command handler (rewind N user turns and echo the
+removed text so the user can copy/edit and resend it).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter, EphemeralReply, MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/undo", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890"):
+    """Build a MessageEvent for testing."""
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(rewind_result):
+    """Create a bare GatewayRunner with a mocked async_session_store."""
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.session_store = MagicMock()
+
+    session_entry = MagicMock()
+    session_entry.session_id = "sess_test"
+    session_entry.last_prompt_tokens = 100
+
+    facade = MagicMock()
+    facade._store = runner.session_store
+    facade.get_or_create_session = AsyncMock(return_value=session_entry)
+    facade.rewind_session = AsyncMock(return_value=rewind_result)
+    runner._async_session_store = facade
+
+    runner._evict_cached_agent = MagicMock(side_effect=Exception("no cache in test"))
+
+    return runner
+
+
+class TestHandleUndoCommand:
+    """Tests for GatewayRunner._handle_undo_command."""
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_undo(self):
+        """When there's nothing to rewind, a plain notice is returned."""
+        runner = _make_runner(rewind_result=None)
+        event = _make_event(text="/undo")
+        result = await runner._handle_undo_command(event)
+        assert "nothing" in result.lower() or result  # locale-dependent, just don't crash
+
+    @pytest.mark.asyncio
+    async def test_invalid_count_shows_message(self):
+        """A non-numeric /undo argument returns an error, no rewind attempted."""
+        runner = _make_runner(rewind_result=None)
+        event = _make_event(text="/undo abc")
+        result = await runner._handle_undo_command(event)
+        assert "abc" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_count_ack_does_not_leak_arg_as_attachment(self):
+        """A bare local path typed as the (invalid) /undo argument must not leak.
+
+        `/undo /tmp/bg.png` is an invalid turn count, but the error message
+        echoes the argument verbatim — the same leak class as the success
+        path, just with the user's own current input instead of history.
+        """
+        runner = _make_runner(rewind_result=None)
+        event = _make_event(text="/undo /tmp/bg.png")
+        result = await runner._handle_undo_command(event)
+
+        assert isinstance(result, EphemeralReply)
+        assert result.ttl_seconds == 0
+        assert "/tmp/bg.png" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_undo_returns_preview(self):
+        """A successful /undo echoes the removed turn's text."""
+        runner = _make_runner(rewind_result={
+            "target_text": "hello world",
+            "turns_undone": 1,
+            "rewound_count": 2,
+        })
+        event = _make_event(text="/undo")
+        result = await runner._handle_undo_command(event)
+        assert "hello world" in result
+
+    @pytest.mark.asyncio
+    async def test_ack_does_not_leak_undone_path_as_attachment(self):
+        """A bare local path in the undone turn must not be extractable.
+
+        The /undo preview echoes the exact text of the removed turn "so the
+        user can copy/edit and resend" it — that text is not agent-authored,
+        so it can contain anything the user or a prior assistant turn wrote,
+        including a bare existing local file path. extract_local_files()
+        (run by _process_message_background on every *non-ephemeral*
+        response) would otherwise upload that path from the undo ack itself,
+        the same class of bug fixed for /background in #64661.
+        """
+        runner = _make_runner(rewind_result={
+            "target_text": "use /tmp/bg.png and return it as an image",
+            "turns_undone": 1,
+            "rewound_count": 2,
+        })
+        event = _make_event(text="/undo")
+        result = await runner._handle_undo_command(event)
+
+        assert isinstance(result, EphemeralReply)
+        assert result.ttl_seconds == 0  # no auto-delete — the preview stays visible
+        assert "use /tmp/bg.png and return it as an image" in result
+
+        # Sanity: the path really would be picked up if this weren't skipped
+        # via the is_ephemeral_response guard.
+        with patch("os.path.isfile", return_value=True):
+            local_files, _ = BasePlatformAdapter.extract_local_files(str(result))
+        assert local_files == ["/tmp/bg.png"]


### PR DESCRIPTION
## What does this PR do?

`_process_message_background()` runs `extract_local_files()` on every non-ephemeral response and
uploads any bare, existing local file path it finds in the text — this is how the agent delivers
files without an explicit `MEDIA:` tag. `/undo`'s acknowledgement echoes the raw text of the
removed turn ("so the user can copy/edit and resend it", per its own docstring), and on invalid
input echoes the user's own just-typed argument verbatim. Either string can contain a bare
existing local file path (e.g. the undone turn mentioned a screenshot, or the user typed
`/undo /tmp/foo.png` by mistake), which would then get uploaded as an unwanted attachment the user
never asked for right now. This is the same leak class as #64661 (fixed for `/background` in
#64668): a status-notice ack that echoes untrusted/historical text without protecting it from the
attachment scanner.

The codebase already has the exact mechanism for this — `EphemeralReply`, used in this same file by
`/stop`, `/restart`, `/reset`, `/yolo`, and now `/background` (#64668) for the identical purpose:
`isinstance(response, EphemeralReply)` gates the `extract_local_files()` call in
`_process_message_background`. `_handle_undo_command` was returning a plain `str` on both its
success and invalid-argument paths. This PR wraps both in `EphemeralReply(..., ttl_seconds=0)` —
`ttl_seconds=0` explicitly disables the wrapper's optional auto-delete-after-TTL behavior, so the
previewed text (which the user is meant to copy/edit and resend) stays fully visible; the only
change is that this reply is no longer scanned for local files.

**Scope note**: hermes-agent's native button-driven slash-confirm delivery — the default UX for
`/undo` (native yes/no buttons on Telegram/Discord/Slack) — resolves and sends its result directly
via the platform adapter (`adapter.send(...)`/equivalent), never re-entering
`_process_message_background`. That path never ran `extract_local_files()` on the `/undo` ack
either way, so it was never exposed to this leak in the first place (fix or no fix — nothing to
regress there). This PR closes the gap for the two paths that genuinely do route back through
`_process_message_background`: `approvals.destructive_slash_confirm: false` (execute runs
immediately, its result becomes the normal message-handler response) and the text-typed
`/approve` fallback (`gateway/run.py`'s `_slash_confirm_mod.resolve(...)` call whose result is
returned as the handler's own response, not sent directly by an adapter).

### How it works

```mermaid
flowchart TD
    A["/undo (or /undo N)"] --> B["_handle_undo_command builds ack\n(echoes removed-turn text or invalid arg)"]
    B --> C{"confirm delivery path"}
    C -->|"native button tap"| D["adapter sends result directly\n(never runs extract_local_files — no leak here, before or after)"]
    C -->|"confirm disabled, or text /approve fallback"| E{"ack return type"}
    E -->|"before: plain str"| F["_process_message_background scans ack\nextract_local_files() finds a bare path\n→ uploads it unexpectedly"]
    E -->|"after: EphemeralReply(ttl_seconds=0)"| G["is_ephemeral_response = True\n→ extract_local_files() skipped for the ack"]
```

## Related Issue

No existing issue filed for `/undo` specifically — found while adversarially reviewing PR #64668
(the `/background` fix for #64661): the same leak-via-untrusted-preview pattern exists in
`_handle_undo_command` in the same file.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: `_handle_undo_command` now returns `EphemeralReply(t(...), ttl_seconds=0)` on both its success path (removed-turn preview) and its invalid-argument path (echoed user input), instead of a plain `str`. Return type annotation updated to `Union[str, EphemeralReply]` to match the sibling handlers that already use this pattern.
- `tests/gateway/test_undo_command.py`: new file (there were previously zero tests for `_handle_undo_command`) — baseline coverage (nothing-to-undo, invalid count, successful preview) plus two regression tests asserting both ack paths are `EphemeralReply` with `ttl_seconds == 0`, and that the underlying leak is real (`extract_local_files()` on the raw string, with `os.path.isfile` mocked true, would otherwise pick up the embedded path).

## Step-by-step

1. Confirmed via `/simplicio-review` (adversarial subagent) that `_handle_undo_command`'s ack is only protected by this fix on the two delivery paths that route through `_process_message_background`; verified independently by reading `_maybe_confirm_destructive_slash`, `_request_slash_confirm`, `tools/slash_confirm.py::resolve()`, and `plugins/platforms/telegram/adapter.py`'s button-callback handler.
2. Changed the success-path return to `EphemeralReply(t("gateway.undo.removed", ...), ttl_seconds=0)`.
3. The same review pass also flagged the invalid-count path (`t("gateway.undo.invalid_count", arg=...)`) as an unprotected echo of the user's own current input — same bug class, same file, same fix — wrapped it too for consistency.
4. Test strategy: added a from-scratch test file (`_make_runner` mocks `runner._async_session_store` with `get_or_create_session`/`rewind_session` as `AsyncMock`s, matching the `async_session_store` property's identity check at `gateway/run.py:10858-10864`). Verified the new leak-regression tests fail against the pre-fix code (`assert False == isinstance(...)`) and pass after.

## Acceptance Criteria

- [x] Given a completed `/undo` whose removed turn contains a bare existing local file path, when the ack is generated via a path that reaches `_process_message_background` (confirm disabled, or text `/approve`), then the ack is an `EphemeralReply` and `extract_local_files()` never scans it.
- [x] Given an invalid `/undo <non-numeric>` argument that is itself a bare existing local file path, when the ack is generated, then the same protection applies.
- [x] Adjacent behavior unchanged: ack still contains the full preview text (unaffected — `ttl_seconds=0` disables auto-delete); all pre-existing `/undo`-adjacent tests (`test_undo_rewind_session.py`, `test_destructive_slash_confirm.py`) still pass.
- [x] Test suite passes locally with the new tests included.

## How to Test

1. On `main`, with `approvals.destructive_slash_confirm: false` (or via the text `/approve` fallback), run `/undo` on a turn whose text contains a bare existing local path — the ack, once processed by `_process_message_background`, has that path extracted (verifiable directly: `BasePlatformAdapter.extract_local_files(ack_text)` returns it, with `os.path.isfile` mocked true in a unit test since no real conversation history is needed to observe the mechanism).
2. Check out this branch.
3. Same call — the ack is now an `EphemeralReply`, so `_process_message_background` skips extraction for it entirely.

## Tests Performed

| Check | Command | Result |
|---|---|---|
| New `/undo` test file | `python -m pytest tests/gateway/test_undo_command.py -q` | ✅ `5 passed in 8.63s` |
| Related suites (rewind, background ack, extraction, destructive-confirm) | `python -m pytest tests/gateway/test_undo_command.py tests/gateway/test_undo_rewind_session.py tests/gateway/test_background_command.py tests/gateway/test_extract_local_files.py tests/gateway/test_destructive_slash_confirm.py -q` | 85 passed, 1 pre-existing unrelated failure (`ModuleNotFoundError: No module named 'prompt_toolkit'` in `test_destructive_slash_confirm.py::test_resolve_always_persists_opt_out_and_runs_execute`) + 1 pre-existing skip — confirmed both reproduce identically on unmodified `main` (missing optional dev dependency in this environment, unrelated to this change) |
| Windows footguns | `python scripts/check-windows-footguns.py gateway/slash_commands.py tests/gateway/test_undo_command.py` | ✅ `No Windows footguns found (2 file(s) scanned).` |
| Lint | `python -m ruff check gateway/slash_commands.py tests/gateway/test_undo_command.py` | ✅ `All checks passed!` |
| Fail-before/pass-after | New tests run against pre-fix code | ❌ fails: `assert False == isinstance(result, EphemeralReply)`; passes after the fix |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updated — N/A (no user-facing docs describe this internal dispatch detail)
- [x] `cli-config.yaml.example` updated if config keys changed — N/A (no config keys changed)
- [x] `CONTRIBUTING.md`/`AGENTS.md` updated if architecture/workflow changed — N/A
- [x] Cross-platform impact considered (Windows, macOS) — `extract_local_files()` and `EphemeralReply` are both platform-agnostic; the button-vs-text-fallback distinction noted above applies identically regardless of host OS
- [x] Tool descriptions/schemas updated if tool behavior changed — N/A (gateway slash-command only, no tool schema affected)

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_undo_command.py -q
.....                                                                    [100%]
5 passed in 8.63s
```
