### PR TITLE
fix: add _has_visible_content guard to thinking-prefill retry gate

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5023,7 +5023,11 @@ def run_conversation(
                         or getattr(assistant_message, "reasoning_details", None)
                         or _has_inline_thinking
                     )
-                    if _has_structured and agent._thinking_prefill_retries < 2:
+                    _has_visible_content = bool(
+                        final_response
+                        and agent._strip_think_blocks(final_response).strip()
+                    )
+                    if _has_structured and not _has_visible_content and agent._thinking_prefill_retries < 2:
                         agent._thinking_prefill_retries += 1
                         logger.info(
                             "Thinking-only response (no visible content) — "


### PR DESCRIPTION
## Summary

Adds a `_has_visible_content` guard to the thinking-prefill retry gate in `agent/conversation_loop.py` so that reasoning models producing both reasoning tokens AND visible text (even a single character like `"."`) skip the prefill cascade and deliver their response immediately.

## Problem

The thinking-prefill continuation logic (line 5026) checks whether the model produced structured reasoning with no visible text, then prefills to let the model continue. However, it only checks `_has_structured` — it never verifies that `final_response` is actually empty.

This means any model with `reasoning_tokens > 0` can trigger the prefill branch even when it DID produce visible output. The prefill logic sees structured reasoning and retries regardless:

```
↻ Thinking-only response — prefilling to continue (1/2)
↻ Thinking-only response — prefilling to continue (2/2)
⚠️ Empty response from model — retrying (1/3)
⚠️ Empty response from model — retrying (2/3)
⚠️ Empty response from model — retrying (3/3)
```

## Fix

Add `_has_visible_content` that strips think blocks from `final_response` and checks for non-whitespace content:

```python
_has_visible_content = bool(
    final_response
    and agent._strip_think_blocks(final_response).strip()
)
if _has_structured and not _has_visible_content and agent._thinking_prefill_retries < 2:
```

This mirrors the existing `_truly_empty` check at line 5055 which already uses this same pattern — the fix brings the prefill gate into alignment. If the model produced any visible text, we skip the prefill retry and deliver it.

## Affected models

Any reasoning model that produces both reasoning tokens and tiny visible responses:
- **DeepSeek-R1 / deepseek-v4-pro** — stand-down protocol `"."` replies
- **OpenAI o-series** (o1, o3, o4-mini)
- **Anthropic extended thinking** (Claude with thinking)
- **Qwen3** with in-content `<think>` blocks

Fixes #64732