### PR TITLE
fix(desktop): accumulate MoA reference reasoning blocks instead of replacing

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -350,7 +350,25 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           const cnt = typeof payload?.count === 'number' ? payload.count : undefined
           const header = idx && cnt ? `◇ Reference ${idx}/${cnt} — ${label}` : `◇ Reference — ${label}`
           const body = coerceThinkingText(payload?.text)
-          appendReasoningDelta(sessionId, `${header}\n${body}\n\n`, true)
+          const text = `${header}\n${body}\n\n`
+          if (idx === undefined || idx <= 1) {
+            // First reference: clear any stale reasoning left over from
+            // before this turn's references start, same as before.
+            appendReasoningDelta(sessionId, text, true)
+          } else {
+            // Later references must accumulate, not replace — otherwise
+            // each new reference wipes out the ones already shown (#64658).
+            // Queue-then-flush (rather than the streamed/batched queue path)
+            // applies it immediately, since each reference arrives as one
+            // complete block rather than incremental tokens. reasoning.delta
+            // cannot be mid-flight here: MoAChatCompletions.reference_callback
+            // (agent/moa_loop.py) fires "moa.reference" once per reference's
+            // already-complete text, with no concurrent token stream for the
+            // reference-gathering phase, so there is no in-flight delta to
+            // collide with in the shared queue bucket.
+            appendReasoningDelta(sessionId, text, false)
+            flushQueuedDeltas(sessionId)
+          }
         }
 
         if (isActiveEvent) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/moa-reference-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/moa-reference-event.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let latestState: ClientSessionState | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      latestState = next
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+}
+
+function reasoningText(): string {
+  const message = latestState?.messages.at(-1)
+  const part = message?.parts.find(p => p.type === 'reasoning')
+
+  return part?.type === 'reasoning' ? part.text : ''
+}
+
+describe('useMessageStream moa.reference accumulation (#64658)', () => {
+  beforeEach(() => {
+    handleEvent = null
+    latestState = null
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps every reference model labelled block instead of only the latest one', async () => {
+    await mountStream()
+
+    emit('moa.reference', { count: 2, index: 1, label: 'model-a', text: 'advice-a' })
+    emit('moa.reference', { count: 2, index: 2, label: 'model-b', text: 'advice-b' })
+
+    const text = reasoningText()
+
+    expect(text).toContain('model-a')
+    expect(text).toContain('advice-a')
+    expect(text).toContain('model-b')
+    expect(text).toContain('advice-b')
+  })
+
+  it('handles a single-reference MoA turn (count=1) without regression', async () => {
+    await mountStream()
+
+    emit('moa.reference', { count: 1, index: 1, label: 'model-a', text: 'only-advice' })
+
+    const text = reasoningText()
+
+    expect(text).toContain('model-a')
+    expect(text).toContain('only-advice')
+  })
+
+  it('accumulates three or more references in order', async () => {
+    await mountStream()
+
+    emit('moa.reference', { count: 3, index: 1, label: 'model-a', text: 'advice-a' })
+    emit('moa.reference', { count: 3, index: 2, label: 'model-b', text: 'advice-b' })
+    emit('moa.reference', { count: 3, index: 3, label: 'model-c', text: 'advice-c' })
+
+    const text = reasoningText()
+    const orderOk =
+      text.indexOf('advice-a') < text.indexOf('advice-b') && text.indexOf('advice-b') < text.indexOf('advice-c')
+
+    expect(text).toContain('advice-a')
+    expect(text).toContain('advice-b')
+    expect(text).toContain('advice-c')
+    expect(orderOk).toBe(true)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop shows Mixture-of-Agents (MoA) reference-model output as labelled reasoning blocks
in the "Thinking" disclosure, one per reference model, before the aggregator's final answer
(behavior introduced in #53855). Every `moa.reference` gateway event, however, called
`appendReasoningDelta(sessionId, text, true)` — `replace=true` — which wipes **all** existing
`reasoning`-type message parts and replaces them with exactly one new part. With two or more
reference models, each later `moa.reference` event erased the reasoning block built by the
earlier one(s), so only the last reference's output ever stayed visible instead of accumulating
one labelled block per reference.

The fix keeps `replace=true` only for the first reference (`index <= 1`, or missing — this
preserves the original intent of clearing any stale reasoning left over from before this turn's
references start) and switches every later reference to the existing "queue then flush
immediately" path instead, so it *appends* onto the already-shown blocks rather than replacing
them. Each reference arrives as one complete text block (not incremental tokens), so applying it
via an immediate flush rather than the streamed/batched queue is correct and matches how a
sibling event elsewhere in this file already applies non-streamed content immediately.

I verified the "in-flight reasoning.delta could interleave with the reference-accumulation flush"
concern raised in review by reading `agent/moa_loop.py`: `MoAChatCompletions.reference_callback`
fires `"moa.reference"` once per reference's **already-complete** text — there is no concurrent
token stream during the reference-gathering phase for the accumulation path to collide with.

### How it works

```mermaid
flowchart TD
    A["moa.reference event (index, count, label, text)"] --> B{"index <= 1?"}
    B -->|"yes (first reference)"| C["appendReasoningDelta(replace=true)\nclears stale reasoning, seeds one fresh block\n(unchanged from before)"]
    B -->|"no (later reference)"| D["appendReasoningDelta(replace=false) queues the block,\nthen flushQueuedDeltas() applies it immediately\n→ appends after the prior reference block(s)"]
    C --> E["◇ Reference 1/2 — model-a\nadvice-a"]
    D --> F["◇ Reference 1/2 — model-a\nadvice-a\n\n◇ Reference 2/2 — model-b\nadvice-b"]
```

## Related Issue

Fixes #64658

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts`: `moa.reference` handler now branches on `index`: `<= 1` (or missing) keeps the original `replace=true` call; every later reference calls `appendReasoningDelta(..., false)` followed immediately by `flushQueuedDeltas(sessionId)` so it accumulates instead of replacing.
- `apps/desktop/src/app/session/hooks/use-message-stream/moa-reference-event.test.tsx`: new test file (following the existing `compaction-event.test.tsx` pattern of rendering the real `useMessageStream` hook and driving `handleGatewayEvent` directly) — covers 2-reference accumulation (the reported repro), a single-reference (count=1) turn for regression safety, and 3+ references landing in order.

## Step-by-step

1. Traced `appendReasoningDelta`'s `replace=true` branch (`use-message-stream/index.ts`) to confirm it filters out every existing `reasoning`-type part before seeding one new part — the exact mechanism the issue describes.
2. Wrote a test reproducing the reported repro (two sequential `moa.reference` events); confirmed it fails against the pre-fix code (only the second reference's text survives).
3. Changed the handler to only replace on the first reference, accumulate on every later one via the already-available `flushQueuedDeltas` dependency (no new API surface needed).
4. Verified the queue-then-flush approach applies synchronously and deterministically (no `await` between `appendReasoningDelta(..., false)` and `flushQueuedDeltas`, so there's no window for the scheduled rAF/setTimeout flush to double-apply).
5. Investigated (via an adversarial review pass) whether an in-flight `reasoning.delta` could land in the same shared per-session queue bucket as a `moa.reference` accumulation flush, producing unseparated/garbled text — confirmed via `agent/moa_loop.py` that the reference-gathering phase has no concurrent token stream, so this isn't reachable.

## Acceptance Criteria

- [x] Given two or more MoA reference-model events in one turn, when each arrives, then every reference's labelled block remains visible afterward (none are wiped by a later one).
- [x] Given a single-reference (count=1) MoA turn, when the reference arrives, then it still renders correctly (no regression for the common case that motivated the original `replace=true`).
- [x] Adjacent behavior unchanged: `reasoning.delta` (streaming) and `reasoning.available` (full-replace) call sites and their existing tests are untouched and still pass.
- [x] Test suite passes locally with the new tests included.

## How to Test

1. On `main`, configure an MoA preset with 2+ reference models, run `/moa <prompt>`, and watch the Thinking disclosure after the second `moa.reference` event lands — only the latest reference's block is visible.
2. Check out this branch.
3. Same flow — every reference's labelled block accumulates in order.

## Tests Performed

| Check | Command | Result |
|---|---|---|
| New MoA reference test file | `npx vitest run src/app/session/hooks/use-message-stream/moa-reference-event.test.tsx` (from `apps/desktop`) | ✅ `3 passed` |
| Full use-message-stream suite | `npx vitest run src/app/session/hooks/use-message-stream/` (from `apps/desktop`) | ✅ `5 test files, 19 passed` |
| Prettier | `npx prettier --check` on both changed files | ✅ new test file clean; the touched section of `gateway-event.ts` matches Prettier's output (two unrelated pre-existing lines elsewhere in the file are not Prettier-clean on `main` already and were intentionally left untouched to keep this diff scoped) |
| TypeScript | `npx tsc --noEmit -p tsconfig.json`, filtered to touched files | ✅ no errors |
| Fail-before/pass-after | New tests run against pre-fix code | ❌ 2 of 3 fail (`expected '...model-b...' to contain 'model-a'`); all 3 pass after the fix |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updated — N/A (internal event-handling detail, no user-facing docs describe it)
- [x] `cli-config.yaml.example` updated if config keys changed — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` updated if architecture/workflow changed — N/A
- [x] Cross-platform impact considered (Windows, macOS) — Desktop UI logic, platform-agnostic; no OS-specific code touched
- [x] Tool descriptions/schemas updated if tool behavior changed — N/A

## Screenshots / Logs

```
$ npx vitest run src/app/session/hooks/use-message-stream/
 Test Files  5 passed (5)
      Tests  19 passed (19)
```
