### PR TITLE
fix(context_references): add return_exceptions=True to asyncio.gather and handle exception results

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -167,9 +167,14 @@ async def preprocess_context_references_async(
                 allowed_root=allowed_root_path,
             )
             for ref in refs
-        )
+        ),
+        return_exceptions=True,
     )
-    for warning, block in expanded:
+    for item in expanded:
+        if isinstance(item, BaseException):
+            warnings.append(f"@ context expansion failed: {item}")
+            continue
+        warning, block = item
         if warning:
             warnings.append(warning)
         if block:


### PR DESCRIPTION
## Summary

Add `return_exceptions=True` to `asyncio.gather()` in `_expand_context_references` and handle `BaseException` results gracefully in the result loop.

## Problem

In `_expand_context_references` (agent/context_references.py:161), `asyncio.gather()` is used to expand multiple @-references concurrently (URLs, files, git refs). Without `return_exceptions=True`, a single failing coroutine (e.g., a bad URL that raises a network error) will cancel all other in-flight coroutines and propagate the exception up, crashing the entire context reference expansion.

This means one bad URL reference kills expansion of all other valid references in the same message.

## Fix

1. Added `return_exceptions=True` to the `asyncio.gather()` call so that failures in individual references are isolated.
2. Added a guard in the result loop to handle `BaseException` items — they are appended as warnings instead of crashing with a tuple unpacking error.

Minimal diff: 7 insertions, 2 deletions, 1 file changed.

## Testing
- Syntax check passed (py_compile)
- Behavior verified: exceptions are caught as warnings, other references still expand