### PR TITLE
feat(observability): add OpenTelemetry OTLP trace export plugin

### DIFF
--- a/plugins/observability/otel/README.md
+++ b/plugins/observability/otel/README.md
@@ -61,8 +61,8 @@ duration metadata.
 The plugin never emits raw user messages, conversation history, API request or
 response bodies, tool arguments or results, command text, goals, summaries,
 error messages, API keys, or headers. It exports only stable IDs, safe labels,
-counts, lengths, durations, token usage, status fields, and short one-way
-digests for command/goal correlation.
+counts, lengths, durations, token usage, status fields, and non-content
+length summaries for commands and delegated goals.
 
 ## Verify
 

--- a/plugins/observability/otel/README.md
+++ b/plugins/observability/otel/README.md
@@ -1,0 +1,75 @@
+# OpenTelemetry OTLP Observability Plugin
+
+This bundled observer exports privacy-safe Hermes trajectories as OpenTelemetry
+traces over OTLP. It is disabled by default and fails open if configuration,
+the optional SDK, or the collector is unavailable.
+
+## Install and enable
+
+```bash
+pip install "hermes-agent[otel]"
+hermes plugins enable observability/otel
+
+export HERMES_OTEL_ENABLED=1
+export HERMES_OTEL_ENDPOINT=http://localhost:4318/v1/traces
+export HERMES_OTEL_PROTOCOL=http
+export HERMES_OTEL_SERVICE_NAME=hermes-agent
+```
+
+For OTLP/gRPC, use a gRPC endpoint and protocol:
+
+```bash
+export HERMES_OTEL_ENDPOINT=http://localhost:4317
+export HERMES_OTEL_PROTOCOL=grpc
+```
+
+Optional collector headers are a JSON object. Keep credentials in the
+environment rather than repository files:
+
+```bash
+export HERMES_OTEL_HEADERS='{"authorization":"Bearer ..."}'
+```
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `HERMES_OTEL_ENABLED` | `0` | Set to `1` to initialize tracing. |
+| `HERMES_OTEL_ENDPOINT` | OTel SDK default | OTLP trace endpoint. |
+| `HERMES_OTEL_PROTOCOL` | `http` | `http` or `grpc`. |
+| `HERMES_OTEL_SERVICE_NAME` | `hermes-agent` | OTel resource service name. |
+| `HERMES_OTEL_HEADERS` | `{}` | JSON object of OTLP headers. |
+
+The provider uses the OTel SDK batch span processor. Hermes calls
+`provider.shutdown()` from `on_session_finalize` to flush queued spans.
+
+## Span model
+
+- `hermes.session` roots each conversation run.
+- `hermes.turn` represents one user turn.
+- `hermes.llm_request` represents one provider API attempt.
+- `hermes.tool.<tool_name>` represents one tool execution.
+- `hermes.subagent` represents delegated child work.
+- `hermes.approval` represents a dangerous-command approval decision.
+
+Correlation attributes include stable Hermes session, turn, request, tool, and
+subagent IDs. Request spans include model, provider, token usage, status, and
+duration metadata.
+
+## Privacy
+
+The plugin never emits raw user messages, conversation history, API request or
+response bodies, tool arguments or results, command text, goals, summaries,
+error messages, API keys, or headers. It exports only stable IDs, safe labels,
+counts, lengths, durations, token usage, status fields, and short one-way
+digests for command/goal correlation.
+
+## Verify
+
+```bash
+hermes plugins list
+hermes chat -q "hello"
+```
+
+Then inspect your collector backend for the `hermes-agent` service. To disable
+export without removing the plugin, set `HERMES_OTEL_ENABLED=0`.

