### PR TITLE
feat(research-protocol): add bounded planner tools

### DIFF
--- a/plugins/research_protocol/README.md
+++ b/plugins/research_protocol/README.md
@@ -1,0 +1,29 @@
+# Hermes Research Protocol
+
+Ce répertoire contient le lot **PR 0** du protocole de recherche Hermes.
+
+Le plugin est volontairement **opt-in** : son manifeste est découvert sous la
+clé `research-protocol`, mais son type `standalone` et l’absence de cette clé
+dans `plugins.enabled` empêchent toute activation par défaut. Il ne s’appuie
+pas sur un champ de manifeste supplémentaire que le chargeur ignorerait.
+
+PR 0 ne fournit encore aucun outil, handler, skill, profil, stockage ou accès
+réseau. Le package est une ancre de découverte et les documents sous `docs/`
+gèlent les contrats qui devront précéder toute implémentation runtime.
+
+## Activation
+
+Aucune activation n’est requise ni effectuée par ce lot. Si un environnement
+de test l’active explicitement, le point d’entrée reste un no-op : il
+n’enregistre aucun outil, hook ou commande. Les capacités runtime ne doivent
+être introduites qu’après les tests de leurs contrats de sécurité et une revue
+indépendante de la menace.
+
+## Périmètre de sécurité gelé
+
+Les invariants détaillés sont dans [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+et les menaces et contrôles correspondants dans
+[`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). La capacité `publish` reste
+manuelle : toute publication externe exige une approbation humaine explicite
+portant sur l'opération exacte. Elle ne peut jamais être auto-routée ni
+auto-approuvée, y compris sous `/yolo` ou avec `approvals.mode: off`.

--- a/plugins/research_protocol/README.md
+++ b/plugins/research_protocol/README.md
@@ -1,29 +1,104 @@
-# Hermes Research Protocol
+# Research Protocol plugin
 
-Ce répertoire contient le lot **PR 0** du protocole de recherche Hermes.
+PR2 exposes exactly three bounded tools in the `planner` toolset:
 
-Le plugin est volontairement **opt-in** : son manifeste est découvert sous la
-clé `research-protocol`, mais son type `standalone` et l’absence de cette clé
-dans `plugins.enabled` empêchent toute activation par défaut. Il ne s’appuie
-pas sur un champ de manifeste supplémentaire que le chargeur ignorerait.
+- `plan_context_read`: executes a closed PostgreSQL query identifier through a read-only transaction with row, byte, statement, and wall-clock caps.
+- `plan_artifact_write`: validates and atomically persists a registered artifact type under an operator-owned root. Callers cannot provide a path.
+- `plan_approval_request`: reloads a plan by artifact ID and expected SHA-256, checks exact scope/plan agreement, requests one-operation native Hermes consent, and persists the result.
 
-PR 0 ne fournit encore aucun outil, handler, skill, profil, stockage ou accès
-réseau. Le package est une ancre de découverte et les documents sous `docs/`
-gèlent les contrats qui devront précéder toute implémentation runtime.
+The plugin remains disabled unless its exact public key is present in `plugins.enabled`. Registration never starts a service, opens a database connection, or performs network I/O.
 
-## Activation
+## Installation
 
-Aucune activation n’est requise ni effectuée par ce lot. Si un environnement
-de test l’active explicitement, le point d’entrée reste un no-op : il
-n’enregistre aucun outil, hook ou commande. Les capacités runtime ne doivent
-être introduites qu’après les tests de leurs contrats de sécurité et une revue
-indépendante de la menace.
+Install the optional database dependency when database-backed tools are needed:
 
-## Périmètre de sécurité gelé
+```bash
+pip install 'hermes-agent[research-protocol]'
+```
 
-Les invariants détaillés sont dans [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-et les menaces et contrôles correspondants dans
-[`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). La capacité `publish` reste
-manuelle : toute publication externe exige une approbation humaine explicite
-portant sur l'opération exacte. Elle ne peut jamais être auto-routée ni
-auto-approuvée, y compris sous `/yolo` ou avec `approvals.mode: off`.
+## Configuration
+
+Use an absolute, private artifact directory. Plugin settings live under `plugins.entries.research-protocol`:
+
+```yaml
+plugins:
+  enabled:
+    - research-protocol
+  entries:
+    research-protocol:
+      artifact_root: /absolute/private/research-protocol
+      database:
+        max_rows: 100
+        max_bytes: 1048576
+        timeout_seconds: 5.0
+        pool_min_size: 1
+        pool_max_size: 4
+```
+
+Database credentials are accepted only from two fixed environment variables:
+
+```bash
+export RESEARCH_PROTOCOL_READER_DATABASE_URL='[REDACTED]'
+export RESEARCH_PROTOCOL_WRITER_DATABASE_URL='[REDACTED]'
+```
+
+The reader and writer DSN strings must be distinct. They are never accepted in a tool call and are redacted from runtime representations and tool errors.
+
+Availability is fail-closed and independent:
+
+- `artifact_root` only: `plan_artifact_write` is available;
+- reader DSN: `plan_context_read` is additionally available;
+- writer DSN: `plan_approval_request` is additionally available;
+- missing or malformed authority: the affected tool remains registered but unavailable through its `check_fn`.
+
+## PostgreSQL bootstrap
+
+Apply migrations in lexical order with an administrative migration identity:
+
+```bash
+psql -v ON_ERROR_STOP=1 "$ADMIN_DATABASE_URL" \
+  -f plugins/research_protocol/migrations/0001_approval_ledger.sql
+psql -v ON_ERROR_STOP=1 "$ADMIN_DATABASE_URL" \
+  -f plugins/research_protocol/migrations/0002_roles.sql
+```
+
+`0001_approval_ledger.sql` and `0002_roles.sql` are intentionally one-shot.
+Pre-existing protocol objects or fixed runtime role names make the transaction
+fail rather than silently accepting an unknown schema or cross-database
+privileges. Apply both only to a fresh installation; never rerun them as a
+repair mechanism.
+
+`0002_roles.sql` creates three NOLOGIN group roles:
+
+- `research_protocol_planner_reader`: schema usage and table SELECT only;
+- `research_protocol_approval_writer`: schema usage plus EXECUTE on the fixed `store_approval` function, with no direct table privileges;
+- `research_protocol_approval_claimant`: schema usage plus EXECUTE on the fixed atomic claim function, with no direct table privileges; it is not used by the PR2 planner runtime.
+
+Grant `research_protocol_planner_reader` and `research_protocol_approval_writer` to different LOGIN identities and put their credentials in the fixed reader/writer environment variables. Reserve `research_protocol_approval_claimant` for a future executor identity. Do not give runtime identities ownership, schema-creation rights, role administration, or migration authority.
+
+## Security boundaries
+
+- All input schemas are closed (`additionalProperties: false`) and expose no free path, SQL, DSN, command, or provider selector. Source URLs can occur only as validated artifact data and are never fetched by these tools.
+- Context SQL comes only from the in-code registry and uses bound parameters.
+- The writer credential is the trusted approval-mint authority. It is available only to the approval service after native consent, never to planner/model inputs, and can execute only the bounded `store_approval` function.
+- Approval claims bind `approval_id`, canonical scope hash, plan hash, expiry, verdict, and execution count inside one fixed `SECURITY DEFINER` function; the claimant role has no direct table access.
+- YOLO and `approvals.mode: off` do not bypass the native per-call elicitation used by this plugin.
+- Artifact reads used for approval require the expected SHA-256 and reject symlink substitution, overwrite races, and receipt/content mismatch.
+
+## Tests
+
+The local suite does not require PostgreSQL:
+
+```bash
+python -m pytest -q tests/plugins/research_protocol \
+  --ignore=tests/plugins/research_protocol/test_postgres_integration.py
+```
+
+The real PostgreSQL gate is opt-in and destructive only inside the database named by the test DSN:
+
+```bash
+RESEARCH_PROTOCOL_TEST_DATABASE_URL='[REDACTED]' \
+  python -m pytest -q tests/plugins/research_protocol/test_postgres_integration.py
+```
+
+Use a fresh disposable database. The gate applies both migrations, truncates the approval table, and exercises replay, expiry, scope mismatch, concurrent claims, read-only transactions, caps, and timeout behavior.

--- a/plugins/research_protocol/__init__.py
+++ b/plugins/research_protocol/__init__.py
@@ -1,0 +1,11 @@
+
+"""Opt-in Hermes Research Protocol plugin.
+
+PR 0 intentionally registers no runtime behavior.  Keeping the loader entry
+point valid lets discovery distinguish an explicitly enabled empty baseline
+from a malformed plugin.
+"""
+
+
+def register(_ctx) -> None:
+    """Register no tools, hooks, or commands until the gated runtime PRs."""

--- a/plugins/research_protocol/__init__.py
+++ b/plugins/research_protocol/__init__.py
@@ -1,11 +1,98 @@
-
 """Opt-in Hermes Research Protocol plugin.
 
-PR 0 intentionally registers no runtime behavior.  Keeping the loader entry
-point valid lets discovery distinguish an explicitly enabled empty baseline
-from a malformed plugin.
+PR2 registers exactly three fail-closed planner tools. Runtime authority remains
+unavailable until an operator supplies an absolute artifact root. Context reads
+and approval writes additionally require distinct
+``RESEARCH_PROTOCOL_READER_DATABASE_URL`` and
+``RESEARCH_PROTOCOL_WRITER_DATABASE_URL`` authorities, respectively.
 """
 
+from __future__ import annotations
 
-def register(_ctx) -> None:
-    """Register no tools, hooks, or commands until the gated runtime PRs."""
+import logging
+from typing import Any
+
+from .planner_tools import (
+    check_planner_approvals,
+    check_planner_artifacts,
+    check_planner_context,
+    configure_planner_runtime,
+    plan_approval_request,
+    plan_artifact_write,
+    plan_context_read,
+)
+from .runtime import RuntimeConfigurationError, build_runtime_bundle
+from .schemas import (
+    PLAN_APPROVAL_REQUEST_SCHEMA,
+    PLAN_ARTIFACT_WRITE_SCHEMA,
+    PLAN_CONTEXT_READ_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+_TOOLS = (
+    (
+        "plan_context_read",
+        PLAN_CONTEXT_READ_SCHEMA,
+        plan_context_read,
+        check_planner_context,
+    ),
+    (
+        "plan_artifact_write",
+        PLAN_ARTIFACT_WRITE_SCHEMA,
+        plan_artifact_write,
+        check_planner_artifacts,
+    ),
+    (
+        "plan_approval_request",
+        PLAN_APPROVAL_REQUEST_SCHEMA,
+        plan_approval_request,
+        check_planner_approvals,
+    ),
+)
+
+
+def _plugin_config() -> dict[str, Any]:
+    from hermes_cli.config import load_config
+
+    config = load_config() or {}
+    plugins = config.get("plugins") or {}
+    entries = plugins.get("entries") or {}
+    entry = entries.get("research-protocol") or {}
+    if not isinstance(entry, dict):
+        raise RuntimeConfigurationError(
+            "plugins.entries.research-protocol must be a mapping"
+        )
+    return entry
+
+
+def _configure_from_local_state() -> None:
+    try:
+        bundle = build_runtime_bundle(_plugin_config())
+    except (RuntimeConfigurationError, OSError, ValueError):
+        configure_planner_runtime(None)
+        logger.info(
+            "Research Protocol planner runtime is unavailable; "
+            "explicit local configuration is incomplete or unsafe"
+        )
+        return
+    configure_planner_runtime(
+        bundle.handlers,
+        artifact_available=bundle.artifact_available,
+        context_available=bundle.context_available,
+        approval_available=bundle.approval_available,
+    )
+
+
+def register(ctx) -> None:
+    """Register exactly the bounded planner tool surface."""
+    _configure_from_local_state()
+    for name, schema, handler, check_fn in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="planner",
+            schema=schema,
+            handler=handler,
+            check_fn=check_fn,
+            is_async=True,
+        )

--- a/plugins/research_protocol/approval.py
+++ b/plugins/research_protocol/approval.py
@@ -1,0 +1,222 @@
+"""Exact, per-call workflow approval primitives."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import secrets
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import AwareDatetime, Field, field_validator, model_validator
+
+from .models import BudgetLimits, Capability, ExternalRight
+from .models.base import Sha256, StrictContract
+from .storage.artifacts import canonical_json_bytes
+
+
+class ApprovalScope(StrictContract):
+    """The immutable capability scope bound to one approval receipt."""
+
+    capability: Capability
+    run_id: str = Field(
+        min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    )
+    plan_sha256: Sha256
+    input_hashes: tuple[Sha256, ...] = Field(min_length=0)
+    budgets: BudgetLimits
+    expires_at: AwareDatetime
+    max_executions: int = Field(strict=True, gt=0)
+    external_rights: tuple[ExternalRight, ...] = ()
+
+    @field_validator("input_hashes", "external_rights", mode="before")
+    @classmethod
+    def accept_json_arrays(cls, value):
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @model_validator(mode="after")
+    def canonicalize_collections(self) -> "ApprovalScope":
+        object.__setattr__(self, "input_hashes", tuple(sorted(set(self.input_hashes))))
+        object.__setattr__(
+            self,
+            "external_rights",
+            tuple(sorted(set(self.external_rights), key=lambda item: item.value)),
+        )
+        if self.max_executions > self.budgets.max_executions:
+            raise ValueError("max_executions cannot exceed budgets.max_executions")
+        return self
+
+    def canonical_json(self) -> str:
+        """Return the canonical JSON representation used by the database."""
+        return canonical_json_bytes(self.model_dump(mode="json")).decode("utf-8")
+
+    def scope_sha256(self) -> str:
+        return hashlib.sha256(self.canonical_json().encode("utf-8")).hexdigest()
+
+    @property
+    def scope_hash(self) -> str:
+        return self.scope_sha256()
+
+
+class WorkflowApprovalDecision(str, Enum):
+    ACCEPT = "accept"
+    DENY = "deny"
+
+
+class ApprovalVerdict(str, Enum):
+    APPROVED = "approved"
+    DENIED = "denied"
+
+
+class ApprovalRecord(StrictContract):
+    """Durable approval decision bound to one exact workflow scope."""
+
+    approval_id: str = Field(min_length=22, max_length=256)
+    scope_sha256: Sha256
+    plan_sha256: Sha256
+    scope_json: str = Field(min_length=2)
+    verdict: ApprovalVerdict
+    surface: str = Field(min_length=1, max_length=128)
+    created_at: AwareDatetime
+    expires_at: AwareDatetime
+    max_executions: int = Field(strict=True, gt=0)
+    consumed_count: int = Field(strict=True, ge=0)
+
+    @model_validator(mode="after")
+    def validate_scope_binding(self) -> "ApprovalRecord":
+        try:
+            scope = ApprovalScope.model_validate_json(self.scope_json, strict=True)
+        except Exception as exc:
+            raise ValueError("scope_json is not a valid approval scope") from exc
+        if scope.canonical_json() != self.scope_json:
+            raise ValueError("scope_json must use the canonical representation")
+        if scope.scope_sha256() != self.scope_sha256:
+            raise ValueError("scope_sha256 does not match scope_json")
+        if scope.plan_sha256 != self.plan_sha256:
+            raise ValueError("plan_sha256 does not match scope_json")
+        if scope.expires_at != self.expires_at:
+            raise ValueError("expires_at does not match scope_json")
+        if scope.max_executions != self.max_executions:
+            raise ValueError("max_executions does not match scope_json")
+        if self.consumed_count > self.max_executions:
+            raise ValueError("consumed_count exceeds max_executions")
+        if (
+            self.verdict is ApprovalVerdict.APPROVED
+            and self.created_at >= self.expires_at
+        ):
+            raise ValueError("approved record must expire after creation")
+        if self.verdict is ApprovalVerdict.DENIED and self.consumed_count != 0:
+            raise ValueError("denied record cannot be consumed")
+        return self
+
+
+class ApprovalService:
+    """Orchestrate native consent and durable approval persistence."""
+
+    def __init__(self, store: Any, *, surface: str = "research-protocol"):
+        self.store = store
+        self.surface = surface
+
+    async def request(
+        self, scope: ApprovalScope, summary: str
+    ) -> ApprovalRecord | None:
+        decision = await asyncio.to_thread(request_workflow_approval, scope, summary)
+        verdict = (
+            ApprovalVerdict.APPROVED
+            if decision is WorkflowApprovalDecision.ACCEPT
+            else ApprovalVerdict.DENIED
+        )
+        record = make_approval_record(scope, surface=self.surface, verdict=verdict)
+        await self.store.create_approval(record)
+        return record if verdict is ApprovalVerdict.APPROVED else None
+
+
+def make_approval_id() -> str:
+    """Generate an opaque identifier with enough entropy for offline guessing resistance."""
+    return secrets.token_urlsafe(32)
+
+
+def make_approval_record(
+    scope: ApprovalScope,
+    *,
+    surface: str = "research-protocol",
+    verdict: ApprovalVerdict = ApprovalVerdict.APPROVED,
+) -> ApprovalRecord:
+    now = datetime.now(UTC)
+    return ApprovalRecord(
+        approval_id=make_approval_id(),
+        scope_sha256=scope.scope_sha256(),
+        plan_sha256=scope.plan_sha256,
+        scope_json=scope.canonical_json(),
+        verdict=verdict,
+        surface=surface,
+        created_at=now,
+        expires_at=scope.expires_at,
+        max_executions=scope.max_executions,
+        consumed_count=0,
+    )
+
+
+def _native_consent(message: str, description: str) -> str:
+    """Call the Hermes native consent API without importing it at module load."""
+    from tools import approval as native_approval
+
+    consent = native_approval.request_elicitation_consent
+    try:
+        signature = inspect.signature(consent)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("native consent API contract is not inspectable") from exc
+    strict_parameter = signature.parameters.get("strict_one_shot")
+    if strict_parameter is None or strict_parameter.kind not in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    ):
+        raise RuntimeError("native consent API lacks strict_one_shot support")
+    return consent(message, description, strict_one_shot=True)
+
+
+def request_workflow_approval(
+    scope: ApprovalScope, summary: str
+) -> WorkflowApprovalDecision:
+    """Request exact per-call consent and fail closed on every non-accept path."""
+    try:
+        validated_scope = ApprovalScope.model_validate(scope)
+        if validated_scope.expires_at <= datetime.now(UTC):
+            return WorkflowApprovalDecision.DENY
+        if not isinstance(summary, str) or not summary.strip():
+            return WorkflowApprovalDecision.DENY
+        description = (
+            "Approve this exact research workflow only once; "
+            f"scope_sha256={validated_scope.scope_sha256()}"
+        )
+        result = _native_consent(summary, description)
+    except Exception:
+        return WorkflowApprovalDecision.DENY
+    return (
+        WorkflowApprovalDecision.ACCEPT
+        if result == "accept"
+        else WorkflowApprovalDecision.DENY
+    )
+
+
+# Convenient aliases for callers that use approval terminology rather than
+# workflow terminology.
+request_exact_approval = request_workflow_approval
+
+
+__all__ = [
+    "ApprovalRecord",
+    "ApprovalScope",
+    "ApprovalService",
+    "ApprovalVerdict",
+    "WorkflowApprovalDecision",
+    "make_approval_id",
+    "make_approval_record",
+    "request_exact_approval",
+    "request_workflow_approval",
+]

--- a/plugins/research_protocol/approval.py
+++ b/plugins/research_protocol/approval.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import Any
 
 from pydantic import AwareDatetime, Field, field_validator, model_validator
+from tools.thread_context import propagate_context_to_thread
 
 from .models import BudgetLimits, Capability, ExternalRight
 from .models.base import Sha256, StrictContract
@@ -125,7 +126,8 @@ class ApprovalService:
     async def request(
         self, scope: ApprovalScope, summary: str
     ) -> ApprovalRecord | None:
-        decision = await asyncio.to_thread(request_workflow_approval, scope, summary)
+        request_with_context = propagate_context_to_thread(request_workflow_approval)
+        decision = await asyncio.to_thread(request_with_context, scope, summary)
         verdict = (
             ApprovalVerdict.APPROVED
             if decision is WorkflowApprovalDecision.ACCEPT

--- a/plugins/research_protocol/docs/ARCHITECTURE.md
+++ b/plugins/research_protocol/docs/ARCHITECTURE.md
@@ -1,0 +1,111 @@
+# Architecture et contrats gelés — PR 0
+
+## Statut
+
+Ce document est l’ADR de la baseline. PR 0 ne contient aucun comportement
+runtime : pas d’outil, pas de handler, pas de routeur, pas de stockage, pas de
+worker et pas d’accès réseau. Toute implémentation ultérieure doit respecter
+les contrats ci-dessous avant d’ajouter une capacité.
+
+## Placement et activation
+
+Le plugin Hermes est placé sous `plugins/research_protocol/`. Son identifiant
+public de découverte est le nom de manifeste `research-protocol`, cohérent avec
+la future entrée `plugins.enabled: [research-protocol]`; l’underscore reste un
+détail du nom de package Python.
+
+Le manifeste déclare `kind: standalone`. Sur cette base Hermes, tous les
+plugins standalone sont visibles pour l’introspection mais restent désactivés
+tant que leur clé n’est pas ajoutée explicitement à `plugins.enabled`. Le
+chargeur ne reconnaît pas de champ `default_enabled`; en inventer un donnerait
+une fausse assurance. PR 0 fournit seulement un `register()` no-op et
+n’enregistre aucun outil ni callback.
+
+## Acteurs et frontières
+
+| Acteur | Responsabilité autorisée | Frontière à préserver |
+|---|---|---|
+| Utilisateur | Définit l’objectif et accorde une approbation explicite de workflow | L’approbation est humaine, exacte, bornée et consommable |
+| Planner | Lit le contexte autorisé et produit un plan canonique | Ne peut pas exécuter, publier ni choisir un chemin arbitraire |
+| Approval service | Présente le résumé construit depuis l’artefact et émet un reçu | Ne valide que le hash et la portée exacts |
+| Worker | Réclame et exécute une capacité déjà autorisée | Ne peut pas élargir capacité, budget, durée ou entrées |
+| DB | Fournit les lectures typées autorisées | Aucun SQL fourni par le modèle ; rôle lecteur sans secrets |
+| Stockage | Persiste les artefacts et leur provenance | Root configuré, chemins sûrs, écriture atomique et hash vérifié |
+| Source externe | Fournit des candidats ou contenus à collecter | Entrée non fiable ; jamais une autorité d’instruction |
+
+## Actifs
+
+Les actifs à protéger et à relier par provenance sont :
+
+- plan canonique ;
+- hash SHA-256 du plan et des artefacts ;
+- approbation et reçu de consommation ;
+- credentials et secrets ;
+- manifest ;
+- evidence ;
+- reports.
+
+Les credentials ne doivent apparaître ni dans les plans, ni dans les artefacts,
+ni dans les rapports, ni dans les logs.
+
+## Contrats de sécurité
+
+### 3.1 Plan canonique et hash
+
+- Le payload validé est converti en JSON canonique UTF-8 avec clés triées, séparateurs compacts et sans valeurs non finies.
+- Le fichier est écrit avec une convention d’octets unique et documentée ; le SHA-256 porte sur les octets exacts persistés.
+- `plan_artifact_write` ne prend jamais de `path`. Il reçoit `artifact_type`, `artifact_id` et `payload`.
+- Les destinations sont dérivées dans un root configuré, résolues par `realpath`, refusent `..`, chemins absolus, composants symlink et écrasement d’un artefact déjà approuvé.
+- La résolution, la création du temporaire et la publication sont relatives à
+  des descripteurs de répertoires de confiance, sans suivre les symlinks.
+- La destination finale est réservée exclusivement et publiée avec une
+  primitive atomique sans remplacement (`RENAME_NOREPLACE` ou équivalent) ;
+  toute collision est refusée.
+- Le temporaire est créé dans le même filesystem ; le fichier puis le
+  répertoire parent sont `fsync`, avant relecture et recalcul du hash.
+- Le reçu renvoie au minimum `artifact_id`, `schema_version`, `path_relative`, `sha256`, `byte_length` et `created_at`.
+
+### 3.2 Approbation exacte
+
+- `plan_approval_request` reçoit uniquement un `artifact_id` existant, un hash attendu et une portée structurée.
+- L’outil relit l’artefact, recalcule le hash, refuse tout écart et construit lui-même le résumé présenté à l’utilisateur.
+- La portée contient : `capability`, `run_id`, `input_hashes`, budgets, durée maximale, nombre maximal d’exécutions, date d’expiration et droits externes demandés.
+- L’interface utilise l’approbation native Hermes. `/yolo` et `approvals.mode: off` ne transforment pas cette autorisation de workflow en approbation implicite.
+- Un reçu d’approbation durable contient un `approval_id` imprévisible, le SHA-256 exact, la portée exacte, le verdict, l’identité/surface disponible, les timestamps et le compteur de consommation.
+- Le worker réclame atomiquement une exécution autorisée ; expiration, capacité différente, budget différent, hash différent, réutilisation au-delà du cap ou approbation absente donnent un refus fail-closed.
+
+### 3.3 Lecture PostgreSQL typée
+
+- `plan_context_read` reçoit un `query_id` parmi une allowlist et des paramètres validés ; jamais du SQL.
+- Le mapping `query_id -> requête paramétrée -> modèle de sortie` est versionné dans le plugin.
+- Le rôle PostgreSQL `planner_reader` est `NOINHERIT`, lecture seule et sans accès aux tables de secrets.
+- Une transaction `READ ONLY`, un timeout, un plafond de lignes et un plafond d’octets sont obligatoires.
+- Les logs contiennent le `query_id`, le nombre de lignes et la latence, jamais la DSN ni les champs classés secrets.
+
+### 3.4 Capacités isolées
+
+Ces noms sont des capacités du plugin, pas des capacités Hermes natives présumées :
+
+Les états du tableau sont les cibles des phases ultérieures. Dans PR 0, toutes
+les capacités et tous les profils ci-dessous sont non implémentés et désactivés.
+
+| Capacité | Skill requis | Toolset plugin | Profil | État initial |
+|---|---|---|---|---|
+| `planner` | `intake-plan`, `research-plan` | `planner` + natif `clarify` | `planner` | activé pilote |
+| `research-collect` | `research-collect` | `research_collect` | `research-collect` | pilote offline/stub |
+| `evidence-review` | `evidence-review` | `evidence_review` | `evidence-review` | désactivé jusqu’à phase 5 |
+| `build` | `research-build` | `research_build` | `research-build` | désactivé jusqu’à phase 7 |
+| `publish` | `research-publish` | `research_publish` | `research-publish` | désactivé ; local export only |
+
+Chaque capacité devra disposer de son propre `check_fn`, de dépendances, de
+tests de schéma, de gates, de configuration de profil et de métriques. Si le
+skill ou le plugin n’est pas présent, la capacité est indisponible et le
+routeur doit la rejeter explicitement.
+
+## Décision de publication
+
+`publish` reste une action manuelle. Une cible externe ne peut **jamais** être
+auto-routée, même si un auto-routing général est activé ultérieurement. Toute
+publication externe exige une approbation humaine explicite pour l'opération
+exacte et une action hors du routage automatique. Cette approbation n'est
+jamais automatique, y compris sous `/yolo` ou avec `approvals.mode: off`.

--- a/plugins/research_protocol/docs/THREAT_MODEL.md
+++ b/plugins/research_protocol/docs/THREAT_MODEL.md
@@ -1,0 +1,62 @@
+# Modèle de menace — Hermes Research Protocol PR 0
+
+## Portée et posture
+
+PR 0 ne traite aucune donnée et n’exécute aucun handler. Ce modèle de menace
+gèle les contrôles requis avant l’ajout du runtime. Les sources externes, les
+instructions du modèle et les chemins d’entrée sont non fiables. La posture
+par défaut est fail-closed : une validation absente, ambiguë ou incohérente
+refuse l’opération.
+
+## Acteurs, actifs et frontières
+
+Les acteurs sont : utilisateur, planner, approval service, worker, DB,
+stockage et source externe. Le planner et le worker sont séparés : le planner
+prépare un artefact ; seul un worker peut réclamer une exécution autorisée.
+
+Les actifs sont : plan, hash, approbation, credentials, manifest, evidence et
+reports. Le stockage est la frontière de persistance ; la DB est une source de
+contexte typé ; la source externe est une entrée non fiable. Les credentials
+sont secrets et ne doivent être exposés dans aucun artefact ou journal.
+
+## Menaces et contrôles obligatoires
+
+| Menace | Scénario | Contrôle gelé |
+|---|---|---|
+| Prompt injection | Une source externe ou un document tente de donner des instructions au planner/worker | Traiter le contenu comme donnée ; aucune source ne devient autorité ; capacités et sorties restent bornées par le plan approuvé |
+| Path traversal | Un modèle fournit `../`, un chemin absolu ou un chemin hors root | Ne jamais accepter `path` pour l’écriture ; dériver depuis des identifiants validés, refuser `..` et chemins absolus, vérifier `realpath` |
+| Symlink | Un composant du chemin pointe vers une cible inattendue | Opérer relativement à des descripteurs de répertoires de confiance, sans suivre les symlinks, et vérifier la destination réelle |
+| TOCTOU | La cible change entre vérification et écriture | Réservation exclusive, temporaire dans le même filesystem, publication atomique sans remplacement (`RENAME_NOREPLACE` ou équivalent), `fsync` du fichier et du répertoire parent, puis relecture et recalcul du hash |
+| Approval replay | Un reçu valide est réutilisé ou consommé au-delà de sa portée | `approval_id` imprévisible, expiration, compteur de consommation et réclamation atomique avec refus au-delà du cap |
+| Confused deputy | Un worker ou plugin utilise une autorité pour une autre capacité ou un autre run | Portée exacte incluant `capability`, `run_id`, hashes, budgets, durée, exécutions et droits externes ; comparaison stricte |
+| SQL injection | Le modèle injecte du SQL ou modifie une requête de contexte | `query_id` allowlisté et paramètres validés ; mapping versionné ; jamais de SQL en entrée |
+| SSRF | Une source ou un paramètre force une requête vers un réseau interne | Les sources et destinations sont allowlistées dans une capacité dédiée ; pas de routage réseau implicite ; refus par défaut |
+| Exfiltration | Credentials ou données privées fuient vers evidence, reports ou une cible externe | Classification des secrets, filtrage avant persistance/sortie, logs sans DSN ni champs secrets, publication externe jamais auto-routée |
+| Partial output | Un artefact ou rapport incomplet est présenté comme valide | Écritures atomiques, reçus avec longueur/hash, relecture de vérification et état explicite ; pas de consommation sans artefact complet |
+
+## Invariants de sécurité à vérifier
+
+Les invariants exacts à préserver sont ceux des sections 3.1 à 3.4 de
+l’architecture :
+
+1. Le hash est celui des octets canoniques effectivement persistés, et toute
+   réécriture approuvée est refusée.
+2. Une approbation porte sur un hash et une portée exacts ; toute divergence,
+   expiration, absence ou réutilisation hors cap est refusée atomiquement.
+3. La lecture DB passe par un `query_id` allowlisté, une requête paramétrée
+   versionnée, un rôle `planner_reader` en lecture seule, une transaction
+   `READ ONLY` et des plafonds de temps/lignes/octets.
+4. Chaque capacité est isolée par toolset, profil, skill requis et `check_fn` ;
+   une capacité indisponible est rejetée explicitement.
+5. Toute publication externe exige une approbation humaine explicite pour
+   l'opération exacte. Cette approbation n'est jamais accordée automatiquement,
+   y compris sous `/yolo` ou avec `approvals.mode: off`.
+
+## Publication externe
+
+La capacité `publish` est manuelle et désactivée initialement. Une publication
+externe ne peut **jamais** être auto-routée vers une cible externe ni être
+auto-approuvée sous `/yolo` ou `approvals.mode: off`. Le routage automatique ne
+peut produire qu’un refus ou un artefact local en attente d’une approbation et
+d’une action humaines explicites ; il ne peut pas transformer un rapport en
+envoi externe.

--- a/plugins/research_protocol/migrations/0001_approval_ledger.sql
+++ b/plugins/research_protocol/migrations/0001_approval_ledger.sql
@@ -1,0 +1,240 @@
+-- Research Protocol PR2: one-shot approval ledger and fixed security-definer APIs.
+-- Apply once as a trusted migration owner. Existing objects make this migration
+-- fail rather than silently accepting an unknown or older schema.
+
+BEGIN;
+
+CREATE SCHEMA research_protocol;
+REVOKE ALL ON SCHEMA research_protocol FROM PUBLIC;
+
+CREATE TABLE research_protocol.approvals (
+    approval_id text PRIMARY KEY,
+    scope_sha256 character(64) NOT NULL,
+    plan_sha256 character(64) NOT NULL,
+    scope_json jsonb NOT NULL,
+    verdict text NOT NULL,
+    surface text NOT NULL,
+    created_at timestamptz NOT NULL,
+    expires_at timestamptz NOT NULL,
+    last_consumed_at timestamptz,
+    max_executions integer NOT NULL,
+    consumed_count integer NOT NULL DEFAULT 0,
+    CONSTRAINT approvals_id_length
+        CHECK (char_length(approval_id) BETWEEN 22 AND 256),
+    CONSTRAINT approvals_scope_sha256_hex
+        CHECK (scope_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT approvals_plan_sha256_hex
+        CHECK (plan_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT approvals_scope_json_object
+        CHECK (jsonb_typeof(scope_json) = 'object'),
+    CONSTRAINT approvals_scope_required_keys
+        CHECK (
+            scope_json ?& ARRAY[
+                'plan_sha256',
+                'max_executions',
+                'expires_at',
+                'run_id',
+                'budgets'
+            ]
+            AND jsonb_typeof(scope_json -> 'budgets') = 'object'
+            AND (scope_json -> 'budgets') ? 'max_executions'
+            AND scope_json ->> 'plan_sha256' IS NOT NULL
+            AND scope_json ->> 'max_executions' IS NOT NULL
+            AND scope_json ->> 'expires_at' IS NOT NULL
+            AND scope_json ->> 'run_id' IS NOT NULL
+            AND scope_json -> 'budgets' ->> 'max_executions' IS NOT NULL
+        ),
+    CONSTRAINT approvals_scope_json_size
+        CHECK (octet_length(scope_json::text) <= 1000000),
+    CONSTRAINT approvals_scope_plan_bound
+        CHECK (scope_json ->> 'plan_sha256' = plan_sha256::text),
+    CONSTRAINT approvals_scope_execution_bound
+        CHECK (scope_json ->> 'max_executions' = max_executions::text),
+    CONSTRAINT approvals_scope_budget_bound
+        CHECK (
+            (scope_json -> 'budgets' ->> 'max_executions')::integer
+            >= max_executions
+        ),
+    CONSTRAINT approvals_scope_expiry_bound
+        CHECK ((scope_json ->> 'expires_at')::timestamptz = expires_at),
+    CONSTRAINT approvals_scope_run_id_bound
+        CHECK (
+            char_length(scope_json ->> 'run_id') BETWEEN 1 AND 128
+            AND scope_json ->> 'run_id' ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'
+        ),
+    CONSTRAINT approvals_verdict_closed
+        CHECK (verdict IN ('approved', 'denied')),
+    CONSTRAINT approvals_surface_length
+        CHECK (char_length(surface) BETWEEN 1 AND 128),
+    CONSTRAINT approvals_max_executions_positive
+        CHECK (max_executions > 0),
+    CONSTRAINT approvals_consumed_count_nonnegative
+        CHECK (consumed_count >= 0),
+    CONSTRAINT approvals_consumed_within_cap
+        CHECK (consumed_count <= max_executions),
+    CONSTRAINT approvals_denied_unconsumed
+        CHECK (verdict = 'approved' OR consumed_count = 0),
+    CONSTRAINT approvals_expiry_after_creation
+        CHECK (verdict = 'denied' OR expires_at > created_at),
+    CONSTRAINT approvals_consumed_timestamp_consistent
+        CHECK (
+            (consumed_count = 0 AND last_consumed_at IS NULL)
+            OR (consumed_count > 0 AND last_consumed_at IS NOT NULL)
+        )
+);
+
+CREATE INDEX approvals_active_expiry_idx
+    ON research_protocol.approvals (expires_at)
+    WHERE verdict = 'approved' AND consumed_count < max_executions;
+
+REVOKE ALL ON research_protocol.approvals FROM PUBLIC;
+
+CREATE FUNCTION research_protocol.store_approval(
+    p_approval_id text,
+    p_scope_sha256 text,
+    p_plan_sha256 text,
+    p_scope_json text,
+    p_verdict text,
+    p_surface text,
+    p_created_at timestamptz,
+    p_expires_at timestamptz,
+    p_max_executions integer
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, research_protocol
+AS $store$
+DECLARE
+    v_scope_json jsonb;
+BEGIN
+    v_scope_json := p_scope_json::jsonb;
+
+    IF p_approval_id IS NULL
+       OR p_scope_sha256 IS NULL
+       OR p_plan_sha256 IS NULL
+       OR p_scope_json IS NULL
+       OR p_verdict IS NULL
+       OR p_surface IS NULL
+       OR p_created_at IS NULL
+       OR p_expires_at IS NULL
+       OR p_max_executions IS NULL
+       OR NOT (
+           v_scope_json ?& ARRAY[
+               'plan_sha256',
+               'max_executions',
+               'expires_at',
+               'run_id',
+               'budgets'
+           ]
+           AND jsonb_typeof(v_scope_json -> 'budgets') = 'object'
+           AND (v_scope_json -> 'budgets') ? 'max_executions'
+           AND v_scope_json ->> 'plan_sha256' IS NOT NULL
+           AND v_scope_json ->> 'max_executions' IS NOT NULL
+           AND v_scope_json ->> 'expires_at' IS NOT NULL
+           AND v_scope_json ->> 'run_id' IS NOT NULL
+           AND v_scope_json -> 'budgets' ->> 'max_executions' IS NOT NULL
+       )
+       OR char_length(p_approval_id) NOT BETWEEN 22 AND 256
+       OR p_scope_sha256 !~ '^[0-9a-f]{64}$'
+       OR p_plan_sha256 !~ '^[0-9a-f]{64}$'
+       OR jsonb_typeof(v_scope_json) <> 'object'
+       OR octet_length(p_scope_json) > 1000000
+       OR pg_catalog.encode(
+           pg_catalog.sha256(
+               pg_catalog.convert_to(p_scope_json, 'UTF8')
+           ),
+           'hex'
+       ) <> p_scope_sha256
+       OR v_scope_json ->> 'plan_sha256' <> p_plan_sha256
+       OR v_scope_json ->> 'max_executions' <> p_max_executions::text
+       OR (v_scope_json -> 'budgets' ->> 'max_executions')::integer
+          < p_max_executions
+       OR (v_scope_json ->> 'expires_at')::timestamptz <> p_expires_at
+       OR char_length(v_scope_json ->> 'run_id') NOT BETWEEN 1 AND 128
+       OR v_scope_json ->> 'run_id' !~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'
+       OR p_verdict NOT IN ('approved', 'denied')
+       OR char_length(p_surface) NOT BETWEEN 1 AND 128
+       OR p_max_executions <= 0
+       OR p_created_at > clock_timestamp()
+       OR (
+           p_verdict = 'approved'
+           AND (
+               p_expires_at <= clock_timestamp()
+               OR p_expires_at <= p_created_at
+           )
+       )
+    THEN
+        RAISE EXCEPTION 'invalid approval record' USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO research_protocol.approvals (
+        approval_id,
+        scope_sha256,
+        plan_sha256,
+        scope_json,
+        verdict,
+        surface,
+        created_at,
+        expires_at,
+        max_executions,
+        consumed_count
+    ) VALUES (
+        p_approval_id,
+        p_scope_sha256::character(64),
+        p_plan_sha256::character(64),
+        v_scope_json,
+        p_verdict,
+        p_surface,
+        p_created_at,
+        p_expires_at,
+        p_max_executions,
+        0
+    );
+
+    RETURN p_approval_id;
+END
+$store$;
+
+REVOKE ALL ON FUNCTION research_protocol.store_approval(
+    text, text, text, text, text, text, timestamptz, timestamptz, integer
+) FROM PUBLIC;
+
+CREATE FUNCTION research_protocol.claim_approval(
+    p_approval_id text,
+    p_scope_sha256 text,
+    p_plan_sha256 text
+)
+RETURNS TABLE (
+    approval_id text,
+    scope_sha256 text,
+    plan_sha256 text,
+    consumed_count integer,
+    max_executions integer
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, research_protocol
+AS $claim$
+    UPDATE research_protocol.approvals AS approval
+    SET consumed_count = approval.consumed_count + 1,
+        last_consumed_at = clock_timestamp()
+    WHERE approval.approval_id = p_approval_id
+      AND approval.scope_sha256::text = p_scope_sha256
+      AND approval.plan_sha256::text = p_plan_sha256
+      AND p_scope_sha256 ~ '^[0-9a-f]{64}$'
+      AND p_plan_sha256 ~ '^[0-9a-f]{64}$'
+      AND approval.verdict = 'approved'
+      AND approval.expires_at > clock_timestamp()
+      AND approval.consumed_count < approval.max_executions
+    RETURNING approval.approval_id,
+              approval.scope_sha256::text,
+              approval.plan_sha256::text,
+              approval.consumed_count,
+              approval.max_executions
+$claim$;
+
+REVOKE ALL ON FUNCTION research_protocol.claim_approval(text, text, text)
+    FROM PUBLIC;
+
+COMMIT;

--- a/plugins/research_protocol/migrations/0002_roles.sql
+++ b/plugins/research_protocol/migrations/0002_roles.sql
@@ -1,0 +1,65 @@
+-- Research Protocol PR2: one-shot least-privilege runtime roles.
+-- Apply once as a trusted cluster administrator after 0001. A pre-existing role
+-- name makes the transaction fail closed; this migration never attempts to
+-- sanitize a role that may hold privileges in another database.
+
+BEGIN;
+
+CREATE ROLE research_protocol_planner_reader
+    NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+
+CREATE ROLE research_protocol_approval_writer
+    NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+
+CREATE ROLE research_protocol_approval_claimant
+    NOLOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+
+REVOKE ALL ON SCHEMA research_protocol FROM PUBLIC;
+REVOKE ALL ON research_protocol.approvals FROM PUBLIC;
+REVOKE ALL ON FUNCTION research_protocol.store_approval(
+    text, text, text, text, text, text, timestamptz, timestamptz, integer
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION research_protocol.claim_approval(text, text, text)
+    FROM PUBLIC;
+
+REVOKE ALL ON SCHEMA research_protocol FROM research_protocol_planner_reader;
+REVOKE ALL ON SCHEMA research_protocol FROM research_protocol_approval_writer;
+REVOKE ALL ON SCHEMA research_protocol FROM research_protocol_approval_claimant;
+
+REVOKE ALL ON research_protocol.approvals FROM research_protocol_planner_reader;
+REVOKE ALL ON research_protocol.approvals FROM research_protocol_approval_writer;
+REVOKE ALL ON research_protocol.approvals FROM research_protocol_approval_claimant;
+
+REVOKE ALL ON FUNCTION research_protocol.store_approval(
+    text, text, text, text, text, text, timestamptz, timestamptz, integer
+) FROM research_protocol_planner_reader;
+REVOKE ALL ON FUNCTION research_protocol.store_approval(
+    text, text, text, text, text, text, timestamptz, timestamptz, integer
+) FROM research_protocol_approval_writer;
+REVOKE ALL ON FUNCTION research_protocol.store_approval(
+    text, text, text, text, text, text, timestamptz, timestamptz, integer
+) FROM research_protocol_approval_claimant;
+
+REVOKE ALL ON FUNCTION research_protocol.claim_approval(text, text, text)
+    FROM research_protocol_planner_reader;
+REVOKE ALL ON FUNCTION research_protocol.claim_approval(text, text, text)
+    FROM research_protocol_approval_writer;
+REVOKE ALL ON FUNCTION research_protocol.claim_approval(text, text, text)
+    FROM research_protocol_approval_claimant;
+
+GRANT USAGE ON SCHEMA research_protocol
+    TO research_protocol_planner_reader;
+GRANT SELECT ON research_protocol.approvals TO research_protocol_planner_reader;
+
+GRANT USAGE ON SCHEMA research_protocol
+    TO research_protocol_approval_writer;
+GRANT EXECUTE ON FUNCTION research_protocol.store_approval(
+    text, text, text, text, text, text, timestamptz, timestamptz, integer
+) TO research_protocol_approval_writer;
+
+GRANT USAGE ON SCHEMA research_protocol
+    TO research_protocol_approval_claimant;
+GRANT EXECUTE ON FUNCTION research_protocol.claim_approval(text, text, text)
+    TO research_protocol_approval_claimant;
+
+COMMIT;

--- a/plugins/research_protocol/models/__init__.py
+++ b/plugins/research_protocol/models/__init__.py
@@ -1,0 +1,48 @@
+"""Public versioned models for the Research Protocol plugin."""
+
+from .base import load_artifact_from_json_bytes
+from .evidence import EvidenceSnapshot, SourceQuality
+from .plan import (
+    BudgetLimits,
+    Capability,
+    CapabilityGrant,
+    ExternalRight,
+    InputReference,
+    OutputRequirement,
+    PlanV1,
+)
+from .publication import FigureKind, FigureSpec
+from .review import (
+    ConflictRecord,
+    ConflictStatus,
+    DedupCluster,
+    Verdict,
+    VerdictRecord,
+)
+from .run import ArtifactStatus, ManifestRecord, RunConfig
+from .source import SourceCandidate, SourceIdentifier
+
+__all__ = [
+    "ArtifactStatus",
+    "BudgetLimits",
+    "Capability",
+    "CapabilityGrant",
+    "ConflictRecord",
+    "ConflictStatus",
+    "DedupCluster",
+    "EvidenceSnapshot",
+    "ExternalRight",
+    "FigureKind",
+    "FigureSpec",
+    "InputReference",
+    "ManifestRecord",
+    "OutputRequirement",
+    "PlanV1",
+    "RunConfig",
+    "SourceCandidate",
+    "SourceIdentifier",
+    "SourceQuality",
+    "Verdict",
+    "VerdictRecord",
+    "load_artifact_from_json_bytes",
+]

--- a/plugins/research_protocol/models/base.py
+++ b/plugins/research_protocol/models/base.py
@@ -1,0 +1,104 @@
+"""Shared strict primitives for versioned research artifacts."""
+
+from collections.abc import Mapping
+import json
+from types import MappingProxyType
+from typing import Annotated, TypeAlias, TypeVar
+
+from pydantic import (
+    AfterValidator,
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    PlainSerializer,
+    StringConstraints,
+)
+
+Identifier = Annotated[
+    str,
+    StringConstraints(
+        strict=True,
+        min_length=1,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$",
+    ),
+]
+NonEmptyText = Annotated[
+    str,
+    StringConstraints(
+        strict=True,
+        min_length=1,
+        pattern=r"^\S(?:[\s\S]*\S)?$",
+    ),
+]
+Sha256 = Annotated[
+    str,
+    StringConstraints(strict=True, pattern=r"^[0-9a-f]{64}$"),
+]
+
+MappingKey = TypeVar("MappingKey")
+MappingValue = TypeVar("MappingValue")
+
+
+def _freeze_mapping(
+    value: Mapping[MappingKey, MappingValue],
+) -> Mapping[MappingKey, MappingValue]:
+    return MappingProxyType(dict(value))
+
+
+def _serialize_mapping(value: Mapping[object, object]) -> dict[object, object]:
+    return dict(value)
+
+
+FrozenMapping: TypeAlias = Annotated[
+    Mapping[MappingKey, MappingValue],
+    AfterValidator(_freeze_mapping),
+    PlainSerializer(_serialize_mapping, return_type=dict),
+]
+
+
+class StrictContract(BaseModel):
+    """Reject unknown fields, coercion, and non-finite numeric values."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        strict=True,
+        allow_inf_nan=False,
+        validate_default=True,
+        frozen=True,
+    )
+
+
+class ArtifactModel(StrictContract):
+    """Metadata and canonical serialization shared by persisted v1 artifacts."""
+
+    producer_version: NonEmptyText
+    run_id: Identifier
+    created_at: AwareDatetime
+
+    def to_canonical_json_bytes(self) -> bytes:
+        """Revalidate current state and return deterministic UTF-8 JSON bytes."""
+
+        validated = type(self).model_validate_json(self.model_dump_json(), strict=True)
+        return json.dumps(
+            validated.model_dump(mode="json"),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+
+ArtifactType = TypeVar("ArtifactType", bound=ArtifactModel)
+
+
+def load_artifact_from_json_bytes(
+    model: type[ArtifactType], payload: bytes
+) -> ArtifactType:
+    """Validate persisted artifact bytes through Pydantic's strict JSON mode."""
+
+    if not isinstance(payload, bytes):
+        raise TypeError("artifact payload must be bytes")
+    if not issubclass(model, ArtifactModel):
+        raise TypeError("model must inherit from ArtifactModel")
+    return model.model_validate_json(payload, strict=True)

--- a/plugins/research_protocol/models/evidence.py
+++ b/plugins/research_protocol/models/evidence.py
@@ -1,0 +1,28 @@
+"""Evidence and deterministic source-quality contracts."""
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from .base import ArtifactModel, FrozenMapping, Identifier, NonEmptyText, Sha256
+
+UnitScore = Annotated[float, Field(strict=True, ge=0.0, le=1.0, allow_inf_nan=False)]
+
+
+class EvidenceSnapshot(ArtifactModel):
+    schema_version: Literal["evidence_snapshot.v1"]
+    evidence_id: Identifier
+    source_id: Identifier
+    locator: NonEmptyText
+    content_sha256: Sha256
+    extract: NonEmptyText
+    provenance_id: Identifier
+
+
+class SourceQuality(ArtifactModel):
+    schema_version: Literal["source_quality.v1"]
+    source_id: Identifier
+    provenance_id: Identifier
+    score: UnitScore
+    dimensions: FrozenMapping[Identifier, UnitScore]
+    rationale: tuple[NonEmptyText, ...]

--- a/plugins/research_protocol/models/plan.py
+++ b/plugins/research_protocol/models/plan.py
@@ -1,0 +1,72 @@
+"""PlanV1 and its bounded execution scope."""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from .base import ArtifactModel, Identifier, NonEmptyText, Sha256, StrictContract
+
+
+class Capability(str, Enum):
+    RESEARCH_COLLECT = "research-collect"
+    EVIDENCE_REVIEW = "evidence-review"
+    BUILD = "build"
+    PUBLISH = "publish"
+
+
+class ExternalRight(str, Enum):
+    NETWORK_READ = "network-read"
+    DATABASE_READ = "database-read"
+    EXTERNAL_PUBLISH = "external-publish"
+
+
+class BudgetLimits(StrictContract):
+    max_duration_seconds: int = Field(strict=True, gt=0)
+    max_executions: int = Field(strict=True, gt=0)
+    max_records: int = Field(strict=True, gt=0)
+    max_bytes: int = Field(strict=True, gt=0)
+    max_external_calls: int = Field(default=0, strict=True, ge=0)
+
+
+class InputReference(StrictContract):
+    input_id: Identifier
+    artifact_type: Identifier
+    sha256: Sha256
+
+
+class OutputRequirement(StrictContract):
+    artifact_id: Identifier
+    artifact_type: Identifier
+    required: bool = True
+
+
+class CapabilityGrant(StrictContract):
+    capability: Capability
+    input_hashes: tuple[Sha256, ...] = Field(min_length=1)
+    external_rights: tuple[ExternalRight, ...] = ()
+
+
+class PlanV1(ArtifactModel):
+    schema_version: Literal["plan.v1"]
+    objective: NonEmptyText
+    constraints: tuple[NonEmptyText, ...]
+    inputs: tuple[InputReference, ...]
+    outputs: tuple[OutputRequirement, ...] = Field(min_length=1)
+    budgets: BudgetLimits
+    capabilities: tuple[CapabilityGrant, ...] = Field(
+        min_length=1,
+        json_schema_extra={
+            "uniqueItems": True,
+            "x-hermes-validation": (
+                "Pydantic requires capability values to be unique across grants."
+            ),
+        },
+    )
+
+    @model_validator(mode="after")
+    def reject_duplicate_capabilities(self) -> "PlanV1":
+        values = [grant.capability for grant in self.capabilities]
+        if len(values) != len(set(values)):
+            raise ValueError("capabilities must be unique")
+        return self

--- a/plugins/research_protocol/models/policy.py
+++ b/plugins/research_protocol/models/policy.py
@@ -1,0 +1,57 @@
+"""Strict schemas for versioned policy documents."""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from .base import StrictContract
+
+UnitValue = Annotated[float, Field(strict=True, ge=0.0, le=1.0, allow_inf_nan=False)]
+
+
+class QualityDimensions(StrictContract):
+    authority: UnitValue
+    methodology: UnitValue
+    recency: UnitValue
+    traceability: UnitValue
+
+
+class QualityThresholds(StrictContract):
+    accept: UnitValue
+    review: UnitValue
+
+
+class SourceQualityPolicy(StrictContract):
+    schema_version: Literal["source_quality_policy.v1"]
+    dimensions: QualityDimensions
+    thresholds: QualityThresholds
+
+    @model_validator(mode="after")
+    def validate_weights_and_thresholds(self) -> "SourceQualityPolicy":
+        total = sum(self.dimensions.model_dump().values())
+        if abs(total - 1.0) > 1e-12:
+            raise ValueError("quality dimension weights must total 1")
+        if self.thresholds.review >= self.thresholds.accept:
+            raise ValueError("review threshold must be below accept threshold")
+        return self
+
+
+class ContradictionPolicy(StrictContract):
+    schema_version: Literal["contradiction_policy.v1"]
+    minimum_confidence: UnitValue
+    temporal_window_days: int = Field(strict=True, gt=0)
+    require_unit_match: bool
+
+
+class DedupPolicy(StrictContract):
+    schema_version: Literal["dedup_policy.v1"]
+    exact_hash_enabled: bool
+    semantic_enabled: bool
+    semantic_threshold: UnitValue
+
+
+POLICY_MODELS: dict[str, type[BaseModel]] = {
+    "source_quality.v1.yaml": SourceQualityPolicy,
+    "contradiction.v1.yaml": ContradictionPolicy,
+    "dedup.v1.yaml": DedupPolicy,
+}

--- a/plugins/research_protocol/models/publication.py
+++ b/plugins/research_protocol/models/publication.py
@@ -1,0 +1,29 @@
+"""Data-bound publication contracts."""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import Field
+
+from .base import ArtifactModel, FrozenMapping, Identifier, NonEmptyText, Sha256
+
+
+class FigureKind(str, Enum):
+    TABLE = "table"
+    BAR = "bar"
+    LINE = "line"
+    SCATTER = "scatter"
+
+
+class FigureSpec(ArtifactModel):
+    schema_version: Literal["figure_spec.v1"]
+    figure_id: Identifier
+    title: NonEmptyText
+    kind: FigureKind
+    data_artifact_id: Identifier
+    data_sha256: Sha256
+    x_field: Identifier
+    y_fields: tuple[Identifier, ...] = Field(min_length=1)
+    units: FrozenMapping[Identifier, NonEmptyText]
+    labels: FrozenMapping[Identifier, NonEmptyText]
+    palette: tuple[str, ...] = Field(min_length=1)

--- a/plugins/research_protocol/models/review.py
+++ b/plugins/research_protocol/models/review.py
@@ -1,0 +1,71 @@
+"""Conflict, deduplication, and verdict records."""
+
+from enum import Enum
+from typing import Annotated, Literal
+
+from pydantic import Field, model_validator
+
+from .base import ArtifactModel, Identifier, NonEmptyText
+
+UnitScore = Annotated[float, Field(strict=True, ge=0.0, le=1.0, allow_inf_nan=False)]
+
+
+class ConflictStatus(str, Enum):
+    OPEN = "open"
+    ADJUDICATED = "adjudicated"
+    INSUFFICIENT = "insufficient"
+
+
+class ConflictRecord(ArtifactModel):
+    schema_version: Literal["conflict_record.v1"]
+    conflict_id: Identifier
+    claim_id: Identifier
+    left_provenance_id: Identifier
+    right_provenance_id: Identifier
+    conflict_type: Identifier
+    status: ConflictStatus
+    rationale: NonEmptyText
+
+    @model_validator(mode="after")
+    def require_distinct_provenance(self) -> "ConflictRecord":
+        if self.left_provenance_id == self.right_provenance_id:
+            raise ValueError("conflict provenance references must be distinct")
+        return self
+
+
+class DedupCluster(ArtifactModel):
+    schema_version: Literal["dedup_cluster.v1"]
+    cluster_id: Identifier
+    canonical_provenance_id: Identifier
+    member_provenance_ids: tuple[Identifier, ...] = Field(
+        min_length=2,
+        json_schema_extra={"uniqueItems": True},
+    )
+    method: Literal["exact", "semantic"]
+    confidence: UnitScore
+
+    @model_validator(mode="after")
+    def validate_members(self) -> "DedupCluster":
+        if len(self.member_provenance_ids) != len(set(self.member_provenance_ids)):
+            raise ValueError("member_provenance_ids must be unique")
+        if self.canonical_provenance_id not in self.member_provenance_ids:
+            raise ValueError("canonical provenance must be a cluster member")
+        return self
+
+
+class Verdict(str, Enum):
+    SUPPORTED = "supported"
+    REJECTED = "rejected"
+    MIXED = "mixed"
+    INSUFFICIENT = "insufficient"
+    BLOCKED = "blocked"
+
+
+class VerdictRecord(ArtifactModel):
+    schema_version: Literal["verdict_record.v1"]
+    verdict_id: Identifier
+    question_id: Identifier
+    verdict: Verdict
+    evidence_provenance_ids: tuple[Identifier, ...] = Field(min_length=1)
+    rationale: NonEmptyText
+    confidence: UnitScore

--- a/plugins/research_protocol/models/run.py
+++ b/plugins/research_protocol/models/run.py
@@ -54,7 +54,7 @@ class ManifestRecord(ArtifactModel):
         json_schema_extra={
             "pattern": SAFE_RELATIVE_POSIX_PATTERN,
             "$comment": PATH_BOUNDARY_COMMENT,
-        }
+        },
     )
     sha256: Sha256
     byte_length: int = Field(strict=True, ge=0)

