### PR TITLE
fix: use sys.getwindowsversion().build for Windows 11 detection

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -7,6 +7,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 import json
 import logging
 import os
+import platform
 import sys
 import threading
 import contextvars
@@ -925,6 +926,31 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 _BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
 
 
+_WINDOWS_11_MIN_BUILD = 22000
+
+
+def _windows_release() -> str:
+    """Return the Windows product release ('10' or '11').
+
+    ``platform.release()`` returns the NT kernel version, which is ``'10'``
+    on Windows 11 for Python < 3.12.  ``platform.win32_ver()[0]`` is also
+    ``'10'`` on CPython 3.11 because its client-release table maps the
+    shared ``(10, 0)`` NT version to ``'10'``.
+
+    The reliable signal is the NT build number from
+    ``sys.getwindowsversion().build``: build ``>= 22000`` is Windows 11.
+    Falls back to ``platform.release()`` when the API is unavailable
+    (non-Windows, ancient CPython, or monkeypatched test stubs).
+    """
+    try:
+        build = sys.getwindowsversion().build  # type: ignore[attr-defined]
+    except AttributeError:
+        return platform.release()
+    if build >= _WINDOWS_11_MIN_BUILD:
+        return "11"
+    return platform.release()
+
+
 _WINDOWS_BASH_SHELL_HINT = (
     "Shell: on this Windows host your `terminal` tool runs commands through "
     "bash (git-bash / MSYS), NOT PowerShell or cmd.exe. Use POSIX shell "
@@ -1098,7 +1124,7 @@ def build_environment_hints() -> str:
         if is_wsl():
             host_lines.append("Host: WSL (Windows Subsystem for Linux)")
         elif sys.platform == "win32":
-            host_lines.append(f"Host: Windows ({platform.release()})")
+            host_lines.append(f"Host: Windows ({_windows_release()})")
         elif sys.platform == "darwin":
             mac_ver = platform.mac_ver()[0]
             host_lines.append(f"Host: macOS ({mac_ver or platform.release()})")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1193,6 +1193,65 @@ class TestEnvironmentHints:
         assert "bash" in result
         assert "PowerShell" in result
 
+    def test_build_environment_hints_windows_11_shows_11(self, monkeypatch):
+        """Windows 11 (build >= 22000) must display '11', not '10'."""
+        import agent.prompt_builder as _pb
+        import sys
+        import platform
+        from collections import namedtuple
+
+        _WinVer = namedtuple("getwindowsversion", "major minor build platform version_string")
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(platform, "release", lambda: "10")
+        monkeypatch.setattr(
+            sys, "getwindowsversion",
+            lambda: _WinVer(10, 0, 26200, 2, "Windows 11"),
+        )
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Host: Windows (11)" in result
+        assert "Windows (10)" not in result
+
+    def test_build_environment_hints_windows_10_shows_10(self, monkeypatch):
+        """Windows 10 (build < 22000) must display '10'."""
+        import agent.prompt_builder as _pb
+        import sys
+        import platform
+        from collections import namedtuple
+
+        _WinVer = namedtuple("getwindowsversion", "major minor build platform version_string")
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(platform, "release", lambda: "10")
+        monkeypatch.setattr(
+            sys, "getwindowsversion",
+            lambda: _WinVer(10, 0, 19045, 2, "Windows 10"),
+        )
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Host: Windows (10)" in result
+
+    def test_build_environment_hints_windows_fallback_no_getwinver(self, monkeypatch):
+        """When sys.getwindowsversion is unavailable, fall back to platform.release()."""
+        import agent.prompt_builder as _pb
+        import sys
+        import platform
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(platform, "release", lambda: "10")
+        # Simulate non-Windows / ancient CPython: no getwindowsversion attr.
+        monkeypatch.delattr(sys, "getwindowsversion", raising=False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Host: Windows (10)" in result
+
     def test_build_environment_hints_on_macos_local(self, monkeypatch):
         import agent.prompt_builder as _pb
         import sys

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1208,6 +1208,7 @@ class TestEnvironmentHints:
         monkeypatch.setattr(
             sys, "getwindowsversion",
             lambda: _WinVer(10, 0, 26200, 2, "Windows 11"),
+            raising=False,
         )
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
         _pb._clear_backend_probe_cache()
@@ -1230,6 +1231,7 @@ class TestEnvironmentHints:
         monkeypatch.setattr(
             sys, "getwindowsversion",
             lambda: _WinVer(10, 0, 19045, 2, "Windows 10"),
+            raising=False,
         )
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
         _pb._clear_backend_probe_cache()


### PR DESCRIPTION
## Problem

`platform.release()` returns `'10'` on Windows 11 for Python < 3.12, so the system prompt shows `Host: Windows (10)` on Windows 11 machines.

The previous attempt used `platform.win32_ver()[0]`, but as @teknium1 noted in the review, this is also `'10'` on CPython 3.11 because its client-release table maps the shared `(10, 0)` NT version to `'10'`.

## Fix

Use `sys.getwindowsversion().build >= 22000` to detect Windows 11, with `platform.release()` as fallback when the API is unavailable.

This matches the established dashboard logic in `hermes_cli/web_server.py:_display_system_platform` (which uses the same `_WINDOWS_11_MIN_BUILD = 22000` threshold).

## Tests

Added 3 portable tests (analogous to `tests/hermes_cli/test_system_stats_platform.py`):
- `test_build_environment_hints_windows_11_shows_11` — build 26200 → displays `'11'`
- `test_build_environment_hints_windows_10_shows_10` — build 19045 → displays `'10'`
- `test_build_environment_hints_windows_fallback_no_getwinver` — no `getwindowsversion` → falls back to `platform.release()`

All 18 `TestEnvironmentHints` tests pass.

Addresses review feedback on #50653.