### PR TITLE
fix: honor display.memory_notifications in the classic CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3729,6 +3729,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
         self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)
+        # memory_notifications: "off" | "on" | "verbose" — whether the
+        # background self-improvement review surfaces its "💾 Self-improvement
+        # review: …" summary in chat. The messaging gateway (gateway/run.py)
+        # and the TUI/desktop backend (tui_gateway/server.py) already honour
+        # display.memory_notifications; the classic CLI ignored it and always
+        # behaved as "on" (AIAgent's hardcoded default). Parity fix.
+        # YAML 1.1 parses bare `off`/`on` as booleans — normalise to string.
+        # Per-platform override via display.platforms.cli.memory_notifications.
+        _raw_mn = CLI_CONFIG["display"].get("memory_notifications", "on")
+        _plat_mn = (
+            CLI_CONFIG["display"].get("platforms", {}).get("cli", {}).get("memory_notifications")
+            if isinstance(CLI_CONFIG["display"].get("platforms"), dict)
+            else None
+        )
+        if _plat_mn is not None:
+            _raw_mn = _plat_mn
+        if isinstance(_raw_mn, bool):
+            self.memory_notifications = "on" if _raw_mn else "off"
+        else:
+            self.memory_notifications = str(_raw_mn).lower() if _raw_mn else "on"
         _configure_output_history(
             enabled=CLI_CONFIG["display"].get("persistent_output", True),
             max_lines=CLI_CONFIG["display"].get("persistent_output_max_lines", 200),

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -406,6 +406,11 @@ class CLIAgentSetupMixin:
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint
+            # Honor display.memory_notifications (off | on | verbose) like the
+            # messaging gateway and the TUI backend. Without this the classic
+            # CLI always used AIAgent's hardcoded "on" and a user-configured
+            # "off" was silently ignored.
+            self.agent.memory_notifications = getattr(self, "memory_notifications", "on")
             # Hydrate credits notices at session OPEN (parity with the TUI), so a
             # depletion / usage-band warning shows before the first message. The
             # notice_callback is bound above → _on_notice renders the line. Idempotent

--- a/tests/cli/test_cli_memory_notifications.py
+++ b/tests/cli/test_cli_memory_notifications.py
@@ -1,0 +1,68 @@
+"""Tests for display.memory_notifications handling in the classic CLI.
+
+The messaging gateway (gateway/run.py) and the TUI/desktop backend
+(tui_gateway/server.py) honour ``display.memory_notifications``
+(off | on | verbose) when surfacing the background self-improvement
+review summary. The classic CLI ignored the setting and always behaved
+as "on" (AIAgent's hardcoded default), so a user-configured ``off`` was
+silently ignored. These tests lock in the parity fix.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tests.cli.test_cli_init import _make_cli
+
+
+def _cli_with_display(display_overrides):
+    display = {"compact": False, "tool_progress": "all"}
+    display.update(display_overrides)
+    return _make_cli(config_overrides={"display": display})
+
+
+class TestMemoryNotificationsConfig:
+    def test_default_is_on(self):
+        cli = _make_cli()
+        assert cli.memory_notifications == "on"
+
+    def test_off_is_honored(self):
+        cli = _cli_with_display({"memory_notifications": "off"})
+        assert cli.memory_notifications == "off"
+
+    def test_verbose_is_honored(self):
+        cli = _cli_with_display({"memory_notifications": "verbose"})
+        assert cli.memory_notifications == "verbose"
+
+    def test_yaml_bool_false_normalized_to_off(self):
+        # YAML 1.1 parses bare `off` as boolean False.
+        cli = _cli_with_display({"memory_notifications": False})
+        assert cli.memory_notifications == "off"
+
+    def test_yaml_bool_true_normalized_to_on(self):
+        cli = _cli_with_display({"memory_notifications": True})
+        assert cli.memory_notifications == "on"
+
+    def test_mixed_case_normalized(self):
+        cli = _cli_with_display({"memory_notifications": "OFF"})
+        assert cli.memory_notifications == "off"
+
+    def test_per_platform_cli_override_wins(self):
+        cli = _cli_with_display(
+            {
+                "memory_notifications": "on",
+                "platforms": {"cli": {"memory_notifications": "off"}},
+            }
+        )
+        assert cli.memory_notifications == "off"
+
+    def test_other_platform_override_ignored(self):
+        cli = _cli_with_display(
+            {
+                "memory_notifications": "off",
+                "platforms": {"weixin": {"memory_notifications": "on"}},
+            }
+        )
+        assert cli.memory_notifications == "off"


### PR DESCRIPTION
Fixes #64736.

## Summary

`display.memory_notifications` (off | on | verbose) is honoured by the messaging gateway (`gateway/run.py`) and the TUI/desktop backend (`tui_gateway/server.py`), but the classic CLI never read it — `AIAgent`'s hardcoded default `"on"` always won, so a user-configured `off` was silently ignored in terminal sessions.

## Changes

- `cli.py` — `HermesCLI.__init__` reads `display.memory_notifications` with the same normalization as the gateway (YAML 1.1 bare `off`/`on` booleans → string, lowercase), plus per-platform override via `display.platforms.cli.memory_notifications` (mirrors the documented per-platform override convention in `hermes_cli/config.py`)
- `hermes_cli/cli_agent_setup_mixin.py` — applies the resolved mode to the agent right after construction, next to the existing `_print_fn` wiring
- `tests/cli/test_cli_memory_notifications.py` — 8 tests: default on, off/verbose honoured, YAML bool normalization both ways, case normalization, cli platform override wins, other platform override ignored

## Test Plan

- [x] `pytest tests/cli/test_cli_memory_notifications.py` — 8 passed
- [x] `pytest tests/cli/test_cli_init.py` — 53 passed (no regression in CLI init)
- [x] `pytest tests/run_agent/test_background_review.py tests/cli/test_cli_active_agent_ref_wiring.py` — 13 passed