### PR TITLE
Expand humanizer patterns (30-34) and humanize the skill's own prose

### DIFF
--- a/skills/creative/humanizer/SKILL.md
+++ b/skills/creative/humanizer/SKILL.md
@@ -28,27 +28,27 @@ Load this skill whenever the user asks to:
 - match their voice in writing they're producing
 - review text for AI tells before publishing
 
-Also apply this skill to **your own** output when writing user-facing prose — release notes, PR descriptions, documentation, long-form explanations, summaries. Hermes's baseline voice already strips most of these, but a focused pass catches what slips through.
+Also apply this skill to **your own** output when writing user-facing prose such as release notes, PR descriptions, docs, and summaries. Hermes's baseline voice already strips most of these, but a focused pass catches what slips through.
 
 ## How to use it in Hermes
 
 The text usually arrives one of three ways:
-1. **Inline** — user pastes the text directly into the message. Work on it in-place, reply with the rewrite.
-2. **File** — user points at a file. Use `read_file` to load it, then `patch` or `write_file` to apply edits. For markdown docs in a repo, a targeted `patch` per section is cleaner than rewriting the whole file.
-3. **Voice calibration sample** — user provides an additional sample of their own writing (inline or by file path) and asks you to match it. Read the sample first, then rewrite. See the Voice Calibration section below.
+1. **Inline.** The user pastes the text into the message. Work on it in place and reply with the rewrite.
+2. **File.** The user points at a file. Use `read_file` to load it, then `patch` or `write_file` to apply edits. For a markdown doc in a repo, a targeted `patch` per section is cleaner than rewriting the whole file.
+3. **Voice calibration sample.** The user provides a sample of their own writing (inline or by file path) and asks you to match it. Read the sample first, then rewrite. See the Voice Calibration section below.
 
-Always show the rewrite to the user. For file edits, show a diff or the changed section — don't silently overwrite.
+Always show the rewrite to the user. For file edits, show a diff or the changed section instead of silently overwriting.
 
 ## Your task
 
 When given text to humanize:
 
-1. **Identify AI patterns** — scan for the 29 patterns listed below.
-2. **Rewrite problematic sections** — replace AI-isms with natural alternatives.
-3. **Preserve meaning** — keep the core message intact.
-4. **Maintain voice** — match the intended tone (formal, casual, technical, etc.). If a voice sample was provided, match it specifically.
-5. **Add soul** — don't just remove bad patterns, inject actual personality. See PERSONALITY AND SOUL below.
-6. **Do a final anti-AI pass** — ask yourself: "What makes the below so obviously AI generated?" Answer briefly with any remaining tells, then revise one more time.
+1. **Identify AI patterns.** Scan for the 34 patterns listed below.
+2. **Rewrite problematic sections.** Replace AI-isms with natural alternatives.
+3. **Preserve meaning.** Keep the core message intact.
+4. **Maintain voice.** Match the intended tone (formal, casual, technical, and so on). If a voice sample was provided, match it specifically.
+5. **Add soul.** Removing bad patterns is only half the job; the rewrite also needs real personality. See PERSONALITY AND SOUL below.
+6. **Do a final anti-AI pass.** Ask yourself: "What makes the below so obviously AI generated?" Answer briefly with any remaining tells, then revise one more time.
 
 
 ## Voice Calibration (optional)
@@ -63,7 +63,7 @@ If the user provides a writing sample (their own previous writing), analyze it b
    - Any recurring phrases or verbal tics
    - How they handle transitions (explicit connectors? Just start the next point?)
 
-2. **Match their voice in the rewrite.** Don't just remove AI patterns — replace them with patterns from the sample. If they write short sentences, don't produce long ones. If they use "stuff" and "things," don't upgrade to "elements" and "components."
+2. **Match their voice in the rewrite.** Removing AI patterns is only half of it; swap in patterns from the sample as well. If they write short sentences, do not produce long ones. If they use "stuff" and "things," do not upgrade to "elements" and "components."
 
 3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
 
@@ -86,23 +86,23 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ### How to add voice:
 
-**Have opinions.** Don't just report facts — react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+**Have opinions.** Report the facts, then react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
 
 **Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
 
 **Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
 
