### PR TITLE
fix(agent): stale verification after terminal mutations

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -62,20 +62,23 @@ _PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch"})
 
 # Patterns that indicate a terminal command may modify/delete files.
 _DESTRUCTIVE_PATTERNS = re.compile(
-    r"""(?:^|\s|&&|\|\||;|`)(?:
-        rm\s|rmdir\s|
+    r"""(?:^|[\s;&|(`'"])(?:
+        rm\s|rmdir\s|unlink\s|
         cp\s|install\s|
-        mv\s|
-        sed\s+-i|
+        mv\s|touch\s|mkdir\s|mktemp\s|ln\s|
+        chmod\s|chown\s|
+        sed\s+(?:[^;&|]*\s)?-i|
+        perl\s+(?:[^;&|]*\s)?-pi|
         truncate\s|
         dd\s|
         shred\s|
-        git\s+(?:reset|clean|checkout)\s
+        tee(?:\s|$)|patch(?:\s|$)|
+        git\s+(?:apply|reset|clean|checkout|restore|revert|merge|rebase|cherry-pick|stash|switch)(?:\s|$)
     )""",
     re.VERBOSE,
 )
-# Output redirects that overwrite files (> but not >>)
-_REDIRECT_OVERWRITE = re.compile(r'[^>]>[^>]|^>[^>]')
+# File redirects, excluding descriptor duplication such as ``2>&1``.
+_REDIRECT_OVERWRITE = re.compile(r"(?<!>)>{1,2}(?![>&])\s*\S")
 
 
 def _is_destructive_command(cmd: str) -> bool:

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -38,3 +38,23 @@ def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
     if tool_name == "patch":
         return data.get("success") is True
     return False
+
+
+def terminal_workspace_mutation_paths(result: Any) -> tuple[str, ...]:
+    """Return workspace paths reported by a mutating terminal call."""
+    if not isinstance(result, str):
+        return ()
+    try:
+        data = json.loads(result.strip())
+    except Exception:
+        return ()
+    if not isinstance(data, dict) or data.get("error"):
+        return ()
+    mutation = data.get("workspace_mutation")
+    if not isinstance(mutation, dict):
+        return ()
+    paths = mutation.get("paths")
+    if isinstance(paths, list):
+        return tuple(dict.fromkeys(str(path) for path in paths if path))
+    cwd = mutation.get("cwd")
+    return (str(cwd),) if cwd else ()

--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -28,7 +28,48 @@ _MAX_EVENTS_PER_SESSION_ROOT = 100
 _MAX_TOTAL_UNREFERENCED_EVENTS = 10_000
 _AD_HOC_SCRIPT_NAME_PREFIXES = ("hermes-verify-", "hermes-ad-hoc-")
 _VERIFY_SCHEMA_VERSION = 1
-_SHELL_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||;)\s*")
+_READ_ONLY_COMMANDS = frozenset({
+    ".",
+    "cat",
+    "cd",
+    "command",
+    "cut",
+    "diff",
+    "dirname",
+    "echo",
+    "env",
+    "false",
+    "fd",
+    "find",
+    "git",
+    "grep",
+    "head",
+    "jq",
+    "ls",
+    "pwd",
+    "readlink",
+    "rg",
+    "sleep",
+    "sort",
+    "source",
+    "stat",
+    "tail",
+    "test",
+    "true",
+    "type",
+    "uniq",
+    "wc",
+    "which",
+})
+_READ_ONLY_GIT_SUBCOMMANDS = frozenset({
+    "diff",
+    "grep",
+    "log",
+    "ls-files",
+    "rev-parse",
+    "show",
+    "status",
+})
 
 
 @dataclass(frozen=True)
@@ -124,7 +165,72 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
 
 def _split_segment_tokens(command: str) -> list[list[str]]:
     segments: list[list[str]] = []
-    for segment in _SHELL_SPLIT_RE.split(command.strip()):
+    raw_segments: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    escaped = False
+    idx = 0
+
+    def flush() -> None:
+        segment = "".join(buf).strip()
+        if segment:
+            raw_segments.append(segment)
+        buf.clear()
+
+    while idx < len(command):
+        char = command[idx]
+        if quote:
+            buf.append(char)
+            if quote == "'":
+                if char == quote:
+                    quote = None
+                idx += 1
+                continue
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            idx += 1
+            continue
+        if escaped:
+            buf.append(char)
+            escaped = False
+            idx += 1
+            continue
+        if char == "\\":
+            buf.append(char)
+            escaped = True
+            idx += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            buf.append(char)
+            idx += 1
+            continue
+        if command.startswith(("&&", "||"), idx):
+            flush()
+            idx += 2
+            continue
+        if char in {";", "|", "\n"}:
+            flush()
+            idx += 1
+            continue
+        if char == "&":
+            is_fd_redirect = (
+                (idx > 0 and command[idx - 1] in {">", "<"})
+                or (idx + 1 < len(command) and command[idx + 1] == ">")
+            )
+            if not is_fd_redirect:
+                flush()
+                idx += 1
+                continue
+        buf.append(char)
+        idx += 1
+    flush()
+
+    for segment in raw_segments:
         if not segment:
             continue
         try:
@@ -133,6 +239,8 @@ def _split_segment_tokens(command: str) -> list[list[str]]:
             continue
         if tokens:
             segments.append(tokens)
+    if any(operator in command for operator in ("$(", "`", "<(", ">(")):
+        segments.append(["__dynamic_shell_expansion__"])
     return segments
 
 
@@ -167,7 +275,7 @@ def _strip_command_prefix(tokens: list[str]) -> list[str]:
         remaining = remaining[1:]
     while remaining and "=" in remaining[0] and not remaining[0].startswith("-"):
         remaining = remaining[1:]
-    while remaining and remaining[0] in {"command", "time", "noglob"}:
+    while remaining and remaining[0] in {"builtin", "command", "time", "noglob"}:
         remaining = remaining[1:]
     return remaining
 
@@ -435,7 +543,16 @@ def record_terminal_result(
     exit_code: int,
     output: str = "",
 ) -> Optional[dict[str, Any]]:
-    """Record a foreground terminal result when it is verification evidence."""
+    """Record verification, or stale it after a recognized workspace mutation."""
+
+    if terminal_result_mutates_workspace(
+        command=command,
+        cwd=cwd,
+        session_id=session_id,
+        exit_code=exit_code,
+    ):
+        mark_workspace_edited(session_id=session_id, cwd=cwd)
+        return None
 
     evidence = classify_verification_command(
         command,
@@ -490,6 +607,142 @@ def record_terminal_result(
             conn.commit()
 
     return {"id": event_id, **evidence.__dict__, "created_at": created_at}
+
+
+def _segment_matches_verification(
+    tokens: list[str], evidence: VerificationEvidence | None
+) -> bool:
+    if evidence is None:
+        return False
+    if evidence.kind == "ad_hoc":
+        return _ad_hoc_script_args(tokens, evidence.root) is not None
+    candidate_tokens = _strip_command_prefix(tokens)
+    canonical = _canonical_tokens(evidence.canonical_command)
+    return any(
+        candidate_tokens[:len(candidate)] == candidate
+        for candidate in _equivalent_needles(canonical)
+    )
+
+
+def _segment_is_read_only(tokens: list[str]) -> bool:
+    candidate = _strip_command_prefix(tokens)
+    if not candidate:
+        return True
+    command = Path(candidate[0]).name
+    if command not in _READ_ONLY_COMMANDS:
+        return False
+    if command == "git":
+        return (
+            len(candidate) > 1
+            and candidate[1] in _READ_ONLY_GIT_SUBCOMMANDS
+            and not any(token.startswith("--output") for token in candidate[2:])
+        )
+    if command in {".", "source"}:
+        if len(candidate) != 2:
+            return False
+        path = candidate[1].replace("\\", "/")
+        return path.endswith("/bin/activate") or path.endswith("/activate.fish")
+    if command in {"fd", "find"}:
+        mutating_flags = {
+            "-delete",
+            "-exec",
+            "-execdir",
+            "-ok",
+            "-okdir",
+            "-x",
+            "-X",
+            "--exec",
+            "--exec-batch",
+        }
+        return not any(
+            token in mutating_flags
+            or token.startswith("--exec=")
+            or token.startswith("--exec-batch=")
+            for token in candidate[1:]
+        )
+    if command == "sort":
+        return not any(
+            token.startswith("-o") or token.startswith("--output")
+            for token in candidate[1:]
+        )
+    return True
+
+
+def terminal_mutation_workspaces(
+    *,
+    command: str,
+    cwd: str | Path | None,
+    final_cwd: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Conservative workspace candidates for a mutating shell command."""
+    current = Path(cwd or ".").expanduser().resolve()
+    candidates = [str(current)]
+    for tokens in _split_segment_tokens(command):
+        segment = _strip_command_prefix(tokens)
+        if not segment:
+            continue
+        if Path(segment[0]).name not in {"cd", "pushd"}:
+            continue
+        args = [token for token in segment[1:] if token != "--"]
+        if not args or args[0] == "-" or any(char in args[0] for char in "$`"):
+            continue
+        destination = Path(args[0]).expanduser()
+        current = (
+            destination.resolve()
+            if destination.is_absolute()
+            else (current / destination).resolve()
+        )
+        candidates.append(str(current))
+    if final_cwd:
+        candidates.append(str(Path(final_cwd).expanduser().resolve()))
+    return tuple(dict.fromkeys(candidates))
+
+
+def terminal_result_mutates_workspace(
+    *,
+    command: str,
+    cwd: str | Path | None = None,
+    session_id: str | None = None,
+    exit_code: int | None,
+) -> bool:
+    """Conservatively detect a terminal command that may have changed files.
+
+    A shell's aggregate exit code cannot reveal whether an earlier command in a
+    compound expression already wrote files. Unknown commands are therefore
+    treated as potential mutators; only canonical verification commands and a
+    small read-only allowlist preserve prior evidence.
+    """
+    segments = _split_segment_tokens(command)
+    if not segments:
+        return False
+
+    evidence = classify_verification_command(
+        command,
+        cwd=cwd,
+        session_id=session_id,
+        exit_code=0,
+    )
+    try:
+        from agent.tool_dispatch_helpers import _is_destructive_command
+
+        explicit_mutation = _is_destructive_command(command)
+    except Exception:
+        explicit_mutation = False
+
+    unknown_segment = any(
+        not _segment_matches_verification(tokens, evidence)
+        and not _segment_is_read_only(tokens)
+        for tokens in segments
+    )
+    if not explicit_mutation and not unknown_segment:
+        return False
+    if len(segments) > 1 or exit_code is None:
+        return True
+    if explicit_mutation:
+        return int(exit_code) == 0
+    if unknown_segment:
+        return True
+    return False
 
 
 def mark_workspace_edited(

--- a/run_agent.py
+++ b/run_agent.py
@@ -196,6 +196,7 @@ from agent.tool_guardrails import (
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
     file_mutation_result_landed,
+    terminal_workspace_mutation_paths,
 )
 from agent.trajectory import (
     convert_scratchpad_to_think,
@@ -2962,10 +2963,16 @@ class AIAgent:
         state dict hasn't been initialised yet (e.g. a tool dispatched
         outside ``run_conversation``).
         """
-        if tool_name not in _FILE_MUTATING_TOOLS:
-            return
         state = getattr(self, "_turn_failed_file_mutations", None)
         if state is None:
+            return
+        if tool_name == "terminal":
+            paths = terminal_workspace_mutation_paths(result)
+            changed = getattr(self, "_turn_file_mutation_paths", None)
+            if changed is not None:
+                changed.update(paths)
+            return
+        if tool_name not in _FILE_MUTATING_TOOLS:
             return
         targets = _extract_file_mutation_targets(tool_name, args)
         if not targets:

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -4,6 +4,8 @@ import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 from agent.verification_evidence import (
     classify_verification_command,
     mark_workspace_edited,
@@ -88,6 +90,215 @@ def test_records_passed_then_marks_stale_after_edit(tmp_path, monkeypatch):
     status = verification_status(session_id="s1", cwd=tmp_path)
     assert status["status"] == "stale"
     assert status["changed_paths"] == [str(tmp_path / "src" / "app.ts")]
+
+
+def test_successful_mutating_terminal_command_stales_prior_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    event = record_terminal_result(
+        command="cp src/app.ts src/app.backup.ts",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+    )
+
+    assert event is None
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "stale"
+
+
+def test_failed_mutating_terminal_command_preserves_prior_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    record_terminal_result(
+        command="cp missing.ts src/app.ts",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=1,
+        output="cp: missing.ts: No such file",
+    )
+
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "passed"
+
+
+def test_mutating_compound_command_cannot_record_fresh_verification(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    event = record_terminal_result(
+        command="pnpm test && cp src/app.ts src/app.backup.ts",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    assert event is None
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "stale"
+
+
+def test_partially_successful_mutating_compound_stales_prior_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    record_terminal_result(
+        command="cp src/app.ts src/app.backup.ts && false",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=1,
+    )
+
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "stale"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "touch generated.ts",
+        "mkdir generated",
+        "printf data >> generated.txt",
+        "printf data | tee generated.txt",
+        "git restore src/app.ts",
+        "find generated -delete",
+        "sort input.txt -o output.txt",
+        "sort -osorted.txt input.txt",
+        "sed -n '1w output.txt' input.txt",
+        "python scripts/generate.py",
+        "source ./mutate.sh",
+        "scripts/run_tests.sh | python scripts/generate.py",
+        "pnpm test && echo $(python scripts/generate.py)",
+        "scripts/run_tests.sh < <(python scripts/generate.py)",
+        "scripts/run_tests.sh 'arg\\'; python scripts/generate.py",
+    ],
+)
+def test_common_terminal_mutations_stale_prior_evidence(
+    tmp_path,
+    monkeypatch,
+    command,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    record_terminal_result(
+        command=command,
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+    )
+
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "stale"
+
+
+def test_mutate_then_verify_compound_requires_separate_verification(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    event = record_terminal_result(
+        command="touch generated.ts && pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    assert event is None
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "stale"
+
+
+def test_stderr_redirection_does_not_look_like_a_file_mutation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+
+    event = record_terminal_result(
+        command="pnpm test 2>&1",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    assert event is not None
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "passed"
+
+
+def test_virtualenv_activation_can_prefix_verification(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+
+    event = record_terminal_result(
+        command="source .venv/bin/activate && pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    assert event is not None
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "passed"
+
+
+def test_read_only_terminal_command_preserves_prior_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    record_terminal_result(
+        command="git status --short",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+    )
+
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "passed"
 
 
 def test_lint_and_typecheck_are_not_reported_as_full_tests(tmp_path, monkeypatch):

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -183,6 +183,32 @@ def test_no_nudge_after_fresh_pass(tmp_path, monkeypatch):
     assert build_verify_on_stop_nudge(session_id="s1", changed_paths=[changed]) is None
 
 
+def test_nudge_after_successful_terminal_mutation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+    record_terminal_result(
+        command="cp src/app.ts src/app.backup.ts",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+    )
+
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[str(tmp_path)],
+    )
+
+    assert nudge is not None
+    assert "fresh passing verification evidence" in nudge
+
+
 def test_nudge_checks_all_edited_workspaces(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     project_a = tmp_path / "a"

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -141,6 +141,38 @@ class TestRecordFileMutationResult:
         )
         assert agent._turn_failed_file_mutations == {}
 
+    def test_terminal_workspace_mutation_records_paths_for_verify_on_stop(self):
+        agent = _bare_agent()
+
+        agent._record_file_mutation_result(
+            "terminal",
+            {"command": "cp src/app.py src/app.backup.py"},
+            json.dumps({
+                "workspace_mutation": {
+                    "paths": ["/tmp/project", "/tmp/sibling"],
+                }
+            }),
+            is_error=False,
+        )
+
+        assert agent._turn_file_mutation_paths == {"/tmp/project", "/tmp/sibling"}
+
+    def test_failed_terminal_result_keeps_conservative_mutation_paths(self):
+        agent = _bare_agent()
+
+        agent._record_file_mutation_result(
+            "terminal",
+            {"command": "cp src/app.py src/app.backup.py && false"},
+            json.dumps({
+                "exit_code": 1,
+                "error": None,
+                "workspace_mutation": {"paths": ["/tmp/project"]},
+            }),
+            is_error=True,
+        )
+
+        assert agent._turn_file_mutation_paths == {"/tmp/project"}
+
     def test_failure_recorded(self):
         agent = _bare_agent()
         result = json.dumps({"success": False, "error": "Could not find old_string"})

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -3,12 +3,20 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 import hermes_cli.plugins as plugins_mod
 import tools.terminal_tool as terminal_tool_module
+from agent.verification_evidence import record_terminal_result, verification_status
 from tools.environments.local import LocalEnvironment
 
 
 _UNSET = object()
+
+
+@pytest.fixture(autouse=True)
+def _clean_terminal_session_cwd(monkeypatch):
+    monkeypatch.setattr(terminal_tool_module, "_session_cwd", {})
 
 
 def _make_env_config(tmp_path, **overrides):
@@ -36,9 +44,13 @@ def _run_terminal(
     invoke_hook=_UNSET,
     approval=None,
     command="echo hello",
+    env_cwd=None,
+    session_id=None,
 ):
     mock_env = MagicMock()
     mock_env.execute.return_value = {"output": output, "returncode": returncode}
+    if env_cwd is not None:
+        mock_env.cwd = env_cwd
 
     monkeypatch.setattr(
         terminal_tool_module, "_get_env_config", lambda: _make_env_config(tmp_path)
@@ -55,7 +67,12 @@ def _run_terminal(
     if invoke_hook is not _UNSET:
         monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
 
-    result = json.loads(terminal_tool_module.terminal_tool(command=command))
+    result = json.loads(
+        terminal_tool_module.terminal_tool(
+            command=command,
+            session_id=session_id,
+        )
+    )
     return result, mock_env
 
 
@@ -98,6 +115,120 @@ def test_terminal_output_uses_first_valid_string_from_hooks(monkeypatch, tmp_pat
     )
 
     assert result["output"] == "first"
+
+
+def test_successful_mutating_command_reports_workspace_cwd(monkeypatch, tmp_path):
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="",
+        command="cp src/app.py src/app.backup.py",
+    )
+
+    assert result["workspace_mutation"] == {"paths": [str(tmp_path)]}
+
+
+def test_failed_mutating_command_does_not_report_workspace_cwd(monkeypatch, tmp_path):
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="missing",
+        returncode=1,
+        command="cp missing.py src/app.py",
+    )
+
+    assert "workspace_mutation" not in result
+
+
+def test_mutating_command_reports_terminal_final_cwd(monkeypatch, tmp_path):
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="",
+        command="cd sibling && cp source.py output.py",
+        env_cwd=str(sibling),
+    )
+
+    assert result["workspace_mutation"] == {
+        "paths": [str(tmp_path), str(sibling)],
+    }
+
+
+def test_mutating_compound_stales_start_and_final_workspaces(monkeypatch, tmp_path):
+    start = tmp_path / "start"
+    final = tmp_path / "final"
+    start.mkdir()
+    final.mkdir()
+    for project in (start, final):
+        project.joinpath("package.json").write_text(
+            '{"scripts":{"test":"vitest"}}',
+            encoding="utf-8",
+        )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    for project in (start, final):
+        record_terminal_result(
+            command="npm test",
+            cwd=project,
+            session_id="conversation",
+            exit_code=0,
+            output="green",
+        )
+
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        start,
+        output="",
+        command="cp source.py output.py && cd ../final",
+        env_cwd=str(final),
+        session_id="conversation",
+    )
+
+    assert result["workspace_mutation"] == {
+        "paths": [str(start), str(final)],
+    }
+    assert verification_status(
+        session_id="conversation",
+        cwd=start,
+    )["status"] == "stale"
+    assert verification_status(
+        session_id="conversation",
+        cwd=final,
+    )["status"] == "stale"
+
+
+def test_verification_followed_by_cd_records_command_cwd(monkeypatch, tmp_path):
+    start = tmp_path / "start"
+    final = tmp_path / "final"
+    start.mkdir()
+    final.mkdir()
+    for project in (start, final):
+        project.joinpath("package.json").write_text(
+            '{"scripts":{"test":"vitest"}}',
+            encoding="utf-8",
+        )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        start,
+        output="green",
+        command="npm test && cd ../final",
+        env_cwd=str(final),
+        session_id="conversation",
+    )
+
+    assert result["verification_evidence"]["status"] == "passed"
+    assert verification_status(
+        session_id="conversation",
+        cwd=start,
+    )["status"] == "passed"
+    assert verification_status(
+        session_id="conversation",
+        cwd=final,
+    )["status"] == "unverified"
 
 
 def test_terminal_output_transform_still_truncates_long_replacement(monkeypatch, tmp_path):

--- a/tests/tools/test_terminal_tool_pty_fallback.py
+++ b/tests/tools/test_terminal_tool_pty_fallback.py
@@ -1,8 +1,16 @@
 import json
 from types import SimpleNamespace
 
+import pytest
+
 import tools.terminal_tool as terminal_tool_module
 from tools import process_registry as process_registry_module
+from agent.verification_evidence import record_terminal_result, verification_status
+
+
+@pytest.fixture(autouse=True)
+def _clean_terminal_session_cwd(monkeypatch):
+    monkeypatch.setattr(terminal_tool_module, "_session_cwd", {})
 
 
 def _base_config(tmp_path):
@@ -89,3 +97,66 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
 
     assert captured["use_pty"] is True
     assert "pty_note" not in result
+
+
+def test_terminal_background_mutation_stales_prior_evidence(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(env={})
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    for project in (tmp_path, sibling):
+        project.joinpath("package.json").write_text(
+            '{"scripts":{"test":"vitest"}}',
+            encoding="utf-8",
+        )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    for project in (tmp_path, sibling):
+        record_terminal_result(
+            command="npm test",
+            cwd=project,
+            session_id="conversation",
+            exit_code=0,
+            output="green",
+        )
+
+    def fake_spawn_local(**_kwargs):
+        return SimpleNamespace(id="proc_test", pid=1234, notify_on_complete=False)
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(
+        process_registry_module.process_registry,
+        "spawn_local",
+        fake_spawn_local,
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="cd sibling && cp source.txt output.txt",
+                background=True,
+                session_id="conversation",
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert result["workspace_mutation"] == {
+        "paths": [str(tmp_path), str(sibling)],
+    }
+    assert verification_status(
+        session_id="conversation",
+        cwd=tmp_path,
+    )["status"] == "stale"
+    assert verification_status(
+        session_id="conversation",
+        cwd=sibling,
+    )["status"] == "stale"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2490,6 +2490,39 @@ def terminal_tool(
                     "exit_code": 0,
                     "error": None,
                 }
+                try:
+                    from agent.verification_evidence import (
+                        mark_workspace_edited,
+                        terminal_mutation_workspaces,
+                        terminal_result_mutates_workspace,
+                    )
+
+                    evidence_session_id = (
+                        session_id or task_id or effective_task_id or "default"
+                    )
+                    if terminal_result_mutates_workspace(
+                        command=command,
+                        cwd=effective_cwd,
+                        session_id=evidence_session_id,
+                        exit_code=None,
+                    ):
+                        mutation_paths = terminal_mutation_workspaces(
+                            command=command,
+                            cwd=effective_cwd,
+                        )
+                        result_data["workspace_mutation"] = {
+                            "paths": list(mutation_paths)
+                        }
+                        for mutation_path in mutation_paths:
+                            mark_workspace_edited(
+                                session_id=evidence_session_id,
+                                cwd=mutation_path,
+                            )
+                except Exception:
+                    logger.debug(
+                        "background mutation recording failed",
+                        exc_info=True,
+                    )
                 # Background spawns detached and returns exit_code 0 immediately;
                 # it never inline-polls is_interrupted(), so the stale-bit kill
                 # cannot occur here and this note never co-occurs with rc=130.
@@ -2854,16 +2887,52 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
+            env_cwd = getattr(env, "cwd", None)
+            result_cwd = (
+                env_cwd
+                if isinstance(env_cwd, (str, Path)) and str(env_cwd)
+                else command_cwd
+            )
             try:
-                from agent.verification_evidence import record_terminal_result
+                from agent.verification_evidence import (
+                    mark_workspace_edited,
+                    record_terminal_result,
+                    terminal_mutation_workspaces,
+                    terminal_result_mutates_workspace,
+                )
 
-                evidence = record_terminal_result(
+                evidence_session_id = (
+                    session_id or task_id or effective_task_id or "default"
+                )
+                mutation_paths = terminal_mutation_workspaces(
                     command=command,
                     cwd=command_cwd,
-                    session_id=session_id or task_id or effective_task_id or "default",
-                    exit_code=returncode,
-                    output=output,
+                    final_cwd=result_cwd,
                 )
+                mutates_workspace = terminal_result_mutates_workspace(
+                    command=command,
+                    cwd=result_cwd,
+                    session_id=evidence_session_id,
+                    exit_code=returncode,
+                )
+                if mutates_workspace:
+                    result_dict["workspace_mutation"] = {
+                        "paths": list(mutation_paths)
+                    }
+                    for mutation_path in mutation_paths:
+                        mark_workspace_edited(
+                            session_id=evidence_session_id,
+                            cwd=mutation_path,
+                        )
+                    evidence = None
+                else:
+                    evidence = record_terminal_result(
+                        command=command,
+                        cwd=command_cwd,
+                        session_id=evidence_session_id,
+                        exit_code=returncode,
+                        output=output,
+                    )
                 if evidence:
                     result_dict["verification_evidence"] = {
                         "status": evidence.get("status"),


### PR DESCRIPTION
## What changed

- stale verification evidence after successful terminal mutations, including common file commands, redirects, generators, compound commands, and background launches
- treat partial compound execution conservatively: aggregate failure cannot prove that an earlier mutating segment did not land
- prevent a verification segment from hiding a later mutator in pipelines, substitutions, or shell chains
- propagate all known launch, literal `cd`/`pushd`, and final workspace paths through the terminal result so both executor paths feed verify-on-stop
- keep non-mutating verification evidence anchored to the command's starting cwd, even when the shell ends in another directory
- keep canonical verification commands and a narrow argument-aware read-only allowlist fresh

## Why

The ledger only observed `write_file` and `patch`. A passing test followed by `cp`, `touch`, `mkdir`, a generator, or a background mutation could leave evidence marked `passed`; verify-on-stop also had no changed path to inspect. Compound exit status made this worse because an earlier mutation can succeed even when the final command fails.

Mutate-and-verify shell chains intentionally remain stale and require a separate verification call. This avoids claiming fresh evidence without pretending to fully interpret shell execution.

This is orthogonal to #62736, which expands recognition of verification commands; this PR invalidates already-recorded evidence after terminal-side mutations.

## Tests

- expanded verification/dispatch/terminal suites: `198 passed, 1 deselected`
- Ruff
- `git diff --check`

The deselected absolute-write case is rejected by the macOS sensitive-path guard and reproduces unchanged on clean upstream `main`.