### PR TITLE
fix: named-profile bg notify + chat_type routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2532,7 +2532,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent" and parts[1]:
         result = {
             "platform": parts[2],
             "chat_type": parts[3],

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -555,4 +555,7 @@ def test_parse_session_key_too_short():
 
 def test_parse_session_key_wrong_prefix():
     assert _parse_session_key("cron:main:telegram:dm:123") is None
-    assert _parse_session_key("agent:cron:telegram:dm:123") is None
+    assert _parse_session_key("foo:bar:baz:dm:123") is None
+    # Named profiles are valid — "agent:coder:..." parses just like "agent:main:..."
+    result = _parse_session_key("agent:coder:telegram:dm:123")
+    assert result == {"platform": "telegram", "chat_type": "dm", "chat_id": "123"}

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -111,6 +111,7 @@ class ProcessSession:
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
+    watcher_chat_type: str = ""                  # "dm" or "group" — routing discriminator
     watcher_user_id: str = ""
     watcher_user_name: str = ""
     watcher_thread_id: str = ""
@@ -321,6 +322,7 @@ class ProcessRegistry:
                     "suppressed": session._watch_suppressed,
                     "platform": session.watcher_platform,
                     "chat_id": session.watcher_chat_id,
+                    "chat_type": session.watcher_chat_type,
                     "user_id": session.watcher_user_id,
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
@@ -354,6 +356,7 @@ class ProcessRegistry:
             "suppressed": suppressed,
             "platform": session.watcher_platform,
             "chat_id": session.watcher_chat_id,
+            "chat_type": session.watcher_chat_type,
             "user_id": session.watcher_user_id,
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
@@ -1869,6 +1872,7 @@ class ProcessRegistry:
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
+                            "watcher_chat_type": s.watcher_chat_type,
                             "watcher_user_id": s.watcher_user_id,
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
@@ -1968,6 +1972,7 @@ class ProcessRegistry:
                     "session_key": session.session_key,
                     "platform": session.watcher_platform,
                     "chat_id": session.watcher_chat_id,
+                    "chat_type": session.watcher_chat_type,
                     "user_id": session.watcher_user_id,
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2571,8 +2571,16 @@ def terminal_tool(
                             _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
                             _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
                             _gw_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
+                            # Extract chat_type from session_key for routing.
+                            # Format: agent:<ns>:<platform>:<chat_type>:<chat_id>[:...]
+                            _gw_chat_type = ""
+                            if session_key:
+                                _parts = session_key.split(":")
+                                if len(_parts) >= 5 and _parts[0] == "agent" and _parts[1]:
+                                    _gw_chat_type = _parts[3]
                             proc_session.watcher_platform = _gw_platform
                             proc_session.watcher_chat_id = _gw_chat_id
+                            proc_session.watcher_chat_type = _gw_chat_type
                             proc_session.watcher_user_id = _gw_user_id
                             proc_session.watcher_user_name = _gw_user_name
                             proc_session.watcher_thread_id = _gw_thread_id
@@ -2610,6 +2618,7 @@ def terminal_tool(
                             "session_key": session_key,
                             "platform": proc_session.watcher_platform,
                             "chat_id": proc_session.watcher_chat_id,
+                            "chat_type": proc_session.watcher_chat_type,
                             "user_id": proc_session.watcher_user_id,
                             "user_name": proc_session.watcher_user_name,
                             "thread_id": proc_session.watcher_thread_id,


### PR DESCRIPTION
- gateway/run.py: _parse_session_key accepts any namespace (agent:coder:...) instead of only 'main', fixing silent drop of background-process notifications for named-profile sessions.

- tools/process_registry.py: add watcher_chat_type field for dm/group routing discrimination, plumbed through all serialization and recovery paths.

- tools/terminal_tool.py: extract chat_type from session_key for background-process watcher routing completeness.

- tests: add named-profile session_key parsing test case.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