--- a/plugins/research_protocol/models/run.py
+++ b/plugins/research_protocol/models/run.py
@@ -1,0 +1,82 @@
+"""Run configuration and immutable manifest records."""
+
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from .base import (
+    ArtifactModel,
+    FrozenMapping,
+    Identifier,
+    Sha256,
+)
+from .plan import BudgetLimits, Capability
+
+SAFE_RELATIVE_POSIX_PATTERN = (
+    r"^(?!\s)(?!.*\s$)(?!/)(?!.*:)(?!.*\\)(?!.*\x00)(?!.*//)"
+    r"(?!.*(?:^|/)\.{1,2}(?:/|$))(?!.*\/$).+$"
+)
+PATH_BOUNDARY_COMMENT = (
+    "Pydantic validation is required to enforce exact, normalized POSIX path "
+    "semantics without coercion in addition to this JSON Schema pattern."
+)
+
+
+class ArtifactStatus(str, Enum):
+    PENDING = "pending"
+    SUCCESS = "success"
+    FAILED = "failed"
+    PARTIAL = "partial"
+    QUARANTINED = "quarantined"
+
+
+class RunConfig(ArtifactModel):
+    schema_version: Literal["run_config.v1"]
+    plan_artifact_id: Identifier
+    plan_sha256: Sha256
+    capability: Capability
+    budgets: BudgetLimits
+    input_hashes: tuple[Sha256, ...] = Field(min_length=1)
+    policy_hashes: FrozenMapping[Identifier, Sha256]
+    seed: int = Field(strict=True, ge=0)
+
+
+class ManifestRecord(ArtifactModel):
+    schema_version: Literal["manifest_record.v1"]
+    artifact_id: Identifier
+    artifact_type: Identifier
+    path_relative: str = Field(
+        strict=True,
+        min_length=1,
+        max_length=8192,
+        json_schema_extra={
+            "pattern": SAFE_RELATIVE_POSIX_PATTERN,
+            "$comment": PATH_BOUNDARY_COMMENT,
+        }
+    )
+    sha256: Sha256
+    byte_length: int = Field(strict=True, ge=0)
+    status: ArtifactStatus
+    provenance_ids: tuple[Identifier, ...]
+
+    @field_validator("path_relative")
+    @classmethod
+    def require_safe_relative_posix_path(cls, value: str) -> str:
+        parts = value.split("/")
+        if (
+            "\x00" in value
+            or "\\" in value
+            or ":" in value
+            or value != value.strip()
+            or value.startswith("/")
+            or value.endswith("/")
+            or any(part in {"", ".", ".."} for part in parts)
+        ):
+            raise ValueError("path_relative must be a safe normalized POSIX path")
+
+        path = PurePosixPath(value)
+        if path.is_absolute() or str(path) != value:
+            raise ValueError("path_relative must be normalized")
+        return value

