### PR TITLE
fix(wecom): add CLOSING state to _wait_for_handshake auth guard (#64703)

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -329,7 +329,7 @@ class WeComAdapter(BasePlatformAdapter):
                 if self._payload_req_id(payload) == req_id:
                     return payload
                 logger.debug("[%s] Ignoring pre-auth payload: %s", self.name, payload.get("cmd"))
-            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR}:
+            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
                 raise RuntimeError("WeCom websocket closed during authentication")
 
     async def _listen_loop(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #64703.

`_wait_for_handshake()` in `plugins/platforms/wecom/adapter.py` did not handle `aiohttp.WSMsgType.CLOSING`, causing permanent reconnect failure when the server sent a closing frame during the authentication handshake.

## Root cause

When #28311 fixed `_read_events()` to handle `WSMsgType.CLOSING` (issue #28293), `_wait_for_handshake()` was missed. Both functions receive WebSocket messages and need to handle all terminal states, but `_wait_for_handshake()` was missing `CLOSING`:

Before: `{WSMsgType.CLOSED, WSMsgType.CLOSE, WSMsgType.ERROR}`
After:  `{WSMsgType.CLOSED, WSMsgType.CLOSE, WSMsgType.ERROR, WSMsgType.CLOSING}`

The `_read_events()` set already includes `CLOSING` (since #28311).

## Impact

All reconnection attempts fail silently (backoff retries all hit the same hang), requiring a manual pod/agent restart to recover. In production: 9/14 WeCom agents permanently lost connectivity after a cluster restart.

## Testing

One-character change (constant added to a set). Matches the identical set in `_read_events()` (line 373).