### PR TITLE
fix: keep web build deps installed under NODE_ENV=production

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4837,6 +4837,13 @@ def _run_npm_install_deterministic(
     # --silent/capture_output). It no-ops when CI is set — same as the TUI
     # install path and nix/lib.nix npm ci hooks.
     run_env = {**os.environ, **(env or {}), "CI": "1"}
+    # Hermes often runs with NODE_ENV=production at the parent-process level.
+    # npm treats that as an implicit omit=dev during install/ci, which drops
+    # build-time workspace deps like TypeScript and makes later `npm run build`
+    # fail with `tsc: command not found` even though the lockfile declares it.
+    # Force development semantics for dependency installation only.
+    run_env["NODE_ENV"] = "development"
+    run_env["NPM_CONFIG_PRODUCTION"] = "false"
 
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -156,6 +156,26 @@ class TestBuildWebUISkipsWhenFresh:
         assert kwargs["env"]["CI"] == "1"
         assert kwargs["env"]["PYTHON"] == "/nix/store/python"
 
+    def test_npm_install_forces_dev_deps_even_when_parent_node_env_is_production(
+        self, tmp_path, monkeypatch
+    ):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("NODE_ENV", "production")
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                web_dir,
+                env={"PYTHON": "/nix/store/python"},
+            )
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["env"]["NODE_ENV"] == "development"
+        assert kwargs["env"]["NPM_CONFIG_PRODUCTION"] == "false"
+        assert kwargs["env"]["PYTHON"] == "/nix/store/python"
+
     def test_npm_install_uses_workspace_web_scope(self, tmp_path):
         web_dir, _ = _make_web_dir(tmp_path)
         # Real workspace checkout: the single lockfile lives at the root, so


### PR DESCRIPTION
## Summary
- force npm install/ci to use development semantics inside `_run_npm_install_deterministic`
- preserve existing caller-provided env vars while overriding the production omit behavior
- add a regression test covering parent `NODE_ENV=production`

## Why
Hermes often runs with `NODE_ENV=production` in the parent process. npm treats that as an implicit omit=dev during install/ci, which drops build-time dependencies like TypeScript and causes later web builds to fail with `tsc: command not found`.

## Verification
- `./venv/bin/python -m pytest tests/hermes_cli/test_web_ui_build.py -q -o 'addopts='`
- manual repro on local checkout:
  - remove installed TypeScript
  - run `_run_npm_install_deterministic(...)` under `NODE_ENV=production`
  - confirm `node_modules/.bin/tsc` is restored
  - `cd web && NODE_ENV=production npm run build` succeeds

Fixes #49920
Refs #27430