--- a/plugins/research_protocol/models/schema_export.py
+++ b/plugins/research_protocol/models/schema_export.py
@@ -1,0 +1,87 @@
+"""Deterministic JSON Schema export for persisted artifact contracts."""
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from .evidence import EvidenceSnapshot, SourceQuality
+from .plan import PlanV1
+from .publication import FigureSpec
+from .review import ConflictRecord, DedupCluster, VerdictRecord
+from .run import ManifestRecord, RunConfig
+from .source import SourceCandidate
+
+SCHEMA_MODELS: dict[str, type[BaseModel]] = {
+    "plan.v1.json": PlanV1,
+    "run_config.v1.json": RunConfig,
+    "manifest_record.v1.json": ManifestRecord,
+    "source_candidate.v1.json": SourceCandidate,
+    "evidence_snapshot.v1.json": EvidenceSnapshot,
+    "source_quality.v1.json": SourceQuality,
+    "conflict_record.v1.json": ConflictRecord,
+    "dedup_cluster.v1.json": DedupCluster,
+    "verdict_record.v1.json": VerdictRecord,
+    "figure_spec.v1.json": FigureSpec,
+}
+BOUNDARY_COMMENT = (
+    "JSON Schema validation is necessary but insufficient; artifact bytes must be "
+    "validated with load_artifact_from_json_bytes and Pydantic model_validate_json."
+)
+SEMANTIC_COMMENTS = {
+    "conflict_record.v1.json": (
+        "Pydantic requires left_provenance_id and right_provenance_id to be distinct."
+    ),
+    "dedup_cluster.v1.json": (
+        "Pydantic requires canonical_provenance_id to be a member of "
+        "member_provenance_ids."
+    ),
+}
+
+
+def _close_pattern_property_objects(node: object) -> None:
+    """Mirror strict Pydantic mapping-key validation in exported schemas."""
+
+    if isinstance(node, dict):
+        if "patternProperties" in node:
+            node["additionalProperties"] = False
+        for value in node.values():
+            _close_pattern_property_objects(value)
+    elif isinstance(node, list):
+        for value in node:
+            _close_pattern_property_objects(value)
+
+
+def render_schema_documents() -> dict[str, bytes]:
+    rendered: dict[str, bytes] = {}
+    for filename, model in SCHEMA_MODELS.items():
+        schema = model.model_json_schema(mode="validation")
+        _close_pattern_property_objects(schema)
+        schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+        schema["$comment"] = " ".join(
+            part
+            for part in (BOUNDARY_COMMENT, SEMANTIC_COMMENTS.get(filename))
+            if part is not None
+        )
+        rendered[filename] = (
+            json.dumps(
+                schema,
+                ensure_ascii=False,
+                allow_nan=False,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("utf-8")
+    return rendered
+
+
+def write_schema_documents(root: Path | None = None) -> None:
+    target = root or Path(__file__).resolve().parents[1] / "schemas"
+    target.mkdir(parents=True, exist_ok=True)
+    for filename, payload in render_schema_documents().items():
+        (target / filename).write_bytes(payload)
+
+
+if __name__ == "__main__":
+    write_schema_documents()

--- a/plugins/research_protocol/models/schema_export.py
+++ b/plugins/research_protocol/models/schema_export.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 from pydantic import BaseModel
 
@@ -43,9 +44,10 @@ def _close_pattern_property_objects(node: object) -> None:
     """Mirror strict Pydantic mapping-key validation in exported schemas."""
 
     if isinstance(node, dict):
-        if "patternProperties" in node:
-            node["additionalProperties"] = False
-        for value in node.values():
+        mapping = cast(dict[str, Any], node)
+        if "patternProperties" in mapping:
+            mapping["additionalProperties"] = False
+        for value in mapping.values():
             _close_pattern_property_objects(value)
     elif isinstance(node, list):
         for value in node:

--- a/plugins/research_protocol/models/source.py
+++ b/plugins/research_protocol/models/source.py
@@ -1,0 +1,25 @@
+"""Source census contracts."""
+
+from typing import Literal
+
+from pydantic import AwareDatetime
+
+from .base import ArtifactModel, Identifier, NonEmptyText, StrictContract
+
+
+class SourceIdentifier(StrictContract):
+    kind: Identifier
+    value: NonEmptyText
+
+
+class SourceCandidate(ArtifactModel):
+    schema_version: Literal["source_candidate.v1"]
+    source_id: Identifier
+    adapter_id: Identifier
+    locator: NonEmptyText
+    title: NonEmptyText
+    identifiers: tuple[SourceIdentifier, ...]
+    authors: tuple[NonEmptyText, ...]
+    published_at: AwareDatetime | None = None
+    license: NonEmptyText | None = None
+    provenance_id: Identifier

--- a/plugins/research_protocol/planner_tools.py
+++ b/plugins/research_protocol/planner_tools.py
@@ -1,0 +1,294 @@
+"""Fail-closed handlers for the bounded planner toolset."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict
+from datetime import UTC, datetime
+import re
+from typing import Any
+
+from pydantic import ValidationError
+
+from .approval import ApprovalScope
+from .models import PlanV1
+from .schemas import ARTIFACT_TYPES, CONTEXT_QUERY_IDS
+from .storage.artifacts import ArtifactSecurityError, ArtifactStore
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_CONTEXT_PARAMETER_RULES = {
+    "approval_status.v1": ({"approval_id"}, {"approval_id"}),
+    "approvals_for_run.v1": ({"run_id"}, {"run_id", "limit"}),
+}
+
+
+class PlannerToolHandlers:
+    """Execute planner operations only through injected bounded dependencies."""
+
+    def __init__(
+        self,
+        *,
+        artifact_store: ArtifactStore | None,
+        context_reader: Any | None,
+        approval_service: Any | None,
+    ):
+        self._artifacts = artifact_store
+        self._context_reader = context_reader
+        self._approvals = approval_service
+
+    async def context_read(self, args: dict[str, Any]) -> dict[str, Any]:
+        if self._context_reader is None:
+            return {"ok": False, "error": "planner database runtime unavailable"}
+        try:
+            query_id, parameters = _validate_context_args(args)
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "invalid context query"}
+
+        try:
+            rows = await self._context_reader.read(query_id, parameters)
+        except Exception:
+            # Dependency errors can include SQL fragments or connection details.
+            return {"ok": False, "error": "planner context read failed"}
+        return {
+            "ok": True,
+            "query_id": query_id,
+            "rows": rows,
+            "row_count": len(rows),
+        }
+
+    async def artifact_write(self, args: dict[str, Any]) -> dict[str, Any]:
+        if self._artifacts is None:
+            return {"ok": False, "error": "planner artifact runtime unavailable"}
+        try:
+            _require_exact_keys(args, {"artifact_type", "artifact_id", "payload"})
+            artifact_type = args["artifact_type"]
+            artifact_id = args["artifact_id"]
+            payload = args["payload"]
+            if artifact_type not in ARTIFACT_TYPES:
+                raise ValueError("unsupported artifact type")
+            if not isinstance(artifact_id, str) or not isinstance(payload, dict):
+                raise TypeError("invalid artifact request")
+        except (TypeError, ValidationError, ValueError):
+            return {"ok": False, "error": "artifact write rejected"}
+        try:
+            receipt = await asyncio.to_thread(
+                self._artifacts.persist,
+                artifact_type,
+                artifact_id,
+                payload,
+            )
+        except (ArtifactSecurityError, FileExistsError, FileNotFoundError, OSError):
+            return {"ok": False, "error": "artifact write failed"}
+
+        return {"ok": True, "receipt": asdict(receipt)}
+
+    async def approval_request(self, args: dict[str, Any]) -> dict[str, Any]:
+        if self._artifacts is None or self._approvals is None:
+            return {"ok": False, "error": "planner database runtime unavailable"}
+        try:
+            _require_exact_keys(
+                args,
+                {"artifact_id", "expected_sha256", "scope"},
+            )
+            artifact_id = args["artifact_id"]
+            expected_sha256 = args["expected_sha256"]
+            if not isinstance(artifact_id, str):
+                raise TypeError("invalid artifact identifier")
+            if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(
+                expected_sha256
+            ):
+                raise ValueError("invalid expected hash")
+            scope_value = args["scope"]
+            scope = (
+                scope_value
+                if isinstance(scope_value, ApprovalScope)
+                else ApprovalScope.model_validate(scope_value)
+            )
+            plan_bytes = await asyncio.to_thread(
+                self._artifacts.read_verified,
+                "plan",
+                artifact_id,
+                expected_sha256=expected_sha256,
+            )
+            plan = PlanV1.model_validate_json(plan_bytes, strict=True)
+        except (
+            ArtifactSecurityError,
+            FileNotFoundError,
+            OSError,
+            TypeError,
+            ValidationError,
+            ValueError,
+        ):
+            return {"ok": False, "error": "approval request rejected"}
+
+        if not _scope_matches_plan(scope, plan, expected_sha256):
+            return {"ok": False, "error": "approval scope does not match plan"}
+
+        summary = _fixed_approval_summary(scope)
+        try:
+            record = await self._approvals.request(scope, summary)
+        except Exception:
+            # Approval backend failures must not expose DSNs or SQL to the model.
+            return {"ok": False, "error": "approval request failed"}
+        if record is None:
+            return {"ok": True, "approved": False}
+        return {
+            "ok": True,
+            "approved": True,
+            "approval": {
+                "approval_id": record.approval_id,
+                "scope_sha256": record.scope_sha256,
+                "plan_sha256": record.plan_sha256,
+                "verdict": record.verdict.value,
+                "surface": record.surface,
+                "created_at": record.created_at.isoformat(),
+                "expires_at": record.expires_at.isoformat(),
+                "max_executions": record.max_executions,
+                "consumed_count": record.consumed_count,
+            },
+        }
+
+
+def _require_exact_keys(args: Any, required: set[str]) -> None:
+    if not isinstance(args, dict) or set(args) != required:
+        raise ValueError("request fields do not match the closed schema")
+
+
+def _validate_context_args(args: Any) -> tuple[str, dict[str, Any]]:
+    _require_exact_keys(args, {"query_id", "parameters"})
+    query_id = args["query_id"]
+    parameters = args["parameters"]
+    if query_id not in CONTEXT_QUERY_IDS or not isinstance(parameters, dict):
+        raise ValueError("unknown context query")
+    required, allowed = _CONTEXT_PARAMETER_RULES[query_id]
+    if not required.issubset(parameters) or not set(parameters).issubset(allowed):
+        raise ValueError("invalid query parameters")
+    for key, value in parameters.items():
+        if key == "limit":
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or not 1 <= value <= 100
+            ):
+                raise ValueError("invalid row limit")
+        elif not isinstance(value, str) or not value or len(value) > 256:
+            raise ValueError("invalid query identifier")
+    return query_id, dict(parameters)
+
+
+def _scope_matches_plan(
+    scope: ApprovalScope,
+    plan: PlanV1,
+    expected_sha256: str,
+) -> bool:
+    if scope.expires_at <= datetime.now(UTC):
+        return False
+    if scope.plan_sha256 != expected_sha256 or scope.run_id != plan.run_id:
+        return False
+    if scope.budgets != plan.budgets:
+        return False
+    if scope.max_executions > plan.budgets.max_executions:
+        return False
+    grant = next(
+        (
+            candidate
+            for candidate in plan.capabilities
+            if candidate.capability is scope.capability
+        ),
+        None,
+    )
+    if grant is None:
+        return False
+    return tuple(scope.input_hashes) == tuple(
+        sorted(set(grant.input_hashes))
+    ) and tuple(scope.external_rights) == tuple(
+        sorted(set(grant.external_rights), key=lambda item: item.value)
+    )
+
+
+def _fixed_approval_summary(scope: ApprovalScope) -> str:
+    budgets = scope.budgets
+    return (
+        "Research protocol approval request\n"
+        f"run_id={scope.run_id}\n"
+        f"capability={scope.capability.value}\n"
+        f"plan_sha256={scope.plan_sha256}\n"
+        f"scope_sha256={scope.scope_sha256()}\n"
+        f"expires_at={scope.expires_at.isoformat()}\n"
+        f"max_executions={scope.max_executions}\n"
+        "budgets="
+        f"duration:{budgets.max_duration_seconds}s,"
+        f"records:{budgets.max_records},"
+        f"bytes:{budgets.max_bytes},"
+        f"external_calls:{budgets.max_external_calls}\n"
+        f"scope_json={scope.canonical_json()}"
+    )
+
+
+_runtime: PlannerToolHandlers | None = None
+_artifact_available = False
+_context_available = False
+_approval_available = False
+
+
+def configure_planner_runtime(
+    runtime: PlannerToolHandlers | None,
+    *,
+    artifact_available: bool = False,
+    context_available: bool = False,
+    approval_available: bool = False,
+) -> None:
+    """Install or clear an explicitly constructed local planner runtime."""
+    global _approval_available, _artifact_available, _context_available, _runtime
+    _runtime = runtime
+    _artifact_available = runtime is not None and artifact_available is True
+    _context_available = runtime is not None and context_available is True
+    _approval_available = runtime is not None and approval_available is True
+
+
+async def _dispatch(method: str, args: dict[str, Any]) -> dict[str, Any]:
+    if _runtime is None:
+        return {
+            "ok": False,
+            "error": "research protocol planner runtime is not configured",
+        }
+    return await getattr(_runtime, method)(args)
+
+
+async def plan_context_read(**kwargs: Any) -> dict[str, Any]:
+    return await _dispatch("context_read", kwargs)
+
+
+async def plan_artifact_write(**kwargs: Any) -> dict[str, Any]:
+    return await _dispatch("artifact_write", kwargs)
+
+
+async def plan_approval_request(**kwargs: Any) -> dict[str, Any]:
+    return await _dispatch("approval_request", kwargs)
+
+
+def check_planner_artifacts() -> bool:
+    """Expose artifact writes only after an explicit safe root is configured."""
+    return _runtime is not None and _artifact_available
+
+
+def check_planner_context() -> bool:
+    """Expose context reads only when the fixed reader authority exists."""
+    return _runtime is not None and _context_available
+
+
+def check_planner_approvals() -> bool:
+    """Expose approvals only when both artifact and writer authority exist."""
+    return _runtime is not None and _artifact_available and _approval_available
+
+
+__all__ = [
+    "PlannerToolHandlers",
+    "check_planner_approvals",
+    "check_planner_artifacts",
+    "check_planner_context",
+    "configure_planner_runtime",
+    "plan_approval_request",
+    "plan_artifact_write",
+    "plan_context_read",
+]

--- a/plugins/research_protocol/plugin.yaml
+++ b/plugins/research_protocol/plugin.yaml
@@ -1,0 +1,5 @@
+name: research-protocol
+version: "0.1.0"
+description: "Baseline opt-in du protocole de recherche reproductible, traçable et fail-closed."
+author: NousResearch
+kind: standalone

--- a/plugins/research_protocol/plugin.yaml
+++ b/plugins/research_protocol/plugin.yaml
@@ -1,5 +1,13 @@
 name: research-protocol
-version: "0.1.0"
-description: "Baseline opt-in du protocole de recherche reproductible, traçable et fail-closed."
-author: NousResearch
+version: 0.2.0
+description: Opt-in bounded research protocol planner tools
 kind: standalone
+entry: __init__.py
+provides_tools:
+  - plan_context_read
+  - plan_artifact_write
+  - plan_approval_request
+provides_hooks: []
+requires_env: []
+toolsets:
+  - planner

--- a/plugins/research_protocol/policies/contradiction.v1.yaml
+++ b/plugins/research_protocol/policies/contradiction.v1.yaml
@@ -1,0 +1,4 @@
+schema_version: contradiction_policy.v1
+minimum_confidence: 0.70
+temporal_window_days: 365
+require_unit_match: true

--- a/plugins/research_protocol/policies/dedup.v1.yaml
+++ b/plugins/research_protocol/policies/dedup.v1.yaml
@@ -1,0 +1,4 @@
+schema_version: dedup_policy.v1
+exact_hash_enabled: true
+semantic_enabled: false
+semantic_threshold: 0.95

--- a/plugins/research_protocol/policies/source_quality.v1.yaml
+++ b/plugins/research_protocol/policies/source_quality.v1.yaml
@@ -1,0 +1,9 @@
+schema_version: source_quality_policy.v1
+dimensions:
+  authority: 0.25
+  methodology: 0.25
+  recency: 0.20
+  traceability: 0.30
+thresholds:
+  accept: 0.70
+  review: 0.45

--- a/plugins/research_protocol/runtime.py
+++ b/plugins/research_protocol/runtime.py
@@ -1,0 +1,288 @@
+"""Explicit local runtime construction for the Research Protocol plugin."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Any
+
+from .approval import ApprovalService
+from .planner_tools import PlannerToolHandlers
+from .storage.artifacts import ArtifactStore
+from .storage.postgres import PostgresApprovalStore, PostgresContextReader
+
+READER_DATABASE_URL_ENV = "RESEARCH_PROTOCOL_READER_DATABASE_URL"
+WRITER_DATABASE_URL_ENV = "RESEARCH_PROTOCOL_WRITER_DATABASE_URL"
+
+
+class RuntimeConfigurationError(ValueError):
+    """Raised when explicit plugin authority is missing or malformed."""
+
+
+class _LazyAcquire:
+    def __init__(self, owner: "LazyAsyncpgPool"):
+        self._owner = owner
+        self._context: Any = None
+
+    async def __aenter__(self) -> Any:
+        pool = await self._owner.get_pool()
+        self._context = pool.acquire()
+        return await self._context.__aenter__()
+
+    async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> Any:
+        if self._context is None:
+            return False
+        return await self._context.__aexit__(exc_type, exc, traceback)
+
+
+class LazyAsyncpgPool:
+    """Create an asyncpg pool only inside the active Hermes event loop."""
+
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        min_size: int = 1,
+        max_size: int = 4,
+        command_timeout: float = 5.0,
+    ):
+        self._dsn = dsn
+        self._min_size = min_size
+        self._max_size = max_size
+        self._command_timeout = command_timeout
+        self._pool: Any = None
+        self._lock: asyncio.Lock | None = None
+
+    def __repr__(self) -> str:
+        return "LazyAsyncpgPool(dsn=[REDACTED], created=%r)" % self.created
+
+    @property
+    def created(self) -> bool:
+        return self._pool is not None
+
+    async def get_pool(self) -> Any:
+        if self._pool is not None:
+            return self._pool
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        async with self._lock:
+            if self._pool is None:
+                try:
+                    import asyncpg
+                except ImportError as exc:
+                    raise RuntimeConfigurationError(
+                        "asyncpg is required for Research Protocol database tools"
+                    ) from exc
+                self._pool = await asyncpg.create_pool(
+                    dsn=self._dsn,
+                    min_size=self._min_size,
+                    max_size=self._max_size,
+                    command_timeout=self._command_timeout,
+                    server_settings={
+                        "application_name": "hermes-research-protocol",
+                    },
+                )
+        return self._pool
+
+    def acquire(self) -> _LazyAcquire:
+        return _LazyAcquire(self)
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+
+
+@dataclass(frozen=True)
+class RuntimeBundle:
+    handlers: PlannerToolHandlers
+    artifact_available: bool
+    context_available: bool
+    approval_available: bool
+    reader_pool: LazyAsyncpgPool | None
+    writer_pool: LazyAsyncpgPool | None
+
+
+def _bounded_int(
+    config: Mapping[str, Any],
+    key: str,
+    default: int,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    value = config.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RuntimeConfigurationError(f"database.{key} must be an integer")
+    if not minimum <= value <= maximum:
+        raise RuntimeConfigurationError(
+            f"database.{key} must be between {minimum} and {maximum}"
+        )
+    return value
+
+
+def _bounded_float(
+    config: Mapping[str, Any],
+    key: str,
+    default: float,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float:
+    value = config.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RuntimeConfigurationError(f"database.{key} must be numeric")
+    result = float(value)
+    if not minimum <= result <= maximum:
+        raise RuntimeConfigurationError(
+            f"database.{key} must be between {minimum} and {maximum}"
+        )
+    return result
+
+
+def build_runtime_bundle(
+    plugin_config: Mapping[str, Any],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> RuntimeBundle:
+    """Build bounded local dependencies without opening a database connection."""
+    if not isinstance(plugin_config, Mapping):
+        raise RuntimeConfigurationError("plugin configuration must be a mapping")
+    root_value = plugin_config.get("artifact_root")
+    if not isinstance(root_value, str) or not root_value.strip():
+        raise RuntimeConfigurationError("an absolute artifact_root is required")
+    root = Path(root_value).expanduser()
+    if not root.is_absolute():
+        raise RuntimeConfigurationError("an absolute artifact_root is required")
+
+    artifact_store = ArtifactStore(root)
+    environment = os.environ if environ is None else environ
+    reader_dsn = environment.get(READER_DATABASE_URL_ENV, "").strip()
+    writer_dsn = environment.get(WRITER_DATABASE_URL_ENV, "").strip()
+    if reader_dsn and writer_dsn and reader_dsn == writer_dsn:
+        raise RuntimeConfigurationError(
+            "reader and writer database DSNs must be distinct"
+        )
+    if not reader_dsn and not writer_dsn:
+        return RuntimeBundle(
+            handlers=PlannerToolHandlers(
+                artifact_store=artifact_store,
+                context_reader=None,
+                approval_service=None,
+            ),
+            artifact_available=True,
+            context_available=False,
+            approval_available=False,
+            reader_pool=None,
+            writer_pool=None,
+        )
+
+    raw_database = plugin_config.get("database", {})
+    if not isinstance(raw_database, Mapping):
+        raise RuntimeConfigurationError("database configuration must be a mapping")
+    max_rows = _bounded_int(
+        raw_database,
+        "max_rows",
+        100,
+        minimum=1,
+        maximum=1000,
+    )
+    max_bytes = _bounded_int(
+        raw_database,
+        "max_bytes",
+        1_048_576,
+        minimum=256,
+        maximum=10_485_760,
+    )
+    timeout_seconds = _bounded_float(
+        raw_database,
+        "timeout_seconds",
+        5.0,
+        minimum=0.1,
+        maximum=30.0,
+    )
+    pool_min_size = _bounded_int(
+        raw_database,
+        "pool_min_size",
+        1,
+        minimum=1,
+        maximum=4,
+    )
+    pool_max_size = _bounded_int(
+        raw_database,
+        "pool_max_size",
+        4,
+        minimum=1,
+        maximum=8,
+    )
+    if pool_min_size > pool_max_size:
+        raise RuntimeConfigurationError(
+            "database.pool_min_size must not exceed database.pool_max_size"
+        )
+
+    reader_pool = (
+        LazyAsyncpgPool(
+            reader_dsn,
+            min_size=pool_min_size,
+            max_size=pool_max_size,
+            command_timeout=timeout_seconds,
+        )
+        if reader_dsn
+        else None
+    )
+    writer_pool = (
+        LazyAsyncpgPool(
+            writer_dsn,
+            min_size=pool_min_size,
+            max_size=pool_max_size,
+            command_timeout=timeout_seconds,
+        )
+        if writer_dsn
+        else None
+    )
+    context_reader = (
+        PostgresContextReader(
+            reader_pool,
+            max_rows=max_rows,
+            max_bytes=max_bytes,
+            timeout_seconds=timeout_seconds,
+        )
+        if reader_pool is not None
+        else None
+    )
+    approval_service = (
+        ApprovalService(
+            PostgresApprovalStore(
+                writer_pool,
+                timeout_seconds=timeout_seconds,
+            ),
+            surface="research-protocol",
+        )
+        if writer_pool is not None
+        else None
+    )
+    return RuntimeBundle(
+        handlers=PlannerToolHandlers(
+            artifact_store=artifact_store,
+            context_reader=context_reader,
+            approval_service=approval_service,
+        ),
+        artifact_available=True,
+        context_available=reader_pool is not None,
+        approval_available=writer_pool is not None,
+        reader_pool=reader_pool,
+        writer_pool=writer_pool,
+    )
+
+
+__all__ = [
+    "LazyAsyncpgPool",
+    "READER_DATABASE_URL_ENV",
+    "RuntimeBundle",
+    "RuntimeConfigurationError",
+    "WRITER_DATABASE_URL_ENV",
+    "build_runtime_bundle",
+]

--- a/plugins/research_protocol/runtime.py
+++ b/plugins/research_protocol/runtime.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+import concurrent.futures
 from dataclasses import dataclass
 import os
 from pathlib import Path
+import threading
 from typing import Any
 
 from .approval import ApprovalService
@@ -16,6 +18,7 @@ from .storage.postgres import PostgresApprovalStore, PostgresContextReader
 
 READER_DATABASE_URL_ENV = "RESEARCH_PROTOCOL_READER_DATABASE_URL"
 WRITER_DATABASE_URL_ENV = "RESEARCH_PROTOCOL_WRITER_DATABASE_URL"
+_REMOTE_CLOSE_POLL_SECONDS = 0.01
 
 
 class RuntimeConfigurationError(ValueError):
@@ -38,8 +41,37 @@ class _LazyAcquire:
         return await self._context.__aexit__(exc_type, exc, traceback)
 
 
+@dataclass
+class _LoopPoolState:
+    lock: asyncio.Lock
+    pool: Any = None
+    closing_pool: Any = None
+    retired: bool = False
+
+
+async def _close_pool_or_terminate(pool: Any) -> None:
+    try:
+        await pool.close()
+    except BaseException:
+        pool.terminate()
+        raise
+
+
+def _consume_future_exception(future: asyncio.Future[Any]) -> None:
+    if not future.cancelled():
+        future.exception()
+
+
+async def _await_shared_close(
+    future: concurrent.futures.Future[None],
+) -> None:
+    wrapped = asyncio.wrap_future(future)
+    wrapped.add_done_callback(_consume_future_exception)
+    await asyncio.shield(wrapped)
+
+
 class LazyAsyncpgPool:
-    """Create an asyncpg pool only inside the active Hermes event loop."""
+    """Create one asyncpg pool per active Hermes event loop."""
 
     def __init__(
         self,
@@ -53,30 +85,59 @@ class LazyAsyncpgPool:
         self._min_size = min_size
         self._max_size = max_size
         self._command_timeout = command_timeout
-        self._pool: Any = None
-        self._lock: asyncio.Lock | None = None
+        self._states: dict[asyncio.AbstractEventLoop, _LoopPoolState] = {}
+        self._states_guard = threading.Lock()
+        self._close_future: concurrent.futures.Future[None] | None = None
 
     def __repr__(self) -> str:
         return "LazyAsyncpgPool(dsn=[REDACTED], created=%r)" % self.created
 
     @property
     def created(self) -> bool:
-        return self._pool is not None
+        with self._states_guard:
+            return any(state.pool is not None for state in self._states.values())
 
     async def get_pool(self) -> Any:
-        if self._pool is not None:
-            return self._pool
-        if self._lock is None:
-            self._lock = asyncio.Lock()
-        async with self._lock:
-            if self._pool is None:
+        loop = asyncio.get_running_loop()
+        while True:
+            stale_pools: list[Any] = []
+            state: _LoopPoolState | None = None
+            with self._states_guard:
+                close_future = self._close_future
+                if close_future is None:
+                    for owner_loop, owner_state in tuple(self._states.items()):
+                        if owner_loop.is_closed():
+                            owner_state.retired = True
+                            self._states.pop(owner_loop)
+                            if owner_state.pool is not None:
+                                stale_pools.append(owner_state.pool)
+                    state = self._states.get(loop)
+                    if state is None:
+                        state = _LoopPoolState(lock=asyncio.Lock())
+                        self._states[loop] = state
+
+            if close_future is not None:
+                await _await_shared_close(close_future)
+                continue
+
+            for stale_pool in stale_pools:
+                stale_pool.terminate()
+
+            assert state is not None
+            async with state.lock:
+                with self._states_guard:
+                    if state.retired or self._states.get(loop) is not state:
+                        continue
+                    if state.pool is not None:
+                        return state.pool
+
                 try:
                     import asyncpg
                 except ImportError as exc:
                     raise RuntimeConfigurationError(
                         "asyncpg is required for Research Protocol database tools"
                     ) from exc
-                self._pool = await asyncpg.create_pool(
+                pool = await asyncpg.create_pool(
                     dsn=self._dsn,
                     min_size=self._min_size,
                     max_size=self._max_size,
@@ -85,15 +146,117 @@ class LazyAsyncpgPool:
                         "application_name": "hermes-research-protocol",
                     },
                 )
-        return self._pool
+                with self._states_guard:
+                    if not state.retired and self._states.get(loop) is state:
+                        state.pool = pool
+                        return pool
+                await _close_pool_or_terminate(pool)
 
     def acquire(self) -> _LazyAcquire:
         return _LazyAcquire(self)
 
     async def close(self) -> None:
-        if self._pool is not None:
-            await self._pool.close()
-            self._pool = None
+        current_loop = asyncio.get_running_loop()
+        with self._states_guard:
+            close_future = self._close_future
+            owns_close = close_future is None
+            if owns_close:
+                close_future = concurrent.futures.Future()
+                self._close_future = close_future
+                states = tuple(self._states.items())
+                self._states.clear()
+                for _owner_loop, state in states:
+                    state.retired = True
+            else:
+                states = ()
+
+        assert close_future is not None
+        if not owns_close:
+            await _await_shared_close(close_future)
+            return
+
+        def terminate_state(state: _LoopPoolState) -> None:
+            pool = state.pool
+            closing_pool = state.closing_pool
+            state.pool = None
+            state.closing_pool = None
+            if pool is not None:
+                pool.terminate()
+            if closing_pool is not None and closing_pool is not pool:
+                closing_pool.terminate()
+
+        async def close_on_owner(state: _LoopPoolState) -> None:
+            async with state.lock:
+                pool = state.pool
+                state.pool = None
+                if pool is not None:
+                    state.closing_pool = pool
+                    try:
+                        await _close_pool_or_terminate(pool)
+                    finally:
+                        state.closing_pool = None
+
+        async def wait_for_remote_close(
+            future: concurrent.futures.Future[None],
+            owner_loop: asyncio.AbstractEventLoop,
+            state: _LoopPoolState,
+        ) -> None:
+            wrapped = asyncio.wrap_future(future)
+            cancellation: asyncio.CancelledError | None = None
+            forced_termination = False
+            while not future.done():
+                if not owner_loop.is_running():
+                    future.cancel()
+                    terminate_state(state)
+                    forced_termination = True
+                    break
+                try:
+                    await asyncio.wait(
+                        {wrapped},
+                        timeout=_REMOTE_CLOSE_POLL_SECONDS,
+                    )
+                except asyncio.CancelledError as exc:
+                    if cancellation is None:
+                        cancellation = exc
+
+            if not forced_termination:
+                try:
+                    future.result()
+                except concurrent.futures.CancelledError:
+                    terminate_state(state)
+            if cancellation is not None:
+                raise cancellation
+
+        close_error: BaseException | None = None
+        for owner_loop, state in states:
+            try:
+                if owner_loop is current_loop:
+                    await close_on_owner(state)
+                elif owner_loop.is_running():
+                    coroutine = close_on_owner(state)
+                    try:
+                        future = asyncio.run_coroutine_threadsafe(
+                            coroutine, owner_loop
+                        )
+                    except RuntimeError:
+                        coroutine.close()
+                        terminate_state(state)
+                    else:
+                        await wait_for_remote_close(future, owner_loop, state)
+                else:
+                    terminate_state(state)
+            except BaseException as exc:
+                if close_error is None:
+                    close_error = exc
+
+        with self._states_guard:
+            self._close_future = None
+            if close_error is None:
+                close_future.set_result(None)
+            else:
+                close_future.set_exception(close_error)
+        if close_error is not None:
+            raise close_error
 
 
 @dataclass(frozen=True)

--- a/plugins/research_protocol/runtime.py
+++ b/plugins/research_protocol/runtime.py
@@ -235,9 +235,7 @@ class LazyAsyncpgPool:
                 elif owner_loop.is_running():
                     coroutine = close_on_owner(state)
                     try:
-                        future = asyncio.run_coroutine_threadsafe(
-                            coroutine, owner_loop
-                        )
+                        future = asyncio.run_coroutine_threadsafe(coroutine, owner_loop)
                     except RuntimeError:
                         coroutine.close()
                         terminate_state(state)

--- a/plugins/research_protocol/schemas.py
+++ b/plugins/research_protocol/schemas.py
@@ -1,0 +1,152 @@
+"""Closed JSON schemas for the three planner-facing tools."""
+
+from __future__ import annotations
+
+from .approval import ApprovalScope
+from .models import (
+    ConflictRecord,
+    DedupCluster,
+    EvidenceSnapshot,
+    FigureSpec,
+    ManifestRecord,
+    PlanV1,
+    RunConfig,
+    SourceCandidate,
+    SourceQuality,
+    VerdictRecord,
+)
+
+from .storage.postgres import CONTEXT_QUERY_IDS
+
+_ARTIFACT_MODELS = {
+    "plan": PlanV1,
+    "run_config": RunConfig,
+    "manifest": ManifestRecord,
+    "source_candidate": SourceCandidate,
+    "source_quality": SourceQuality,
+    "evidence_snapshot": EvidenceSnapshot,
+    "conflict_record": ConflictRecord,
+    "dedup_cluster": DedupCluster,
+    "verdict_record": VerdictRecord,
+    "figure_spec": FigureSpec,
+}
+ARTIFACT_TYPES = tuple(_ARTIFACT_MODELS)
+
+
+def _tool_schema(name: str, description: str, parameters: dict) -> dict:
+    return {
+        "name": name,
+        "description": description,
+        "parameters": parameters,
+    }
+
+
+def _close_pattern_mappings(node: object) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object" and "patternProperties" in node:
+            node["additionalProperties"] = False
+        for value in node.values():
+            _close_pattern_mappings(value)
+    elif isinstance(node, list):
+        for value in node:
+            _close_pattern_mappings(value)
+
+
+def _closed_model_schema(model) -> dict:
+    schema = model.model_json_schema(mode="validation")
+    _close_pattern_mappings(schema)
+    return schema
+
+
+PLAN_CONTEXT_READ_SCHEMA = _tool_schema(
+    "plan_context_read",
+    "Read bounded planner context through a versioned query identifier; never accepts SQL or a DSN.",
+    {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "query_id": {
+                "type": "string",
+                "enum": list(CONTEXT_QUERY_IDS),
+            },
+            "parameters": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "approval_id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256,
+                    },
+                    "run_id": {
+                        "type": "string",
+                        "pattern": r"^[A-Za-z0-9][A-Za-z0-9._-]*$",
+                        "maxLength": 128,
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                    },
+                },
+            },
+        },
+        "required": ["query_id", "parameters"],
+    },
+)
+
+PLAN_ARTIFACT_WRITE_SCHEMA = _tool_schema(
+    "plan_artifact_write",
+    "Validate and atomically persist one versioned research artifact below the configured root.",
+    {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "artifact_type": {
+                "type": "string",
+                "enum": list(ARTIFACT_TYPES),
+            },
+            "artifact_id": {
+                "type": "string",
+                "pattern": r"^[A-Za-z0-9][A-Za-z0-9._-]*$",
+                "maxLength": 128,
+            },
+            "payload": {
+                "oneOf": [
+                    _closed_model_schema(model) for model in _ARTIFACT_MODELS.values()
+                ],
+            },
+        },
+        "required": ["artifact_type", "artifact_id", "payload"],
+    },
+)
+
+PLAN_APPROVAL_REQUEST_SCHEMA = _tool_schema(
+    "plan_approval_request",
+    "Request native approval for an existing plan whose bytes match the expected hash and exact scope.",
+    {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "artifact_id": {
+                "type": "string",
+                "pattern": r"^[A-Za-z0-9][A-Za-z0-9._-]*$",
+                "maxLength": 128,
+            },
+            "expected_sha256": {
+                "type": "string",
+                "pattern": r"^[0-9a-f]{64}$",
+            },
+            "scope": _closed_model_schema(ApprovalScope),
+        },
+        "required": ["artifact_id", "expected_sha256", "scope"],
+    },
+)
+
+__all__ = [
+    "ARTIFACT_TYPES",
+    "CONTEXT_QUERY_IDS",
+    "PLAN_APPROVAL_REQUEST_SCHEMA",
+    "PLAN_ARTIFACT_WRITE_SCHEMA",
+    "PLAN_CONTEXT_READ_SCHEMA",
+]

--- a/plugins/research_protocol/schemas.py
+++ b/plugins/research_protocol/schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from .approval import ApprovalScope
 from .models import (
     ConflictRecord,
@@ -43,9 +45,10 @@ def _tool_schema(name: str, description: str, parameters: dict) -> dict:
 
 def _close_pattern_mappings(node: object) -> None:
     if isinstance(node, dict):
-        if node.get("type") == "object" and "patternProperties" in node:
-            node["additionalProperties"] = False
-        for value in node.values():
+        mapping = cast(dict[str, Any], node)
+        if mapping.get("type") == "object" and "patternProperties" in mapping:
+            mapping["additionalProperties"] = False
+        for value in mapping.values():
             _close_pattern_mappings(value)
     elif isinstance(node, list):
         for value in node:

--- a/plugins/research_protocol/schemas/conflict_record.v1.json
+++ b/plugins/research_protocol/schemas/conflict_record.v1.json
@@ -1,0 +1,100 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json. Pydantic requires left_provenance_id and right_provenance_id to be distinct.",
+  "$defs": {
+    "ConflictStatus": {
+      "enum": [
+        "open",
+        "adjudicated",
+        "insufficient"
+      ],
+      "title": "ConflictStatus",
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "claim_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Claim Id",
+      "type": "string"
+    },
+    "conflict_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Conflict Id",
+      "type": "string"
+    },
+    "conflict_type": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Conflict Type",
+      "type": "string"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "left_provenance_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Left Provenance Id",
+      "type": "string"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "rationale": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Rationale",
+      "type": "string"
+    },
+    "right_provenance_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Right Provenance Id",
+      "type": "string"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "conflict_record.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "status": {
+      "$ref": "#/$defs/ConflictStatus"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "conflict_id",
+    "claim_id",
+    "left_provenance_id",
+    "right_provenance_id",
+    "conflict_type",
+    "status",
+    "rationale"
+  ],
+  "title": "ConflictRecord",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/dedup_cluster.v1.json
+++ b/plugins/research_protocol/schemas/dedup_cluster.v1.json
@@ -1,0 +1,83 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json. Pydantic requires canonical_provenance_id to be a member of member_provenance_ids.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "canonical_provenance_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Canonical Provenance Id",
+      "type": "string"
+    },
+    "cluster_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Cluster Id",
+      "type": "string"
+    },
+    "confidence": {
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence",
+      "type": "number"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "member_provenance_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+        "type": "string"
+      },
+      "minItems": 2,
+      "title": "Member Provenance Ids",
+      "type": "array",
+      "uniqueItems": true
+    },
+    "method": {
+      "enum": [
+        "exact",
+        "semantic"
+      ],
+      "title": "Method",
+      "type": "string"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "dedup_cluster.v1",
+      "title": "Schema Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "cluster_id",
+    "canonical_provenance_id",
+    "member_provenance_ids",
+    "method",
+    "confidence"
+  ],
+  "title": "DedupCluster",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/evidence_snapshot.v1.json
+++ b/plugins/research_protocol/schemas/evidence_snapshot.v1.json
@@ -1,0 +1,82 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "content_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Content Sha256",
+      "type": "string"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "evidence_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Evidence Id",
+      "type": "string"
+    },
+    "extract": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Extract",
+      "type": "string"
+    },
+    "locator": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Locator",
+      "type": "string"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "provenance_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Provenance Id",
+      "type": "string"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "evidence_snapshot.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "source_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Source Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "evidence_id",
+    "source_id",
+    "locator",
+    "content_sha256",
+    "extract",
+    "provenance_id"
+  ],
+  "title": "EvidenceSnapshot",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/figure_spec.v1.json
+++ b/plugins/research_protocol/schemas/figure_spec.v1.json
@@ -1,0 +1,146 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$defs": {
+    "FigureKind": {
+      "enum": [
+        "table",
+        "bar",
+        "line",
+        "scatter"
+      ],
+      "title": "FigureKind",
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "data_artifact_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Data Artifact Id",
+      "type": "string"
+    },
+    "data_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Data Sha256",
+      "type": "string"
+    },
+    "figure_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Figure Id",
+      "type": "string"
+    },
+    "kind": {
+      "$ref": "#/$defs/FigureKind"
+    },
+    "labels": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[A-Za-z0-9][A-Za-z0-9._-]*$": {
+          "minLength": 1,
+          "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+          "type": "string"
+        }
+      },
+      "propertyNames": {
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "title": "Labels",
+      "type": "object"
+    },
+    "palette": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Palette",
+      "type": "array"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "figure_spec.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "title": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Title",
+      "type": "string"
+    },
+    "units": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[A-Za-z0-9][A-Za-z0-9._-]*$": {
+          "minLength": 1,
+          "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+          "type": "string"
+        }
+      },
+      "propertyNames": {
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "title": "Units",
+      "type": "object"
+    },
+    "x_field": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "X Field",
+      "type": "string"
+    },
+    "y_fields": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Y Fields",
+      "type": "array"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "figure_id",
+    "title",
+    "kind",
+    "data_artifact_id",
+    "data_sha256",
+    "x_field",
+    "y_fields",
+    "units",
+    "labels",
+    "palette"
+  ],
+  "title": "FigureSpec",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/manifest_record.v1.json
+++ b/plugins/research_protocol/schemas/manifest_record.v1.json
@@ -1,0 +1,103 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$defs": {
+    "ArtifactStatus": {
+      "enum": [
+        "pending",
+        "success",
+        "failed",
+        "partial",
+        "quarantined"
+      ],
+      "title": "ArtifactStatus",
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Artifact Id",
+      "type": "string"
+    },
+    "artifact_type": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Artifact Type",
+      "type": "string"
+    },
+    "byte_length": {
+      "minimum": 0,
+      "title": "Byte Length",
+      "type": "integer"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "path_relative": {
+      "$comment": "Pydantic validation is required to enforce exact, normalized POSIX path semantics without coercion in addition to this JSON Schema pattern.",
+      "maxLength": 8192,
+      "minLength": 1,
+      "pattern": "^(?!\\s)(?!.*\\s$)(?!/)(?!.*:)(?!.*\\\\)(?!.*\\x00)(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*\\/$).+$",
+      "title": "Path Relative",
+      "type": "string"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "provenance_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+        "type": "string"
+      },
+      "title": "Provenance Ids",
+      "type": "array"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "manifest_record.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Sha256",
+      "type": "string"
+    },
+    "status": {
+      "$ref": "#/$defs/ArtifactStatus"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "artifact_id",
+    "artifact_type",
+    "path_relative",
+    "sha256",
+    "byte_length",
+    "status",
+    "provenance_ids"
+  ],
+  "title": "ManifestRecord",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/plan.v1.json
+++ b/plugins/research_protocol/schemas/plan.v1.json
@@ -1,0 +1,239 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$defs": {
+    "BudgetLimits": {
+      "additionalProperties": false,
+      "properties": {
+        "max_bytes": {
+          "exclusiveMinimum": 0,
+          "title": "Max Bytes",
+          "type": "integer"
+        },
+        "max_duration_seconds": {
+          "exclusiveMinimum": 0,
+          "title": "Max Duration Seconds",
+          "type": "integer"
+        },
+        "max_executions": {
+          "exclusiveMinimum": 0,
+          "title": "Max Executions",
+          "type": "integer"
+        },
+        "max_external_calls": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Max External Calls",
+          "type": "integer"
+        },
+        "max_records": {
+          "exclusiveMinimum": 0,
+          "title": "Max Records",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "max_duration_seconds",
+        "max_executions",
+        "max_records",
+        "max_bytes"
+      ],
+      "title": "BudgetLimits",
+      "type": "object"
+    },
+    "Capability": {
+      "enum": [
+        "research-collect",
+        "evidence-review",
+        "build",
+        "publish"
+      ],
+      "title": "Capability",
+      "type": "string"
+    },
+    "CapabilityGrant": {
+      "additionalProperties": false,
+      "properties": {
+        "capability": {
+          "$ref": "#/$defs/Capability"
+        },
+        "external_rights": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ExternalRight"
+          },
+          "title": "External Rights",
+          "type": "array"
+        },
+        "input_hashes": {
+          "items": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Input Hashes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "capability",
+        "input_hashes"
+      ],
+      "title": "CapabilityGrant",
+      "type": "object"
+    },
+    "ExternalRight": {
+      "enum": [
+        "network-read",
+        "database-read",
+        "external-publish"
+      ],
+      "title": "ExternalRight",
+      "type": "string"
+    },
+    "InputReference": {
+      "additionalProperties": false,
+      "properties": {
+        "artifact_type": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+          "title": "Artifact Type",
+          "type": "string"
+        },
+        "input_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+          "title": "Input Id",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "input_id",
+        "artifact_type",
+        "sha256"
+      ],
+      "title": "InputReference",
+      "type": "object"
+    },
+    "OutputRequirement": {
+      "additionalProperties": false,
+      "properties": {
+        "artifact_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+          "title": "Artifact Id",
+          "type": "string"
+        },
+        "artifact_type": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+          "title": "Artifact Type",
+          "type": "string"
+        },
+        "required": {
+          "default": true,
+          "title": "Required",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "artifact_id",
+        "artifact_type"
+      ],
+      "title": "OutputRequirement",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "budgets": {
+      "$ref": "#/$defs/BudgetLimits"
+    },
+    "capabilities": {
+      "items": {
+        "$ref": "#/$defs/CapabilityGrant"
+      },
+      "minItems": 1,
+      "title": "Capabilities",
+      "type": "array",
+      "uniqueItems": true,
+      "x-hermes-validation": "Pydantic requires capability values to be unique across grants."
+    },
+    "constraints": {
+      "items": {
+        "minLength": 1,
+        "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+        "type": "string"
+      },
+      "title": "Constraints",
+      "type": "array"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "inputs": {
+      "items": {
+        "$ref": "#/$defs/InputReference"
+      },
+      "title": "Inputs",
+      "type": "array"
+    },
+    "objective": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Objective",
+      "type": "string"
+    },
+    "outputs": {
+      "items": {
+        "$ref": "#/$defs/OutputRequirement"
+      },
+      "minItems": 1,
+      "title": "Outputs",
+      "type": "array"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "plan.v1",
+      "title": "Schema Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "objective",
+    "constraints",
+    "inputs",
+    "outputs",
+    "budgets",
+    "capabilities"
+  ],
+  "title": "PlanV1",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/run_config.v1.json
+++ b/plugins/research_protocol/schemas/run_config.v1.json
@@ -1,0 +1,143 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$defs": {
+    "BudgetLimits": {
+      "additionalProperties": false,
+      "properties": {
+        "max_bytes": {
+          "exclusiveMinimum": 0,
+          "title": "Max Bytes",
+          "type": "integer"
+        },
+        "max_duration_seconds": {
+          "exclusiveMinimum": 0,
+          "title": "Max Duration Seconds",
+          "type": "integer"
+        },
+        "max_executions": {
+          "exclusiveMinimum": 0,
+          "title": "Max Executions",
+          "type": "integer"
+        },
+        "max_external_calls": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Max External Calls",
+          "type": "integer"
+        },
+        "max_records": {
+          "exclusiveMinimum": 0,
+          "title": "Max Records",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "max_duration_seconds",
+        "max_executions",
+        "max_records",
+        "max_bytes"
+      ],
+      "title": "BudgetLimits",
+      "type": "object"
+    },
+    "Capability": {
+      "enum": [
+        "research-collect",
+        "evidence-review",
+        "build",
+        "publish"
+      ],
+      "title": "Capability",
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "budgets": {
+      "$ref": "#/$defs/BudgetLimits"
+    },
+    "capability": {
+      "$ref": "#/$defs/Capability"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "input_hashes": {
+      "items": {
+        "pattern": "^[0-9a-f]{64}$",
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Input Hashes",
+      "type": "array"
+    },
+    "plan_artifact_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Plan Artifact Id",
+      "type": "string"
+    },
+    "plan_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Plan Sha256",
+      "type": "string"
+    },
+    "policy_hashes": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[A-Za-z0-9][A-Za-z0-9._-]*$": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "propertyNames": {
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "title": "Policy Hashes",
+      "type": "object"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "run_config.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "seed": {
+      "minimum": 0,
+      "title": "Seed",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "plan_artifact_id",
+    "plan_sha256",
+    "capability",
+    "budgets",
+    "input_hashes",
+    "policy_hashes",
+    "seed"
+  ],
+  "title": "RunConfig",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/source_candidate.v1.json
+++ b/plugins/research_protocol/schemas/source_candidate.v1.json
@@ -1,0 +1,147 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$defs": {
+    "SourceIdentifier": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+          "title": "Kind",
+          "type": "string"
+        },
+        "value": {
+          "minLength": 1,
+          "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "title": "SourceIdentifier",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Adapter Id",
+      "type": "string"
+    },
+    "authors": {
+      "items": {
+        "minLength": 1,
+        "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+        "type": "string"
+      },
+      "title": "Authors",
+      "type": "array"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "identifiers": {
+      "items": {
+        "$ref": "#/$defs/SourceIdentifier"
+      },
+      "title": "Identifiers",
+      "type": "array"
+    },
+    "license": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "License"
+    },
+    "locator": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Locator",
+      "type": "string"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "provenance_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Provenance Id",
+      "type": "string"
+    },
+    "published_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Published At"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "source_candidate.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "source_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Source Id",
+      "type": "string"
+    },
+    "title": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Title",
+      "type": "string"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "source_id",
+    "adapter_id",
+    "locator",
+    "title",
+    "identifiers",
+    "authors",
+    "provenance_id"
+  ],
+  "title": "SourceCandidate",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/source_quality.v1.json
+++ b/plugins/research_protocol/schemas/source_quality.v1.json
@@ -1,0 +1,88 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "dimensions": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[A-Za-z0-9][A-Za-z0-9._-]*$": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        }
+      },
+      "propertyNames": {
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "title": "Dimensions",
+      "type": "object"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "provenance_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Provenance Id",
+      "type": "string"
+    },
+    "rationale": {
+      "items": {
+        "minLength": 1,
+        "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+        "type": "string"
+      },
+      "title": "Rationale",
+      "type": "array"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "source_quality.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "score": {
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Score",
+      "type": "number"
+    },
+    "source_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Source Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "source_id",
+    "provenance_id",
+    "score",
+    "dimensions",
+    "rationale"
+  ],
+  "title": "SourceQuality",
+  "type": "object"
+}

