### PR TITLE
fix(telegram): make polling network retry cap env-configurable

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2220,15 +2220,22 @@ class TelegramAdapter(BasePlatformAdapter):
         connection silently dies; without this handler the bot never recovers.
 
         Strategy: exponential back-off (5s, 10s, 20s, 40s, 60s cap) up to
-        MAX_NETWORK_RETRIES attempts, then mark the adapter retryable-fatal so
-        the supervisor restarts the gateway process.
+        MAX_NETWORK_RETRIES attempts (default 10, ~8 min of outage; override
+        via HERMES_TELEGRAM_MAX_NETWORK_RETRIES for hosts with longer
+        connectivity gaps such as laptop sleep or flaky DNS), then mark the
+        adapter retryable-fatal so the supervisor restarts the gateway process.
         """
         if getattr(self, "_polling_teardown_started", False):
             return
         if self.has_fatal_error:
             return
 
-        MAX_NETWORK_RETRIES = 10
+        try:
+            MAX_NETWORK_RETRIES = max(
+                1, int(os.getenv("HERMES_TELEGRAM_MAX_NETWORK_RETRIES", "10"))
+            )
+        except (TypeError, ValueError):
+            MAX_NETWORK_RETRIES = 10
         BASE_DELAY = 5
         MAX_DELAY = 60
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -224,6 +224,65 @@ async def test_reconnect_triggers_fatal_after_max_retries():
     fatal_handler.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_reconnect_retry_cap_env_override(monkeypatch):
+    """
+    HERMES_TELEGRAM_MAX_NETWORK_RETRIES raises the retry cap, so an attempt
+    count that would exhaust the default of 10 keeps retrying instead of
+    marking the adapter fatal (and restarting the gateway).
+    """
+    monkeypatch.setenv("HERMES_TELEGRAM_MAX_NETWORK_RETRIES", "30")
+
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 10  # would be fatal at the default cap
+
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(Exception("still failing"))
+
+    assert not adapter.has_fatal_error
+    fatal_handler.assert_not_called()
+
+    # Clean up any self-scheduled retry/verifier tasks
+    for t in list(adapter._background_tasks):
+        t.cancel()
+        try:
+            await t
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_reconnect_retry_cap_env_invalid_falls_back_to_default(monkeypatch):
+    """An unparseable override falls back to the default cap of 10."""
+    monkeypatch.setenv("HERMES_TELEGRAM_MAX_NETWORK_RETRIES", "not-a-number")
+
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 10
+
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    adapter._app = MagicMock()
+
+    await adapter._handle_polling_network_error(Exception("still failing"))
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "telegram_network_error"
+    fatal_handler.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # Connection pool drain tests (PR #16466 salvage)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`_handle_polling_network_error` hardcodes `MAX_NETWORK_RETRIES = 10`. With the 5s→60s exponential back-off that is roughly 8 minutes of tolerance before the adapter is marked retryable-fatal and the supervisor restarts the entire gateway — killing in-flight cron runs and agent sessions.

Any host whose connectivity gaps routinely exceed 8 minutes (laptop sleep, flaky DNS, VPN/Wi-Fi transitions) hits this constantly. On my macOS deployment the gateway restarted 3–7 times per day, every one traced to:

```
ERROR hermes_plugins.telegram_platform.adapter: [Telegram] Telegram polling could not reconnect after 10 network error retries. Restarting gateway.
ERROR gateway.run: Fatal telegram adapter error (telegram_network_error): ...
```

## Fix

Read the cap from `HERMES_TELEGRAM_MAX_NETWORK_RETRIES` (default 10, floor 1, unparseable values fall back to the default). This follows the existing `HERMES_TELEGRAM_HTTP_POOL_SIZE` / `HERMES_TELEGRAM_HTTP_*` env-override idiom already used in this adapter for the same class of "PTB defaults too aggressive for flaky networks" problem.

Default behavior is unchanged.

## Tests

- `test_reconnect_retry_cap_env_override` — cap raised via env: attempt 10 keeps retrying instead of going fatal
- `test_reconnect_retry_cap_env_invalid_falls_back_to_default` — garbage value falls back to 10
- Full file passes: 44 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)