### PR TITLE
fix(tools): don't strip shared tools when disabling a toolset (#64503)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -424,7 +424,26 @@ def _compute_tool_definitions(
                         )
                 else:
                     resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
+                    # Don't strip a tool that another *enabled* toolset also
+                    # claims — otherwise disabling `browser` (which statically
+                    # lists `web_search` for URL discovery) silently removes
+                    # `web_search` even when the `web` toolset is explicitly
+                    # enabled (issue #64503). Only subtract tools that are
+                    # unique to this disabled toolset.
+                    if enabled_toolsets is not None:
+                        retained = set()
+                        for other_ts in enabled_toolsets:
+                            if other_ts == toolset_name:
+                                continue
+                            try:
+                                retained.update(resolve_toolset(other_ts))
+                            except Exception:
+                                pass
+                        removed = set(resolved) - retained
+                        tools_to_include.difference_update(removed)
+                        resolved = sorted(removed)
+                    else:
+                        tools_to_include.difference_update(resolved)
                 if not quiet_mode:
                     print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:


### PR DESCRIPTION
## Summary

Fixes #64503.

`disabled_toolsets: [browser]` silently removed `web_search` from every session's tool schema, even when the `web` toolset was explicitly enabled and the Tavily key was valid. The browser-less Docker/headless deployment is the natural place users hit this — disabling browser is the obvious thing to do, and there is no warning that web search goes with it.

### Root cause

In `model_tools.py::_compute_tool_definitions`, the disabled-toolset branch did:

```python
resolved = resolve_toolset(toolset_name)
tools_to_include.difference_update(resolved)
```

`browser` statically lists `web_search` (for URL discovery alongside the 12 `browser_*` tools), so subtracting the whole toolset also subtracted `web_search` — even though `web` (also enabled) claims it independently. The shared-core-tool protection from #33924/#57315 only covers `hermes-*` platform bundles and `posture: True` toolsets, not regular toolsets like `browser`.

## Fix

When `enabled_toolsets` is known, compute the set of tools retained by *other* enabled toolsets and only subtract tools unique to the disabled toolset:

```python
if enabled_toolsets is not None:
    retained = set()
    for other_ts in enabled_toolsets:
        if other_ts == toolset_name:
            continue
        retained.update(resolve_toolset(other_ts))
    removed = set(resolved) - retained
    tools_to_include.difference_update(removed)
    resolved = sorted(removed)
else:
    tools_to_include.difference_update(resolved)
```

So a tool that lives in both `web` and `browser` is preserved when only `browser` is disabled.

When `enabled_toolsets` is None (default-universe path), behavior is unchanged — full subtraction.

## Testing

Reproduced the bug, then verified the fix:

```python
from model_tools import _compute_tool_definitions
from tools import registry
# Bypass check_fn to inspect pure subtract logic
registry.registry.get_definitions = lambda tools, quiet=False: [{'function': {'name': n}} for n in sorted(tools)]

# enabled=['web'], disabled=['browser'] → web_search must survive
defs = _compute_tool_definitions(enabled_toolsets={'web'}, disabled_toolsets=['browser'], quiet_mode=True)
assert 'web_search' in {d['function']['name'] for d in defs}
assert 'browser_navigate' not in {d['function']['name'] for d in defs}

# enabled=['browser'] only, disabled=['browser'] → both gone (no other toolset claims them)
defs2 = _compute_tool_definitions(enabled_toolsets={'browser'}, disabled_toolsets=['browser'], quiet_mode=True)
assert 'browser_navigate' not in {d['function']['name'] for d in defs2}
assert 'web_search' not in {d['function']['name'] for d in defs2}
```

No regression in existing test suite.