### PR TITLE
Scoped operator tokens, one-time enrollment, and scoped profile contracts (milestone 0)

### DIFF
--- a/gateway/api_operator_auth.py
+++ b/gateway/api_operator_auth.py
@@ -79,15 +79,75 @@ def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
+def _parse_record(record: object) -> Optional[dict]:
+    """Interpret one stored credential record, failing closed.
+
+    Returns a record dict with a validated, normalized ``scopes`` tuple and a
+    numeric ``created_at`` when the record is structurally sound, or ``None``
+    when it is malformed or forward-incompatible. Any single corrupt record is
+    dropped from the active set rather than propagated, so one bad entry can
+    never raise out of (and thereby DoS) ``authenticate`` or
+    ``list_credentials``.
+
+    A record is dropped when it is not a dict, its ``token_hash`` is not an
+    ASCII string, its ``scopes`` is not a list of known scope strings, or its
+    ``created_at`` is not numeric.
+    """
+    if not isinstance(record, dict):
+        return None
+
+    token_hash = record.get("token_hash")
+    if not isinstance(token_hash, str) or not token_hash.isascii():
+        return None
+
+    raw_scopes = record.get("scopes")
+    if not isinstance(raw_scopes, list) or not all(
+        isinstance(scope, str) for scope in raw_scopes
+    ):
+        return None
+    try:
+        scopes = normalize_scopes(raw_scopes)
+    except ValueError:
+        return None
+
+    created_at = record.get("created_at")
+    if not isinstance(created_at, (int, float)) or isinstance(created_at, bool):
+        return None
+
+    revoked_at = record.get("revoked_at")
+    if revoked_at is not None and not isinstance(revoked_at, (int, float)):
+        return None
+
+    return {
+        "token_hash": token_hash,
+        "label": record.get("label", "") if isinstance(record.get("label"), str) else "",
+        "scopes": scopes,
+        "created_at": float(created_at),
+        "revoked_at": revoked_at,
+    }
+
+
 class OperatorCredentialStore:
     """Persists hashed, revocable operator bearer tokens.
 
     Storage is versioned JSON at the configured path. Only SHA-256 token
     hashes are ever written to disk; the raw token is returned exactly once,
-    from :meth:`issue`. All read-modify-write cycles are guarded by a single
-    ``threading.RLock`` and persisted via a temp-file-then-atomic-replace
+    from :meth:`issue`. Persistence goes through a temp-file-then-atomic-replace
     sequence with owner-only (``0600``) permissions, mirroring
     ``gateway/pairing.py``.
+
+    Concurrency invariant: this class assumes a single, long-lived instance per
+    store path within one process (the way ``APIServerAdapter`` wires it in
+    Task 3). The internal ``threading.RLock`` serializes read-modify-write
+    cycles only across threads sharing that one instance. Instantiating two
+    stores over the same path — or running two processes against it — is
+    unsupported: their writes are not coordinated and concurrent :meth:`issue`
+    or :meth:`revoke` calls can lose updates. No cross-process file locking is
+    implemented by design.
+
+    Records are parsed defensively on every read: any structurally invalid or
+    forward-incompatible record is skipped rather than raised, so a single
+    corrupt entry cannot poison authentication or listing for the valid ones.
     """
 
     def __init__(self, path: Path):
@@ -121,25 +181,20 @@ class OperatorCredentialStore:
         )
 
     def authenticate(self, token: str) -> Optional[AuthPrincipal]:
-        if not token:
+        if not isinstance(token, str) or not token:
             return None
         candidate_hash = _hash_token(token)
 
         with self._lock:
             data = self._load()
-            for credential_id, record in data["credentials"].items():
-                if not isinstance(record, dict):
+            for credential_id, raw_record in data["credentials"].items():
+                record = _parse_record(raw_record)
+                if record is None or record["revoked_at"] is not None:
                     continue
-                if record.get("revoked_at") is not None:
-                    continue
-                stored_hash = record.get("token_hash")
-                if not isinstance(stored_hash, str):
-                    continue
-                if hmac.compare_digest(candidate_hash, stored_hash):
-                    scopes = normalize_scopes(record.get("scopes") or [])
+                if hmac.compare_digest(candidate_hash, record["token_hash"]):
                     return AuthPrincipal(
                         credential_id=credential_id,
-                        scopes=scopes,
+                        scopes=record["scopes"],
                         is_superuser=False,
                     )
         return None
@@ -150,16 +205,17 @@ class OperatorCredentialStore:
             records = list(data["credentials"].items())
 
         summaries = []
-        for credential_id, record in records:
-            if not isinstance(record, dict):
+        for credential_id, raw_record in records:
+            record = _parse_record(raw_record)
+            if record is None:
                 continue
             summaries.append(
                 CredentialSummary(
                     credential_id=credential_id,
-                    label=record.get("label", ""),
-                    scopes=normalize_scopes(record.get("scopes") or []),
-                    created_at=record.get("created_at", 0.0),
-                    revoked_at=record.get("revoked_at"),
+                    label=record["label"],
+                    scopes=record["scopes"],
+                    created_at=record["created_at"],
+                    revoked_at=record["revoked_at"],
                 )
             )
         summaries.sort(key=lambda summary: summary.created_at)
@@ -168,8 +224,11 @@ class OperatorCredentialStore:
     def revoke(self, credential_id: str) -> bool:
         with self._lock:
             data = self._load()
-            record = data["credentials"].get(credential_id)
-            if not isinstance(record, dict) or record.get("revoked_at") is not None:
+            raw_record = data["credentials"].get(credential_id)
+            if _parse_record(raw_record) is None:
+                return False
+            record = data["credentials"][credential_id]
+            if record.get("revoked_at") is not None:
                 return False
             record["revoked_at"] = time.time()
             self._save(data)
@@ -190,7 +249,7 @@ class OperatorCredentialStore:
         return {"version": STORE_SCHEMA_VERSION, "credentials": credentials}
 
     def _save(self, data: dict) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         payload = json.dumps(data, indent=2, ensure_ascii=False)
         fd, tmp_path = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
         try:

--- a/gateway/api_operator_auth.py
+++ b/gateway/api_operator_auth.py
@@ -8,8 +8,19 @@ Kept independent of aiohttp so it can be imported by storage and enrollment
 modules without pulling in the HTTP server.
 """
 
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import tempfile
+import threading
+import time
 from dataclasses import dataclass
-from typing import Iterable
+from pathlib import Path
+from typing import Iterable, Optional
+
+from utils import atomic_replace
 
 VALID_SCOPE_DOMAINS = frozenset({
     "chat", "sessions", "profiles", "providers", "skills",
@@ -56,3 +67,146 @@ class CredentialSummary:
     scopes: tuple[str, ...]
     created_at: float
     revoked_at: float | None
+
+
+STORE_SCHEMA_VERSION = 1
+TOKEN_PREFIX = "hop_"
+CREDENTIAL_ID_PREFIX = "hoc_"
+LABEL_MAX_LENGTH = 80
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class OperatorCredentialStore:
+    """Persists hashed, revocable operator bearer tokens.
+
+    Storage is versioned JSON at the configured path. Only SHA-256 token
+    hashes are ever written to disk; the raw token is returned exactly once,
+    from :meth:`issue`. All read-modify-write cycles are guarded by a single
+    ``threading.RLock`` and persisted via a temp-file-then-atomic-replace
+    sequence with owner-only (``0600``) permissions, mirroring
+    ``gateway/pairing.py``.
+    """
+
+    def __init__(self, path: Path):
+        self._path = Path(path)
+        self._lock = threading.RLock()
+
+    def issue(self, label: str, scopes: Iterable[str]) -> IssuedCredential:
+        normalized_scopes = normalize_scopes(scopes)
+        clean_label = str(label or "").strip()[:LABEL_MAX_LENGTH]
+        token = TOKEN_PREFIX + secrets.token_urlsafe(32)
+        credential_id = CREDENTIAL_ID_PREFIX + secrets.token_hex(8)
+        created_at = time.time()
+
+        with self._lock:
+            data = self._load()
+            data["credentials"][credential_id] = {
+                "token_hash": _hash_token(token),
+                "label": clean_label,
+                "scopes": list(normalized_scopes),
+                "created_at": created_at,
+                "revoked_at": None,
+            }
+            self._save(data)
+
+        return IssuedCredential(
+            credential_id=credential_id,
+            token=token,
+            label=clean_label,
+            scopes=normalized_scopes,
+            created_at=created_at,
+        )
+
+    def authenticate(self, token: str) -> Optional[AuthPrincipal]:
+        if not token:
+            return None
+        candidate_hash = _hash_token(token)
+
+        with self._lock:
+            data = self._load()
+            for credential_id, record in data["credentials"].items():
+                if not isinstance(record, dict):
+                    continue
+                if record.get("revoked_at") is not None:
+                    continue
+                stored_hash = record.get("token_hash")
+                if not isinstance(stored_hash, str):
+                    continue
+                if hmac.compare_digest(candidate_hash, stored_hash):
+                    scopes = normalize_scopes(record.get("scopes") or [])
+                    return AuthPrincipal(
+                        credential_id=credential_id,
+                        scopes=scopes,
+                        is_superuser=False,
+                    )
+        return None
+
+    def list_credentials(self) -> list[CredentialSummary]:
+        with self._lock:
+            data = self._load()
+            records = list(data["credentials"].items())
+
+        summaries = []
+        for credential_id, record in records:
+            if not isinstance(record, dict):
+                continue
+            summaries.append(
+                CredentialSummary(
+                    credential_id=credential_id,
+                    label=record.get("label", ""),
+                    scopes=normalize_scopes(record.get("scopes") or []),
+                    created_at=record.get("created_at", 0.0),
+                    revoked_at=record.get("revoked_at"),
+                )
+            )
+        summaries.sort(key=lambda summary: summary.created_at)
+        return summaries
+
+    def revoke(self, credential_id: str) -> bool:
+        with self._lock:
+            data = self._load()
+            record = data["credentials"].get(credential_id)
+            if not isinstance(record, dict) or record.get("revoked_at") is not None:
+                return False
+            record["revoked_at"] = time.time()
+            self._save(data)
+        return True
+
+    def _load(self) -> dict:
+        if not self._path.exists():
+            return {"version": STORE_SCHEMA_VERSION, "credentials": {}}
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"version": STORE_SCHEMA_VERSION, "credentials": {}}
+        if not isinstance(raw, dict):
+            return {"version": STORE_SCHEMA_VERSION, "credentials": {}}
+        credentials = raw.get("credentials")
+        if not isinstance(credentials, dict):
+            credentials = {}
+        return {"version": STORE_SCHEMA_VERSION, "credentials": credentials}
+
+    def _save(self, data: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(data, indent=2, ensure_ascii=False)
+        fd, tmp_path = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp_path, 0o600)
+            atomic_replace(tmp_path, self._path)
+            try:
+                os.chmod(self._path, 0o600)
+            except OSError:
+                pass  # Windows doesn't support chmod the same way.
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise

--- a/gateway/api_operator_auth.py
+++ b/gateway/api_operator_auth.py
@@ -19,12 +19,14 @@ VALID_SCOPE_DOMAINS = frozenset({
 
 def normalize_scopes(values: Iterable[str]) -> tuple[str, ...]:
     scopes = {str(value).strip().lower() for value in values if str(value).strip()}
-    if "*" in scopes:
-        return ("*",)
     for scope in scopes:
+        if scope == "*":
+            continue
         domain, separator, access = scope.partition(":")
         if separator != ":" or domain not in VALID_SCOPE_DOMAINS or access not in {"read", "write"}:
             raise ValueError(f"unknown scope: {scope}")
+    if "*" in scopes:
+        return ("*",)
     return tuple(sorted(scopes))
 
 

--- a/gateway/api_operator_auth.py
+++ b/gateway/api_operator_auth.py
@@ -1,0 +1,56 @@
+"""Hermes operator authorization vocabulary.
+
+Defines the scope domains, scope normalization, and the credential/principal
+types shared by the canonical API server's operator-token authentication and
+credential-issuance paths (pairing, storage, and per-request scope checks).
+
+Kept independent of aiohttp so it can be imported by storage and enrollment
+modules without pulling in the HTTP server.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+VALID_SCOPE_DOMAINS = frozenset({
+    "chat", "sessions", "profiles", "providers", "skills",
+    "tools", "memory", "tasks", "gateway", "settings",
+})
+
+
+def normalize_scopes(values: Iterable[str]) -> tuple[str, ...]:
+    scopes = {str(value).strip().lower() for value in values if str(value).strip()}
+    if "*" in scopes:
+        return ("*",)
+    for scope in scopes:
+        domain, separator, access = scope.partition(":")
+        if separator != ":" or domain not in VALID_SCOPE_DOMAINS or access not in {"read", "write"}:
+            raise ValueError(f"unknown scope: {scope}")
+    return tuple(sorted(scopes))
+
+
+@dataclass(frozen=True)
+class AuthPrincipal:
+    credential_id: str
+    scopes: tuple[str, ...]
+    is_superuser: bool = False
+
+    def allows(self, required: str) -> bool:
+        return self.is_superuser or "*" in self.scopes or required in self.scopes
+
+
+@dataclass(frozen=True)
+class IssuedCredential:
+    credential_id: str
+    token: str
+    label: str
+    scopes: tuple[str, ...]
+    created_at: float
+
+
+@dataclass(frozen=True)
+class CredentialSummary:
+    credential_id: str
+    label: str
+    scopes: tuple[str, ...]
+    created_at: float
+    revoked_at: float | None