--- a/plugins/observability/otel/__init__.py
+++ b/plugins/observability/otel/__init__.py
@@ -1,0 +1,145 @@
+"""OpenTelemetry OTLP trace export for Hermes observer trajectories."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable
+
+from .config import load_config
+from .exporter import create_runtime
+from .span_builder import SpanBuilder
+
+
+logger = logging.getLogger(__name__)
+_LOCK = threading.RLock()
+_RUNTIME: Any = None
+_BUILDER: SpanBuilder | None = None
+_INIT_FAILED = object()
+
+
+def _get_builder() -> SpanBuilder | None:
+    global _RUNTIME, _BUILDER
+    with _LOCK:
+        if _RUNTIME is _INIT_FAILED:
+            return None
+        if _BUILDER is not None:
+            return _BUILDER
+
+        config = load_config()
+        if not config.enabled:
+            _RUNTIME = _INIT_FAILED
+            return None
+        try:
+            _RUNTIME = create_runtime(config)
+            _BUILDER = SpanBuilder(_RUNTIME.tracer)
+        except Exception:
+            logger.debug("OpenTelemetry observer initialization failed", exc_info=True)
+            _RUNTIME = _INIT_FAILED
+            _BUILDER = None
+        return _BUILDER
+
+
+def _safe(callback: Callable[[], None]) -> None:
+    try:
+        callback()
+    except Exception:
+        logger.debug("OpenTelemetry observer hook failed", exc_info=True)
+
+
+def _dispatch(method: str, kwargs: dict[str, Any]) -> None:
+    builder = _get_builder()
+    if builder is not None:
+        _safe(lambda: getattr(builder, method)(kwargs))
+
+
+def register(ctx: Any) -> None:
+    """Register the complete Hermes observer lifecycle."""
+    ctx.register_hook("on_session_start", on_session_start)
+    ctx.register_hook("on_session_end", on_session_end)
+    ctx.register_hook("on_session_finalize", on_session_finalize)
+    ctx.register_hook("on_session_reset", on_session_reset)
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
+    ctx.register_hook("post_llm_call", on_post_llm_call)
+    ctx.register_hook("pre_api_request", on_pre_api_request)
+    ctx.register_hook("post_api_request", on_post_api_request)
+    ctx.register_hook("api_request_error", on_api_request_error)
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("subagent_start", on_subagent_start)
+    ctx.register_hook("subagent_stop", on_subagent_stop)
+    ctx.register_hook("pre_approval_request", on_pre_approval_request)
+    ctx.register_hook("post_approval_response", on_post_approval_response)
+
+
+def on_session_start(**kwargs: Any) -> None:
+    _dispatch("start_session", kwargs)
+
+
+def on_session_end(**kwargs: Any) -> None:
+    _dispatch("mark_session_end", kwargs)
+
+
+def on_session_finalize(**kwargs: Any) -> None:
+    global _RUNTIME, _BUILDER
+    with _LOCK:
+        runtime = _RUNTIME
+        builder = _BUILDER
+        if builder is not None:
+            _safe(lambda: builder.finalize_session(kwargs))
+        if runtime not in (None, _INIT_FAILED):
+            _safe(runtime.provider.shutdown)
+        _RUNTIME = None
+        _BUILDER = None
+
+
+def on_session_reset(**kwargs: Any) -> None:
+    _dispatch("finalize_session", kwargs)
+
+
+def on_pre_llm_call(**kwargs: Any) -> None:
+    _dispatch("start_turn", kwargs)
+
+
+def on_post_llm_call(**kwargs: Any) -> None:
+    _dispatch("end_turn", kwargs)
+
+
+def on_pre_api_request(**kwargs: Any) -> None:
+    _dispatch("start_llm_request", kwargs)
+
+
+def on_post_api_request(**kwargs: Any) -> None:
+    builder = _get_builder()
+    if builder is not None:
+        _safe(lambda: builder.end_llm_request(kwargs))
+
+
+def on_api_request_error(**kwargs: Any) -> None:
+    builder = _get_builder()
+    if builder is not None:
+        _safe(lambda: builder.end_llm_request(kwargs, error=True))
+
+
+def on_pre_tool_call(**kwargs: Any) -> None:
+    _dispatch("start_tool", kwargs)
+
+
+def on_post_tool_call(**kwargs: Any) -> None:
+    _dispatch("end_tool", kwargs)
+
+
+def on_subagent_start(**kwargs: Any) -> None:
+    _dispatch("start_subagent", kwargs)
+
+
+def on_subagent_stop(**kwargs: Any) -> None:
+    _dispatch("end_subagent", kwargs)
+
+
+def on_pre_approval_request(**kwargs: Any) -> None:
+    _dispatch("start_approval", kwargs)
+
+
+def on_post_approval_response(**kwargs: Any) -> None:
+    _dispatch("end_approval", kwargs)

--- a/plugins/observability/otel/__init__.py
+++ b/plugins/observability/otel/__init__.py
@@ -85,12 +85,16 @@ def on_session_finalize(**kwargs: Any) -> None:
     with _LOCK:
         runtime = _RUNTIME
         builder = _BUILDER
+        remaining_sessions = 0
         if builder is not None:
-            _safe(lambda: builder.finalize_session(kwargs))
-        if runtime not in (None, _INIT_FAILED):
+            try:
+                remaining_sessions = builder.finalize_session(kwargs)
+            except Exception:
+                logger.debug("OpenTelemetry session finalization failed", exc_info=True)
+        if runtime not in (None, _INIT_FAILED) and remaining_sessions == 0:
             _safe(runtime.provider.shutdown)
-        _RUNTIME = None
-        _BUILDER = None
+            _RUNTIME = None
+            _BUILDER = None
 
 
 def on_session_reset(**kwargs: Any) -> None:

--- a/plugins/observability/otel/config.py
+++ b/plugins/observability/otel/config.py
@@ -1,0 +1,64 @@
+"""Environment configuration for the OpenTelemetry observer plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off", ""}
+_VALID_PROTOCOLS = {"http", "grpc"}
+
+
+@dataclass(frozen=True)
+class OTelConfig:
+    enabled: bool = False
+    endpoint: str = ""
+    protocol: str = "http"
+    service_name: str = "hermes-agent"
+    headers: dict[str, str] | None = None
+
+
+def _parse_enabled(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    return False
+
+
+def _parse_headers(value: str) -> dict[str, str]:
+    if not value.strip():
+        return {}
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        str(key): str(header_value)
+        for key, header_value in parsed.items()
+        if isinstance(key, str) and isinstance(header_value, (str, int, float, bool))
+    }
+
+
+def load_config(environ: Mapping[str, str] | None = None) -> OTelConfig:
+    """Load fail-closed activation settings from environment variables."""
+    env = environ if environ is not None else os.environ
+    protocol = env.get("HERMES_OTEL_PROTOCOL", "http").strip().lower()
+    if protocol not in _VALID_PROTOCOLS:
+        protocol = "http"
+
+    service_name = env.get("HERMES_OTEL_SERVICE_NAME", "hermes-agent").strip()
+    return OTelConfig(
+        enabled=_parse_enabled(env.get("HERMES_OTEL_ENABLED", "0")),
+        endpoint=env.get("HERMES_OTEL_ENDPOINT", "").strip(),
+        protocol=protocol,
+        service_name=service_name or "hermes-agent",
+        headers=_parse_headers(env.get("HERMES_OTEL_HEADERS", "")),
+    )

--- a/plugins/observability/otel/exporter.py
+++ b/plugins/observability/otel/exporter.py
@@ -1,0 +1,49 @@
+"""OTLP exporter and tracer provider setup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .config import OTelConfig
+
+
+@dataclass
+class OTelRuntime:
+    provider: Any
+    tracer: Any
+
+
+def create_runtime(config: OTelConfig, *, span_exporter: Any = None) -> OTelRuntime:
+    """Create an isolated provider without changing OTel's global provider."""
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    exporter = span_exporter or _create_otlp_exporter(config)
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": config.service_name})
+    )
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    return OTelRuntime(
+        provider=provider,
+        tracer=provider.get_tracer("hermes-agent.observability.otel"),
+    )
+
+
+def _create_otlp_exporter(config: OTelConfig) -> Any:
+    kwargs: dict[str, Any] = {}
+    if config.endpoint:
+        kwargs["endpoint"] = config.endpoint
+    if config.headers:
+        kwargs["headers"] = config.headers
+
+    if config.protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    else:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    return OTLPSpanExporter(**kwargs)

--- a/plugins/observability/otel/plugin.yaml
+++ b/plugins/observability/otel/plugin.yaml
@@ -1,0 +1,20 @@
+name: otel
+version: "1.0.0"
+description: "Optional OpenTelemetry observability for Hermes trajectories via OTLP traces."
+author: NousResearch
+hooks:
+  - on_session_start
+  - on_session_end
+  - on_session_finalize
+  - on_session_reset
+  - pre_llm_call
+  - post_llm_call
+  - pre_api_request
+  - post_api_request
+  - api_request_error
+  - pre_tool_call
+  - post_tool_call
+  - subagent_start
+  - subagent_stop
+  - pre_approval_request
+  - post_approval_response

--- a/plugins/observability/otel/span_builder.py
+++ b/plugins/observability/otel/span_builder.py
@@ -91,6 +91,7 @@ class SpanBuilder:
         self._requests: dict[str, _SpanEntry] = {}
         self._tools: dict[str, _SpanEntry] = {}
         self._subagents: dict[str, _SpanEntry] = {}
+        self._subagent_by_child_session: dict[str, _SpanEntry] = {}
         self._approvals: dict[str, list[_SpanEntry]] = defaultdict(list)
 
     @staticmethod
@@ -167,7 +168,11 @@ class SpanBuilder:
                     "hermes.platform": _safe_label(kwargs.get("platform")),
                 }
             )
-            self._sessions[session_id] = self._start("hermes.session", attributes)
+            self._sessions[session_id] = self._start(
+                "hermes.session",
+                attributes,
+                parent=self._subagent_by_child_session.get(session_id),
+            )
 
     def mark_session_end(self, kwargs: dict[str, Any]) -> None:
         session_id = _text(kwargs.get("session_id"))
@@ -335,14 +340,18 @@ class SpanBuilder:
             parent = self._turn(_text(kwargs.get("parent_turn_id"))) or self._session(
                 _text(kwargs.get("parent_session_id"))
             )
