### PR TITLE
Fix standalone TUI cwd and shell cancellation

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5308,6 +5308,112 @@ def test_interrupt_clears_multiple_own_pending():
             server._answers.pop(key, None)
 
 
+def test_interrupt_terminates_active_shell_exec_for_session(monkeypatch, tmp_path):
+    """Ctrl+C must stop a ``!command`` process tree, not only repaint the TUI."""
+    started = threading.Event()
+    terminated = threading.Event()
+    response = {}
+
+    class _BlockingProc:
+        pid = 424242
+        returncode = None
+
+        def communicate(self, timeout=None):
+            started.set()
+            assert terminated.wait(timeout=2), "shell.exec was not terminated"
+            self.returncode = -15
+            return ("SHOULD_NOT_PRINT\n", "")
+
+        def poll(self):
+            return self.returncode
+
+    proc = _BlockingProc()
+    popen_call = {}
+    session = _session(
+        agent=types.SimpleNamespace(interrupt=lambda: None),
+        cwd=str(tmp_path),
+    )
+    server._sessions["sid-shell"] = session
+
+    try:
+        def _popen(*args, **kwargs):
+            popen_call.update(kwargs)
+            return proc
+
+        monkeypatch.setattr(server.subprocess, "Popen", _popen)
+        monkeypatch.setattr(
+            server,
+            "_terminate_shell_process_tree",
+            lambda active: terminated.set(),
+        )
+
+        worker = threading.Thread(
+            target=lambda: response.update(
+                server._methods["shell.exec"](
+                    "shell-rid",
+                    {"command": "sleep 30; echo SHOULD_NOT_PRINT", "session_id": "sid-shell"},
+                )
+            )
+        )
+        worker.start()
+        assert started.wait(timeout=2), "shell.exec did not start"
+
+        interrupted = server._methods["session.interrupt"](
+            "interrupt-rid", {"session_id": "sid-shell"}
+        )
+        worker.join(timeout=2)
+
+        assert interrupted["result"]["status"] == "interrupted"
+        assert terminated.is_set()
+        assert not worker.is_alive()
+        assert response["result"] == {
+            "stdout": "",
+            "stderr": "",
+            "code": 130,
+            "interrupted": True,
+        }
+        assert popen_call["cwd"] == str(tmp_path)
+        if os.name != "nt":
+            assert popen_call["start_new_session"] is True
+    finally:
+        server._sessions.pop("sid-shell", None)
+        server._active_shell_execs.pop("sid-shell", None)
+
+
+def test_close_session_terminates_active_shell_exec(monkeypatch):
+    """Closing a TUI session must not leave its foreground command alive."""
+    proc = types.SimpleNamespace(poll=lambda: None)
+    interrupted = threading.Event()
+    terminated = []
+    server._sessions["sid-close-shell"] = _session()
+    try:
+        assert server._register_shell_exec(
+            "sid-close-shell", "exec-token", proc, interrupted
+        )
+        monkeypatch.setattr(
+            server, "_terminate_shell_process_tree", lambda active: terminated.append(active)
+        )
+
+        assert server._close_session_by_id("sid-close-shell") is True
+
+        assert interrupted.is_set()
+        assert terminated == [proc]
+    finally:
+        server._sessions.pop("sid-close-shell", None)
+        server._active_shell_execs.pop("sid-close-shell", None)
+
+
+def test_shell_exec_registration_fails_closed_after_session_close():
+    """A command spawned during teardown cannot register against a dead session."""
+    proc = types.SimpleNamespace(poll=lambda: None)
+    interrupted = threading.Event()
+
+    assert not server._register_shell_exec(
+        "missing-shell-session", "exec-token", proc, interrupted
+    )
+    assert "missing-shell-session" not in server._active_shell_execs
+
+
 def test_run_prompt_submit_registers_turn_thread_for_interrupt(monkeypatch):
     """_run_prompt_submit must expose the actual turn thread to session.interrupt.
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import signal
 import subprocess
 import sys
 import threading
@@ -136,6 +137,10 @@ _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
+_shell_exec_lock = threading.Lock()
+_active_shell_execs: dict[
+    str, dict[str, tuple[subprocess.Popen, threading.Event]]
+] = {}
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
@@ -739,6 +744,12 @@ def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
         session = _sessions.pop(sid, None)
     if session is None:
         return False
+    # A foreground ``!command`` is owned by the TUI session just like an
+    # in-flight model turn.  Pop first so a concurrent shell.exec registration
+    # observes the closed session and terminates itself; then stop every command
+    # that registered before the pop.  This ordering closes the spawn/close
+    # race without holding the session lock while waiting on a process tree.
+    _interrupt_shell_execs(sid)
     # The session is already out of _sessions here, so downstream teardown
     # (e.g. _finalize_session's per-session async-delegation interrupt) can't
     # recover its live id by scanning the dict — stamp it on the record.
@@ -834,6 +845,9 @@ def _shutdown_sessions() -> None:
         sids = list(_sessions)
     for sid in sids:
         _close_session_by_id(sid, end_reason="tui_shutdown")
+    # Defense in depth for any registered command whose owning session was
+    # concurrently removed by another teardown path.
+    _interrupt_all_shell_execs()
 
 
 # Last-resort net for any disconnect path that slips past the WS finally. TTL is
@@ -8167,6 +8181,7 @@ def _(rid, params: dict) -> dict:
     with session["history_lock"]:
         session["_turn_cancel_requested"] = True
         session["queued_prompt"] = None
+    _interrupt_shell_execs(params.get("session_id", ""))
     if not run_thread_alive:
         with session["history_lock"]:
             if session.get("running"):
@@ -14459,6 +14474,106 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5026, str(e))
 
 
+def _terminate_shell_process_tree(proc: subprocess.Popen) -> None:
+    """Stop a ``shell.exec`` wrapper and every descendant it launched."""
+    if proc.poll() is not None:
+        return
+
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                stdin=subprocess.DEVNULL,
+            )
+            return
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            return
+
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, OSError):
+        return
+
+    # ``shell.exec`` always starts a fresh session below. Refuse a group signal
+    # if that invariant is ever broken so cancellation cannot hit the gateway.
+    if pgid == os.getpgrp():
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        return
+
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        return
+
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(pgid, 0)
+        except (ProcessLookupError, PermissionError, OSError):
+            return
+        time.sleep(0.05)
+
+    try:
+        os.killpg(pgid, getattr(signal, "SIGKILL", signal.SIGTERM))
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
+def _register_shell_exec(
+    session_id: str, token: str, proc: subprocess.Popen, interrupted: threading.Event
+) -> bool:
+    if not session_id:
+        return True
+    # Serialize the ownership check with _close_session_by_id's pop.  If the
+    # session was already closed, the caller must terminate the just-spawned
+    # process instead of creating an orphan that no later interrupt can find.
+    with _sessions_lock:
+        if session_id not in _sessions:
+            return False
+        with _shell_exec_lock:
+            _active_shell_execs.setdefault(session_id, {})[token] = (proc, interrupted)
+    return True
+
+
+def _unregister_shell_exec(session_id: str, token: str) -> None:
+    if not session_id:
+        return
+    with _shell_exec_lock:
+        active = _active_shell_execs.get(session_id)
+        if active is None:
+            return
+        active.pop(token, None)
+        if not active:
+            _active_shell_execs.pop(session_id, None)
+
+
+def _interrupt_shell_execs(session_id: str) -> int:
+    if not session_id:
+        return 0
+    with _shell_exec_lock:
+        active = list(_active_shell_execs.get(session_id, {}).values())
+    for proc, interrupted in active:
+        interrupted.set()
+        _terminate_shell_process_tree(proc)
+    return len(active)
+
+
+def _interrupt_all_shell_execs() -> int:
+    with _shell_exec_lock:
+        session_ids = list(_active_shell_execs)
+    return sum(_interrupt_shell_execs(session_id) for session_id in session_ids)
+
+
 @method("shell.exec")
 def _(rid, params: dict) -> dict:
     cmd = params.get("command", "")
@@ -14479,20 +14594,60 @@ def _(rid, params: dict) -> dict:
             )
     except ImportError:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
-    try:
-        r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
-            stdin=subprocess.DEVNULL,
+
+    session_id = str(params.get("session_id") or "").strip()
+    session = _sessions.get(session_id)
+    cwd = _session_cwd(session) if session is not None else os.getcwd()
+    interrupted = threading.Event()
+    token = uuid.uuid4().hex
+    popen_kwargs: dict[str, Any] = {}
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
         )
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            **popen_kwargs,
+        )
+        if not _register_shell_exec(session_id, token, proc, interrupted):
+            interrupted.set()
+            _terminate_shell_process_tree(proc)
+        stdout, stderr = proc.communicate(timeout=30)
+        if interrupted.is_set():
+            return _ok(
+                rid,
+                {"stdout": "", "stderr": "", "code": 130, "interrupted": True},
+            )
         return _ok(
             rid,
             {
-                "stdout": r.stdout[-4000:],
-                "stderr": r.stderr[-2000:],
-                "code": r.returncode,
+                "stdout": stdout[-4000:],
+                "stderr": stderr[-2000:],
+                "code": proc.returncode,
             },
         )
     except subprocess.TimeoutExpired:
+        if proc is not None:
+            _terminate_shell_process_tree(proc)
+            try:
+                proc.communicate(timeout=1)
+            except Exception:
+                pass
         return _err(rid, 5002, "command timed out (30s)")
     except Exception as e:
+        if proc is not None and proc.poll() is None:
+            _terminate_shell_process_tree(proc)
         return _err(rid, 5003, str(e))
+    finally:
+        _unregister_shell_exec(session_id, token)

--- a/ui-tui/src/__tests__/shellExecCancellation.test.ts
+++ b/ui-tui/src/__tests__/shellExecCancellation.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildShellExecParams, shellExecResultLines } from '../app/useSubmission.js'
+
+describe('TUI shell command cancellation', () => {
+  it('binds shell.exec to the live session so Ctrl+C can terminate it', () => {
+    expect(buildShellExecParams('sleep 30', 'sid-123')).toEqual({
+      command: 'sleep 30',
+      session_id: 'sid-123'
+    })
+  })
+
+  it('suppresses output from a command completed by interruption', () => {
+    expect(
+      shellExecResultLines({
+        code: 130,
+        interrupted: true,
+        stderr: '',
+        stdout: 'SHOULD_NOT_PRINT\n'
+      })
+    ).toEqual([])
+  })
+})

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -10,9 +10,28 @@ import { patchUiState, resetUiState } from '../app/uiStore.js'
 import {
   hydrateLiveSessionInflight,
   liveSessionInflightMessages,
+  resolveStandaloneSessionCwd,
   scheduleResumeScrollToBottom,
   writeActiveSessionFile
 } from '../app/useSessionLifecycle.js'
+
+describe('standalone session cwd', () => {
+  it('uses the launch directory for standalone TUI sessions', () => {
+    expect(resolveStandaloneSessionCwd({ HERMES_CWD: '/tmp/hermes-project' }, '/fallback')).toBe(
+      '/tmp/hermes-project'
+    )
+    expect(resolveStandaloneSessionCwd({}, '/fallback')).toBe('/fallback')
+  })
+
+  it('leaves attached dashboard sessions under gateway profile resolution', () => {
+    expect(
+      resolveStandaloneSessionCwd(
+        { HERMES_CWD: '/tmp/stale-launch', HERMES_TUI_GATEWAY_URL: 'ws://127.0.0.1:8642/ws' },
+        '/fallback'
+      )
+    ).toBeUndefined()
+  })
+})
 
 describe('writeActiveSessionFile', () => {
   let dir = ''

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -28,6 +28,17 @@ import { getUiState, patchUiState } from './uiStore.js'
 
 const usageFrom = (info: null | SessionInfo): Usage => (info?.usage ? { ...ZERO, ...info.usage } : ZERO)
 
+export const resolveStandaloneSessionCwd = (
+  env: Record<string, string | undefined> = process.env,
+  processCwd = process.cwd()
+): string | undefined => {
+  if (env.HERMES_TUI_GATEWAY_URL?.trim()) {
+    return undefined
+  }
+
+  return env.HERMES_CWD?.trim() || processCwd
+}
+
 const statusFromLiveSession = (status?: string, running = false) => {
   if (status === 'waiting') {
     return 'waiting for input…'
@@ -206,7 +217,12 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         await closeSession(getUiState().sid)
       }
 
-      const r = await rpc<SessionCreateResponse>('session.create', { cols: colsRef.current })
+      const cwd = resolveStandaloneSessionCwd()
+
+      const r = await rpc<SessionCreateResponse>('session.create', {
+        cols: colsRef.current,
+        ...(cwd ? { cwd } : {})
+      })
 
       if (!r) {
         patchUiState({ status: 'ready' })

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -16,6 +16,21 @@ import { getUiState, patchUiState } from './uiStore.js'
 
 const DOUBLE_ENTER_MS = 450
 
+export const buildShellExecParams = (command: string, sessionId?: string | null) => ({
+  command,
+  ...(sessionId ? { session_id: sessionId } : {})
+})
+
+export const shellExecResultLines = (result: ShellExecResponse): string[] => {
+  if (result.interrupted) {
+    return []
+  }
+
+  const out = [result.stdout, result.stderr].filter(Boolean).join('\n').trim()
+
+  return [...(out ? [out] : []), ...(result.code !== 0 || !out ? [`exit ${result.code}`] : [])]
+}
+
 const expandSnips = (snips: PasteSnippet[]) => {
   const byLabel = new Map<string, string[]>()
 
@@ -100,7 +115,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
       appendMessage({ role: 'user', text: `!${cmd}` })
       patchUiState({ busy: true, status: 'running…' })
 
-      gw.request<ShellExecResponse>('shell.exec', { command: cmd })
+      gw.request<ShellExecResponse>('shell.exec', buildShellExecParams(cmd, getUiState().sid))
         .then(raw => {
           const r = asRpcResult<ShellExecResponse>(raw)
 
@@ -108,14 +123,8 @@ export function useSubmission(opts: UseSubmissionOptions) {
             return sys('error: invalid response: shell.exec')
           }
 
-          const out = [r.stdout, r.stderr].filter(Boolean).join('\n').trim()
-
-          if (out) {
-            sys(out)
-          }
-
-          if (r.code !== 0 || !out) {
-            sys(`exit ${r.code}`)
+          for (const line of shellExecResultLines(r)) {
+            sys(line)
           }
         })
         .catch((e: Error) => sys(`error: ${e.message}`))
@@ -132,15 +141,30 @@ export function useSubmission(opts: UseSubmissionOptions) {
       Promise.all(
         matches.map(m =>
           gw
-            .request<ShellExecResponse>('shell.exec', { command: m[1]! })
+            .request<ShellExecResponse>('shell.exec', buildShellExecParams(m[1]!, getUiState().sid))
             .then(raw => {
               const r = asRpcResult<ShellExecResponse>(raw)
 
-              return [r?.stdout, r?.stderr].filter(Boolean).join('\n').trim()
+              return {
+                interrupted: Boolean(r?.interrupted),
+                text: [r?.stdout, r?.stderr].filter(Boolean).join('\n').trim()
+              }
             })
-            .catch(() => '(error)')
+            .catch(() => ({ interrupted: false, text: '(error)' }))
         )
-      ).then(results => then(spliceMatches(text, matches, results)))
+      ).then(results => {
+        if (results.some(result => result.interrupted)) {
+          return
+        }
+
+        then(
+          spliceMatches(
+            text,
+            matches,
+            results.map(result => result.text)
+          )
+        )
+      })
     },
     [gw]
   )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -402,6 +402,7 @@ export interface SecretRespondResponse {
 
 export interface ShellExecResponse {
   code: number
+  interrupted?: boolean
   stderr?: string
   stdout?: string
 }


### PR DESCRIPTION
## What changed

- propagate the actual launch directory into standalone TUI session creation while leaving dashboard-attached sessions under gateway profile resolution
- bind foreground `!command` execution to the live session
- start shell commands in an isolated process group and terminate the full tree on interrupt, session close, timeout, or gateway shutdown
- suppress stale command output after an interrupt and prevent interrupted interpolation from resuming a prompt
- add Python and TypeScript regression coverage for cwd propagation, Ctrl+C, teardown, and the spawn/close race

## Root cause

The standalone Node TUI created sessions with only terminal columns, so the Python gateway fell back to the configured profile cwd instead of the directory from which the TUI was launched. Separately, `shell.exec` used a blocking `subprocess.run` with no session ownership or process-group handle, while `session.interrupt` only reached model turns. The UI therefore displayed `interrupted` even though the command and its children remained alive.

## Validation

- `./scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 325 passed
- `npm test -- --run` in `ui-tui` — 1,127 passed, 1 skipped
- `npm run typecheck` in `ui-tui` — passed
- real standalone TUI on Linux: launch cwd matched the sandbox; Ctrl+C removed the wrapper and child process; the forbidden marker was absent; the same session accepted a follow-up command