--- a/gateway/api_operator_enrollment.py
+++ b/gateway/api_operator_enrollment.py
@@ -1,0 +1,328 @@
+"""One-time operator enrollment codes and token lifecycle.
+
+Lets an already-authorized caller (typically the desktop/CLI owner) mint a
+short-lived, single-use pairing code that a new device (e.g. the Navivox
+Android app) exchanges for a scoped operator bearer token, without ever
+placing that bearer token in a QR code, deep link, or handoff payload.
+
+Mirrors ``gateway/pairing.py``'s salted-hash storage, ``threading.RLock``
+guard, and temp-file/atomic-replace persistence conventions, but is kept
+intentionally independent of any messaging-platform allowlist: enrollment
+codes exist purely to bootstrap :class:`~gateway.api_operator_auth.
+OperatorCredentialStore` tokens for the canonical API server.
+"""
+
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from gateway.api_operator_auth import IssuedCredential, OperatorCredentialStore, normalize_scopes
+from utils import atomic_replace
+
+# Pairing codes expire five minutes after creation (Global Constraints).
+PAIRING_CODE_TTL_SECONDS = 300
+
+# Wrong-code guesses lock further attempts out for an hour, mirroring
+# gateway/pairing.py's per-platform lockout. Lockout is global to the store
+# (there is one enrollment store per Hermes install) rather than per-code,
+# since the attack this defends against — brute-forcing the code space — is
+# not scoped to any single pending grant.
+MAX_FAILED_ATTEMPTS = 5
+LOCKOUT_SECONDS = 3600
+
+LABEL_MAX_LENGTH = 80
+CODE_ENTROPY_BYTES = 24  # secrets.token_urlsafe(24)
+
+STORE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class EnrollmentGrant:
+    code: str
+    label: str
+    origin: str
+    scopes: tuple[str, ...]
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class EnrollmentPreview:
+    label: str
+    origin: str
+    scopes: tuple[str, ...]
+    expires_at: float
+
+
+def _normalize_origin(origin: object) -> str:
+    """Normalize an origin string for exact-match comparison.
+
+    Origins carry no path/query worth parsing further, so normalization is
+    deliberately narrow: trim surrounding whitespace, drop one trailing
+    slash, and case-fold. This keeps comparison exact (no scheme/host
+    equivalence heuristics) while tolerating the trivial formatting
+    variance a client's URL library might introduce.
+    """
+    text = str(origin or "").strip()
+    if text.endswith("/"):
+        text = text[:-1]
+    return text.lower()
+
+
+def _hash_code(code: str, salt: bytes) -> str:
+    return hashlib.sha256(salt + code.encode("utf-8")).hexdigest()
+
+
+def _empty_store() -> dict:
+    return {
+        "version": STORE_SCHEMA_VERSION,
+        "enrollments": {},
+        "failed_attempts": 0,
+        "lockout_until": None,
+    }
+
+
+class OperatorEnrollmentStore:
+    """One-time pairing-code enrollment that mints scoped operator tokens.
+
+    ``now`` is an injectable clock (defaults to :func:`time.time`) so tests
+    can advance time deterministically instead of sleeping past the TTL /
+    lockout window.
+
+    Concurrency invariant matches :class:`OperatorCredentialStore`: one
+    long-lived instance per store path within a process. The internal
+    ``threading.RLock`` serializes read-modify-write cycles across threads
+    sharing that instance; it does not coordinate multiple processes.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        credentials: OperatorCredentialStore,
+        now: Callable[[], float] = time.time,
+    ):
+        self._path = Path(path)
+        self._credentials = credentials
+        self._now = now
+        self._lock = threading.RLock()
+
+    def create(self, label: str, origin: str, scopes: Iterable[str]) -> EnrollmentGrant:
+        """Mint a new one-time pairing code.
+
+        Raises ``ValueError`` (via :func:`normalize_scopes`) for an unknown
+        scope domain — callers at the HTTP layer are expected to translate
+        that into a 400 response.
+        """
+        normalized_scopes = normalize_scopes(scopes)
+        clean_label = str(label or "").strip()[:LABEL_MAX_LENGTH]
+        normalized_origin = _normalize_origin(origin)
+        code = secrets.token_urlsafe(CODE_ENTROPY_BYTES)
+        salt = os.urandom(16)
+        entry_id = secrets.token_hex(8)
+        created_at = self._now()
+        expires_at = created_at + PAIRING_CODE_TTL_SECONDS
+
+        with self._lock:
+            data = self._load()
+            # Only these fields are ever persisted for an enrollment entry —
+            # the raw code itself is never written to disk.
+            data["enrollments"][entry_id] = {
+                "hash": _hash_code(code, salt),
+                "salt": salt.hex(),
+                "label": clean_label,
+                "origin": normalized_origin,
+                "scopes": list(normalized_scopes),
+                "created_at": created_at,
+                "expires_at": expires_at,
+                "consumed_at": None,
+            }
+            self._save(data)
+
+        return EnrollmentGrant(
+            code=code,
+            label=clean_label,
+            origin=normalized_origin,
+            scopes=normalized_scopes,
+            expires_at=expires_at,
+        )
+
+    def inspect(self, code: str, origin: str) -> Optional[EnrollmentPreview]:
+        """Preview a pending grant without consuming it.
+
+        Returns ``None`` for any of: malformed input, unknown code, expired
+        or already-consumed code, origin mismatch, or an active lockout.
+        Every failure path returns the identical ``None`` — nothing about
+        *why* a lookup failed is observable from the return value.
+        """
+        with self._lock:
+            entry = self._locate(code, origin, consume=False)
+        if entry is None:
+            return None
+        return EnrollmentPreview(
+            label=entry["label"],
+            origin=entry["origin"],
+            scopes=tuple(entry["scopes"]),
+            expires_at=entry["expires_at"],
+        )
+
+    def exchange(self, code: str, origin: str) -> Optional[IssuedCredential]:
+        """Consume a pending grant and mint a scoped operator token.
+
+        The code is marked consumed inside the same locked read-modify-write
+        cycle that located it, so two concurrent callers racing the same
+        code can never both succeed. Token issuance is delegated to
+        :meth:`OperatorCredentialStore.issue` after that consumption has
+        already been durably persisted.
+        """
+        with self._lock:
+            entry = self._locate(code, origin, consume=True)
+        if entry is None:
+            return None
+        return self._credentials.issue(entry["label"], entry["scopes"])
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _locate(self, code: object, origin: object, *, consume: bool) -> Optional[dict]:
+        """Find, validate, and (optionally) consume the entry for ``code``.
+
+        Must be called while holding ``self._lock``. A wrong or unknown code,
+        and a matched-but-expired-or-already-consumed code, count as a
+        failed attempt toward the store-wide lockout (this is the
+        brute-force-guessing surface). A matched code presented with the
+        wrong origin does *not* count toward the lockout, is not consumed,
+        and leaks nothing back to the caller beyond "not found" — the
+        presenter already demonstrated knowledge of the code; only the
+        origin binding failed.
+        """
+        if not isinstance(code, str) or not code:
+            return None
+
+        normalized_origin = _normalize_origin(origin)
+        now = self._now()
+
+        data = self._load()
+        if self._is_locked_out(data, now):
+            return None
+
+        matched_id = None
+        matched_entry = None
+        for entry_id, entry in data["enrollments"].items():
+            if not isinstance(entry, dict):
+                continue
+            salt_hex = entry.get("salt")
+            hash_hex = entry.get("hash")
+            if not isinstance(salt_hex, str) or not isinstance(hash_hex, str):
+                continue
+            try:
+                salt = bytes.fromhex(salt_hex)
+            except ValueError:
+                continue
+            if hmac.compare_digest(_hash_code(code, salt), hash_hex):
+                matched_id, matched_entry = entry_id, entry
+                break
+
+        if matched_entry is None:
+            self._record_failed_attempt(data, now)
+            self._save(data)
+            return None
+
+        expires_at = matched_entry.get("expires_at")
+        is_expired = not isinstance(expires_at, (int, float)) or expires_at <= now
+        is_consumed = matched_entry.get("consumed_at") is not None
+        if is_expired or is_consumed:
+            self._record_failed_attempt(data, now)
+            self._save(data)
+            return None
+
+        if matched_entry.get("origin") != normalized_origin:
+            return None  # No lockout bump, no consumption, no leak.
+
+        result = {
+            "label": matched_entry.get("label") or "",
+            "origin": matched_entry.get("origin") or "",
+            "scopes": list(matched_entry.get("scopes") or []),
+            "expires_at": expires_at,
+        }
+
+        if consume:
+            matched_entry["consumed_at"] = now
+            data["enrollments"][matched_id] = matched_entry
+            self._save(data)
+
+        return result
+
+    @staticmethod
+    def _is_locked_out(data: dict, now: float) -> bool:
+        locked_until = data.get("lockout_until")
+        return isinstance(locked_until, (int, float)) and now < locked_until
+
+    @staticmethod
+    def _record_failed_attempt(data: dict, now: float) -> None:
+        failures = data.get("failed_attempts", 0)
+        if not isinstance(failures, int):
+            failures = 0
+        failures += 1
+        if failures >= MAX_FAILED_ATTEMPTS:
+            data["lockout_until"] = now + LOCKOUT_SECONDS
+            failures = 0
+        data["failed_attempts"] = failures
+
+    def _load(self) -> dict:
+        if not self._path.exists():
+            return _empty_store()
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return _empty_store()
+        if not isinstance(raw, dict):
+            return _empty_store()
+
+        enrollments = raw.get("enrollments")
+        if not isinstance(enrollments, dict):
+            enrollments = {}
+
+        failed_attempts = raw.get("failed_attempts", 0)
+        if not isinstance(failed_attempts, int) or isinstance(failed_attempts, bool):
+            failed_attempts = 0
+
+        lockout_until = raw.get("lockout_until")
+        if not isinstance(lockout_until, (int, float)):
+            lockout_until = None
+
+        return {
+            "version": STORE_SCHEMA_VERSION,
+            "enrollments": enrollments,
+            "failed_attempts": failed_attempts,
+            "lockout_until": lockout_until,
+        }
+
+    def _save(self, data: dict) -> None:
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        payload = json.dumps(data, indent=2, ensure_ascii=False)
+        fd, tmp_path = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp_path, 0o600)
+            atomic_replace(tmp_path, self._path)
+            try:
+                os.chmod(self._path, 0o600)
+            except OSError:
+                pass  # Windows doesn't support chmod the same way.
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -59,6 +59,7 @@ from gateway.platforms.base import (
     is_network_accessible,
 )
 from agent.redact import redact_sensitive_text
+from gateway.api_operator_auth import AuthPrincipal, OperatorCredentialStore
 
 logger = logging.getLogger(__name__)
 
@@ -777,6 +778,11 @@ class APIServerAdapter(BasePlatformAdapter):
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
+        # Hashed, revocable scoped operator tokens. Left unset until the server
+        # starts (connect() wires it to <HERMES_HOME>/operator_credentials.json).
+        # When None *and* no API_SERVER_KEY is configured, the server is open
+        # (dev/test wiring), matching the historical _check_auth behavior.
+        self._operator_credentials: Optional[OperatorCredentialStore] = None
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
@@ -982,6 +988,85 @@ class APIServerAdapter(BasePlatformAdapter):
             status=401,
         )
 
+    def _authorize(
+        self,
+        request: "web.Request",
+        required_scope: Optional[str],
+    ) -> tuple[Optional[AuthPrincipal], Optional["web.Response"]]:
+        """Resolve the caller's principal and enforce ``required_scope``.
+
+        Returns ``(principal, None)`` when the request is authorized, or
+        ``(None, response)`` with a sanitized 401/403 when it is not. When
+        ``required_scope`` is ``None`` the caller only needs an authenticated
+        principal (used by ``/v1/capabilities``), not a specific scope.
+
+        Resolution order is exact:
+
+        1. Constant-time compare the bearer against ``API_SERVER_KEY`` — the
+           legacy superuser credential, mapped to scope ``*``.
+        2. Otherwise authenticate the bearer against the operator credential
+           store — a hashed, revocable scoped token.
+        3. Otherwise return the same ``invalid_api_key`` 401 as ``_check_auth``.
+        4. If authenticated but the principal lacks ``required_scope``, return
+           ``insufficient_scope`` 403 that names only the *required* scope —
+           never the granted ones — so an under-scoped token learns nothing
+           about the wider grant space.
+
+        Compatibility: when neither an API key nor an operator store is
+        configured (dev/test wiring) the server is open, mirroring
+        ``_check_auth``'s no-key branch, and an anonymous superuser principal
+        is returned.
+        """
+        if not self._api_key and self._operator_credentials is None:
+            return AuthPrincipal("anonymous", ("*",), True), None
+
+        auth_header = request.headers.get("Authorization", "")
+        token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else ""
+
+        principal: Optional[AuthPrincipal] = None
+        if token and self._api_key and hmac.compare_digest(token, self._api_key):
+            principal = AuthPrincipal("legacy-api-key", ("*",), True)
+        elif token and self._operator_credentials is not None:
+            principal = self._operator_credentials.authenticate(token)
+
+        if principal is None:
+            logger.warning(
+                "API server rejected invalid API key: %s",
+                self._request_audit_log_suffix(request),
+            )
+            return None, web.json_response(
+                {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
+                status=401,
+            )
+
+        if required_scope is not None and not principal.allows(required_scope):
+            return None, web.json_response(
+                {
+                    "error": {
+                        "message": "The presented credential is missing the scope required for this operation.",
+                        "type": "invalid_request_error",
+                        "code": "insufficient_scope",
+                        "required_scope": required_scope,
+                    }
+                },
+                status=403,
+            )
+
+        return principal, None
+
+    @staticmethod
+    def _capability_auth_view(principal: Optional[AuthPrincipal]) -> tuple[list[str], str]:
+        """Return ``(granted_scopes, credential_kind)`` for the capability doc.
+
+        Never leaks the raw token or the credential id — only the scope grant
+        and a coarse credential kind. Superuser principals report ``["*"]``.
+        """
+        if principal is None or (principal.is_superuser and principal.credential_id == "anonymous"):
+            return ["*"], "none"
+        if principal.is_superuser:
+            return ["*"], "legacy_api_key"
+        return list(principal.scopes), "operator_token"
+
     # ------------------------------------------------------------------
     # Session header helpers
     # ------------------------------------------------------------------
@@ -1167,7 +1252,7 @@ class APIServerAdapter(BasePlatformAdapter):
         dashboard can display full status without needing a shared PID file or
         /proc access.  Requires the same Bearer auth as other API routes.
         """
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "gateway:read")
         if auth_err:
             return auth_err
 
@@ -1207,7 +1292,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_models(self, request: "web.Request") -> "web.Response":
         """GET /v1/models — return hermes-agent as an available model."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:read")
         if auth_err:
             return auth_err
 
@@ -1233,17 +1318,28 @@ class APIServerAdapter(BasePlatformAdapter):
         server's plugin-safe contract without scraping docs or assuming that
         every Hermes version exposes the same endpoints.
         """
-        auth_err = self._check_auth(request)
+        principal, auth_err = self._authorize(request, None)
         if auth_err:
             return auth_err
+
+        granted_scopes, credential_kind = self._capability_auth_view(principal)
 
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
             "model": self._model_name,
+            "schema_version": 1,
+            "profile_context": {
+                "type": "query",
+                "name": "profile",
+                "required": True,
+                "default_profile_id": "default",
+            },
             "auth": {
                 "type": "bearer",
                 "required": bool(self._api_key),
+                "granted_scopes": granted_scopes,
+                "credential_kind": credential_kind,
             },
             "runtime": {
                 "mode": "server_agent",
@@ -1282,27 +1378,27 @@ class APIServerAdapter(BasePlatformAdapter):
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
-                "health": {"method": "GET", "path": "/health"},
-                "health_detailed": {"method": "GET", "path": "/health/detailed"},
-                "models": {"method": "GET", "path": "/v1/models"},
-                "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
-                "responses": {"method": "POST", "path": "/v1/responses"},
-                "runs": {"method": "POST", "path": "/v1/runs"},
-                "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
-                "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
-                "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
-                "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
-                "skills": {"method": "GET", "path": "/v1/skills"},
-                "toolsets": {"method": "GET", "path": "/v1/toolsets"},
-                "sessions": {"method": "GET", "path": "/api/sessions"},
-                "session_create": {"method": "POST", "path": "/api/sessions"},
-                "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
-                "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
-                "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
-                "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
-                "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
-                "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
-                "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
+                "health": {"method": "GET", "path": "/health", "required_scopes": [], "profile_scoped": False},
+                "health_detailed": {"method": "GET", "path": "/health/detailed", "required_scopes": ["gateway:read"], "profile_scoped": False},
+                "models": {"method": "GET", "path": "/v1/models", "required_scopes": ["chat:read"], "profile_scoped": False},
+                "chat_completions": {"method": "POST", "path": "/v1/chat/completions", "required_scopes": ["chat:write"], "profile_scoped": False},
+                "responses": {"method": "POST", "path": "/v1/responses", "required_scopes": ["chat:write"], "profile_scoped": False},
+                "runs": {"method": "POST", "path": "/v1/runs", "required_scopes": ["chat:write"], "profile_scoped": False},
+                "run_status": {"method": "GET", "path": "/v1/runs/{run_id}", "required_scopes": ["chat:read"], "profile_scoped": False},
+                "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events", "required_scopes": ["chat:read"], "profile_scoped": False},
+                "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval", "required_scopes": ["chat:write"], "profile_scoped": False},
+                "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop", "required_scopes": ["chat:write"], "profile_scoped": False},
+                "skills": {"method": "GET", "path": "/v1/skills", "required_scopes": ["skills:read"], "profile_scoped": False},
+                "toolsets": {"method": "GET", "path": "/v1/toolsets", "required_scopes": ["tools:read"], "profile_scoped": False},
+                "sessions": {"method": "GET", "path": "/api/sessions", "required_scopes": ["sessions:read"], "profile_scoped": False},
+                "session_create": {"method": "POST", "path": "/api/sessions", "required_scopes": ["sessions:write"], "profile_scoped": False},
+                "session": {"method": "GET", "path": "/api/sessions/{session_id}", "required_scopes": ["sessions:read"], "profile_scoped": False},
+                "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}", "required_scopes": ["sessions:write"], "profile_scoped": False},
+                "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}", "required_scopes": ["sessions:write"], "profile_scoped": False},
+                "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages", "required_scopes": ["sessions:read"], "profile_scoped": False},
+                "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork", "required_scopes": ["sessions:write"], "profile_scoped": False},
+                "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat", "required_scopes": ["sessions:write"], "profile_scoped": False},
+                "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream", "required_scopes": ["sessions:write"], "profile_scoped": False},
             },
         })
 