-            self._subagents[child_id] = self._start(
-                "hermes.subagent", attributes, parent=parent
-            )
+            entry = self._start("hermes.subagent", attributes, parent=parent)
+            self._subagents[child_id] = entry
+            if child_session_id:
+                self._subagent_by_child_session[child_session_id] = entry
 
     def end_subagent(self, kwargs: dict[str, Any]) -> None:
         child_id = _text(kwargs.get("child_subagent_id")) or _text(kwargs.get("child_session_id"))
         status = _safe_label(kwargs.get("child_status"), "unknown")
         with self._lock:
+            child_session_id = _text(kwargs.get("child_session_id"))
+            if child_session_id:
+                self._subagent_by_child_session.pop(child_session_id, None)
             self._end(
                 self._subagents.pop(child_id, None),
                 {

--- a/plugins/observability/otel/span_builder.py
+++ b/plugins/observability/otel/span_builder.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import re
 import threading
 import time
@@ -22,10 +21,6 @@ def _safe_label(value: Any, default: str = "unknown") -> str:
     text = _text(value).strip()
     return text if _SAFE_LABEL.fullmatch(text) else default
 
-
-def _stable_digest(value: Any) -> str:
-    text = _text(value)
-    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16] if text else ""
 
 
 def _int(value: Any) -> int | None:
@@ -87,6 +82,7 @@ class SpanBuilder:
         self.tracer = tracer
         self._lock = threading.RLock()
         self._sessions: dict[str, _SpanEntry] = {}
+        self._known_sessions: set[str] = set()
         self._turns: dict[str, _SpanEntry] = {}
         self._requests: dict[str, _SpanEntry] = {}
         self._tools: dict[str, _SpanEntry] = {}
@@ -159,6 +155,7 @@ class SpanBuilder:
         if not session_id:
             return
         with self._lock:
+            self._known_sessions.add(session_id)
             if session_id in self._sessions:
                 return
             attributes = _ids(kwargs)
@@ -185,11 +182,13 @@ class SpanBuilder:
                     attributes[f"hermes.session.{key}"] = value
             self._end(entry, attributes, error=bool(kwargs.get("interrupted")))
 
-    def finalize_session(self, kwargs: dict[str, Any]) -> None:
+    def finalize_session(self, kwargs: dict[str, Any]) -> int:
         session_id = _text(kwargs.get("session_id") or kwargs.get("old_session_id"))
         with self._lock:
+            self._known_sessions.discard(session_id)
             self._end(self._sessions.pop(session_id, None), {"hermes.session.finalized": True})
             self._finish_session_children(session_id)
+            return len(self._known_sessions)
 
     def _finish_session_children(self, session_id: str) -> None:
         for mapping in (self._turns, self._requests, self._tools, self._subagents):
@@ -334,7 +333,7 @@ class SpanBuilder:
                 {
                     "hermes.subagent.role": _safe_label(kwargs.get("child_role"), "custom"),
                     "hermes.subagent.goal_length": len(goal),
-                    "hermes.subagent.goal_id": _stable_digest(goal),
+                    "hermes.subagent.goal_summary": f"length:{len(goal)}",
                 }
             )
             parent = self._turn(_text(kwargs.get("parent_turn_id"))) or self._session(
@@ -371,7 +370,7 @@ class SpanBuilder:
                 {
                     "hermes.approval.surface": _safe_label(kwargs.get("surface")),
                     "hermes.approval.command_length": len(command),
-                    "hermes.approval.command_id": _stable_digest(command),
+                    "hermes.approval.command_summary": f"length:{len(command)}",
                     "hermes.approval.description_length": len(_text(kwargs.get("description"))),
                     "hermes.approval.pattern_count": len(kwargs.get("pattern_keys") or []),
                 }

--- a/plugins/observability/otel/span_builder.py
+++ b/plugins/observability/otel/span_builder.py
@@ -1,0 +1,376 @@
+"""Privacy-safe OpenTelemetry span lifecycle management for Hermes hooks."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+
+_SAFE_LABEL = re.compile(r"^[A-Za-z0-9_.:/-]{1,128}$")
+
+
+def _text(value: Any) -> str:
+    return str(value or "")
+
+
+def _safe_label(value: Any, default: str = "unknown") -> str:
+    text = _text(value).strip()
+    return text if _SAFE_LABEL.fullmatch(text) else default
+
+
+def _stable_digest(value: Any) -> str:
+    text = _text(value)
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16] if text else ""
+
+
+def _int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _duration_ms(kwargs: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _float(kwargs.get(key))
+        if value is not None:
+            return value * 1000 if key == "api_duration" else value
+    return None
+
+
+def _ids(kwargs: dict[str, Any]) -> dict[str, str]:
+    attributes = {}
+    for key in (
+        "session_id",
+        "task_id",
+        "turn_id",
+        "api_request_id",
+        "tool_call_id",
+        "parent_session_id",
+        "parent_turn_id",
+        "parent_subagent_id",
+        "child_session_id",
+        "child_subagent_id",
+    ):
+        value = _text(kwargs.get(key))
+        if value:
+            attributes[f"hermes.{key}"] = value
+    schema = _text(kwargs.get("telemetry_schema_version"))
+    if schema:
+        attributes["hermes.telemetry_schema_version"] = schema
+    return attributes
+
+
+@dataclass
+class _SpanEntry:
+    span: Any
+    started_ns: int
+
+
+class SpanBuilder:
+    """Build and correlate Hermes spans without exporting sensitive payloads."""
+
+    def __init__(self, tracer: Any) -> None:
+        self.tracer = tracer
+        self._lock = threading.RLock()
+        self._sessions: dict[str, _SpanEntry] = {}
+        self._turns: dict[str, _SpanEntry] = {}
+        self._requests: dict[str, _SpanEntry] = {}
+        self._tools: dict[str, _SpanEntry] = {}
+        self._subagents: dict[str, _SpanEntry] = {}
+        self._approvals: dict[str, list[_SpanEntry]] = defaultdict(list)
+
+    @staticmethod
+    def _now_ns() -> int:
+        return time.time_ns()
+
+    def _parent_context(self, span: Any) -> Any:
+        if span is None:
+            return None
+        from opentelemetry import trace
+
+        return trace.set_span_in_context(span)
+
+    def _start(
+        self,
+        name: str,
+        attributes: dict[str, Any],
+        *,
+        parent: _SpanEntry | None = None,
+        started_at: Any = None,
+    ) -> _SpanEntry:
+        start_ns = self._now_ns()
+        started = _float(started_at)
+        if started is not None:
+            start_ns = int(started * 1_000_000_000)
+        span = self.tracer.start_span(
+            name,
+            context=self._parent_context(parent.span if parent else None),
+            attributes={key: value for key, value in attributes.items() if value is not None},
+            start_time=start_ns,
+        )
+        return _SpanEntry(span=span, started_ns=start_ns)
+
+    def _end(
+        self,
+        entry: _SpanEntry | None,
+        attributes: dict[str, Any] | None = None,
+        *,
+        error: bool = False,
+    ) -> None:
+        if entry is None:
+            return
+        if attributes:
+            for key, value in attributes.items():
+                if value is not None:
+                    entry.span.set_attribute(key, value)
+        if error:
+            from opentelemetry.trace import Status, StatusCode
+
+            entry.span.set_status(Status(StatusCode.ERROR))
+        entry.span.end()
+
+    def _session(self, session_id: str) -> _SpanEntry | None:
+        return self._sessions.get(session_id) if session_id else None
+
+    def _turn(self, turn_id: str) -> _SpanEntry | None:
+        return self._turns.get(turn_id) if turn_id else None
+
+    def start_session(self, kwargs: dict[str, Any]) -> None:
+        session_id = _text(kwargs.get("session_id"))
+        if not session_id:
+            return
+        with self._lock:
+            if session_id in self._sessions:
+                return
+            attributes = _ids(kwargs)
+            attributes.update(
+                {
+                    "hermes.model": _safe_label(kwargs.get("model")),
+                    "hermes.platform": _safe_label(kwargs.get("platform")),
+                }
+            )
+            self._sessions[session_id] = self._start("hermes.session", attributes)
+
+    def mark_session_end(self, kwargs: dict[str, Any]) -> None:
+        session_id = _text(kwargs.get("session_id"))
+        with self._lock:
+            entry = self._sessions.get(session_id)
+            if entry is None:
+                return
+            for key in ("completed", "interrupted"):
+                value = kwargs.get(key)
+                if isinstance(value, bool):
+                    entry.span.set_attribute(f"hermes.session.{key}", value)
+
+    def finalize_session(self, kwargs: dict[str, Any]) -> None:
+        session_id = _text(kwargs.get("session_id") or kwargs.get("old_session_id"))
+        with self._lock:
+            self._end(self._sessions.pop(session_id, None), {"hermes.session.finalized": True})
+            self._finish_session_children(session_id)
+
+    def _finish_session_children(self, session_id: str) -> None:
+        for mapping in (self._turns, self._requests, self._tools, self._subagents):
+            stale = [key for key, entry in mapping.items() if entry.span.attributes.get("hermes.session_id") == session_id]
+            for key in stale:
+                self._end(mapping.pop(key, None), {"hermes.incomplete": True}, error=True)
+
+    def start_turn(self, kwargs: dict[str, Any]) -> None:
+        turn_id = _text(kwargs.get("turn_id"))
+        if not turn_id:
+            return
+        with self._lock:
+            if turn_id in self._turns:
+                return
+            session_id = _text(kwargs.get("session_id"))
+            attributes = _ids(kwargs)
+            attributes.update(
+                {
+                    "hermes.model": _safe_label(kwargs.get("model")),
+                    "hermes.platform": _safe_label(kwargs.get("platform")),
+                    "hermes.turn.is_first": bool(kwargs.get("is_first_turn", False)),
+                    "hermes.turn.user_message_length": len(_text(kwargs.get("user_message"))),
+                    "hermes.turn.history_count": len(kwargs.get("conversation_history") or []),
+                }
+            )
+            self._turns[turn_id] = self._start(
+                "hermes.turn", attributes, parent=self._session(session_id)
+            )
+
+    def end_turn(self, kwargs: dict[str, Any]) -> None:
+        turn_id = _text(kwargs.get("turn_id"))
+        with self._lock:
+            self._end(
+                self._turns.pop(turn_id, None),
+                {
+                    "hermes.turn.assistant_response_length": len(
+                        _text(kwargs.get("assistant_response"))
+                    ),
+                    "hermes.turn.history_count": len(kwargs.get("conversation_history") or []),
+                },
+            )
+
+    def start_llm_request(self, kwargs: dict[str, Any]) -> None:
+        request_id = _text(kwargs.get("api_request_id"))
+        if not request_id:
+            return
+        with self._lock:
+            attributes = _ids(kwargs)
+            attributes.update(
+                {
+                    "gen_ai.request.model": _safe_label(kwargs.get("model")),
+                    "gen_ai.provider.name": _safe_label(kwargs.get("provider")),
+                    "hermes.api_mode": _safe_label(kwargs.get("api_mode")),
+                    "hermes.api_call_count": _int(kwargs.get("api_call_count")),
+                    "hermes.request.message_count": _int(kwargs.get("message_count")),
+                    "hermes.request.tool_count": _int(kwargs.get("tool_count")),
+                    "hermes.request.approx_input_tokens": _int(kwargs.get("approx_input_tokens")),
+                    "hermes.request.char_count": _int(kwargs.get("request_char_count")),
+                }
+            )
+            parent = self._turn(_text(kwargs.get("turn_id"))) or self._session(
+                _text(kwargs.get("session_id"))
+            )
+            self._requests[request_id] = self._start(
+                "hermes.llm_request",
+                attributes,
+                parent=parent,
+                started_at=kwargs.get("started_at"),
+            )
+
+    def end_llm_request(self, kwargs: dict[str, Any], *, error: bool = False) -> None:
+        request_id = _text(kwargs.get("api_request_id"))
+        usage = kwargs.get("usage") if isinstance(kwargs.get("usage"), dict) else {}
+        attributes = {
+            "hermes.api.duration_ms": _duration_ms(kwargs, "api_duration"),
+            "gen_ai.response.finish_reasons": _safe_label(kwargs.get("finish_reason"), ""),
+            "gen_ai.response.model": _safe_label(kwargs.get("response_model"), ""),
+            "gen_ai.usage.input_tokens": _int(usage.get("input_tokens")),
+            "gen_ai.usage.output_tokens": _int(usage.get("output_tokens")),
+            "hermes.usage.cache_read_tokens": _int(usage.get("cache_read_tokens")),
+            "hermes.usage.cache_write_tokens": _int(usage.get("cache_write_tokens")),
+            "hermes.response.content_length": _int(kwargs.get("assistant_content_chars")),
+            "hermes.response.tool_call_count": _int(kwargs.get("assistant_tool_call_count")),
+            "hermes.error.type": _safe_label(
+                (kwargs.get("error") or {}).get("type") if isinstance(kwargs.get("error"), dict) else None,
+                "unknown" if error else "",
+            ),
+            "hermes.error.reason": _safe_label(kwargs.get("reason"), ""),
+            "hermes.error.status_code": _int(kwargs.get("status_code")),
+            "hermes.error.retryable": kwargs.get("retryable") if isinstance(kwargs.get("retryable"), bool) else None,
+        }
+        with self._lock:
+            self._end(self._requests.pop(request_id, None), attributes, error=error)
+
+    def start_tool(self, kwargs: dict[str, Any]) -> None:
+        call_id = _text(kwargs.get("tool_call_id"))
+        if not call_id:
+            return
+        with self._lock:
+            tool_name = _safe_label(kwargs.get("tool_name"))
+            attributes = _ids(kwargs)
+            attributes.update(
+                {
+                    "hermes.tool.name": tool_name,
+                    "hermes.tool.arg_count": len(kwargs.get("args") or {})
+                    if isinstance(kwargs.get("args"), dict)
+                    else 0,
+                }
+            )
+            parent = self._turn(_text(kwargs.get("turn_id"))) or self._session(
+                _text(kwargs.get("session_id"))
+            )
+            self._tools[call_id] = self._start(
+                f"hermes.tool.{tool_name}", attributes, parent=parent
+            )
+
+    def end_tool(self, kwargs: dict[str, Any]) -> None:
+        call_id = _text(kwargs.get("tool_call_id"))
+        status = _safe_label(kwargs.get("status"), "unknown")
+        attributes = {
+            "hermes.tool.status": status,
+            "hermes.tool.duration_ms": _duration_ms(kwargs, "duration_ms"),
+            "hermes.tool.result_length": len(_text(kwargs.get("result"))),
+            "hermes.tool.error_type": _safe_label(kwargs.get("error_type"), ""),
+        }
+        with self._lock:
+            self._end(self._tools.pop(call_id, None), attributes, error=status != "ok")
+
+    def start_subagent(self, kwargs: dict[str, Any]) -> None:
+        child_session_id = _text(kwargs.get("child_session_id"))
+        child_id = _text(kwargs.get("child_subagent_id")) or child_session_id
+        if not child_id:
+            return
+        with self._lock:
+            attributes = _ids(kwargs)
+            goal = _text(kwargs.get("child_goal"))
+            attributes.update(
+                {
+                    "hermes.subagent.role": _safe_label(kwargs.get("child_role"), "custom"),
+                    "hermes.subagent.goal_length": len(goal),
+                    "hermes.subagent.goal_id": _stable_digest(goal),
+                }
+            )
+            parent = self._turn(_text(kwargs.get("parent_turn_id"))) or self._session(
+                _text(kwargs.get("parent_session_id"))
+            )
+            self._subagents[child_id] = self._start(
+                "hermes.subagent", attributes, parent=parent
+            )
+
+    def end_subagent(self, kwargs: dict[str, Any]) -> None:
+        child_id = _text(kwargs.get("child_subagent_id")) or _text(kwargs.get("child_session_id"))
+        status = _safe_label(kwargs.get("child_status"), "unknown")
+        with self._lock:
+            self._end(
+                self._subagents.pop(child_id, None),
+                {
+                    "hermes.subagent.status": status,
+                    "hermes.subagent.duration_ms": _duration_ms(kwargs, "duration_ms"),
+                    "hermes.subagent.summary_length": len(_text(kwargs.get("child_summary"))),
+                },
+                error=status not in {"ok", "completed", "success"},
+            )
+
+    def start_approval(self, kwargs: dict[str, Any]) -> None:
+        key = _text(kwargs.get("session_key") or kwargs.get("session_id")) or "global"
+        with self._lock:
+            command = _text(kwargs.get("command"))
+            attributes = _ids(kwargs)
+            attributes.update(
+                {
+                    "hermes.approval.surface": _safe_label(kwargs.get("surface")),
+                    "hermes.approval.command_length": len(command),
+                    "hermes.approval.command_id": _stable_digest(command),
+                    "hermes.approval.description_length": len(_text(kwargs.get("description"))),
+                    "hermes.approval.pattern_count": len(kwargs.get("pattern_keys") or []),
+                }
+            )
+            parent = self._session(_text(kwargs.get("session_id") or kwargs.get("session_key")))
+            self._approvals[key].append(self._start("hermes.approval", attributes, parent=parent))
+
+    def end_approval(self, kwargs: dict[str, Any]) -> None:
+        key = _text(kwargs.get("session_key") or kwargs.get("session_id")) or "global"
+        choice = _safe_label(kwargs.get("choice"), "unknown")
+        with self._lock:
+            entries = self._approvals.get(key, [])
+            entry = entries.pop(0) if entries else None
+            if not entries:
+                self._approvals.pop(key, None)
+            self._end(
+                entry,
+                {"hermes.approval.decision": choice},
+                error=choice in {"deny", "timeout", "smart_deny"},
+            )

--- a/plugins/observability/otel/span_builder.py
+++ b/plugins/observability/otel/span_builder.py
@@ -77,6 +77,7 @@ def _ids(kwargs: dict[str, Any]) -> dict[str, str]:
 class _SpanEntry:
     span: Any
     started_ns: int
+    session_id: str = ""
 
 
 class SpanBuilder:
@@ -121,7 +122,11 @@ class SpanBuilder:
             attributes={key: value for key, value in attributes.items() if value is not None},
             start_time=start_ns,
         )
-        return _SpanEntry(span=span, started_ns=start_ns)
+        return _SpanEntry(
+            span=span,
+            started_ns=start_ns,
+            session_id=_text(attributes.get("hermes.session_id")),
+        )
 
     def _end(
         self,
@@ -167,13 +172,13 @@ class SpanBuilder:
     def mark_session_end(self, kwargs: dict[str, Any]) -> None:
         session_id = _text(kwargs.get("session_id"))
         with self._lock:
-            entry = self._sessions.get(session_id)
-            if entry is None:
-                return
+            entry = self._sessions.pop(session_id, None)
+            attributes: dict[str, Any] = {}
             for key in ("completed", "interrupted"):
                 value = kwargs.get(key)
                 if isinstance(value, bool):
-                    entry.span.set_attribute(f"hermes.session.{key}", value)
+                    attributes[f"hermes.session.{key}"] = value
+            self._end(entry, attributes, error=bool(kwargs.get("interrupted")))
 
     def finalize_session(self, kwargs: dict[str, Any]) -> None:
         session_id = _text(kwargs.get("session_id") or kwargs.get("old_session_id"))
@@ -183,7 +188,9 @@ class SpanBuilder:
 
     def _finish_session_children(self, session_id: str) -> None:
         for mapping in (self._turns, self._requests, self._tools, self._subagents):
-            stale = [key for key, entry in mapping.items() if entry.span.attributes.get("hermes.session_id") == session_id]
+            stale = [
+                key for key, entry in mapping.items() if entry.session_id == session_id
+            ]
             for key in stale:
                 self._end(mapping.pop(key, None), {"hermes.incomplete": True}, error=True)
 
@@ -195,6 +202,8 @@ class SpanBuilder:
             if turn_id in self._turns:
                 return
             session_id = _text(kwargs.get("session_id"))
+            if session_id not in self._sessions:
+                self.start_session(kwargs)
             attributes = _ids(kwargs)
             attributes.update(
                 {

--- a/plugins/observability/otel/tests/test_otel_plugin.py
+++ b/plugins/observability/otel/tests/test_otel_plugin.py
@@ -234,6 +234,8 @@ def test_subagent_and_approval_spans_use_safe_summaries(monkeypatch):
         child_role="researcher",
         child_goal="sensitive delegated goal",
     )
+    plugin.on_session_start(session_id="child", model="m", platform="subagent")
+    plugin.on_session_end(session_id="child", completed=True, interrupted=False)
     plugin.on_subagent_stop(
         parent_session_id="parent",
         parent_turn_id="turn",
@@ -274,6 +276,12 @@ def test_subagent_and_approval_spans_use_safe_summaries(monkeypatch):
     assert approval.attributes["hermes.approval.command_length"] > 0
     assert len(approval.attributes["hermes.approval.command_id"]) == 16
     assert subagent.parent.span_id == spans["hermes.turn"].context.span_id
+    child_session = next(
+        span
+        for span in runtime.exporter.get_finished_spans()
+        if span.name == "hermes.session" and span.attributes["hermes.session_id"] == "child"
+    )
+    assert child_session.parent.span_id == subagent.context.span_id
     serialized = repr([dict(subagent.attributes), dict(approval.attributes)])
     assert "sensitive delegated goal" not in serialized
     assert "sensitive child result" not in serialized

--- a/plugins/observability/otel/tests/test_otel_plugin.py
+++ b/plugins/observability/otel/tests/test_otel_plugin.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import importlib
 import sys
+from pathlib import Path
+
+import tomllib
 from types import SimpleNamespace
 
 import pytest
@@ -50,6 +53,19 @@ def _in_memory_runtime():
         tracer=provider.get_tracer("test.hermes.otel"),
         exporter=exporter,
     )
+
+
+def test_manifest_and_optional_extra():
+    repo_root = Path(__file__).resolve().parents[4]
+    manifest = (repo_root / "plugins/observability/otel/plugin.yaml").read_text()
+    project = tomllib.loads((repo_root / "pyproject.toml").read_text())
+
+    assert "name: otel" in manifest
+    assert all(f"  - {hook}" in manifest for hook in HOOKS)
+    assert project["project"]["optional-dependencies"]["otel"] == [
+        "opentelemetry-sdk==1.39.1",
+        "opentelemetry-exporter-otlp==1.39.1",
+    ]
 
 
 def test_registers_all_observer_hooks():

--- a/plugins/observability/otel/tests/test_otel_plugin.py
+++ b/plugins/observability/otel/tests/test_otel_plugin.py
@@ -1,0 +1,302 @@
+"""Tests for the bundled observability/otel plugin."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.observability.otel.config import load_config
+
+
+HOOKS = {
+    "on_session_start",
+    "on_session_end",
+    "on_session_finalize",
+    "on_session_reset",
+    "pre_llm_call",
+    "post_llm_call",
+    "pre_api_request",
+    "post_api_request",
+    "api_request_error",
+    "pre_tool_call",
+    "post_tool_call",
+    "subagent_start",
+    "subagent_stop",
+    "pre_approval_request",
+    "post_approval_response",
+}
+
+
+def _fresh_plugin():
+    sys.modules.pop("plugins.observability.otel", None)
+    return importlib.import_module("plugins.observability.otel")
+
+
+def _in_memory_runtime():
+    pytest.importorskip("opentelemetry.sdk")
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test-hermes"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return SimpleNamespace(
+        provider=provider,
+        tracer=provider.get_tracer("test.hermes.otel"),
+        exporter=exporter,
+    )
+
+
+def test_registers_all_observer_hooks():
+    plugin = _fresh_plugin()
+    registered = {}
+    ctx = SimpleNamespace(
+        register_hook=lambda name, callback: registered.setdefault(name, callback)
+    )
+
+    plugin.register(ctx)
+
+    assert set(registered) == HOOKS
+    assert all(callable(callback) for callback in registered.values())
+
+
+def test_config_defaults_disabled():
+    config = load_config({})
+
+    assert config.enabled is False
+    assert config.protocol == "http"
+    assert config.service_name == "hermes-agent"
+    assert config.endpoint == ""
+    assert config.headers == {}
+
+
+def test_config_parses_environment_values():
+    config = load_config(
+        {
+            "HERMES_OTEL_ENABLED": "1",
+            "HERMES_OTEL_ENDPOINT": "http://collector:4318/v1/traces",
+            "HERMES_OTEL_PROTOCOL": "grpc",
+            "HERMES_OTEL_SERVICE_NAME": "hermes-test",
+            "HERMES_OTEL_HEADERS": '{"authorization":"Bearer test","tenant":7}',
+        }
+    )
+
+    assert config.enabled is True
+    assert config.endpoint == "http://collector:4318/v1/traces"
+    assert config.protocol == "grpc"
+    assert config.service_name == "hermes-test"
+    assert config.headers == {"authorization": "Bearer test", "tenant": "7"}
+
+
+def test_config_invalid_values_fail_closed():
+    config = load_config(
+        {
+            "HERMES_OTEL_ENABLED": "maybe",
+            "HERMES_OTEL_PROTOCOL": "udp",
+            "HERMES_OTEL_HEADERS": "not-json",
+        }
+    )
+
+    assert config.enabled is False
+    assert config.protocol == "http"
+    assert config.headers == {}
+
+
+def test_hooks_create_correlated_privacy_safe_spans(monkeypatch):
+    runtime = _in_memory_runtime()
+    plugin = _fresh_plugin()
+    monkeypatch.setenv("HERMES_OTEL_ENABLED", "1")
+    monkeypatch.setattr(plugin, "create_runtime", lambda config: runtime)
+
+    base = {
+        "session_id": "session-1",
+        "task_id": "task-1",
+        "turn_id": "turn-1",
+        "telemetry_schema_version": "hermes.observer.v1",
+    }
+    plugin.on_session_start(**base, model="test-model", platform="cli")
+    plugin.on_pre_llm_call(
+        **base,
+        model="test-model",
+        platform="cli",
+        user_message="private user text",
+        conversation_history=[{"content": "private history"}],
+        is_first_turn=True,
+    )
+    plugin.on_pre_api_request(
+        **base,
+        api_request_id="api-1",
+        model="test-model",
+        provider="openai",
+        api_mode="chat_completions",
+        message_count=2,
+        tool_count=1,
+        approx_input_tokens=17,
+        request_char_count=420,
+        request={"body": {"messages": [{"content": "secret"}]}},
+    )
+    plugin.on_post_api_request(
+        **base,
+        api_request_id="api-1",
+        response_model="test-model-v2",
+        finish_reason="stop",
+        api_duration=0.25,
+        usage={"input_tokens": 20, "output_tokens": 5},
+        assistant_content_chars=12,
+        assistant_tool_call_count=0,
+        response={"body": {"content": "private response"}},
+    )
+    plugin.on_pre_tool_call(
+        **base,
+        tool_call_id="tool-1",
+        tool_name="read_file",
+        args={"path": "/secret/path"},
+    )
+    plugin.on_post_tool_call(
+        **base,
+        tool_call_id="tool-1",
+        tool_name="read_file",
+        args={"path": "/secret/path"},
+        result="private file contents",
+        duration_ms=15,
+        status="ok",
+    )
+    plugin.on_post_llm_call(
+        **base,
+        assistant_response="private final answer",
+        conversation_history=[{"content": "private history"}],
+    )
+    plugin.on_session_end(**base, completed=True, interrupted=False)
+
+    spans = {span.name: span for span in runtime.exporter.get_finished_spans()}
+    assert set(spans) >= {
+        "hermes.session",
+        "hermes.turn",
+        "hermes.llm_request",
+        "hermes.tool.read_file",
+    }
+    assert spans["hermes.turn"].parent.span_id == spans["hermes.session"].context.span_id
+    assert spans["hermes.llm_request"].parent.span_id == spans["hermes.turn"].context.span_id
+    assert spans["hermes.tool.read_file"].parent.span_id == spans["hermes.turn"].context.span_id
+    assert spans["hermes.llm_request"].attributes["gen_ai.request.model"] == "test-model"
+    assert spans["hermes.llm_request"].attributes["gen_ai.provider.name"] == "openai"
+    assert spans["hermes.llm_request"].attributes["gen_ai.usage.input_tokens"] == 20
+    assert spans["hermes.llm_request"].attributes["hermes.api.duration_ms"] == 250
+    assert spans["hermes.tool.read_file"].attributes["hermes.tool.status"] == "ok"
+
+    serialized_attributes = repr(
+        [dict(span.attributes) for span in runtime.exporter.get_finished_spans()]
+    )
+    for secret in (
+        "private user text",
+        "private history",
+        "private response",
+        "private file contents",
+        "/secret/path",
+    ):
+        assert secret not in serialized_attributes
+
+
+def test_subagent_and_approval_spans_use_safe_summaries(monkeypatch):
+    runtime = _in_memory_runtime()
+    plugin = _fresh_plugin()
+    monkeypatch.setenv("HERMES_OTEL_ENABLED", "1")
+    monkeypatch.setattr(plugin, "create_runtime", lambda config: runtime)
+
+    plugin.on_session_start(session_id="parent", model="m", platform="cli")
+    plugin.on_pre_llm_call(session_id="parent", turn_id="turn", user_message="x")
+    plugin.on_subagent_start(
+        parent_session_id="parent",
+        parent_turn_id="turn",
+        child_session_id="child",
+        child_subagent_id="sub-1",
+        child_role="researcher",
+        child_goal="sensitive delegated goal",
+    )
+    plugin.on_subagent_stop(
+        parent_session_id="parent",
+        parent_turn_id="turn",
+        child_session_id="child",
+        child_subagent_id="sub-1",
+        child_role="researcher",
+        child_status="completed",
+        child_summary="sensitive child result",
+        duration_ms=50,
+    )
+    plugin.on_pre_approval_request(
+        session_id="parent",
+        session_key="parent",
+        command="curl -H 'Authorization: secret' private.example",
+        description="sensitive command description",
+        pattern_keys=["network"],
+        surface="cli",
+    )
+    plugin.on_post_approval_response(
+        session_id="parent",
+        session_key="parent",
+        choice="deny",
+    )
+
+    spans = {span.name: span for span in runtime.exporter.get_finished_spans()}
+    subagent = spans["hermes.subagent"]
+    approval = spans["hermes.approval"]
+    assert subagent.attributes["hermes.subagent.role"] == "researcher"
+    assert subagent.attributes["hermes.subagent.goal_length"] == 24
+    assert len(subagent.attributes["hermes.subagent.goal_id"]) == 16
+    assert approval.attributes["hermes.approval.decision"] == "deny"
+    assert approval.attributes["hermes.approval.command_length"] > 0
+    assert len(approval.attributes["hermes.approval.command_id"]) == 16
+    assert subagent.parent.span_id == spans["hermes.turn"].context.span_id
+    serialized = repr([dict(subagent.attributes), dict(approval.attributes)])
+    assert "sensitive delegated goal" not in serialized
+    assert "sensitive child result" not in serialized
+    assert "Authorization: secret" not in serialized
+
+
+def test_finalize_shuts_down_provider(monkeypatch):
+    plugin = _fresh_plugin()
+    calls = []
+    runtime = SimpleNamespace(
+        tracer=SimpleNamespace(),
+        provider=SimpleNamespace(shutdown=lambda: calls.append("shutdown")),
+    )
+    builder = SimpleNamespace(finalize_session=lambda kwargs: calls.append(kwargs["session_id"]))
+    monkeypatch.setattr(plugin, "_RUNTIME", runtime)
+    monkeypatch.setattr(plugin, "_BUILDER", builder)
+
+    plugin.on_session_finalize(session_id="session-1")
+
+    assert calls == ["session-1", "shutdown"]
+    assert plugin._RUNTIME is None
+    assert plugin._BUILDER is None
+
+
+def test_hook_errors_fail_open(monkeypatch):
+    plugin = _fresh_plugin()
+    monkeypatch.setattr(
+        plugin,
+        "_get_builder",
+        lambda: SimpleNamespace(start_tool=lambda kwargs: (_ for _ in ()).throw(RuntimeError("boom"))),
+    )
+
+    plugin.on_pre_tool_call(tool_call_id="tool-1", tool_name="shell")
+
+
+def test_initialization_errors_fail_open(monkeypatch):
+    plugin = _fresh_plugin()
+    monkeypatch.setenv("HERMES_OTEL_ENABLED", "1")
+    monkeypatch.setattr(
+        plugin,
+        "create_runtime",
+        lambda config: (_ for _ in ()).throw(RuntimeError("missing SDK")),
+    )
+
+    plugin.on_session_start(session_id="session-1")
+    plugin.on_session_start(session_id="session-1")
+
+    assert plugin._RUNTIME is plugin._INIT_FAILED

