### PR TITLE
fix(gateway): emit Codex app-server tool progress

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -16,6 +16,7 @@ compatibility.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -173,6 +174,71 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     }
 
 
+def _codex_tool_progress(note: dict) -> tuple[str, str, str, dict] | None:
+    """Translate a Codex app-server item notification to Hermes tool progress."""
+    method = note.get("method") or ""
+    if method not in {"item/started", "item/completed"}:
+        return None
+
+    item = (note.get("params") or {}).get("item") or {}
+    item_type = item.get("type") or ""
+    if item_type == "commandExecution":
+        args = {
+            "command": item.get("command") or "",
+            "workdir": item.get("cwd") or "",
+        }
+        tool_name = "terminal"
+        preview = args["command"]
+    elif item_type == "fileChange":
+        changes = item.get("changes") or []
+        paths = [change.get("path") for change in changes if isinstance(change, dict) and change.get("path")]
+        args = {"paths": paths}
+        tool_name = "patch"
+        preview = ", ".join(paths[:3])
+    elif item_type == "mcpToolCall":
+        server = item.get("server") or "mcp"
+        tool = item.get("tool") or "unknown"
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        tool_name = tool if server in {"hermes", "hermes-tools", "hermes_tools"} else f"mcp.{server}.{tool}"
+        preview = json.dumps(args, ensure_ascii=False, sort_keys=True)
+    elif item_type == "dynamicToolCall":
+        tool_name = item.get("tool") or "unknown"
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        preview = json.dumps(args, ensure_ascii=False, sort_keys=True)
+    else:
+        return None
+
+    event_type = "tool.started" if method == "item/started" else "tool.completed"
+    return event_type, tool_name, preview, args
+
+
+def _emit_codex_tool_progress(agent, note: dict) -> None:
+    """Bridge native Codex tools into the callback used by gateway platforms."""
+    callback = getattr(agent, "tool_progress_callback", None)
+    if callback is None:
+        return
+    progress = _codex_tool_progress(note)
+    if progress is None:
+        return
+    event_type, tool_name, preview, args = progress
+    if event_type == "tool.started":
+        callback(event_type, tool_name, preview, args)
+        return
+    status = ((note.get("params") or {}).get("item") or {}).get("status") or ""
+    callback(
+        event_type,
+        tool_name,
+        preview,
+        args,
+        duration=0,
+        is_error=str(status).lower() in {"failed", "error", "declined"},
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -207,6 +273,13 @@ def run_codex_app_server_turn(
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            on_event=lambda note: _emit_codex_tool_progress(agent, note),
+        )
+    else:
+        # Gateway display callbacks are rebound per turn on cached agents.
+        # Keep a reused Codex session pointed at the current callback state.
+        agent._codex_session.set_event_callback(
+            lambda note: _emit_codex_tool_progress(agent, note)
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -234,6 +234,21 @@ class CodexAppServerSession:
         self._pending_file_changes: dict[str, str] = {}
         self._closed = False
 
+    def set_event_callback(
+        self, callback: Optional[Callable[[dict], None]]
+    ) -> None:
+        """Replace the live notification callback for subsequent turn events."""
+        self._on_event = callback
+
+    def _emit_event(self, note: dict) -> None:
+        """Forward one Codex notification to the presentation layer."""
+        if self._on_event is None:
+            return
+        try:
+            self._on_event(note)
+        except Exception:  # pragma: no cover - display callback
+            logger.debug("on_event callback raised", exc_info=True)
+
     # ---------- lifecycle ----------
 
     def ensure_started(self) -> str:
@@ -504,6 +519,7 @@ class CodexAppServerSession:
                     pending = self._client.take_notification(timeout=0)
                     if pending is None:
                         break
+                    self._emit_event(pending)
                     _apply_token_usage_notification(result, pending)
                     self._track_pending_file_change(pending)
                     proj = projector.project(pending)
@@ -534,11 +550,7 @@ class CodexAppServerSession:
                 continue
 
             method = note.get("method", "")
-            if self._on_event is not None:
-                try:
-                    self._on_event(note)
-                except Exception:  # pragma: no cover - display callback
-                    logger.debug("on_event callback raised", exc_info=True)
+            self._emit_event(note)
 
             _apply_token_usage_notification(result, note)
 

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -104,6 +104,57 @@ class TestMaybeApplyCodexAppServerRuntime:
         )
 
 
+class TestCodexToolProgressBridge:
+    def test_command_start_maps_to_terminal_progress(self) -> None:
+        from types import SimpleNamespace
+
+        from agent.codex_runtime import _emit_codex_tool_progress
+
+        calls = []
+        agent = SimpleNamespace(
+            tool_progress_callback=lambda *args, **kwargs: calls.append((args, kwargs))
+        )
+
+        _emit_codex_tool_progress(
+            agent,
+            {
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "type": "commandExecution",
+                        "id": "cmd-1",
+                        "command": "pwd",
+                        "cwd": "/tmp",
+                    }
+                },
+            },
+        )
+
+        assert calls == [
+            (("tool.started", "terminal", "pwd", {"command": "pwd", "workdir": "/tmp"}), {})
+        ]
+
+    def test_non_tool_notifications_are_ignored(self) -> None:
+        from types import SimpleNamespace
+
+        from agent.codex_runtime import _emit_codex_tool_progress
+
+        calls = []
+        agent = SimpleNamespace(
+            tool_progress_callback=lambda *args, **kwargs: calls.append((args, kwargs))
+        )
+
+        _emit_codex_tool_progress(
+            agent,
+            {
+                "method": "item/started",
+                "params": {"item": {"type": "agentMessage", "text": "hello"}},
+            },
+        )
+
+        assert calls == []
+
+
 class TestCodexAppServerModule:
     """Module-surface tests for the JSON-RPC speaker. Don't require codex CLI."""
 


### PR DESCRIPTION
## What
Bridge native Codex app-server tool lifecycle notifications into Hermes' existing gateway `tool_progress_callback`.

## Why
The `codex_app_server` runtime bypasses `agent/tool_executor.py`, so messaging platforms configured for tool progress receive no live tool events even though Codex executes terminal, patch, MCP, and dynamic tools.

## How
- translate Codex `item/started` / `item/completed` notifications into Hermes tool-progress events
- bind and refresh the event callback on cached Codex app-server sessions
- emit callbacks for notifications drained ahead of approval requests too
- cover command progress mapping and non-tool filtering

## Testing
- [x] `python -m pytest -q tests/agent/transports/test_codex_app_server_runtime.py tests/agent/transports/test_codex_app_server_session.py` (87 passed)
- [x] `python -m pytest -q tests/agent/transports/test_codex_event_projector.py tests/run_agent/test_codex_app_server_integration.py` (40 passed)
- [x] `ruff check agent/codex_runtime.py agent/transports/codex_app_server_session.py tests/agent/transports/test_codex_app_server_runtime.py`
- [x] Live Threads verification: Codex terminal execution produced an immediate `progress` reply with `metadata.trigger_id`, followed by the final `response`
