### PR TITLE
feat(time-awareness): inject time-context annotation on user gap turns

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1389,7 +1389,19 @@ def init_agent(
                 agent._memory_store.load_from_disk()
         except Exception:
             pass  # Memory is optional -- don't break agent init
-    
+
+    # Time-awareness config (context.time_awareness) — opt-in, default off.
+    # Read before the memory-provider block since it's lightweight and
+    # unrelated to the memory subsystem.
+    try:
+        _context_cfg = _agent_cfg.get("context", {})
+        _ta_cfg = _context_cfg.get("time_awareness", {}) if isinstance(_context_cfg, dict) else {}
+        agent._time_awareness_enabled = bool(_ta_cfg.get("enabled", False)) if isinstance(_ta_cfg, dict) else False
+        _ta_threshold = _ta_cfg.get("threshold_minutes", 120) if isinstance(_ta_cfg, dict) else 120
+        agent._time_awareness_threshold = max(1.0, float(_ta_threshold)) * 60.0  # minutes → seconds
+    except Exception:
+        agent._time_awareness_enabled = False
+        agent._time_awareness_threshold = 7200.0  # 120 min default
 
 
     # Memory provider plugin (external — one at a time, alongside built-in)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -672,6 +672,12 @@ def init_agent(
     # notifications to show progress.
     agent._last_activity_ts: float = time.time()
     agent._last_activity_desc: str = "initializing"
+    # User-turn timestamp — tracks when the most recent user turn started.
+    # Separate from _last_activity_ts (heartbeat/activity tracking) because
+    # the gateway resets _last_activity_ts before each turn, which would
+    # destroy the gap signal used by the time-skip awareness feature.
+    # Updated unconditionally at the end of build_turn_context.
+    agent._last_user_turn_ts: float = time.time()
     agent._current_tool: str | None = None
     agent._api_call_count: int = 0
     # Opt-out flag for the between-turns MCP tool refresh (build_turn_context).

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -36,6 +37,24 @@ from agent.model_metadata import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Format a time duration (in seconds) into a concise human-readable string.
+
+    Granularity decreases with duration: reports the largest whole unit
+    (days, hours, or minutes).  "A few seconds" for gaps under a minute.
+    """
+    minutes = int(seconds // 60)
+    if minutes < 1:
+        return "a few seconds"
+    hours = minutes // 60
+    if hours < 1:
+        return f"{minutes} minute{'s' if minutes > 1 else ''}"
+    days = hours // 24
+    if days < 1:
+        return f"{hours} hour{'s' if hours > 1 else ''}"
+    return f"{days} day{'s' if days > 1 else ''}"
 
 
 def _compression_made_progress(
@@ -307,6 +326,35 @@ def build_turn_context(
             agent._user_turn_count = prior_user_turns
             if agent._memory_nudge_interval > 0 and agent._turns_since_memory == 0:
                 agent._turns_since_memory = prior_user_turns % agent._memory_nudge_interval
+
+    # ── Time-awareness injection ──
+    # When enabled and a significant gap has passed since the last user
+    # turn, prepend a brief annotation to the user message so the agent
+    # knows time has elapsed.  Skips the first turn (no history to compare
+    # against).  The annotation is stripped from transcripts via the
+    # persist override mechanism below.
+    if getattr(agent, "_time_awareness_enabled", False) and conversation_history:
+        _ta_threshold = getattr(agent, "_time_awareness_threshold", 7200.0)
+        _elapsed = time.time() - getattr(agent, "_last_activity_ts", time.time())
+        if _elapsed >= _ta_threshold:
+            try:
+                from hermes_time import now as _hermes_now
+                _now = _hermes_now()
+                _elapsed_str = _format_elapsed(_elapsed)
+                _annotation = (
+                    f"[It is now {_now.strftime('%A, %B %d, %I:%M %p %Z')}. "
+                    f"Your last message was about {_elapsed_str} ago.]"
+                )
+                user_msg["content"] = f"{_annotation}\n\n{user_msg['content']}"
+
+                # Ensure the annotation does not leak into the persisted
+                # transcript.  The gateway already provides a clean
+                # persist_user_message; for CLI/TUI we set the override
+                # to the original unmodified content.
+                if persist_user_message is None and getattr(agent, "_persist_user_message_override", None) is None:
+                    agent._persist_user_message_override = user_message
+            except Exception:
+                logger.debug("Time-awareness injection failed (non-fatal)", exc_info=True)
 
     # Add the current user message after the prompt/session setup has made
     # close persistence safe. The handoff above preserves any marker already

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -335,7 +335,7 @@ def build_turn_context(
     # persist override mechanism below.
     if getattr(agent, "_time_awareness_enabled", False) and conversation_history:
         _ta_threshold = getattr(agent, "_time_awareness_threshold", 7200.0)
-        _elapsed = time.time() - getattr(agent, "_last_activity_ts", time.time())
+        _elapsed = time.time() - getattr(agent, "_last_user_turn_ts", time.time())
         if _elapsed >= _ta_threshold:
             try:
                 from hermes_time import now as _hermes_now
@@ -650,6 +650,13 @@ def build_turn_context(
             ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
         except Exception:
             pass
+
+    # Stamp the user-turn timestamp for the NEXT turn's gap check.
+    # Unconditional so _last_user_turn_ts stays accurate even when
+    # time-awareness is disabled or this is the first turn — the
+    # gateway does NOT reset this between turns (_last_activity_ts
+    # is the heartbeat that gets reset, see _init_cached_agent_for_turn).
+    agent._last_user_turn_ts = time.time()
 
     return TurnContext(
         user_message=user_message,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -43,8 +43,11 @@ def _format_elapsed(seconds: float) -> str:
     """Format a time duration (in seconds) into a concise human-readable string.
 
     Granularity decreases with duration: reports the largest whole unit
-    (days, hours, or minutes).  "A few seconds" for gaps under a minute.
+    (days, hours, or minutes).  "A few seconds" for gaps under a minute
+    or any negative value.
     """
+    if seconds < 0:
+        return "a few seconds"
     minutes = int(seconds // 60)
     if minutes < 1:
         return "a few seconds"
@@ -327,6 +330,21 @@ def build_turn_context(
             if agent._memory_nudge_interval > 0 and agent._turns_since_memory == 0:
                 agent._turns_since_memory = prior_user_turns % agent._memory_nudge_interval
 
+    # Rehydrate the time-awareness baseline from persisted timestamps so a
+    # session restored with nonempty history measures the actual conversation
+    # gap rather than time since agent reconstruction (teknium1, PR #64696).
+    # Compute user-turn count independently so this block doesn't silently
+    # break if the nudge-counter hydration above is refactored.
+    if conversation_history and getattr(agent, "_time_awareness_enabled", False):
+        _rehydrate_turn_count = agent._user_turn_count or sum(
+            1 for m in conversation_history if m.get("role") == "user"
+        )
+        if _rehydrate_turn_count > 0:
+            for _msg in reversed(conversation_history):
+                if _msg.get("role") == "user" and "timestamp" in _msg:
+                    agent._last_user_turn_ts = float(_msg["timestamp"])
+                    break
+
     # ── Time-awareness injection ──
     # When enabled and a significant gap has passed since the last user
     # turn, prepend a brief annotation to the user message so the agent
@@ -345,14 +363,30 @@ def build_turn_context(
                     f"[It is now {_now.strftime('%A, %B %d, %I:%M %p %Z')}. "
                     f"Your last message was about {_elapsed_str} ago.]"
                 )
-                user_msg["content"] = f"{_annotation}\n\n{user_msg['content']}"
+                # Preserve native multimodal content lists (gateway image/audio
+                # blocks) by prepending a text part rather than coercing the
+                # list to a string via format.  See teknium1 review on PR #64696.
+                if isinstance(user_msg["content"], list):
+                    user_msg["content"] = [
+                        {"type": "text", "text": f"{_annotation}\n\n"},
+                        *user_msg["content"],
+                    ]
+                else:
+                    user_msg["content"] = f"{_annotation}\n\n{user_msg['content']}"
 
                 # Ensure the annotation does not leak into the persisted
-                # transcript.  The gateway already provides a clean
-                # persist_user_message; for CLI/TUI we set the override
-                # to the original unmodified content.
-                if persist_user_message is None and getattr(agent, "_persist_user_message_override", None) is None:
+                # transcript.  For text content, prefer the gateway-provided
+                # persist_user_message (which excludes system notes); for
+                # multimodal content, the original user_message IS the clean
+                # content list — using it as a list override is required
+                # because _apply_persist_user_message_override refuses to
+                # replace list content with a plain string (PR #64696).
+                if isinstance(user_msg["content"], list):
                     agent._persist_user_message_override = user_message
+                else:
+                    agent._persist_user_message_override = (
+                        persist_user_message if persist_user_message is not None else user_message
+                    )
             except Exception:
                 logger.debug("Time-awareness injection failed (non-fatal)", exc_info=True)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16537,6 +16537,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         fresh external turns (depth 0); they are semantically paired —
         desc describes the activity *at* ts, so updating one without the
         other would make get_activity_summary() misleading.
+        _last_user_turn_ts is NOT reset here — it tracks the start of the
+        previous user turn for time-skip gap detection, and resetting it
+        would destroy the gap signal across cached-agent reuse.
         For interrupt-recursive turns both are preserved so the inactivity
         watchdog can accumulate stuck-turn idle time and fire the 30-min
         timeout (#15654).  The depth-0 reset is still needed: a session

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1500,6 +1500,8 @@ DEFAULT_CONFIG = {
         "auto_subscribe_on_create": True,
     },
 
+    # Context-awareness features for the per-turn context the model sees.
+    # All opt-in; none affect the cached system prompt.
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
@@ -2188,6 +2190,17 @@ DEFAULT_CONFIG = {
     # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+        # Time awareness: when a user sends a message after a significant
+        # quiet gap, prepend a brief annotation so the agent knows how
+        # much time has passed since the last turn.  Opt-in (default off)
+        # because even a single-line annotation changes what the model
+        # sees on gap-crossing turns.
+        "time_awareness": {
+            "enabled": False,
+            # Threshold in minutes — inject annotation when the gap since
+            # the last user turn exceeds this value.
+            "threshold_minutes": 120,
+        },
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -456,7 +456,7 @@ def test_time_awareness_injects_when_threshold_exceeded(monkeypatch):
     agent = _FakeAgent()
     agent._time_awareness_enabled = True
     agent._time_awareness_threshold = 3600.0  # 1 hour
-    agent._last_activity_ts = 1000.0  # far in the past
+    agent._last_user_turn_ts = 1000.0  # far in the past
 
     monkeypatch.setattr("time.time", lambda: 1000.0 + 7200.0)  # 2h gap
     # Mock hermes_time.now() to return a fixed weekday datetime
@@ -481,7 +481,7 @@ def test_time_awareness_skips_when_threshold_not_exceeded():
     agent = _FakeAgent()
     agent._time_awareness_enabled = True
     agent._time_awareness_threshold = 3600.0  # 1 hour
-    agent._last_activity_ts = 1000.0
+    agent._last_user_turn_ts = 1000.0
 
     with patch("time.time", return_value=1000.0 + 600.0):  # 10min gap
         ctx = _build(
@@ -496,7 +496,7 @@ def test_time_awareness_skips_when_disabled():
     agent = _FakeAgent()
     agent._time_awareness_enabled = False
     agent._time_awareness_threshold = 3600.0
-    agent._last_activity_ts = 1000.0
+    agent._last_user_turn_ts = 1000.0
 
     with patch("time.time", return_value=1000.0 + 7200.0):  # 2h gap
         ctx = _build(
@@ -512,7 +512,7 @@ def test_time_awareness_skips_first_turn():
     agent = _FakeAgent()
     agent._time_awareness_enabled = True
     agent._time_awareness_threshold = 3600.0
-    agent._last_activity_ts = 1000.0
+    agent._last_user_turn_ts = 1000.0
 
     with patch("time.time", return_value=1000.0 + 7200.0):
         ctx = _build(agent, conversation_history=None)
@@ -526,7 +526,7 @@ def test_time_awareness_sets_persist_override_for_cli():
     agent = _FakeAgent()
     agent._time_awareness_enabled = True
     agent._time_awareness_threshold = 3600.0
-    agent._last_activity_ts = 1000.0
+    agent._last_user_turn_ts = 1000.0
     agent._persist_user_message_override = None
 
     with patch("time.time", return_value=1000.0 + 7200.0):
@@ -547,7 +547,7 @@ def test_time_awareness_does_not_override_gateway_persist():
     agent = _FakeAgent()
     agent._time_awareness_enabled = True
     agent._time_awareness_threshold = 3600.0
-    agent._last_activity_ts = 1000.0
+    agent._last_user_turn_ts = 1000.0
     agent._persist_user_message_override = "gateway-clean-msg"
 
     with patch("time.time", return_value=1000.0 + 7200.0):
@@ -569,7 +569,7 @@ def test_time_awareness_safe_on_injection_failure():
     agent = _FakeAgent()
     agent._time_awareness_enabled = True
     agent._time_awareness_threshold = 3600.0
-    agent._last_activity_ts = 1000.0
+    agent._last_user_turn_ts = 1000.0
 
     with patch("time.time", return_value=1000.0 + 7200.0):
         # Force the hermes_time import to raise.

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -417,3 +417,168 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
 
+
+# ── _format_elapsed ──────────────────────────────────────────────────────
+
+
+def test_format_elapsed_sub_minute():
+    from agent.turn_context import _format_elapsed
+    assert _format_elapsed(0) == "a few seconds"
+    assert _format_elapsed(30) == "a few seconds"
+    assert _format_elapsed(59) == "a few seconds"
+
+
+def test_format_elapsed_minutes():
+    from agent.turn_context import _format_elapsed
+    assert _format_elapsed(60) == "1 minute"
+    assert _format_elapsed(120) == "2 minutes"
+    assert _format_elapsed(3540) == "59 minutes"
+
+
+def test_format_elapsed_hours():
+    from agent.turn_context import _format_elapsed
+    assert _format_elapsed(3600) == "1 hour"
+    assert _format_elapsed(7200) == "2 hours"
+    assert _format_elapsed(82800) == "23 hours"
+
+
+def test_format_elapsed_days():
+    from agent.turn_context import _format_elapsed
+    assert _format_elapsed(86400) == "1 day"
+    assert _format_elapsed(172800) == "2 days"
+    assert _format_elapsed(604800) == "7 days"
+
+
+# ── Time-awareness injection ─────────────────────────────────────────────
+
+
+def test_time_awareness_injects_when_threshold_exceeded(monkeypatch):
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0  # 1 hour
+    agent._last_activity_ts = 1000.0  # far in the past
+
+    monkeypatch.setattr("time.time", lambda: 1000.0 + 7200.0)  # 2h gap
+    # Mock hermes_time.now() to return a fixed weekday datetime
+    mock_now = __import__("datetime").datetime(2026, 6, 16, 14, 30, 0)
+    monkeypatch.setattr(
+        "hermes_time.now", lambda: mock_now
+    )
+
+    ctx = _build(
+        agent,
+        conversation_history=[{"role": "assistant", "content": "prior"}],
+        persist_user_message=None,
+    )
+
+    msg = ctx.messages[-1]["content"]
+    assert "It is now" in msg
+    assert "Your last message was about" in msg
+    assert "2 hours" in msg
+
+
+def test_time_awareness_skips_when_threshold_not_exceeded():
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0  # 1 hour
+    agent._last_activity_ts = 1000.0
+
+    with patch("time.time", return_value=1000.0 + 600.0):  # 10min gap
+        ctx = _build(
+            agent,
+            conversation_history=[{"role": "assistant", "content": "prior"}],
+        )
+
+    assert ctx.messages[-1]["content"] == "hello"
+
+
+def test_time_awareness_skips_when_disabled():
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = False
+    agent._time_awareness_threshold = 3600.0
+    agent._last_activity_ts = 1000.0
+
+    with patch("time.time", return_value=1000.0 + 7200.0):  # 2h gap
+        ctx = _build(
+            agent,
+            conversation_history=[{"role": "assistant", "content": "prior"}],
+        )
+
+    assert ctx.messages[-1]["content"] == "hello"
+
+
+def test_time_awareness_skips_first_turn():
+    """No conversation_history means no prior turn to compute a gap from."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0
+    agent._last_activity_ts = 1000.0
+
+    with patch("time.time", return_value=1000.0 + 7200.0):
+        ctx = _build(agent, conversation_history=None)
+
+    assert ctx.messages[-1]["content"] == "hello"
+
+
+def test_time_awareness_sets_persist_override_for_cli():
+    """CLI path (persist_user_message=None) must set the override so the
+    annotation doesn't leak into the session transcript."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0
+    agent._last_activity_ts = 1000.0
+    agent._persist_user_message_override = None
+
+    with patch("time.time", return_value=1000.0 + 7200.0):
+        ctx = _build(
+            agent,
+            conversation_history=[{"role": "assistant", "content": "prior"}],
+            persist_user_message=None,
+        )
+
+    # The override should be set to the original clean message.
+    assert agent._persist_user_message_override == "hello"
+    # The model sees the annotation.
+    assert "It is now" in ctx.messages[-1]["content"]
+
+
+def test_time_awareness_does_not_override_gateway_persist():
+    """Gateway already provides persist_user_message; must not clobber it."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0
+    agent._last_activity_ts = 1000.0
+    agent._persist_user_message_override = "gateway-clean-msg"
+
+    with patch("time.time", return_value=1000.0 + 7200.0):
+        ctx = _build(
+            agent,
+            conversation_history=[{"role": "assistant", "content": "prior"}],
+            persist_user_message="gateway-clean-msg",
+        )
+
+    # Gateway's persist override must be preserved.
+    assert agent._persist_user_message_override == "gateway-clean-msg"
+    # The model sees the annotation.
+    assert "It is now" in ctx.messages[-1]["content"]
+
+
+def test_time_awareness_safe_on_injection_failure():
+    """A failure in the injection logic (bad import, clock error) must not
+    crash the turn or lose the user message."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0
+    agent._last_activity_ts = 1000.0
+
+    with patch("time.time", return_value=1000.0 + 7200.0):
+        # Force the hermes_time import to raise.
+        with patch("hermes_time.now", side_effect=ImportError):
+            ctx = _build(
+                agent,
+                conversation_history=[{"role": "assistant", "content": "prior"}],
+            )
+
+    # User message is preserved even though injection failed.
+    assert ctx.messages[-1]["content"] == "hello"
+

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -16,6 +16,7 @@ import pytest
 
 from agent.context_compressor import ContextCompressor
 from agent.turn_context import TurnContext, build_turn_context
+from agent.codex_responses_adapter import _summarize_user_message_for_log
 from hermes_state import SessionDB
 
 
@@ -581,4 +582,125 @@ def test_time_awareness_safe_on_injection_failure():
 
     # User message is preserved even though injection failed.
     assert ctx.messages[-1]["content"] == "hello"
+
+
+def test_time_awareness_preserves_multimodal_content_list(monkeypatch):
+    """Gateway multimodal content lists (text + image_url) must stay as lists
+    with the annotation prepended as a text part, not coerced to a string."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0  # 1 hour
+    agent._last_user_turn_ts = 1000.0  # far in the past
+
+    monkeypatch.setattr("time.time", lambda: 1000.0 + 7200.0)  # 2h gap
+    mock_now = __import__("datetime").datetime(2026, 6, 16, 14, 30, 0)
+    monkeypatch.setattr("hermes_time.now", lambda: mock_now)
+
+    multimodal_content = [
+        {"type": "text", "text": "what's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+    ]
+
+    ctx = _build(
+        agent,
+        user_message=multimodal_content,
+        conversation_history=[{"role": "assistant", "content": "prior"}],
+        persist_user_message="what's in this image?",
+        summarize_user_message_for_log=_summarize_user_message_for_log,
+    )
+
+    content = ctx.messages[-1]["content"]
+    assert isinstance(content, list), "Multimodal content must remain a list"
+    assert content[0]["type"] == "text"
+    assert "It is now" in content[0]["text"]
+    assert "2 hours" in content[0]["text"]
+    assert content[1] == {"type": "text", "text": "what's in this image?"}
+    assert content[2] == {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}}
+
+
+def test_time_awareness_rehydrates_last_turn_ts_from_history(monkeypatch):
+    """When a session is restored with nonempty history carrying timestamps,
+    the gap must be measured from the persisted user turn timestamp rather
+    than from agent construction time."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0  # 1 hour
+    # Simulate a baseline set by init_agent at a far-future moment — without
+    # rehydration the gap would be negative and injection would be skipped.
+    agent._last_user_turn_ts = 9999999999.0
+
+    # conversation_history has a user message timestamped long ago
+    old_msg_ts = 1000.0
+    monkeypatch.setattr("time.time", lambda: old_msg_ts + 10800.0)  # 3h after old ts
+    mock_now = __import__("datetime").datetime(2026, 6, 16, 14, 30, 0)
+    monkeypatch.setattr("hermes_time.now", lambda: mock_now)
+
+    ctx = _build(
+        agent,
+        conversation_history=[
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "old message", "timestamp": old_msg_ts},
+        ],
+        persist_user_message=None,
+    )
+
+    content = ctx.messages[-1]["content"]
+    assert "It is now" in content
+    assert "3 hours" in content
+
+
+def test_time_awareness_multimodal_persist_override_is_list(monkeypatch):
+    """When injection fires on multimodal content, _persist_user_message_override
+    must be set to the original content list (not the clean text string) so
+    _apply_persist_user_message_override can replace the annotated list with
+    the clean one — the guard refuses to replace a list with a string."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0
+    agent._last_user_turn_ts = 1000.0
+
+    monkeypatch.setattr("time.time", lambda: 1000.0 + 7200.0)
+    mock_now = __import__("datetime").datetime(2026, 6, 16, 14, 30, 0)
+    monkeypatch.setattr("hermes_time.now", lambda: mock_now)
+
+    multimodal_content = [
+        {"type": "text", "text": "describe this image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,xyz"}},
+    ]
+
+    _build(
+        agent,
+        user_message=multimodal_content,
+        conversation_history=[{"role": "assistant", "content": "prior"}],
+        persist_user_message="describe this image",
+        summarize_user_message_for_log=_summarize_user_message_for_log,
+    )
+
+    # The override must be the original content list (not the clean text string)
+    # so _apply_persist_user_message_override accepts it as a list-over-list swap.
+    override = agent._persist_user_message_override
+    assert isinstance(override, list), "Override must be a list for multimodal"
+    assert override == multimodal_content, "Override must be the original clean list"
+
+
+def test_time_awareness_persist_override_with_provided_clean_text(monkeypatch):
+    """Gateway text path: persist_user_message is the clean text. The override
+    must be set to that clean text, not the API-facing user_message (which may
+    have system notes prepended)."""
+    agent = _FakeAgent()
+    agent._time_awareness_enabled = True
+    agent._time_awareness_threshold = 3600.0
+    agent._last_user_turn_ts = 1000.0
+
+    monkeypatch.setattr("time.time", lambda: 1000.0 + 7200.0)
+    mock_now = __import__("datetime").datetime(2026, 6, 16, 14, 30, 0)
+    monkeypatch.setattr("hermes_time.now", lambda: mock_now)
+
+    _build(
+        agent,
+        conversation_history=[{"role": "assistant", "content": "prior"}],
+        persist_user_message="the-clean-text",
+    )
+
+    assert agent._persist_user_message_override == "the-clean-text"
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -823,6 +823,22 @@ Plugin engines are **never auto-activated** — you must explicitly set `context
 
 See [Memory Providers](/user-guide/features/memory-providers) for the analogous single-select system for memory plugins.
 
+### Time Awareness
+
+When enabled, Hermes injects a brief temporal annotation into the user message when a significant gap has elapsed since the last conversation turn. This helps the model reason correctly across time gaps — understanding that "yesterday" or "a few hours ago" refers to real elapsed time.
+
+```yaml
+context:
+  engine: "compressor"
+  time_awareness:
+    enabled: false           # opt-in (default off)
+    threshold_minutes: 120   # gap in minutes before annotation fires
+```
+
+The annotation is injected into the **user message content** (not the system prompt), preserving byte-stable prompt caching. It is stripped from persisted session transcripts so it does not leak into stored history. Skipped on the first turn of a session (no prior turn to compare against).
+
+**Note:** When a session is resumed from stored history, the gap is measured from the persisted user-turn timestamp if available, not from agent reconstruction time.
+
 ## Iteration Budget
 
 When the agent is working on a complex task with many tool calls, it can burn through its iteration budget (default: 90 turns). Hermes does **not** inject mid-task pressure warnings — earlier builds warned the model at 70%/90% budget, which caused models to abandon complex tasks prematurely and was removed in April 2026.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in **time-skip awareness** feature that injects a brief time-context annotation into the user message when a significant gap has elapsed since the last conversation turn. When enabled (`context.time_awareness.enabled: true`), the agent sees something like:

> `[It is now Tuesday, June 16, 02:30 PM UTC. Your last message was about 2 hours ago.]`
>
> *user message here…*

This helps the model reason correctly across time gaps — for example, understanding that "yesterday" or "a few hours ago" refers to real elapsed time, or that the context of a previous instruction may be stale.

This varies from the current related option, which includes a timestamp with every new user message.

**Design decisions:**
- **Opt-in, default off** — Even a single-line annotation changes what the model sees on gap-crossing turns.
- **Cache-safe** — Annotation is injected into the *user message content*, not the system prompt, preserving byte-stable prompt caching across the conversation.
- **Transcript-safe** — The annotation is stripped from persisted session transcripts via the existing `_persist_user_message_override` mechanism.
- **First-turn skip** — No injection on the first turn (no prior turn to compare the gap against).
- **Graceful failure** — If `hermes_time.now()` or any other dependency fails, the injection is silently skipped (logged at DEBUG), and the conversation continues unaffected.

## Related Issue

N/A — New feature, no issue filed.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`agent/agent_init.py`** — Reads `context.time_awareness` config from `_agent_cfg`, sets `_time_awareness_enabled` and `_time_awareness_threshold` (converted to seconds) on the agent.
- **`agent/turn_context.py`** — Adds `_format_elapsed()` helper for human-readable duration formatting, and injects the time annotation into `user_msg["content"]` in `build_turn_context()` when the gap threshold is exceeded.
- **`hermes_cli/config.py`** — Adds `context.time_awareness` config block with `enabled` (default: `false`) and `threshold_minutes` (default: `120`).
- **`tests/agent/test_turn_context.py`** — 9 new tests covering: injection when threshold exceeded, no injection when threshold not met, disabled feature, first-turn skip, CLI persist override, gateway persist preservation, and graceful failure on import error.

## How to Test

1. Set `context.time_awareness.enabled: true` in your `~/.hermes/config.yaml`.
2. Start a conversation, send a message, then wait at least 2 hours (or lower `threshold_minutes` for a quicker test).
3. Send another message — the agent's response should reference the time gap.
4. Verify the annotation does **not** appear in the persisted session transcript.
5. Run the test suite: `scripts/run_tests.sh tests/agent/test_turn_context.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(time-awareness): inject time-context annotation on user gap turns`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_turn_context.py` and all 28 tests pass
- [x] I've added tests for my changes (9 new tests covering all key scenarios)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `hermes_cli/config.py` with config defaults and inline docs
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — uses stdlib only, no platform-specific code
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```
# When threshold exceeded, agent.turn_context logs at DEBUG:
# (annotation content visible in the model's received messages)
```