@@ -1318,7 +1414,7 @@ class APIServerAdapter(BasePlatformAdapter):
         skills hub uses internally. Disabled skills are excluded so the
         listing matches what the agent actually loads.
         """
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "skills:read")
         if auth_err:
             return auth_err
 
@@ -1346,7 +1442,7 @@ class APIServerAdapter(BasePlatformAdapter):
         equivalent of what a client would otherwise have to recover by
         asking the model what tools it can call.
         """
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tools:read")
         if auth_err:
             return auth_err
 
@@ -1464,7 +1560,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions — list persisted Hermes sessions."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:read")
         if auth_err:
             return auth_err
 
@@ -1493,7 +1589,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_create_session(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions — create an empty Hermes session row."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:write")
         if auth_err:
             return auth_err
         body, err = await self._read_json_body(request)
@@ -1531,7 +1627,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_get_session(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions/{session_id}."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:read")
         if auth_err:
             return auth_err
         session, err = self._get_existing_session_or_404(request.match_info["session_id"])
@@ -1541,7 +1637,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_patch_session(self, request: "web.Request") -> "web.Response":
         """PATCH /api/sessions/{session_id} — update client-safe session metadata."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:write")
         if auth_err:
             return auth_err
         session_id = request.match_info["session_id"]
@@ -1569,7 +1665,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_delete_session(self, request: "web.Request") -> "web.Response":
         """DELETE /api/sessions/{session_id}."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:write")
         if auth_err:
             return auth_err
         session_id = request.match_info["session_id"]
@@ -1582,7 +1678,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_session_messages(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions/{session_id}/messages."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:read")
         if auth_err:
             return auth_err
         session_id = request.match_info["session_id"]
@@ -1600,7 +1696,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/fork — branch via current SessionDB primitives."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:write")
         if auth_err:
             return auth_err
         source_id = request.match_info["session_id"]
@@ -1647,7 +1743,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/chat — one synchronous agent turn."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:write")
         if auth_err:
             return auth_err
         gateway_session_key, key_err = self._parse_session_key_header(request)
@@ -1691,7 +1787,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_session_chat_stream(self, request: "web.Request") -> "web.StreamResponse":
         """POST /api/sessions/{session_id}/chat/stream — SSE wrapper over _run_agent."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "sessions:write")
         if auth_err:
             return auth_err
         gateway_session_key, key_err = self._parse_session_key_header(request)
@@ -1832,7 +1928,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:write")
         if auth_err:
             return auth_err
 
@@ -2961,7 +3057,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_responses(self, request: "web.Request") -> "web.Response":
         """POST /v1/responses — OpenAI Responses API format."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:write")
         if auth_err:
             return auth_err
 
@@ -3250,7 +3346,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_get_response(self, request: "web.Request") -> "web.Response":
         """GET /v1/responses/{response_id} — retrieve a stored response."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:read")
         if auth_err:
             return auth_err
 
@@ -3263,7 +3359,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_delete_response(self, request: "web.Request") -> "web.Response":
         """DELETE /v1/responses/{response_id} — delete a stored response."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:write")
         if auth_err:
             return auth_err
 
@@ -3313,7 +3409,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_list_jobs(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs — list all cron jobs."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:read")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3328,7 +3424,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_create_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs — create a new cron job."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:write")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3382,7 +3478,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_get_job(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs/{job_id} — get a single cron job."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:read")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3401,7 +3497,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_update_job(self, request: "web.Request") -> "web.Response":
         """PATCH /api/jobs/{job_id} — update a cron job."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:write")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3439,7 +3535,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_delete_job(self, request: "web.Request") -> "web.Response":
         """DELETE /api/jobs/{job_id} — delete a cron job."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:write")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3459,7 +3555,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_pause_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/pause — pause a cron job."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:write")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3479,7 +3575,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_resume_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/resume — resume a paused cron job."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:write")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3499,7 +3595,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/run — trigger immediate execution."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "tasks:write")
         if auth_err:
             return auth_err
         cron_err = self._check_jobs_available()
@@ -3921,7 +4017,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:write")
         if auth_err:
             return auth_err
 
@@ -4228,7 +4324,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_get_run(self, request: "web.Request") -> "web.Response":
         """GET /v1/runs/{run_id} — return pollable run status for external UIs."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:read")
         if auth_err:
             return auth_err
 
@@ -4243,7 +4339,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:read")
         if auth_err:
             return auth_err
 
@@ -4293,7 +4389,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_run_approval(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/approval — resolve a pending run approval."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:write")
         if auth_err:
             return auth_err
 
@@ -4381,7 +4477,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/stop — interrupt a running agent."""
-        auth_err = self._check_auth(request)
+        _principal, auth_err = self._authorize(request, "chat:write")
         if auth_err:
             return auth_err
 
@@ -4511,6 +4607,24 @@ class APIServerAdapter(BasePlatformAdapter):
 
         if not self._port_is_available():
             return False
+
+        # Wire the hashed, revocable scoped-operator-token store. Kept out of
+        # __init__ so directly-constructed test adapters stay open (no key, no
+        # store) unless a test injects one explicitly.
+        if self._operator_credentials is None:
+            try:
+                from hermes_cli.config import get_hermes_home
+
+                self._operator_credentials = OperatorCredentialStore(
+                    get_hermes_home() / "operator_credentials.json"
+                )
+            except Exception:
+                logger.warning(
+                    "[%s] Could not initialize operator credential store; "
+                    "only API_SERVER_KEY (superuser) auth will be available.",
+                    self.name,
+                    exc_info=True,
+                )
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -19,6 +19,12 @@ Exposes an HTTP server with endpoints:
 - GET  /api/sessions/{session_id}/messages — read session message history
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
+- GET  /api/profiles                — list profiles (profiles:read)
+- POST /api/profiles                — create/clone a profile (profiles:write)
+- PATCH /api/profiles/{name}        — rename a profile (profiles:write, If-Match)
+- DELETE /api/profiles/{name}       — delete a profile (profiles:write, If-Match)
+- GET  /api/profiles/{name}/soul    — read profile persona (profiles:read)
+- PUT  /api/profiles/{name}/soul    — write profile persona (profiles:write, If-Match)
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
@@ -42,9 +48,11 @@ import hmac
 import json
 import logging
 import os
+import secrets
 import socket as _socket
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -600,6 +608,84 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+# ---------------------------------------------------------------------------
+# Profile resource revisions (opaque If-Match tokens for /api/profiles)
+# ---------------------------------------------------------------------------
+#
+# hermes_cli.profiles has no built-in revision/etag concept — it's a local
+# CLI/Dashboard surface with no concurrent-writer story. The API server adds
+# one so remote scoped clients get optimistic-concurrency safety without
+# hermes_cli.profiles itself changing. A hidden per-profile marker file (not
+# filesystem mtimes, which have platform-dependent granularity) is the source
+# of truth for "did a mutation happen since this token was issued."
+
+_PROFILE_REVISION_MARKER = ".hermes_api_revision"
+
+
+def _compute_profile_revision(canon: str, profile_dir: "Path") -> str:
+    """Return the current opaque revision for a profile directory.
+
+    Reads the marker file written by :func:`_bump_profile_revision` after
+    every successful mutation. A profile never touched through this API
+    (no marker yet) falls back to a hash of its mutable file state so a
+    freshly-discovered profile still has a valid, reproducible revision to
+    hand back as an ``If-Match`` candidate.
+    """
+    marker = profile_dir / _PROFILE_REVISION_MARKER
+    token = ""
+    try:
+        token = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        token = ""
+
+    if token:
+        seed = f"{canon}:{token}"
+    else:
+        parts = [canon]
+        for fname in ("SOUL.md", "profile.yaml", "config.yaml"):
+            fpath = profile_dir / fname
+            try:
+                st = fpath.stat()
+                parts.append(f"{fname}:{st.st_mtime_ns}:{st.st_size}")
+            except OSError:
+                parts.append(f"{fname}:missing")
+        seed = "|".join(parts)
+
+    return "rev-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _bump_profile_revision(profile_dir: "Path") -> None:
+    """Write a fresh random marker so the profile's next revision differs.
+
+    Called at the end of every successful profile mutation (create, rename
+    target, soul write), inside the caller's ``_profiles_lock``. Best-effort:
+    a failure here just means the profile falls back to the mtime-derived
+    revision on the next read, which still changed after a real write.
+    """
+    marker = profile_dir / _PROFILE_REVISION_MARKER
+    try:
+        marker.write_text(secrets.token_hex(16), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _ensure_default_hermes_home() -> None:
+    """Best-effort bootstrap of the default Hermes home directory.
+
+    Profile list/create read and clone from the default profile's root
+    (``HERMES_HOME``). Every other Hermes entrypoint creates this directory
+    implicitly on first run; the API server is itself long-running and must
+    not assume some other process already did so (e.g. a freshly mounted
+    container volume). Creates only the bare directory — clone/list already
+    tolerate its subtrees being absent.
+    """
+    from hermes_cli import profiles as profiles_mod
+    try:
+        profiles_mod._get_default_hermes_home().mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -818,6 +904,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        # Serializes profile mutations (create/rename/delete/soul-write) so
+        # the If-Match revision check-and-mutate is atomic even if a future
+        # handler offloads work to a thread pool. See _compute_profile_revision.
+        self._profiles_lock = threading.RLock()
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
         # config.yaml gateway.api_server.max_concurrent_runs; 0 disables
@@ -1410,6 +1500,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork", "required_scopes": ["sessions:write"], "profile_scoped": False},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat", "required_scopes": ["sessions:write"], "profile_scoped": False},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream", "required_scopes": ["sessions:write"], "profile_scoped": False},
+                "profiles": {"method": "GET", "path": "/api/profiles", "required_scopes": ["profiles:read"], "profile_scoped": False},
+                "profile_create": {"method": "POST", "path": "/api/profiles", "required_scopes": ["profiles:write"], "profile_scoped": False},
+                "profile_update": {"method": "PATCH", "path": "/api/profiles/{name}", "required_scopes": ["profiles:write"], "profile_scoped": False},
+                "profile_delete": {"method": "DELETE", "path": "/api/profiles/{name}", "required_scopes": ["profiles:write"], "profile_scoped": False},
+                "profile_soul": {"method": "GET", "path": "/api/profiles/{name}/soul", "required_scopes": ["profiles:read"], "profile_scoped": False},
+                "profile_soul_update": {"method": "PUT", "path": "/api/profiles/{name}/soul", "required_scopes": ["profiles:write"], "profile_scoped": False},
             },
         })
 
@@ -2110,6 +2206,338 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
         return response
