### PR TITLE
fix(desktop): resolve fflate import in Windows workspace and harden RDP GPU fallback

### DIFF
--- a/apps/desktop/electron/bootstrap-platform.test.ts
+++ b/apps/desktop/electron/bootstrap-platform.test.ts
@@ -6,7 +6,8 @@ import {
   bundledRuntimeImportCheck,
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
-  isWslEnvironment
+  isWslEnvironment,
+  remoteDisplayGpuSwitches
 } from './bootstrap-platform'
 
 test('isWslEnvironment detects WSL2 env vars on linux', () => {
@@ -67,6 +68,28 @@ test('detectRemoteDisplay flags forwarded X11 displays but not local ones', () =
 
 test('detectRemoteDisplay flags RDP sessions', () => {
   assert.match(String(detectRemoteDisplay({ env: { SESSIONNAME: 'RDP-Tcp#7' }, platform: 'win32' })), /^rdp/)
+})
+
+test('remoteDisplayGpuSwitches adds only non-sandbox hardening for Windows RDP', () => {
+  const reason = detectRemoteDisplay({ env: { SESSIONNAME: 'RDP-Tcp#7' }, platform: 'win32' })
+  const switches = remoteDisplayGpuSwitches(reason)
+
+  assert.deepEqual(switches, ['disable-gpu', 'disable-gpu-compositing', 'in-process-gpu'])
+  assert.equal(switches.some(switchName => switchName.includes('sandbox')), false)
+})
+
+test('remoteDisplayGpuSwitches keeps SSH and X11 on the existing fallback', () => {
+  const sshReason = detectRemoteDisplay({
+    env: { SSH_CONNECTION: '1.2.3.4 5 6.7.8.9 22' },
+    platform: 'linux'
+  })
+  const x11Reason = detectRemoteDisplay({
+    env: { DISPLAY: 'localhost:10.0' },
+    platform: 'linux'
+  })
+
+  assert.deepEqual(remoteDisplayGpuSwitches(sshReason), ['disable-gpu-compositing'])
+  assert.deepEqual(remoteDisplayGpuSwitches(x11Reason), ['disable-gpu-compositing'])
 })
 
 test('detectRemoteDisplay honors the HERMES_DESKTOP_DISABLE_GPU override both ways', () => {

--- a/apps/desktop/electron/bootstrap-platform.ts
+++ b/apps/desktop/electron/bootstrap-platform.ts
@@ -107,4 +107,22 @@ function detectRemoteDisplay(options: { env?: NodeJS.ProcessEnv; platform?: Node
   return null
 }
 
-export { bundledRuntimeImportCheck, detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment }
+function remoteDisplayGpuSwitches(reason: string | null) {
+  if (!reason) {
+    return []
+  }
+
+  if (reason.startsWith('rdp ')) {
+    return ['disable-gpu', 'disable-gpu-compositing', 'in-process-gpu']
+  }
+
+  return ['disable-gpu-compositing']
+}
+
+export {
+  bundledRuntimeImportCheck,
+  detectRemoteDisplay,
+  isWindowsBinaryPathInWsl,
+  isWslEnvironment,
+  remoteDisplayGpuSwitches
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -46,7 +46,12 @@ import {
 } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
-import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
+import {
+  detectRemoteDisplay,
+  isWindowsBinaryPathInWsl,
+  isWslEnvironment,
+  remoteDisplayGpuSwitches
+} from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
@@ -289,9 +294,11 @@ const REMOTE_DISPLAY_REASON = detectRemoteDisplay()
 
 if (REMOTE_DISPLAY_REASON) {
   app.disableHardwareAcceleration()
-  // Belt-and-suspenders for X11/VNC, where the Viz compositor can still glitch
-  // with only --disable-gpu: force compositing onto the CPU too.
-  app.commandLine.appendSwitch('disable-gpu-compositing')
+  // Keep the existing software-compositing fallback for every remote display,
+  // but apply the additional process switches only to Windows RDP.
+  for (const gpuSwitch of remoteDisplayGpuSwitches(REMOTE_DISPLAY_REASON)) {
+    app.commandLine.appendSwitch(gpuSwitch)
+  }
   console.log(
     `[hermes] remote display detected (${REMOTE_DISPLAY_REASON}); disabling GPU hardware acceleration to prevent flicker`
   )

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -150,7 +150,8 @@ export default defineConfig(({ command }) => ({
       react: path.resolve(__dirname, '../../node_modules/react'),
       'react-dom': path.resolve(__dirname, '../../node_modules/react-dom'),
       'react/jsx-dev-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-dev-runtime.js'),
-      'react/jsx-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-runtime.js')
+      'react/jsx-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-runtime.js'),
+      fflate: path.resolve(__dirname, '../../node_modules/fflate')
     },
     dedupe: ['react', 'react-dom']
   },


### PR DESCRIPTION
Fixes two Windows desktop issues:

1. **Vite build failure on Windows**: Rolldown fails to resolve the workspace-hoisted `fflate` dependency from `apps/desktop`. Add an explicit alias to the root `node_modules` copy.
2. **Renderer crash under Windows RDP**: Keep the existing software-compositing fallback for remote displays, and add `--disable-gpu` plus `--in-process-gpu` only when `detectRemoteDisplay()` reports Windows RDP.

The RDP hardening does not automatically disable Chromium's renderer sandbox or GPU sandbox. SSH sessions, Linux X11 forwarding, local GPU acceleration, and non-Windows local sessions retain their existing behavior.

Unit coverage distinguishes Windows RDP from SSH and X11 forwarding.