### PR TITLE
fix(clarify): 説明付き選択カードを通常チャットに表示

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2314,6 +2314,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 _clarify_tool(
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
+                    context=next_args.get("context", ""),
+                    recommendation=next_args.get("recommendation", ""),
                     callback=agent.clarify_callback,
                 ),
                 next_args,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1324,6 +1324,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 return _clarify_tool(
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
+                    context=next_args.get("context", ""),
+                    recommendation=next_args.get("recommendation", ""),
                     callback=agent.clarify_callback,
                 )
             function_result, function_args = _run_agent_tool_execution_middleware(

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,14 +1,27 @@
-import { cleanup, render, screen } from '@testing-library/react'
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { HermesGateway } from '@/hermes'
 import { I18nProvider } from '@/i18n'
+import { $clarifyRequests, setClarifyRequest } from '@/store/clarify'
+import { $gateway } from '@/store/gateway'
+import { $activeSessionId } from '@/store/session'
 
 import { ClarifyTool, readClarifyResult } from './clarify-tool'
 
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (state: unknown) => unknown) =>
+    selector({ thread: { isRunning: true }, message: { status: { type: 'running' } } })
+}))
+
 afterEach(() => {
   cleanup()
+  $clarifyRequests.set({})
+  $gateway.set(null)
+  $activeSessionId.set(null)
+  vi.clearAllMocks()
 })
 
 function renderClarify(ui: ReactNode) {
@@ -38,19 +51,70 @@ function settledClarifyProps(
   }
 }
 