--- a/plugins/research_protocol/schemas/verdict_record.v1.json
+++ b/plugins/research_protocol/schemas/verdict_record.v1.json
@@ -1,0 +1,97 @@
+{
+  "$comment": "JSON Schema validation is necessary but insufficient; artifact bytes must be validated with load_artifact_from_json_bytes and Pydantic model_validate_json.",
+  "$defs": {
+    "Verdict": {
+      "enum": [
+        "supported",
+        "rejected",
+        "mixed",
+        "insufficient",
+        "blocked"
+      ],
+      "title": "Verdict",
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "confidence": {
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence",
+      "type": "number"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "evidence_provenance_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Evidence Provenance Ids",
+      "type": "array"
+    },
+    "producer_version": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "question_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Question Id",
+      "type": "string"
+    },
+    "rationale": {
+      "minLength": 1,
+      "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
+      "title": "Rationale",
+      "type": "string"
+    },
+    "run_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "verdict_record.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "verdict": {
+      "$ref": "#/$defs/Verdict"
+    },
+    "verdict_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "title": "Verdict Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "producer_version",
+    "run_id",
+    "created_at",
+    "schema_version",
+    "verdict_id",
+    "question_id",
+    "verdict",
+    "evidence_provenance_ids",
+    "rationale",
+    "confidence"
+  ],
+  "title": "VerdictRecord",
+  "type": "object"
+}

--- a/plugins/research_protocol/storage/__init__.py
+++ b/plugins/research_protocol/storage/__init__.py
@@ -1,0 +1,15 @@
+"""Storage backends for the research protocol plugin."""
+
+from .artifacts import (
+    ArtifactReceipt,
+    ArtifactSecurityError,
+    ArtifactStore,
+    canonical_json_bytes,
+)
+
+__all__ = [
+    "ArtifactReceipt",
+    "ArtifactSecurityError",
+    "ArtifactStore",
+    "canonical_json_bytes",
+]

--- a/plugins/research_protocol/storage/artifacts.py
+++ b/plugins/research_protocol/storage/artifacts.py
@@ -169,7 +169,12 @@ class ArtifactStore:
         model: type[BaseModel], payload: Any
     ) -> tuple[bytes, BaseModel]:
         try:
-            validated = model.model_validate(payload)
+            try:
+                incoming_json = canonical_json_bytes(payload)
+            except ValueError:
+                validated = model.model_validate(payload)
+            else:
+                validated = model.model_validate_json(incoming_json, strict=True)
             encoded = canonical_json_bytes(validated.model_dump(mode="json"))
         except (ValidationError, ValueError, TypeError) as exc:
             raise ArtifactSecurityError(f"artifact validation failed: {exc}") from exc

