### PR TITLE
fix(sessions): restore complete remote profile listings

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -65,7 +65,6 @@ import {
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
-import { resolvePickerDefaultPath } from './wsl-path-bridge'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
 import {
@@ -97,6 +96,7 @@ import {
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import { normalizeRemoteSessionList } from './remote-session-list'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -131,6 +131,7 @@ import { buildPathExtCandidates, chooseUpdaterArgs, getVenvSitePackagesEntries, 
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
+import { resolvePickerDefaultPath } from './wsl-path-bridge'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 
@@ -7777,12 +7778,7 @@ async function remoteSessionList(profile, searchParams) {
   qs.delete('profile') // remote serves its own db; no cross-profile read there
   const data = await fetchJsonForProfile(profile, `/api/sessions?${qs}`)
 
-  for (const s of rowsOf(data)) {
-    s.profile = profile
-    s.is_default_profile = false
-  }
-
-  return { ...(data as any), sessions: rowsOf(data) }
+  return normalizeRemoteSessionList(profile, data)
 }
 
 // Unified list: primary's local aggregate, with each remote profile's stale local

--- a/apps/desktop/electron/remote-session-list.test.ts
+++ b/apps/desktop/electron/remote-session-list.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { normalizeRemoteSessionList } from './remote-session-list'
+
+test('normalizeRemoteSessionList preserves pagination and exposes the owning profile total', () => {
+  const response = normalizeRemoteSessionList('implementer', {
+    limit: 40,
+    offset: 0,
+    sessions: [{ id: 'newest' }, { id: 'older' }],
+    total: 107
+  })
+
+  assert.equal(response.limit, 40)
+  assert.equal(response.offset, 0)
+  assert.equal(response.total, 107)
+  assert.deepEqual(response.profile_totals, { implementer: 107 })
+  assert.deepEqual(response.sessions, [
+    { id: 'newest', profile: 'implementer', is_default_profile: false },
+    { id: 'older', profile: 'implementer', is_default_profile: false }
+  ])
+})
+
+test('normalizeRemoteSessionList falls back to returned row count when a legacy backend omits total', () => {
+  const response = normalizeRemoteSessionList('remote', {
+    sessions: [{ id: 'only-row' }]
+  })
+
+  assert.equal(response.total, 1)
+  assert.deepEqual(response.profile_totals, { remote: 1 })
+})

--- a/apps/desktop/electron/remote-session-list.ts
+++ b/apps/desktop/electron/remote-session-list.ts
@@ -1,0 +1,35 @@
+interface SessionListResponse {
+  limit?: number
+  offset?: number
+  sessions?: unknown
+  total?: number
+  [key: string]: unknown
+}
+
+/**
+ * Adapt one remote backend's `/api/sessions` response to the
+ * `/api/profiles/sessions` contract consumed by Desktop.
+ *
+ * The single-profile endpoint does not know the Desktop profile name and does
+ * not return `profile_totals`. The latter is pagination metadata: without it,
+ * a profile-scoped sidebar treats the first page as the complete result set.
+ */
+export function normalizeRemoteSessionList(profile: string, data: unknown) {
+  const source = data && typeof data === 'object' ? (data as SessionListResponse) : {}
+  const rawSessions = Array.isArray(source.sessions) ? source.sessions : []
+
+  const sessions = rawSessions.map(session =>
+    session && typeof session === 'object'
+      ? { ...session, profile, is_default_profile: false }
+      : session
+  )
+
+  const total = Number.isFinite(source.total) ? Number(source.total) : sessions.length
+
+  return {
+    ...source,
+    sessions,
+    total,
+    profile_totals: { [profile]: total }
+  }
+}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1018,6 +1018,7 @@ class SessionDB:
         self._trigram_available = False
         self._fts_unavailable_warned = False
         self._conn = None
+        self._read_only_session_compact_cols_sql: Optional[str] = None
         try:
             if read_only:
                 # Read-only attach for cross-profile aggregation: SELECT-only,
@@ -3300,20 +3301,51 @@ class SessionDB:
     # declarative reconciliation are included automatically instead of
     # silently dropping out of list rows.
     _SESSION_COMPACT_EXCLUDED = frozenset({"system_prompt"})
+    _session_compact_col_names: Optional[Tuple[str, ...]] = None
     _session_compact_cols_sql: Optional[str] = None
 
     @classmethod
-    def _compact_session_cols(cls) -> str:
-        """SELECT list for compact_rows: every ``sessions`` column declared in
-        SCHEMA_SQL except the ``system_prompt`` blob, aliased with the ``s``
-        prefix used by list_sessions_rich/_get_session_rich_row queries."""
-        if cls._session_compact_cols_sql is None:
+    def _compact_session_col_names(cls) -> Tuple[str, ...]:
+        if cls._session_compact_col_names is None:
             declared = cls._parse_schema_columns(SCHEMA_SQL)["sessions"]
-            cls._session_compact_cols_sql = ", ".join(
-                f"s.{name}" for name in declared
+            cls._session_compact_col_names = tuple(
+                name for name in declared
                 if name not in cls._SESSION_COMPACT_EXCLUDED
             )
-        return cls._session_compact_cols_sql
+        return cls._session_compact_col_names
+
+    def _compact_session_cols(self) -> str:
+        """SELECT list for compact_rows: every ``sessions`` column declared in
+        SCHEMA_SQL except the ``system_prompt`` blob, aliased with the ``s``
+        prefix used by list_sessions_rich/_get_session_rich_row queries.
+
+        Read-only connections deliberately skip schema reconciliation so polling
+        another profile never takes a write lock. An inactive profile can
+        therefore be one additive migration behind the running binary. Preserve
+        the current compact-row shape with NULL aliases for those not-yet-added
+        columns instead of dropping the profile from cross-profile lists.
+        """
+        cls = type(self)
+        column_names = cls._compact_session_col_names()
+        if not self.read_only:
+            if cls._session_compact_cols_sql is None:
+                cls._session_compact_cols_sql = ", ".join(
+                    f"s.{name}" for name in column_names
+                )
+            return cls._session_compact_cols_sql
+
+        if self._read_only_session_compact_cols_sql is None:
+            with self._lock:
+                rows = self._conn.execute("PRAGMA table_info(sessions)").fetchall()
+            live_columns = {
+                row["name"] if isinstance(row, sqlite3.Row) else row[1]
+                for row in rows
+            }
+            self._read_only_session_compact_cols_sql = ", ".join(
+                f's."{name}"' if name in live_columns else f'NULL AS "{name}"'
+                for name in column_names
+            )
+        return self._read_only_session_compact_cols_sql
 
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1403,6 +1403,31 @@ class TestWebServerEndpoints:
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
 
+    def test_profiles_sessions_reads_inactive_profile_with_older_schema(self):
+        """Read-only aggregation must tolerate optional columns added since an
+        inactive profile last opened its state database."""
+        from hermes_cli import profiles as profiles_mod
+        from hermes_state import SessionDB
+
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+        worker_db = SessionDB(db_path=worker_home / "state.db")
+        try:
+            worker_db.create_session(session_id="legacy-worker", source="cli")
+            worker_db.append_message("legacy-worker", role="user", content="still list me")
+            worker_db._conn.execute(
+                "ALTER TABLE sessions DROP COLUMN compression_fallback_streak"
+            )
+        finally:
+            worker_db.close()
+
+        resp = self.client.get("/api/profiles/sessions?limit=20&min_messages=0")
+        assert resp.status_code == 200
+        data = resp.json()
+        row = next(s for s in data["sessions"] if s["id"] == "legacy-worker")
+        assert row["profile"] == "worker"
+        assert data["errors"] == []
+
     def test_profiles_sessions_rejects_unknown_archived_value(self):
         resp = self.client.get("/api/profiles/sessions?archived=bogus")
         assert resp.status_code == 400


### PR DESCRIPTION
## Bug Description

Hermes Desktop could silently show an incomplete all-profile session history in two cases:

1. A remote profile returned more sessions than the requested page, but Electron adapted `/api/sessions` without the `profile_totals` metadata expected by the Desktop sidebar. The first page was then treated as the complete result set and **Load more** was hidden.
2. An inactive profile database predated a newly added `sessions` column. Cross-profile aggregation opens inactive databases read-only, so it could not reconcile the schema, while compact list SQL still selected every column declared by the current runtime. SQLite raised (for example) `no such column: s.compression_fallback_streak`, and that profile was omitted from the aggregate.

## Root Cause

The remote-session adapter preserved rows and the global `total`, but did not adapt the single-profile response to the `/api/profiles/sessions` pagination contract.

Separately, `SessionDB._compact_session_cols()` derived its projection exclusively from the current declared schema. That assumption is valid after writable initialization, but not for intentionally non-migrating `SessionDB(read_only=True)` connections.

## Fix

- Normalize remote session-list responses at the Electron boundary:
  - tag rows with their owning Desktop profile,
  - preserve the backend total,
  - expose `{ profile_totals: { [profile]: total } }`,
  - fall back to the returned row count for older backends that omit `total`.
- For read-only `SessionDB` instances, inspect the physical `sessions` table once per connection and project missing declared columns as `NULL AS "column"`.
- Keep the existing cached fast path unchanged for writable/current-schema databases.
- Add regressions for both the Desktop response contract and an inactive profile whose physical schema lacks a current optional column.

The compatibility path does not migrate or otherwise write to inactive profile databases.

## How to Verify

1. Create a secondary profile database and remove an additive `sessions` column.
2. Request `/api/profiles/sessions`; the profile remains present and `errors` is empty.
3. Normalize a remote `/api/sessions` page whose `total` exceeds its row count; the response carries the owning profile's full total so Desktop can paginate.

## Test Plan

- [x] `scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_cli/test_web_server.py -k 'CompactRows or profiles_sessions_reads_inactive_profile_with_older_schema or profiles_sessions_tags_default_profile or profiles_sessions_strips_heavy_fields_by_default' -q --file-timeout 120` — 12 passed
- [x] `npm test -- --project electron electron/remote-session-list.test.ts` — 2 passed
- [x] `npm run typecheck`
- [x] `npx eslint electron/main.ts electron/remote-session-list.ts electron/remote-session-list.test.ts` — 0 errors
- [x] `npm run build`
- [x] Real read-only aggregation against multiple current and legacy profile databases returned every eligible profile with no errors

## Risk Assessment

Low. The schema fallback is restricted to read-only connections and preserves the current row shape. Writable databases retain the existing cached projection. The Desktop change is a pure response normalizer covered by focused contract tests.