+function pendingClarifyProps(args: ToolCallMessagePartProps['args'], toolCallId: string): ToolCallMessagePartProps {
+  return {
+    addResult: vi.fn(),
+    args,
+    argsText: JSON.stringify(args),
+    isError: false,
+    result: undefined,
+    resume: vi.fn(),
+    status: { type: 'running' },
+    toolCallId,
+    toolName: 'clarify',
+    type: 'tool-call'
+  }
+}
+
+function attachClarifyRequest(question: string) {
+  const request = vi.fn().mockResolvedValue({ ok: true })
+
+  $activeSessionId.set(null)
+  setClarifyRequest({
+    choices: null,
+    question,
+    requestId: 'clarify-request-1',
+    sessionId: null
+  })
+  $gateway.set({ request } as unknown as HermesGateway)
+
+  return request
+}
+
+const structuredArgs = {
+  question: 'Which rollout should we use?',
+  context: 'Production currently has no canary traffic.',
+  recommendation: 'Choose Safe because it preserves rollback capacity.',
+  choices: [
+    {
+      id: 'fast',
+      label: 'Fast',
+      description: 'Deploy to every instance immediately.',
+      value: 'fast-rollout'
+    },
+    {
+      id: 'safe',
+      label: 'Safe',
+      description: 'Canary first, then expand after verification.',
+      value: 'safe-rollout'
+    }
+  ]
+}
+
 describe('readClarifyResult', () => {
   it('reads question + user_response from the tool JSON payload', () => {
-    expect(
-      readClarifyResult({
-        question: 'Which target?',
-        choices_offered: ['staging', 'prod'],
-        user_response: 'staging'
-      })
-    ).toEqual({
+    const result = readClarifyResult({
+      question: 'Which target?',
+      choices_offered: ['staging', 'prod'],
+      user_response: 'staging'
+    })
+
+    expect(result).toMatchObject({
       question: 'Which target?',
       answer: 'staging',
       error: undefined
     })
+    expect(result.options?.map(option => option.label)).toEqual(['staging', 'prod'])
   })
 
   it('parses a JSON string result the same way as an object', () => {
@@ -61,7 +125,7 @@ describe('readClarifyResult', () => {
           user_response: 'yes'
         })
       )
-    ).toEqual({
+    ).toMatchObject({
       question: 'Ship it?',
       answer: 'yes',
       error: undefined
@@ -69,11 +133,150 @@ describe('readClarifyResult', () => {
   })
 
   it('keeps an empty user_response so Skip can render as skipped', () => {
-    expect(readClarifyResult({ question: 'Ok?', user_response: '' })).toEqual({
+    expect(readClarifyResult({ question: 'Ok?', user_response: '' })).toMatchObject({
       question: 'Ok?',
       answer: '',
       error: undefined
     })
+  })
+
+  it('reads structured result metadata', () => {
+    const result = readClarifyResult({
+      question: 'Which rollout should we use?',
+      context: 'Production currently has no canary traffic.',
+      recommendation: 'Choose Safe because it preserves rollback capacity.',
+      options: structuredArgs.choices,
+      selected_option: {
+        id: 'safe',
+        index: 2,
+        label: 'Safe',
+        description: 'Canary first, then expand after verification.',
+        value: 'safe-rollout'
+      },
+      user_response: 'safe-rollout'
+    })
+
+    expect(result.context).toBe('Production currently has no canary traffic.')
+    expect(result.recommendation).toBe('Choose Safe because it preserves rollback capacity.')
+    expect(result.options?.[1]).toMatchObject({
+      id: 'safe',
+      index: 2,
+      label: 'Safe',
+      description: 'Canary first, then expand after verification.',
+      value: 'safe-rollout'
+    })
+    expect(result.selectedOption).toMatchObject({
+      id: 'safe',
+      label: 'Safe',
+      description: 'Canary first, then expand after verification.',
+      value: 'safe-rollout'
+    })
+  })
+})
+
+describe('ClarifyTool pending view', () => {
+  it('renders structured choices with numeric badges and sends the canonical value', async () => {
+    const request = attachClarifyRequest(
+      'Which rollout should we use?\n\nContext: Production currently has no canary traffic.'
+    )
+
+    renderClarify(<ClarifyTool {...pendingClarifyProps(structuredArgs, 'clarify-pending-1')} />)
+
+    expect(screen.getByText('Which rollout should we use?')).toBeTruthy()
+    expect(screen.getByText('Production currently has no canary traffic.')).toBeTruthy()
+    expect(screen.getByText('Choose Safe because it preserves rollback capacity.')).toBeTruthy()
+    expect(screen.getByText('Fast')).toBeTruthy()
+    expect(screen.getByText('Deploy to every instance immediately.')).toBeTruthy()
+    expect(screen.getByText('Safe')).toBeTruthy()
+    expect(screen.getByText('Canary first, then expand after verification.')).toBeTruthy()
+    expect([...globalThis.document.querySelectorAll('[data-slot="kbd"]')].map(node => node.textContent)).toEqual([
+      '1',
+      '2',
+      '3'
+    ])
+
+    fireEvent.click(screen.getByRole('button', { name: /Safe/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'clarify-request-1',
+        answer: 'safe-rollout',
+        option_id: 'safe'
+      })
+    )
+  })
+
+  it('supports numeric choice shortcuts and Enter confirmation', async () => {
+    const request = attachClarifyRequest('Which rollout should we use?')
+
+    renderClarify(<ClarifyTool {...pendingClarifyProps(structuredArgs, 'clarify-pending-2')} />)
+
+    fireEvent.keyDown(window, { key: '2' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'clarify-request-1',
+        answer: 'safe-rollout',
+        option_id: 'safe'
+      })
+    )
+  })
+
+  it('focuses Other with the trailing numeric shortcut', () => {
+    attachClarifyRequest('Which rollout should we use?')
+
+    renderClarify(<ClarifyTool {...pendingClarifyProps(structuredArgs, 'clarify-pending-3')} />)
+
+    fireEvent.keyDown(window, { key: '3' })
+
+    expect(globalThis.document.activeElement).toBe(screen.getByPlaceholderText('Other (type your answer)'))
+  })
+
+  it('marks Other text as custom even when it matches an option label', async () => {
+    const request = attachClarifyRequest('Which rollout should we use?')
+
+    renderClarify(<ClarifyTool {...pendingClarifyProps(structuredArgs, 'clarify-pending-custom')} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Other (type your answer)'), {
+      target: { value: 'Safe' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'clarify-request-1',
+        answer: 'Safe',
+        response_kind: 'custom'
+      })
+    )
+  })
+
+  it('renders at most four choices plus Other', () => {
+    attachClarifyRequest('Pick one')
+
+    renderClarify(
+      <ClarifyTool
+        {...pendingClarifyProps(
+          {
+            question: 'Pick one',
+            choices: ['One', 'Two', 'Three', 'Four', 'Five']
+          },
+          'clarify-pending-max'
+        )}
+      />
+    )
+
+    expect(screen.getByText('Four')).toBeTruthy()
+    expect(screen.queryByText('Five')).toBeNull()
+    expect([...globalThis.document.querySelectorAll('[data-slot="kbd"]')].map(node => node.textContent)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5'
+    ])
   })
 })
 
@@ -95,8 +298,102 @@ describe('ClarifyTool settled view', () => {
 
     expect(screen.getByText('Which deployment target?')).toBeTruthy()
     expect(screen.getByText('staging')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-settled]')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
+    expect(screen.getByText('prod')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-clarify-settled]')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-selected="true"]')?.textContent).toContain('staging')
+    expect(globalThis.document.querySelector('[data-clarify-answer]')?.textContent).toBe('1. staging')
+  })
+
+  it('marks the selected structured option from selected_option', () => {
+    renderClarify(
+      <ClarifyTool
+        {...settledClarifyProps(
+          structuredArgs,
+          {
+            question: 'Which rollout should we use?',
+            context: 'Production currently has no canary traffic.',
+            recommendation: 'Choose Safe because it preserves rollback capacity.',
+            options: structuredArgs.choices,
+            selected_option: {
+              id: 'safe',
+              index: 2,
+              label: 'Safe',
+              description: 'Canary first, then expand after verification.',
+              value: 'safe-rollout'
+            },
+            user_response: 'safe-rollout'
+          },
+          'clarify-structured-settled'
+        )}
+      />
+    )
+
+    expect(screen.getByText('Which rollout should we use?')).toBeTruthy()
+    expect(screen.getByText('Production currently has no canary traffic.')).toBeTruthy()
+    expect(screen.getByText('Choose Safe because it preserves rollback capacity.')).toBeTruthy()
+    expect(screen.getByText('Fast')).toBeTruthy()
+    expect(screen.getByText('Deploy to every instance immediately.')).toBeTruthy()
+    expect(screen.getByText('Safe')).toBeTruthy()
+    expect(screen.getByText('Canary first, then expand after verification.')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-selected="true"]')?.textContent).toContain('Safe')
+    expect(globalThis.document.querySelector('[data-clarify-answer]')?.textContent).toBe('2. Safe')
+  })
+
+  it('uses selected_option id before an ambiguous answer value', () => {
+    const ambiguousOptions = [
+      {
+        id: 'first',
+        index: 1,
+        label: 'First',
+        description: 'Shares a value.',
+        value: 'shared'
+      },
+      {
+        id: 'second',
+        index: 2,
+        label: 'Second',
+        description: 'Was actually selected.',
+        value: 'shared'
+      }
+    ]
+
+    renderClarify(
+      <ClarifyTool
+        {...settledClarifyProps(
+          { question: 'Which duplicate?', choices: ambiguousOptions },
+          {
+            question: 'Which duplicate?',
+            options: ambiguousOptions,
+            selected_option: ambiguousOptions[1],
+            user_response: 'shared'
+          },
+          'clarify-ambiguous-value'
+        )}
+      />
+    )
+
+    expect(globalThis.document.querySelector('[data-clarify-option="first"]')?.getAttribute('data-selected')).toBeNull()
+    expect(globalThis.document.querySelector('[data-clarify-option="second"]')?.getAttribute('data-selected')).toBe('true')
+    expect(globalThis.document.querySelector('[data-clarify-answer]')?.textContent).toBe('2. Second')
+  })
+
+  it('keeps legacy user_response-only results readable', () => {
+    renderClarify(
+      <ClarifyTool
+        {...settledClarifyProps(
+          { question: 'Which deployment target?', choices: ['staging', 'prod'] },
+          {
+            question: 'Which deployment target?',
+            user_response: 'staging'
+          },
+          'clarify-legacy-result'
+        )}
+      />
+    )
+
+    expect(screen.getByText('Which deployment target?')).toBeTruthy()
+    expect(screen.getByText('staging')).toBeTruthy()
+    expect(screen.getByText('prod')).toBeTruthy()
   })
 
   it('labels an empty response as Skipped', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -19,7 +19,7 @@ import { Kbd } from '@/components/ui/kbd'
 import { Textarea } from '@/components/ui/textarea'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
+import { Check, CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $clarifyRequest, clearClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -28,16 +28,28 @@ import { notifyError } from '@/store/notifications'
 import { selectMessageRunning } from './tool/fallback-model'
 import { parseMaybeObject } from './tool/fallback-model/format'
 
-interface ClarifyArgs {
-  question?: string
-  choices?: string[] | null
+interface ClarifyOption {
+  id: string
+  index: number
+  label: string
+  description: string
+  value: string
 }
 
-interface ClarifyResult {
+interface ClarifyArgs {
   question?: string
+  context?: string
+  recommendation?: string
+  options?: ClarifyOption[] | null
+}
+
+interface ClarifyResult extends ClarifyArgs {
+  selectedOption?: ClarifyOption | null
   answer?: string
   error?: string
 }
+
+const MAX_CLARIFY_CHOICES = 4
 
 function stringField(row: Record<string, unknown>, ...keys: string[]): string | undefined {
   for (const key of keys) {
@@ -49,17 +61,167 @@ function stringField(row: Record<string, unknown>, ...keys: string[]): string | 
   }
 }
 
-function readClarifyArgs(args: unknown): ClarifyArgs {
-  const row = parseMaybeObject(args)
-  const choices = Array.isArray(row.choices) ? row.choices.filter((c): c is string => typeof c === 'string') : null
+function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function cleanStringField(row: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = cleanText(row[key])
+
+    if (value) {
+      return value
+    }
+  }
+
+  return ''
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function scalarLabel(value: unknown): string {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  return typeof value === 'string' ? value.trim() : String(value).trim()
+}
+
+function normalizeClarifyChoices(choices: unknown): ClarifyOption[] | null {
+  if (!Array.isArray(choices)) {
+    return null
+  }
+
+  const options: ClarifyOption[] = []
+  const usedIds = new Set<string>()
+
+  for (const raw of choices) {
+    if (options.length >= MAX_CLARIFY_CHOICES) {
+      break
+    }
+
+    const row = recordValue(raw)
+    let id = ''
+    let label = ''
+    let description = ''
+    let value = ''
+
+    if (row) {
+      id = cleanText(row.id)
+      label = cleanStringField(row, 'label', 'text', 'title')
+      description = cleanText(row.description)
+      value = cleanText(row.value)
+
+      if (!label) {
+        label = description
+        description = ''
+      }
+    } else {
+      label = scalarLabel(raw)
+    }
+
+    if (!label) {
+      continue
+    }
+
+    const index = options.length + 1
+    const fallbackId = `option-${index}`
+    let optionId = id || fallbackId
+
+    if (usedIds.has(optionId)) {
+      optionId = fallbackId
+
+      let suffix = 2
+
+      while (usedIds.has(optionId)) {
+        optionId = `${fallbackId}-${suffix}`
+        suffix += 1
+      }
+    }
+
+    usedIds.add(optionId)
+    options.push({
+      id: optionId,
+      index,
+      label,
+      description,
+      value: value || label
+    })
+  }
+
+  return options.length > 0 ? options : null
+}
+
+function normalizeSelectedOption(value: unknown): ClarifyOption | null {
+  const row = recordValue(value)
+
+  if (!row) {
+    return null
+  }
+
+  const rawIndex = typeof row.index === 'number' && Number.isFinite(row.index) ? row.index : 1
+  const index = Math.max(1, Math.floor(rawIndex))
+  const description = cleanText(row.description)
+  const label = cleanStringField(row, 'label', 'text', 'title') || description || cleanText(row.value) || cleanText(row.id)
+
+  if (!label) {
+    return null
+  }
 
   return {
-    question: stringField(row, 'question'),
-    choices: choices && choices.length > 0 ? choices : null
+    id: cleanText(row.id) || `option-${index}`,
+    index,
+    label,
+    description: label === description ? '' : description,
+    value: cleanText(row.value) || label
   }
 }
 
-/** Parse clarify tool JSON (`question` + `user_response`). */
+function parsePromptParts(value: unknown): Pick<ClarifyArgs, 'question' | 'context' | 'recommendation'> {
+  const text = cleanText(value)
+
+  if (!text) {
+    return {}
+  }
+
+  const firstSection = text.search(/\n\s*\n(?:Context|Recommendation):/i)
+  const question = (firstSection >= 0 ? text.slice(0, firstSection) : text).trim()
+  const context = text.match(/(?:^|\n\s*\n)Context:\s*([\s\S]*?)(?=\n\s*\nRecommendation:|$)/i)?.[1]?.trim()
+  const recommendation = text.match(/(?:^|\n\s*\n)Recommendation:\s*([\s\S]*)$/i)?.[1]?.trim()
+
+  return {
+    question: question || undefined,
+    context: context || undefined,
+    recommendation: recommendation || undefined
+  }
+}
+
+function questionMatchValue(value: unknown): string {
+  return (parsePromptParts(value).question ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function questionsMatch(left: unknown, right: unknown): boolean {
+  const leftQuestion = questionMatchValue(left)
+  const rightQuestion = questionMatchValue(right)
+
+  return Boolean(leftQuestion && rightQuestion && leftQuestion === rightQuestion)
+}
+
+function readClarifyArgs(args: unknown): ClarifyArgs {
+  const row = parseMaybeObject(args)
+  const prompt = parsePromptParts(row.question)
+
+  return {
+    question: prompt.question,
+    context: cleanText(row.context) || prompt.context,
+    recommendation: cleanText(row.recommendation) || prompt.recommendation,
+    options: normalizeClarifyChoices(row.choices)
+  }
+}
+
+/** Parse clarify tool JSON (`question` + `user_response`) plus structured option metadata. */
 export function readClarifyResult(result: unknown): ClarifyResult {
   const row = parseMaybeObject(result)
 
@@ -67,14 +229,18 @@ export function readClarifyResult(result: unknown): ClarifyResult {
     return typeof result === 'string' && result.trim() ? { answer: result.trim() } : {}
   }
 
+  const prompt = parsePromptParts(row.question)
+
   return {
-    question: stringField(row, 'question'),
+    question: prompt.question,
+    context: cleanText(row.context) || prompt.context,
+    recommendation: cleanText(row.recommendation) || prompt.recommendation,
+    options: normalizeClarifyChoices(row.options) ?? normalizeClarifyChoices(row.choices_offered),
+    selectedOption: normalizeSelectedOption(row.selected_option),
     answer: stringField(row, 'user_response', 'answer'),
     error: stringField(row, 'error')
   }
 }
-
-const letterFor = (index: number): string => String.fromCharCode(65 + index)
 
 const OPTION_ROW_CLASS =
   'flex w-full items-start gap-2 rounded-[0.25rem] px-1.5 py-1 text-left disabled:cursor-not-allowed disabled:opacity-50'
@@ -124,8 +290,80 @@ function KeyBadge({ char, preview, selected }: { char: string; preview?: boolean
   )
 }
 
+function ClarifyPromptBlock({
+  context,
+  question,
+  recommendation
+}: {
+  context?: string
+  question: string
+  recommendation?: string
+}) {
+  return (
+    <div className="grid gap-1.5">
+      {question ? (
+        <ClarifyLine icon={MessageQuestion}>
+          <span className="whitespace-pre-wrap font-medium leading-(--conversation-line-height)">{question}</span>
+        </ClarifyLine>
+      ) : null}
+      {context ? (
+        <p className="whitespace-pre-wrap text-(--ui-text-secondary)" data-clarify-context="">
+          {context}
+        </p>
+      ) : null}
+      {recommendation ? (
+        <p className="whitespace-pre-wrap font-medium text-primary" data-clarify-recommendation="">
+          {recommendation}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function optionDisplayText(option: ClarifyOption): string {
+  return option.description && option.description !== option.label
+    ? `${option.label} - ${option.description}`
+    : option.label
+}
+
+function optionMatchesAnswer(option: ClarifyOption, answer: string | undefined, selected?: ClarifyOption | null): boolean {
+  if (selected) {
+    return option.id === selected.id
+  }
+
+  const aliases = [answer].map(value => cleanText(value).toLowerCase()).filter(Boolean)
+
+  if (aliases.length === 0) {
+    return false
+  }
+
+  const optionAliases = [
+    option.id,
+    option.value,
+    option.label,
+    String(option.index),
+    optionDisplayText(option),
+    option.description && option.description !== option.label
+      ? `${option.label} \u2013 ${option.description}`
+      : ''
+  ].map(value => cleanText(value).toLowerCase())
+
+  return aliases.some(alias => optionAliases.includes(alias))
+}
+
+function ClarifyOptionContent({ option }: { option: ClarifyOption }) {
+  return (
+    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+      <span className="wrap-anywhere font-medium">{option.label}</span>
+      {option.description ? (
+        <span className="wrap-anywhere text-[0.875em] text-(--ui-text-secondary)">{option.description}</span>
+      ) : null}
+    </span>
+  )
+}
+
 export const ClarifyTool = (props: ToolCallMessagePartProps) => {
-  // Answered → settled Q&A (ToolFallback collapsed the answer away).
+  // Answered -> settled Q&A (ToolFallback collapsed the answer away).
   if (props.result !== undefined) {
     return <ClarifyToolSettled {...props} />
   }
@@ -136,7 +374,7 @@ export const ClarifyTool = (props: ToolCallMessagePartProps) => {
 function ClarifyToolLive(props: ToolCallMessagePartProps) {
   const messageRunning = useAuiState(selectMessageRunning)
 
-  // Stopped mid-prompt with no result — don't leave a dead interactive panel.
+  // Stopped mid-prompt with no result: don't leave a dead interactive panel.
   if (!messageRunning) {
     return <ToolFallback {...props} />
   }
@@ -151,17 +389,49 @@ function ClarifyToolSettled({ args, result }: ToolCallMessagePartProps) {
   const fromResult = useMemo(() => readClarifyResult(result), [result])
 
   const question = fromResult.question || fromArgs.question || ''
+  const context = fromResult.context || fromArgs.context
+  const recommendation = fromResult.recommendation || fromArgs.recommendation
+  const options = fromResult.options ?? fromArgs.options ?? []
   const answer = fromResult.answer
   const error = fromResult.error
   const skipped = !error && answer !== undefined && !answer.trim()
-  const answerText = error || (skipped ? copy.skipped : (answer ?? '').trim())
+  const selectedOption = options.find(option => optionMatchesAnswer(option, answer, fromResult.selectedOption))
+
+  const answerText =
+    error ||
+    (skipped
+      ? copy.skipped
+      : selectedOption
+        ? `${selectedOption.index}. ${selectedOption.label}`
+        : (answer ?? '').trim())
 
   return (
     <ClarifyShell className="grid gap-1.5 px-2.5 py-2" data-clarify-settled="">
-      {question ? (
-        <ClarifyLine icon={MessageQuestion}>
-          <span className="whitespace-pre-wrap font-medium leading-(--conversation-line-height)">{question}</span>
-        </ClarifyLine>
+      <ClarifyPromptBlock context={context} question={question} recommendation={recommendation} />
+      {options.length > 0 ? (
+        <div className="grid gap-px" data-clarify-options="" role="list">
+          {options.map(option => {
+            const selected = selectedOption?.id === option.id
+
+            return (
+              <div
+                className={cn(
+                  OPTION_ROW_CLASS,
+                  'text-(--ui-text-secondary)',
+                  selected && 'bg-primary/10 text-(--ui-text-primary)'
+                )}
+                data-clarify-option={option.id}
+                data-selected={selected ? 'true' : undefined}
+                key={option.id}
+                role="listitem"
+              >
+                <KeyBadge char={String(option.index)} selected={selected} />
+                <ClarifyOptionContent option={option} />
+                {selected ? <Check aria-hidden className="mt-0.5 size-3.5 shrink-0 text-primary" /> : null}
+              </div>
+            )
+          })}
+        </div>
       ) : null}
       {answerText ? (
         <ClarifyLine icon={CircleLetterA}>
@@ -193,37 +463,40 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
       return null
     }
 
-    if (fromArgs.question && request.question && fromArgs.question !== request.question) {
+    if (fromArgs.question && request.question && !questionsMatch(fromArgs.question, request.question)) {
       return null
     }
 
     return request
   }, [fromArgs.question, request])
 
-  const question = fromArgs.question || matchingRequest?.question || ''
+  const requestPrompt = useMemo(() => parsePromptParts(matchingRequest?.question), [matchingRequest?.question])
+  const question = fromArgs.question || requestPrompt.question || ''
+  const context = fromArgs.context || requestPrompt.context
+  const recommendation = fromArgs.recommendation || requestPrompt.recommendation
 
-  const choices = useMemo(
-    () => fromArgs.choices ?? matchingRequest?.choices ?? [],
-    [fromArgs.choices, matchingRequest?.choices]
+  const options = useMemo(
+    () => fromArgs.options ?? normalizeClarifyChoices(matchingRequest?.choices) ?? [],
+    [fromArgs.options, matchingRequest?.choices]
   )
 
-  const hasChoices = choices.length > 0
+  const hasChoices = options.length > 0
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
-  const [selectedChoice, setSelectedChoice] = useState<string | null>(null)
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null)
   const [otherFocused, setOtherFocused] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. Hold the whole panel on a
-  // spinner until the gateway request is wired — showing disabled choices or
+  // spinner until the gateway request is wired; showing disabled choices or
   // a "loading question" stub is worse than a brief wait.
   const ready = Boolean(matchingRequest?.requestId)
   const loading = !ready && !submitting
 
   const respond = useCallback(
-    async (answer: string) => {
+    async (answer: string, optionId?: string, responseKind?: 'custom') => {
       if (!ready || !matchingRequest) {
         notifyError(new Error(copy.notReady), copy.sendFailed)
 
@@ -241,11 +514,13 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
       try {
         await gateway.request<{ ok?: boolean }>('clarify.respond', {
           request_id: matchingRequest.requestId,
-          answer
+          answer,
+          ...(optionId ? { option_id: optionId } : {}),
+          ...(responseKind ? { response_kind: responseKind } : {})
         })
         triggerHaptic('submit')
         clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
-        // tool.complete lands next → ClarifyToolSettled.
+        // tool.complete lands next -> ClarifyToolSettled.
       } catch (error) {
         notifyError(error, copy.sendFailed)
         setSubmitting(false)
@@ -255,28 +530,33 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const trimmedDraft = draft.trim()
-  // The answer is whichever input is active: a picked choice, or typed text.
-  // Picking a choice no longer fires immediately — it selects, then the user
-  // confirms with Continue (or Enter from the field).
-  const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
 
-  const selectChoice = useCallback((choice: string) => {
+  const selectedOption = useMemo(
+    () => options.find(option => option.id === selectedOptionId) ?? null,
+    [options, selectedOptionId]
+  )
+
+  // The answer is whichever input is active: a picked choice, or typed text.
+  // Picking a choice selects, then the user confirms with Continue or Enter.
+  const pendingAnswer = selectedOption?.value ?? (trimmedDraft || null)
+
+  const selectOption = useCallback((option: ClarifyOption) => {
     // Picking a choice and typing are mutually exclusive answers.
     setDraft('')
-    setSelectedChoice(choice)
+    setSelectedOptionId(option.id)
   }, [])
 
   const submitAnswer = useCallback(() => {
-    if (selectedChoice !== null) {
-      void respond(selectedChoice)
+    if (selectedOption) {
+      void respond(selectedOption.value, selectedOption.id)
 
       return
     }
 
     if (trimmedDraft) {
-      void respond(trimmedDraft)
+      void respond(trimmedDraft, undefined, 'custom')
     }
-  }, [respond, selectedChoice, trimmedDraft])
+  }, [respond, selectedOption, trimmedDraft])
 
   const handleTextareaKey = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -300,10 +580,8 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     [submitAnswer]
   )
 
-  // Letter shortcuts: A/B/C… pick the matching option, the trailing letter jumps
-  // into "Other", and Enter confirms the current pick. Stands down whenever a
-  // field is focused (you're typing, not navigating) so it never eats keystrokes
-  // meant for the composer or the Other box.
+  // Numeric shortcuts: 1..N pick the matching option, N+1 jumps into Other,
+  // and Enter confirms the current pick. Stands down whenever a field is focused.
   useEffect(() => {
     if (!ready || !hasChoices || submitting) {
       return
@@ -320,15 +598,14 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
         return
       }
 
-      const key = event.key.toLowerCase()
+      if (/^\d$/.test(event.key)) {
+        const shortcut = Number(event.key)
+        const index = shortcut - 1
 
-      if (key.length === 1 && key >= 'a' && key <= 'z') {
-        const index = key.charCodeAt(0) - 97
-
-        if (index < choices.length) {
+        if (index >= 0 && index < options.length) {
           event.preventDefault()
-          selectChoice(choices[index])
-        } else if (index === choices.length) {
+          selectOption(options[index]!)
+        } else if (shortcut === options.length + 1) {
           event.preventDefault()
           textareaRef.current?.focus()
         }
@@ -345,7 +622,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     window.addEventListener('keydown', onKeyDown)
 
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [choices, hasChoices, pendingAnswer, ready, selectChoice, submitAnswer, submitting])
+  }, [hasChoices, options, pendingAnswer, ready, selectOption, submitAnswer, submitting])
 
   if (loading) {
     return (
@@ -362,49 +639,47 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const onDraftChange = (value: string) => {
     setDraft(value)
 
-    // Typing is its own answer — drop any picked choice so the two inputs can't
+    // Typing is its own answer; drop any picked choice so the two inputs can't
     // both look selected.
     if (value.trim()) {
-      setSelectedChoice(null)
+      setSelectedOptionId(null)
     }
   }
 
   return (
     <ClarifyShell className="grid gap-2 px-2.5 py-2">
-      <div className="flex items-start gap-2">
-        <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">{question}</span>
-        <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />
-      </div>
+      <ClarifyPromptBlock context={context} question={question} recommendation={recommendation} />
 
       <form className="grid gap-2" onSubmit={handleSubmit}>
         {hasChoices ? (
           <div className="grid gap-px" role="group">
-            {choices.map((choice, index) => (
+            {options.map(option => (
               <button
+                aria-pressed={selectedOptionId === option.id}
                 className={cn(
                   OPTION_ROW_CLASS,
                   'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
-                  selectedChoice === choice && 'text-(--ui-text-primary)'
+                  selectedOptionId === option.id && 'text-(--ui-text-primary)'
                 )}
                 data-choice
                 disabled={submitting}
-                key={`${index}-${choice}`}
-                onClick={() => selectChoice(choice)}
+                key={option.id}
+                onClick={() => selectOption(option)}
                 type="button"
               >
-                <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
-                <span className="flex-1 wrap-anywhere">{choice}</span>
+                <KeyBadge char={String(option.index)} selected={selectedOptionId === option.id} />
+                <ClarifyOptionContent option={option} />
               </button>
             ))}
             <label className={cn(OPTION_ROW_CLASS, 'items-center')}>
-              <KeyBadge char={letterFor(choices.length)} preview={otherFocused} selected={Boolean(trimmedDraft)} />
+              <KeyBadge char={String(options.length + 1)} preview={otherFocused} selected={Boolean(trimmedDraft)} />
               <Textarea
                 className={CLARIFY_TEXTAREA_CLASS}
                 disabled={submitting}
                 onBlur={() => setOtherFocused(false)}
                 onChange={event => onDraftChange(event.target.value)}
                 onFocus={() => {
-                  setSelectedChoice(null)
+                  setSelectedOptionId(null)
                   setOtherFocused(true)
                 }}
                 onKeyDown={handleTextareaKey}

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3127,7 +3127,7 @@ class BasePlatformAdapter(ABC):
             MUST resolve via
             ``tools.clarify_gateway.resolve_gateway_clarify(clarify_id, response)``
             with the chosen string.  Picking the "Other" button calls
-            ``mark_awaiting_text(clarify_id)`` so the next message in the
+            ``mark_awaiting_text(clarify_id, custom=True)`` so the next message in the
             session is captured as the response.
 
           * **Open-ended** (``choices`` is None or empty) — render the

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1699,7 +1699,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 # current task" loop.
                 try:
                     from tools.clarify_gateway import mark_awaiting_text
-                    flipped = mark_awaiting_text(clarify_id)
+                    flipped = mark_awaiting_text(clarify_id, custom=True)
                 except Exception:
                     logger.exception(
                         "[whatsapp_cloud] mark_awaiting_text failed for %s",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7709,7 +7709,7 @@ def _define_discord_view_classes() -> None:
             # and disable the buttons so the user can't double-click.
             try:
                 from tools.clarify_gateway import mark_awaiting_text
-                mark_awaiting_text(self.clarify_id)
+                mark_awaiting_text(self.clarify_id, custom=True)
             except Exception as exc:
                 logger.warning(
                     "Discord clarify mark_awaiting_text failed (id=%s): %s",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5560,7 +5560,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     flipped = False
                     try:
                         from tools.clarify_gateway import mark_awaiting_text
-                        flipped = mark_awaiting_text(clarify_id)
+                        flipped = mark_awaiting_text(clarify_id, custom=True)
                     except Exception as exc:
                         logger.warning("[%s] mark_awaiting_text failed: %s", self.name, exc)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,64 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+def test_clarify_respond_prefers_structured_option_id():
+    from tools.clarify_tool import CLARIFY_OPTION_RESPONSE_PREFIX
+
+    request_id = "clarify-option-id-test"
+    event = threading.Event()
+
+    with server._prompt_lock:
+        server._pending[request_id] = ("sid", event)
+
+    try:
+        response = server._methods["clarify.respond"](
+            "rpc-1",
+            {
+                "request_id": request_id,
+                "answer": "2",
+                "option_id": "first",
+            },
+        )
+
+        assert response["result"]["status"] == "ok"
+        assert server._answers[request_id] == (
+            f"{CLARIFY_OPTION_RESPONSE_PREFIX}first"
+        )
+        assert event.is_set()
+    finally:
+        with server._prompt_lock:
+            server._pending.pop(request_id, None)
+            server._answers.pop(request_id, None)
+
+
+def test_clarify_respond_marks_custom_text_without_aliasing():
+    from tools.clarify_tool import CLARIFY_CUSTOM_RESPONSE_PREFIX
+
+    request_id = "clarify-custom-text-test"
+    event = threading.Event()
+
+    with server._prompt_lock:
+        server._pending[request_id] = ("sid", event)
+
+    try:
+        response = server._methods["clarify.respond"](
+            "rpc-custom",
+            {
+                "request_id": request_id,
+                "answer": "1",
+                "response_kind": "custom",
+            },
+        )
+
+        assert response["result"]["status"] == "ok"
+        assert server._answers[request_id] == f"{CLARIFY_CUSTOM_RESPONSE_PREFIX}1"
+        assert event.is_set()
+    finally:
+        with server._prompt_lock:
+            server._pending.pop(request_id, None)
+            server._answers.pop(request_id, None)
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -104,6 +104,25 @@ class TestClarifyPrimitive:
         assert pending is not None
         assert pending.clarify_id == "id4"
 
+    def test_other_button_text_is_marked_custom_even_when_it_matches_a_choice(self):
+        from tools import clarify_gateway as cm
+        from tools.clarify_tool import CLARIFY_CUSTOM_RESPONSE_PREFIX
+
+        cm.register("id4-custom", "sk4-custom", "Pick", ["Safe", "Fast"])
+        assert cm.mark_awaiting_text("id4-custom", custom=True) is True
+        assert cm.resolve_text_response_for_session("sk4-custom", "Safe") is True
+        assert cm.wait_for_response("id4-custom", timeout=0.1) == (
+            f"{CLARIFY_CUSTOM_RESPONSE_PREFIX}Safe"
+        )
+
+    def test_default_text_fallback_still_maps_numeric_choices(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("id4-fallback", "sk4-fallback", "Pick", ["Safe", "Fast"])
+        assert cm.mark_awaiting_text("id4-fallback") is True
+        assert cm.resolve_text_response_for_session("sk4-fallback", "2") is True
+        assert cm.wait_for_response("id4-fallback", timeout=0.1) == "Fast"
+
     def test_mark_awaiting_text_unknown_id(self):
         """mark_awaiting_text on a non-existent id returns False."""
         from tools import clarify_gateway as cm

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -1,14 +1,19 @@
 """Tests for tools/clarify_tool.py - Interactive clarifying questions."""
 
 import json
+from types import SimpleNamespace
 from typing import List, Optional
+from unittest.mock import patch
 
+from agent.gemini_schema import sanitize_gemini_tool_parameters
 
 from tools.clarify_tool import (
     clarify_tool,
     check_clarify_requirements,
     MAX_CHOICES,
     CLARIFY_SCHEMA,
+    CLARIFY_CUSTOM_RESPONSE_PREFIX,
+    CLARIFY_OPTION_RESPONSE_PREFIX,
     _flatten_choice,
 )
 
@@ -228,6 +233,164 @@ class TestClarifyDictChoices:
         assert "{" not in result["user_response"]
         assert all("{" not in c for c in result["choices_offered"])
 
+    def test_structured_choices_preserve_description_and_canonical_selection(self):
+        """One structured source must drive readable UI text and the selected value."""
+        seen = {}
+
+        def cb(question, choices):
+            seen["question"] = question
+            seen["choices"] = choices
+            # Desktop responds with the stable option id instead of display text.
+            return "safe"
+
+        result = json.loads(clarify_tool(
+            "Which rollout should we use?",
+            context="Production currently has no canary traffic.",
+            recommendation="Choose Safe because it preserves rollback capacity.",
+            choices=[
+                {
+                    "id": "fast",
+                    "label": "Fast",
+                    "description": "Deploy to every instance immediately.",
+                    "value": "fast-rollout",
+                },
+                {
+                    "id": "safe",
+                    "label": "Safe",
+                    "description": "Canary first, then expand after verification.",
+                    "value": "safe-rollout",
+                },
+            ],
+            callback=cb,
+        ))
+
+        assert seen["question"] == (
+            "Which rollout should we use?\n\n"
+            "Context: Production currently has no canary traffic.\n\n"
+            "Recommendation: Choose Safe because it preserves rollback capacity."
+        )
+        assert seen["choices"] == [
+            "Fast — Deploy to every instance immediately.",
+            "Safe — Canary first, then expand after verification.",
+        ]
+        assert result["question"] == "Which rollout should we use?"
+        assert result["context"] == "Production currently has no canary traffic."
+        assert result["recommendation"] == "Choose Safe because it preserves rollback capacity."
+        assert result["options"][1] == {
+            "id": "safe",
+            "index": 2,
+            "label": "Safe",
+            "description": "Canary first, then expand after verification.",
+            "value": "safe-rollout",
+        }
+        assert result["selected_option"] == result["options"][1]
+        assert result["user_response"] == "safe-rollout"
+
+    def test_structured_choice_transport_token_resolves_exact_id(self):
+        """A clicked option id wins even when its value looks like another index."""
+        result = json.loads(clarify_tool(
+            "Which option?",
+            choices=[
+                {
+                    "id": "first",
+                    "label": "Looks numeric",
+                    "description": "First option.",
+                    "value": "2",
+                },
+                {
+                    "id": "second",
+                    "label": "Second",
+                    "description": "Second option.",
+                    "value": "other",
+                },
+            ],
+            callback=lambda _question, _choices: (
+                f"{CLARIFY_OPTION_RESPONSE_PREFIX}first"
+            ),
+        ))
+
+        assert result["selected_option"]["id"] == "first"
+        assert result["selected_option"]["index"] == 1
+        assert result["user_response"] == "2"
+
+    def test_unknown_structured_choice_id_returns_error_without_leaking_token(self):
+        result = json.loads(clarify_tool(
+            "Which option?",
+            choices=[{"id": "known", "label": "Known", "description": "Valid."}],
+            callback=lambda _question, _choices: (
+                f"{CLARIFY_OPTION_RESPONSE_PREFIX}missing"
+            ),
+        ))
+
+        assert result["error"] == "Selected clarify option is no longer available."
+        assert result["selected_option"] is None
+        assert result["user_response"] == ""
+        assert CLARIFY_OPTION_RESPONSE_PREFIX not in json.dumps(result)
+
+    def test_custom_response_does_not_alias_to_an_existing_option(self):
+        result = json.loads(clarify_tool(
+            "Which option?",
+            choices=[
+                {"id": "first", "label": "Safe", "description": "First.", "value": "safe"},
+                {"id": "second", "label": "Other option", "description": "Second.", "value": "other"},
+            ],
+            callback=lambda _question, _choices: (
+                f"{CLARIFY_CUSTOM_RESPONSE_PREFIX}Safe"
+            ),
+        ))
+
+        assert result["selected_option"] is None
+        assert result["user_response"] == "Safe"
+        assert result["response_kind"] == "custom"
+        assert CLARIFY_CUSTOM_RESPONSE_PREFIX not in json.dumps(result)
+
+    def test_agent_runtime_dispatch_forwards_context_and_recommendation(self):
+        from agent.agent_runtime_helpers import invoke_tool
+
+        seen = {}
+
+        def callback(question, choices):
+            seen["question"] = question
+            seen["choices"] = choices
+            return "1"
+
+        agent = SimpleNamespace(
+            _memory_manager=None,
+            clarify_callback=callback,
+            session_id="",
+            valid_tool_names=set(),
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+        )
+
+        def run_middleware(_name, payload, execute, **_kwargs):
+            return execute(payload)
+
+        with patch(
+            "hermes_cli.middleware.run_tool_execution_middleware",
+            side_effect=run_middleware,
+        ):
+            result = json.loads(invoke_tool(
+                agent,
+                "clarify",
+                {
+                    "question": "Which rollout?",
+                    "context": "No canary traffic.",
+                    "recommendation": "Choose Safe.",
+                    "choices": ["Fast", "Safe"],
+                },
+                "",
+                pre_tool_block_checked=True,
+                skip_tool_request_middleware=True,
+            ))
+
+        assert seen["question"] == (
+            "Which rollout?\n\nContext: No canary traffic.\n\n"
+            "Recommendation: Choose Safe."
+        )
+        assert seen["choices"] == ["Fast", "Safe"]
+        assert result["user_response"] == "Fast"
+
 
 class TestClarifySchema:
     """Tests for the OpenAI function-calling schema."""
@@ -253,6 +416,22 @@ class TestClarifySchema:
         """Schema should specify max items for choices."""
         choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]
         assert choices_spec.get("maxItems") == MAX_CHOICES
+
+    def test_schema_accepts_legacy_strings_and_structured_choices(self):
+        choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]
+        variants = choices_spec["items"]["anyOf"]
+
+        assert {variant.get("type") for variant in variants} == {"string", "object"}
+        object_variant = next(variant for variant in variants if variant.get("type") == "object")
+        assert object_variant["required"] == ["label", "description"]
+        assert "context" in CLARIFY_SCHEMA["parameters"]["properties"]
+        assert "recommendation" in CLARIFY_SCHEMA["parameters"]["properties"]
+
+    def test_structured_choice_union_survives_gemini_sanitizing(self):
+        sanitized = sanitize_gemini_tool_parameters(CLARIFY_SCHEMA["parameters"])
+        variants = sanitized["properties"]["choices"]["items"]["anyOf"]
+
+        assert {variant.get("type") for variant in variants} == {"string", "object"}
 
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -54,6 +54,7 @@ class _ClarifyEntry:
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
+    awaiting_custom_text: bool = False  # set only when a rich UI's "Other" button was picked
 
     def signature(self) -> Dict[str, object]:
         return {
@@ -190,6 +191,10 @@ def get_pending_for_session(
 def _coerce_text_response(entry: _ClarifyEntry, response: str) -> str:
     """Map typed choice replies to canonical choice text, otherwise keep custom text."""
     text = str(response).strip()
+    if entry.awaiting_custom_text:
+        from tools.clarify_tool import CLARIFY_CUSTOM_RESPONSE_PREFIX
+
+        return f"{CLARIFY_CUSTOM_RESPONSE_PREFIX}{text}"
     if entry.choices:
         try:
             idx = int(text) - 1
@@ -214,16 +219,20 @@ def resolve_text_response_for_session(session_key: str, response: str) -> bool:
     )
 
 
-def mark_awaiting_text(clarify_id: str) -> bool:
-    """Flip an entry into text-capture mode (user picked the 'Other' button).
+def mark_awaiting_text(clarify_id: str, *, custom: bool = False) -> bool:
+    """Enable text capture for a pending clarify request.
 
-    Returns True if the entry exists and was flipped, False otherwise.
+    Set ``custom=True`` only for a rich UI's explicit "Other" action so the
+    next typed value cannot be reinterpreted as a numbered or labelled choice.
+    The default text fallback leaves it false so replies like ``2`` still map
+    to the second option. Returns False when the entry no longer exists.
     """
     with _lock:
         entry = _entries.get(clarify_id)
         if entry is None:
             return False
         entry.awaiting_text = True
+        entry.awaiting_custom_text = custom
         return True
 
 

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -12,12 +12,19 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
-from typing import List, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional
 
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
+
+# Desktop may send the selected option id alongside the legacy string answer.
+# New gateways wrap that id in this transport-only token before resolving the
+# blocking callback. Old gateways ignore the extra field and keep returning the
+# legacy answer, so mixed Desktop/runtime versions remain compatible.
+CLARIFY_OPTION_RESPONSE_PREFIX = "__hermes_clarify_option__:"
+CLARIFY_CUSTOM_RESPONSE_PREFIX = "__hermes_clarify_custom__:"
 
 
 def _flatten_choice(c) -> str:
@@ -53,9 +60,119 @@ def _flatten_choice(c) -> str:
     return str(c).strip()
 
 
+def _clean_text(value: Any) -> str:
+    """Return trimmed schema text without leaking container representations."""
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalize_choices(choices: List[Any]) -> List[Dict[str, Any]]:
+    """Normalize legacy strings and structured choices into canonical options."""
+    options: List[Dict[str, Any]] = []
+    used_ids = set()
+
+    for raw in choices:
+        label = ""
+        description = ""
+        option_id = ""
+        value = ""
+
+        if isinstance(raw, dict):
+            label = next(
+                (
+                    text
+                    for key in ("label", "text", "title")
+                    if (text := _clean_text(raw.get(key)))
+                ),
+                "",
+            )
+            description = _clean_text(raw.get("description"))
+            if not label:
+                label, description = description, ""
+            option_id = _clean_text(raw.get("id"))
+            value = _clean_text(raw.get("value"))
+        else:
+            label = _flatten_choice(raw)
+
+        if not label:
+            continue
+
+        index = len(options) + 1
+        fallback_id = f"option-{index}"
+        option_id = option_id or fallback_id
+        if option_id in used_ids:
+            option_id = fallback_id
+            suffix = 2
+            while option_id in used_ids:
+                option_id = f"{fallback_id}-{suffix}"
+                suffix += 1
+        used_ids.add(option_id)
+
+        options.append({
+            "id": option_id,
+            "index": index,
+            "label": label,
+            "description": description,
+            "value": value or label,
+        })
+
+    return options
+
+
+def _format_choice(option: Dict[str, Any]) -> str:
+    """Render one canonical option for text-only and legacy callback surfaces."""
+    label = str(option.get("label") or "").strip()
+    description = str(option.get("description") or "").strip()
+    if description and description != label:
+        return f"{label} — {description}"
+    return label
+
+
+def _format_prompt(question: str, context: str, recommendation: str) -> str:
+    """Render a context-rich prompt for surfaces without a dedicated card."""
+    parts = [question]
+    if context:
+        parts.append(f"Context: {context}")
+    if recommendation:
+        parts.append(f"Recommendation: {recommendation}")
+    return "\n\n".join(parts)
+
+
+def _resolve_selected_option(
+    response: str,
+    options: List[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Resolve a callback answer through id/value/label/display/index aliases."""
+    if response.startswith(CLARIFY_OPTION_RESPONSE_PREFIX):
+        selected_id = response[len(CLARIFY_OPTION_RESPONSE_PREFIX):].strip()
+        return next(
+            (
+                option
+                for option in options
+                if str(option.get("id") or "").strip() == selected_id
+            ),
+            None,
+        )
+
+    folded = response.casefold()
+    numeric_index = int(response) if response.isdigit() else None
+
+    for option in options:
+        aliases = {
+            str(option.get("id") or "").strip().casefold(),
+            str(option.get("value") or "").strip().casefold(),
+            str(option.get("label") or "").strip().casefold(),
+            _format_choice(option).casefold(),
+        }
+        if folded in aliases or numeric_index == option.get("index"):
+            return option
+    return None
+
+
 def clarify_tool(
     question: str,
-    choices: Optional[List[str]] = None,
+    choices: Optional[List[Any]] = None,
+    context: str = "",
+    recommendation: str = "",
     callback: Optional[Callable] = None,
 ) -> str:
     """
@@ -63,8 +180,9 @@ def clarify_tool(
 
     Args:
         question: The question text to present.
-        choices:  Up to 4 predefined answer choices. When omitted the
-                  question is purely open-ended.
+        choices: Up to 4 legacy string or structured answer choices.
+        context: Decision context shown with the question when provided.
+        recommendation: Optional recommendation reason.
         callback: Platform-provided function that handles the actual UI
                   interaction. Signature: callback(question, choices) -> str.
                   Injected by the agent runner (cli.py / gateway).
@@ -76,21 +194,20 @@ def clarify_tool(
         return tool_error("Question text is required.")
 
     question = question.strip()
+    context = _clean_text(context)
+    recommendation = _clean_text(recommendation)
 
     # Validate and trim choices
+    options: Optional[List[Dict[str, Any]]] = None
+    display_choices: Optional[List[str]] = None
     if choices is not None:
         if not isinstance(choices, list):
-            return tool_error("choices must be a list of strings.")
-        # LLMs sometimes emit dict-shaped choices (e.g. [{"description": "..."}])
-        # instead of bare strings. _flatten_choice unwraps them to their
-        # user-facing text here — the single platform-agnostic entry point —
-        # so the CLI panel, Discord buttons, and Telegram list all render clean
-        # text and the resolved answer is never a raw Python dict repr.
-        choices = [s for s in (_flatten_choice(c) for c in choices) if s]
-        if len(choices) > MAX_CHOICES:
-            choices = choices[:MAX_CHOICES]
-        if not choices:
-            choices = None  # empty list → open-ended
+            return tool_error("choices must be a list.")
+        options = _normalize_choices(choices)[:MAX_CHOICES]
+        if options:
+            display_choices = [_format_choice(option) for option in options]
+        else:
+            options = None  # empty list → open-ended
 
     if callback is None:
         return json.dumps(
@@ -99,17 +216,66 @@ def clarify_tool(
         )
 
     try:
-        user_response = callback(question, choices)
+        user_response = callback(
+            _format_prompt(question, context, recommendation),
+            display_choices,
+        )
     except Exception as exc:
         return json.dumps(
             {"error": f"Failed to get user input: {exc}"},
             ensure_ascii=False,
         )
 
+    raw_response = str(user_response).strip()
+    is_custom_response = raw_response.startswith(CLARIFY_CUSTOM_RESPONSE_PREFIX)
+    custom_response = (
+        raw_response[len(CLARIFY_CUSTOM_RESPONSE_PREFIX):].strip()
+        if is_custom_response
+        else ""
+    )
+    selected_option = (
+        None
+        if is_custom_response
+        else _resolve_selected_option(raw_response, options or [])
+    )
+    if (
+        raw_response.startswith(CLARIFY_OPTION_RESPONSE_PREFIX)
+        and selected_option is None
+    ):
+        return json.dumps({
+            "question": question,
+            "context": context,
+            "recommendation": recommendation,
+            "choices_offered": display_choices,
+            "options": options,
+            "selected_option": None,
+            "user_response": "",
+            "error": "Selected clarify option is no longer available.",
+        }, ensure_ascii=False)
+
+    canonical_response = (
+        custom_response
+        if is_custom_response
+        else (
+            str(selected_option["value"]).strip()
+            if selected_option is not None
+            else raw_response
+        )
+    )
+
     return json.dumps({
         "question": question,
-        "choices_offered": choices,
-        "user_response": str(user_response).strip(),
+        "context": context,
+        "recommendation": recommendation,
+        "choices_offered": display_choices,
+        "options": options,
+        "selected_option": selected_option,
+        "user_response": canonical_response,
+        "response_kind": (
+            "custom"
+            if is_custom_response
+            else ("option" if selected_option is not None else "free_text")
+        ),
     }, ensure_ascii=False)
 
 
@@ -157,13 +323,55 @@ CLARIFY_SCHEMA = {
                     "— pass them as separate elements in `choices`."
                 ),
             },
+            "context": {
+                "type": "string",
+                "description": (
+                    "Decision context the user needs to compare the options. "
+                    "Keep it concise and factual."
+                ),
+            },
+            "recommendation": {
+                "type": "string",
+                "description": (
+                    "Optional recommendation and its concrete reason. Omit it "
+                    "when there is no justified recommendation."
+                ),
+            },
             "choices": {
                 "type": "array",
-                "items": {"type": "string"},
+                "items": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "Stable internal option id.",
+                                },
+                                "label": {
+                                    "type": "string",
+                                    "description": "Short clickable option label.",
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "Concrete explanation of this option.",
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "description": "Canonical answer value returned after selection.",
+                                },
+                            },
+                            "required": ["label", "description"],
+                        },
+                    ],
+                },
                 "maxItems": MAX_CHOICES,
                 "description": (
                     "REQUIRED whenever you are presenting selectable options: "
                     "each distinct option is its own array element (up to 4). "
+                    "Prefer structured objects with a short `label` and a "
+                    "specific `description`; legacy string choices remain valid. "
                     "The UI renders these as pickable rows and auto-appends an "
                     "'Other (type your answer)' option. Omit this parameter "
                     "entirely ONLY for a genuinely open-ended free-text question."
@@ -185,6 +393,8 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
+        context=args.get("context", ""),
+        recommendation=args.get("recommendation", ""),
         callback=kw.get("callback")),
     check_fn=check_clarify_requirements,
     emoji="❓",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10237,6 +10237,21 @@ def _respond(rid, params, key, *, allow_expired=False):
 
 @method("clarify.respond")
 def _(rid, params: dict) -> dict:
+    option_id = params.get("option_id")
+    if option_id is not None and str(option_id).strip():
+        from tools.clarify_tool import CLARIFY_OPTION_RESPONSE_PREFIX
+
+        params = {
+            **params,
+            "answer": f"{CLARIFY_OPTION_RESPONSE_PREFIX}{str(option_id).strip()}",
+        }
+    elif params.get("response_kind") == "custom":
+        from tools.clarify_tool import CLARIFY_CUSTOM_RESPONSE_PREFIX
+
+        params = {
+            **params,
+            "answer": f"{CLARIFY_CUSTOM_RESPONSE_PREFIX}{str(params.get('answer', ''))}",
+        }
     return _respond(rid, params, "answer")
 
 


### PR DESCRIPTION
## 概要

- `clarify` を通常チャット領域の説明付き選択カードとして表示します
- question / context / recommendation と、各選択肢の番号・label・descriptionを同じ構造化データから生成します
- 選択後も専用カードを履歴に残し、選択済み番号・label・内容を表示します

## 背景

従来の `clarify` は文字列選択肢を前提としていたため、モデルが `{label, description}` を返してもdescriptionが失われていました。またDesktopでは回答後に汎用tool表示へ落ち、判断材料や選択内容を履歴から確認しにくい状態でした。

## 変更内容

- legacy string choicesとstructured choicesを共通のcanonical optionへ正規化
- stable `option_id` によるDesktop → TUI Gateway → Python toolの選択解決
- pending／resolved両状態の専用Desktopカード
- click／数字shortcut／Other／Skip／open-ended入力の維持
- Other入力をcustom responseとして扱い、`1`や既存label/valueとの衝突を防止
- DesktopとPythonを最大4候補＋Otherへ統一
- text fallbackでlabel＋descriptionと番号順を維持
- Telegram／Discord／WhatsAppのOther入力をcustomとして識別
- 並列・逐次の両tool dispatchでcontext／recommendationを伝播
- Gemini schema sanitizerでstructured choice unionを保持

## 検証

- [x] Desktop Vitest: 14/14 PASS
- [x] Desktop typecheck: PASS
- [x] 対象TSX ESLint: PASS
- [x] Desktop production build: PASS
- [x] Python clarify tool／gateway直接テスト: 55/55 PASS
- [x] TUI Gateway option/custom response往復: PASS
- [x] 並列・逐次dispatchの引数確認: PASS
- [x] Python `py_compile`: PASS
- [x] `git diff --check`: PASS
- [x] actual component render harnessでtypography、padding/gap、番号badge、label/description、selected/resolved stateを確認

## 未実行・既知事項

- 環境に`pytest` packageがないため、canonical pytest commandは未実行です。対象のpytest形式テストは依存fixtureを考慮した直接runnerで実行しています。
- build時に既存のCSS解析警告と巨大chunk警告が出ますが、buildと`assert-dist-built`は成功しています。
- 独立reviewer実行はタイムアウトしたため、PRレビューでは特にcustom Otherとtext fallbackの分岐、stable option IDの往復を確認してください。

## レビュー重点箇所

- Desktopの表示番号とbackend canonical optionが常に一致すること
- Other入力が既存番号・label・valueへ誤変換されないこと
- buttonなしtext fallbackでは従来どおり番号／label選択できること
- legacy transcriptとopen-ended clarifyが後方互換で表示されること
