### PR TITLE
fix(wecom): make _cleanup_ws exception-safe (#64512)

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -270,13 +270,26 @@ class WeComAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _cleanup_ws(self) -> None:
-        """Close the live websocket/session, if any."""
+        """Close the live websocket/session, if any.
+
+        Defensive against transport-in-closing-state: ``ws.close()`` can raise
+        ``RuntimeError("Cannot write to closing transport")`` when the asyncio
+        transport is mid-close. Without the try/except, the exception skips
+        ``self._ws = None``, leaving a dangling broken transport that blocks
+        every subsequent reconnect attempt (issue #64512).
+        """
         if self._ws and not self._ws.closed:
-            await self._ws.close()
+            try:
+                await self._ws.close()
+            except Exception as exc:
+                logger.debug("[%s] ws.close() raised (already closing): %s", self.name, exc)
         self._ws = None
 
         if self._session and not self._session.closed:
-            await self._session.close()
+            try:
+                await self._session.close()
+            except Exception as exc:
+                logger.debug("[%s] session.close() raised: %s", self.name, exc)
         self._session = None
 
     async def _open_connection(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #64512.

`_cleanup_ws()` in `plugins/platforms/wecom/adapter.py` was exception-unsafe. If `await self._ws.close()` raised (e.g. `RuntimeError: "Cannot write to closing transport"` when the asyncio transport was mid-close), the assignment `self._ws = None` on L276 was skipped, leaving a dangling broken transport object. Every subsequent `_open_connection()` re-entry called `_cleanup_ws()` again, hit the same transport, and raised again — a dead loop that only resolved when the OS TCP timeout (30-120s) cleared the transport state.

In production: permanent WebSocket disconnect with zero observability. Only a manual pod/agent restart recovered.

## Fix

Wrap both `ws.close()` and `session.close()` in `try/except`. On exception, log at debug level (transient transport state) and clear the reference anyway, so the next reconnect attempt starts from a clean socket.

```python
async def _cleanup_ws(self) -> None:
    if self._ws and not self._ws.closed:
        try:
            await self._ws.close()
        except Exception as exc:
            logger.debug("[%s] ws.close() raised (already closing): %s", self.name, exc)
    self._ws = None
    if self._session and not self._session.closed:
        try:
            await self._session.close()
        except Exception as exc:
            logger.debug("[%s] session.close() raised: %s", self.name, exc)
    self._session = None
```

## Testing

`pytest tests/gateway/test_wecom.py tests/gateway/test_wecom_callback.py` — 59 pass, 3 fail (pre-existing lxml `fromstring` AttributeError on `callback_adapter.py:360`, unrelated to this patch; verified by stashing the diff and re-running).