--- a/plugins/observability/otel/tests/test_otel_plugin.py
+++ b/plugins/observability/otel/tests/test_otel_plugin.py
@@ -241,6 +241,12 @@ def test_subagent_and_approval_spans_use_safe_summaries(monkeypatch):
         session_key="parent",
         choice="deny",
     )
+    plugin.on_post_llm_call(
+        session_id="parent",
+        turn_id="turn",
+        assistant_response="done",
+    )
+    plugin.on_session_end(session_id="parent", completed=True, interrupted=False)
 
     spans = {span.name: span for span in runtime.exporter.get_finished_spans()}
     subagent = spans["hermes.subagent"]

--- a/plugins/observability/otel/tests/test_otel_plugin.py
+++ b/plugins/observability/otel/tests/test_otel_plugin.py
@@ -11,7 +11,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from plugins.observability.otel.config import load_config
+from plugins.observability.otel.config import OTelConfig, load_config
+from plugins.observability.otel.exporter import _create_otlp_exporter
 
 
 HOOKS = {
@@ -271,10 +272,10 @@ def test_subagent_and_approval_spans_use_safe_summaries(monkeypatch):
     approval = spans["hermes.approval"]
     assert subagent.attributes["hermes.subagent.role"] == "researcher"
     assert subagent.attributes["hermes.subagent.goal_length"] == 24
-    assert len(subagent.attributes["hermes.subagent.goal_id"]) == 16
+    assert subagent.attributes["hermes.subagent.goal_summary"] == "length:24"
     assert approval.attributes["hermes.approval.decision"] == "deny"
     assert approval.attributes["hermes.approval.command_length"] > 0
-    assert len(approval.attributes["hermes.approval.command_id"]) == 16
+    assert approval.attributes["hermes.approval.command_summary"].startswith("length:")
     assert subagent.parent.span_id == spans["hermes.turn"].context.span_id
     child_session = next(
         span
@@ -295,7 +296,9 @@ def test_finalize_shuts_down_provider(monkeypatch):
         tracer=SimpleNamespace(),
         provider=SimpleNamespace(shutdown=lambda: calls.append("shutdown")),
     )
-    builder = SimpleNamespace(finalize_session=lambda kwargs: calls.append(kwargs["session_id"]))
+    builder = SimpleNamespace(
+        finalize_session=lambda kwargs: (calls.append(kwargs["session_id"]), 0)[1]
+    )
     monkeypatch.setattr(plugin, "_RUNTIME", runtime)
     monkeypatch.setattr(plugin, "_BUILDER", builder)
 
@@ -304,6 +307,57 @@ def test_finalize_shuts_down_provider(monkeypatch):
     assert calls == ["session-1", "shutdown"]
     assert plugin._RUNTIME is None
     assert plugin._BUILDER is None
+
+
+def test_finalize_keeps_provider_for_other_sessions(monkeypatch):
+    plugin = _fresh_plugin()
+    calls = []
+    runtime = SimpleNamespace(
+        tracer=SimpleNamespace(),
+        provider=SimpleNamespace(shutdown=lambda: calls.append("shutdown")),
+    )
+    builder = SimpleNamespace(finalize_session=lambda kwargs: 1)
+    monkeypatch.setattr(plugin, "_RUNTIME", runtime)
+    monkeypatch.setattr(plugin, "_BUILDER", builder)
+
+    plugin.on_session_finalize(session_id="session-1")
+
+    assert calls == []
+    assert plugin._RUNTIME is runtime
+    assert plugin._BUILDER is builder
+
+
+def test_otlp_exporter_selects_protocol_and_forwards_config(monkeypatch):
+    calls = []
+
+    class FakeExporter:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+        SimpleNamespace(OTLPSpanExporter=FakeExporter),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+        SimpleNamespace(OTLPSpanExporter=FakeExporter),
+    )
+
+    http = _create_otlp_exporter(
+        OTelConfig(enabled=True, endpoint="http://collector/v1/traces", headers={"x": "y"})
+    )
+    grpc = _create_otlp_exporter(
+        OTelConfig(enabled=True, endpoint="http://collector:4317", protocol="grpc")
+    )
+
+    assert isinstance(http, FakeExporter)
+    assert isinstance(grpc, FakeExporter)
+    assert calls == [
+        {"endpoint": "http://collector/v1/traces", "headers": {"x": "y"}},
+        {"endpoint": "http://collector:4317"},
+    ]
 
 
 def test_hook_errors_fail_open(monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ vision = []
 # a vulnerable pre-1.0.1 transitive. Bump in lockstep with uv.lock.
 mcp = ["mcp==1.26.0", "starlette==1.0.1"]  # starlette: CVE-2026-48710
 nemo-relay = ["nemo-relay>=0.5,<1.0"]
+otel = ["opentelemetry-sdk==1.39.1", "opentelemetry-exporter-otlp==1.39.1"]
 homeassistant = ["aiohttp==3.14.1"]
 sms = ["aiohttp==3.14.1"]
 teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525

--- a/uv.lock
+++ b/uv.lock
@@ -1665,6 +1665,10 @@ modal = [
 nemo-relay = [
     { name = "nemo-relay" },
 ]
+otel = [
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+]
 parallel-web = [
     { name = "parallel-web" },
 ]
@@ -1807,6 +1811,8 @@ requires-dist = [
     { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = ">=0.5,<1.0" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "openai", specifier = "==2.24.0" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = "==1.39.1" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = "==1.39.1" },
     { name = "packaging", specifier = "==26.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
@@ -1853,7 +1859,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "otel", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2808,6 +2814,19 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/9c/3ab1db90f32da200dba332658f2bbe602369e3d19f6aba394031a42635be/opentelemetry_exporter_otlp-1.39.1.tar.gz", hash = "sha256:7cf7470e9fd0060c8a38a23e4f695ac686c06a48ad97f8d4867bc9b420180b9c", size = 6147, upload-time = "2025-12-11T13:32:40.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/6c/bdc82a066e6fb1dcf9e8cc8d4e026358fe0f8690700cc6369a6bf9bd17a7/opentelemetry_exporter_otlp-1.39.1-py3-none-any.whl", hash = "sha256:68ae69775291f04f000eb4b698ff16ff685fdebe5cb52871bc4e87938a7b00fe", size = 7019, upload-time = "2025-12-11T13:32:19.387Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2817,6 +2836,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- add bundled `observability/otel` observer plugin with HTTP/gRPC OTLP export
- emit correlated session, turn, LLM request, tool, subagent, and approval spans
- keep exporter initialization and every hook fail-open; flush the provider on final session finalization
- add the exact-pinned `otel` optional extra and synchronized `uv.lock`
- document collector setup, environment variables, span model, and privacy guarantees

## Privacy

The exporter never attaches raw user messages, conversation history, API payloads, tool arguments/results, command text, goals, summaries, error messages, API keys, or OTLP headers to spans. It emits stable correlation IDs, safe model/provider/status labels, counts, lengths, durations, and token usage only.

## Validation

- `uv run --locked --extra dev --extra otel pytest -q plugins/observability/otel/tests/test_otel_plugin.py tests/plugins/test_langfuse_plugin.py tests/plugins/test_nemo_relay_plugin.py tests/hermes_cli/test_plugins.py tests/test_project_metadata.py tests/test_packaging_metadata.py` — **253 passed**
- `uv run ruff check plugins/observability/otel` — **passed**
- `git diff --check` — **passed**

## OODA log

1. **Observe:** read the observer contract and Langfuse/NeMo Relay implementations; confirmed lifecycle payloads and packaging policy.
2. **Orient:** mapped correlation IDs to an isolated OTel provider and privacy-safe span attributes; retained disabled-by-default/fail-open behavior.
3. **Decide:** implemented and committed in small phases, then added lifecycle, child-session, privacy, and concurrent-session invariants as tests exposed or review identified them.
4. **Act:** ran focused, metadata, packaging, and broader plugin-manager suites; pushed from a fork after upstream write access was denied.

## Commits

- `a108ebd58` feat(observability): add OpenTelemetry span runtime
- `02483ff47` feat(observability): register OpenTelemetry observer hooks
- `1390d9f4d` test(observability): cover OpenTelemetry trajectories
- `b27f27c59` fix(observability): close OpenTelemetry session spans
- `34a7ee69d` docs(observability): document OpenTelemetry OTLP export
- `f418f925f` fix(observability): link child OpenTelemetry sessions
- `a69f693f2` fix(observability): harden OpenTelemetry lifecycle privacy