+
+    # ------------------------------------------------------------------
+    # /api/profiles — scoped profile CRUD + persona (SOUL.md) contracts
+    # ------------------------------------------------------------------
+    #
+    # Thin HTTP wrappers over hermes_cli.profiles — the same domain module
+    # the Dashboard calls. No Dashboard HTTP proxying and no active-profile
+    # mutation endpoint: Navivox profile selection is client state, never a
+    # server-selected "current" profile. Responses only ever carry stable
+    # ids/names, opaque revisions, descriptions, model/skills summaries, and
+    # gateway status — never filesystem paths, env values, or wrapper/alias
+    # commands.
+
+    @staticmethod
+    def _profile_public_dict(info: Any, revision: str) -> Dict[str, Any]:
+        return {
+            "id": info.name,
+            "name": info.name,
+            "revision": revision,
+            "description": info.description or "",
+            "model": info.model or "",
+            "skills_count": int(info.skill_count or 0),
+            "gateway_running": bool(info.gateway_running),
+            "is_default": bool(info.is_default),
+        }
+
+    @staticmethod
+    def _find_profile_info(canon: str) -> Optional[Any]:
+        from hermes_cli import profiles as profiles_mod
+        for info in profiles_mod.list_profiles():
+            if info.name == canon:
+                return info
+        return None
+
+    def _resolve_profile_or_error(self, name: str) -> tuple[Optional[Path], Optional["web.Response"]]:
+        """Validate and resolve a path-segment profile name to its directory.
+
+        Returns ``(None, response)`` with a 400 for a malformed/reserved
+        name or a 404 when the profile doesn't exist. Never includes a
+        filesystem path in the error body.
+        """
+        from hermes_cli import profiles as profiles_mod
+        try:
+            profiles_mod.validate_profile_name(name)
+        except ValueError as exc:
+            return None, web.json_response(
+                _openai_error(str(exc), code="invalid_profile_name"), status=400
+            )
+        if not profiles_mod.profile_exists(name):
+            return None, web.json_response(
+                _openai_error(f"Profile '{name}' does not exist.", code="profile_not_found"),
+                status=404,
+            )
+        return profiles_mod.get_profile_dir(name), None
+
+    @staticmethod
+    def _require_if_match(request: "web.Request") -> tuple[Optional[str], Optional["web.Response"]]:
+        raw = request.headers.get("If-Match", "").strip()
+        if not raw:
+            return None, web.json_response(
+                _openai_error(
+                    "If-Match header is required for this mutation.",
+                    code="if_match_required",
+                ),
+                status=428,
+            )
+        return raw, None
+
+    async def _handle_list_profiles(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles — list profiles known to this Hermes instance.
+
+        Calls ``hermes_cli.profiles.list_profiles()`` directly (the same
+        function the Dashboard uses). Never reflects any sticky
+        ``active_profile`` state — list contents and ordering don't depend
+        on it.
+        """
+        _principal, auth_err = self._authorize(request, "profiles:read")
+        if auth_err:
+            return auth_err
+
+        _ensure_default_hermes_home()
+        from hermes_cli import profiles as profiles_mod
+        infos = profiles_mod.list_profiles()
+        data = [
+            self._profile_public_dict(info, _compute_profile_revision(info.name, info.path))
+            for info in infos
+        ]
+        return web.json_response({"object": "list", "data": data})
+
+    async def _handle_create_profile(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles — create, optionally cloning, a new profile.
+
+        ``clone_from`` names a source profile ("default" or a named profile)
+        whose config/.env/SOUL.md/skills/memory are copied into the new
+        profile; omit it for an empty profile. Never creates a CLI wrapper
+        alias — that's a local-shell artifact irrelevant (and unwanted) for
+        a remote scoped client.
+        """
+        _principal, auth_err = self._authorize(request, "profiles:write")
+        if auth_err:
+            return auth_err
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+
+        name = body.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return web.json_response(_openai_error("name is required", code="invalid_profile_name"), status=400)
+        clone_from = body.get("clone_from")
+        if clone_from is not None and (not isinstance(clone_from, str) or not clone_from.strip()):
+            return web.json_response(_openai_error("clone_from must be a non-empty string", code="invalid_clone_from"), status=400)
+        description = body.get("description")
+        if description is not None and not isinstance(description, str):
+            return web.json_response(_openai_error("description must be a string", code="invalid_description"), status=400)
+
+        _ensure_default_hermes_home()
+        from hermes_cli import profiles as profiles_mod
+        with self._profiles_lock:
+            try:
+                path = profiles_mod.create_profile(
+                    name=name,
+                    clone_from=clone_from,
+                    clone_config=bool(clone_from),
+                    no_alias=True,
+                    description=description,
+                )
+            except FileExistsError as exc:
+                return web.json_response(_openai_error(str(exc), code="profile_exists"), status=409)
+            except FileNotFoundError as exc:
+                return web.json_response(_openai_error(str(exc), code="clone_source_not_found"), status=404)
+            except ValueError as exc:
+                return web.json_response(_openai_error(str(exc), code="invalid_profile_create"), status=400)
+            except Exception:
+                logger.exception("POST /api/profiles failed")
+                return web.json_response(
+                    _openai_error("Failed to create profile", err_type="server_error"), status=500
+                )
+
+            if not clone_from:
+                try:
+                    profiles_mod.seed_profile_skills(path, quiet=True)
+                except Exception:
+                    logger.exception("POST /api/profiles: skill seeding failed for %s", name)
+
+            _bump_profile_revision(path)
+            canon = profiles_mod.normalize_profile_name(name)
+            info = self._find_profile_info(canon)
+            if info is None:
+                return web.json_response(
+                    _openai_error("Profile created but could not be read back", err_type="server_error"),
+                    status=500,
+                )
+            payload = self._profile_public_dict(info, _compute_profile_revision(info.name, info.path))
+
+        return web.json_response({"object": "hermes.profile", **payload}, status=201)
+
+    async def _handle_patch_profile(self, request: "web.Request") -> "web.Response":
+        """PATCH /api/profiles/{name} — rename a profile.
+
+        Requires ``If-Match`` against the profile's current opaque revision;
+        validated and applied inside one locked read-modify-write so a stale
+        caller cannot silently clobber a concurrent rename.
+        """
+        _principal, auth_err = self._authorize(request, "profiles:write")
+        if auth_err:
+            return auth_err
+        old_name = request.match_info["name"]
+        if_match, err = self._require_if_match(request)
+        if err:
+            return err
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        new_name = body.get("new_name")
+        if not isinstance(new_name, str) or not new_name.strip():
+            return web.json_response(_openai_error("new_name is required", code="invalid_new_name"), status=400)
+
+        from hermes_cli import profiles as profiles_mod
+        with self._profiles_lock:
+            old_dir, err = self._resolve_profile_or_error(old_name)
+            if err:
+                return err
+            canon = profiles_mod.normalize_profile_name(old_name)
+            current_revision = _compute_profile_revision(canon, old_dir)
+            if not hmac.compare_digest(if_match, current_revision):
+                return web.json_response(
+                    _openai_error("Profile has been modified since the given revision.", code="revision_conflict"),
+                    status=412,
+                )
+            try:
+                new_dir = profiles_mod.rename_profile(old_name, new_name)
+            except FileNotFoundError as exc:
+                return web.json_response(_openai_error(str(exc), code="profile_not_found"), status=404)
+            except FileExistsError as exc:
+                return web.json_response(_openai_error(str(exc), code="profile_exists"), status=409)
+            except ValueError as exc:
+                return web.json_response(_openai_error(str(exc), code="invalid_profile_rename"), status=400)
+            except Exception:
+                logger.exception("PATCH /api/profiles/%s failed", old_name)
+                return web.json_response(
+                    _openai_error("Failed to rename profile", err_type="server_error"), status=500
+                )
+
+            _bump_profile_revision(new_dir)
+            new_canon = profiles_mod.normalize_profile_name(new_name)
+            info = self._find_profile_info(new_canon)
+            if info is None:
+                return web.json_response(
+                    _openai_error("Profile renamed but could not be read back", err_type="server_error"),
+                    status=500,
+                )
+            payload = self._profile_public_dict(info, _compute_profile_revision(info.name, info.path))
+
+        return web.json_response({"object": "hermes.profile", **payload})
+
+    async def _handle_delete_profile(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/profiles/{name} — permanently delete a profile.
+
+        Requires ``If-Match``. The default profile can never be deleted
+        (rejected by ``hermes_cli.profiles.delete_profile`` itself).
+        """
+        _principal, auth_err = self._authorize(request, "profiles:write")
+        if auth_err:
+            return auth_err
+        name = request.match_info["name"]
+        if_match, err = self._require_if_match(request)
+        if err:
+            return err
+
+        from hermes_cli import profiles as profiles_mod
+        with self._profiles_lock:
+            profile_dir, err = self._resolve_profile_or_error(name)
+            if err:
+                return err
+            canon = profiles_mod.normalize_profile_name(name)
+            current_revision = _compute_profile_revision(canon, profile_dir)
+            if not hmac.compare_digest(if_match, current_revision):
+                return web.json_response(
+                    _openai_error("Profile has been modified since the given revision.", code="revision_conflict"),
+                    status=412,
+                )
+            try:
+                profiles_mod.delete_profile(name, yes=True)
+            except FileNotFoundError as exc:
+                return web.json_response(_openai_error(str(exc), code="profile_not_found"), status=404)
+            except ValueError as exc:
+                return web.json_response(_openai_error(str(exc), code="invalid_profile_delete"), status=400)
+            except Exception:
+                logger.exception("DELETE /api/profiles/%s failed", name)
+                return web.json_response(
+                    _openai_error("Failed to delete profile", err_type="server_error"), status=500
+                )
+
+            new_revision = f"rev-deleted-{secrets.token_hex(8)}"
+
+        return web.json_response({
+            "object": "hermes.profile.deleted",
+            "id": canon,
+            "deleted": True,
+            "revision": new_revision,
+        })
+
+    async def _handle_get_profile_soul(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles/{name}/soul — read the profile's persona (SOUL.md)."""
+        _principal, auth_err = self._authorize(request, "profiles:read")
+        if auth_err:
+            return auth_err
+        name = request.match_info["name"]
+        profile_dir, err = self._resolve_profile_or_error(name)
+        if err:
+            return err
+
+        from hermes_cli import profiles as profiles_mod
+        canon = profiles_mod.normalize_profile_name(name)
+        soul_path = profile_dir / "SOUL.md"
+        exists = soul_path.exists()
+        content = ""
+        if exists:
+            try:
+                content = soul_path.read_text(encoding="utf-8")
+            except OSError:
+                logger.exception("GET /api/profiles/%s/soul failed", name)
+                return web.json_response(
+                    _openai_error("Could not read profile persona", err_type="server_error"), status=500
+                )
+        revision = _compute_profile_revision(canon, profile_dir)
+        return web.json_response({"id": canon, "content": content, "exists": exists, "revision": revision})
+
+    async def _handle_put_profile_soul(self, request: "web.Request") -> "web.Response":
+        """PUT /api/profiles/{name}/soul — replace the profile's persona (SOUL.md).
+
+        Requires ``If-Match``; validated and written inside one locked
+        read-modify-write.
+        """
+        _principal, auth_err = self._authorize(request, "profiles:write")
+        if auth_err:
+            return auth_err
+        name = request.match_info["name"]
+        if_match, err = self._require_if_match(request)
+        if err:
+            return err
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        content = body.get("content")
+        if not isinstance(content, str):
+            return web.json_response(_openai_error("content must be a string", code="invalid_soul_content"), status=400)
+
+        from hermes_cli import profiles as profiles_mod
+        with self._profiles_lock:
+            profile_dir, err = self._resolve_profile_or_error(name)
+            if err:
+                return err
+            canon = profiles_mod.normalize_profile_name(name)
+            current_revision = _compute_profile_revision(canon, profile_dir)
+            if not hmac.compare_digest(if_match, current_revision):
+                return web.json_response(
+                    _openai_error("Profile has been modified since the given revision.", code="revision_conflict"),
+                    status=412,
+                )
+            soul_path = profile_dir / "SOUL.md"
+            try:
+                soul_path.write_text(content, encoding="utf-8")
+            except OSError:
+                logger.exception("PUT /api/profiles/%s/soul failed", name)
+                return web.json_response(
+                    _openai_error("Could not write profile persona", err_type="server_error"), status=500
+                )
+            _bump_profile_revision(profile_dir)
+            new_revision = _compute_profile_revision(canon, profile_dir)
+
+        return web.json_response({"id": canon, "ok": True, "revision": new_revision})
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -4860,6 +5288,15 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/sessions/{session_id}/fork", self._handle_fork_session)
             self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
             self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
+            # Scoped profile CRUD + persona (SOUL.md) contracts. Reuses
+            # hermes_cli.profiles directly — no Dashboard HTTP proxy, no
+            # active-profile mutation endpoint.
+            self._app.router.add_get("/api/profiles", self._handle_list_profiles)
+            self._app.router.add_post("/api/profiles", self._handle_create_profile)
+            self._app.router.add_patch("/api/profiles/{name}", self._handle_patch_profile)
+            self._app.router.add_delete("/api/profiles/{name}", self._handle_delete_profile)
+            self._app.router.add_get("/api/profiles/{name}/soul", self._handle_get_profile_soul)
+            self._app.router.add_put("/api/profiles/{name}/soul", self._handle_put_profile_soul)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -8,6 +8,11 @@ Exposes an HTTP server with endpoints:
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent as an available model
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
+- POST /v1/operator/enrollments            — mint a one-time pairing code (settings:write)
+- POST /v1/operator/enrollments/inspect    — preview a pending grant by code + origin
+- POST /v1/operator/enrollments/exchange   — consume a code, mint a scoped operator token
+- GET  /v1/operator/credentials            — list issued operator credentials (settings:read)
+- DELETE /v1/operator/credentials/{credential_id} — revoke an operator credential (settings:write)
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
@@ -44,6 +49,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
 
 try:
     from aiohttp import web
@@ -60,6 +66,7 @@ from gateway.platforms.base import (
 )
 from agent.redact import redact_sensitive_text
 from gateway.api_operator_auth import AuthPrincipal, OperatorCredentialStore
+from gateway.api_operator_enrollment import OperatorEnrollmentStore
 
 logger = logging.getLogger(__name__)
 
@@ -783,6 +790,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # When None *and* no API_SERVER_KEY is configured, the server is open
         # (dev/test wiring), matching the historical _check_auth behavior.
         self._operator_credentials: Optional[OperatorCredentialStore] = None
+        # One-time pairing-code enrollment store, wired alongside
+        # _operator_credentials in connect() (shares that credential store
+        # so a successful exchange can mint a token directly).
+        self._operator_enrollments: Optional[OperatorEnrollmentStore] = None
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
@@ -1538,6 +1549,180 @@ class APIServerAdapter(BasePlatformAdapter):
         if not isinstance(body, dict):
             return {}, web.json_response(_openai_error("Request body must be a JSON object"), status=400)
         return body, None
+
+    # ------------------------------------------------------------------
+    # Operator enrollment (one-time pairing codes) and credential lifecycle
+    # ------------------------------------------------------------------
+
+    async def _handle_create_enrollment(self, request: "web.Request") -> "web.Response":
+        """POST /v1/operator/enrollments — mint a one-time pairing code.
+
+        Requires ``settings:write`` (or superuser). The response carries a
+        ``pairing_uri`` embedding the raw code for the caller to relay
+        out-of-band (QR code, deep link) to the enrolling device — the code
+        itself is never written to disk in plaintext.
+        """
+        _principal, auth_err = self._authorize(request, "settings:write")
+        if auth_err:
+            return auth_err
+        if self._operator_enrollments is None:
+            return web.json_response(
+                _openai_error("Operator enrollment store unavailable", code="operator_enrollment_unavailable"),
+                status=503,
+            )
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+
+        label = body.get("label")
+        if not isinstance(label, str) or not label.strip():
+            return web.json_response(_openai_error("label is required", code="invalid_label"), status=400)
+        origin = body.get("origin")
+        if not isinstance(origin, str) or not origin.strip():
+            return web.json_response(_openai_error("origin is required", code="invalid_origin"), status=400)
+        raw_scopes = body.get("scopes")
+        if not isinstance(raw_scopes, list) or not raw_scopes or not all(isinstance(s, str) for s in raw_scopes):
+            return web.json_response(
+                _openai_error("scopes must be a non-empty array of strings", code="invalid_scopes"), status=400,
+            )
+
+        try:
+            grant = self._operator_enrollments.create(label=label, origin=origin, scopes=raw_scopes)
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_scopes"), status=400)
+
+        pairing_uri = "navivox://connect?" + urlencode({"origin": grant.origin, "code": grant.code})
+        return web.json_response(
+            {
+                "pairing_uri": pairing_uri,
+                "expires_at": grant.expires_at,
+                "scopes": list(grant.scopes),
+            },
+            status=201,
+        )
+
+    async def _handle_inspect_enrollment(self, request: "web.Request") -> "web.Response":
+        """POST /v1/operator/enrollments/inspect — preview a pending grant.
+
+        No bearer auth: the caller authenticates by presenting the one-time
+        code and matching origin, before it has any credential. The request
+        body (which carries the raw code) is never logged — only the
+        sanitized, code-free audit context helpers are used elsewhere.
+        """
+        if self._operator_enrollments is None:
+            return web.json_response(
+                _openai_error("Operator enrollment store unavailable", code="operator_enrollment_unavailable"),
+                status=503,
+            )
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        code = body.get("code")
+        origin = body.get("origin")
+        if not isinstance(code, str) or not code or not isinstance(origin, str) or not origin:
+            return web.json_response(
+                _openai_error("code and origin are required", code="invalid_enrollment_request"), status=400,
+            )
+
+        preview = self._operator_enrollments.inspect(code, origin)
+        if preview is None:
+            return web.json_response(
+                _openai_error("Invalid or expired pairing code", code="enrollment_not_found"), status=404,
+            )
+        return web.json_response({
+            "label": preview.label,
+            "origin": preview.origin,
+            "scopes": list(preview.scopes),
+            "expires_at": preview.expires_at,
+        })
+
+    async def _handle_exchange_enrollment(self, request: "web.Request") -> "web.Response":
+        """POST /v1/operator/enrollments/exchange — consume the code, mint a token.
+
+        No bearer auth (same rationale as inspect). Returns the raw operator
+        token exactly once; it is never persisted in plaintext nor logged.
+        """
+        if self._operator_enrollments is None:
+            return web.json_response(
+                _openai_error("Operator enrollment store unavailable", code="operator_enrollment_unavailable"),
+                status=503,
+            )
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        code = body.get("code")
+        origin = body.get("origin")
+        if not isinstance(code, str) or not code or not isinstance(origin, str) or not origin:
+            return web.json_response(
+                _openai_error("code and origin are required", code="invalid_enrollment_request"), status=400,
+            )
+
+        issued = self._operator_enrollments.exchange(code, origin)
+        if issued is None:
+            return web.json_response(
+                _openai_error("Invalid or expired pairing code", code="enrollment_not_found"), status=404,
+            )
+        return web.json_response({
+            "token": issued.token,
+            "credential": {
+                "credential_id": issued.credential_id,
+                "label": issued.label,
+                "scopes": list(issued.scopes),
+                "created_at": issued.created_at,
+            },
+        })
+
+    async def _handle_list_operator_credentials(self, request: "web.Request") -> "web.Response":
+        """GET /v1/operator/credentials — list issued credential summaries.
+
+        Requires ``settings:read``. Summaries never carry the token itself
+        (only :class:`~gateway.api_operator_auth.CredentialSummary` fields).
+        """
+        _principal, auth_err = self._authorize(request, "settings:read")
+        if auth_err:
+            return auth_err
+        if self._operator_credentials is None:
+            return web.json_response(
+                _openai_error("Operator credential store unavailable", code="operator_credentials_unavailable"),
+                status=503,
+            )
+        summaries = self._operator_credentials.list_credentials()
+        return web.json_response({
+            "object": "list",
+            "data": [
+                {
+                    "credential_id": summary.credential_id,
+                    "label": summary.label,
+                    "scopes": list(summary.scopes),
+                    "created_at": summary.created_at,
+                    "revoked_at": summary.revoked_at,
+                }
+                for summary in summaries
+            ],
+        })
+
+    async def _handle_revoke_operator_credential(self, request: "web.Request") -> "web.Response":
+        """DELETE /v1/operator/credentials/{credential_id} — revoke a token.
+
+        Requires ``settings:write``.
+        """
+        _principal, auth_err = self._authorize(request, "settings:write")
+        if auth_err:
+            return auth_err
+        if self._operator_credentials is None:
+            return web.json_response(
+                _openai_error("Operator credential store unavailable", code="operator_credentials_unavailable"),
+                status=503,
+            )
+        credential_id = request.match_info["credential_id"]
+        revoked = self._operator_credentials.revoke(credential_id)
+        if not revoked:
+            return web.json_response(
+                _openai_error(f"Credential not found: {credential_id}", code="credential_not_found"), status=404,
+            )
+        return web.json_response(
+            {"object": "hermes.operator_credential.deleted", "id": credential_id, "deleted": True}
+        )
 
     def _get_existing_session_or_404(self, session_id: str) -> tuple[Optional[Dict[str, Any]], Optional["web.Response"]]:
         db = self._ensure_session_db()
@@ -4626,6 +4811,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
+        # Wire the one-time enrollment store on top of whichever credential
+        # store just got set up (directly-constructed test adapters keep it
+        # unset unless a test injects one explicitly, same pattern as above).
+        if self._operator_enrollments is None and self._operator_credentials is not None:
+            try:
+                from hermes_cli.config import get_hermes_home
+
+                self._operator_enrollments = OperatorEnrollmentStore(
+                    get_hermes_home() / "operator_enrollments.json",
+                    self._operator_credentials,
+                )
+            except Exception:
+                logger.warning(
+                    "[%s] Could not initialize operator enrollment store; "
+                    "one-time pairing-code enrollment will be unavailable.",
+                    self.name,
+                    exc_info=True,
+                )
+
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
@@ -4637,6 +4841,15 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/capabilities", self._handle_capabilities)
             self._app.router.add_get("/v1/skills", self._handle_skills)
             self._app.router.add_get("/v1/toolsets", self._handle_toolsets)
+            # One-time operator enrollment (pairing codes) and scoped
+            # operator-token lifecycle. Creation requires settings:write;
+            # inspect/exchange authenticate via the code + origin itself
+            # (no bearer token exists yet at that point in the flow).
+            self._app.router.add_post("/v1/operator/enrollments", self._handle_create_enrollment)
+            self._app.router.add_post("/v1/operator/enrollments/inspect", self._handle_inspect_enrollment)
+            self._app.router.add_post("/v1/operator/enrollments/exchange", self._handle_exchange_enrollment)
+            self._app.router.add_get("/v1/operator/credentials", self._handle_list_operator_credentials)
+            self._app.router.add_delete("/v1/operator/credentials/{credential_id}", self._handle_revoke_operator_credential)
             # Session/client control surface (thin wrappers over SessionDB + _run_agent)
             self._app.router.add_get("/api/sessions", self._handle_list_sessions)
             self._app.router.add_post("/api/sessions", self._handle_create_session)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2332,10 +2332,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     no_alias=True,
                     description=description,
                 )
-            except FileExistsError as exc:
-                return web.json_response(_openai_error(str(exc), code="profile_exists"), status=409)
-            except FileNotFoundError as exc:
-                return web.json_response(_openai_error(str(exc), code="clone_source_not_found"), status=404)
+            except FileExistsError:
+                return web.json_response(
+                    _openai_error(f"Profile '{name}' already exists", code="profile_exists"), status=409
+                )
+            except FileNotFoundError:
+                return web.json_response(
+                    _openai_error(f"Clone source '{clone_from}' does not exist", code="clone_source_not_found"),
+                    status=404,
+                )
             except ValueError as exc:
                 return web.json_response(_openai_error(str(exc), code="invalid_profile_create"), status=400)
             except Exception:
@@ -2367,7 +2372,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Requires ``If-Match`` against the profile's current opaque revision;
         validated and applied inside one locked read-modify-write so a stale
-        caller cannot silently clobber a concurrent rename.
+        caller cannot silently clobber a concurrent rename. Never creates a
+        CLI wrapper alias — that's a local-shell artifact irrelevant (and
+        unwanted) for a remote scoped client.
         """
         _principal, auth_err = self._authorize(request, "profiles:write")
         if auth_err:
@@ -2396,7 +2403,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=412,
                 )
             try:
-                new_dir = profiles_mod.rename_profile(old_name, new_name)
+                new_dir = profiles_mod.rename_profile(old_name, new_name, no_alias=True)
             except FileNotFoundError as exc:
                 return web.json_response(_openai_error(str(exc), code="profile_not_found"), status=404)
             except FileExistsError as exc:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1926,8 +1926,14 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
         print(f"✓ Honcho host updated: {source_host} → {new_host}")
 
 
-def rename_profile(old_name: str, new_name: str) -> Path:
+def rename_profile(old_name: str, new_name: str, no_alias: bool = False) -> Path:
     """Rename a profile: directory, wrapper script, service, active_profile.
