### PR TITLE
feat(profile): add read-only effectiveness audit

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11547,6 +11547,43 @@ def cmd_profile(args):
             sys.exit(0 if ok_count == 1 else 1)
         sys.exit(0 if ok_count > 0 else 1)
 
+    elif action == "audit":
+        from hermes_cli.profile_audit import (
+            audit_profiles,
+            load_policy,
+            render_text,
+        )
+        from hermes_cli.profiles import _get_profiles_root
+
+        profiles_root = Path(
+            getattr(args, "profiles_root", None) or _get_profiles_root()
+        ).expanduser()
+        kanban_db = Path(
+            getattr(args, "kanban_db", None) or profiles_root.parent / "kanban.db"
+        ).expanduser()
+        since_days = getattr(args, "since_days", 30)
+        if since_days < 0:
+            print("profile audit: --since-days must be 0 or greater", file=sys.stderr)
+            sys.exit(2)
+        try:
+            policy_arg = getattr(args, "policy", None)
+            policy = load_policy(Path(policy_arg).expanduser() if policy_arg else None)
+        except ValueError as exc:
+            print(f"profile audit: {exc}", file=sys.stderr)
+            sys.exit(2)
+        report = audit_profiles(
+            profiles_root,
+            kanban_db,
+            policy=policy,
+            since_days=since_days,
+        )
+        if getattr(args, "format", "text") == "json":
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(render_text(report))
+        if getattr(args, "strict", False) and report["summary"]["issues"]:
+            sys.exit(1)
+
     elif action == "show":
         name = args.profile_name
         from hermes_cli.profiles import (

--- a/hermes_cli/profile_audit.py
+++ b/hermes_cli/profile_audit.py
@@ -1,0 +1,250 @@
+"""Read-only effectiveness and policy audit for Hermes profiles."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+_COMPLETED_OUTCOMES = frozenset({"completed", "success"})
+_ACTIVE_OUTCOMES = frozenset({None, ""})
+
+_SOUL_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("role", ("you are", "# identity", "# role", "mission")),
+    ("responsibilities", ("responsibil", "your job", "mission", "duties")),
+    ("process", ("process", "workflow", "procedure", "how you work", "approach", "operating rules")),
+    ("quality_standards", ("quality", "correctness", "security", "maintainab", "test", "verif")),
+    ("output_or_dod", ("definition of done", "done means", "output", "deliverable", "report", "complete")),
+    ("block_or_escalation", ("block", "escalat", "genuine gate", "missing access", "ambigu")),
+    ("preflight", ("preflight", "prerequisite", "before starting", "before you start", "inspect the", "read first")),
+)
+_EXTERNAL_DEPENDENCIES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("Claude subscription wrapper", ("claude-sub", "claude code through", "claude subscription")),
+    ("external browser automation", ("browser-use cloud", "browserbase", "stagehand cloud")),
+)
+
+
+def _issue(rule: str, message: str, severity: str = "warning") -> dict[str, str]:
+    return {"rule": rule, "severity": severity, "message": message}
+
+
+def lint_soul(text: str) -> list[dict[str, str]]:
+    """Return missing effectiveness-policy requirements for one SOUL.md."""
+    lowered = text.casefold()
+    issues = [
+        _issue(f"soul.{rule}", f"SOUL.md does not document {rule.replace('_', ' ')}")
+        for rule, terms in _SOUL_RULES
+        if not any(term in lowered for term in terms)
+    ]
+    if not ("kanban_complete" in lowered and "kanban_block" in lowered):
+        issues.append(
+            _issue(
+                "soul.kanban_handoff",
+                "SOUL.md must require Kanban workers to call kanban_complete or kanban_block",
+            )
+        )
+    for name, indicators in _EXTERNAL_DEPENDENCIES:
+        if any(indicator in lowered for indicator in indicators):
+            has_preflight = any(term in lowered for term in ("preflight", "prerequisite", "check access", "verify access", "command -v"))
+            has_fallback = any(term in lowered for term in ("fallback", "fall back", "if unavailable", "if it fails", "block"))
+            if not (has_preflight and has_fallback):
+                issues.append(
+                    _issue(
+                        "soul.external_dependency",
+                        f"{name} is referenced without both a preflight and fallback/block policy",
+                    )
+                )
+    return issues
+
+
+def _read_mapping(path: Path) -> tuple[dict[str, Any], str | None]:
+    if not path.is_file():
+        return {}, None
+    try:
+        value = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return {}, f"{type(exc).__name__}: could not parse {path.name}"
+    if not isinstance(value, dict):
+        return {}, f"{path.name} must contain a mapping"
+    return value, None
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            decoded = None
+        value = decoded if isinstance(decoded, list) else [value]
+    if not isinstance(value, list):
+        return []
+    return sorted({str(item) for item in value if str(item).strip()})
+
+
+def _safe_config_inventory(config: dict[str, Any]) -> dict[str, Any]:
+    model_cfg = config.get("model") if isinstance(config.get("model"), dict) else {}
+    platforms = config.get("platform_toolsets")
+    platform_cli = platforms.get("cli") if isinstance(platforms, dict) else None
+    toolsets = _string_list(platform_cli if isinstance(platform_cli, list) else config.get("toolsets"))
+    return {
+        "model": str(model_cfg.get("default") or "") or None,
+        "provider": str(model_cfg.get("provider") or "") or None,
+        "toolsets": toolsets,
+    }
+
+
+def _policy_issues(inventory: dict[str, Any], policy: dict[str, Any]) -> list[dict[str, str]]:
+    issues: list[dict[str, str]] = []
+    expected_model = policy.get("model")
+    if expected_model and inventory["model"] != str(expected_model):
+        issues.append(_issue("config.model", f"model does not match policy (expected {expected_model!s})"))
+    expected_provider = policy.get("provider")
+    if expected_provider and inventory["provider"] != str(expected_provider):
+        issues.append(_issue("config.provider", f"provider does not match policy (expected {expected_provider!s})"))
+    actual = set(inventory["toolsets"])
+    for required in _string_list(policy.get("required_toolsets")):
+        if required not in actual:
+            issues.append(_issue("config.required_toolset", f"required toolset is missing: {required}"))
+    for forbidden in _string_list(policy.get("forbidden_toolsets")):
+        if forbidden in actual:
+            issues.append(_issue("config.forbidden_toolset", f"forbidden toolset is enabled: {forbidden}"))
+    return issues
+
+
+def _profile_directories(root: Path) -> Iterable[Path]:
+    try:
+        entries = sorted(root.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return []
+    return [
+        path for path in entries
+        if path.is_dir() and not path.name.startswith((".", "_"))
+        and ((path / "config.yaml").exists() or (path / "SOUL.md").exists())
+    ]
+
+
+def _run_stats(db_path: Path, since_epoch: int) -> tuple[dict[str, dict[str, Any]], str | None]:
+    if not db_path.is_file():
+        return {}, "kanban database not found"
+    try:
+        uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as conn:
+            rows = conn.execute(
+                "SELECT profile, outcome FROM task_runs WHERE started_at >= ?",
+                (since_epoch,),
+            ).fetchall()
+    except (OSError, sqlite3.Error) as exc:
+        return {}, f"{type(exc).__name__}: could not read task_runs"
+
+    grouped: dict[str, Counter[str]] = {}
+    active: Counter[str] = Counter()
+    for profile, outcome in rows:
+        name = str(profile or "unassigned")
+        if outcome in _ACTIVE_OUTCOMES:
+            active[name] += 1
+            continue
+        grouped.setdefault(name, Counter())[str(outcome)] += 1
+
+    result: dict[str, dict[str, Any]] = {}
+    for name in sorted(set(grouped) | set(active)):
+        outcomes = grouped.get(name, Counter())
+        finished = sum(outcomes.values())
+        completed = sum(outcomes[value] for value in _COMPLETED_OUTCOMES)
+        result[name] = {
+            "finished": finished,
+            "active": active[name],
+            "completed": completed,
+            "completion_rate": round(completed / finished, 4) if finished else None,
+            "outcomes": dict(sorted(outcomes.items())),
+        }
+    return result, None
+
+
+def audit_profiles(
+    profiles_root: Path,
+    kanban_db: Path,
+    *,
+    policy: dict[str, Any] | None = None,
+    since_days: int = 30,
+    now: int | None = None,
+) -> dict[str, Any]:
+    """Build a secret-safe report without writing profiles or the board."""
+    now = int(time.time()) if now is None else now
+    since_epoch = 0 if since_days == 0 else now - (since_days * 86_400)
+    profile_policy = (policy or {}).get("profiles", {})
+    if not isinstance(profile_policy, dict):
+        profile_policy = {}
+
+    profiles: list[dict[str, Any]] = []
+    for profile_dir in _profile_directories(profiles_root):
+        issues: list[dict[str, str]] = []
+        config, config_error = _read_mapping(profile_dir / "config.yaml")
+        if config_error:
+            issues.append(_issue("config.parse", config_error, "error"))
+        inventory = _safe_config_inventory(config)
+        soul_path = profile_dir / "SOUL.md"
+        if not soul_path.is_file():
+            issues.append(_issue("soul.missing", "SOUL.md is missing", "error"))
+        else:
+            try:
+                issues.extend(lint_soul(soul_path.read_text(encoding="utf-8")))
+            except OSError:
+                issues.append(_issue("soul.read", "SOUL.md could not be read", "error"))
+        one_policy = profile_policy.get(profile_dir.name, {})
+        if isinstance(one_policy, dict):
+            issues.extend(_policy_issues(inventory, one_policy))
+        profiles.append({"name": profile_dir.name, "config": inventory, "issues": issues})
+
+    stats, stats_error = _run_stats(kanban_db, since_epoch)
+    total_issues = sum(len(profile["issues"]) for profile in profiles)
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "profiles_root": str(profiles_root),
+        "kanban_db": str(kanban_db),
+        "since_days": since_days,
+        "summary": {"profiles": len(profiles), "issues": total_issues},
+        "profiles": profiles,
+        "run_stats": stats,
+    }
+    if stats_error:
+        report["run_stats_error"] = stats_error
+    return report
+
+
+def render_text(report: dict[str, Any]) -> str:
+    """Render the JSON report as a compact human-readable summary."""
+    summary = report["summary"]
+    lines = [
+        "Profile effectiveness audit",
+        f"Profiles: {summary['profiles']}  Issues: {summary['issues']}  Window: {report['since_days']} day(s)",
+        "",
+    ]
+    stats = report.get("run_stats", {})
+    for profile in report["profiles"]:
+        name = profile["name"]
+        one_stats = stats.get(name, {})
+        rate = one_stats.get("completion_rate")
+        rate_text = "n/a" if rate is None else f"{rate * 100:.1f}%"
+        lines.append(
+            f"{name}: {len(profile['issues'])} issue(s); "
+            f"runs {one_stats.get('completed', 0)}/{one_stats.get('finished', 0)} completed ({rate_text})"
+        )
+        for issue in profile["issues"]:
+            lines.append(f"  - [{issue['severity']}] {issue['rule']}: {issue['message']}")
+    if report.get("run_stats_error"):
+        lines.extend(("", f"Run stats unavailable: {report['run_stats_error']}"))
+    return "\n".join(lines)
+
+
+def load_policy(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    policy, error = _read_mapping(path)
+    if error:
+        raise ValueError(error)
+    return policy

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -106,6 +106,43 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
     profile_show = profile_subparsers.add_parser("show", help="Show profile details")
     profile_show.add_argument("profile_name", help="Profile to show")
 
+    profile_audit = profile_subparsers.add_parser(
+        "audit",
+        help="Read-only profile effectiveness, policy, and Kanban outcome report",
+    )
+    profile_audit.add_argument(
+        "--profiles-root",
+        default=None,
+        help="Profile directory root (default: <Hermes home>/profiles)",
+    )
+    profile_audit.add_argument(
+        "--kanban-db",
+        default=None,
+        help="Kanban database (default: sibling kanban.db of profiles root)",
+    )
+    profile_audit.add_argument(
+        "--policy",
+        default=None,
+        help="Optional YAML/JSON model, provider, and toolset policy",
+    )
+    profile_audit.add_argument(
+        "--since-days",
+        type=int,
+        default=30,
+        help="Recent run window in days; 0 includes all runs (default: 30)",
+    )
+    profile_audit.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Report format (default: text)",
+    )
+    profile_audit.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when the report contains issues",
+    )
+
     profile_alias = profile_subparsers.add_parser(
         "alias", help="Manage wrapper scripts"
     )

--- a/tests/hermes_cli/test_profile_audit.py
+++ b/tests/hermes_cli/test_profile_audit.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import yaml
+
+from hermes_cli.profile_audit import audit_profiles, lint_soul, render_text
+
+
+_COMPLETE_SOUL = """# Identity
+You are the reviewer. Your job and responsibilities are to review changes.
+## Process
+Before starting, inspect the repository and follow this workflow.
+## Quality standards
+Verify correctness, security, and tests.
+## Output and definition of done
+Report findings and deliverables only when complete.
+## Escalation
+Block on a genuine external gate.
+When dispatched by Kanban, call kanban_complete or kanban_block.
+"""
+
+
+def _make_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """CREATE TABLE task_runs (
+                profile TEXT, outcome TEXT, started_at INTEGER
+            )"""
+        )
+        conn.executemany(
+            "INSERT INTO task_runs VALUES (?, ?, ?)",
+            [
+                ("coder", "completed", 99_900),
+                ("coder", "crashed", 99_950),
+                ("coder", None, 99_980),
+                ("coder", "completed", 100),
+                ("retired", "completed", 99_900),
+            ],
+        )
+
+
+def test_lint_soul_accepts_complete_worker_contract():
+    assert lint_soul(_COMPLETE_SOUL) == []
+
+
+def test_lint_soul_flags_missing_requirements_and_brittle_dependency():
+    issues = lint_soul("You are Fable. Always invoke claude-sub through a Claude subscription.")
+    rules = {issue["rule"] for issue in issues}
+    assert "soul.process" in rules
+    assert "soul.kanban_handoff" in rules
+    assert "soul.external_dependency" in rules
+
+
+def test_audit_is_secret_safe_and_applies_policy(tmp_path):
+    root = tmp_path / "profiles"
+    profile = root / "coder"
+    profile.mkdir(parents=True)
+    (profile / "SOUL.md").write_text(_COMPLETE_SOUL, encoding="utf-8")
+    (profile / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {"default": "gpt-test", "provider": "openai-codex"},
+                "toolsets": ["file", "terminal"],
+                "api_key": "TOP-SECRET",
+                "nested": {"password": "ALSO-SECRET"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "kanban.db"
+    _make_db(db_path)
+
+    report = audit_profiles(
+        root,
+        db_path,
+        policy={
+            "profiles": {
+                "coder": {
+                    "model": "gpt-required",
+                    "provider": "openai-codex",
+                    "required_toolsets": ["terminal", "web"],
+                    "forbidden_toolsets": ["browser"],
+                }
+            }
+        },
+        since_days=1,
+        now=100_000,
+    )
+
+    profile_report = report["profiles"][0]
+    assert profile_report["config"] == {
+        "model": "gpt-test",
+        "provider": "openai-codex",
+        "toolsets": ["file", "terminal"],
+    }
+    assert {issue["rule"] for issue in profile_report["issues"]} == {
+        "config.model",
+        "config.required_toolset",
+    }
+    assert "TOP-SECRET" not in json.dumps(report)
+    assert "ALSO-SECRET" not in json.dumps(report)
+
+
+def test_audit_reports_recent_outcomes_for_installed_and_retired_profiles(tmp_path):
+    root = tmp_path / "profiles"
+    profile = root / "coder"
+    profile.mkdir(parents=True)
+    (profile / "SOUL.md").write_text(_COMPLETE_SOUL, encoding="utf-8")
+    (profile / "config.yaml").write_text("toolsets: '[\"terminal\", \"file\"]'\n", encoding="utf-8")
+    (root / "_archive").mkdir()
+    (root / "_archive" / "SOUL.md").write_text("ignored", encoding="utf-8")
+    db_path = tmp_path / "kanban.db"
+    _make_db(db_path)
+
+    report = audit_profiles(root, db_path, since_days=1, now=100_000)
+
+    assert [item["name"] for item in report["profiles"]] == ["coder"]
+    assert report["run_stats"]["coder"] == {
+        "finished": 2,
+        "active": 1,
+        "completed": 1,
+        "completion_rate": 0.5,
+        "outcomes": {"completed": 1, "crashed": 1},
+    }
+    assert report["run_stats"]["retired"]["completion_rate"] == 1.0
+    assert "coder: 0 issue(s); runs 1/2 completed (50.0%)" in render_text(report)
+
+
+def test_missing_database_is_reported_without_failing_profile_lint(tmp_path):
+    root = tmp_path / "profiles"
+    profile = root / "reviewer"
+    profile.mkdir(parents=True)
+    (profile / "SOUL.md").write_text(_COMPLETE_SOUL, encoding="utf-8")
+
+    report = audit_profiles(root, tmp_path / "missing.db", since_days=30, now=1_000)
+
+    assert report["summary"] == {"profiles": 1, "issues": 0}
+    assert report["run_stats_error"] == "kanban database not found"

--- a/tests/hermes_cli/test_subcommands_profile_gateway.py
+++ b/tests/hermes_cli/test_subcommands_profile_gateway.py
@@ -66,6 +66,7 @@ def test_profile_has_expected_actions():
         "use": ["work"],
         "create": ["work"],
         "delete": ["work"],
+        "audit": [],
         "show": ["work"],
         "rename": ["old", "new"],
         "export": ["work"],
@@ -74,6 +75,25 @@ def test_profile_has_expected_actions():
     for action, extra in cases.items():
         ns = p.parse_args(["profile", action, *extra])
         assert ns.profile_action == action
+
+
+def test_profile_audit_options():
+    p = _profile_parser()
+    ns = p.parse_args([
+        "profile", "audit",
+        "--profiles-root", "/profiles",
+        "--kanban-db", "/state/kanban.db",
+        "--policy", "/policy.yaml",
+        "--since-days", "7",
+        "--format", "json",
+        "--strict",
+    ])
+    assert ns.profiles_root == "/profiles"
+    assert ns.kanban_db == "/state/kanban.db"
+    assert ns.policy == "/policy.yaml"
+    assert ns.since_days == 7
+    assert ns.format == "json"
+    assert ns.strict is True
 
 
 def test_gateway_and_proxy_dispatch():

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -22,6 +22,7 @@ Top-level command for managing profiles. Running `hermes profile` without a subc
 | `describe` | Read or set a profile's description (used by the kanban orchestrator for routing). |
 | `delete` | Delete a profile. |
 | `show` | Show details about a profile. |
+| `audit` | Read-only effectiveness, policy, and Kanban outcome report. |
 | `alias` | Regenerate the shell alias for a profile. |
 | `rename` | Rename a profile. |
 | `export` | Export a profile to a tar.gz archive. |
@@ -193,6 +194,44 @@ Skills:  12
 SOUL.md: exists
 Alias:   ~/.local/bin/work
 ```
+
+## `hermes profile audit`
+
+```bash
+hermes profile audit [options]
+```
+
+Audits every named profile without modifying profile files or the Kanban
+database. The report inventories model, provider, and CLI toolsets; checks each
+`SOUL.md` for a role, responsibilities, process, quality standards, output or
+definition of done, escalation policy, Kanban handoff, and preflight; and
+summarizes recent `task_runs` outcomes by profile. Only those recognized config
+fields are emitted, so credentials and unrelated config values are excluded.
+
+| Option | Description |
+|--------|-------------|
+| `--profiles-root <path>` | Profile directory root (default: `<Hermes home>/profiles`). |
+| `--kanban-db <path>` | Kanban database (default: `kanban.db` next to the profiles root). |
+| `--policy <path>` | Optional YAML/JSON routing policy for expected model, provider, and toolsets. |
+| `--since-days <n>` | Run window in days; `0` includes all runs (default: `30`). |
+| `--format text\|json` | Human-readable or machine-readable output. |
+| `--strict` | Exit with status 1 when lint or policy issues are found. |
+
+Policy files are keyed by profile. For example:
+
+```yaml
+profiles:
+  coder:
+    model: gpt-5.6-sol
+    provider: openai-codex
+    required_toolsets: [file, terminal]
+    forbidden_toolsets: [browser]
+```
+
+Use `--strict --format json` in a scheduled check or CI gate. References to
+known brittle external automation paths (such as a Claude subscription wrapper)
+are flagged unless the SOUL documents both a preflight and a fallback or block
+policy.
 
 ## `hermes profile alias`
 


### PR DESCRIPTION
## Summary
- add a read-only `hermes profile audit` command with text and JSON output
- lint SOUL worker contracts and optional model/provider/toolset policy
- report recent Kanban run outcomes without exposing unrelated config or credentials
- document the command and policy format

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profile_audit.py tests/hermes_cli/test_subcommands_profile_gateway.py -q --tb=short` (167 passed)
- `ruff check hermes_cli/profile_audit.py hermes_cli/subcommands/profile.py tests/hermes_cli/test_profile_audit.py tests/hermes_cli/test_subcommands_profile_gateway.py`
- live audit against `/persisted/.hermes/profiles` and `/persisted/.hermes/kanban.db`; before/after hashes, sizes, and mtimes were unchanged

## Broader suite
`scripts/run_tests.sh tests/hermes_cli/ -q --tb=short` passed 8,688 tests and hit 7 unrelated systemd-environment failures in existing gateway tests (no gateway files changed).