### PR TITLE
fix(telegram): stop typing refresh before final delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5035,6 +5035,12 @@ class BasePlatformAdapter(ABC):
                 # refresh can otherwise race the send and re-arm the indicator.
                 await _stop_typing_task()
 
+                # _stop_typing_refresh() also catches cancellation of this
+                # processor. Restore propagation before final delivery starts.
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    raise asyncio.CancelledError
+
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
                 if _tts_path and Path(_tts_path).exists():

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5030,6 +5030,11 @@ class BasePlatformAdapter(ABC):
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 
+                # Stop the refresh loop before the first final delivery. Some
+                # platforms clear typing when a message arrives, so a concurrent
+                # refresh can otherwise race the send and re-arm the indicator.
+                await _stop_typing_task()
+
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
                 if _tts_path and Path(_tts_path).exists():

--- a/tests/gateway/test_ephemeral_reply.py
+++ b/tests/gateway/test_ephemeral_reply.py
@@ -246,9 +246,11 @@ async def test_process_message_unwraps_ephemeral_before_send():
     adapter.set_message_handler(_handler)
 
     sleeps: list[float] = []
+    real_sleep = asyncio.sleep
 
     async def _fake_sleep(duration):
         sleeps.append(duration)
+        await real_sleep(0)
 
     event = _make_event()
     session_key = "agent:main:telegram:private:42"

--- a/tests/gateway/test_session_split_brain_11016.py
+++ b/tests/gateway/test_session_split_brain_11016.py
@@ -155,8 +155,12 @@ class TestAdapterSessionCancellation:
         await adapter.handle_message(
             _make_event("/model xiaomi/mimo-v2-pro --provider nous")
         )
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        owner_task = adapter._session_tasks.get(sk)
+        assert owner_task is not None
+        await asyncio.wait_for(
+            asyncio.shield(owner_task),
+            timeout=1.0,
+        )
 
         assert any("handled:model" in r for r in adapter.sent_responses), (
             f"follow-up /model stayed blocked after {command_text}"
@@ -260,9 +264,12 @@ class TestStaleSessionLockSelfHeal:
         # An ordinary message should heal the stale lock, then fall through
         # to normal dispatch.  User gets a reply instead of a busy ack.
         await adapter.handle_message(_make_event("hello"))
-        # Drain any spawned background tasks.
-        for _ in range(5):
-            await asyncio.sleep(0)
+        owner_task = adapter._session_tasks.get(sk)
+        assert owner_task is not None
+        await asyncio.wait_for(
+            asyncio.shield(owner_task),
+            timeout=1.0,
+        )
 
         assert any("handled:text" in r for r in adapter.sent_responses), (
             "stale lock trapped a normal message — split-brain not healed"

--- a/tests/gateway/test_typing_indicator_toggle.py
+++ b/tests/gateway/test_typing_indicator_toggle.py
@@ -142,3 +142,56 @@ async def test_typing_refresh_stops_before_final_delivery():
 
     assert typing_calls["before_delivery"] >= 1
     assert typing_calls["after_delivery"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_processor_does_not_deliver_after_typing_stop(tmp_path):
+    adapter = _make_adapter(typing_indicator=True)
+    typing_cleanup_started = asyncio.Event()
+    release_typing_cleanup = asyncio.Event()
+
+    attachment = tmp_path / "result.pdf"
+    attachment.write_bytes(b"test attachment")
+
+    async def _handler(_event):
+        await asyncio.sleep(0)
+        return f"Stale final response\nMEDIA:{attachment}"
+
+    async def _slow_typing_refresh(chat_id, metadata=None, stop_event=None):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            typing_cleanup_started.set()
+            await release_typing_cleanup.wait()
+            raise
+
+    adapter._message_handler = _handler
+    adapter._keep_typing = _slow_typing_refresh
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="text")
+    )
+    adapter.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="document")
+    )
+    adapter.filter_media_delivery_paths = lambda paths: paths
+    adapter._get_human_delay = lambda: 0
+
+    event = _make_event()
+    session_key = _sk()
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    task = asyncio.create_task(
+        adapter._process_message_background(event, session_key)
+    )
+    adapter._session_tasks[session_key] = task
+
+    await asyncio.wait_for(typing_cleanup_started.wait(), timeout=1.0)
+
+    task.cancel()
+    release_typing_cleanup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    adapter._send_with_retry.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()

