### PR TITLE
perf: short-circuit scratch disk usage scan

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,5 +1,10 @@
 """Regression tests for sudo detection and sudo password handling."""
 
+import glob
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import tools.terminal_tool as terminal_tool
 
 
@@ -323,3 +328,45 @@ def test_transform_sudo_command_pipes_one_password_line_per_invocation(monkeypat
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+def test_disk_usage_warning_short_circuits_after_threshold(monkeypatch):
+    """Avoid walking the full scratch tree after the warning threshold is crossed."""
+    stat_calls = []
+    warning_mock = MagicMock()
+    monkeypatch.setattr(terminal_tool.logger, "warning", warning_mock)
+
+    class FakeFile:
+        def __init__(self, name, size):
+            self.name = name
+            self.size = size
+
+        def is_file(self):
+            return True
+
+        def stat(self):
+            stat_calls.append(self.name)
+            if self.name == "second":
+                raise AssertionError("second file should not be statted")
+            return SimpleNamespace(st_size=self.size)
+
+    class FakePath:
+        def __init__(self, path):
+            self.path = path
+
+        def rglob(self, pattern):
+            assert pattern == "*"
+            yield FakeFile("first", 2 * 1024 ** 3)
+            yield FakeFile("second", 1)
+
+    monkeypatch.setattr(terminal_tool, "_get_scratch_dir", lambda: Path("/scratch"))
+    monkeypatch.setattr(terminal_tool, "DISK_USAGE_WARNING_THRESHOLD_GB", 1.0)
+    monkeypatch.setattr(terminal_tool, "Path", FakePath)
+    monkeypatch.setattr(glob, "glob", lambda _pattern: ["/scratch/hermes-test"])
+
+    assert terminal_tool._check_disk_usage_warning() is True
+    assert stat_calls == ["first"]
+    # Verify the warning was emitted with the expected threshold message.
+    warning_mock.assert_called_once()
+    assert "Disk usage" in warning_mock.call_args[0][0]
+    assert "exceeds threshold" in warning_mock.call_args[0][0]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -127,12 +127,26 @@ def _check_disk_usage_warning():
 
         # Get total size of hermes directories
         total_bytes = 0
+        threshold_bytes = DISK_USAGE_WARNING_THRESHOLD_GB * (1024 ** 3)
         import glob
         for path in glob.glob(str(scratch_dir / "hermes-*")):
             for f in Path(path).rglob('*'):
                 if f.is_file():
                     try:
                         total_bytes += f.stat().st_size
+                        # Short-circuit: once the threshold is crossed, stop walking
+                        # remaining files. This intentionally skips stat() and OSError
+                        # logging for files after the threshold, trading visibility for
+                        # I/O savings on large scratch trees.
+                        if total_bytes > threshold_bytes:
+                            total_gb = total_bytes / (1024 ** 3)
+                            logger.warning(
+                                "Disk usage (%.1fGB) exceeds threshold (%.0fGB). "
+                                "Consider running cleanup_all_environments().",
+                                total_gb,
+                                DISK_USAGE_WARNING_THRESHOLD_GB,
+                            )
+                            return True
                     except OSError as e:
                         logger.debug("Could not stat file %s: %s", f, e)
         


### PR DESCRIPTION
## Summary
- stop walking Hermes scratch files once the disk usage warning threshold has already been exceeded
- preserve the existing warning behavior and OSError-tolerant stat handling
- add a focused regression test that verifies the scan short-circuits before visiting later files
- verify warning log emission in the short-circuit test
- document the early-return OSError trade-off as intentional design

## Why
The scratch disk usage check currently walks every file under matching hermes-* scratch directories before deciding whether to warn. On large scratch trees this can add avoidable I/O after the threshold has already been crossed.

## Tests
- python -m pytest tests/tools/test_terminal_tool.py -q
- python -m py_compile tools/terminal_tool.py tests/tools/test_terminal_tool.py
- git diff --check

## Notes
- Replaces closed PR #46164 which had merge conflicts after upstream main added new test functions to the same file. This branch is rebased on the latest main with the conflict resolved (both sets of test functions preserved).
- Sego review passed: 2 findings addressed (warning log verification added, OSError trade-off documented), 2 false positives ignored.

## Notes
- I attempted ruff on the touched files, but the local environment does not have ruff or uv on PATH.