### PR TITLE
fix(desktop): support spaced Windows Git paths in review

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 
 import { afterEach, test } from 'vitest'
 
-import { repoStatus, resolveRenamePath } from './git-review-ops'
+import { gitFor, repoStatus, resolveRenamePath } from './git-review-ops'
 
 const tempDirs: string[] = []
 
@@ -29,6 +29,38 @@ function makeRepo() {
 
   return dir
 }
+
+test('gitFor accepts an internally resolved git binary path containing spaces', () => {
+  assert.doesNotThrow(() => gitFor(process.cwd(), 'C:\\Program Files\\Git\\cmd\\git.exe'))
+})
+
+test('gitFor executes status with the spaced Git for Windows binary instead of a repo-local executable', async () => {
+  if (process.platform !== 'win32') {
+    return
+  }
+
+  const gitBin = path.join(process.env.ProgramFiles || String.raw`C:\Program Files`, 'Git', 'cmd', 'git.exe')
+  const windowsRoot = process.env.SystemRoot || process.env.WINDIR || String.raw`C:\Windows`
+  const decoyGit = path.join(windowsRoot, 'System32', 'where.exe')
+
+  if (!fs.existsSync(gitBin) || !fs.existsSync(decoyGit)) {
+    return
+  }
+
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-git-review-'))
+
+  try {
+    execFileSync(gitBin, ['init', repo], { stdio: 'ignore' })
+    fs.copyFileSync(decoyGit, path.join(repo, 'git.exe'))
+    fs.writeFileSync(path.join(repo, 'changed.txt'), 'review me\n')
+
+    const status = await gitFor(repo, gitBin).status()
+
+    assert.equal(status.not_added.includes('changed.txt'), true)
+  } finally {
+    fs.rmSync(repo, { force: true, recursive: true })
+  }
+})
 
 test('resolveRenamePath: plain path is unchanged', () => {
   assert.equal(resolveRenamePath('src/a.ts'), 'src/a.ts')

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -11,6 +11,7 @@ import path from 'node:path'
 import simpleGit from 'simple-git'
 
 import { resolveRequestedPathForIpc } from './hardening'
+import { toWindowsShortPath } from './windows-short-path'
 
 const COMMIT_CONTEXT_DIFF_MAX_CHARS = 120_000
 const COMMIT_CONTEXT_UNTRACKED_MAX = 80
@@ -43,7 +44,20 @@ function runGh(args, cwd, ghBin): Promise<{ ok: boolean; stdout: string }> {
 }
 
 function gitFor(cwd, gitBin) {
-  return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
+  // `gitBin` is resolved inside the Electron main process from known install
+  // locations or PATH; it is never renderer/user input. Prefer a warning-free
+  // Windows 8.3 path when available. If short names are disabled, use
+  // simple-git's explicit trusted-binary escape hatch rather than falling back
+  // to PATH (which may be absent in GUI apps or resolve a repo-local git.exe).
+  const binary = gitBin && process.platform === 'win32' ? toWindowsShortPath(gitBin) : gitBin || 'git'
+
+  return simpleGit({
+    baseDir: cwd,
+    binary,
+    maxConcurrentProcesses: 4,
+    trimmed: false,
+    ...(gitBin ? { unsafe: { allowUnsafeCustomBinary: true } } : {})
+  })
 }
 
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve
@@ -680,6 +694,7 @@ async function repoStatus(repoPath, gitBin) {
 export {
   branchBase,
   fileDiffVsHead,
+  gitFor,
   repoStatus,
   resolveRenamePath,
   reviewCommit,

--- a/apps/desktop/electron/windows-short-path.test.ts
+++ b/apps/desktop/electron/windows-short-path.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { toWindowsShortPath } from './windows-short-path'
+
+test('toWindowsShortPath uses verbatim cmd arguments and returns a valid short path', () => {
+  const original = String.raw`C:\Program Files\Git\cmd\git.exe`
+  const expected = String.raw`C:\PROGRA~1\Git\cmd\git.exe`
+  let invocation: { args: string[]; command: string; options: Record<string, any> } | null = null
+
+  const result = toWindowsShortPath(original, (command, args, options) => {
+    invocation = { args, command, options }
+
+    return expected
+  })
+
+  assert.equal(result, expected)
+  assert.equal(path.win32.isAbsolute(invocation?.command || ''), true)
+  assert.equal(path.win32.basename(invocation?.command || '').toLowerCase(), 'cmd.exe')
+  assert.deepEqual(invocation?.args, ['/d', '/s', '/c', 'for %A in ("%HERMES_GIT_BINARY_PATH%") do @echo %~sA'])
+  assert.equal(invocation?.options.windowsVerbatimArguments, true)
+  assert.equal(invocation?.options.env.HERMES_GIT_BINARY_PATH, original)
+})
+
+test('toWindowsShortPath does not invoke cmd for an already safe path', () => {
+  const original = String.raw`C:\PortableGit\cmd\git.exe`
+  let invoked = false
+
+  const result = toWindowsShortPath(original, () => {
+    invoked = true
+
+    return ''
+  })
+
+  assert.equal(result, original)
+  assert.equal(invoked, false)
+})
+
+test('toWindowsShortPath keeps the original when short-name expansion is unavailable', () => {
+  const original = String.raw`D:\Git Install\cmd\git.exe`
+
+  assert.equal(
+    toWindowsShortPath(original, () => original),
+    original
+  )
+  assert.equal(
+    toWindowsShortPath(original, () => {
+      throw new Error('8.3 names disabled')
+    }),
+    original
+  )
+})
+
+test('toWindowsShortPath resolves the default Git for Windows install when available', () => {
+  if (process.platform !== 'win32') {
+    return
+  }
+
+  const git = String.raw`C:\Program Files\Git\cmd\git.exe`
+
+  if (!fs.existsSync(git)) {
+    return
+  }
+
+  const resolved = toWindowsShortPath(git)
+
+  assert.equal(fs.existsSync(resolved), true)
+  assert.equal(/\s/.test(resolved), false)
+})

--- a/apps/desktop/electron/windows-short-path.ts
+++ b/apps/desktop/electron/windows-short-path.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+
+const SHORT_PATH_ENV = 'HERMES_GIT_BINARY_PATH'
+const SHORT_PATH_COMMAND = `for %A in ("%${SHORT_PATH_ENV}%") do @echo %~sA`
+
+const windowsRoot = [process.env.SystemRoot, process.env.WINDIR].find((candidate): candidate is string =>
+  Boolean(candidate && path.win32.isAbsolute(candidate))
+)
+
+const CMD_EXE =
+  process.env.ComSpec && path.win32.isAbsolute(process.env.ComSpec)
+    ? process.env.ComSpec
+    : path.win32.join(windowsRoot || String.raw`C:\Windows`, 'System32', 'cmd.exe')
+
+interface ShortPathExecOptions {
+  encoding: 'utf8'
+  env: NodeJS.ProcessEnv
+  timeout: number
+  windowsHide: boolean
+  windowsVerbatimArguments: boolean
+}
+
+type ShortPathExec = (command: string, args: string[], options: ShortPathExecOptions) => Buffer | string
+
+const defaultShortPathExec = execFileSync as ShortPathExec
+const shortPathCache = new Map<string, string>()
+
+// Matches simple-git's custom-binary allowlist. Keep this local guard so the
+// Windows short-path result is accepted only when simple-git will accept it.
+function isSimpleGitSafeBinary(binary: string): boolean {
+  return /^([a-z]:)?([a-z0-9/.\\_~-]+)$/i.test(binary)
+}
+
+/**
+ * Convert a spaced Windows executable path to its 8.3 form for simple-git.
+ *
+ * `windowsVerbatimArguments` is required here. Without it Node re-quotes the
+ * command passed to `cmd.exe /c`, and `%~sA` echoes a malformed long path rather
+ * than performing short-name expansion. The executable path travels through an
+ * environment variable so it is never interpolated into cmd syntax.
+ *
+ * Volumes may disable 8.3 names. In that case the original path is returned and
+ * the caller can use simple-git's trusted-custom-binary escape hatch.
+ */
+export function toWindowsShortPath(filePath: string, exec: ShortPathExec = defaultShortPathExec): string {
+  if (!/\s/.test(filePath)) {
+    return filePath
+  }
+
+  // The main process resolves one git binary for its lifetime. Cache only the
+  // production executor path; injected test executors must remain isolated.
+  if (exec === defaultShortPathExec) {
+    const cached = shortPathCache.get(filePath)
+
+    if (cached) {
+      return cached
+    }
+  }
+
+  let resolved = filePath
+
+  try {
+    const result = String(
+      exec(CMD_EXE, ['/d', '/s', '/c', SHORT_PATH_COMMAND], {
+        encoding: 'utf8',
+        env: { ...process.env, [SHORT_PATH_ENV]: filePath },
+        timeout: 5_000,
+        windowsHide: true,
+        windowsVerbatimArguments: true
+      })
+    ).trim()
+
+    if (path.win32.isAbsolute(result) && isSimpleGitSafeBinary(result)) {
+      resolved = result
+    }
+  } catch {
+    // 8.3 names may be unavailable; the caller has a safe fallback.
+  }
+
+  if (exec === defaultShortPathExec) {
+    shortPathCache.set(filePath, resolved)
+  }
+
+  return resolved
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows Desktop Review pane silently showing **No diffs** when Git is installed at a path containing spaces, such as `C:\Program Files\Git\cmd\git.exe`.

The Electron main process deliberately resolves an absolute Git executable, but `simple-git` rejects custom binary strings containing spaces. `repoStatus`/`reviewList` then fail and the renderer clears the Review file list.

This change preserves the trusted absolute executable instead of falling back to `git` on PATH:

1. On Windows, convert the internally resolved executable to a validated 8.3 path when short names are available.
2. Invoke an absolute system `cmd.exe` with `windowsVerbatimArguments`; pass the source path through an environment variable rather than interpolating it into cmd syntax.
3. Cache the result so Review refreshes do not repeatedly spawn `cmd.exe`.
4. If 8.3 names are disabled, retain the absolute path and use `simple-git`'s supported `unsafe.allowUnsafeCustomBinary` escape hatch. This is limited to the executable resolved inside the Electron main process, never renderer/user input.

This supersedes the stale/conflicting approaches in #55337 and #60156 against the current TypeScript implementation. Unlike a plain-PATH fallback, it still works when GUI-launched Electron does not inherit Git on PATH and cannot select a repository-local `git.exe`.

## Related Issue

Fixes #54888

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/electron/git-review-ops.ts` to normalize the trusted Windows binary before constructing `simple-git` and retain a safe no-8.3 fallback.
- Added `apps/desktop/electron/windows-short-path.ts` with absolute `cmd.exe` resolution, safe argument handling, output validation, and caching.
- Added unit coverage for short-path conversion, failed/disabled 8.3 resolution, and real Git for Windows conversion.
- Added a Windows integration test that initializes a repository, places a decoy `git.exe` in it, and verifies `gitFor(...).status()` still executes the explicitly resolved Program Files binary.

## How to Test

1. Install Git for Windows at `C:\Program Files\Git\cmd\git.exe`.
2. Open a repository in Hermes Desktop and make staged, unstaged, or untracked changes.
3. Open Review and verify the changes populate rather than showing **No diffs**.

Commands run:

```text
npx vitest run --project electron electron/git-review-ops.test.ts electron/windows-short-path.test.ts
# 10 passed

npm run typecheck
# passed

npm run build
# passed, including assert-dist-built

npx eslint electron/git-review-ops.ts electron/git-review-ops.test.ts electron/windows-short-path.ts electron/windows-short-path.test.ts --quiet
# passed

npx prettier --check electron/git-review-ops.ts electron/git-review-ops.test.ts electron/windows-short-path.ts electron/windows-short-path.test.ts
# passed
```

Live Windows backend verification using the exact failing binary path:

```json
{
  "ok": true,
  "branch": "master",
  "changed": 3,
  "files": [
    "client/src/lib/rawDataColumns.spec.ts",
    "client/src/lib/rawDataColumns.ts",
    "client/src/pages/RawData.tsx"
  ]
}
```

Full Electron tests currently report 416 passed, 1 skipped, and two unrelated Windows-host failures in `update-relaunch.test.ts` and `windows-hermes-path.test.ts`; both failures reproduce unchanged with this patch stashed. Full desktop lint likewise has five pre-existing import-order failures, while all changed files pass lint. `scripts/run_tests.sh` could not run because this managed checkout has no repository-local `.venv` or `venv`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and reviewed #55337 and #60156
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (checkout has no repository-local virtualenv)
- [x] I've added tests for my changes
- [x] I've tested on Windows 10 with Git for Windows under Program Files

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered Windows, macOS, and Linux behavior
- [x] Tool descriptions/schema updates are N/A

## Screenshots / Logs

The live backend probe above returned all three staged/unstaged/untracked Review entries through `C:\Program Files\Git\cmd\git.exe`; before this patch the same call threw `GitPluginError: Invalid value supplied for custom binary`.
