### PR TITLE
fix(wecom): add CLOSING state to _wait_for_handshake terminal handler

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -359,7 +359,7 @@ class WeComAdapter(BasePlatformAdapter):
                 if self._payload_req_id(payload) == req_id:
                     return payload
                 logger.debug("[%s] Ignoring pre-auth payload: %s", self.name, payload.get("cmd"))
-            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR}:
+            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
                 raise RuntimeError("WeCom websocket closed during authentication")
 
     async def _listen_loop(self) -> None:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -483,3 +483,94 @@ class TestTextBatchFlushRace:
             "superseded task must not pop the event"
         )
 
+
+class TestWaitForHandshakeClosing:
+    """Tests for _wait_for_handshake() handling CLOSING state (PR #64716).
+
+    _read_events() was fixed to handle WSMsgType.CLOSING in #28311
+    (issue #28293), but _wait_for_handshake() was overlooked.
+    These tests prove the fix closes that gap.
+    """
+
+    @pytest.mark.asyncio
+    async def test_handshake_raises_on_closing_frame(self):
+        """_wait_for_handshake() raises immediately on CLOSING frame.
+
+        Before the fix, the handshake loop would ignore CLOSING frames,
+        eventually timing out after CONNECT_TIMEOUT_SECONDS (20s) instead
+        of surfacing the real error immediately.
+        """
+        import aiohttp
+        from types import SimpleNamespace
+        from plugins.platforms.wecom.adapter import WeComAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+
+        class _ClosingWS:
+            closed = False
+
+            async def receive(self):
+                return SimpleNamespace(type=aiohttp.WSMsgType.CLOSING)
+
+            async def close(self):
+                return None
+
+        adapter._ws = _ClosingWS()
+
+        with pytest.raises(RuntimeError, match="WeCom websocket closed during authentication"):
+            await adapter._wait_for_handshake("subscribe-req-id")
+
+    @pytest.mark.asyncio
+    async def test_handshake_raises_on_closed_frame(self):
+        """Existing terminal state (CLOSED) still raises correctly."""
+        import aiohttp
+        from types import SimpleNamespace
+        from plugins.platforms.wecom.adapter import WeComAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+
+        class _ClosedWS:
+            closed = False
+
+            async def receive(self):
+                return SimpleNamespace(type=aiohttp.WSMsgType.CLOSED)
+
+            async def close(self):
+                return None
+
+        adapter._ws = _ClosedWS()
+
+        with pytest.raises(RuntimeError, match="WeCom websocket closed during authentication"):
+            await adapter._wait_for_handshake("subscribe-req-id")
+
+    @pytest.mark.asyncio
+    async def test_handshake_raises_on_error_frame(self):
+        """Existing terminal state (ERROR) still raises correctly."""
+        import aiohttp
+        from types import SimpleNamespace
+        from plugins.platforms.wecom.adapter import WeComAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+
+        class _ErrorWS:
+            closed = False
+
+            async def receive(self):
+                return SimpleNamespace(type=aiohttp.WSMsgType.ERROR)
+
+            async def close(self):
+                return None
+
+        adapter._ws = _ErrorWS()
+
+        with pytest.raises(RuntimeError, match="WeCom websocket closed during authentication"):
+            await adapter._wait_for_handshake("subscribe-req-id")


### PR DESCRIPTION
## What

Adds `aiohttp.WSMsgType.CLOSING` to the terminal state check in `_wait_for_handshake()`, matching the identical fix already applied to `_read_events()` in #28311 (for issue #28293).

## Why

`_wait_for_handshake()` was missing `WSMsgType.CLOSING` from its terminal state handler, causing WeCom reconnection to fail permanently with "closed during authentication" when the server sends a CLOSING frame during the authentication handshake.

When #28311 fixed `_read_events()` for issue #28293, `_wait_for_handshake()` was overlooked — both functions handle WebSocket messages and need to recognize all terminal states.

## Impact

In production with multiple WeCom agents: after a mass restart event, agents that receive a CLOSING frame during the reconnection handshake get stuck in a permanent failure loop — manual pod restart is required to recover.

## Fix

One-line change in `plugins/platforms/wecom/adapter.py`:

```diff
-            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR}:
+            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
```

Identical to the pattern already in `_read_events()` (line ~370).

Fixes: #64703