-**Use "I" when it fits.** First person isn't unprofessional — it's honest. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
+**Use "I" when it fits.** First person reads as honest and fits most prose. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
 
 **Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
 
-**Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+**Be specific about feelings.** Instead of "this is concerning," write "there's something unsettling about agents churning away at 3am while nobody's watching."
 
 ### Before (clean but soulless):
 > The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
 
 ### After (has a pulse):
-> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle — but I keep thinking about those agents working through the night.
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle, but I keep thinking about those agents working through the night.
 
 
 ## CONTENT PATTERNS
@@ -190,6 +190,8 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 ### 7. Overused "AI Vocabulary" Words
 
 **High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Marketing and blog clichés (same tell, different register):** at the end of the day, when it comes to, in a world where, moving forward, circle back, deep dive, game-changer, double down, take a step back, on the same page, make no mistake, it turns out, let me be clear, navigate (for challenges), lean into, unpack (before analysis), straightforward (to describe anything)
 
 **Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
 
@@ -477,6 +479,73 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 >
 > When users hit a slow page, they leave.
 
+
+## STYLE, RHYTHM, AND RHETORIC PATTERNS
+
+### 30. Forced Metaphors and Figurative Overwriting
+
+**Signs to watch:** original but strained metaphors, mixed metaphors, figurative substitutions where a plain word is clearer, a metaphor that gets explained right after it is used
+
+**Problem:** Beyond the stock figurative words flagged in patterns 4 and 7, LLMs invent decorative metaphors that add imagery without adding meaning, then often explain them. Plain description is usually clearer and more honest. If the metaphor does not earn its place, cut it and say the literal thing.
+
+**Before:**
+> The codebase is a garden we must tend, pruning dead branches and planting seeds of innovation so the whole ecosystem can flourish. In other words, delete unused code and add features.
+
+**After:**
+> Delete unused code and add the features users are asking for.
+
+
+### 31. Dramatic Fragmentation and Punchy Kickers
+
+**Signs to watch:** two- or three-word subjectless sentences used for drama, staccato "X. And Y. And Z." runs, a short quotable line ending every paragraph or section, cutesy appositive fragments ("the catalog, honestly priced")
+
+**Problem:** LLMs chop sentences into fragments for false emphasis and end sections with a quotable "mic-drop" line. It reads like ad copy or a motivational poster. If a line sounds like it belongs on a poster, cut it or fold it back into a real sentence with a subject. This is distinct from pattern 13 (which is about grammatical passive voice); here the tell is rhythm and showmanship, not a hidden actor.
+
+**Before:**
+> The catalog, honestly priced. Pay for what it does. Not promises. It just works. Every time.
+
+**After:**
+> The catalog is priced by usage, so you pay for the calls you actually make rather than a flat monthly fee.
+
+
+### 32. Rhetorical Questions Answered Immediately
+
+**Signs to watch:** "What if...?", "The question is...", "Ever wondered...?", a question immediately followed by its own answer, "Think about it."
+
+**Problem:** LLMs pose a question only to answer it a beat later. The question adds no information and stalls the sentence. State the point directly.
+
+**Before:**
+> What makes an API good? It comes down to predictability. Think about it: developers want to know exactly what they will get back.
+
+**After:**
+> A good API is predictable, so developers know exactly what they will get back.
+
+
+### 33. Sentence-Opener Tics
+
+**Words to watch:** So..., Look,, habitual sentence-initial And/But, "I think"/"I believe" when stating a fact, adverb openers (Interestingly, Importantly, Notably, Crucially, Essentially, Ultimately)
+
+**Problem:** LLMs lean on a small set of openers. Adverb openers tell the reader how to feel instead of earning it, and "So" or "Look" fake conversational warmth. Drop the opener and start with the substance.
+
+**Before:**
+> So, the results were mixed. Interestingly, adoption went up. Importantly, churn went up too. I think that means the feature still needs work.
+
+**After:**
+> The results were mixed: adoption rose, but churn rose alongside it, so the feature still needs work.
+
+
+### 34. Reassurance Kickers
+
+**Signs to watch:** And that's okay., And that's fine., There's nothing wrong with that., no shame in..., you're not alone, it's completely normal
+
+**Problem:** LLMs tack on reassurance the reader never asked for. It softens the writing and assumes the reader needs comforting. Trust the reader: make the point and stop.
+
+**Before:**
+> You might not have a testing setup yet. And that's okay. Plenty of teams start without one, and there's nothing wrong with that.
+
+**After:**
+> Many teams start without a testing setup and add one once regressions begin costing real time.
+
 ---
 
 ## Process