+
+    no_alias:
+        If True, skip all wrapper-script work (removing the old alias,
+        checking for alias collisions, and creating the new alias). Used by
+        remote/API callers for whom a local shell wrapper under
+        ``~/.local/bin`` is irrelevant (and unwanted).
 
     Returns the new profile directory.
     """
@@ -1962,13 +1968,14 @@ def rename_profile(old_name: str, new_name: str) -> Path:
     _migrate_honcho_profile_host(old_canon, new_canon, new_dir)
 
     # 4. Update wrapper script
-    remove_wrapper_script(old_canon)
-    collision = check_alias_collision(new_canon)
-    if not collision:
-        create_wrapper_script(new_canon)
-        print(f"✓ Alias updated: {new_canon}")
-    else:
-        print(f"⚠ Cannot create alias '{new_canon}' — {collision}")
+    if not no_alias:
+        remove_wrapper_script(old_canon)
+        collision = check_alias_collision(new_canon)
+        if not collision:
+            create_wrapper_script(new_canon)
+            print(f"✓ Alias updated: {new_canon}")
+        else:
+            print(f"⚠ Cannot create alias '{new_canon}' — {collision}")
 
     # 5. Update active_profile if it pointed to old name
     try:

--- a/tests/gateway/test_api_operator_auth.py
+++ b/tests/gateway/test_api_operator_auth.py
@@ -1,5 +1,7 @@
 """Tests for the Hermes operator authorization vocabulary."""
 
+import hashlib
+import json
 import stat
 import sys
 
@@ -102,3 +104,91 @@ def test_store_file_has_owner_only_permissions(tmp_path):
 
     mode = stat.S_IMODE((tmp_path / "operator_credentials.json").stat().st_mode)
     assert mode == 0o600
+
+
+def test_authenticate_returns_none_for_non_string_token(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    store.issue("phone", ["chat:read"])
+
+    assert store.authenticate(None) is None
+    assert store.authenticate(1234) is None
+    assert store.authenticate(b"hop_bytes") is None
+
+
+def _write_store(path, credentials):
+    path.write_text(
+        json.dumps({"version": 1, "credentials": credentials}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        "not-a-dict-record",
+        {"token_hash": "abc", "scopes": 123, "created_at": 1.0},
+        {"token_hash": "abc", "scopes": "chat:read", "created_at": 1.0},
+        {"token_hash": "abc", "scopes": ["filesystem:write"], "created_at": 1.0},
+        {"token_hash": "abc", "scopes": ["chat:read"], "created_at": "soon"},
+        {"token_hash": "abcé", "scopes": ["chat:read"], "created_at": 1.0},
+        {"token_hash": 12345, "scopes": ["chat:read"], "created_at": 1.0},
+        {"scopes": ["chat:read"], "created_at": 1.0},
+    ],
+)
+def test_corrupt_record_is_skipped_not_raised(tmp_path, record):
+    path = tmp_path / "operator_credentials.json"
+    _write_store(path, {"hoc_bad": record})
+    store = OperatorCredentialStore(path)
+
+    assert store.list_credentials() == []
+    assert store.authenticate("hop_anything") is None
+    assert store.revoke("hoc_bad") is False
+
+
+def test_top_level_json_list_fails_closed(tmp_path):
+    path = tmp_path / "operator_credentials.json"
+    path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+    store = OperatorCredentialStore(path)
+
+    assert store.list_credentials() == []
+    assert store.authenticate("hop_anything") is None
+
+
+def test_nested_garbage_credentials_object_fails_closed(tmp_path):
+    path = tmp_path / "operator_credentials.json"
+    path.write_text(
+        json.dumps({"version": 1, "credentials": "totally-not-a-mapping"}),
+        encoding="utf-8",
+    )
+    store = OperatorCredentialStore(path)
+
+    assert store.list_credentials() == []
+    assert store.authenticate("hop_anything") is None
+
+
+def test_valid_record_survives_alongside_corrupt_record(tmp_path):
+    path = tmp_path / "operator_credentials.json"
+    token = "hop_valid-token-value"
+    token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    _write_store(
+        path,
+        {
+            "hoc_bad": {"token_hash": "abc", "scopes": 123, "created_at": "soon"},
+            "hoc_good": {
+                "token_hash": token_hash,
+                "label": "Good Device",
+                "scopes": ["chat:read"],
+                "created_at": 100.0,
+                "revoked_at": None,
+            },
+        },
+    )
+    store = OperatorCredentialStore(path)
+
+    summaries = store.list_credentials()
+    assert [summary.credential_id for summary in summaries] == ["hoc_good"]
+    assert summaries[0].label == "Good Device"
+
+    principal = store.authenticate(token)
+    assert principal is not None
+    assert principal.credential_id == "hoc_good"

--- a/tests/gateway/test_api_operator_auth.py
+++ b/tests/gateway/test_api_operator_auth.py
@@ -1,8 +1,15 @@
 """Tests for the Hermes operator authorization vocabulary."""
 
+import stat
+import sys
+
 import pytest
 
-from gateway.api_operator_auth import AuthPrincipal, normalize_scopes
+from gateway.api_operator_auth import (
+    AuthPrincipal,
+    OperatorCredentialStore,
+    normalize_scopes,
+)
 
 
 def test_normalize_scopes_accepts_domain_read_write_and_deduplicates():
@@ -28,3 +35,70 @@ def test_normalize_scopes_wildcard_with_valid_scopes_collapses_to_wildcard():
 
 def test_superuser_satisfies_every_scope():
     assert AuthPrincipal("legacy-api-key", ("*",), True).allows("profiles:write")
+
+
+def test_issue_authenticate_list_revoke_round_trip(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    issued = store.issue("Galaxy S24", ["chat:write", "profiles:read"])
+
+    assert issued.token.startswith("hop_")
+    assert issued.token not in (tmp_path / "operator_credentials.json").read_text()
+    assert store.authenticate(issued.token).credential_id == issued.credential_id
+    assert store.list_credentials()[0].label == "Galaxy S24"
+    assert store.revoke(issued.credential_id)
+    assert store.authenticate(issued.token) is None
+
+
+def test_authenticate_uses_full_hash_not_token_prefix(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    issued = store.issue("phone", ["chat:read"])
+    assert store.authenticate(issued.token[:-1] + "x") is None
+
+
+def test_authenticate_rejects_unknown_token(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    store.issue("phone", ["chat:read"])
+    assert store.authenticate("hop_not-a-real-token") is None
+
+
+def test_malformed_store_file_fails_closed(tmp_path):
+    path = tmp_path / "operator_credentials.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    store = OperatorCredentialStore(path)
+
+    assert store.list_credentials() == []
+    assert store.authenticate("hop_anything") is None
+    assert store.revoke("hoc_missing") is False
+
+
+def test_duplicate_revocation_returns_false(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    issued = store.issue("phone", ["chat:read"])
+
+    assert store.revoke(issued.credential_id) is True
+    assert store.revoke(issued.credential_id) is False
+
+
+def test_revoke_unknown_credential_returns_false(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    assert store.revoke("hoc_does-not-exist") is False
+
+
+def test_label_is_trimmed_and_bounded_to_eighty_characters(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    issued = store.issue("  padded label  ", ["chat:read"])
+    assert issued.label == "padded label"
+
+    long_label = "x" * 200
+    issued_long = store.issue(long_label, ["chat:read"])
+    assert issued_long.label == "x" * 80
+    assert store.list_credentials()[-1].label == "x" * 80
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes only")
+def test_store_file_has_owner_only_permissions(tmp_path):
+    store = OperatorCredentialStore(tmp_path / "operator_credentials.json")
+    store.issue("phone", ["chat:read"])
+
+    mode = stat.S_IMODE((tmp_path / "operator_credentials.json").stat().st_mode)
+    assert mode == 0o600

--- a/tests/gateway/test_api_operator_auth.py
+++ b/tests/gateway/test_api_operator_auth.py
@@ -1,0 +1,21 @@
+"""Tests for the Hermes operator authorization vocabulary."""
+
+import pytest
+
+from gateway.api_operator_auth import AuthPrincipal, normalize_scopes
+
+
+def test_normalize_scopes_accepts_domain_read_write_and_deduplicates():
+    assert normalize_scopes(["profiles:write", "profiles:read", "profiles:read"]) == (
+        "profiles:read",
+        "profiles:write",
+    )
+
+
+def test_normalize_scopes_rejects_unknown_domain():
+    with pytest.raises(ValueError, match="unknown scope"):
+        normalize_scopes(["filesystem:write"])
+
+
+def test_superuser_satisfies_every_scope():
+    assert AuthPrincipal("legacy-api-key", ("*",), True).allows("profiles:write")

--- a/tests/gateway/test_api_operator_auth.py
+++ b/tests/gateway/test_api_operator_auth.py
@@ -17,5 +17,14 @@ def test_normalize_scopes_rejects_unknown_domain():
         normalize_scopes(["filesystem:write"])
 
 
+def test_normalize_scopes_rejects_unknown_scope_even_with_wildcard():
+    with pytest.raises(ValueError, match="unknown scope"):
+        normalize_scopes(["*", "filesystem:read"])
+
+
+def test_normalize_scopes_wildcard_with_valid_scopes_collapses_to_wildcard():
+    assert normalize_scopes(["*", "profiles:read"]) == ("*",)
+
+
 def test_superuser_satisfies_every_scope():
     assert AuthPrincipal("legacy-api-key", ("*",), True).allows("profiles:write")

--- a/tests/gateway/test_api_operator_enrollment.py
+++ b/tests/gateway/test_api_operator_enrollment.py
@@ -1,0 +1,140 @@
+"""Tests for one-time operator enrollment codes and token lifecycle."""
+
+import json
+
+import pytest
+
+from gateway.api_operator_auth import OperatorCredentialStore
+from gateway.api_operator_enrollment import (
+    MAX_FAILED_ATTEMPTS,
+    PAIRING_CODE_TTL_SECONDS,
+    OperatorEnrollmentStore,
+)
+
+
+class FakeClock:
+    def __init__(self, value: float):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def test_enrollment_is_single_use_and_returns_token_once(tmp_path):
+    clock = FakeClock(1000.0)
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(
+        tmp_path / "enrollments.json", credentials, now=clock
+    )
+    grant = enrollments.create(
+        label="Galaxy S24",
+        origin="https://hermes.example",
+        scopes=["chat:write", "profiles:read"],
+    )
+
+    preview = enrollments.inspect(grant.code, "https://hermes.example")
+    issued = enrollments.exchange(grant.code, "https://hermes.example")
+
+    assert preview.scopes == ("chat:write", "profiles:read")
+    assert issued.token.startswith("hop_")
+    assert enrollments.exchange(grant.code, "https://hermes.example") is None
+
+
+def test_origin_mismatch_does_not_consume_code(tmp_path):
+    clock = FakeClock(1000.0)
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(
+        tmp_path / "enrollments.json", credentials, now=clock
+    )
+    grant = enrollments.create(
+        label="Galaxy S24",
+        origin="https://hermes.example",
+        scopes=["profiles:read"],
+    )
+
+    assert enrollments.inspect(grant.code, "https://attacker.example") is None
+    assert enrollments.exchange(grant.code, "https://attacker.example") is None
+    assert enrollments.exchange(grant.code, "https://hermes.example").token.startswith("hop_")
+
+
+def test_expired_code_is_rejected(tmp_path):
+    clock = FakeClock(1000.0)
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(
+        tmp_path / "enrollments.json", credentials, now=clock
+    )
+    grant = enrollments.create(
+        label="Galaxy S24",
+        origin="https://hermes.example",
+        scopes=["chat:read"],
+    )
+
+    clock.advance(PAIRING_CODE_TTL_SECONDS + 1)
+
+    assert enrollments.inspect(grant.code, "https://hermes.example") is None
+    assert enrollments.exchange(grant.code, "https://hermes.example") is None
+
+
+def test_malformed_code_is_rejected_without_raising(tmp_path):
+    clock = FakeClock(1000.0)
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(
+        tmp_path / "enrollments.json", credentials, now=clock
+    )
+    enrollments.create(
+        label="Galaxy S24",
+        origin="https://hermes.example",
+        scopes=["chat:read"],
+    )
+
+    assert enrollments.inspect("", "https://hermes.example") is None
+    assert enrollments.inspect("not-a-real-code", "https://hermes.example") is None
+    assert enrollments.inspect(None, "https://hermes.example") is None
+    assert enrollments.exchange("\x00\x01garbage", "https://hermes.example") is None
+
+
+def test_repeated_failed_attempts_trigger_lockout(tmp_path):
+    clock = FakeClock(1000.0)
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(
+        tmp_path / "enrollments.json", credentials, now=clock
+    )
+    grant = enrollments.create(
+        label="Galaxy S24",
+        origin="https://hermes.example",
+        scopes=["chat:read"],
+    )
+
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        assert enrollments.exchange("wrong-code", "https://hermes.example") is None
+
+    # Locked out now: even the correct code + origin is rejected until the
+    # lockout window clears.
+    assert enrollments.exchange(grant.code, "https://hermes.example") is None
+    assert enrollments.inspect(grant.code, "https://hermes.example") is None
+
+
+def test_plaintext_code_is_never_persisted(tmp_path):
+    clock = FakeClock(1000.0)
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(
+        tmp_path / "enrollments.json", credentials, now=clock
+    )
+    grant = enrollments.create(
+        label="Galaxy S24",
+        origin="https://hermes.example",
+        scopes=["chat:read"],
+    )
+
+    raw_text = (tmp_path / "enrollments.json").read_text(encoding="utf-8")
+    assert grant.code not in raw_text
+
+    stored = json.loads(raw_text)
+    entry = next(iter(stored["enrollments"].values()))
+    assert set(entry.keys()) == {
+        "hash", "salt", "label", "origin", "scopes",
+        "created_at", "expires_at", "consumed_at",
+    }

--- a/tests/gateway/test_api_profiles.py
+++ b/tests/gateway/test_api_profiles.py
@@ -130,6 +130,21 @@ class TestProfileCreate:
         assert second.status == 409
 
     @pytest.mark.asyncio
+    async def test_create_duplicate_name_body_has_no_filesystem_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "dup"})
+            second = await client.post("/api/profiles", headers=headers, json={"name": "dup"})
+            body = await second.json()
+
+        assert second.status == 409
+        message = body["error"]["message"]
+        assert str(tmp_path) not in message
+        assert "Profile 'dup' already exists" == message
+
+    @pytest.mark.asyncio
     async def test_create_clone_source_missing_is_not_found(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
         adapter, headers = _make_adapter(tmp_path)
@@ -142,6 +157,24 @@ class TestProfileCreate:
             )
 
         assert response.status == 404
+
+    @pytest.mark.asyncio
+    async def test_create_clone_source_missing_body_has_no_filesystem_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            response = await client.post(
+                "/api/profiles",
+                headers=headers,
+                json={"name": "coder", "clone_from": "does-not-exist"},
+            )
+            body = await response.json()
+
+        assert response.status == 404
+        message = body["error"]["message"]
+        assert str(tmp_path) not in message
+        assert "Clone source 'does-not-exist' does not exist" == message
 
     @pytest.mark.asyncio
     async def test_create_does_not_create_wrapper_alias(self, tmp_path, monkeypatch):
@@ -204,6 +237,7 @@ class TestProfileScopeEnforcement:
     @pytest.mark.asyncio
     async def test_read_only_scope_cannot_rename(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         write_adapter, write_headers = _make_adapter(tmp_path, scopes=("profiles:read", "profiles:write"))
 
         async with TestClient(TestServer(_profile_test_app(write_adapter))) as client:
@@ -223,6 +257,7 @@ class TestProfileScopeEnforcement:
     @pytest.mark.asyncio
     async def test_read_only_scope_cannot_delete(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         adapter, headers = _make_adapter(tmp_path, scopes=("profiles:read", "profiles:write"))
 
         async with TestClient(TestServer(_profile_test_app(adapter))) as client:
@@ -267,6 +302,7 @@ class TestProfileConcurrency:
     @pytest.mark.asyncio
     async def test_default_profile_delete_is_rejected(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         adapter, headers = _make_adapter(tmp_path)
 
         async with TestClient(TestServer(_profile_test_app(adapter))) as client:
@@ -285,6 +321,7 @@ class TestProfileConcurrency:
     @pytest.mark.asyncio
     async def test_missing_if_match_returns_428_for_rename(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         adapter, headers = _make_adapter(tmp_path)
 
         async with TestClient(TestServer(_profile_test_app(adapter))) as client:
@@ -300,6 +337,7 @@ class TestProfileConcurrency:
     @pytest.mark.asyncio
     async def test_missing_if_match_returns_428_for_delete(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         adapter, headers = _make_adapter(tmp_path)
 
         async with TestClient(TestServer(_profile_test_app(adapter))) as client:
@@ -324,6 +362,7 @@ class TestProfileConcurrency:
     @pytest.mark.asyncio
     async def test_stale_revision_returns_412_and_performs_no_write(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         adapter, headers = _make_adapter(tmp_path)
 
         async with TestClient(TestServer(_profile_test_app(adapter))) as client:
@@ -346,6 +385,7 @@ class TestProfileConcurrency:
     @pytest.mark.asyncio
     async def test_successful_rename_returns_new_revision(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         adapter, headers = _make_adapter(tmp_path)
 
         async with TestClient(TestServer(_profile_test_app(adapter))) as client:
@@ -363,8 +403,30 @@ class TestProfileConcurrency:
         assert renamed_body["revision"] != created_body["revision"]
 
     @pytest.mark.asyncio
+    async def test_rename_does_not_create_wrapper_alias(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        wrapper_dir = tmp_path / "local_bin"
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: wrapper_dir)
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            created = await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            created_body = await created.json()
+            renamed = await client.patch(
+                "/api/profiles/coder",
+                headers=dict(headers, **{"If-Match": created_body["revision"]}),
+                json={"new_name": "coder2"},
+            )
+
+        assert renamed.status == 200
+        assert not (wrapper_dir / "coder").exists()
+        assert not (wrapper_dir / "coder2").exists()
+        assert not wrapper_dir.exists()
+
+    @pytest.mark.asyncio
     async def test_successful_delete_returns_new_revision(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "local_bin")
         adapter, headers = _make_adapter(tmp_path)
         monkeypatch.setattr("hermes_cli.profiles._cleanup_gateway_service", lambda *a, **kw: None)
 

--- a/tests/gateway/test_api_profiles.py
+++ b/tests/gateway/test_api_profiles.py
@@ -1,0 +1,422 @@
+"""Tests for scoped profile contracts exposed by the canonical API server.
+
+Covers GET/POST/PATCH/DELETE /api/profiles and GET/PUT /api/profiles/{name}/soul:
+list/create/clone/rename/delete and persona (SOUL.md) read/write, all reusing
+hermes_cli.profiles domain functions directly (no Dashboard HTTP proxy, no
+active-profile mutation endpoint, no leaked filesystem paths/env values/
+wrapper commands).
+"""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.api_operator_auth import OperatorCredentialStore
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _profile_test_app(adapter):
+    app = web.Application()
+    app.router.add_get("/api/profiles", adapter._handle_list_profiles)
+    app.router.add_post("/api/profiles", adapter._handle_create_profile)
+    app.router.add_patch("/api/profiles/{name}", adapter._handle_patch_profile)
+    app.router.add_delete("/api/profiles/{name}", adapter._handle_delete_profile)
+    app.router.add_get("/api/profiles/{name}/soul", adapter._handle_get_profile_soul)
+    app.router.add_put("/api/profiles/{name}/soul", adapter._handle_put_profile_soul)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+def _make_adapter(tmp_path, scopes=("profiles:read", "profiles:write")):
+    """Return (adapter, headers) wired to a fresh credential store with the given scopes."""
+    store = OperatorCredentialStore(tmp_path / "credentials.json")
+    token = store.issue("phone", list(scopes)).token
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+    adapter._operator_credentials = store
+    return adapter, {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_profile_contract_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    store = OperatorCredentialStore(tmp_path / "credentials.json")
+    token = store.issue("phone", ["profiles:read", "profiles:write"]).token
+    headers = {"Authorization": f"Bearer {token}"}
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+    adapter._operator_credentials = store
+
+    async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+        created = await client.post(
+            "/api/profiles",
+            headers=headers,
+            json={"name": "coder", "clone_from": "default"},
+        )
+        listed = await client.get("/api/profiles", headers=headers)
+        created_body = await created.json()
+        listed_body = await listed.json()
+
+    assert created.status == 201
+    assert created_body["name"] == "coder"
+    assert any(item["id"] == "coder" for item in listed_body["data"])
+    assert not (tmp_path / "hermes" / "active_profile").exists()
+
+
+class TestProfileList:
+    @pytest.mark.asyncio
+    async def test_list_never_returns_filesystem_paths_or_wrapper_info(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+        monkeypatch.setattr("hermes_cli.profiles._cleanup_gateway_service", lambda *a, **kw: None)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "widget"})
+            listed = await client.get("/api/profiles", headers=headers)
+            body = await listed.json()
+
+        assert listed.status == 200
+        for item in body["data"]:
+            serialized = str(item)
+            assert "path" not in item
+            assert "alias" not in item
+            assert "wrapper" not in item
+            assert str(tmp_path) not in serialized
+
+    @pytest.mark.asyncio
+    async def test_list_and_create_independent_of_existing_active_profile_file(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        hermes_home.mkdir(parents=True)
+        active_profile = hermes_home / "active_profile"
+        active_profile.write_text("ghost\n", encoding="utf-8")
+
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            created = await client.post("/api/profiles", headers=headers, json={"name": "widget"})
+            listed = await client.get("/api/profiles", headers=headers)
+            body = await listed.json()
+
+        assert created.status == 201
+        assert active_profile.read_text(encoding="utf-8") == "ghost\n"
+        for item in body["data"]:
+            assert "active" not in item
+            assert "is_active" not in item
+
+
+class TestProfileCreate:
+    @pytest.mark.asyncio
+    async def test_create_rejects_traversal_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            response = await client.post(
+                "/api/profiles", headers=headers, json={"name": "../../etc"}
+            )
+
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_name_is_conflict(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            first = await client.post("/api/profiles", headers=headers, json={"name": "dup"})
+            second = await client.post("/api/profiles", headers=headers, json={"name": "dup"})
+
+        assert first.status == 201
+        assert second.status == 409
+
+    @pytest.mark.asyncio
+    async def test_create_clone_source_missing_is_not_found(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            response = await client.post(
+                "/api/profiles",
+                headers=headers,
+                json={"name": "coder", "clone_from": "does-not-exist"},
+            )
+
+        assert response.status == 404
+
+    @pytest.mark.asyncio
+    async def test_create_does_not_create_wrapper_alias(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        wrapper_dir = tmp_path / "local_bin"
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: wrapper_dir)
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            created = await client.post("/api/profiles", headers=headers, json={"name": "widget"})
+
+        assert created.status == 201
+        assert not (wrapper_dir / "widget").exists()
+
+
+class TestProfileSoul:
+    @pytest.mark.asyncio
+    async def test_soul_round_trip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+
+            initial = await client.get("/api/profiles/coder/soul", headers=headers)
+            initial_body = await initial.json()
+
+            write_headers = dict(headers, **{"If-Match": initial_body["revision"]})
+            written = await client.put(
+                "/api/profiles/coder/soul",
+                headers=write_headers,
+                json={"content": "You are a focused coding agent."},
+            )
+            written_body = await written.json()
+
+            after = await client.get("/api/profiles/coder/soul", headers=headers)
+            after_body = await after.json()
+
+        assert initial.status == 200
+        assert written.status == 200
+        assert after_body["content"] == "You are a focused coding agent."
+        assert after_body["exists"] is True
+        assert written_body["revision"] != initial_body["revision"]
+        assert after_body["revision"] == written_body["revision"]
+
+
+class TestProfileScopeEnforcement:
+    @pytest.mark.asyncio
+    async def test_read_only_scope_cannot_create(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path, scopes=("profiles:read",))
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            response = await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            response_body = await response.json()
+
+        assert response.status == 403
+        assert response_body["error"]["code"] == "insufficient_scope"
+
+    @pytest.mark.asyncio
+    async def test_read_only_scope_cannot_rename(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        write_adapter, write_headers = _make_adapter(tmp_path, scopes=("profiles:read", "profiles:write"))
+
+        async with TestClient(TestServer(_profile_test_app(write_adapter))) as client:
+            await client.post("/api/profiles", headers=write_headers, json={"name": "coder"})
+            read_token = write_adapter._operator_credentials.issue("reader", ["profiles:read"]).token
+            read_headers = {"Authorization": f"Bearer {read_token}"}
+            response = await client.patch(
+                "/api/profiles/coder",
+                headers=dict(read_headers, **{"If-Match": "irrelevant"}),
+                json={"new_name": "coder2"},
+            )
+            response_body = await response.json()
+
+        assert response.status == 403
+        assert response_body["error"]["code"] == "insufficient_scope"
+
+    @pytest.mark.asyncio
+    async def test_read_only_scope_cannot_delete(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path, scopes=("profiles:read", "profiles:write"))
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            read_token = adapter._operator_credentials.issue("reader", ["profiles:read"]).token
+            read_headers = {"Authorization": f"Bearer {read_token}"}
+            response = await client.delete(
+                "/api/profiles/coder", headers=dict(read_headers, **{"If-Match": "irrelevant"})
+            )
+
+        assert response.status == 403
+
+    @pytest.mark.asyncio
+    async def test_read_only_scope_cannot_write_soul(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path, scopes=("profiles:read", "profiles:write"))
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            read_token = adapter._operator_credentials.issue("reader", ["profiles:read"]).token
+            read_headers = {"Authorization": f"Bearer {read_token}"}
+            response = await client.put(
+                "/api/profiles/coder/soul",
+                headers=dict(read_headers, **{"If-Match": "irrelevant"}),
+                json={"content": "nope"},
+            )
+
+        assert response.status == 403
+
+    @pytest.mark.asyncio
+    async def test_unrelated_scope_cannot_create(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path, scopes=("chat:read", "chat:write"))
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            response = await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+
+        assert response.status == 403
+
+
+class TestProfileConcurrency:
+    @pytest.mark.asyncio
+    async def test_default_profile_delete_is_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            listed = await client.get("/api/profiles", headers=headers)
+            listed_body = await listed.json()
+            default_revision = next(
+                item["revision"] for item in listed_body["data"] if item["id"] == "default"
+            )
+            response = await client.delete(
+                "/api/profiles/default",
+                headers=dict(headers, **{"If-Match": default_revision}),
+            )
+
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_if_match_returns_428_for_rename(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            response = await client.patch(
+                "/api/profiles/coder", headers=headers, json={"new_name": "coder2"}
+            )
+            response_body = await response.json()
+
+        assert response.status == 428
+        assert response_body["error"]["code"] == "if_match_required"
+
+    @pytest.mark.asyncio
+    async def test_missing_if_match_returns_428_for_delete(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            response = await client.delete("/api/profiles/coder", headers=headers)
+
+        assert response.status == 428
+
+    @pytest.mark.asyncio
+    async def test_missing_if_match_returns_428_for_soul_write(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            response = await client.put(
+                "/api/profiles/coder/soul", headers=headers, json={"content": "hi"}
+            )
+
+        assert response.status == 428
+
+    @pytest.mark.asyncio
+    async def test_stale_revision_returns_412_and_performs_no_write(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            response = await client.patch(
+                "/api/profiles/coder",
+                headers=dict(headers, **{"If-Match": "rev-stale-does-not-match"}),
+                json={"new_name": "coder2"},
+            )
+            response_body = await response.json()
+            listed = await client.get("/api/profiles", headers=headers)
+            listed_body = await listed.json()
+
+        assert response.status == 412
+        assert response_body["error"]["code"] == "revision_conflict"
+        names = {item["id"] for item in listed_body["data"]}
+        assert "coder" in names
+        assert "coder2" not in names
+
+    @pytest.mark.asyncio
+    async def test_successful_rename_returns_new_revision(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            created = await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            created_body = await created.json()
+            renamed = await client.patch(
+                "/api/profiles/coder",
+                headers=dict(headers, **{"If-Match": created_body["revision"]}),
+                json={"new_name": "coder2"},
+            )
+            renamed_body = await renamed.json()
+
+        assert renamed.status == 200
+        assert renamed_body["id"] == "coder2"
+        assert renamed_body["revision"] != created_body["revision"]
+
+    @pytest.mark.asyncio
+    async def test_successful_delete_returns_new_revision(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+        monkeypatch.setattr("hermes_cli.profiles._cleanup_gateway_service", lambda *a, **kw: None)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            created = await client.post("/api/profiles", headers=headers, json={"name": "coder"})
+            created_body = await created.json()
+            deleted = await client.delete(
+                "/api/profiles/coder",
+                headers=dict(headers, **{"If-Match": created_body["revision"]}),
+            )
+            deleted_body = await deleted.json()
+            listed = await client.get("/api/profiles", headers=headers)
+            listed_body = await listed.json()
+
+        assert deleted.status == 200
+        assert deleted_body["deleted"] is True
+        assert deleted_body["revision"] != created_body["revision"]
+        assert "coder" not in {item["id"] for item in listed_body["data"]}
+
+
+class TestProfileCapabilities:
+    @pytest.mark.asyncio
+    async def test_capabilities_advertise_exact_profile_endpoints(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter, headers = _make_adapter(tmp_path)
+
+        async with TestClient(TestServer(_profile_test_app(adapter))) as client:
+            response = await client.get("/v1/capabilities", headers=headers)
+            body = await response.json()
+
+        endpoints = body["endpoints"]
+        assert endpoints["profiles"] == {
+            "method": "GET", "path": "/api/profiles",
+            "required_scopes": ["profiles:read"], "profile_scoped": False,
+        }
+        assert endpoints["profile_create"] == {
+            "method": "POST", "path": "/api/profiles",
+            "required_scopes": ["profiles:write"], "profile_scoped": False,
+        }
+        assert endpoints["profile_update"] == {
+            "method": "PATCH", "path": "/api/profiles/{name}",
+            "required_scopes": ["profiles:write"], "profile_scoped": False,
+        }
+        assert endpoints["profile_delete"] == {
+            "method": "DELETE", "path": "/api/profiles/{name}",
+            "required_scopes": ["profiles:write"], "profile_scoped": False,
+        }
+        assert endpoints["profile_soul"] == {
+            "method": "GET", "path": "/api/profiles/{name}/soul",
+            "required_scopes": ["profiles:read"], "profile_scoped": False,
+        }
+        assert endpoints["profile_soul_update"] == {
+            "method": "PUT", "path": "/api/profiles/{name}/soul",
+            "required_scopes": ["profiles:write"], "profile_scoped": False,
+        }

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -24,6 +24,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from gateway.api_operator_auth import OperatorCredentialStore
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
@@ -887,8 +888,18 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
-            assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
-            assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
+            assert data["endpoints"]["skills"] == {
+                "method": "GET",
+                "path": "/v1/skills",
+                "required_scopes": ["skills:read"],
+                "profile_scoped": False,
+            }
+            assert data["endpoints"]["toolsets"] == {
+                "method": "GET",
+                "path": "/v1/toolsets",
+                "required_scopes": ["tools:read"],
+                "profile_scoped": False,
+            }
 
     @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):
@@ -904,6 +915,137 @@ class TestCapabilitiesEndpoint:
             assert authed.status == 200
             data = await authed.json()
             assert data["auth"]["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Scoped operator-token authorization (_authorize) and caller-specific
+# capability serialization.
+# ---------------------------------------------------------------------------
+
+
+async def _auth_test_client(adapter):
+    async def protected_write(request):
+        _principal, error = adapter._authorize(request, "profiles:write")
+        return error or web.json_response({"ok": True})
+
+    app = web.Application()
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_post("/test/profiles-write", protected_write)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+class TestScopedAuthorization:
+    @pytest.mark.asyncio
+    async def test_scoped_token_cannot_use_ungranted_write_scope(self, tmp_path):
+        store = OperatorCredentialStore(tmp_path / "credentials.json")
+        token = store.issue("phone", ["profiles:read"]).token
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+        adapter._operator_credentials = store
+        client = await _auth_test_client(adapter)
+        try:
+            response = await client.post(
+                "/test/profiles-write",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status == 403
+            assert (await response.json())["error"]["code"] == "insufficient_scope"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_legacy_api_key_remains_superuser(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+        client = await _auth_test_client(adapter)
+        try:
+            response = await client.get(
+                "/v1/capabilities",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert response.status == 200
+            assert (await response.json())["auth"]["granted_scopes"] == ["*"]
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_insufficient_scope_error_never_echoes_granted_scopes(self, tmp_path):
+        store = OperatorCredentialStore(tmp_path / "credentials.json")
+        token = store.issue("phone", ["profiles:read", "chat:write"]).token
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+        adapter._operator_credentials = store
+        client = await _auth_test_client(adapter)
+        try:
+            response = await client.post(
+                "/test/profiles-write",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status == 403
+            body = await response.json()
+            assert body["error"]["required_scope"] == "profiles:write"
+            # The granted scopes must not leak back to an under-scoped caller.
+            serialized = json.dumps(body)
+            assert "profiles:read" not in serialized
+            assert "chat:write" not in serialized
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_scoped_token_capabilities_report_only_granted_scopes(self, tmp_path):
+        store = OperatorCredentialStore(tmp_path / "credentials.json")
+        token = store.issue("phone", ["profiles:read"]).token
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+        adapter._operator_credentials = store
+        client = await _auth_test_client(adapter)
+        try:
+            response = await client.get(
+                "/v1/capabilities",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status == 200
+            data = await response.json()
+            assert data["auth"]["granted_scopes"] == ["profiles:read"]
+            assert data["auth"]["credential_kind"] == "operator_token"
+            # Raw tokens and credential ids never appear in the capability doc.
+            serialized = json.dumps(data)
+            assert token not in serialized
+            assert "credential_id" not in serialized
+
+            # An unauthenticated caller is rejected when a key is configured.
+            rejected = await client.get("/v1/capabilities")
+            assert rejected.status == 401
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_capabilities_declare_schema_profile_context_and_scopes(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+        client = await _auth_test_client(adapter)
+        try:
+            response = await client.get(
+                "/v1/capabilities",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert response.status == 200
+            data = await response.json()
+
+            assert data["schema_version"] == 1
+            assert data["profile_context"] == {
+                "type": "query",
+                "name": "profile",
+                "required": True,
+                "default_profile_id": "default",
+            }
+            assert data["auth"]["credential_kind"] == "legacy_api_key"
+
+            endpoints = data["endpoints"]
+            assert endpoints["sessions"]["required_scopes"] == ["sessions:read"]
+            assert endpoints["sessions"]["profile_scoped"] is False
+            assert endpoints["session_create"]["required_scopes"] == ["sessions:write"]
+            assert endpoints["chat_completions"]["required_scopes"] == ["chat:write"]
+            assert endpoints["health"]["required_scopes"] == []
+        finally:
+            await client.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -14,6 +14,7 @@ Tests cover:
 
 import asyncio
 import json
+import logging
 import os
 import stat
 import time
@@ -25,6 +26,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.api_operator_auth import OperatorCredentialStore
+from gateway.api_operator_enrollment import OperatorEnrollmentStore
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
@@ -613,6 +615,11 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
+    app.router.add_post("/v1/operator/enrollments", adapter._handle_create_enrollment)
+    app.router.add_post("/v1/operator/enrollments/inspect", adapter._handle_inspect_enrollment)
+    app.router.add_post("/v1/operator/enrollments/exchange", adapter._handle_exchange_enrollment)
+    app.router.add_get("/v1/operator/credentials", adapter._handle_list_operator_credentials)
+    app.router.add_delete("/v1/operator/credentials/{credential_id}", adapter._handle_revoke_operator_credential)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
@@ -3940,3 +3947,215 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
+
+
+# ---------------------------------------------------------------------------
+# Operator enrollment (one-time pairing codes) and credential lifecycle HTTP
+# handlers.
+# ---------------------------------------------------------------------------
+
+
+def _enrollment_adapter(tmp_path, *, api_key: str = "sk-test"):
+    """Adapter wired with both operator stores, sharing one credential store."""
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(tmp_path / "enrollments.json", credentials)
+    adapter = _make_adapter(api_key=api_key)
+    adapter._operator_credentials = credentials
+    adapter._operator_enrollments = enrollments
+    return adapter, credentials, enrollments
+
+
+class TestOperatorEnrollmentEndpoints:
+    @pytest.mark.asyncio
+    async def test_create_enrollment_requires_settings_write_scope(self, tmp_path):
+        adapter, credentials, _enrollments = _enrollment_adapter(tmp_path)
+        # A token scoped only to profiles:read must not be able to mint
+        # pairing codes.
+        under_scoped = credentials.issue("phone", ["profiles:read"]).token
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            unauthenticated = await cli.post(
+                "/v1/operator/enrollments",
+                json={"label": "Pixel", "origin": "https://hermes.example", "scopes": ["chat:read"]},
+            )
+            assert unauthenticated.status == 401
+
+            forbidden = await cli.post(
+                "/v1/operator/enrollments",
+                headers={"Authorization": f"Bearer {under_scoped}"},
+                json={"label": "Pixel", "origin": "https://hermes.example", "scopes": ["chat:read"]},
+            )
+            assert forbidden.status == 403
+            assert (await forbidden.json())["error"]["code"] == "insufficient_scope"
+
+    @pytest.mark.asyncio
+    async def test_create_enrollment_returns_pairing_uri_expiry_and_scopes(self, tmp_path):
+        adapter, _credentials, _enrollments = _enrollment_adapter(tmp_path)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/operator/enrollments",
+                headers={"Authorization": "Bearer sk-test"},
+                json={
+                    "label": "Galaxy S24",
+                    "origin": "https://hermes.example",
+                    "scopes": ["chat:write", "profiles:read"],
+                },
+            )
+            assert resp.status == 201
+            data = await resp.json()
+            assert data["scopes"] == ["chat:write", "profiles:read"]
+            assert isinstance(data["expires_at"], (int, float))
+            assert data["pairing_uri"].startswith("navivox://connect?")
+            assert "origin=https%3A%2F%2Fhermes.example" in data["pairing_uri"]
+            assert "code=" in data["pairing_uri"]
+
+    @pytest.mark.asyncio
+    async def test_create_enrollment_rejects_unknown_scope(self, tmp_path):
+        adapter, _credentials, _enrollments = _enrollment_adapter(tmp_path)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/operator/enrollments",
+                headers={"Authorization": "Bearer sk-test"},
+                json={"label": "Pixel", "origin": "https://hermes.example", "scopes": ["filesystem:write"]},
+            )
+            assert resp.status == 400
+            assert (await resp.json())["error"]["code"] == "invalid_scopes"
+
+    @pytest.mark.asyncio
+    async def test_inspect_and_exchange_do_not_require_auth(self, tmp_path):
+        adapter, _credentials, enrollments = _enrollment_adapter(tmp_path)
+        grant = enrollments.create(label="Pixel", origin="https://hermes.example", scopes=["chat:read"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            inspect_resp = await cli.post(
+                "/v1/operator/enrollments/inspect",
+                json={"code": grant.code, "origin": "https://hermes.example"},
+            )
+            assert inspect_resp.status == 200
+            preview = await inspect_resp.json()
+            assert preview == {
+                "label": "Pixel",
+                "origin": "https://hermes.example",
+                "scopes": ["chat:read"],
+                "expires_at": grant.expires_at,
+            }
+
+            exchange_resp = await cli.post(
+                "/v1/operator/enrollments/exchange",
+                json={"code": grant.code, "origin": "https://hermes.example"},
+            )
+            assert exchange_resp.status == 200
+            issued = await exchange_resp.json()
+            assert issued["token"].startswith("hop_")
+            assert issued["credential"]["scopes"] == ["chat:read"]
+            assert "token" not in issued["credential"]
+
+            # The code is now consumed: a second exchange must fail.
+            replay = await cli.post(
+                "/v1/operator/enrollments/exchange",
+                json={"code": grant.code, "origin": "https://hermes.example"},
+            )
+            assert replay.status == 404
+            assert (await replay.json())["error"]["code"] == "enrollment_not_found"
+
+    @pytest.mark.asyncio
+    async def test_exchange_rejects_origin_mismatch_without_leaking(self, tmp_path):
+        adapter, _credentials, enrollments = _enrollment_adapter(tmp_path)
+        grant = enrollments.create(label="Pixel", origin="https://hermes.example", scopes=["chat:read"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            mismatched = await cli.post(
+                "/v1/operator/enrollments/exchange",
+                json={"code": grant.code, "origin": "https://attacker.example"},
+            )
+            assert mismatched.status == 404
+            body = await mismatched.json()
+            assert body["error"]["code"] == "enrollment_not_found"
+            serialized = json.dumps(body)
+            assert grant.code not in serialized
+
+            # The code must still be usable from the correct origin.
+            ok = await cli.post(
+                "/v1/operator/enrollments/exchange",
+                json={"code": grant.code, "origin": "https://hermes.example"},
+            )
+            assert ok.status == 200
+
+    @pytest.mark.asyncio
+    async def test_inspect_and_exchange_do_not_log_code_or_token(self, tmp_path, caplog):
+        adapter, _credentials, enrollments = _enrollment_adapter(tmp_path)
+        grant = enrollments.create(label="Pixel", origin="https://hermes.example", scopes=["chat:read"])
+        app = _create_app(adapter)
+
+        with caplog.at_level(logging.DEBUG):
+            async with TestClient(TestServer(app)) as cli:
+                # A wrong-code guess must not log the guessed value either.
+                await cli.post(
+                    "/v1/operator/enrollments/inspect",
+                    json={"code": "guessed-wrong-code", "origin": "https://hermes.example"},
+                )
+                inspect_resp = await cli.post(
+                    "/v1/operator/enrollments/inspect",
+                    json={"code": grant.code, "origin": "https://hermes.example"},
+                )
+                assert inspect_resp.status == 200
+
+                exchange_resp = await cli.post(
+                    "/v1/operator/enrollments/exchange",
+                    json={"code": grant.code, "origin": "https://hermes.example"},
+                )
+                assert exchange_resp.status == 200
+                token = (await exchange_resp.json())["token"]
+
+        log_text = caplog.text
+        assert grant.code not in log_text
+        assert "guessed-wrong-code" not in log_text
+        assert token not in log_text
+
+    @pytest.mark.asyncio
+    async def test_list_operator_credentials_requires_settings_read(self, tmp_path):
+        adapter, credentials, _enrollments = _enrollment_adapter(tmp_path)
+        issued = credentials.issue("Pixel", ["chat:read"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            unauthenticated = await cli.get("/v1/operator/credentials")
+            assert unauthenticated.status == 401
+
+            authed = await cli.get(
+                "/v1/operator/credentials", headers={"Authorization": "Bearer sk-test"},
+            )
+            assert authed.status == 200
+            data = await authed.json()
+            assert data["data"][0]["credential_id"] == issued.credential_id
+            assert data["data"][0]["label"] == "Pixel"
+            serialized = json.dumps(data)
+            assert issued.token not in serialized
+
+    @pytest.mark.asyncio
+    async def test_revoke_operator_credential_requires_settings_write(self, tmp_path):
+        adapter, credentials, _enrollments = _enrollment_adapter(tmp_path)
+        issued = credentials.issue("Pixel", ["chat:read"])
+        under_scoped = credentials.issue("phone", ["profiles:read"]).token
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            forbidden = await cli.delete(
+                f"/v1/operator/credentials/{issued.credential_id}",
+                headers={"Authorization": f"Bearer {under_scoped}"},
+            )
+            assert forbidden.status == 403
+
+            revoked = await cli.delete(
+                f"/v1/operator/credentials/{issued.credential_id}",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert revoked.status == 200
+            assert (await revoked.json())["deleted"] is True
+            assert credentials.authenticate(issued.token) is None
+
+            missing = await cli.delete(
+                "/v1/operator/credentials/hoc_does-not-exist",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert missing.status == 404

--- a/tests/gateway/test_milestone0_receipt.py
+++ b/tests/gateway/test_milestone0_receipt.py
@@ -1,0 +1,189 @@
+"""Milestone-0 end-to-end contract receipt.
+
+Drives the real shipped operator-enrollment, scope-authorization, and scoped
+profile handlers through the full lifecycle exactly as a paired Android client
+would: mint a one-time enrollment -> inspect -> exchange for a scoped token ->
+exercise profile CRUD + soul with If-Match optimistic concurrency -> revoke the
+credential -> confirm the revoked token is refused. This is an auditable receipt
+that the milestone-0 server contract works as an integrated whole, not just as
+per-handler unit tests.
+
+Run: uv run --extra dev pytest tests/gateway/test_milestone0_receipt.py -q -s
+"""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.api_operator_auth import OperatorCredentialStore
+from gateway.api_operator_enrollment import OperatorEnrollmentStore
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _receipt_app(adapter):
+    app = web.Application()
+    app.router.add_post(
+        "/v1/operator/enrollments/inspect", adapter._handle_inspect_enrollment
+    )
+    app.router.add_post(
+        "/v1/operator/enrollments/exchange", adapter._handle_exchange_enrollment
+    )
+    app.router.add_get("/v1/operator/credentials", adapter._handle_list_operator_credentials)
+    app.router.add_delete(
+        "/v1/operator/credentials/{credential_id}",
+        adapter._handle_revoke_operator_credential,
+    )
+    app.router.add_get("/api/profiles", adapter._handle_list_profiles)
+    app.router.add_post("/api/profiles", adapter._handle_create_profile)
+    app.router.add_patch("/api/profiles/{name}", adapter._handle_patch_profile)
+    app.router.add_delete("/api/profiles/{name}", adapter._handle_delete_profile)
+    app.router.add_get(
+        "/api/profiles/{name}/soul", adapter._handle_get_profile_soul
+    )
+    app.router.add_put(
+        "/api/profiles/{name}/soul", adapter._handle_put_profile_soul
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_milestone0_full_lifecycle_receipt(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    origin = "https://hermes.receipt.example"
+
+    credentials = OperatorCredentialStore(tmp_path / "credentials.json")
+    enrollments = OperatorEnrollmentStore(
+        tmp_path / "enrollments.json", credentials
+    )
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-super"}))
+    adapter._operator_credentials = credentials
+    adapter._operator_enrollments = enrollments
+
+    log = []
+
+    async with TestClient(TestServer(_receipt_app(adapter))) as client:
+        # 1. Operator mints a one-time pairing grant for the phone (server-side,
+        #    what POST /v1/operator/enrollments does for a settings:write caller).
+        grant = enrollments.create(
+            label="Galaxy S24 (receipt)",
+            origin=origin,
+            scopes=["profiles:read", "profiles:write"],
+        )
+        log.append(f"1. enrollment minted: code len={len(grant.code)}, ttl bound")
+
+        # 2. Phone inspects the code before consenting.
+        inspect = await client.post(
+            "/v1/operator/enrollments/inspect",
+            json={"code": grant.code, "origin": origin},
+        )
+        assert inspect.status == 200, await inspect.text()
+        preview = await inspect.json()
+        assert preview["origin"] == origin
+        assert sorted(preview["scopes"]) == ["profiles:read", "profiles:write"]
+        log.append(f"2. inspect ok: scopes={preview['scopes']}")
+
+        # 3. Phone exchanges the code once for a scoped bearer token.
+        exch = await client.post(
+            "/v1/operator/enrollments/exchange",
+            json={"code": grant.code, "origin": origin},
+        )
+        assert exch.status == 200, await exch.text()
+        issued = await exch.json()
+        token = issued["token"]
+        credential_id = issued["credential"]["credential_id"]
+        assert token.startswith("hop_")
+        headers = {"Authorization": f"Bearer {token}"}
+        log.append(f"3. exchanged for scoped token; credential={credential_id}")
+
+        # 3a. The one-time code is now spent.
+        replay = await client.post(
+            "/v1/operator/enrollments/exchange",
+            json={"code": grant.code, "origin": origin},
+        )
+        assert replay.status in (400, 404, 409), await replay.text()
+        log.append("3a. code replay refused (single-use)")
+
+        # 4. Scoped token creates a cloned profile.
+        created = await client.post(
+            "/api/profiles",
+            headers=headers,
+            json={"name": "receiptbot", "clone_from": "default"},
+        )
+        assert created.status == 201, await created.text()
+        created_body = await created.json()
+        assert created_body["name"] == "receiptbot"
+        revision = created_body["revision"]
+        log.append(f"4. profile created: revision={revision[:12]}...")
+
+        # 5. It appears in the list.
+        listed = await client.get("/api/profiles", headers=headers)
+        listed_body = await listed.json()
+        assert any(p["id"] == "receiptbot" for p in listed_body["data"])
+        log.append("5. profile appears in list")
+
+        # 6. Soul write requires the current revision (If-Match).
+        no_match = await client.put(
+            "/api/profiles/receiptbot/soul",
+            headers=headers,
+            json={"content": "You are the receipt agent."},
+        )
+        assert no_match.status == 428  # missing If-Match
+        soul_write = await client.put(
+            "/api/profiles/receiptbot/soul",
+            headers={**headers, "If-Match": revision},
+            json={"content": "You are the receipt agent."},
+        )
+        assert soul_write.status == 200, await soul_write.text()
+        revision2 = (await soul_write.json())["revision"]
+        assert revision2 != revision
+        log.append("6. soul write: 428 without If-Match, ok with revision")
+
+        # 7. A stale revision is rejected with no write (optimistic concurrency).
+        stale = await client.patch(
+            "/api/profiles/receiptbot",
+            headers={**headers, "If-Match": revision},  # the OLD revision
+            json={"new_name": "receiptbot2"},
+        )
+        assert stale.status == 412, await stale.text()
+        still = await client.get("/api/profiles", headers=headers)
+        assert any(p["id"] == "receiptbot" for p in (await still.json())["data"])
+        log.append("7. stale-revision rename rejected 412, no write")
+
+        # 8. Rename with the fresh revision.
+        renamed = await client.patch(
+            "/api/profiles/receiptbot",
+            headers={**headers, "If-Match": revision2},
+            json={"new_name": "receiptbot2"},
+        )
+        assert renamed.status == 200, await renamed.text()
+        revision3 = (await renamed.json())["revision"]
+        log.append("8. renamed receiptbot -> receiptbot2")
+
+        # 9. Delete it.
+        deleted = await client.delete(
+            "/api/profiles/receiptbot2",
+            headers={**headers, "If-Match": revision3},
+        )
+        assert deleted.status == 200, await deleted.text()
+        gone = await client.get("/api/profiles", headers=headers)
+        assert not any(p["id"] == "receiptbot2" for p in (await gone.json())["data"])
+        log.append("9. profile deleted")
+
+        # 10. Operator revokes the credential (superuser).
+        super_headers = {"Authorization": "Bearer sk-super"}
+        revoke = await client.delete(
+            f"/v1/operator/credentials/{credential_id}", headers=super_headers
+        )
+        assert revoke.status in (200, 204), await revoke.text()
+        log.append("10. credential revoked")
+
+        # 11. The revoked token is now refused (fail closed).
+        after = await client.get("/api/profiles", headers=headers)
+        assert after.status == 401, await after.text()
+        log.append("11. revoked token -> 401 (fail closed)")
+
+    print("\n=== MILESTONE-0 RECEIPT ===")
+    for line in log:
+        print("  " + line)
+    print("=== all steps passed ===")

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -68,10 +68,17 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
     assert features["realtime_voice"] is False
-    assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
+    assert data["endpoints"]["sessions"] == {
+        "method": "GET",
+        "path": "/api/sessions",
+        "required_scopes": ["sessions:read"],
+        "profile_scoped": False,
+    }
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
+        "required_scopes": ["sessions:write"],
+        "profile_scoped": False,
     }
 
 


### PR DESCRIPTION
> **Draft — not requesting review/merge yet.** Opening for visibility and discussion of the contract. One validation step (on-device enrollment + accessibility receipt) is still outstanding; see caveats below.

## What this adds

A scoped-operator-token trust foundation for the API server, so a mobile client can be granted **least-privilege, revocable** access without sharing the superuser `API_SERVER_KEY`. This is milestone 0 ("Remote trust foundation") of a Flutter client's parity effort; it is **purely additive** — the existing `API_SERVER_KEY` path is unchanged and continues to authenticate as superuser (`*`).

### New surface (all under `gateway/`)

- **`api_operator_auth.py`** — scope vocabulary (`normalize_scopes`, `AuthPrincipal`), and a hashed, revocable `OperatorCredentialStore` (SHA-256 of a 256-bit token, `hmac.compare_digest`, one-time raw return, 0600 atomic writes, per-record fail-closed loading).
- **`api_operator_enrollment.py`** — one-time, origin-bound, TTL-limited pairing-code enrollment that mints scoped tokens (salted-hash code storage, single-use atomic consume, lockout).
- **`api_server.py`** — `_authorize(request, required_scope)`: constant-time `API_SERVER_KEY` → superuser, else operator-token → scoped principal, else 401; `insufficient_scope` 403 never echoes granted scopes. Every mutating route is `:write`-gated. `/v1/capabilities` now advertises `schema_version`, an `auth` block, and per-endpoint `required_scopes` / `profile_scoped`. Adds scoped **profile CRUD + soul** contracts (`profiles:read/write`) with `If-Match` optimistic concurrency (428 missing, 412 stale-no-write) that reuse the existing `hermes_cli.profiles` domain functions — no Dashboard proxy, no `active_profile` mutation, no shell-wrapper creation for remote clients.

## Evidence

- **257 gateway tests pass** on the merged tree (the pre-existing Telegram/Wecom failures are unrelated and unchanged).
- **`tests/gateway/test_milestone0_receipt.py`** drives the real handlers end-to-end: mint → inspect → single-use exchange → scoped profile create/list/soul/rename/delete with `If-Match` → revoke → **revoked token 401 (fail closed)**.
- Each piece was security-reviewed; fixes in-branch cover wildcard scope validation, per-record fail-closed credential loading, path-free error bodies, and suppressing remote-rename wrapper creation.

## Caveats / not-yet-done

- **On-device receipt pending:** a real phone enrolling against a running instance (and the client-side accessibility pass) has not yet been captured, so the client parity rows remain `implementing`, not `validated`.
- `/api/cron/fire` keeps its purpose-built NAS-JWT auth (an audited exception to the operator-scope gating).
- Operator enrollment uses a store-global lockout (single-owner-install assumption); expired/consumed rows are not pruned.

Happy to split this into smaller PRs (vocabulary/store → authorization → enrollment → profiles) if that's easier to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
