### PR TITLE
feat(auth): honor suppressed_sources for Claude Code credentials in Anthropic token resolution

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1284,8 +1284,33 @@ def resolve_anthropic_token() -> Optional[str]:
       5. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
 
     Returns the token string or None.
+
+    When the user has suppressed the ``claude_code`` source for anthropic
+    (via ``hermes auth remove`` / ``suppressed_sources`` in auth.json), the
+    Claude Code keychain/file credentials are never read here: resolving
+    them would shadow the hermes-managed credential_pool entry, and the
+    refresh path would consume Claude Code's single-use rotating refresh
+    token, invalidating the user's Claude Code login.
     """
-    creds = read_claude_code_credentials()
+    _cc_suppressed = False
+    try:
+        from hermes_cli.auth import is_source_suppressed as _is_suppressed
+
+        _cc_suppressed = _is_suppressed("anthropic", "claude_code")
+    except Exception:
+        pass
+    if not _cc_suppressed:
+        # Also honor a global-root suppression marker so profiles without
+        # their own auth.json (e.g. freshly created ones) inherit the policy.
+        try:
+            _root_auth = Path.home() / ".hermes" / "auth.json"
+            if _root_auth.exists():
+                _supp = json.loads(_root_auth.read_text()).get("suppressed_sources", {})
+                _cc_suppressed = "claude_code" in _supp.get("anthropic", [])
+        except Exception:
+            pass
+
+    creds = None if _cc_suppressed else read_claude_code_credentials()
 
     # 1. Hermes-managed OAuth/setup token env var
     token = os.getenv("ANTHROPIC_TOKEN", "").strip()
@@ -1304,9 +1329,10 @@ def resolve_anthropic_token() -> Optional[str]:
         return cc_token
 
     # 3. Claude Code credential file
-    resolved_claude_token = _resolve_claude_code_token_from_credentials(creds)
-    if resolved_claude_token:
-        return resolved_claude_token
+    if not _cc_suppressed:
+        resolved_claude_token = _resolve_claude_code_token_from_credentials(creds)
+        if resolved_claude_token:
+            return resolved_claude_token
 
     # 4. Hermes credential_pool OAuth entry.
     resolved_pool_token = _resolve_anthropic_pool_token()

--- a/tests/agent/test_anthropic_suppressed_sources.py
+++ b/tests/agent/test_anthropic_suppressed_sources.py
@@ -1,0 +1,109 @@
+"""resolve_anthropic_token honours suppressed_sources for the claude_code source.
+
+Operators can suppress a credential source per provider via the
+``suppressed_sources`` key in auth.json (managed by ``hermes auth`` and
+read through ``hermes_cli.auth.is_source_suppressed``). Before this fix,
+``resolve_anthropic_token`` unconditionally read the local Claude Code
+credentials (keychain / ~/.claude files) at priority 3, shadowing the
+hermes-managed ``credential_pool`` entry at priority 4 — and worse, the
+refresh path could consume Claude Code's single-use rotating refresh
+token, invalidating the user's separate Claude Code login.
+
+These tests pin the new contract: when ``claude_code`` is suppressed for
+``anthropic``, the Claude Code credential sources are never read; when it
+is not suppressed, the historical priority order is unchanged.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent.anthropic_adapter import resolve_anthropic_token
+
+CC_CREDS = {
+    "claudeAiOauth": {"accessToken": "cc-token", "expiresAt": 9999999999999}
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(monkeypatch, tmp_path):
+    """Clear token env vars and point the root-auth fallback at an empty home.
+
+    Without this, a developer's real environment (ANTHROPIC_TOKEN etc.) or
+    their real ~/.hermes/auth.json suppression marker would leak into the
+    resolution chain under test.
+    """
+    for var in ("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    with patch("agent.anthropic_adapter.Path.home", return_value=fake_home):
+        yield fake_home
+
+
+class TestClaudeCodeSuppression:
+    def test_suppressed_source_is_never_read_and_pool_wins(self):
+        """With claude_code suppressed, neither the credential read nor the
+        token resolution for Claude Code may run — the credential_pool entry
+        becomes the effective source."""
+        with patch("hermes_cli.auth.is_source_suppressed", return_value=True), \
+             patch("agent.anthropic_adapter.read_claude_code_credentials") as read_cc, \
+             patch("agent.anthropic_adapter._resolve_claude_code_token_from_credentials") as resolve_cc, \
+             patch("agent.anthropic_adapter._resolve_anthropic_pool_token", return_value="pool-token"):
+            assert resolve_anthropic_token() == "pool-token"
+        read_cc.assert_not_called()
+        resolve_cc.assert_not_called()
+
+    def test_unsuppressed_keeps_claude_code_priority(self):
+        """Regression guard: without suppression, the Claude Code credential
+        file still outranks the credential_pool entry (historical order)."""
+        with patch("hermes_cli.auth.is_source_suppressed", return_value=False), \
+             patch("agent.anthropic_adapter.read_claude_code_credentials", return_value=CC_CREDS), \
+             patch("agent.anthropic_adapter._resolve_claude_code_token_from_credentials", return_value="cc-token"), \
+             patch("agent.anthropic_adapter._resolve_anthropic_pool_token", return_value="pool-token"):
+            assert resolve_anthropic_token() == "cc-token"
+
+    def test_root_auth_json_marker_suppresses_for_profiles_without_own_auth(self, _isolated_env):
+        """Profiles without their own auth.json inherit the root suppression
+        marker (the fallback read of ~/.hermes/auth.json)."""
+        auth_dir = _isolated_env / ".hermes"
+        auth_dir.mkdir()
+        (auth_dir / "auth.json").write_text(
+            json.dumps({"suppressed_sources": {"anthropic": ["claude_code"]}})
+        )
+        with patch("hermes_cli.auth.is_source_suppressed", return_value=False), \
+             patch("agent.anthropic_adapter.read_claude_code_credentials") as read_cc, \
+             patch("agent.anthropic_adapter._resolve_anthropic_pool_token", return_value="pool-token"):
+            assert resolve_anthropic_token() == "pool-token"
+        read_cc.assert_not_called()
+
+    def test_suppressed_with_no_pool_falls_back_to_api_key(self, monkeypatch):
+        """Suppression removes one source; the rest of the chain is intact
+        (ANTHROPIC_API_KEY remains the final fallback)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fallback")
+        with patch("hermes_cli.auth.is_source_suppressed", return_value=True), \
+             patch("agent.anthropic_adapter.read_claude_code_credentials") as read_cc, \
+             patch("agent.anthropic_adapter._resolve_anthropic_pool_token", return_value=None):
+            assert resolve_anthropic_token() == "sk-ant-fallback"
+        read_cc.assert_not_called()
+
+    def test_env_token_still_wins_when_suppressed(self, monkeypatch):
+        """ANTHROPIC_TOKEN (priority 1) is unaffected by suppression — and
+        with the Claude Code credentials unread, the refreshable-credential
+        preference can no longer swap the env token for a Claude Code one."""
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "env-token")
+        with patch("hermes_cli.auth.is_source_suppressed", return_value=True), \
+             patch("agent.anthropic_adapter.read_claude_code_credentials") as read_cc, \
+             patch("agent.anthropic_adapter._resolve_anthropic_pool_token", return_value="pool-token"):
+            assert resolve_anthropic_token() == "env-token"
+        read_cc.assert_not_called()
+
+    def test_suppression_helper_failure_fails_open(self):
+        """If the suppression lookup itself blows up, behaviour must fall
+        back to today's (Claude Code readable) rather than breaking auth."""
+        with patch("hermes_cli.auth.is_source_suppressed", side_effect=RuntimeError("boom")), \
+             patch("agent.anthropic_adapter.read_claude_code_credentials", return_value=CC_CREDS), \
+             patch("agent.anthropic_adapter._resolve_claude_code_token_from_credentials", return_value="cc-token"), \
+             patch("agent.anthropic_adapter._resolve_anthropic_pool_token", return_value="pool-token"):
+            assert resolve_anthropic_token() == "cc-token"


### PR DESCRIPTION
## Problem

`hermes_cli.auth` already supports a `suppressed_sources` key in
auth.json (with an `is_source_suppressed()` helper), letting an
operator exclude a specific credential source for a provider. But
`resolve_anthropic_token()` never consults it: it unconditionally
reads the local Claude Code credentials (macOS Keychain /
`~/.claude` credential files) at priority 3, ahead of the
hermes-managed `credential_pool` entry at priority 4.

For an operator who wants hermes to use its *own* Anthropic
credential rather than piggy-backing on a local Claude Code login,
this has two consequences:

1. **Silent shadowing** — on any machine where Claude Code is
   installed and logged in, `hermes auth add anthropic` appears to do
   nothing: the Claude Code login always outranks the credential_pool
   entry the operator just added.
2. **Refresh-token theft** — the auto-refresh path can consume Claude
   Code's *single-use rotating* refresh token. When hermes refreshes
   a Claude Code credential it does not own, the rotation invalidates
   the refresh token Claude Code itself still holds, effectively
   logging the user out of Claude Code.

(Incidentally, the existing `TestResolveAnthropicToken` tests in
`tests/agent/test_anthropic_adapter.py` fail on any macOS dev machine
with a live Claude Code keychain entry for exactly this reason — the
tests patch `Path.home()` but the keychain read goes through the
`security` binary and finds the developer's real token. That's a
pre-existing test-isolation issue this PR doesn't try to fix, but it
demonstrates the shadowing concretely.)

## Fix

`resolve_anthropic_token()` now honors the suppression: when
`claude_code` is suppressed for `anthropic`, the Claude Code
credential sources are never read — neither the credential-file /
keychain read nor the token resolution+refresh step. Details:

- Primary check via `hermes_cli.auth.is_source_suppressed("anthropic",
  "claude_code")` (the existing per-profile mechanism).
- Fallback check of a root-level `~/.hermes/auth.json`
  `suppressed_sources` marker, so profiles without their own
  auth.json (e.g. freshly created ones) inherit the operator's
  policy.
- Both lookups **fail open**: any exception preserves today's
  behavior, so this cannot break auth resolution for anyone not
  using suppression.
- Everything else is unchanged: `ANTHROPIC_TOKEN` /
  `CLAUDE_CODE_OAUTH_TOKEN` env vars keep their priority,
  `credential_pool` and `ANTHROPIC_API_KEY` keep theirs, and the
  historical priority order is untouched when nothing is suppressed.

## Tests

`tests/agent/test_anthropic_suppressed_sources.py` (new, 6 tests):

- suppression skips both Claude Code reads entirely (asserted via
  mock call counts) and the credential_pool entry becomes the
  effective source
- without suppression, the historical priority (Claude Code file over
  pool) is preserved — regression guard
- the root-auth.json fallback marker suppresses on its own, even when
  the per-profile helper says not suppressed
- with suppression and no pool entry, the chain still falls through
  to `ANTHROPIC_API_KEY`
- `ANTHROPIC_TOKEN` (priority 1) still wins under suppression, and
  with Claude Code credentials unread, the refreshable-credential
  preference can no longer swap the env token for a Claude Code one
- a failing suppression lookup fails open to today's behavior

Test run: `pytest tests/agent/test_anthropic_suppressed_sources.py
tests/agent/test_anthropic_keychain.py -q` → **24 passed**.

Regression note: `tests/agent/test_anthropic_adapter.py` shows 14
failures on the dev machine used to prepare this, but the identical
14 failures occur on pristine `origin/main` in the same environment
(verified by diffing the failure sets with the patch stashed) — they
are the pre-existing macOS keychain test-isolation issue described
above, not regressions from this change. They pass on Linux CI where
the keychain read returns None.

Local dev install: `uv venv .venv --python 3.11 && uv pip install -e ".[dev]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