--- a/plugins/research_protocol/storage/artifacts.py
+++ b/plugins/research_protocol/storage/artifacts.py
@@ -1,0 +1,627 @@
+"""Safe local persistence for canonical research protocol artifacts."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from ..models import (
+    ConflictRecord,
+    DedupCluster,
+    EvidenceSnapshot,
+    FigureSpec,
+    ManifestRecord,
+    PlanV1,
+    RunConfig,
+    SourceCandidate,
+    SourceQuality,
+    VerdictRecord,
+)
+
+
+class ArtifactSecurityError(ValueError):
+    """Raised when an artifact request violates the closed storage policy."""
+
+
+@dataclass(frozen=True)
+class ArtifactReceipt:
+    """Receipt for the exact bytes that were atomically persisted."""
+
+    artifact_id: str
+    artifact_type: str
+    schema_version: str
+    path_relative: str
+    sha256: str
+    byte_length: int
+    created_at: str
+
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_OPEN_DIRECTORY_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_OPEN_FILE_FLAGS = (
+    os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+)
+
+# This is deliberately closed: adding a type requires adding its validated model
+# and its fixed directory in the same reviewed change.
+_ARTIFACT_TYPES: dict[str, tuple[type[BaseModel], str]] = {
+    "plan": (PlanV1, "plans"),
+    "run_config": (RunConfig, "runs"),
+    "manifest": (ManifestRecord, "manifests"),
+    "source_candidate": (SourceCandidate, "sources"),
+    "source_quality": (SourceQuality, "source_quality"),
+    "evidence_snapshot": (EvidenceSnapshot, "evidence"),
+    "conflict_record": (ConflictRecord, "conflicts"),
+    "dedup_cluster": (DedupCluster, "dedup"),
+    "verdict_record": (VerdictRecord, "verdicts"),
+    "figure_spec": (FigureSpec, "figures"),
+}
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Encode JSON deterministically as the bytes that will be hashed."""
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError) as exc:
+        raise ValueError(f"value is not canonical JSON: {exc}") from exc
+
+
+def _reject_symlink_components(path: Path) -> None:
+    """Reject symlinks in an already-created path, including its root."""
+    absolute = Path(os.path.abspath(path))
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        if os.path.lexists(current) and current.is_symlink():
+            raise ArtifactSecurityError("symlink path component is not allowed")
+
+
+def _validate_identifier(value: str, label: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER.fullmatch(value):
+        raise ArtifactSecurityError(f"invalid {label}")
+    if "/" in value or "\\" in value or ".." in value:
+        raise ArtifactSecurityError(f"invalid {label}")
+    return value
+
+
+def _same_inode(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
+
+
+def _safe_close(fd: int | None) -> None:
+    if fd is not None:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def _safe_unlink(name: str | None, directory_fd: int | None) -> None:
+    if name is None or directory_fd is None:
+        return
+    try:
+        os.unlink(name, dir_fd=directory_fd)
+    except FileNotFoundError:
+        pass
+
+
+class ArtifactStore:
+    """Persist validated artifacts below one explicitly configured root.
+
+    Publication uses stable directory descriptors and hard-link no-clobber
+    semantics. This implementation deliberately fails closed on platforms that
+    cannot provide POSIX ``dir_fd`` operations.
+    """
+
+    def __init__(self, root: str | os.PathLike[str]):
+        if root is None:
+            raise ArtifactSecurityError("artifact root is required")
+        if os.name != "posix":
+            raise ArtifactSecurityError(
+                "secure artifact storage requires POSIX dir_fd support"
+            )
+        raw_root = Path(root)
+        if raw_root.exists() and raw_root.is_symlink():
+            raise ArtifactSecurityError("artifact root must not be a symlink")
+        raw_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        _reject_symlink_components(raw_root)
+        if not raw_root.is_dir():
+            raise ArtifactSecurityError("artifact root must be a directory")
+        self.root = Path(os.path.abspath(raw_root))
+
+        root_fd = self._open_root()
+        os.close(root_fd)
+
+    @staticmethod
+    def _artifact_definition(
+        artifact_type: str,
+    ) -> tuple[type[BaseModel], str]:
+        try:
+            return _ARTIFACT_TYPES[artifact_type]
+        except (KeyError, TypeError) as exc:
+            raise ArtifactSecurityError("unsupported artifact type") from exc
+
+    @staticmethod
+    def _validated_bytes(
+        model: type[BaseModel], payload: Any
+    ) -> tuple[bytes, BaseModel]:
+        try:
+            validated = model.model_validate(payload)
+            encoded = canonical_json_bytes(validated.model_dump(mode="json"))
+        except (ValidationError, ValueError, TypeError) as exc:
+            raise ArtifactSecurityError(f"artifact validation failed: {exc}") from exc
+        return encoded, validated
+
+    def _open_root(self) -> int:
+        try:
+            root_fd = os.open(self.root, _OPEN_DIRECTORY_FLAGS)
+        except OSError as exc:
+            raise ArtifactSecurityError(
+                "artifact root is not a safe directory"
+            ) from exc
+        try:
+            self._assert_root_attached(root_fd)
+        except Exception:
+            os.close(root_fd)
+            raise
+        return root_fd
+
+    def _assert_root_attached(self, root_fd: int) -> None:
+        try:
+            path_stat = os.stat(self.root, follow_symlinks=False)
+            descriptor_stat = os.fstat(root_fd)
+        except OSError as exc:
+            raise ArtifactSecurityError(
+                "artifact root changed during operation"
+            ) from exc
+        if not stat.S_ISDIR(path_stat.st_mode) or not _same_inode(
+            path_stat, descriptor_stat
+        ):
+            raise ArtifactSecurityError("artifact root changed during operation")
+        if stat.S_IMODE(descriptor_stat.st_mode) & 0o077:
+            raise ArtifactSecurityError("artifact root must be private")
+        if descriptor_stat.st_uid != os.geteuid():
+            raise ArtifactSecurityError("artifact root must be owned by effective user")
+
+    @staticmethod
+    def _open_subdirectory(root_fd: int, name: str, *, create: bool) -> int:
+        created = False
+        if create:
+            try:
+                os.mkdir(name, mode=0o700, dir_fd=root_fd)
+                created = True
+            except FileExistsError:
+                pass
+        try:
+            directory_fd = os.open(name, _OPEN_DIRECTORY_FLAGS, dir_fd=root_fd)
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise ArtifactSecurityError("artifact directory is not safe") from exc
+        try:
+            ArtifactStore._assert_directory_attached(root_fd, name, directory_fd)
+            if created:
+                os.fsync(root_fd)
+        except Exception:
+            os.close(directory_fd)
+            raise
+        return directory_fd
+
+    @staticmethod
+    def _assert_directory_attached(
+        root_fd: int,
+        name: str,
+        directory_fd: int,
+    ) -> None:
+        try:
+            entry_stat = os.stat(
+                name,
+                dir_fd=root_fd,
+                follow_symlinks=False,
+            )
+            descriptor_stat = os.fstat(directory_fd)
+        except OSError as exc:
+            raise ArtifactSecurityError(
+                "artifact directory changed during operation"
+            ) from exc
+        if not stat.S_ISDIR(entry_stat.st_mode) or not _same_inode(
+            entry_stat, descriptor_stat
+        ):
+            raise ArtifactSecurityError("artifact directory changed during operation")
+
+    @staticmethod
+    def _ensure_absent(directory_fd: int, name: str, path_relative: str) -> None:
+        try:
+            target_stat = os.stat(
+                name,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(target_stat.st_mode):
+            raise ArtifactSecurityError("artifact target must not be a symlink")
+        raise FileExistsError(f"artifact already exists: {path_relative}")
+
+    @staticmethod
+    def _write_temporary(directory_fd: int, stem: str, payload: bytes) -> str:
+        name = f".{stem}.{secrets.token_hex(16)}.tmp"
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        fd = os.open(name, flags, 0o600, dir_fd=directory_fd)
+        try:
+            with os.fdopen(fd, "wb", closefd=False) as handle:
+                handle.write(payload)
+                handle.flush()
+            os.fsync(fd)
+        except Exception:
+            _safe_close(fd)
+            _safe_unlink(name, directory_fd)
+            raise
+        os.close(fd)
+        return name
+
+    @staticmethod
+    def _publish_temporary(directory_fd: int, temporary: str, target: str) -> None:
+        os.link(
+            temporary,
+            target,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        os.fsync(directory_fd)
+        os.unlink(temporary, dir_fd=directory_fd)
+
+    @staticmethod
+    def _read_from_directory(directory_fd: int, name: str) -> bytes:
+        try:
+            fd = os.open(name, _OPEN_FILE_FLAGS, dir_fd=directory_fd)
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise ArtifactSecurityError("artifact target is not a safe file") from exc
+        try:
+            target_stat = os.fstat(fd)
+            if not stat.S_ISREG(target_stat.st_mode):
+                raise ArtifactSecurityError("artifact target is not a regular file")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(fd, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return b"".join(chunks)
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _acquire_lock(lock_directory_fd: int, name: str) -> int:
+        flags = (
+            os.O_RDWR
+            | os.O_CREAT
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        try:
+            lock_fd = os.open(name, flags, 0o600, dir_fd=lock_directory_fd)
+        except OSError as exc:
+            raise ArtifactSecurityError("artifact lock is not safe") from exc
+        try:
+            lock_stat = os.fstat(lock_fd)
+            if not stat.S_ISREG(lock_stat.st_mode) or lock_stat.st_mode & 0o077:
+                raise ArtifactSecurityError("artifact lock has unsafe permissions")
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            return lock_fd
+        except Exception:
+            os.close(lock_fd)
+            raise
+
+    @staticmethod
+    def _cleanup_temporaries(directory_fd: int, stem: str) -> None:
+        prefix = f".{stem}."
+        removed = False
+        for name in os.listdir(directory_fd):
+            if name.startswith(prefix) and name.endswith(".tmp"):
+                _safe_unlink(name, directory_fd)
+                removed = True
+        if removed:
+            os.fsync(directory_fd)
+
+    @staticmethod
+    def _entry_exists(directory_fd: int, name: str) -> bool:
+        try:
+            entry_stat = os.stat(
+                name,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return False
+        if stat.S_ISLNK(entry_stat.st_mode) or not stat.S_ISREG(entry_stat.st_mode):
+            raise ArtifactSecurityError("artifact target is not a safe regular file")
+        return True
+
+    @classmethod
+    def _recover_matching_receipt_orphan(
+        cls,
+        *,
+        artifact_fd: int,
+        target_name: str,
+        receipt_fd: int,
+        receipt_name: str,
+        expected: ArtifactReceipt,
+        path_relative: str,
+    ) -> None:
+        artifact_exists = cls._entry_exists(artifact_fd, target_name)
+        receipt_exists = cls._entry_exists(receipt_fd, receipt_name)
+        if artifact_exists:
+            raise FileExistsError(f"artifact already exists: {path_relative}")
+        if not receipt_exists:
+            return
+
+        try:
+            raw = cls._read_from_directory(receipt_fd, receipt_name)
+            existing = ArtifactReceipt(**json.loads(raw.decode("utf-8")))
+        except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ArtifactSecurityError("orphan artifact receipt is invalid") from exc
+
+        stable_fields = (
+            "artifact_id",
+            "artifact_type",
+            "schema_version",
+            "path_relative",
+            "sha256",
+            "byte_length",
+        )
+        if any(
+            getattr(existing, field) != getattr(expected, field)
+            for field in stable_fields
+        ):
+            raise FileExistsError(
+                f"artifact receipt already exists: receipts/{receipt_name}"
+            )
+        os.unlink(receipt_name, dir_fd=receipt_fd)
+        os.fsync(receipt_fd)
+
+    def persist(
+        self,
+        artifact_type: str,
+        artifact_id: str,
+        payload: Any,
+    ) -> ArtifactReceipt:
+        """Validate, publish without replacement, reread, and hash an artifact."""
+        model, subdirectory = self._artifact_definition(artifact_type)
+        safe_id = _validate_identifier(artifact_id, "artifact id")
+        target_name = f"{safe_id}.json"
+        path_relative = f"{subdirectory}/{target_name}"
+        receipt_name = f"{artifact_type}-{safe_id}.receipt.json"
+        encoded, validated = self._validated_bytes(model, payload)
+        created_at = datetime.now(UTC).isoformat()
+        digest = hashlib.sha256(encoded).hexdigest()
+        receipt = ArtifactReceipt(
+            artifact_id=safe_id,
+            artifact_type=artifact_type,
+            schema_version=str(getattr(validated, "schema_version")),
+            path_relative=path_relative,
+            sha256=digest,
+            byte_length=len(encoded),
+            created_at=created_at,
+        )
+        receipt_bytes = canonical_json_bytes(asdict(receipt))
+
+        root_fd: int | None = None
+        artifact_fd: int | None = None
+        receipt_fd: int | None = None
+        lock_directory_fd: int | None = None
+        lock_fd: int | None = None
+        artifact_temp: str | None = None
+        receipt_temp: str | None = None
+        artifact_published = False
+        receipt_published = False
+        try:
+            root_fd = self._open_root()
+            artifact_fd = self._open_subdirectory(root_fd, subdirectory, create=True)
+            receipt_fd = self._open_subdirectory(root_fd, "receipts", create=True)
+            lock_directory_fd = self._open_subdirectory(root_fd, ".locks", create=True)
+            lock_fd = self._acquire_lock(
+                lock_directory_fd,
+                f"{artifact_type}-{safe_id}.lock",
+            )
+            self._cleanup_temporaries(artifact_fd, target_name)
+            self._cleanup_temporaries(receipt_fd, receipt_name)
+            self._recover_matching_receipt_orphan(
+                artifact_fd=artifact_fd,
+                target_name=target_name,
+                receipt_fd=receipt_fd,
+                receipt_name=receipt_name,
+                expected=receipt,
+                path_relative=path_relative,
+            )
+            artifact_temp = self._write_temporary(artifact_fd, target_name, encoded)
+            receipt_temp = self._write_temporary(
+                receipt_fd, receipt_name, receipt_bytes
+            )
+
+            # Receipt-first ordering makes a crash before artifact publication
+            # fail closed: no artifact name is visible without its receipt.
+            self._publish_temporary(receipt_fd, receipt_temp, receipt_name)
+            receipt_temp = None
+            receipt_published = True
+            self._publish_temporary(artifact_fd, artifact_temp, target_name)
+            artifact_temp = None
+            artifact_published = True
+
+            self._assert_root_attached(root_fd)
+            self._assert_directory_attached(root_fd, subdirectory, artifact_fd)
+            self._assert_directory_attached(root_fd, "receipts", receipt_fd)
+            actual = self._read_from_directory(artifact_fd, target_name)
+            actual_receipt = self._read_from_directory(receipt_fd, receipt_name)
+            if actual_receipt != receipt_bytes:
+                raise ArtifactSecurityError(
+                    "persisted receipt bytes changed during operation"
+                )
+            if hashlib.sha256(actual).hexdigest() != digest or len(actual) != len(
+                encoded
+            ):
+                raise ArtifactSecurityError(
+                    "persisted artifact hash or length mismatch"
+                )
+            return receipt
+        except Exception:
+            if artifact_published:
+                _safe_unlink(target_name, artifact_fd)
+            if receipt_published:
+                _safe_unlink(receipt_name, receipt_fd)
+            if artifact_fd is not None:
+                try:
+                    os.fsync(artifact_fd)
+                except OSError:
+                    pass
+            if receipt_fd is not None:
+                try:
+                    os.fsync(receipt_fd)
+                except OSError:
+                    pass
+            raise
+        finally:
+            _safe_unlink(artifact_temp, artifact_fd)
+            _safe_unlink(receipt_temp, receipt_fd)
+            _safe_close(lock_fd)
+            _safe_close(lock_directory_fd)
+            _safe_close(receipt_fd)
+            _safe_close(artifact_fd)
+            _safe_close(root_fd)
+
+    def read_bytes(self, artifact_type: str, artifact_id: str) -> bytes:
+        _model, subdirectory = self._artifact_definition(artifact_type)
+        safe_id = _validate_identifier(artifact_id, "artifact id")
+        root_fd: int | None = None
+        directory_fd: int | None = None
+        try:
+            root_fd = self._open_root()
+            try:
+                directory_fd = self._open_subdirectory(
+                    root_fd,
+                    subdirectory,
+                    create=False,
+                )
+            except FileNotFoundError as exc:
+                raise FileNotFoundError(f"artifact not found: {safe_id}") from exc
+            try:
+                data = self._read_from_directory(directory_fd, f"{safe_id}.json")
+            except FileNotFoundError as exc:
+                raise FileNotFoundError(f"artifact not found: {safe_id}") from exc
+            self._assert_root_attached(root_fd)
+            self._assert_directory_attached(root_fd, subdirectory, directory_fd)
+            return data
+        finally:
+            _safe_close(directory_fd)
+            _safe_close(root_fd)
+
+    def _read_receipt(self, artifact_type: str, artifact_id: str) -> ArtifactReceipt:
+        safe_id = _validate_identifier(artifact_id, "artifact id")
+        receipt_name = f"{artifact_type}-{safe_id}.receipt.json"
+        root_fd: int | None = None
+        receipt_fd: int | None = None
+        try:
+            root_fd = self._open_root()
+            try:
+                receipt_fd = self._open_subdirectory(
+                    root_fd,
+                    "receipts",
+                    create=False,
+                )
+                payload = self._read_from_directory(receipt_fd, receipt_name)
+            except FileNotFoundError as exc:
+                raise ArtifactSecurityError("artifact receipt is missing") from exc
+            self._assert_root_attached(root_fd)
+            self._assert_directory_attached(root_fd, "receipts", receipt_fd)
+        finally:
+            _safe_close(receipt_fd)
+            _safe_close(root_fd)
+        try:
+            value = json.loads(payload.decode("utf-8"))
+            return ArtifactReceipt(**value)
+        except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ArtifactSecurityError("artifact receipt is invalid") from exc
+
+    def read_verified(
+        self,
+        artifact_type: str,
+        artifact_id: str,
+        *,
+        expected_sha256: str | None = None,
+    ) -> bytes:
+        data = self.read_bytes(artifact_type, artifact_id)
+        receipt = self._read_receipt(artifact_type, artifact_id)
+        digest = hashlib.sha256(data).hexdigest()
+        if receipt.artifact_type != artifact_type or receipt.artifact_id != artifact_id:
+            raise ArtifactSecurityError("artifact receipt identity mismatch")
+        if receipt.sha256 != digest or receipt.byte_length != len(data):
+            raise ArtifactSecurityError(
+                "artifact hash or length does not match receipt"
+            )
+        if expected_sha256 is not None and digest != expected_sha256:
+            raise ArtifactSecurityError("artifact hash does not match expected hash")
+        return data
+
+    def read_payload(
+        self,
+        artifact_type: str,
+        artifact_id: str,
+        *,
+        expected_sha256: str | None = None,
+    ) -> dict[str, Any]:
+        data = self.read_verified(
+            artifact_type,
+            artifact_id,
+            expected_sha256=expected_sha256,
+        )
+        try:
+            value = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ArtifactSecurityError("artifact is not valid UTF-8 JSON") from exc
+        if not isinstance(value, dict):
+            raise ArtifactSecurityError("artifact payload must be a JSON object")
+        return value
+
+    # Explicit aliases make the storage boundary readable to handlers and callers.
+    write = persist
+    read = read_payload
+
+
+__all__ = [
+    "ArtifactReceipt",
+    "ArtifactSecurityError",
+    "ArtifactStore",
+    "canonical_json_bytes",
+]

--- a/plugins/research_protocol/storage/artifacts.py
+++ b/plugins/research_protocol/storage/artifacts.py
@@ -58,6 +58,8 @@ _OPEN_DIRECTORY_FLAGS = (
 _OPEN_FILE_FLAGS = (
     os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
 )
+_REQUIRED_DIR_FD_FUNCTIONS = (os.open, os.mkdir, os.stat, os.unlink, os.link)
+_REQUIRED_FOLLOW_SYMLINKS_FUNCTIONS = (os.stat, os.link)
 
 # This is deliberately closed: adding a type requires adding its validated model
 # and its fixed directory in the same reviewed change.
@@ -89,14 +91,77 @@ def canonical_json_bytes(value: Any) -> bytes:
         raise ValueError(f"value is not canonical JSON: {exc}") from exc
 
 
-def _reject_symlink_components(path: Path) -> None:
-    """Reject symlinks in an already-created path, including its root."""
+def _secure_storage_capabilities_available() -> bool:
+    """Return whether the runtime can enforce the no-symlink storage contract."""
+    supports_dir_fd = getattr(os, "supports_dir_fd", ())
+    supports_follow_symlinks = getattr(os, "supports_follow_symlinks", ())
+    return (
+        os.name == "posix"
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and all(function in supports_dir_fd for function in _REQUIRED_DIR_FD_FUNCTIONS)
+        and all(
+            function in supports_follow_symlinks
+            for function in _REQUIRED_FOLLOW_SYMLINKS_FUNCTIONS
+        )
+    )
+
+
+def _open_directory_path(path: Path, *, create: bool) -> int:
+    """Open a directory path without following any symlink component."""
     absolute = Path(os.path.abspath(path))
-    current = Path(absolute.anchor)
-    for component in absolute.parts[1:]:
-        current /= component
-        if os.path.lexists(current) and current.is_symlink():
-            raise ArtifactSecurityError("symlink path component is not allowed")
+    directory_fd: int | None = None
+    try:
+        directory_fd = os.open(absolute.anchor, _OPEN_DIRECTORY_FLAGS)
+        for component in absolute.parts[1:]:
+            created = False
+            if create:
+                try:
+                    os.mkdir(component, mode=0o700, dir_fd=directory_fd)
+                    created = True
+                except FileExistsError:
+                    pass
+                except OSError as exc:
+                    raise ArtifactSecurityError(
+                        "artifact root could not be created safely"
+                    ) from exc
+
+            try:
+                child_fd = os.open(
+                    component,
+                    _OPEN_DIRECTORY_FLAGS,
+                    dir_fd=directory_fd,
+                )
+            except OSError as exc:
+                raise ArtifactSecurityError(
+                    "artifact path component is not a safe directory"
+                ) from exc
+
+            try:
+                entry_stat = os.stat(
+                    component,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                descriptor_stat = os.fstat(child_fd)
+                if not stat.S_ISDIR(entry_stat.st_mode) or not _same_inode(
+                    entry_stat, descriptor_stat
+                ):
+                    raise ArtifactSecurityError(
+                        "artifact path component changed during operation"
+                    )
+                if created:
+                    os.fsync(directory_fd)
+            except Exception:
+                os.close(child_fd)
+                raise
+
+            os.close(directory_fd)
+            directory_fd = child_fd
+        return directory_fd
+    except Exception:
+        _safe_close(directory_fd)
+        raise
 
 
 def _validate_identifier(value: str, label: str) -> str:
@@ -139,21 +204,16 @@ class ArtifactStore:
     def __init__(self, root: str | os.PathLike[str]):
         if root is None:
             raise ArtifactSecurityError("artifact root is required")
-        if os.name != "posix":
+        if not _secure_storage_capabilities_available():
             raise ArtifactSecurityError(
-                "secure artifact storage requires POSIX dir_fd support"
+                "secure artifact storage requires POSIX O_NOFOLLOW and dir_fd support"
             )
-        raw_root = Path(root)
-        if raw_root.exists() and raw_root.is_symlink():
-            raise ArtifactSecurityError("artifact root must not be a symlink")
-        raw_root.mkdir(mode=0o700, parents=True, exist_ok=True)
-        _reject_symlink_components(raw_root)
-        if not raw_root.is_dir():
-            raise ArtifactSecurityError("artifact root must be a directory")
-        self.root = Path(os.path.abspath(raw_root))
-
-        root_fd = self._open_root()
-        os.close(root_fd)
+        self.root = Path(os.path.abspath(Path(root)))
+        root_fd = _open_directory_path(self.root, create=True)
+        try:
+            self._assert_root_attached(root_fd)
+        finally:
+            os.close(root_fd)
 
     @staticmethod
     def _artifact_definition(
@@ -181,12 +241,7 @@ class ArtifactStore:
         return encoded, validated
 
     def _open_root(self) -> int:
-        try:
-            root_fd = os.open(self.root, _OPEN_DIRECTORY_FLAGS)
-        except OSError as exc:
-            raise ArtifactSecurityError(
-                "artifact root is not a safe directory"
-            ) from exc
+        root_fd = _open_directory_path(self.root, create=False)
         try:
             self._assert_root_attached(root_fd)
         except Exception:

--- a/plugins/research_protocol/storage/artifacts.py
+++ b/plugins/research_protocol/storage/artifacts.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import errno
-import fcntl
 import hashlib
+import importlib
 import json
 import os
 import re
@@ -14,6 +14,11 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+try:
+    fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover - covered by isolated Windows-like discovery
+    fcntl = None
 
 from pydantic import BaseModel, ValidationError
 
@@ -97,6 +102,7 @@ def _secure_storage_capabilities_available() -> bool:
     supports_follow_symlinks = getattr(os, "supports_follow_symlinks", ())
     return (
         os.name == "posix"
+        and fcntl is not None
         and hasattr(os, "O_DIRECTORY")
         and hasattr(os, "O_NOFOLLOW")
         and all(function in supports_dir_fd for function in _REQUIRED_DIR_FD_FUNCTIONS)
@@ -385,6 +391,8 @@ class ArtifactStore:
 
     @staticmethod
     def _acquire_lock(lock_directory_fd: int, name: str) -> int:
+        if fcntl is None:
+            raise ArtifactSecurityError("artifact locking is unavailable")
         flags = (
             os.O_RDWR
             | os.O_CREAT

--- a/plugins/research_protocol/storage/postgres.py
+++ b/plugins/research_protocol/storage/postgres.py
@@ -1,0 +1,337 @@
+"""Fixed PostgreSQL operations for context reads and durable approvals."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum
+import json
+import logging
+import re
+import time
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
+
+from ..approval import ApprovalRecord, ApprovalScope
+
+
+logger = logging.getLogger(__name__)
+
+
+_CREATE_APPROVAL_SQL = """
+SELECT research_protocol.store_approval(
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+)
+"""
+
+_CLAIM_APPROVAL_SQL = """
+SELECT approval_id, scope_sha256, plan_sha256, consumed_count, max_executions
+FROM research_protocol.claim_approval($1, $2, $3)
+"""
+
+_SET_LOCAL_STATEMENT_TIMEOUT_SQL = "SELECT set_config('statement_timeout', $1, true)"
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class UnknownContextQueryError(ValueError):
+    """Raised before database access when a query identifier is not registered."""
+
+
+class ContextReadLimitError(RuntimeError):
+    """Raised when a bounded context result exceeds a configured cap."""
+
+
+class ContextReadTimeoutError(TimeoutError):
+    """Raised when the wall-clock bound is exceeded."""
+
+
+class ApprovalStoreTimeoutError(TimeoutError):
+    """Raised when a bounded approval store operation exceeds its deadline."""
+
+
+@dataclass(frozen=True)
+class _ReadQuery:
+    sql: str
+    bind: Callable[[Mapping[str, Any], int], tuple[Any, ...]]
+
+
+def _bind_approval_status(
+    parameters: Mapping[str, Any], _max_rows: int
+) -> tuple[Any, ...]:
+    if set(parameters) != {"approval_id"}:
+        raise ValueError("approval_status.v1 requires only approval_id")
+    approval_id = parameters["approval_id"]
+    if not isinstance(approval_id, str) or not approval_id or len(approval_id) > 256:
+        raise ValueError("invalid approval_id")
+    return (approval_id,)
+
+
+def _bind_approvals_for_run(
+    parameters: Mapping[str, Any], max_rows: int
+) -> tuple[Any, ...]:
+    if not {"run_id"}.issubset(parameters) or not set(parameters).issubset({
+        "run_id",
+        "limit",
+    }):
+        raise ValueError("approvals_for_run.v1 requires run_id and optional limit")
+    run_id = parameters["run_id"]
+    if (
+        not isinstance(run_id, str)
+        or len(run_id) > 128
+        or _IDENTIFIER_RE.fullmatch(run_id) is None
+    ):
+        raise ValueError("invalid run_id")
+    requested = parameters.get("limit", max_rows)
+    if isinstance(requested, bool) or not isinstance(requested, int):
+        raise ValueError("invalid limit")
+    if requested < 1 or requested > min(max_rows, 100):
+        raise ValueError("limit exceeds configured row cap")
+    return run_id, requested + 1
+
+
+_READ_QUERIES: Mapping[str, _ReadQuery] = MappingProxyType({
+    "approval_status.v1": _ReadQuery(
+        sql="""
+SELECT approval_id, scope_sha256, plan_sha256, verdict, surface,
+       created_at, expires_at, max_executions, consumed_count,
+       last_consumed_at
+FROM research_protocol.approvals
+WHERE approval_id = $1
+""",
+        bind=_bind_approval_status,
+    ),
+    "approvals_for_run.v1": _ReadQuery(
+        sql="""
+SELECT approval_id, scope_sha256, plan_sha256, verdict, surface,
+       created_at, expires_at, max_executions, consumed_count,
+       last_consumed_at
+FROM research_protocol.approvals
+WHERE scope_json ->> 'run_id' = $1
+ORDER BY created_at DESC, approval_id DESC
+LIMIT $2
+""",
+        bind=_bind_approvals_for_run,
+    ),
+})
+CONTEXT_QUERY_IDS = tuple(_READ_QUERIES)
+
+
+class PostgresContextReader:
+    """Execute only registered SELECTs under independent resource bounds."""
+
+    def __init__(
+        self,
+        pool: Any,
+        *,
+        max_rows: int = 100,
+        max_bytes: int = 256_000,
+        timeout_seconds: float = 5.0,
+    ):
+        if pool is None:
+            raise ValueError("PostgreSQL pool is required")
+        if isinstance(max_rows, bool) or not isinstance(max_rows, int) or max_rows < 1:
+            raise ValueError("max_rows must be a positive integer")
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes < 1
+        ):
+            raise ValueError("max_bytes must be a positive integer")
+        if (
+            isinstance(timeout_seconds, bool)
+            or not isinstance(timeout_seconds, (int, float))
+            or timeout_seconds <= 0
+        ):
+            raise ValueError("timeout_seconds must be positive")
+        self._pool = pool
+        self._max_rows = max_rows
+        self._max_bytes = max_bytes
+        self._timeout_seconds = float(timeout_seconds)
+
+    async def read(
+        self,
+        query_id: str,
+        parameters: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        query = _READ_QUERIES.get(query_id)
+        if query is None:
+            raise UnknownContextQueryError("unknown context query identifier")
+        if not isinstance(parameters, Mapping):
+            raise ValueError("context query parameters must be an object")
+        bind_values = query.bind(parameters, self._max_rows)
+        row_cap = self._max_rows
+        if query_id == "approvals_for_run.v1":
+            row_cap = int(parameters.get("limit", self._max_rows))
+        started_at = time.perf_counter()
+        try:
+            rows = await asyncio.wait_for(
+                self._read(query, bind_values, row_cap),
+                timeout=self._timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            raise ContextReadTimeoutError("context read timed out") from None
+        logger.info(
+            "research_protocol_context_read query_id=%s row_count=%d latency_ms=%.3f",
+            query_id,
+            len(rows),
+            (time.perf_counter() - started_at) * 1000,
+        )
+        return rows
+
+    async def _read(
+        self,
+        query: _ReadQuery,
+        bind_values: tuple[Any, ...],
+        row_cap: int,
+    ) -> list[dict[str, Any]]:
+        timeout_ms = max(1, int(self._timeout_seconds * 1000))
+        async with self._pool.acquire() as connection:
+            async with connection.transaction(readonly=True):
+                await connection.execute(
+                    _SET_LOCAL_STATEMENT_TIMEOUT_SQL,
+                    f"{timeout_ms}ms",
+                )
+                records = await connection.fetch(query.sql, *bind_values)
+
+        if len(records) > row_cap:
+            raise ContextReadLimitError("context row cap exceeded")
+        rows = [_normalize_row(record) for record in records]
+        serialized = json.dumps(
+            rows,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        if len(serialized) > self._max_bytes:
+            raise ContextReadLimitError("context byte cap exceeded")
+        return rows
+
+
+class PostgresApprovalStore:
+    """Persist and consume exact workflow approvals through fixed SQL only."""
+
+    def __init__(self, pool: Any, *, timeout_seconds: float = 5.0):
+        if pool is None:
+            raise ValueError("PostgreSQL pool is required")
+        if (
+            isinstance(timeout_seconds, bool)
+            or not isinstance(timeout_seconds, (int, float))
+            or timeout_seconds <= 0
+        ):
+            raise ValueError("timeout_seconds must be positive")
+        self._pool = pool
+        self._timeout_seconds = float(timeout_seconds)
+        self._statement_timeout_ms = max(1, int(self._timeout_seconds * 1000))
+
+    async def create_approval(self, record: ApprovalRecord) -> None:
+        """Insert one approval record without accepting caller-provided SQL."""
+        if not isinstance(record, ApprovalRecord):
+            raise TypeError("record must be a validated ApprovalRecord")
+        if record.consumed_count != 0:
+            raise ValueError("only fresh decision records can be stored")
+        try:
+            async with asyncio.timeout(self._timeout_seconds):
+                async with self._pool.acquire() as connection:
+                    async with connection.transaction():
+                        await connection.execute(
+                            _SET_LOCAL_STATEMENT_TIMEOUT_SQL,
+                            f"{self._statement_timeout_ms}ms",
+                        )
+                        await connection.execute(
+                            _CREATE_APPROVAL_SQL,
+                            record.approval_id,
+                            record.scope_sha256,
+                            record.plan_sha256,
+                            record.scope_json,
+                            record.verdict.value,
+                            record.surface,
+                            record.created_at,
+                            record.expires_at,
+                            record.max_executions,
+                        )
+        except TimeoutError as exc:
+            raise ApprovalStoreTimeoutError(
+                "approval store operation timed out"
+            ) from exc
+
+    async def claim_approval(
+        self,
+        *,
+        approval_id: str,
+        scope: ApprovalScope,
+        plan_sha256: str,
+    ) -> bool:
+        """Atomically claim one execution bound to the exact scope and plan."""
+        if not isinstance(approval_id, str) or not approval_id:
+            return False
+        if not isinstance(scope, ApprovalScope):
+            return False
+        if (
+            not isinstance(plan_sha256, str)
+            or _SHA256_RE.fullmatch(plan_sha256) is None
+        ):
+            return False
+        try:
+            scope_sha256 = scope.scope_sha256()
+        except (AttributeError, TypeError, ValueError):
+            return False
+        if _SHA256_RE.fullmatch(scope_sha256) is None:
+            return False
+
+        try:
+            async with asyncio.timeout(self._timeout_seconds):
+                async with self._pool.acquire() as connection:
+                    async with connection.transaction():
+                        await connection.execute(
+                            _SET_LOCAL_STATEMENT_TIMEOUT_SQL,
+                            f"{self._statement_timeout_ms}ms",
+                        )
+                        row = await connection.fetchrow(
+                            _CLAIM_APPROVAL_SQL,
+                            approval_id,
+                            scope_sha256,
+                            plan_sha256,
+                        )
+        except TimeoutError as exc:
+            raise ApprovalStoreTimeoutError(
+                "approval store operation timed out"
+            ) from exc
+        return row is not None
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _normalize_row(record: Any) -> dict[str, Any]:
+    try:
+        values = dict(record)
+    except (TypeError, ValueError) as exc:
+        raise ContextReadLimitError("context row is not a mapping") from exc
+    return {str(key): _normalize_value(value) for key, value in values.items()}
+
+
+__all__ = [
+    "ApprovalStoreTimeoutError",
+    "CONTEXT_QUERY_IDS",
+    "ContextReadLimitError",
+    "ContextReadTimeoutError",
+    "PostgresApprovalStore",
+    "PostgresContextReader",
+    "UnknownContextQueryError",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", 
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.29.0", "slack-sdk==3.43.0", "aiohttp==3.14.1"]
 matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.1"]  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
+research-protocol = ["asyncpg==0.31.0"]
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,6 +333,15 @@ hermes_cli = ["observability/schemas/*.json"]
 # topic-setup image disappears. Loaded via Path(__file__).parent / "assets"
 # in gateway/status_phrases.py and gateway/run.py.
 gateway = ["assets/**/*"]
+# Research Protocol ships versioned runtime contracts and operational data.
+# Keep these scoped to this plugin rather than broadening package-data for
+# every bundled plugin.
+plugins = [
+    "research_protocol/**/*.json",
+    "research_protocol/**/*.yaml",
+    "research_protocol/**/*.sql",
+    "research_protocol/**/*.md",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/plugins/research_protocol/test_approval.py
+++ b/tests/plugins/research_protocol/test_approval.py
@@ -1,0 +1,437 @@
+"""TDD contract tests for exact workflow approvals and atomic claims."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+import json
+import threading
+
+import pytest
+
+from plugins.research_protocol.approval import (
+    ApprovalRecord,
+    ApprovalService,
+    ApprovalScope,
+    ApprovalVerdict,
+    WorkflowApprovalDecision,
+    make_approval_record,
+    request_workflow_approval,
+)
+from plugins.research_protocol.models import (
+    BudgetLimits,
+    Capability,
+    ExternalRight,
+)
+from plugins.research_protocol.storage.postgres import (
+    ApprovalStoreTimeoutError,
+    PostgresApprovalStore,
+)
+
+
+NOW = datetime.now(UTC)
+PLAN_SHA = "a" * 64
+INPUT_A = "b" * 64
+INPUT_B = "c" * 64
+
+
+def make_scope(**changes):
+    values = {
+        "capability": Capability.RESEARCH_COLLECT,
+        "run_id": "run-001",
+        "plan_sha256": PLAN_SHA,
+        "input_hashes": [INPUT_B, INPUT_A],
+        "budgets": {
+            "max_duration_seconds": 60,
+            "max_executions": 2,
+            "max_records": 10,
+            "max_bytes": 1000,
+            "max_external_calls": 0,
+        },
+        "expires_at": NOW + timedelta(minutes=10),
+        "max_executions": 2,
+        "external_rights": [
+            ExternalRight.DATABASE_READ,
+            ExternalRight.NETWORK_READ,
+        ],
+    }
+    values.update(changes)
+    return ApprovalScope.model_validate(values)
+
+
+def test_scope_is_canonical_and_order_independent():
+    left = make_scope()
+    right = make_scope(
+        input_hashes=[INPUT_A, INPUT_B],
+        external_rights=[
+            ExternalRight.NETWORK_READ,
+            ExternalRight.DATABASE_READ,
+        ],
+    )
+
+    assert left.input_hashes == (INPUT_A, INPUT_B)
+    assert left.external_rights == (
+        ExternalRight.DATABASE_READ,
+        ExternalRight.NETWORK_READ,
+    )
+    assert left.scope_sha256() == right.scope_sha256()
+    assert left.canonical_json() == right.canonical_json()
+    with pytest.raises(AttributeError):
+        left.input_hashes.append(INPUT_A)
+    with pytest.raises(AttributeError):
+        left.external_rights.append(ExternalRight.NETWORK_READ)
+
+
+def test_approval_record_rejects_any_scope_binding_mismatch():
+    record = make_approval_record(make_scope())
+    valid = record.model_dump()
+    mutations = (
+        {"scope_json": "{}"},
+        {"scope_json": json.dumps(json.loads(record.scope_json), indent=2)},
+        {"scope_sha256": "d" * 64},
+        {"plan_sha256": "e" * 64},
+        {"expires_at": record.expires_at + timedelta(seconds=1)},
+        {"max_executions": record.max_executions - 1},
+        {"consumed_count": record.max_executions + 1},
+    )
+
+    for mutation in mutations:
+        with pytest.raises(ValueError):
+            ApprovalRecord.model_validate(valid | mutation)
+
+
+class RecordingApprovalStore:
+    def __init__(self):
+        self.records = []
+
+    async def create_approval(self, record):
+        self.records.append(record)
+
+
+def test_approval_service_does_not_block_the_async_event_loop(monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def blocking_native_approval(scope, summary):
+        entered.set()
+        release.wait(timeout=0.5)
+        finished.set()
+        return WorkflowApprovalDecision.DENY
+
+    monkeypatch.setattr(
+        "plugins.research_protocol.approval.request_workflow_approval",
+        blocking_native_approval,
+    )
+    store = RecordingApprovalStore()
+    service = ApprovalService(store=store)
+
+    async def exercise():
+        task = asyncio.create_task(service.request(make_scope(), "bounded summary"))
+        for _ in range(100):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.001)
+        assert entered.is_set()
+        await asyncio.sleep(0)
+        assert finished.is_set() is False
+        release.set()
+        assert await task is None
+        assert len(store.records) == 1
+        assert store.records[0].verdict is ApprovalVerdict.DENIED
+        assert store.records[0].scope_json == make_scope().canonical_json()
+
+    asyncio.run(exercise())
+
+
+def test_approval_service_persists_expired_denial_with_exact_scope(monkeypatch):
+    monkeypatch.setattr(
+        "plugins.research_protocol.approval.request_workflow_approval",
+        lambda _scope, _summary: WorkflowApprovalDecision.DENY,
+    )
+    expired_scope = make_scope(expires_at=NOW - timedelta(seconds=1))
+    store = RecordingApprovalStore()
+    service = ApprovalService(store=store)
+
+    assert asyncio.run(service.request(expired_scope, "bounded summary")) is None
+
+    assert len(store.records) == 1
+    denied = store.records[0]
+    assert denied.verdict is ApprovalVerdict.DENIED
+    assert denied.scope_json == expired_scope.canonical_json()
+    assert denied.scope_sha256 == expired_scope.scope_sha256()
+    assert denied.created_at > denied.expires_at
+
+
+def test_workflow_approval_always_calls_native_api_even_when_yolo_or_off(
+    monkeypatch,
+    tmp_path,
+):
+    import tools.approval as native_approval
+
+    calls = []
+
+    def fake_prompt(message, description, **kwargs):
+        calls.append((message, description, kwargs))
+        return "once"
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "approvals:\n  mode: off\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(native_approval, "_YOLO_MODE_FROZEN", True)
+    monkeypatch.setattr(native_approval, "_is_gateway_approval_context", lambda: False)
+    monkeypatch.setattr(native_approval, "prompt_dangerous_approval", fake_prompt)
+
+    decision = request_workflow_approval(make_scope(), "exact plan summary")
+
+    assert decision == WorkflowApprovalDecision.ACCEPT
+    assert len(calls) == 1
+    assert calls[0][0] == "exact plan summary"
+    assert calls[0][2]["allow_permanent"] is False
+
+
+def test_workflow_approval_fails_closed_without_explicit_strict_native_contract(
+    monkeypatch,
+):
+    calls = []
+
+    def permissive_legacy_consent(
+        message,
+        description,
+        *,
+        timeout_seconds=None,
+        surface="mcp-elicitation",
+    ):
+        calls.append((message, description, timeout_seconds, surface))
+        return "accept"
+
+    monkeypatch.setattr(
+        "tools.approval.request_elicitation_consent",
+        permissive_legacy_consent,
+    )
+
+    assert (
+        request_workflow_approval(make_scope(), "summary")
+        is WorkflowApprovalDecision.DENY
+    )
+    assert calls == []
+
+
+def test_workflow_approval_requests_explicit_strict_one_shot(monkeypatch):
+    calls = []
+
+    def strict_consent(
+        message,
+        description,
+        *,
+        timeout_seconds=None,
+        surface="mcp-elicitation",
+        strict_one_shot=False,
+    ):
+        calls.append((message, description, timeout_seconds, surface, strict_one_shot))
+        return "accept"
+
+    monkeypatch.setattr(
+        "tools.approval.request_elicitation_consent",
+        strict_consent,
+    )
+
+    assert (
+        request_workflow_approval(make_scope(), "summary")
+        is WorkflowApprovalDecision.ACCEPT
+    )
+    assert len(calls) == 1
+    assert calls[0][0] == "summary"
+    assert calls[0][4] is True
+
+
+def test_workflow_approval_rejects_expired_scope_before_native_prompt(monkeypatch):
+    calls = []
+
+    def recording_prompt(*_args, **_kwargs):
+        calls.append(True)
+        return "accept"
+
+    monkeypatch.setattr(
+        "tools.approval.request_elicitation_consent",
+        recording_prompt,
+    )
+    expired = make_scope(expires_at=datetime.now(UTC) - timedelta(seconds=1))
+
+    assert (
+        request_workflow_approval(expired, "summary") is WorkflowApprovalDecision.DENY
+    )
+    assert calls == []
+
+
+@pytest.mark.parametrize("native_result", ["decline", "cancel"])
+def test_workflow_approval_denies_non_accept_results(monkeypatch, native_result):
+    monkeypatch.setattr(
+        "tools.approval.request_elicitation_consent",
+        lambda *_args, **_kwargs: native_result,
+    )
+
+    assert (
+        request_workflow_approval(make_scope(), "summary")
+        is WorkflowApprovalDecision.DENY
+    )
+
+
+def test_workflow_approval_denies_native_exception(monkeypatch):
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("native approval unavailable")
+
+    monkeypatch.setattr("tools.approval.request_elicitation_consent", explode)
+
+    assert (
+        request_workflow_approval(make_scope(), "summary")
+        is WorkflowApprovalDecision.DENY
+    )
+
+
+class FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class FakeConnection:
+    def __init__(self, row):
+        self.row = row
+        self.calls = []
+        self.executions = []
+
+    def transaction(self):
+        return FakeTransaction()
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        return self.row
+
+    async def execute(self, query, *args):
+        self.executions.append((query, args))
+
+
+class FakeAcquire:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class FakePool:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def acquire(self):
+        return FakeAcquire(self.connection)
+
+
+def test_postgres_create_uses_fixed_store_function_and_writer_timeout():
+    scope = make_scope()
+    record = make_approval_record(scope)
+    connection = FakeConnection(None)
+    store = PostgresApprovalStore(FakePool(connection), timeout_seconds=2.5)
+
+    asyncio.run(store.create_approval(record))
+
+    assert len(connection.executions) == 2
+    timeout_sql, timeout_args = connection.executions[0]
+    assert "set_config" in timeout_sql
+    assert timeout_args == ("2500ms",)
+    query, args = connection.executions[1]
+    assert "research_protocol.store_approval" in query
+    assert "INSERT" not in query
+    assert args == (
+        record.approval_id,
+        record.scope_sha256,
+        record.plan_sha256,
+        record.scope_json,
+        record.verdict.value,
+        record.surface,
+        record.created_at,
+        record.expires_at,
+        record.max_executions,
+    )
+
+
+def test_postgres_create_accepts_fresh_denied_record():
+    denied = make_approval_record(make_scope(), verdict=ApprovalVerdict.DENIED)
+    connection = FakeConnection(None)
+    store = PostgresApprovalStore(FakePool(connection))
+
+    asyncio.run(store.create_approval(denied))
+
+    _query, args = connection.executions[1]
+    assert args[4] == "denied"
+
+
+def test_postgres_writer_deadline_includes_pool_acquisition():
+    class SlowAcquire:
+        async def __aenter__(self):
+            await asyncio.sleep(1)
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class SlowPool:
+        @staticmethod
+        def acquire():
+            return SlowAcquire()
+
+    store = PostgresApprovalStore(SlowPool(), timeout_seconds=0.01)
+
+    with pytest.raises(ApprovalStoreTimeoutError, match="timed out"):
+        asyncio.run(store.create_approval(make_approval_record(make_scope())))
+
+
+def test_postgres_claim_is_atomic_and_binds_exact_scope_and_hashes():
+    scope = make_scope()
+    row = {
+        "approval_id": "approval-001",
+        "scope_sha256": scope.scope_sha256(),
+        "plan_sha256": PLAN_SHA,
+        "consumed_count": 1,
+        "max_executions": 2,
+    }
+    connection = FakeConnection(row)
+    store = PostgresApprovalStore(FakePool(connection))
+
+    claimed = asyncio.run(
+        store.claim_approval(
+            approval_id="approval-001",
+            scope=scope,
+            plan_sha256=PLAN_SHA,
+        )
+    )
+
+    assert claimed is True
+    query, args = connection.calls[0]
+    assert "research_protocol.claim_approval" in query
+    assert "UPDATE" not in query
+    assert args[0] == "approval-001"
+    assert scope.scope_sha256() in args
+    assert PLAN_SHA in args
+
+
+def test_postgres_claim_returns_false_for_no_matching_atomic_row():
+    connection = FakeConnection(None)
+    store = PostgresApprovalStore(FakePool(connection))
+
+    claimed = asyncio.run(
+        store.claim_approval(
+            approval_id="missing",
+            scope=make_scope(),
+            plan_sha256=PLAN_SHA,
+        )
+    )
+
+    assert claimed is False

--- a/tests/plugins/research_protocol/test_approval.py
+++ b/tests/plugins/research_protocol/test_approval.py
@@ -151,9 +151,11 @@ def test_approval_service_propagates_cli_callback_to_native_consent_thread(
     callback_observations = []
 
     def approve_once(_message, _description, **kwargs):
-        callback_observations.append(
-            (threading.get_ident(), terminal_tool._get_approval_callback(), kwargs)
-        )
+        callback_observations.append((
+            threading.get_ident(),
+            terminal_tool._get_approval_callback(),
+            kwargs,
+        ))
         return "once"
 
     monkeypatch.setattr(

--- a/tests/plugins/research_protocol/test_approval.py
+++ b/tests/plugins/research_protocol/test_approval.py
@@ -142,6 +142,50 @@ def test_approval_service_does_not_block_the_async_event_loop(monkeypatch):
     asyncio.run(exercise())
 
 
+def test_approval_service_propagates_cli_callback_to_native_consent_thread(
+    monkeypatch,
+):
+    from tools import terminal_tool
+
+    parent_thread_id = threading.get_ident()
+    callback_observations = []
+
+    def approve_once(_message, _description, **kwargs):
+        callback_observations.append(
+            (threading.get_ident(), terminal_tool._get_approval_callback(), kwargs)
+        )
+        return "once"
+
+    monkeypatch.setattr(
+        "tools.approval._is_gateway_approval_context",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "prompt_toolkit.application.current.get_app_or_none",
+        lambda: object(),
+    )
+    previous_callback = terminal_tool._get_approval_callback()
+    terminal_tool.set_approval_callback(approve_once)
+    try:
+        store = RecordingApprovalStore()
+        result = asyncio.run(
+            ApprovalService(store=store).request(make_scope(), "bounded summary")
+        )
+    finally:
+        terminal_tool.set_approval_callback(previous_callback)
+
+    assert len(callback_observations) == 1
+    worker_thread_id, visible_callback, callback_kwargs = callback_observations[0]
+    assert worker_thread_id != parent_thread_id
+    assert visible_callback is approve_once
+    assert callback_kwargs == {"allow_permanent": False}
+    assert len(store.records) == 1
+    assert result is not None
+    assert result is store.records[0]
+    assert result.verdict is ApprovalVerdict.APPROVED
+    assert store.records[0].verdict is ApprovalVerdict.APPROVED
+
+
 def test_approval_service_persists_expired_denial_with_exact_scope(monkeypatch):
     monkeypatch.setattr(
         "plugins.research_protocol.approval.request_workflow_approval",

--- a/tests/plugins/research_protocol/test_artifact_store.py
+++ b/tests/plugins/research_protocol/test_artifact_store.py
@@ -1,0 +1,354 @@
+"""TDD contract tests for safe research protocol artifact persistence."""
+
+import hashlib
+import json
+import multiprocessing
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from plugins.research_protocol.models import (
+    BudgetLimits,
+    Capability,
+    CapabilityGrant,
+    OutputRequirement,
+    PlanV1,
+)
+from plugins.research_protocol.storage.artifacts import (
+    ArtifactStore,
+    ArtifactSecurityError,
+    canonical_json_bytes,
+)
+
+
+SHA_A = "a" * 64
+
+
+def plan_payload() -> dict:
+    return {
+        "schema_version": "plan.v1",
+        "producer_version": "test",
+        "run_id": "run-001",
+        "created_at": datetime(2026, 7, 13, 20, 0, tzinfo=UTC),
+        "objective": "Offline test plan",
+        "constraints": ("offline",),
+        "inputs": (),
+        "outputs": (
+            OutputRequirement(
+                artifact_id="manifest-001",
+                artifact_type="manifest",
+            ),
+        ),
+        "budgets": BudgetLimits(
+            max_duration_seconds=60,
+            max_executions=1,
+            max_records=10,
+            max_bytes=1000,
+            max_external_calls=0,
+        ).model_dump(),
+        "capabilities": (
+            CapabilityGrant(
+                capability=Capability.RESEARCH_COLLECT,
+                input_hashes=(SHA_A,),
+                external_rights=(),
+            ),
+        ),
+    }
+
+
+def _concurrent_persist_worker(root: str, start, results) -> None:
+    store = ArtifactStore(root)
+    start.wait(timeout=5)
+    try:
+        receipt = store.persist("plan", "plan-concurrent", plan_payload())
+        results.put(("persisted", receipt.sha256))
+    except FileExistsError:
+        results.put(("exists", None))
+
+
+def test_canonical_json_is_utf8_sorted_compact_and_hashes_exact_bytes():
+    value = {"z": "é", "a": [1, 2]}
+
+    encoded = canonical_json_bytes(value)
+
+    assert encoded == b'{"a":[1,2],"z":"\xc3\xa9"}'
+    assert hashlib.sha256(encoded).hexdigest() == (
+        "69ed5fc8c2388fea22214cceadcebfe6171cbb85cb913d7adb3281efe7431141"
+    )
+
+
+def test_new_storage_subdirectories_are_made_durable_in_the_root(
+    tmp_path,
+    monkeypatch,
+):
+    store = ArtifactStore(tmp_path)
+    root_stat = os.stat(tmp_path)
+    real_fsync = os.fsync
+    root_fsyncs = 0
+
+    def track_fsync(fd):
+        nonlocal root_fsyncs
+        descriptor_stat = os.fstat(fd)
+        if (
+            descriptor_stat.st_dev == root_stat.st_dev
+            and descriptor_stat.st_ino == root_stat.st_ino
+        ):
+            root_fsyncs += 1
+        return real_fsync(fd)
+
+    monkeypatch.setattr(
+        "plugins.research_protocol.storage.artifacts.os.fsync",
+        track_fsync,
+    )
+
+    store.persist("plan", "plan-root-fsync", plan_payload())
+
+    assert root_fsyncs == 3
+
+
+def test_canonical_json_rejects_non_finite_numbers():
+    with pytest.raises(ValueError):
+        canonical_json_bytes({"value": float("nan")})
+
+
+def test_store_rejects_group_or_world_accessible_root(tmp_path):
+    os.chmod(tmp_path, 0o777)
+    try:
+        with pytest.raises(ArtifactSecurityError, match="private"):
+            ArtifactStore(tmp_path)
+    finally:
+        os.chmod(tmp_path, 0o700)
+
+
+def test_store_rejects_root_not_owned_by_effective_user(tmp_path, monkeypatch):
+    owner_uid = os.stat(tmp_path).st_uid
+    monkeypatch.setattr(
+        "plugins.research_protocol.storage.artifacts.os.geteuid",
+        lambda: owner_uid + 1,
+    )
+
+    with pytest.raises(ArtifactSecurityError, match="owned"):
+        ArtifactStore(tmp_path)
+
+
+def test_store_validates_model_and_returns_readback_hash_and_length(tmp_path):
+    store = ArtifactStore(tmp_path)
+    payload = plan_payload()
+
+    receipt = store.persist("plan", "plan-001", payload)
+
+    expected = canonical_json_bytes(
+        PlanV1.model_validate(payload).model_dump(mode="json")
+    )
+    assert receipt.artifact_id == "plan-001"
+    assert receipt.path_relative == "plans/plan-001.json"
+    assert receipt.sha256 == hashlib.sha256(expected).hexdigest()
+    assert receipt.byte_length == len(expected)
+    assert store.read_bytes("plan", "plan-001") == expected
+    assert json.loads(
+        (tmp_path / receipt.path_relative).read_text(encoding="utf-8")
+    ) == json.loads(expected)
+
+
+@pytest.mark.parametrize(
+    "artifact_id",
+    ["../escape", "a/b", "/absolute", "", ".", "a\\b", "a//b"],
+)
+def test_store_rejects_traversal_absolute_and_ambiguous_identifiers(
+    tmp_path, artifact_id
+):
+    with pytest.raises(ArtifactSecurityError):
+        ArtifactStore(tmp_path).persist("plan", artifact_id, plan_payload())
+
+
+def test_store_rejects_unknown_artifact_type(tmp_path):
+    with pytest.raises(ArtifactSecurityError):
+        ArtifactStore(tmp_path).persist("arbitrary", "id-001", {})
+
+
+def test_store_rejects_symlinked_directory_and_target(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    root_link = tmp_path / "link"
+    root_link.symlink_to(real, target_is_directory=True)
+
+    with pytest.raises(ArtifactSecurityError):
+        ArtifactStore(root_link)
+
+    (tmp_path / "root").mkdir(mode=0o700)
+    store = ArtifactStore(tmp_path / "root")
+    (tmp_path / "root" / "plans").symlink_to(real, target_is_directory=True)
+    with pytest.raises(ArtifactSecurityError):
+        store.persist("plan", "plan-001", plan_payload())
+
+
+def test_store_never_overwrites_existing_target(tmp_path):
+    store = ArtifactStore(tmp_path)
+    receipt = store.persist("plan", "plan-001", plan_payload())
+    original = (tmp_path / receipt.path_relative).read_bytes()
+
+    with pytest.raises(FileExistsError):
+        store.persist("plan", "plan-001", plan_payload())
+
+    assert (tmp_path / receipt.path_relative).read_bytes() == original
+
+
+def test_failed_atomic_publish_does_not_publish_partial_artifact(tmp_path, monkeypatch):
+    store = ArtifactStore(tmp_path)
+
+    def fail_link(*_args, **_kwargs):
+        raise OSError("simulated crash before publish")
+
+    monkeypatch.setattr(
+        "plugins.research_protocol.storage.artifacts.os.link", fail_link
+    )
+    with pytest.raises(OSError, match="simulated crash"):
+        store.persist("plan", "plan-001", plan_payload())
+
+    assert not (tmp_path / "plans" / "plan-001.json").exists()
+    assert list((tmp_path / "plans").iterdir()) == []
+
+
+def test_failure_after_receipt_publish_rolls_back_both_names(tmp_path, monkeypatch):
+    store = ArtifactStore(tmp_path)
+    real_link = __import__("os").link
+    calls = 0
+
+    def fail_second_link(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("simulated crash before artifact publish")
+        return real_link(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "plugins.research_protocol.storage.artifacts.os.link",
+        fail_second_link,
+    )
+
+    with pytest.raises(OSError, match="simulated crash"):
+        store.persist("plan", "plan-001", plan_payload())
+
+    assert list((tmp_path / "plans").iterdir()) == []
+    assert list((tmp_path / "receipts").iterdir()) == []
+
+
+def test_retry_recovers_receipt_orphan_left_by_process_termination(
+    tmp_path,
+    monkeypatch,
+):
+    store = ArtifactStore(tmp_path)
+    real_publish = store._publish_temporary
+    calls = 0
+
+    def terminate_after_first_publish(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        real_publish(*args, **kwargs)
+        if calls == 1:
+            raise SystemExit("simulated process termination")
+
+    monkeypatch.setattr(store, "_publish_temporary", terminate_after_first_publish)
+    with pytest.raises(SystemExit, match="simulated process termination"):
+        store.persist("plan", "plan-001", plan_payload())
+
+    assert not (tmp_path / "plans" / "plan-001.json").exists()
+    assert (tmp_path / "receipts" / "plan-plan-001.receipt.json").is_file()
+
+    monkeypatch.setattr(store, "_publish_temporary", real_publish)
+    receipt = store.persist("plan", "plan-001", plan_payload())
+
+    assert store.read_verified(
+        "plan",
+        "plan-001",
+        expected_sha256=receipt.sha256,
+    )
+
+
+def test_concurrent_processes_publish_exactly_once(tmp_path):
+    context = multiprocessing.get_context("fork")
+    start = context.Event()
+    results = context.Queue()
+    workers = [
+        context.Process(
+            target=_concurrent_persist_worker,
+            args=(str(tmp_path), start, results),
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+    start.set()
+    for worker in workers:
+        worker.join(timeout=10)
+        if worker.is_alive():
+            worker.terminate()
+            worker.join(timeout=2)
+            pytest.fail("concurrent artifact writer hung")
+        assert worker.exitcode == 0
+
+    outcomes = sorted(results.get(timeout=2) for _ in workers)
+    assert [outcome for outcome, _digest in outcomes] == ["exists", "persisted"]
+
+    digest = next(digest for outcome, digest in outcomes if outcome == "persisted")
+    assert ArtifactStore(tmp_path).read_verified(
+        "plan",
+        "plan-concurrent",
+        expected_sha256=digest,
+    )
+
+
+def test_store_does_not_use_replacing_publish_primitive(tmp_path, monkeypatch):
+    def reject_replace(*_args, **_kwargs):
+        raise AssertionError("os.replace must not be used for no-clobber persistence")
+
+    monkeypatch.setattr(
+        "plugins.research_protocol.storage.artifacts.os.replace",
+        reject_replace,
+    )
+
+    receipt = ArtifactStore(tmp_path).persist("plan", "plan-001", plan_payload())
+
+    assert (tmp_path / receipt.path_relative).is_file()
+
+
+def test_store_detects_directory_symlink_swap_during_publish(tmp_path, monkeypatch):
+    store = ArtifactStore(tmp_path / "artifacts")
+    plans = tmp_path / "artifacts" / "plans"
+    moved = tmp_path / "plans-before-swap"
+    attacker = tmp_path / "attacker"
+    attacker.mkdir()
+    real_link = __import__("os").link
+    swapped = False
+
+    def swap_then_link(*args, **kwargs):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            plans.rename(moved)
+            plans.symlink_to(attacker, target_is_directory=True)
+        return real_link(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "plugins.research_protocol.storage.artifacts.os.link",
+        swap_then_link,
+    )
+
+    with pytest.raises(ArtifactSecurityError, match="changed during operation"):
+        store.persist("plan", "plan-001", plan_payload())
+
+    assert not (attacker / "plan-001.json").exists()
+    assert not (moved / "plan-001.json").exists()
+    assert list((tmp_path / "artifacts" / "receipts").iterdir()) == []
+
+
+def test_readback_detects_modified_bytes(tmp_path):
+    store = ArtifactStore(tmp_path)
+    receipt = store.persist("plan", "plan-001", plan_payload())
+    path = tmp_path / receipt.path_relative
+    path.write_bytes(path.read_bytes() + b"x")
+
+    with pytest.raises(ArtifactSecurityError, match="hash"):
+        store.read_verified("plan", "plan-001", expected_sha256=receipt.sha256)

--- a/tests/plugins/research_protocol/test_artifact_store.py
+++ b/tests/plugins/research_protocol/test_artifact_store.py
@@ -184,6 +184,49 @@ def test_store_rejects_symlinked_directory_and_target(tmp_path):
         store.persist("plan", "plan-001", plan_payload())
 
 
+def test_store_rejects_new_root_below_symlinked_parent_without_creating_it(tmp_path):
+    real_parent = tmp_path / "real-parent"
+    real_parent.mkdir()
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    root = linked_parent / "artifacts"
+
+    with pytest.raises(ArtifactSecurityError):
+        ArtifactStore(root)
+
+    assert not os.path.lexists(real_parent / "artifacts")
+
+
+def test_store_fails_closed_without_o_nofollow_before_creating_root(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "artifacts"
+    monkeypatch.delattr("plugins.research_protocol.storage.artifacts.os.O_NOFOLLOW")
+
+    with pytest.raises(ArtifactSecurityError, match="O_NOFOLLOW"):
+        ArtifactStore(root)
+
+    assert not os.path.lexists(root)
+
+
+def test_store_fails_closed_without_required_dir_fd_support(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "artifacts"
+    supported = set(os.supports_dir_fd) - {os.open}
+    monkeypatch.setattr(
+        "plugins.research_protocol.storage.artifacts.os.supports_dir_fd",
+        supported,
+    )
+
+    with pytest.raises(ArtifactSecurityError, match="dir_fd"):
+        ArtifactStore(root)
+
+    assert not os.path.lexists(root)
+
+
 def test_store_never_overwrites_existing_target(tmp_path):
     store = ArtifactStore(tmp_path)
     receipt = store.persist("plan", "plan-001", plan_payload())

--- a/tests/plugins/research_protocol/test_migrations.py
+++ b/tests/plugins/research_protocol/test_migrations.py
@@ -1,0 +1,163 @@
+"""Migration and packaging gates for Research Protocol PR2."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATIONS = REPO_ROOT / "plugins" / "research_protocol" / "migrations"
+
+
+def test_pr2_migration_set_is_exact_and_versioned():
+    assert [path.name for path in sorted(MIGRATIONS.glob("*.sql"))] == [
+        "0001_approval_ledger.sql",
+        "0002_roles.sql",
+    ]
+
+
+def test_approval_migration_enforces_replay_expiry_and_hash_invariants():
+    sql = (MIGRATIONS / "0001_approval_ledger.sql").read_text(encoding="utf-8").lower()
+
+    assert "create schema research_protocol" in sql
+    assert "create schema if not exists" not in sql
+    assert "create table research_protocol.approvals" in sql
+    assert "approval_id" in sql and "primary key" in sql
+    assert "scope_sha256" in sql and "plan_sha256" in sql
+    assert "scope_json jsonb" in sql
+    assert "max_executions > 0" in sql
+    assert "consumed_count >= 0" in sql
+    assert "consumed_count <= max_executions" in sql
+    assert "expires_at > created_at" in sql
+    assert "verdict in ('approved', 'denied')" in sql
+    assert "check (verdict = 'denied' or expires_at > created_at)" in sql
+    assert "function research_protocol.claim_approval" in sql
+    assert "security definer" in sql
+    assert "set search_path = pg_catalog, research_protocol" in sql
+    assert "revoke all on function research_protocol.claim_approval" in sql
+    assert "clock_timestamp()" in sql
+    assert "current_timestamp" not in sql
+    assert "create function research_protocol.store_approval" in sql
+    assert "p_verdict text" in sql
+    assert "p_verdict not in ('approved', 'denied')" in sql
+    assert "p_verdict = 'approved'" in sql
+    assert "p_verdict," in sql
+    assert "revoke all on function research_protocol.store_approval" in sql
+    assert "create table if not exists" not in sql
+    assert "create index if not exists" not in sql
+    assert "create or replace function" not in sql
+    assert "char_length(approval_id) between 22 and 256" in sql
+    assert "char_length(surface) between 1 and 128" in sql
+    assert "revoke all on" in sql and "from public" in sql
+
+
+def test_approval_migration_matches_runtime_record_and_claim_columns():
+    sql = (MIGRATIONS / "0001_approval_ledger.sql").read_text(encoding="utf-8").lower()
+
+    for declaration in (
+        "surface text not null",
+        "last_consumed_at timestamptz",
+    ):
+        assert declaration in sql
+    assert "schema_version text not null" not in sql
+    assert "\n    consumed_at timestamptz" not in sql
+    assert "consumed_count = 0 and last_consumed_at is null" in sql
+    assert "consumed_count > 0 and last_consumed_at is not null" in sql
+
+
+def test_store_approval_recomputes_scope_sha256_from_exact_json():
+    sql = (MIGRATIONS / "0001_approval_ledger.sql").read_text(encoding="utf-8").lower()
+
+    assert "create extension" not in sql
+    assert "p_scope_json text" in sql
+    assert "pg_catalog.sha256(" in sql
+    assert "pg_catalog.convert_to(p_scope_json, 'utf8')" in sql
+    assert "<> p_scope_sha256" in sql
+
+
+def test_roles_are_non_login_non_inheriting_and_least_privilege():
+    sql = (MIGRATIONS / "0002_roles.sql").read_text(encoding="utf-8").lower()
+
+    roles = (
+        "research_protocol_planner_reader",
+        "research_protocol_approval_writer",
+        "research_protocol_approval_claimant",
+    )
+    for role in roles:
+        assert f"create role {role}" in sql
+    assert "if not exists" not in sql
+    assert "pg_roles" not in sql
+    assert "pg_auth_members" not in sql
+    assert "alter role" not in sql
+    assert sql.count("nologin noinherit") >= 3
+    assert (
+        "grant select on research_protocol.approvals to research_protocol_planner_reader"
+        in sql
+    )
+    assert (
+        "grant insert on research_protocol.approvals to research_protocol_approval_writer"
+        not in sql
+    )
+    assert "grant select, update on research_protocol.approvals" not in sql
+    assert "grant insert (" not in sql
+    assert "grant execute on function research_protocol.store_approval" in sql
+    assert "to research_protocol_approval_writer" in sql
+    assert "grant select (" not in sql
+    assert "grant update" not in sql
+    assert "grant execute on function research_protocol.claim_approval" in sql
+    assert "to research_protocol_approval_claimant" in sql
+    for role in roles:
+        assert f"revoke all on research_protocol.approvals from {role}" in sql
+        assert f"revoke all on schema research_protocol from {role}" in sql
+        assert f"nosuperuser nocreatedb nocreaterole noreplication nobypassrls" in sql
+    assert "revoke all on function research_protocol.store_approval" in sql
+    assert "revoke all on function research_protocol.claim_approval" in sql
+    assert "grant delete" not in sql
+    assert "grant all" not in sql
+
+
+def test_research_protocol_extra_is_consistent_with_uv_lock():
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["optional-dependencies"]["research-protocol"] == [
+        "asyncpg==0.31.0"
+    ]
+    root_package = next(
+        package for package in lock["package"] if package["name"] == "hermes-agent"
+    )
+    assert root_package["optional-dependencies"]["research-protocol"] == [
+        {"name": "asyncpg"}
+    ]
+    assert {
+        "name": "asyncpg",
+        "marker": "extra == 'research-protocol'",
+        "specifier": "==0.31.0",
+    } in root_package["metadata"]["requires-dist"]
+
+
+def test_migrations_are_declared_for_wheel_and_sdist():
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    plugin_data = pyproject["tool"]["setuptools"]["package-data"]["plugins"]
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+
+    assert "research_protocol/**/*.sql" in plugin_data
+    assert (
+        "recursive-include plugins/research_protocol *.json *.yaml *.sql *.md"
+        in manifest
+    )
+
+
+def test_asyncpg_is_isolated_in_research_protocol_extra():
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert pyproject["project"]["optional-dependencies"]["research-protocol"] == [
+        "asyncpg==0.31.0"
+    ]

--- a/tests/plugins/research_protocol/test_migrations.py
+++ b/tests/plugins/research_protocol/test_migrations.py
@@ -139,18 +139,13 @@ def test_research_protocol_extra_is_consistent_with_uv_lock():
     } in root_package["metadata"]["requires-dist"]
 
 
-def test_migrations_are_declared_for_wheel_and_sdist():
+def test_migrations_are_declared_in_package_data():
     pyproject = tomllib.loads(
         (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     )
     plugin_data = pyproject["tool"]["setuptools"]["package-data"]["plugins"]
-    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
 
     assert "research_protocol/**/*.sql" in plugin_data
-    assert (
-        "recursive-include plugins/research_protocol *.json *.yaml *.sql *.md"
-        in manifest
-    )
 
 
 def test_asyncpg_is_isolated_in_research_protocol_extra():

--- a/tests/plugins/research_protocol/test_models.py
+++ b/tests/plugins/research_protocol/test_models.py
@@ -1,0 +1,417 @@
+"""Strict model contracts for Hermes Research Protocol v1 artifacts."""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from plugins.research_protocol.models import (
+    ArtifactStatus,
+    BudgetLimits,
+    Capability,
+    CapabilityGrant,
+    ConflictRecord,
+    ConflictStatus,
+    DedupCluster,
+    EvidenceSnapshot,
+    FigureKind,
+    FigureSpec,
+    InputReference,
+    ManifestRecord,
+    OutputRequirement,
+    PlanV1,
+    RunConfig,
+    SourceCandidate,
+    SourceIdentifier,
+    SourceQuality,
+    Verdict,
+    VerdictRecord,
+    load_artifact_from_json_bytes,
+)
+
+NOW = datetime(2026, 7, 13, 20, 0, tzinfo=UTC)
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+META = {
+    "producer_version": "0.18.2",
+    "run_id": "run-001",
+    "created_at": NOW,
+}
+
+
+def _plan_payload() -> dict:
+    return {
+        "schema_version": "plan.v1",
+        **META,
+        "objective": "Produce a reproducible offline evidence report.",
+        "constraints": ("offline", "no external publication"),
+        "inputs": (
+            InputReference(
+                input_id="input-001",
+                artifact_type="fixture",
+                sha256=SHA_A,
+            ),
+        ),
+        "outputs": (
+            OutputRequirement(
+                artifact_id="manifest-001",
+                artifact_type="manifest",
+            ),
+        ),
+        "budgets": BudgetLimits(
+            max_duration_seconds=60,
+            max_executions=1,
+            max_records=100,
+            max_bytes=1_000_000,
+            max_external_calls=0,
+        ),
+        "capabilities": (
+            CapabilityGrant(
+                capability=Capability.RESEARCH_COLLECT,
+                input_hashes=(SHA_A,),
+                external_rights=(),
+            ),
+        ),
+    }
+
+
+def test_plan_v1_accepts_minimal_strict_contract():
+    plan = PlanV1.model_validate(_plan_payload())
+
+    assert plan.schema_version == "plan.v1"
+    assert plan.capabilities[0].capability is Capability.RESEARCH_COLLECT
+    assert plan.budgets.max_external_calls == 0
+
+    encoded = plan.model_dump_json()
+    assert PlanV1.model_validate_json(encoded) == plan
+
+
+def test_plan_v1_rejects_unknown_fields():
+    payload = _plan_payload()
+    payload["sql"] = "select * from secrets"
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        PlanV1.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("run_id", " run-001"),
+        ("producer_version", "0.18.2 "),
+        ("objective", " Produce a reproducible offline evidence report."),
+    ],
+)
+def test_strict_string_contracts_reject_instead_of_normalizing_whitespace(
+    field, value
+):
+    payload = _plan_payload()
+    payload[field] = value
+
+    with pytest.raises(ValidationError) as exc_info:
+        PlanV1.model_validate(payload)
+
+    assert {error["loc"] for error in exc_info.value.errors()} == {(field,)}
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_artifact_models_reject_non_finite_numbers(value):
+    with pytest.raises(ValidationError):
+        SourceQuality(
+            schema_version="source_quality.v1",
+            **META,
+            source_id="source-001",
+            provenance_id="prov-001",
+            score=value,
+            dimensions={"authority": 0.8},
+            rationale=("fixture",),
+        )
+
+
+def test_strict_mapping_contracts_reject_keys_outside_identifier_pattern():
+    with pytest.raises(ValidationError) as exc_info:
+        SourceQuality(
+            schema_version="source_quality.v1",
+            **META,
+            source_id="source-001",
+            provenance_id="prov-001",
+            score=0.8,
+            dimensions={"invalid key": 0.8},
+            rationale=("fixture",),
+        )
+
+    assert {error["loc"] for error in exc_info.value.errors()} == {
+        ("dimensions", "invalid key", "[key]")
+    }
+
+
+def test_run_and_manifest_models_include_provenance_metadata():
+    run = RunConfig(
+        schema_version="run_config.v1",
+        **META,
+        plan_artifact_id="plan-001",
+        plan_sha256=SHA_A,
+        capability=Capability.RESEARCH_COLLECT,
+        budgets=_plan_payload()["budgets"],
+        input_hashes=(SHA_A,),
+        policy_hashes={"source_quality.v1": SHA_B},
+        seed=7,
+    )
+    manifest = ManifestRecord(
+        schema_version="manifest_record.v1",
+        **META,
+        artifact_id="evidence-001",
+        artifact_type="evidence_snapshot",
+        path_relative="evidence/evidence-001.json",
+        sha256=SHA_B,
+        byte_length=42,
+        status=ArtifactStatus.SUCCESS,
+        provenance_ids=("prov-001",),
+    )
+
+    assert run.plan_sha256 == SHA_A
+    assert manifest.status is ArtifactStatus.SUCCESS
+    assert manifest.provenance_ids == ("prov-001",)
+
+
+def test_source_and_evidence_models_require_stable_provenance():
+    source = SourceCandidate(
+        schema_version="source_candidate.v1",
+        **META,
+        source_id="source-001",
+        adapter_id="fixtures.v1",
+        locator="fixture://source-001",
+        title="Fixture source",
+        identifiers=(SourceIdentifier(kind="fixture", value="source-001"),),
+        authors=("Example Author",),
+        published_at=NOW,
+        license="CC0-1.0",
+        provenance_id="prov-source-001",
+    )
+    evidence = EvidenceSnapshot(
+        schema_version="evidence_snapshot.v1",
+        **META,
+        evidence_id="evidence-001",
+        source_id=source.source_id,
+        locator=source.locator,
+        content_sha256=SHA_A,
+        extract="A bounded fixture extract.",
+        provenance_id="prov-evidence-001",
+    )
+
+    assert evidence.source_id == source.source_id
+    assert evidence.provenance_id != source.provenance_id
+
+
+def test_review_models_bind_bilateral_provenance_and_verdict_evidence():
+    conflict = ConflictRecord(
+        schema_version="conflict_record.v1",
+        **META,
+        conflict_id="conflict-001",
+        claim_id="claim-001",
+        left_provenance_id="prov-left",
+        right_provenance_id="prov-right",
+        conflict_type="direction",
+        status=ConflictStatus.OPEN,
+        rationale="Fixtures disagree on direction.",
+    )
+    cluster = DedupCluster(
+        schema_version="dedup_cluster.v1",
+        **META,
+        cluster_id="cluster-001",
+        canonical_provenance_id="prov-left",
+        member_provenance_ids=("prov-left", "prov-duplicate"),
+        method="exact",
+        confidence=1.0,
+    )
+    verdict = VerdictRecord(
+        schema_version="verdict_record.v1",
+        **META,
+        verdict_id="verdict-001",
+        question_id="question-001",
+        verdict=Verdict.MIXED,
+        evidence_provenance_ids=(
+            conflict.left_provenance_id,
+            conflict.right_provenance_id,
+        ),
+        rationale="The bounded fixture evidence conflicts.",
+        confidence=0.5,
+    )
+
+    assert cluster.canonical_provenance_id in cluster.member_provenance_ids
+    assert verdict.verdict is Verdict.MIXED
+
+
+def test_plan_rejects_duplicate_capability_grants():
+    payload = _plan_payload()
+    payload["capabilities"] = (
+        CapabilityGrant(
+            capability=Capability.RESEARCH_COLLECT,
+            input_hashes=(SHA_A,),
+        ),
+        CapabilityGrant(
+            capability=Capability.RESEARCH_COLLECT,
+            input_hashes=(SHA_B,),
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="capabilities must be unique"):
+        PlanV1.model_validate(payload)
+
+
+def test_conflict_rejects_identical_provenance_references():
+    with pytest.raises(ValidationError, match="provenance references must be distinct"):
+        ConflictRecord(
+            schema_version="conflict_record.v1",
+            **META,
+            conflict_id="conflict-001",
+            claim_id="claim-001",
+            left_provenance_id="prov-same",
+            right_provenance_id="prov-same",
+            conflict_type="direction",
+            status=ConflictStatus.OPEN,
+            rationale="A source cannot conflict with itself.",
+        )
+
+
+def test_dedup_cluster_rejects_duplicate_members():
+    with pytest.raises(ValidationError, match="member_provenance_ids must be unique"):
+        DedupCluster(
+            schema_version="dedup_cluster.v1",
+            **META,
+            cluster_id="cluster-001",
+            canonical_provenance_id="prov-same",
+            member_provenance_ids=("prov-same", "prov-same"),
+            method="exact",
+            confidence=1.0,
+        )
+
+
+def test_dedup_cluster_requires_canonical_member():
+    with pytest.raises(ValidationError, match="canonical provenance must be a cluster member"):
+        DedupCluster(
+            schema_version="dedup_cluster.v1",
+            **META,
+            cluster_id="cluster-001",
+            canonical_provenance_id="prov-canonical",
+            member_provenance_ids=("prov-left", "prov-right"),
+            method="semantic",
+            confidence=0.9,
+        )
+
+
+def test_figure_spec_is_data_bound_not_an_opaque_image():
+    figure = FigureSpec(
+        schema_version="figure_spec.v1",
+        **META,
+        figure_id="figure-001",
+        title="Fixture comparison",
+        kind=FigureKind.BAR,
+        data_artifact_id="manifest-001",
+        data_sha256=SHA_A,
+        x_field="source",
+        y_fields=("score",),
+        units={"score": "ratio"},
+        labels={"score": "Quality score"},
+        palette=("#3366CC",),
+    )
+
+    assert figure.data_sha256 == SHA_A
+    assert figure.kind is FigureKind.BAR
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "..\\\\secret.json",
+        "foo\\\\..\\\\secret.json",
+        ".",
+        "..",
+        "/absolute/file.json",
+        "C:/absolute/file.json",
+        "foo//bar.json",
+        "foo/./bar.json",
+        "foo/../bar.json",
+        "foo/bar.json/",
+        "foo\x00bar.json",
+        " evidence/evidence-001.json",
+        "evidence/evidence-001.json ",
+    ],
+)
+def test_manifest_rejects_every_unsafe_relative_path_form(path):
+    with pytest.raises(ValidationError) as exc_info:
+        ManifestRecord(
+            schema_version="manifest_record.v1",
+            **META,
+            artifact_id="evidence-001",
+            artifact_type="evidence_snapshot",
+            path_relative=path,
+            sha256=SHA_B,
+            byte_length=42,
+            status=ArtifactStatus.SUCCESS,
+            provenance_ids=("prov-001",),
+        )
+
+    assert {error["loc"] for error in exc_info.value.errors()} == {("path_relative",)}
+
+
+def test_manifest_rejects_path_exceeding_bounded_text_limit():
+    with pytest.raises(ValidationError) as exc_info:
+        ManifestRecord(
+            schema_version="manifest_record.v1",
+            **META,
+            artifact_id="artifact-001",
+            artifact_type="evidence_snapshot",
+            path_relative="a" * 8193,
+            sha256=SHA_B,
+            byte_length=42,
+            status=ArtifactStatus.SUCCESS,
+            provenance_ids=("prov-001",),
+        )
+
+    assert {error["loc"] for error in exc_info.value.errors()} == {("path_relative",)}
+
+
+def test_artifact_bytes_loader_round_trips_enum_and_aware_timestamp():
+    plan = PlanV1.model_validate(_plan_payload())
+
+    encoded = plan.to_canonical_json_bytes()
+    loaded = load_artifact_from_json_bytes(PlanV1, encoded)
+
+    assert loaded == plan
+    assert loaded.capabilities[0].capability is Capability.RESEARCH_COLLECT
+    assert loaded.created_at == NOW
+
+
+def test_artifact_bytes_loader_is_bytes_only():
+    plan = PlanV1.model_validate(_plan_payload())
+
+    with pytest.raises(TypeError, match="bytes"):
+        load_artifact_from_json_bytes(PlanV1, plan.to_canonical_json_bytes().decode())
+
+
+def test_artifact_sequential_collections_are_deeply_immutable():
+    plan = PlanV1.model_validate(_plan_payload())
+
+    assert isinstance(plan.constraints, tuple)
+    with pytest.raises(AttributeError):
+        plan.constraints.append("mutated")
+
+
+def test_artifact_mappings_are_deeply_immutable_and_serializable():
+    run = RunConfig(
+        schema_version="run_config.v1",
+        **META,
+        plan_artifact_id="plan-001",
+        plan_sha256=SHA_A,
+        capability=Capability.RESEARCH_COLLECT,
+        budgets=_plan_payload()["budgets"],
+        input_hashes=(SHA_A,),
+        policy_hashes={"source_quality.v1": SHA_B},
+        seed=7,
+    )
+
+    with pytest.raises(TypeError):
+        run.policy_hashes["source_quality.v1"] = "not-a-sha"
+
+    assert load_artifact_from_json_bytes(RunConfig, run.to_canonical_json_bytes()) == run

--- a/tests/plugins/research_protocol/test_models.py
+++ b/tests/plugins/research_protocol/test_models.py
@@ -102,9 +102,7 @@ def test_plan_v1_rejects_unknown_fields():
         ("objective", " Produce a reproducible offline evidence report."),
     ],
 )
-def test_strict_string_contracts_reject_instead_of_normalizing_whitespace(
-    field, value
-):
+def test_strict_string_contracts_reject_instead_of_normalizing_whitespace(field, value):
     payload = _plan_payload()
     payload[field] = value
 
@@ -288,7 +286,9 @@ def test_dedup_cluster_rejects_duplicate_members():
 
 
 def test_dedup_cluster_requires_canonical_member():
-    with pytest.raises(ValidationError, match="canonical provenance must be a cluster member"):
+    with pytest.raises(
+        ValidationError, match="canonical provenance must be a cluster member"
+    ):
         DedupCluster(
             schema_version="dedup_cluster.v1",
             **META,
@@ -414,4 +414,6 @@ def test_artifact_mappings_are_deeply_immutable_and_serializable():
     with pytest.raises(TypeError):
         run.policy_hashes["source_quality.v1"] = "not-a-sha"
 
-    assert load_artifact_from_json_bytes(RunConfig, run.to_canonical_json_bytes()) == run
+    assert (
+        load_artifact_from_json_bytes(RunConfig, run.to_canonical_json_bytes()) == run
+    )

--- a/tests/plugins/research_protocol/test_packaged_schemas.py
+++ b/tests/plugins/research_protocol/test_packaged_schemas.py
@@ -1,0 +1,148 @@
+"""Generated schema and policy packaging contracts."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from plugins.research_protocol.models.schema_export import render_schema_documents
+from plugins.research_protocol.models.policy import POLICY_MODELS
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[3] / "plugins" / "research_protocol"
+SCHEMA_ROOT = PLUGIN_ROOT / "schemas"
+POLICY_ROOT = PLUGIN_ROOT / "policies"
+EXPECTED_SCHEMAS = {
+    "plan.v1.json",
+    "run_config.v1.json",
+    "manifest_record.v1.json",
+    "source_candidate.v1.json",
+    "evidence_snapshot.v1.json",
+    "source_quality.v1.json",
+    "conflict_record.v1.json",
+    "dedup_cluster.v1.json",
+    "verdict_record.v1.json",
+    "figure_spec.v1.json",
+}
+EXPECTED_POLICIES = {
+    "source_quality.v1.yaml",
+    "contradiction.v1.yaml",
+    "dedup.v1.yaml",
+}
+BOUNDARY_COMMENT = (
+    "JSON Schema validation is necessary but insufficient; artifact bytes must be "
+    "validated with load_artifact_from_json_bytes and Pydantic model_validate_json."
+)
+
+
+def test_json_schemas_are_generated_deterministically_from_models():
+    rendered = render_schema_documents()
+
+    assert set(rendered) == EXPECTED_SCHEMAS
+    for filename, expected_bytes in rendered.items():
+        packaged_bytes = (SCHEMA_ROOT / filename).read_bytes()
+        assert packaged_bytes == expected_bytes
+        parsed = json.loads(packaged_bytes)
+        assert parsed["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert "schema_version" in parsed["properties"]
+        assert "producer_version" in parsed["properties"]
+        assert "run_id" in parsed["properties"]
+        assert "created_at" in parsed["properties"]
+
+
+def test_all_ten_schemas_declare_the_pydantic_boundary_contract():
+    schemas = {
+        filename: json.loads((SCHEMA_ROOT / filename).read_bytes())
+        for filename in EXPECTED_SCHEMAS
+    }
+
+    assert len(schemas) == 10
+    for schema in schemas.values():
+        assert BOUNDARY_COMMENT in schema["$comment"]
+        assert schema["additionalProperties"] is False
+
+
+@pytest.mark.parametrize(
+    ("schema_name", "field_name"),
+    [
+        ("run_config.v1.json", "policy_hashes"),
+        ("source_quality.v1.json", "dimensions"),
+        ("figure_spec.v1.json", "units"),
+        ("figure_spec.v1.json", "labels"),
+    ],
+)
+def test_mapping_schemas_reject_keys_outside_identifier_pattern(
+    schema_name, field_name
+):
+    schema = json.loads((SCHEMA_ROOT / schema_name).read_bytes())
+    mapping_schema = schema["properties"][field_name]
+
+    assert "patternProperties" in mapping_schema
+    assert mapping_schema["additionalProperties"] is False
+
+
+def test_schema_expresses_path_shape_and_documents_semantic_path_validation():
+    schema = json.loads((SCHEMA_ROOT / "manifest_record.v1.json").read_bytes())
+    path_schema = schema["properties"]["path_relative"]
+    path_pattern = re.compile(path_schema["pattern"])
+
+    assert path_schema["maxLength"] == 8192
+    assert path_pattern.fullmatch("evidence/evidence-001.json")
+    for unsafe in (
+        "..\\\\secret.json",
+        "foo\\\\..\\\\secret.json",
+        ".",
+        "..",
+        "/absolute.json",
+        "foo//bar.json",
+        "foo/./bar.json",
+        "foo/../bar.json",
+        "foo/bar.json/",
+        "foo\x00bar.json",
+        " evidence/evidence-001.json",
+        "evidence/evidence-001.json ",
+    ):
+        assert path_pattern.fullmatch(unsafe) is None
+    assert "Pydantic" in path_schema["$comment"]
+
+
+def test_schema_annotations_cover_cross_field_and_nested_collection_invariants():
+    plan = json.loads((SCHEMA_ROOT / "plan.v1.json").read_bytes())
+    conflict = json.loads((SCHEMA_ROOT / "conflict_record.v1.json").read_bytes())
+    dedup = json.loads((SCHEMA_ROOT / "dedup_cluster.v1.json").read_bytes())
+
+    capabilities = plan["properties"]["capabilities"]
+    assert capabilities["uniqueItems"] is True
+    assert "capability" in capabilities["x-hermes-validation"]
+    assert "left_provenance_id" in conflict["$comment"]
+    assert "right_provenance_id" in conflict["$comment"]
+    assert "distinct" in conflict["$comment"]
+
+    members = dedup["properties"]["member_provenance_ids"]
+    assert members["uniqueItems"] is True
+    assert "canonical_provenance_id" in dedup["$comment"]
+    assert "member" in dedup["$comment"]
+
+
+def test_versioned_policy_documents_validate_strictly():
+    assert {path.name for path in POLICY_ROOT.glob("*.yaml")} == EXPECTED_POLICIES
+
+    for filename, model in POLICY_MODELS.items():
+        payload = yaml.safe_load((POLICY_ROOT / filename).read_text(encoding="utf-8"))
+        validated = model.model_validate(payload)
+        assert validated.schema_version.endswith(".v1")
+
+        payload["unknown_top_level_key"] = True
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            model.model_validate(payload)
+
+
+def test_packaging_metadata_covers_all_research_protocol_data_channels():
+    pyproject = (PLUGIN_ROOT.parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    manifest = (PLUGIN_ROOT.parents[1] / "MANIFEST.in").read_text(encoding="utf-8")
+
+    for suffix in ("*.json", "*.yaml", "*.sql", "*.md"):
+        assert f'"research_protocol/**/*{suffix[1:]}"' in pyproject
+    assert "recursive-include plugins/research_protocol *.json *.yaml *.sql *.md" in manifest

--- a/tests/plugins/research_protocol/test_packaged_schemas.py
+++ b/tests/plugins/research_protocol/test_packaged_schemas.py
@@ -145,4 +145,7 @@ def test_packaging_metadata_covers_all_research_protocol_data_channels():
 
     for suffix in ("*.json", "*.yaml", "*.sql", "*.md"):
         assert f'"research_protocol/**/*{suffix[1:]}"' in pyproject
-    assert "recursive-include plugins/research_protocol *.json *.yaml *.sql *.md" in manifest
+    assert (
+        "recursive-include plugins/research_protocol *.json *.yaml *.sql *.md"
+        in manifest
+    )

--- a/tests/plugins/research_protocol/test_packaged_schemas.py
+++ b/tests/plugins/research_protocol/test_packaged_schemas.py
@@ -141,11 +141,6 @@ def test_versioned_policy_documents_validate_strictly():
 
 def test_packaging_metadata_covers_all_research_protocol_data_channels():
     pyproject = (PLUGIN_ROOT.parents[1] / "pyproject.toml").read_text(encoding="utf-8")
-    manifest = (PLUGIN_ROOT.parents[1] / "MANIFEST.in").read_text(encoding="utf-8")
 
     for suffix in ("*.json", "*.yaml", "*.sql", "*.md"):
         assert f'"research_protocol/**/*{suffix[1:]}"' in pyproject
-    assert (
-        "recursive-include plugins/research_protocol *.json *.yaml *.sql *.md"
-        in manifest
-    )

--- a/tests/plugins/research_protocol/test_planner_tools.py
+++ b/tests/plugins/research_protocol/test_planner_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+import json
 import threading
 
 from plugins.research_protocol import register
@@ -362,6 +363,25 @@ def test_artifact_write_persists_without_accepting_a_path(tmp_path):
         "byte_length",
         "created_at",
     }
+
+
+def test_artifact_write_accepts_json_deserialized_payload(tmp_path):
+    json_payload = json.loads(PlanV1.model_validate(_plan_payload()).model_dump_json())
+
+    result = asyncio.run(
+        _handlers(tmp_path).artifact_write({
+            "artifact_type": "plan",
+            "artifact_id": "plan-json-boundary",
+            "payload": json_payload,
+        })
+    )
+
+    assert result["ok"] is True
+    assert result["receipt"]["path_relative"] == "plans/plan-json-boundary.json"
+    persisted = json.loads(
+        (tmp_path / result["receipt"]["path_relative"]).read_text(encoding="utf-8")
+    )
+    assert persisted == json_payload
 
 
 def test_artifact_write_redacts_filesystem_error_details():

--- a/tests/plugins/research_protocol/test_planner_tools.py
+++ b/tests/plugins/research_protocol/test_planner_tools.py
@@ -1,0 +1,461 @@
+"""Contracts for the closed planner tool surface."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+import threading
+
+from plugins.research_protocol import register
+from plugins.research_protocol.approval import (
+    ApprovalRecord,
+    ApprovalScope,
+    ApprovalVerdict,
+)
+from plugins.research_protocol.models import (
+    BudgetLimits,
+    Capability,
+    CapabilityGrant,
+    ExternalRight,
+    OutputRequirement,
+    PlanV1,
+)
+from plugins.research_protocol.planner_tools import (
+    PlannerToolHandlers,
+    _scope_matches_plan,
+    configure_planner_runtime,
+    plan_context_read,
+)
+from plugins.research_protocol.storage.artifacts import ArtifactReceipt, ArtifactStore
+
+EXPECTED_TOOLS = {
+    "plan_context_read",
+    "plan_artifact_write",
+    "plan_approval_request",
+}
+PLAN_SHA_INPUT = "a" * 64
+
+
+def _plan_payload() -> dict:
+    return {
+        "schema_version": "plan.v1",
+        "producer_version": "test",
+        "run_id": "run-001",
+        "created_at": datetime(2026, 7, 14, 2, 0, tzinfo=UTC),
+        "objective": "SECRET_OBJECTIVE_MUST_NOT_REACH_CONSENT",
+        "constraints": ("offline",),
+        "inputs": (),
+        "outputs": (
+            OutputRequirement(
+                artifact_id="manifest-001",
+                artifact_type="manifest",
+            ),
+        ),
+        "budgets": BudgetLimits(
+            max_duration_seconds=60,
+            max_executions=1,
+            max_records=10,
+            max_bytes=1000,
+            max_external_calls=0,
+        ),
+        "capabilities": (
+            CapabilityGrant(
+                capability=Capability.RESEARCH_COLLECT,
+                input_hashes=(PLAN_SHA_INPUT,),
+                external_rights=(),
+            ),
+        ),
+    }
+
+
+def _approval_scope(plan_sha256: str, **changes) -> ApprovalScope:
+    values = {
+        "capability": Capability.RESEARCH_COLLECT,
+        "run_id": "run-001",
+        "plan_sha256": plan_sha256,
+        "input_hashes": [PLAN_SHA_INPUT],
+        "budgets": BudgetLimits(
+            max_duration_seconds=60,
+            max_executions=1,
+            max_records=10,
+            max_bytes=1000,
+            max_external_calls=0,
+        ),
+        "expires_at": datetime(2099, 1, 1, tzinfo=UTC),
+        "max_executions": 1,
+        "external_rights": [],
+    }
+    values.update(changes)
+    return ApprovalScope.model_validate(values)
+
+
+class RecordingContext:
+    def __init__(self):
+        self.calls = []
+
+    def register_tool(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_register_exposes_exactly_three_planner_tools():
+    context = RecordingContext()
+
+    register(context)
+
+    assert {call["name"] for call in context.calls} == EXPECTED_TOOLS
+    assert {call["toolset"] for call in context.calls} == {"planner"}
+    assert all(call["check_fn"] is not None for call in context.calls)
+    assert all(call["is_async"] is True for call in context.calls)
+
+
+def test_planner_tool_schemas_have_closed_top_level_inputs_without_free_authority():
+    context = RecordingContext()
+    register(context)
+
+    for call in context.calls:
+        parameters = call["schema"]["parameters"]
+        assert parameters["type"] == "object"
+        assert parameters["additionalProperties"] is False
+        assert not ({"path", "sql", "dsn"} & set(parameters.get("properties", {})))
+
+    schemas = {call["name"]: call["schema"] for call in context.calls}
+    assert schemas["plan_context_read"]["parameters"]["properties"]["query_id"]["enum"]
+    assert schemas["plan_artifact_write"]["parameters"]["properties"]["artifact_type"][
+        "enum"
+    ]
+    assert "summary" not in schemas["plan_approval_request"]["parameters"]["properties"]
+
+    def assert_objects_are_closed(node):
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                assert node.get("additionalProperties") is False
+            for value in node.values():
+                assert_objects_are_closed(value)
+        elif isinstance(node, list):
+            for value in node:
+                assert_objects_are_closed(value)
+
+    for schema in schemas.values():
+        assert_objects_are_closed(schema["parameters"])
+
+
+class FakeContextReader:
+    def __init__(self):
+        self.calls = []
+
+    async def read(self, query_id, parameters):
+        self.calls.append((query_id, parameters))
+        return [{"approval_id": parameters["approval_id"], "verdict": "approved"}]
+
+
+class FailingContextReader:
+    async def read(self, query_id, parameters):
+        del query_id, parameters
+        raise RuntimeError("postgresql://user:secret@example.invalid/database")
+
+
+class FailingArtifactStore:
+    def persist(self, artifact_type, artifact_id, payload):
+        del artifact_type, artifact_id, payload
+        raise OSError("cannot write /operator/private/artifacts")
+
+
+def test_artifact_write_does_not_block_the_event_loop():
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    class BlockingArtifactStore(ArtifactStore):
+        def __init__(self):
+            pass
+
+        def persist(self, artifact_type, artifact_id, payload):
+            del payload
+            entered.set()
+            release.wait(timeout=0.5)
+            finished.set()
+            return ArtifactReceipt(
+                artifact_id=artifact_id,
+                artifact_type=artifact_type,
+                schema_version="plan.v1",
+                path_relative="plans/plan-001.json",
+                sha256="a" * 64,
+                byte_length=1,
+                created_at="2026-07-14T02:00:00+00:00",
+            )
+
+    handlers = PlannerToolHandlers(
+        artifact_store=BlockingArtifactStore(),
+        context_reader=None,
+        approval_service=None,
+    )
+
+    async def scenario():
+        task = asyncio.create_task(
+            handlers.artifact_write({
+                "artifact_type": "plan",
+                "artifact_id": "plan-001",
+                "payload": _plan_payload(),
+            })
+        )
+        while not entered.is_set():
+            await asyncio.sleep(0.001)
+        await asyncio.sleep(0)
+        assert not finished.is_set(), "synchronous artifact I/O blocked the event loop"
+        release.set()
+        return await task
+
+    result = asyncio.run(scenario())
+
+    assert result["ok"] is True
+
+
+class RecordingApprovalService:
+    def __init__(self):
+        self.calls = []
+
+    async def request(self, scope, summary):
+        self.calls.append((scope, summary))
+        return ApprovalRecord(
+            approval_id="approval-record-000001",
+            scope_sha256=scope.scope_sha256(),
+            plan_sha256=scope.plan_sha256,
+            scope_json=scope.canonical_json(),
+            verdict=ApprovalVerdict.APPROVED,
+            surface="test",
+            created_at=datetime(2026, 7, 14, 2, 0, tzinfo=UTC),
+            expires_at=scope.expires_at,
+            max_executions=scope.max_executions,
+            consumed_count=0,
+        )
+
+
+def test_approval_plan_read_does_not_block_the_event_loop():
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    plan_bytes = (
+        PlanV1.model_validate(_plan_payload()).model_dump_json().encode("utf-8")
+    )
+
+    class BlockingArtifactStore(ArtifactStore):
+        def __init__(self):
+            pass
+
+        def read_verified(
+            self,
+            artifact_type,
+            artifact_id,
+            *,
+            expected_sha256=None,
+        ):
+            del artifact_type, artifact_id, expected_sha256
+            entered.set()
+            release.wait(timeout=0.5)
+            finished.set()
+            return plan_bytes
+
+    expected_sha256 = "c" * 64
+    handlers = PlannerToolHandlers(
+        artifact_store=BlockingArtifactStore(),
+        context_reader=None,
+        approval_service=RecordingApprovalService(),
+    )
+
+    async def scenario():
+        task = asyncio.create_task(
+            handlers.approval_request({
+                "artifact_id": "plan-001",
+                "expected_sha256": expected_sha256,
+                "scope": _approval_scope(expected_sha256),
+            })
+        )
+        while not entered.is_set():
+            await asyncio.sleep(0.001)
+        await asyncio.sleep(0)
+        assert not finished.is_set(), "synchronous plan read blocked the event loop"
+        release.set()
+        return await task
+
+    result = asyncio.run(scenario())
+
+    assert result["ok"] is True
+    assert result["approved"] is True
+
+
+def _handlers(tmp_path, *, approvals=None, reader=None):
+    return PlannerToolHandlers(
+        artifact_store=ArtifactStore(tmp_path),
+        context_reader=reader or FakeContextReader(),
+        approval_service=approvals or RecordingApprovalService(),
+    )
+
+
+def test_context_read_delegates_only_query_id_and_validated_parameters(tmp_path):
+    reader = FakeContextReader()
+    handlers = _handlers(tmp_path, reader=reader)
+
+    result = asyncio.run(
+        handlers.context_read({
+            "query_id": "approval_status.v1",
+            "parameters": {"approval_id": "approval-001"},
+        })
+    )
+
+    assert result == {
+        "ok": True,
+        "query_id": "approval_status.v1",
+        "rows": [{"approval_id": "approval-001", "verdict": "approved"}],
+        "row_count": 1,
+    }
+    assert reader.calls == [("approval_status.v1", {"approval_id": "approval-001"})]
+
+
+def test_context_read_redacts_dependency_error_details(tmp_path):
+    handlers = _handlers(tmp_path, reader=FailingContextReader())
+
+    result = asyncio.run(
+        handlers.context_read({
+            "query_id": "approval_status.v1",
+            "parameters": {"approval_id": "approval-001"},
+        })
+    )
+
+    assert result == {"ok": False, "error": "planner context read failed"}
+    assert "secret" not in repr(result)
+
+
+def test_registered_handler_accepts_registry_keyword_arguments(tmp_path):
+    reader = FakeContextReader()
+    configure_planner_runtime(_handlers(tmp_path, reader=reader))
+    try:
+        result = asyncio.run(
+            plan_context_read(
+                query_id="approval_status.v1",
+                parameters={"approval_id": "approval-001"},
+            )
+        )
+    finally:
+        configure_planner_runtime(None)
+
+    assert result["ok"] is True
+    assert reader.calls == [("approval_status.v1", {"approval_id": "approval-001"})]
+
+
+def test_artifact_write_persists_without_accepting_a_path(tmp_path):
+    result = asyncio.run(
+        _handlers(tmp_path).artifact_write({
+            "artifact_type": "plan",
+            "artifact_id": "plan-001",
+            "payload": _plan_payload(),
+        })
+    )
+
+    assert result["ok"] is True
+    assert result["receipt"]["path_relative"] == "plans/plan-001.json"
+    assert set(result["receipt"]) == {
+        "artifact_id",
+        "artifact_type",
+        "schema_version",
+        "path_relative",
+        "sha256",
+        "byte_length",
+        "created_at",
+    }
+
+
+def test_artifact_write_redacts_filesystem_error_details():
+    handlers = PlannerToolHandlers(
+        artifact_store=FailingArtifactStore(),
+        context_reader=FakeContextReader(),
+        approval_service=RecordingApprovalService(),
+    )
+
+    result = asyncio.run(
+        handlers.artifact_write({
+            "artifact_type": "plan",
+            "artifact_id": "plan-redaction",
+            "payload": _plan_payload(),
+        })
+    )
+
+    assert result == {"ok": False, "error": "artifact write failed"}
+    assert "/operator/private" not in repr(result)
+
+
+def test_scope_matching_is_order_independent_for_exact_hashes_and_rights():
+    plan_sha256 = "c" * 64
+    payload = _plan_payload()
+    payload["capabilities"] = (
+        CapabilityGrant(
+            capability=Capability.RESEARCH_COLLECT,
+            input_hashes=("b" * 64, "a" * 64),
+            external_rights=(
+                ExternalRight.NETWORK_READ,
+                ExternalRight.DATABASE_READ,
+            ),
+        ),
+    )
+    plan = PlanV1.model_validate(payload)
+    scope = _approval_scope(
+        plan_sha256,
+        input_hashes=["a" * 64, "b" * 64],
+        external_rights=[
+            ExternalRight.DATABASE_READ,
+            ExternalRight.NETWORK_READ,
+        ],
+    )
+
+    assert _scope_matches_plan(scope, plan, plan_sha256) is True
+
+
+def test_approval_request_reloads_exact_plan_and_builds_fixed_redacted_summary(
+    tmp_path,
+):
+    store = ArtifactStore(tmp_path)
+    receipt = store.persist("plan", "plan-001", _plan_payload())
+    approvals = RecordingApprovalService()
+    handlers = PlannerToolHandlers(
+        artifact_store=store,
+        context_reader=FakeContextReader(),
+        approval_service=approvals,
+    )
+
+    result = asyncio.run(
+        handlers.approval_request({
+            "artifact_id": "plan-001",
+            "expected_sha256": receipt.sha256,
+            "scope": _approval_scope(receipt.sha256),
+        })
+    )
+
+    assert result["ok"] is True
+    assert result["approval"]["approval_id"] == "approval-record-000001"
+    assert len(approvals.calls) == 1
+    scope, summary = approvals.calls[0]
+    assert receipt.sha256 in summary
+    assert f"scope_sha256={scope.scope_sha256()}" in summary
+    assert f"scope_json={scope.canonical_json()}" in summary
+    assert "SECRET_OBJECTIVE" not in summary
+
+
+def test_approval_request_rejects_scope_drift_before_native_consent(tmp_path):
+    store = ArtifactStore(tmp_path)
+    receipt = store.persist("plan", "plan-001", _plan_payload())
+    approvals = RecordingApprovalService()
+    handlers = PlannerToolHandlers(
+        artifact_store=store,
+        context_reader=FakeContextReader(),
+        approval_service=approvals,
+    )
+
+    result = asyncio.run(
+        handlers.approval_request({
+            "artifact_id": "plan-001",
+            "expected_sha256": receipt.sha256,
+            "scope": _approval_scope(receipt.sha256, run_id="other-run"),
+        })
+    )
+
+    assert result == {"ok": False, "error": "approval scope does not match plan"}
+    assert approvals.calls == []

--- a/tests/plugins/research_protocol/test_plugin_discovery.py
+++ b/tests/plugins/research_protocol/test_plugin_discovery.py
@@ -1,0 +1,99 @@
+"""Discovery contract for the opt-in research protocol plugin."""
+
+import pytest
+import yaml
+
+from hermes_cli.plugins import PluginManager
+
+
+PLUGIN_KEY = "research-protocol"
+
+
+def _configure_plugins(hermes_home, plugins):
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": plugins}),
+        encoding="utf-8",
+    )
+
+
+def _discover(tmp_path, monkeypatch, plugins=None):
+    hermes_home = tmp_path / "hermes-home"
+    if plugins is not None:
+        _configure_plugins(hermes_home, plugins)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_BUNDLED_PLUGINS", raising=False)
+    manager = PluginManager()
+    manager.discover_and_load()
+    return manager._plugins[PLUGIN_KEY]
+
+
+def _assert_no_runtime_registrations(loaded):
+    assert loaded.tools_registered == []
+    assert loaded.hooks_registered == []
+    assert loaded.middleware_registered == []
+    assert loaded.commands_registered == []
+
+
+def test_research_protocol_is_discovered_but_not_enabled_by_default(
+    tmp_path, monkeypatch
+):
+    """The bundled plugin is visible to discovery but remains opt-in."""
+    loaded = _discover(tmp_path, monkeypatch)
+
+    assert loaded.manifest.name == PLUGIN_KEY
+    assert loaded.manifest.key == PLUGIN_KEY
+    assert loaded.manifest.kind == "standalone"
+    assert loaded.enabled is False
+    assert loaded.module is None
+    assert "not enabled in config" in (loaded.error or "")
+    _assert_no_runtime_registrations(loaded)
+
+
+def test_research_protocol_explicit_enable_loads_no_runtime_behavior(
+    tmp_path, monkeypatch
+):
+    """The exact public key opts in, but the PR 0 entry point is a no-op."""
+    loaded = _discover(tmp_path, monkeypatch, {"enabled": [PLUGIN_KEY]})
+
+    assert loaded.enabled is True
+    assert loaded.error is None
+    _assert_no_runtime_registrations(loaded)
+
+
+@pytest.mark.parametrize("enabled", [None, "", {}, [], PLUGIN_KEY])
+def test_research_protocol_malformed_or_empty_enabled_fails_closed(
+    tmp_path, monkeypatch, enabled
+):
+    """Only an explicit list containing the exact plugin key enables code."""
+    loaded = _discover(tmp_path, monkeypatch, {"enabled": enabled})
+
+    assert loaded.enabled is False
+    assert loaded.module is None
+    assert "not enabled in config" in (loaded.error or "")
+    _assert_no_runtime_registrations(loaded)
+
+
+def test_research_protocol_disabled_list_has_priority(tmp_path, monkeypatch):
+    """An explicit deny wins even if the same plugin is allowlisted."""
+    loaded = _discover(
+        tmp_path,
+        monkeypatch,
+        {"enabled": [PLUGIN_KEY], "disabled": [PLUGIN_KEY]},
+    )
+
+    assert loaded.enabled is False
+    assert loaded.module is None
+    assert "disabled via config" in (loaded.error or "")
+    _assert_no_runtime_registrations(loaded)
+
+
+def test_pr0_register_entry_point_cannot_touch_any_plugin_surface():
+    """The PR 0 entry point must remain a true no-op on every context API."""
+    from plugins.research_protocol import register
+
+    class RejectEveryContextAccess:
+        def __getattr__(self, name):
+            pytest.fail(f"register() accessed plugin context surface {name!r}")
+
+    assert register(RejectEveryContextAccess()) is None

--- a/tests/plugins/research_protocol/test_plugin_discovery.py
+++ b/tests/plugins/research_protocol/test_plugin_discovery.py
@@ -44,21 +44,34 @@ def test_research_protocol_is_discovered_but_not_enabled_by_default(
     assert loaded.manifest.name == PLUGIN_KEY
     assert loaded.manifest.key == PLUGIN_KEY
     assert loaded.manifest.kind == "standalone"
+    assert loaded.manifest.version == "0.2.0"
+    assert set(loaded.manifest.provides_tools) == {
+        "plan_context_read",
+        "plan_artifact_write",
+        "plan_approval_request",
+    }
     assert loaded.enabled is False
     assert loaded.module is None
     assert "not enabled in config" in (loaded.error or "")
     _assert_no_runtime_registrations(loaded)
 
 
-def test_research_protocol_explicit_enable_loads_no_runtime_behavior(
+def test_research_protocol_explicit_enable_registers_exact_pr2_surface(
     tmp_path, monkeypatch
 ):
-    """The exact public key opts in, but the PR 0 entry point is a no-op."""
+    """The exact public key opts into only the three bounded planner tools."""
     loaded = _discover(tmp_path, monkeypatch, {"enabled": [PLUGIN_KEY]})
 
     assert loaded.enabled is True
     assert loaded.error is None
-    _assert_no_runtime_registrations(loaded)
+    assert set(loaded.tools_registered) == {
+        "plan_context_read",
+        "plan_artifact_write",
+        "plan_approval_request",
+    }
+    assert loaded.hooks_registered == []
+    assert loaded.middleware_registered == []
+    assert loaded.commands_registered == []
 
 
 @pytest.mark.parametrize("enabled", [None, "", {}, [], PLUGIN_KEY])
@@ -88,12 +101,84 @@ def test_research_protocol_disabled_list_has_priority(tmp_path, monkeypatch):
     _assert_no_runtime_registrations(loaded)
 
 
-def test_pr0_register_entry_point_cannot_touch_any_plugin_surface():
-    """The PR 0 entry point must remain a true no-op on every context API."""
+def test_pr2_register_entry_point_only_touches_tool_registration(
+    tmp_path,
+    monkeypatch,
+):
+    """PR2 must not gain hooks, middleware, commands, LLM, or other surfaces."""
     from plugins.research_protocol import register
 
-    class RejectEveryContextAccess:
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("plugins: {}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    calls = []
+
+    class ToolOnlyContext:
+        def register_tool(self, **kwargs):
+            calls.append(kwargs)
+
         def __getattr__(self, name):
             pytest.fail(f"register() accessed plugin context surface {name!r}")
 
-    assert register(RejectEveryContextAccess()) is None
+    assert register(ToolOnlyContext()) is None
+    assert {call["name"] for call in calls} == {
+        "plan_context_read",
+        "plan_artifact_write",
+        "plan_approval_request",
+    }
+    assert {call["toolset"] for call in calls} == {"planner"}
+    assert all(call["is_async"] is True for call in calls)
+    assert all(call["check_fn"]() is False for call in calls)
+
+
+def test_register_reads_real_plugin_entry_config_without_opening_database(
+    tmp_path,
+    monkeypatch,
+):
+    from plugins.research_protocol import register
+    from plugins.research_protocol.runtime import (
+        READER_DATABASE_URL_ENV,
+        WRITER_DATABASE_URL_ENV,
+    )
+
+    artifact_root = tmp_path / "artifacts"
+    hermes_home = tmp_path / "hermes-home"
+    _configure_plugins(
+        hermes_home,
+        {
+            "enabled": [PLUGIN_KEY],
+            "entries": {
+                PLUGIN_KEY: {
+                    "artifact_root": str(artifact_root),
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv(
+        READER_DATABASE_URL_ENV,
+        "postgresql://reader@localhost/research-reader",
+    )
+    monkeypatch.setenv(
+        WRITER_DATABASE_URL_ENV,
+        "postgresql://writer@localhost/research-writer",
+    )
+    calls = []
+
+    class ToolOnlyContext:
+        def register_tool(self, **kwargs):
+            calls.append(kwargs)
+
+        def __getattr__(self, name):
+            pytest.fail(f"register() accessed plugin context surface {name!r}")
+
+    register(ToolOnlyContext())
+
+    assert artifact_root.is_dir()
+    assert {call["name"] for call in calls} == {
+        "plan_context_read",
+        "plan_artifact_write",
+        "plan_approval_request",
+    }
+    assert all(call["check_fn"]() is True for call in calls)

--- a/tests/plugins/research_protocol/test_plugin_discovery.py
+++ b/tests/plugins/research_protocol/test_plugin_discovery.py
@@ -1,5 +1,10 @@
 """Discovery contract for the opt-in research protocol plugin."""
 
+import os
+from pathlib import Path
+import subprocess
+import sys
+
 import pytest
 import yaml
 
@@ -72,6 +77,78 @@ def test_research_protocol_explicit_enable_registers_exact_pr2_surface(
     assert loaded.hooks_registered == []
     assert loaded.middleware_registered == []
     assert loaded.commands_registered == []
+
+
+def test_enabled_discovery_without_fcntl_registers_unavailable_tools(tmp_path):
+    """Windows-like discovery must load the plugin and fail closed at runtime."""
+    hermes_home = tmp_path / "hermes-home"
+    _configure_plugins(
+        hermes_home,
+        {
+            "enabled": [PLUGIN_KEY],
+            "entries": {
+                PLUGIN_KEY: {
+                    "artifact_root": str(tmp_path / "artifacts"),
+                }
+            },
+        },
+    )
+    script = """
+import builtins
+import importlib
+
+original_import = builtins.__import__
+original_import_module = importlib.import_module
+
+
+def import_without_fcntl(name, *args, **kwargs):
+    if name == "fcntl":
+        raise ModuleNotFoundError("No module named 'fcntl'")
+    return original_import(name, *args, **kwargs)
+
+
+def import_module_without_fcntl(name, *args, **kwargs):
+    if name == "fcntl":
+        raise ModuleNotFoundError("No module named 'fcntl'")
+    return original_import_module(name, *args, **kwargs)
+
+
+builtins.__import__ = import_without_fcntl
+importlib.import_module = import_module_without_fcntl
+
+from hermes_cli.plugins import PluginManager
+from tools.registry import registry
+
+manager = PluginManager()
+manager.discover_and_load()
+loaded = manager._plugins["research-protocol"]
+assert loaded.enabled is True
+assert loaded.error is None
+assert set(loaded.tools_registered) == {
+    "plan_context_read",
+    "plan_artifact_write",
+    "plan_approval_request",
+}
+assert all(
+    registry.get_entry(name) is not None
+    and registry.get_entry(name).check_fn is not None
+    and not registry.get_entry(name).check_fn()
+    for name in loaded.tools_registered
+)
+"""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_BUNDLED_PLUGINS", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[3],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 @pytest.mark.parametrize("enabled", [None, "", {}, [], PLUGIN_KEY])

--- a/tests/plugins/research_protocol/test_postgres_integration.py
+++ b/tests/plugins/research_protocol/test_postgres_integration.py
@@ -1,0 +1,559 @@
+"""Disposable PostgreSQL integration gate for PR2.
+
+Set RESEARCH_PROTOCOL_TEST_DATABASE_URL to a dedicated disposable database.
+The test is skipped otherwise and never falls back to a developer database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+import os
+from pathlib import Path
+
+import pytest
+
+from plugins.research_protocol.approval import (
+    ApprovalRecord,
+    ApprovalScope,
+    ApprovalVerdict,
+)
+from plugins.research_protocol.models import BudgetLimits, Capability
+from plugins.research_protocol.storage.postgres import (
+    ApprovalStoreTimeoutError,
+    ContextReadLimitError,
+    ContextReadTimeoutError,
+    PostgresApprovalStore,
+    PostgresContextReader,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEST_DSN_ENV = "RESEARCH_PROTOCOL_TEST_DATABASE_URL"
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+APPROVAL_SINGLE = "approval-single-00000001"
+APPROVAL_WRONG_HASH = "approval-wrong-hash-0001"
+APPROVAL_EXPIRED = "approval-expired-0000001"
+APPROVAL_DENIED = "approval-denied-00000001"
+APPROVAL_CONCURRENT = "approval-concurrent-0001"
+APPROVAL_RESTRICTIVE_SCOPE = "approval-restrictive-0001"
+
+
+def _scope(
+    *,
+    run_id: str = "run-integration",
+    expires_at: datetime = datetime(2099, 1, 1, tzinfo=UTC),
+    budget_max_executions: int = 1,
+    max_executions: int = 1,
+) -> ApprovalScope:
+    return ApprovalScope.model_validate({
+        "capability": Capability.RESEARCH_COLLECT,
+        "run_id": run_id,
+        "plan_sha256": SHA_B,
+        "input_hashes": ["a" * 64],
+        "budgets": BudgetLimits(
+            max_duration_seconds=60,
+            max_executions=budget_max_executions,
+            max_records=10,
+            max_bytes=4096,
+            max_external_calls=0,
+        ),
+        "expires_at": expires_at,
+        "max_executions": max_executions,
+        "external_rights": [],
+    })
+
+
+def _record(
+    approval_id: str,
+    *,
+    scope: ApprovalScope,
+    created_at: datetime = datetime(2026, 1, 1, tzinfo=UTC),
+    verdict: ApprovalVerdict = ApprovalVerdict.APPROVED,
+) -> ApprovalRecord:
+    return ApprovalRecord(
+        approval_id=approval_id,
+        scope_sha256=scope.scope_sha256(),
+        plan_sha256=scope.plan_sha256,
+        scope_json=scope.canonical_json(),
+        verdict=verdict,
+        surface="integration-test",
+        created_at=created_at,
+        expires_at=scope.expires_at,
+        max_executions=scope.max_executions,
+        consumed_count=0,
+    )
+
+
+async def _exercise_database(dsn: str) -> None:
+    import asyncpg
+
+    admin = await asyncpg.connect(dsn)
+    try:
+        for name in ("0001_approval_ledger.sql", "0002_roles.sql"):
+            sql = (
+                REPO_ROOT / "plugins" / "research_protocol" / "migrations" / name
+            ).read_text(encoding="utf-8")
+            await admin.execute(sql)
+        await admin.execute("TRUNCATE TABLE research_protocol.approvals")
+    finally:
+        await admin.close()
+
+    collision = await asyncpg.connect(dsn)
+    try:
+        roles_sql = (
+            REPO_ROOT
+            / "plugins"
+            / "research_protocol"
+            / "migrations"
+            / "0002_roles.sql"
+        ).read_text(encoding="utf-8")
+        with pytest.raises(asyncpg.DuplicateObjectError):
+            await collision.execute(roles_sql)
+    finally:
+        await collision.close()
+
+    pool = await asyncpg.create_pool(dsn, min_size=1, max_size=4)
+    try:
+        store = PostgresApprovalStore(pool)
+
+        valid_scope = _scope()
+        await store.create_approval(_record(APPROVAL_SINGLE, scope=valid_scope))
+        assert (
+            await store.claim_approval(
+                approval_id=APPROVAL_SINGLE,
+                scope=valid_scope,
+                plan_sha256=SHA_B,
+            )
+            is True
+        )
+        assert (
+            await store.claim_approval(
+                approval_id=APPROVAL_SINGLE,
+                scope=valid_scope,
+                plan_sha256=SHA_B,
+            )
+            is False
+        )
+
+        restrictive_scope = _scope(
+            run_id="run-restrictive-scope",
+            budget_max_executions=2,
+            max_executions=1,
+        )
+        await store.create_approval(
+            _record(APPROVAL_RESTRICTIVE_SCOPE, scope=restrictive_scope)
+        )
+        assert (
+            await store.claim_approval(
+                approval_id=APPROVAL_RESTRICTIVE_SCOPE,
+                scope=restrictive_scope,
+                plan_sha256=SHA_B,
+            )
+            is True
+        )
+        assert (
+            await store.claim_approval(
+                approval_id=APPROVAL_RESTRICTIVE_SCOPE,
+                scope=restrictive_scope,
+                plan_sha256=SHA_B,
+            )
+            is False
+        )
+
+        await store.create_approval(_record(APPROVAL_WRONG_HASH, scope=valid_scope))
+        wrong_scope = _scope(run_id="run-other")
+        assert (
+            await store.claim_approval(
+                approval_id=APPROVAL_WRONG_HASH,
+                scope=wrong_scope,
+                plan_sha256=SHA_B,
+            )
+            is False
+        )
+
+        expired_scope = _scope(
+            expires_at=datetime(2021, 1, 1, tzinfo=UTC),
+        )
+        with pytest.raises(asyncpg.InvalidParameterValueError):
+            await store.create_approval(
+                _record(
+                    APPROVAL_EXPIRED,
+                    scope=expired_scope,
+                    created_at=datetime(2020, 1, 1, tzinfo=UTC),
+                )
+            )
+
+        denied = _record(
+            APPROVAL_DENIED,
+            scope=expired_scope,
+            verdict=ApprovalVerdict.DENIED,
+        )
+        await store.create_approval(denied)
+        assert (
+            await store.claim_approval(
+                approval_id=APPROVAL_DENIED,
+                scope=expired_scope,
+                plan_sha256=SHA_B,
+            )
+            is False
+        )
+
+        await store.create_approval(_record(APPROVAL_CONCURRENT, scope=valid_scope))
+        claims = await asyncio.gather(
+            store.claim_approval(
+                approval_id=APPROVAL_CONCURRENT,
+                scope=valid_scope,
+                plan_sha256=SHA_B,
+            ),
+            store.claim_approval(
+                approval_id=APPROVAL_CONCURRENT,
+                scope=valid_scope,
+                plan_sha256=SHA_B,
+            ),
+        )
+        assert sum(claims) == 1
+
+        reader = PostgresContextReader(
+            pool,
+            max_rows=10,
+            max_bytes=16_384,
+            timeout_seconds=2.0,
+        )
+        rows = await reader.read(
+            "approval_status.v1",
+            {"approval_id": APPROVAL_SINGLE},
+        )
+        assert len(rows) == 1
+        assert rows[0]["approval_id"] == APPROVAL_SINGLE
+        assert rows[0]["consumed_count"] == 1
+
+        denied_rows = await reader.read(
+            "approval_status.v1",
+            {"approval_id": APPROVAL_DENIED},
+        )
+        assert len(denied_rows) == 1
+        assert denied_rows[0]["verdict"] == "denied"
+        assert denied_rows[0]["consumed_count"] == 0
+
+        run_rows = await reader.read(
+            "approvals_for_run.v1",
+            {"run_id": "run-integration", "limit": 10},
+        )
+        assert 1 <= len(run_rows) <= 10
+
+        capped_reader = PostgresContextReader(
+            pool,
+            max_rows=1,
+            max_bytes=16_384,
+            timeout_seconds=2.0,
+        )
+        with pytest.raises(ContextReadLimitError, match="row cap"):
+            await capped_reader.read(
+                "approvals_for_run.v1",
+                {"run_id": "run-integration", "limit": 1},
+            )
+
+        byte_capped_reader = PostgresContextReader(
+            pool,
+            max_rows=10,
+            max_bytes=64,
+            timeout_seconds=2.0,
+        )
+        with pytest.raises(ContextReadLimitError, match="byte cap"):
+            await byte_capped_reader.read(
+                "approval_status.v1",
+                {"approval_id": APPROVAL_SINGLE},
+            )
+
+        claimant_scope = _scope(run_id="run-role-claimant")
+        claimant_approval_id = "approval-role-claimant-0001"
+        await store.create_approval(_record(claimant_approval_id, scope=claimant_scope))
+        expiring_scope = _scope(
+            run_id="run-long-transaction-expiry",
+            expires_at=datetime.now(UTC) + timedelta(seconds=1),
+        )
+        expiring_approval_id = "approval-long-expiry-0001"
+        await store.create_approval(_record(expiring_approval_id, scope=expiring_scope))
+
+        role_connection = await pool.acquire()
+        try:
+            role_rows = await role_connection.fetch(
+                """
+                SELECT rolname, rolsuper, rolinherit, rolcreaterole,
+                       rolcreatedb, rolcanlogin, rolreplication, rolbypassrls
+                FROM pg_roles
+                WHERE rolname = ANY($1::text[])
+                ORDER BY rolname
+                """,
+                [
+                    "research_protocol_approval_claimant",
+                    "research_protocol_approval_writer",
+                    "research_protocol_planner_reader",
+                ],
+            )
+            assert len(role_rows) == 3
+            for role_row in role_rows:
+                assert all(
+                    role_row[field] is False
+                    for field in (
+                        "rolsuper",
+                        "rolinherit",
+                        "rolcreaterole",
+                        "rolcreatedb",
+                        "rolcanlogin",
+                        "rolreplication",
+                        "rolbypassrls",
+                    )
+                )
+            assert (
+                await role_connection.fetchval(
+                    """
+                    SELECT count(*)
+                    FROM pg_auth_members AS membership
+                    JOIN pg_roles AS child ON child.oid = membership.member
+                    WHERE child.rolname = ANY($1::text[])
+                    """,
+                    [
+                        "research_protocol_approval_claimant",
+                        "research_protocol_approval_writer",
+                        "research_protocol_planner_reader",
+                    ],
+                )
+                == 0
+            )
+
+            async with role_connection.transaction():
+                await role_connection.execute(
+                    "SET LOCAL ROLE research_protocol_planner_reader"
+                )
+                assert (
+                    await role_connection.fetchval(
+                        "SELECT count(*) FROM research_protocol.approvals"
+                    )
+                    >= 1
+                )
+
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_planner_reader"
+                    )
+                    await role_connection.execute(
+                        "UPDATE research_protocol.approvals "
+                        "SET consumed_count = consumed_count WHERE false"
+                    )
+
+            role_record = _record(
+                "approval-role-writer-0001",
+                scope=_scope(),
+            )
+            writer_transaction = role_connection.transaction()
+            await writer_transaction.start()
+            try:
+                await role_connection.execute(
+                    "SET LOCAL ROLE research_protocol_approval_writer"
+                )
+                await role_connection.execute(
+                    """
+                    SELECT research_protocol.store_approval(
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9
+                    )
+                    """,
+                    role_record.approval_id,
+                    role_record.scope_sha256,
+                    role_record.plan_sha256,
+                    role_record.scope_json,
+                    role_record.verdict.value,
+                    role_record.surface,
+                    role_record.created_at,
+                    role_record.expires_at,
+                    role_record.max_executions,
+                )
+            finally:
+                await writer_transaction.rollback()
+
+            tampered_scope = _scope(run_id="run-tampered-scope-hash")
+            tampered_record = _record(
+                "approval-tampered-hash-0001",
+                scope=tampered_scope,
+            )
+            with pytest.raises(asyncpg.InvalidParameterValueError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_approval_writer"
+                    )
+                    await role_connection.execute(
+                        """
+                        SELECT research_protocol.store_approval(
+                            $1, $2, $3, $4, $5, $6, $7, $8, $9
+                        )
+                        """,
+                        tampered_record.approval_id,
+                        SHA_A,
+                        tampered_record.plan_sha256,
+                        tampered_record.scope_json,
+                        tampered_record.verdict.value,
+                        tampered_record.surface,
+                        tampered_record.created_at,
+                        tampered_record.expires_at,
+                        tampered_record.max_executions,
+                    )
+            assert (
+                await role_connection.fetchval(
+                    "SELECT count(*) FROM research_protocol.approvals "
+                    "WHERE approval_id = $1",
+                    tampered_record.approval_id,
+                )
+                == 0
+            )
+
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_approval_writer"
+                    )
+                    await role_connection.execute(
+                        "CREATE TABLE research_protocol.forbidden_writer_table "
+                        "(id integer)"
+                    )
+
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_approval_writer"
+                    )
+                    await role_connection.fetchrow(
+                        "SELECT * FROM research_protocol.claim_approval($1, $2, $3)",
+                        claimant_approval_id,
+                        claimant_scope.scope_sha256(),
+                        SHA_B,
+                    )
+
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_approval_writer"
+                    )
+                    await role_connection.execute(
+                        "INSERT INTO research_protocol.approvals "
+                        "(last_consumed_at) VALUES (CURRENT_TIMESTAMP)"
+                    )
+
+            async with role_connection.transaction():
+                await role_connection.execute(
+                    "SET LOCAL ROLE research_protocol_approval_claimant"
+                )
+                claimant_row = await role_connection.fetchrow(
+                    "SELECT approval_id, consumed_count "
+                    "FROM research_protocol.claim_approval($1, $2, $3)",
+                    claimant_approval_id,
+                    claimant_scope.scope_sha256(),
+                    SHA_B,
+                )
+                assert claimant_row is not None
+                assert claimant_row["approval_id"] == claimant_approval_id
+                assert claimant_row["consumed_count"] == 1
+
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_approval_claimant"
+                    )
+                    await role_connection.execute(
+                        "SELECT research_protocol.store_approval("
+                        "NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)"
+                    )
+
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_approval_claimant"
+                    )
+                    await role_connection.execute(
+                        "UPDATE research_protocol.approvals "
+                        "SET consumed_count = consumed_count WHERE false"
+                    )
+
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                async with role_connection.transaction():
+                    await role_connection.execute(
+                        "SET LOCAL ROLE research_protocol_approval_claimant"
+                    )
+                    await role_connection.execute(
+                        "UPDATE research_protocol.approvals "
+                        "SET verdict = verdict WHERE false"
+                    )
+
+            expiry_transaction = role_connection.transaction()
+            await expiry_transaction.start()
+            try:
+                await role_connection.execute(
+                    "SET LOCAL ROLE research_protocol_approval_claimant"
+                )
+                await role_connection.fetchval("SELECT CURRENT_TIMESTAMP")
+                await asyncio.sleep(2)
+                expired_row = await role_connection.fetchrow(
+                    "SELECT approval_id FROM "
+                    "research_protocol.claim_approval($1, $2, $3)",
+                    expiring_approval_id,
+                    expiring_scope.scope_sha256(),
+                    SHA_B,
+                )
+                assert expired_row is None
+            finally:
+                await expiry_transaction.rollback()
+        finally:
+            await pool.release(role_connection)
+
+        timeout_claim_scope = _scope(run_id="run-timeout-claim")
+        timeout_claim_id = "approval-timeout-claim-0001"
+        await store.create_approval(
+            _record(timeout_claim_id, scope=timeout_claim_scope)
+        )
+
+        blocker = await pool.acquire()
+        blocker_transaction = blocker.transaction()
+        await blocker_transaction.start()
+        try:
+            await blocker.execute(
+                "LOCK TABLE research_protocol.approvals IN ACCESS EXCLUSIVE MODE"
+            )
+            timeout_reader = PostgresContextReader(
+                pool,
+                max_rows=10,
+                max_bytes=16_384,
+                timeout_seconds=0.05,
+            )
+            with pytest.raises(ContextReadTimeoutError):
+                await timeout_reader.read(
+                    "approval_status.v1",
+                    {"approval_id": APPROVAL_SINGLE},
+                )
+
+            timeout_store = PostgresApprovalStore(pool, timeout_seconds=0.05)
+            with pytest.raises(ApprovalStoreTimeoutError):
+                await timeout_store.create_approval(
+                    _record(
+                        "approval-timeout-create-0001",
+                        scope=_scope(run_id="run-timeout-create"),
+                    )
+                )
+            with pytest.raises(ApprovalStoreTimeoutError):
+                await timeout_store.claim_approval(
+                    approval_id=timeout_claim_id,
+                    scope=timeout_claim_scope,
+                    plan_sha256=SHA_B,
+                )
+        finally:
+            await blocker_transaction.rollback()
+            await pool.release(blocker)
+    finally:
+        await pool.close()
+
+
+def test_disposable_postgres_approval_claims_and_context_reads():
+    dsn = os.environ.get(TEST_DSN_ENV)
+    if not dsn:
+        pytest.skip(f"{TEST_DSN_ENV} is not set to a disposable database")
+    asyncio.run(_exercise_database(dsn))

--- a/tests/plugins/research_protocol/test_postgres_storage.py
+++ b/tests/plugins/research_protocol/test_postgres_storage.py
@@ -1,0 +1,228 @@
+"""Bounded PostgreSQL registry and read-only adapter tests."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+
+import pytest
+
+from plugins.research_protocol.storage.postgres import (
+    ContextReadLimitError,
+    ContextReadTimeoutError,
+    PostgresApprovalStore,
+    PostgresContextReader,
+    UnknownContextQueryError,
+)
+
+
+class FakeTransaction:
+    def __init__(self, owner, kwargs):
+        self.owner = owner
+        self.kwargs = kwargs
+
+    async def __aenter__(self):
+        self.owner.transactions.append(self.kwargs)
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeConnection:
+    def __init__(self, rows=None, *, delay=0):
+        self.rows = rows or []
+        self.delay = delay
+        self.transactions = []
+        self.executions = []
+        self.fetches = []
+
+    def transaction(self, **kwargs):
+        return FakeTransaction(self, kwargs)
+
+    async def execute(self, sql, *args):
+        self.executions.append((sql, args))
+
+    async def fetch(self, sql, *args):
+        self.fetches.append((sql, args))
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return self.rows
+
+
+class AcquireContext:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakePool:
+    def __init__(self, connection):
+        self.connection = connection
+        self.acquire_count = 0
+
+    def acquire(self):
+        self.acquire_count += 1
+        return AcquireContext(self.connection)
+
+
+def test_unknown_query_is_rejected_before_pool_access():
+    pool = FakePool(FakeConnection())
+    reader = PostgresContextReader(pool)
+
+    with pytest.raises(UnknownContextQueryError):
+        asyncio.run(reader.read("SELECT secret FROM anything", {}))
+
+    assert pool.acquire_count == 0
+
+
+def test_approval_store_rejects_unvalidated_record_before_pool_access():
+    pool = FakePool(FakeConnection())
+    store = PostgresApprovalStore(pool)
+
+    with pytest.raises(TypeError, match="ApprovalRecord"):
+        asyncio.run(store.create_approval(object()))
+
+    assert pool.acquire_count == 0
+
+
+def test_approval_claim_rejects_unvalidated_scope_before_pool_access():
+    pool = FakePool(FakeConnection())
+    store = PostgresApprovalStore(pool)
+
+    class ForgedScope:
+        @staticmethod
+        def scope_sha256():
+            return "a" * 64
+
+    claimed = asyncio.run(
+        store.claim_approval(
+            approval_id="approval-001",
+            scope=ForgedScope(),
+            plan_sha256="b" * 64,
+        )
+    )
+
+    assert claimed is False
+    assert pool.acquire_count == 0
+
+
+def test_context_read_uses_fixed_query_bound_parameters_and_readonly_transaction():
+    connection = FakeConnection([
+        {"approval_id": "approval-001", "verdict": "approved"}
+    ])
+    reader = PostgresContextReader(FakePool(connection), timeout_seconds=2.5)
+
+    rows = asyncio.run(
+        reader.read(
+            "approval_status.v1",
+            {"approval_id": "approval-001"},
+        )
+    )
+
+    assert rows == [{"approval_id": "approval-001", "verdict": "approved"}]
+    assert connection.transactions == [{"readonly": True}]
+    assert len(connection.executions) == 1
+    timeout_sql, timeout_args = connection.executions[0]
+    assert "set_config" in timeout_sql
+    assert timeout_args == ("2500ms",)
+    assert len(connection.fetches) == 1
+    query_sql, query_args = connection.fetches[0]
+    assert "FROM research_protocol.approvals" in query_sql
+    assert query_args == ("approval-001",)
+    assert "approval-001" not in query_sql
+
+
+def test_context_read_logs_bounded_metrics_without_parameters(caplog):
+    sensitive_parameter = "postgresql://sensitive-canary.example.invalid/db"
+    connection = FakeConnection([{"approval_id": sensitive_parameter}])
+    reader = PostgresContextReader(FakePool(connection))
+
+    with caplog.at_level(
+        logging.INFO,
+        logger="plugins.research_protocol.storage.postgres",
+    ):
+        rows = asyncio.run(
+            reader.read(
+                "approval_status.v1",
+                {"approval_id": sensitive_parameter},
+            )
+        )
+
+    assert rows == [{"approval_id": sensitive_parameter}]
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "query_id=approval_status.v1" in messages
+    assert "row_count=1" in messages
+    assert re.search(r"latency_ms=\d+(?:\.\d+)?", messages)
+    assert sensitive_parameter not in messages
+    assert "sensitive-canary" not in messages
+
+
+def test_context_read_enforces_row_cap_after_fetch():
+    connection = FakeConnection([
+        {"approval_id": "one"},
+        {"approval_id": "two"},
+        {"approval_id": "three"},
+    ])
+    reader = PostgresContextReader(FakePool(connection), max_rows=2)
+
+    with pytest.raises(ContextReadLimitError, match="row cap"):
+        asyncio.run(
+            reader.read(
+                "approvals_for_run.v1",
+                {"run_id": "run-001", "limit": 2},
+            )
+        )
+
+    _sql, args = connection.fetches[0]
+    assert args == ("run-001", 3)
+
+
+def test_context_read_enforces_caller_limit_below_global_cap():
+    connection = FakeConnection([
+        {"approval_id": "one"},
+        {"approval_id": "two"},
+    ])
+    reader = PostgresContextReader(FakePool(connection), max_rows=100)
+
+    with pytest.raises(ContextReadLimitError, match="row cap"):
+        asyncio.run(
+            reader.read(
+                "approvals_for_run.v1",
+                {"run_id": "run-001", "limit": 1},
+            )
+        )
+
+    _sql, args = connection.fetches[0]
+    assert args == ("run-001", 2)
+
+
+def test_context_read_enforces_serialized_byte_cap():
+    connection = FakeConnection([{"approval_id": "a" * 200}])
+    reader = PostgresContextReader(FakePool(connection), max_bytes=64)
+
+    with pytest.raises(ContextReadLimitError, match="byte cap"):
+        asyncio.run(
+            reader.read(
+                "approval_status.v1",
+                {"approval_id": "approval-001"},
+            )
+        )
+
+
+def test_context_read_enforces_wall_clock_timeout():
+    connection = FakeConnection([{"approval_id": "approval-001"}], delay=0.05)
+    reader = PostgresContextReader(FakePool(connection), timeout_seconds=0.01)
+
+    with pytest.raises(ContextReadTimeoutError):
+        asyncio.run(
+            reader.read(
+                "approval_status.v1",
+                {"approval_id": "approval-001"},
+            )
+        )

--- a/tests/plugins/research_protocol/test_runtime.py
+++ b/tests/plugins/research_protocol/test_runtime.py
@@ -1,0 +1,130 @@
+"""Fail-closed runtime configuration tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from plugins.research_protocol.planner_tools import (
+    check_planner_approvals,
+    check_planner_artifacts,
+    check_planner_context,
+    configure_planner_runtime,
+)
+from plugins.research_protocol.runtime import (
+    RuntimeConfigurationError,
+    build_runtime_bundle,
+)
+
+
+def test_runtime_rejects_missing_or_relative_artifact_root(tmp_path):
+    with pytest.raises(RuntimeConfigurationError, match="absolute artifact_root"):
+        build_runtime_bundle({}, environ={})
+    with pytest.raises(RuntimeConfigurationError, match="absolute artifact_root"):
+        build_runtime_bundle({"artifact_root": "relative/artifacts"}, environ={})
+
+
+def test_artifact_only_runtime_does_not_enable_database_tools(tmp_path):
+    bundle = build_runtime_bundle(
+        {"artifact_root": str(tmp_path / "artifacts")},
+        environ={},
+    )
+    configure_planner_runtime(
+        bundle.handlers,
+        artifact_available=bundle.artifact_available,
+        context_available=bundle.context_available,
+        approval_available=bundle.approval_available,
+    )
+    try:
+        assert check_planner_artifacts() is True
+        assert check_planner_context() is False
+        assert check_planner_approvals() is False
+        result = asyncio.run(
+            bundle.handlers.context_read({
+                "query_id": "approval_status.v1",
+                "parameters": {"approval_id": "approval-001"},
+            })
+        )
+        assert result == {"ok": False, "error": "planner database runtime unavailable"}
+    finally:
+        configure_planner_runtime(None)
+
+
+def test_database_runtime_uses_distinct_lazy_reader_and_writer_pools(tmp_path):
+    bundle = build_runtime_bundle(
+        {
+            "artifact_root": str(tmp_path / "artifacts"),
+            "database": {
+                "max_rows": 7,
+                "max_bytes": 4096,
+                "timeout_seconds": 2.0,
+            },
+        },
+        environ={
+            "RESEARCH_PROTOCOL_READER_DATABASE_URL": (
+                "postgresql://reader:not-contacted@invalid/read"
+            ),
+            "RESEARCH_PROTOCOL_WRITER_DATABASE_URL": (
+                "postgresql://writer:not-contacted@invalid/write"
+            ),
+        },
+    )
+
+    assert bundle.artifact_available is True
+    assert bundle.context_available is True
+    assert bundle.approval_available is True
+    assert bundle.reader_pool is not None
+    assert bundle.writer_pool is not None
+    assert bundle.reader_pool is not bundle.writer_pool
+    assert bundle.reader_pool.created is False
+    assert bundle.writer_pool.created is False
+
+
+def test_database_runtime_keeps_reader_and_writer_authority_independent(tmp_path):
+    reader_only = build_runtime_bundle(
+        {"artifact_root": str(tmp_path / "reader-artifacts")},
+        environ={
+            "RESEARCH_PROTOCOL_READER_DATABASE_URL": (
+                "postgresql://reader:not-contacted@invalid/read"
+            )
+        },
+    )
+    assert reader_only.context_available is True
+    assert reader_only.approval_available is False
+
+    writer_only = build_runtime_bundle(
+        {"artifact_root": str(tmp_path / "writer-artifacts")},
+        environ={
+            "RESEARCH_PROTOCOL_WRITER_DATABASE_URL": (
+                "postgresql://writer:not-contacted@invalid/write"
+            )
+        },
+    )
+    assert writer_only.context_available is False
+    assert writer_only.approval_available is True
+
+
+def test_database_runtime_rejects_shared_reader_writer_dsn(tmp_path):
+    dsn = "postgresql://combined:not-contacted@invalid/database"
+    with pytest.raises(RuntimeConfigurationError, match="must be distinct"):
+        build_runtime_bundle(
+            {"artifact_root": str(tmp_path / "artifacts")},
+            environ={
+                "RESEARCH_PROTOCOL_READER_DATABASE_URL": dsn,
+                "RESEARCH_PROTOCOL_WRITER_DATABASE_URL": dsn,
+            },
+        )
+
+
+def test_runtime_rejects_out_of_range_database_caps(tmp_path):
+    with pytest.raises(RuntimeConfigurationError, match="max_rows"):
+        build_runtime_bundle(
+            {
+                "artifact_root": str(tmp_path / "artifacts"),
+                "database": {"max_rows": 0},
+            },
+            environ={
+                "RESEARCH_PROTOCOL_READER_DATABASE_URL": "postgresql://example/read"
+            },
+        )

--- a/tests/plugins/research_protocol/test_runtime.py
+++ b/tests/plugins/research_protocol/test_runtime.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import queue
+import sys
+import threading
+import types
 
 import pytest
 
@@ -13,9 +17,70 @@ from plugins.research_protocol.planner_tools import (
     configure_planner_runtime,
 )
 from plugins.research_protocol.runtime import (
+    LazyAsyncpgPool,
     RuntimeConfigurationError,
     build_runtime_bundle,
 )
+
+
+class _RuntimeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _RuntimeConnection:
+    def transaction(self, **_kwargs):
+        return _RuntimeTransaction()
+
+    async def execute(self, *_args):
+        return None
+
+    async def fetch(self, *_args):
+        return []
+
+
+class _RuntimeAcquire:
+    def __init__(self, pool):
+        self._pool = pool
+
+    async def __aenter__(self):
+        if asyncio.get_running_loop() is not self._pool.creation_loop:
+            raise RuntimeError("pool used from a different event loop")
+        return _RuntimeConnection()
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _RuntimeLoopBoundPool:
+    def __init__(self, *, block_close=False, fail_close=False):
+        self.creation_loop = asyncio.get_running_loop()
+        self.close_calls = 0
+        self.close_loops = []
+        self.fail_close = fail_close
+        self.terminate_calls = 0
+        self.close_started = asyncio.Event() if block_close else None
+        self.allow_close = asyncio.Event() if block_close else None
+
+    def acquire(self):
+        return _RuntimeAcquire(self)
+
+    async def close(self):
+        if asyncio.get_running_loop() is not self.creation_loop:
+            raise RuntimeError("pool closed from a different event loop")
+        if self.close_started is not None and self.allow_close is not None:
+            self.close_started.set()
+            await self.allow_close.wait()
+        self.close_loops.append(asyncio.get_running_loop())
+        if self.fail_close:
+            raise RuntimeError("pool close failed")
+        self.close_calls += 1
+
+    def terminate(self):
+        self.terminate_calls += 1
 
 
 def test_runtime_rejects_missing_or_relative_artifact_root(tmp_path):
@@ -79,6 +144,441 @@ def test_database_runtime_uses_distinct_lazy_reader_and_writer_pools(tmp_path):
     assert bundle.reader_pool is not bundle.writer_pool
     assert bundle.reader_pool.created is False
     assert bundle.writer_pool.created is False
+
+
+def test_database_runtime_replaces_pool_from_closed_loop_and_terminates_it(
+    tmp_path, monkeypatch
+):
+    created_pools = []
+
+    async def create_pool(**_kwargs):
+        pool = _RuntimeLoopBoundPool()
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+    bundle = build_runtime_bundle(
+        {"artifact_root": str(tmp_path / "artifacts")},
+        environ={
+            "RESEARCH_PROTOCOL_READER_DATABASE_URL": (
+                "postgresql://reader.invalid/research"
+            )
+        },
+    )
+    request = {
+        "query_id": "approval_status.v1",
+        "parameters": {"approval_id": "approval-001"},
+    }
+    reader_pool = bundle.reader_pool
+    assert reader_pool is not None
+
+    first = asyncio.run(bundle.handlers.context_read(request))
+    first_loop = created_pools[0].creation_loop
+    second = asyncio.run(bundle.handlers.context_read(request))
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first_loop.is_closed()
+    assert len(created_pools) == 2
+    assert created_pools[0].terminate_calls == 1
+    assert created_pools[1].creation_loop is not first_loop
+    asyncio.run(reader_pool.close())
+    assert reader_pool.created is False
+    assert created_pools[1].terminate_calls == 1
+
+
+def test_lazy_pool_deduplicates_concurrent_creation_on_same_loop(monkeypatch):
+    created_pools = []
+
+    async def create_pool(**_kwargs):
+        await asyncio.sleep(0)
+        pool = _RuntimeLoopBoundPool()
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+
+    async def exercise_concurrent_creation():
+        lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+        pools = await asyncio.gather(*(lazy_pool.get_pool() for _ in range(20)))
+        assert len({id(pool) for pool in pools}) == 1
+        assert lazy_pool.created is True
+        await lazy_pool.close()
+        assert lazy_pool.created is False
+
+    asyncio.run(exercise_concurrent_creation())
+
+    assert len(created_pools) == 1
+    assert created_pools[0].close_calls == 1
+
+
+def test_lazy_pool_isolates_concurrent_loops_and_closes_on_each_owner(
+    monkeypatch,
+):
+    created_pools = []
+    created_guard = threading.Lock()
+    ready = threading.Barrier(3)
+    release = threading.Event()
+    worker_errors = queue.Queue()
+
+    async def create_pool(**_kwargs):
+        pool = _RuntimeLoopBoundPool()
+        with created_guard:
+            created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+    lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+
+    async def hold_owner_loop_open():
+        await lazy_pool.get_pool()
+        ready.wait(timeout=5)
+        while not release.is_set():
+            await asyncio.sleep(0.01)
+
+    def run_owner_loop():
+        try:
+            asyncio.run(hold_owner_loop_open())
+        except BaseException as exc:
+            worker_errors.put(exc)
+
+    threads = [threading.Thread(target=run_owner_loop) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    try:
+        ready.wait(timeout=5)
+        with created_guard:
+            pools = tuple(created_pools)
+        assert len(pools) == 2
+        assert pools[0] is not pools[1]
+        assert pools[0].creation_loop is not pools[1].creation_loop
+
+        asyncio.run(lazy_pool.close())
+        assert lazy_pool.created is False
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join(timeout=5)
+
+    assert all(thread.is_alive() is False for thread in threads)
+    assert worker_errors.empty()
+    assert [pool.close_calls for pool in pools] == [1, 1]
+    assert [pool.terminate_calls for pool in pools] == [0, 0]
+    assert [pool.close_loops for pool in pools] == [
+        [pools[0].creation_loop],
+        [pools[1].creation_loop],
+    ]
+
+
+def test_lazy_pool_close_blocks_new_pool_until_cleanup_finishes(monkeypatch):
+    created_pools = []
+
+    async def create_pool(**_kwargs):
+        pool = _RuntimeLoopBoundPool(block_close=not created_pools)
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+
+    async def exercise_close_barrier():
+        lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+        original = await lazy_pool.get_pool()
+        close_task = asyncio.create_task(lazy_pool.close())
+        await original.close_started.wait()
+        second_close_task = asyncio.create_task(lazy_pool.close())
+        acquire_task = asyncio.create_task(lazy_pool.get_pool())
+        await asyncio.sleep(0)
+        try:
+            assert acquire_task.done() is False
+            assert second_close_task.done() is False
+        finally:
+            original.allow_close.set()
+            await asyncio.gather(close_task, second_close_task)
+            replacement = await acquire_task
+            await lazy_pool.close()
+        assert replacement is not original
+
+    asyncio.run(exercise_close_barrier())
+
+    assert len(created_pools) == 2
+    assert created_pools[0].close_calls == 1
+    assert created_pools[1].close_calls == 1
+
+
+def test_lazy_pool_cancelled_waiters_do_not_cancel_shared_close(monkeypatch):
+    created_pools = []
+
+    async def create_pool(**_kwargs):
+        pool = _RuntimeLoopBoundPool(block_close=True)
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+
+    async def exercise_cancelled_waiters():
+        lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+        original = await lazy_pool.get_pool()
+        close_task = asyncio.create_task(lazy_pool.close())
+        await original.close_started.wait()
+        acquire_waiter = asyncio.create_task(lazy_pool.get_pool())
+        close_waiter = asyncio.create_task(lazy_pool.close())
+        await asyncio.sleep(0)
+
+        acquire_waiter.cancel()
+        close_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await acquire_waiter
+        with pytest.raises(asyncio.CancelledError):
+            await close_waiter
+
+        assert close_task.done() is False
+        original.allow_close.set()
+        await close_task
+        assert lazy_pool.created is False
+
+    asyncio.run(exercise_cancelled_waiters())
+
+    assert len(created_pools) == 1
+    assert created_pools[0].close_calls == 1
+    assert created_pools[0].terminate_calls == 0
+
+
+def test_lazy_pool_cancelled_remote_close_waits_for_owner_cleanup(monkeypatch):
+    created_pools = []
+    created_guard = threading.Lock()
+    owner_ready = threading.Event()
+    release_owner = threading.Event()
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+    worker_errors = queue.Queue()
+
+    async def create_pool(**_kwargs):
+        pool = _RuntimeLoopBoundPool()
+        with created_guard:
+            created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+    lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+
+    async def hold_owner_loop_open():
+        await lazy_pool.get_pool()
+        owner_ready.set()
+        while not release_owner.is_set():
+            await asyncio.sleep(0.01)
+
+    def run_owner_loop():
+        try:
+            asyncio.run(hold_owner_loop_open())
+        except BaseException as exc:
+            worker_errors.put(exc)
+
+    owner_thread = threading.Thread(target=run_owner_loop)
+    owner_thread.start()
+    try:
+        assert owner_ready.wait(timeout=5)
+        with created_guard:
+            original = created_pools[0]
+        with lazy_pool._states_guard:
+            state = lazy_pool._states[original.creation_loop]
+
+        async def hold_state_lock():
+            async with state.lock:
+                lock_held.set()
+                while not release_lock.is_set():
+                    await asyncio.sleep(0.01)
+
+        lock_future = asyncio.run_coroutine_threadsafe(
+            hold_state_lock(), original.creation_loop
+        )
+        assert lock_held.wait(timeout=5)
+
+        async def exercise_cancelled_close():
+            close_task = asyncio.create_task(lazy_pool.close())
+            await asyncio.sleep(0.05)
+            close_task.cancel()
+            await asyncio.sleep(0.05)
+            assert close_task.done() is False
+            release_lock.set()
+            with pytest.raises(asyncio.CancelledError):
+                await close_task
+
+        asyncio.run(exercise_cancelled_close())
+        lock_future.result(timeout=5)
+    finally:
+        release_lock.set()
+        release_owner.set()
+        owner_thread.join(timeout=5)
+
+    assert owner_thread.is_alive() is False
+    assert worker_errors.empty()
+    assert original.close_calls == 1
+    assert original.terminate_calls == 0
+    assert original.close_loops == [original.creation_loop]
+
+
+def test_lazy_pool_terminates_when_owner_loop_stops_after_submission(monkeypatch):
+    created_pools = []
+    owner_loops = []
+    owner_ready = threading.Event()
+    owner_stopped = threading.Event()
+    allow_shutdown = threading.Event()
+    worker_errors = queue.Queue()
+
+    async def create_pool(**_kwargs):
+        pool = _RuntimeLoopBoundPool()
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+    lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+
+    def run_owner_loop():
+        loop = asyncio.new_event_loop()
+        owner_loops.append(loop)
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(lazy_pool.get_pool())
+            loop.call_soon(owner_ready.set)
+            loop.run_forever()
+            owner_stopped.set()
+            allow_shutdown.wait(timeout=5)
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+        except BaseException as exc:
+            worker_errors.put(exc)
+        finally:
+            loop.close()
+
+    owner_thread = threading.Thread(target=run_owner_loop)
+    owner_thread.start()
+    try:
+        assert owner_ready.wait(timeout=5)
+        original_submit = asyncio.run_coroutine_threadsafe
+
+        def submit_then_stop(coroutine, owner_loop):
+            future = original_submit(coroutine, owner_loop)
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+            return future
+
+        monkeypatch.setattr(
+            asyncio,
+            "run_coroutine_threadsafe",
+            submit_then_stop,
+        )
+        asyncio.run(asyncio.wait_for(lazy_pool.close(), timeout=0.5))
+        assert owner_stopped.wait(timeout=5)
+    finally:
+        allow_shutdown.set()
+        owner_thread.join(timeout=5)
+
+    assert owner_thread.is_alive() is False
+    assert worker_errors.empty()
+    assert len(owner_loops) == 1
+    assert len(created_pools) == 1
+    assert created_pools[0].terminate_calls == 1
+    assert created_pools[0].close_calls == 0
+
+
+def test_lazy_pool_close_terminates_failed_pool_and_propagates(monkeypatch):
+    created_pools = []
+
+    async def create_pool(**_kwargs):
+        pool = _RuntimeLoopBoundPool(fail_close=not created_pools)
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(create_pool=create_pool),
+    )
+
+    async def exercise_failed_close():
+        lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+        original = await lazy_pool.get_pool()
+        with pytest.raises(RuntimeError, match="pool close failed"):
+            await lazy_pool.close()
+        assert lazy_pool.created is False
+        replacement = await lazy_pool.get_pool()
+        await lazy_pool.close()
+        return original, replacement
+
+    original, replacement = asyncio.run(exercise_failed_close())
+
+    assert replacement is not original
+    assert original.terminate_calls == 1
+    assert replacement.close_calls == 1
+
+
+def test_lazy_pool_terminates_failed_creation_retired_by_close(monkeypatch):
+    created_pools = []
+
+    async def exercise_retired_creation():
+        create_started = asyncio.Event()
+        allow_create = asyncio.Event()
+
+        async def create_pool(**_kwargs):
+            create_started.set()
+            await allow_create.wait()
+            pool = _RuntimeLoopBoundPool(fail_close=True)
+            created_pools.append(pool)
+            return pool
+
+        monkeypatch.setitem(
+            sys.modules,
+            "asyncpg",
+            types.SimpleNamespace(create_pool=create_pool),
+        )
+        lazy_pool = LazyAsyncpgPool("postgresql://reader.invalid/research")
+        acquire_task = asyncio.create_task(lazy_pool.get_pool())
+        await create_started.wait()
+        close_task = asyncio.create_task(lazy_pool.close())
+        await asyncio.sleep(0)
+        allow_create.set()
+
+        with pytest.raises(RuntimeError, match="pool close failed"):
+            await acquire_task
+        await close_task
+        assert lazy_pool.created is False
+
+    asyncio.run(exercise_retired_creation())
+
+    assert len(created_pools) == 1
+    assert created_pools[0].terminate_calls == 1
 
 
 def test_database_runtime_keeps_reader_and_writer_authority_independent(tmp_path):

--- a/tests/test_research_protocol_packaging.py
+++ b/tests/test_research_protocol_packaging.py
@@ -1,0 +1,136 @@
+"""Build-level wheel/sdist coverage for Research Protocol data files."""
+
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tarfile
+from uuid import uuid4
+import zipfile
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "research_protocol"
+DATA_SUFFIXES = {".json", ".yaml", ".sql", ".md"}
+
+SECRET_PATTERNS = (
+    ("postgresql_dsn", re.compile(rb"postgres(?:ql)?://[^\s\"'<>]+", re.IGNORECASE)),
+    ("private_key_pem", re.compile(rb"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")),
+    (
+        "credential_assignment",
+        re.compile(
+            rb"\b(?:token|password|secret|api[_-]?key)\s*[:=]\s*"
+            rb"[\"']?[^\s,;\"']+",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+
+def _secret_canaries() -> tuple[bytes, bytes]:
+    nonce = uuid4().hex.encode("ascii")
+    return b"token-" + nonce, b"postgresql://" + nonce
+
+
+def _required_data_paths() -> set[str]:
+    required = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in PLUGIN_ROOT.rglob("*")
+        if path.is_file() and path.suffix in DATA_SUFFIXES
+    }
+    required.add("plugins/research_protocol/plugin.yaml")
+    return required
+
+
+def _wheel_entries(path: Path) -> dict[str, bytes]:
+    with zipfile.ZipFile(path) as archive:
+        return {
+            name: archive.read(name)
+            for name in archive.namelist()
+            if not name.endswith("/")
+        }
+
+
+def _sdist_entries(path: Path) -> dict[str, bytes]:
+    with tarfile.open(path, "r:gz") as archive:
+        members = [member for member in archive.getmembers() if member.isfile()]
+        entries = {}
+        for member in members:
+            extracted = archive.extractfile(member)
+            assert extracted is not None
+            entries[member.name.split("/", 1)[1]] = extracted.read()
+    return entries
+
+
+def _scan_research_protocol_payloads(entries: dict[str, bytes]) -> list[str]:
+    """Scan only packaged payloads below the plugin subtree.
+
+    Keeping the path filter here prevents the scanner's own test regexes, which
+    are included in the sdist under ``tests/``, from matching themselves.
+    """
+
+    findings = []
+    for name, payload in entries.items():
+        if not name.startswith("plugins/research_protocol/"):
+            continue
+        for label, pattern in SECRET_PATTERNS:
+            if pattern.search(payload):
+                findings.append(f"{name}:{label}")
+    return findings
+
+
+def test_secret_scanner_detects_synthetic_payloads_without_scanning_other_subtrees():
+    malicious = {
+        "plugins/research_protocol/fixtures/dsn.txt": b"postgresql://user:pw@host/db",
+        "plugins/research_protocol/fixtures/key.txt": (
+            b"-----BEGIN PRIVATE KEY-----\\nsecret\\n-----END PRIVATE KEY-----"
+        ),
+        "plugins/research_protocol/fixtures/token.txt": b"api_key=synthetic-token",
+        "tests/test_research_protocol_packaging.py": (
+            b"postgresql://source-code-must-not-be-scanned"
+        ),
+    }
+
+    findings = _scan_research_protocol_payloads(malicious)
+
+    assert {
+        "plugins/research_protocol/fixtures/dsn.txt:postgresql_dsn",
+        "plugins/research_protocol/fixtures/key.txt:private_key_pem",
+        "plugins/research_protocol/fixtures/token.txt:credential_assignment",
+    } <= set(findings)
+    assert all(not finding.startswith("tests/") for finding in findings)
+
+
+def test_wheel_and_sdist_ship_every_versioned_protocol_data_file(tmp_path):
+    uv = shutil.which("uv")
+    assert uv is not None, "uv is required by the Hermes development workflow"
+    canaries = _secret_canaries()
+    env = os.environ.copy()
+    env.update(
+        {
+            "RESEARCH_PROTOCOL_TOKEN": canaries[0].decode(),
+            "RESEARCH_PROTOCOL_DSN": canaries[1].decode(),
+        }
+    )
+    subprocess.run(
+        [uv, "build", "--offline", "--out-dir", str(tmp_path)],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    wheel = next(tmp_path.glob("*.whl"))
+    sdist = next(tmp_path.glob("*.tar.gz"))
+    required = _required_data_paths()
+    wheel_entries = _wheel_entries(wheel)
+    sdist_entries = _sdist_entries(sdist)
+
+    assert required <= wheel_entries.keys()
+    assert required <= sdist_entries.keys()
+    for canary in canaries:
+        assert all(canary not in payload for payload in wheel_entries.values())
+        assert all(canary not in payload for payload in sdist_entries.values())
+    assert _scan_research_protocol_payloads(wheel_entries) == []
+    assert _scan_research_protocol_payloads(sdist_entries) == []

--- a/tests/test_research_protocol_packaging.py
+++ b/tests/test_research_protocol_packaging.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 from uuid import uuid4
 import zipfile
@@ -102,27 +103,54 @@ def test_secret_scanner_detects_synthetic_payloads_without_scanning_other_subtre
 
 
 def test_wheel_and_sdist_ship_every_versioned_protocol_data_file(tmp_path):
-    uv = shutil.which("uv")
-    assert uv is not None, "uv is required by the Hermes development workflow"
     canaries = _secret_canaries()
-    env = os.environ.copy()
-    env.update(
-        {
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    for filename in ("setup.py", "pyproject.toml", "README.md", "LICENSE"):
+        shutil.copy2(REPO_ROOT / filename, source_root / filename)
+    isolated_plugins = source_root / "plugins"
+    isolated_plugins.mkdir()
+    shutil.copy2(PLUGIN_ROOT.parent / "__init__.py", isolated_plugins / "__init__.py")
+    shutil.copytree(
+        PLUGIN_ROOT,
+        isolated_plugins / "research_protocol",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    output_dir = tmp_path / "dist"
+    output_dir.mkdir()
+
+    for kind in ("sdist", "wheel"):
+        env = os.environ.copy()
+        env["HERMES_NIX_BUILD"] = "1"
+        env.update({
             "RESEARCH_PROTOCOL_TOKEN": canaries[0].decode(),
             "RESEARCH_PROTOCOL_DSN": canaries[1].decode(),
-        }
-    )
-    subprocess.run(
-        [uv, "build", "--offline", "--out-dir", str(tmp_path)],
-        cwd=REPO_ROOT,
-        env=env,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+        })
+        scratch = tmp_path / f"{kind}-scratch"
+        scratch.mkdir()
+        extra_cfg = tmp_path / f"{kind}-dist-extra.cfg"
+        extra_cfg.write_text(
+            f"[build]\nbuild_base = {scratch / 'build'}\n\n"
+            f"[egg_info]\negg_base = {scratch}\n",
+            encoding="utf-8",
+        )
+        env["DIST_EXTRA_CONFIG"] = str(extra_cfg)
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                f"from setuptools.build_meta import build_{kind}; "
+                f"build_{kind}({str(output_dir)!r})",
+            ],
+            cwd=source_root,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
-    wheel = next(tmp_path.glob("*.whl"))
-    sdist = next(tmp_path.glob("*.tar.gz"))
+    wheel = next(output_dir.glob("*.whl"))
+    sdist = next(output_dir.glob("*.tar.gz"))
     required = _required_data_paths()
     wheel_entries = _wheel_entries(wheel)
     sdist_entries = _sdist_entries(sdist)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2523,6 +2523,59 @@ class TestTirithImportErrorFailOpenPolicy:
         assert result.get("approved") is True
 
 
+class TestStrictElicitationConsent:
+    @pytest.mark.parametrize(
+        ("choice", "expected"),
+        (("once", "accept"), ("session", "decline"), ("always", "decline")),
+    )
+    def test_cli_strict_one_shot_accepts_only_once(self, choice, expected):
+        with mock_patch.object(
+            approval_module, "_is_gateway_approval_context", return_value=False
+        ):
+            with mock_patch.object(
+                approval_module, "prompt_dangerous_approval", return_value=choice
+            ):
+                result = approval_module.request_elicitation_consent(
+                    "Approve this workflow scope",
+                    "scope summary",
+                    timeout_seconds=5,
+                    strict_one_shot=True,
+                )
+
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        ("choice", "expected"),
+        (("once", "accept"), ("session", "decline"), ("always", "decline")),
+    )
+    def test_gateway_strict_one_shot_accepts_only_once(
+        self, monkeypatch, choice, expected
+    ):
+        session_key = "gateway:research-protocol-strict-one-shot"
+        monkeypatch.setitem(
+            approval_module._gateway_notify_cbs, session_key, lambda _data: None
+        )
+        with mock_patch.object(
+            approval_module, "get_current_session_key", return_value=session_key
+        ):
+            with mock_patch.object(
+                approval_module, "_is_gateway_approval_context", return_value=True
+            ):
+                with mock_patch.object(
+                    approval_module,
+                    "_await_gateway_decision",
+                    return_value={"resolved": True, "choice": choice},
+                ):
+                    result = approval_module.request_elicitation_consent(
+                        "Approve this workflow scope",
+                        "scope summary",
+                        timeout_seconds=5,
+                        strict_one_shot=True,
+                    )
+
+        assert result == expected
+
+
 class TestApprovalPromptRedaction:
     """Secrets are masked in user-facing approval surfaces (#13139).
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4050,6 +4050,7 @@ def request_elicitation_consent(
     *,
     timeout_seconds: int | None = None,
     surface: str = "mcp-elicitation",
+    strict_one_shot: bool = False,
 ) -> str:
     """Route an MCP elicitation request to whichever approval surface owns
     the active session and return a normalized result.
@@ -4061,7 +4062,9 @@ def request_elicitation_consent(
 
     Always fails closed: missing notify_cb in a gateway session, timeouts,
     and exceptions all map to ``"decline"`` so a server treats them as
-    "user did not approve" rather than retrying or hanging.
+    "user did not approve" rather than retrying or hanging. When
+    ``strict_one_shot`` is true, only an explicit ``"once"`` choice is
+    accepted; session and permanent choices are rejected.
 
     Returns one of ``"accept" | "decline" | "cancel"``.
     """
@@ -4103,6 +4106,8 @@ def request_elicitation_consent(
         if not decision.get("resolved"):
             return "cancel"
         choice = decision.get("choice")
+        if strict_one_shot:
+            return "accept" if choice == "once" else "decline"
         if choice in ("once", "session", "always"):
             return "accept"
         return "decline"
@@ -4110,11 +4115,14 @@ def request_elicitation_consent(
     # CLI / TUI path. allow_permanent=False because elicitation is a
     # per-call confirmation — there is no pattern to remember.
     try:
+        from tools.terminal_tool import _get_approval_callback
+
         choice = prompt_dangerous_approval(
             message,
             description,
             timeout_seconds=timeout_seconds,
             allow_permanent=False,
+            approval_callback=_get_approval_callback(),
         )
     except Exception as exc:
         logger.error(
@@ -4122,6 +4130,8 @@ def request_elicitation_consent(
         )
         return "decline"
 
+    if strict_one_shot:
+        return "accept" if choice == "once" else "decline"
     if choice in ("once", "session", "always"):
         return "accept"
     return "decline"

--- a/uv.lock
+++ b/uv.lock
@@ -1669,6 +1669,9 @@ modal = [
 parallel-web = [
     { name = "parallel-web" },
 ]
+research-protocol = [
+    { name = "asyncpg" },
+]
 slack = [
     { name = "aiohttp" },
     { name = "slack-bolt" },
@@ -1745,6 +1748,7 @@ requires-dist = [
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = "==0.31.0" },
+    { name = "asyncpg", marker = "extra == 'research-protocol'", specifier = "==0.31.0" },
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
@@ -1855,7 +1859,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "research-protocol", "wecom", "cli", "tts-premium", "voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Research Protocol plugin that gives the `planner` toolset exactly three bounded capabilities:

- read approved PostgreSQL context through fixed query identifiers and strict row/byte/time caps;
- atomically write registered research artifacts under an operator-owned private root;
- request native one-operation approval and persist the exact approved scope in a least-privilege PostgreSQL ledger.

The plugin is disabled by default. Enabling it without local artifact/database authority registers the tool surface but keeps execution unavailable through fail-closed `check_fn` gates. Registration does not start a service, connect to PostgreSQL, call an LLM, or publish anything.

Workflow consent goes through Hermes' native approval surface with `strict_one_shot=True`: only an explicit `once` choice is accepted; session/permanent choices and every error path fail closed.

## Related Issue

No linked issue. This is the PR2 implementation of the staged Research Protocol work.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the opt-in `plugins/research_protocol` plugin and manifest.
- Add strict Pydantic models, 10 generated/versioned JSON schemas, and three versioned policy documents.
- Add descriptor-checked atomic artifact storage that rejects traversal and symlinked artifact parents.
- Keep enabled plugin discovery working without POSIX `fcntl`; storage remains registered but unavailable through fail-closed gates.
- Accept JSON-deserialized artifact payloads through strict JSON-mode validation.
- Add bounded read-only PostgreSQL queries and one-shot least-privilege migrations/roles.
- Isolate asyncpg pools by event loop and close them on their owning loop.
- Add exact-scope approval hashing, expiry, execution caps, durable decisions, and atomic claims.
- Extend the native elicitation API with a fail-closed `strict_one_shot` contract while preserving the CLI approval callback context.
- Package plugin manifests, schemas, policies, migrations, and documentation through current setuptools package-data metadata; `MANIFEST.in` is no longer used on `main`.
- Build wheel and sdist coverage from an isolated temporary source tree so setuptools staging cannot race with parallel packaging tests.

## Current-main reconstruction

The branch was rebuilt from current `main` (`585726ac2e08dcc2bd32c134e0124e0657ecc519`) instead of resolving conflicts inside the previous mixed history.

- Final pushed HEAD: `8175f39bde3df6a49879bfcc19f4ba488a3644ff`.
- Ten Conventional Commits, all scoped to Research Protocol.
- 53 changed files; all 53 are the plugin, its tests, the Research Protocol packaging test, or its four shared integration files (`pyproject.toml`, `uv.lock`, `tools/approval.py`, `tests/tools/test_approval.py`).
- `git merge-tree --write-tree HEAD upstream/main`: zero conflicts.
- P2 symlink-parent remediation: `d5d1fc6ae683003adf9e9653fc3f87bf81a336d5`.
- Current-main packaging adaptation: `f1b47ddb93744e89e6d8b0ddcc4968b92bb93f02`.
- Windows `fcntl` discovery remediation: `8175f39bde3df6a49879bfcc19f4ba488a3644ff`.

## How to Test

```bash
# Plugin, real wheel/sdist payloads, and adjacent packaging guard
scripts/run_tests.sh \
  tests/plugins/research_protocol \
  tests/test_research_protocol_packaging.py \
  tests/test_packaging_build_guard.py

# Exact one-shot native approval contract
scripts/run_tests.sh tests/tools/test_approval.py -k StrictElicitationConsent -q

# Lint and formatting for PR-owned files
ruff check --no-cache \
  plugins/research_protocol tests/plugins/research_protocol \
  tools/approval.py tests/tools/test_approval.py \
  tests/test_research_protocol_packaging.py
ruff format --check \
  plugins/research_protocol tests/plugins/research_protocol \
  tests/test_research_protocol_packaging.py

ty check --python .venv/bin/python plugins/research_protocol
uv lock --check
```

Exact local validation on Linux / CPython 3.12.13:

- Research Protocol plus adjacent packaging guard: **150 passed, 0 failed**.
- Windows-like enabled discovery without `fcntl`: **plugin loaded, three tools registered, all runtime gates unavailable**.
- Strict one-shot approval contract: **6 passed, 0 failed**.
- Remaining approval tests with three known baseline nodes excluded: **317 passed, 0 failed**.
- Full `tests/tools/test_approval.py`: **317 passed, 3 failed**; the same three node IDs fail identically on clean current `main`:
  - `TestTeePattern::test_tee_absolute_home_bashrc`
  - `TestSensitiveRedirectPattern::test_append_to_absolute_home_ssh_authorized_keys`
  - `TestSensitiveRedirectPattern::test_redirect_to_absolute_home_bashrc`
- Isolated wheel/sdist test run in parallel with the repository packaging guard three consecutive times: **6/6 each run, no retry/flaky result**.
- Ruff, targeted format check, plugin type-check, Python compilation, `uv lock --check`, and `git diff --check`: **PASS**.

A full repository test run has not been rerun for this reconstructed HEAD; CI remains the public integration gate.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and found no PR from this branch.
- [x] My PR contains only changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass. Targeted and adjacent gates are green; three approval failures are reproduced identically on current clean `main`.
- [x] I've added tests for the change.
- [x] I've tested the reconstructed snapshot on Linux with CPython 3.12.13.

### Documentation & Housekeeping

- [x] Relevant README, architecture, threat-model, and docstrings are included.
- [x] `cli-config.yaml.example` is N/A; the plugin is opt-in and documented under the existing plugin config structure.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; no repository workflow is changed.
- [x] Cross-platform behavior was considered in path and packaging design; this reconstructed snapshot has currently been executed on Linux only.
- [x] Tool schemas and descriptions are included for all three tools.

## Screenshots / Logs

No UI change. Exact commands and results are listed above; CI logs will provide the public integration evidence for this draft PR.