--- a/tests/gateway/test_typing_indicator_toggle.py
+++ b/tests/gateway/test_typing_indicator_toggle.py
@@ -20,6 +20,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    SendResult,
 )
 from gateway.session import SessionSource, build_session_key
 
@@ -97,3 +98,47 @@ async def test_typing_indicator_disabled_never_calls_send_typing():
     adapter.send_typing.assert_not_awaited()
     # Delivery still happened — disabling typing must not suppress the reply.
     adapter._send_with_retry.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_typing_refresh_stops_before_final_delivery():
+    """The refresh loop cannot re-arm typing after final delivery starts."""
+    adapter = _make_adapter(typing_indicator=True)
+    typing_started = asyncio.Event()
+    final_delivery_started = asyncio.Event()
+    typing_calls = {"before_delivery": 0, "after_delivery": 0}
+
+    async def _record_typing(*_args, **_kwargs):
+        phase = (
+            "after_delivery" if final_delivery_started.is_set() else "before_delivery"
+        )
+        typing_calls[phase] += 1
+        typing_started.set()
+
+    async def _fast_keep_typing(chat_id, metadata=None, stop_event=None):
+        while stop_event is None or not stop_event.is_set():
+            await adapter.send_typing(chat_id, metadata=metadata)
+            await asyncio.sleep(0)
+
+    async def _handler(_event):
+        await asyncio.wait_for(typing_started.wait(), timeout=1.0)
+        return "All done."
+
+    async def _slow_final_delivery(**_kwargs):
+        final_delivery_started.set()
+        # Give a still-live refresh task ample opportunity to race the final
+        # send and re-arm Telegram's typing indicator afterward.
+        await asyncio.sleep(0.02)
+        return SendResult(success=True, message_id="final")
+
+    adapter.send_typing.side_effect = _record_typing
+    adapter._keep_typing = _fast_keep_typing
+    adapter._message_handler = _handler
+    adapter._send_with_retry.side_effect = _slow_final_delivery
+    event = _make_event()
+    adapter._active_sessions[_sk()] = asyncio.Event()
+
+    await adapter._process_message_background(event, _sk())
+
+    assert typing_calls["before_delivery"] >= 1
+    assert typing_calls["after_delivery"] == 0


### PR DESCRIPTION
## Summary

- stop the shared `_keep_typing` refresh task before the first final user-visible delivery
- keep typing active through agent processing and optional auto-TTS generation
- add a behavioral concurrency regression test that rejects typing calls after final delivery begins

## Why

Commit 565b7c8d9 fixed #48678 by preventing `TelegramAdapter.send()` from directly calling `send_typing()` when `metadata["notify"]` marks a final response. That guard is necessary but insufficient: `BasePlatformAdapter._process_message_background()` independently starts a generic `_keep_typing` task with the unmarked thread metadata.

That task runs concurrently with final delivery. Telegram clears the current typing action when `sendMessage` arrives, but the refresh loop can race the delivery and issue another `sendChatAction` afterward, re-arming the indicator after the final reply.

The refresh task is now stopped after any auto-TTS generation but before `play_tts`, text, image, media, or file-only delivery. Intermediate and progress messages retain typing because the loop remains active until this final-delivery boundary. The existing outer `finally` cleanup remains in place as an idempotent safety net.

The new test starts a fast refresh loop, waits until typing is active, makes final delivery deliberately slow, and asserts that no typing calls occur once delivery begins. It fails on current `main` and passes with this fix.

## Tests

- `scripts/run_tests.sh tests/gateway/test_typing_indicator_toggle.py tests/gateway/test_telegram_format.py -q` — 112 passed
- `scripts/run_tests.sh tests/gateway/test_keep_typing_timeout.py tests/gateway/test_tts_media_routing.py tests/gateway/test_media_metadata_contract.py tests/gateway/test_tool_response_drop_recovery.py -q` — 38 passed
- `uv run ruff check gateway/platforms/base.py tests/gateway/test_typing_indicator_toggle.py` — passed

## Production verification

The fix was verified against a live Telegram gateway after restart; the phantom typing indicator disappeared after final replies.