@@ -573,6 +642,6 @@ Provide:
 
 This skill is ported from [blader/humanizer](https://github.com/blader/humanizer) (MIT licensed), which is itself based on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
 
-Original author: Siqi Chen ([@blader](https://github.com/blader)). Original repo: https://github.com/blader/humanizer (version 2.5.1). Ported to Hermes Agent with Hermes-native tool references (`read_file`, `patch`, `write_file`) and guidance for when to load the skill; the 29 patterns, personality/soul section, and full worked example are preserved verbatim from the source. Original MIT license preserved in the `LICENSE` file alongside this `SKILL.md`.
+Original author: Siqi Chen ([@blader](https://github.com/blader)). Original repo: https://github.com/blader/humanizer (version 2.5.1). Ported to Hermes Agent with Hermes-native tool references (`read_file`, `patch`, `write_file`) and guidance for when to load the skill. The original 29 patterns come from the source, and the before/after examples (including the full worked example) are kept as demonstrations. Patterns 30-34 and the "marketing and blog clichés" list added to pattern 7 are Hermes additions and are not part of the upstream source. The skill's own instructional prose has also been lightly edited to follow its own guidance (for example, removing em dashes and negative parallelism from the narration) so the skill models the writing it asks for. Original MIT license preserved in the `LICENSE` file alongside this `SKILL.md`.
 
 Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."


### PR DESCRIPTION
## What

Expands the `humanizer` skill and brings its own prose in line with what it teaches.

**New patterns (30-34):**
- **30. Forced Metaphors and Figurative Overwriting.** Decorative or strained metaphors that add imagery without meaning. The existing patterns only flag specific figurative *words* (patterns 4 and 7); nothing caught an original but forced metaphor.
- **31. Dramatic Fragmentation and Punchy Kickers.** Two or three word subjectless dramatic fragments, "X. And Y. And Z." staccato, section-ending mic-drop lines, and cutesy aphorisms ("the catalog, honestly priced"). Pattern 13 only covered grammatical passive/subjectless; this is the rhythm and showmanship tell.
- **32. Rhetorical Questions Answered Immediately.** The skill had nothing on rhetorical question-and-answer.
- **33. Sentence-Opener Tics.** "So,", "Look,", habitual And/But openers, and adverb openers (Interestingly, Importantly, Crucially).
- **34. Reassurance Kickers.** Unrequested "And that's okay." style reassurance.

**Pattern 7:** added a "marketing and blog cliches" list (game-changer, circle back, deep dive, moving forward, at the end of the day, and so on). The current list is encyclopedic in register and misses the business/blog register.

**The skill now follows its own advice.** The instructional prose used em dashes after almost every bold lead-in, plus several "isn't X, it's Y" negations, which are the exact tells the skill flags (patterns 9 and 14). Agents learn from the surrounding prose, so the narration is now de-slopped. The Before/After example blockquotes are left untouched so the demonstrations still contain the tells they teach.

## Why

The skill claims to strip AI tells but demonstrated several of them in its own voice, and the pattern set had structural gaps (metaphor, dramatic fragmentation, rhetorical questions) that come up constantly in real drafts.

## Notes

- This intentionally diverges from the upstream `blader/humanizer` 2.5.1 port. The attribution note is updated to mark patterns 30-34 and the pattern-7 list as Hermes additions, and to record the prose edits.
- One change lands inside an example: the "After (has a pulse)" soul demo itself used an em dash. Removed, since it is a *good* example and should model the rule.
- Docs-only change to a single skill file (+86 / -17). No code, no new tool, no token-budget impact beyond the skill's on-demand body.
