### PR TITLE
fix(feishu): detect Lark SDK reconnect exhaustion and trigger reconnection

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1356,6 +1356,20 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             pass
         adapter._ws_thread_loop = None
+        # Notify the adapter that the WebSocket client stopped.  The Lark SDK
+        # handles internal reconnect silently (exponential backoff up to
+        # _reconnect_nonce attempts).  When all attempts are exhausted,
+        # start() returns and the adapter would otherwise stay in a
+        # "connected but dead" state.  Route the notification through the
+        # adapter's event loop so it can report a retryable fatal error and
+        # trigger the gateway's reconnect watcher.
+        if getattr(adapter, "_running", False) and getattr(adapter, "_loop", None) is not None:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    adapter._on_ws_stopped(), adapter._loop
+                )
+            except Exception:
+                pass
 
 
 def check_feishu_requirements() -> bool:
@@ -1870,6 +1884,32 @@ class FeishuAdapter(BasePlatformAdapter):
             pass
         finally:
             self._ws_client = None
+
+    async def _on_ws_stopped(self) -> None:
+        """Called from the WS thread when ``start()`` finishes.
+
+        The Lark SDK internally retries WebSocket reconnection with
+        exponential backoff up to ``_reconnect_nonce`` attempts.  When all
+        attempts are exhausted the SDK gives up silently and ``start()``
+        returns — the adapter would otherwise stay in a "connected but dead"
+        state.  This handler reports a retryable fatal error so the gateway's
+        reconnect watcher creates a fresh WebSocket connection.
+        """
+        # Double-check the adapter is still supposed to be running — the
+        # disconnect() path deliberately stops the WS client and sets
+        # _running = False before the thread exits.
+        if not self._running:
+            return
+        logger.error(
+            "[Feishu] WebSocket client stopped unexpectedly "
+            "(Lark SDK reconnect exhausted?) — reconnecting"
+        )
+        self._set_fatal_error(
+            "feishu_ws_died",
+            "WebSocket client stopped unexpectedly (reconnect exhausted)",
+            retryable=True,
+        )
+        await self._notify_fatal_error()
 
     async def _stop_webhook_server(self) -> None:
         if self._webhook_runner is None:


### PR DESCRIPTION
Fixes #64712

When Feishu's WebSocket connection drops, the Lark SDK internally retries reconnection with exponential backoff (default: up to 30 attempts over ~17 minutes).  When all SDK-level retries are exhausted, the SDK gives up silently — `ws_client.start()` returns — but the adapter never learns about this failure and remains in a "connected but dead" state.

**Changes:**
1. In `_run_official_feishu_ws_client()`, after `ws_client.start()` returns (either normally or with an exception), schedule a coroutine on the adapter's event loop to report a retryable fatal error.
2. New `_on_ws_stopped()` method on `FeishuAdapter` that calls `_set_fatal_error()` and `_notify_fatal_error()` to queue the platform for reconnection through the gateway's existing `_platform_reconnect_watcher`.
3. The notification is skipped during intentional `disconnect()` (which sets `_running = False` before stopping the WS client).

All 210 Feishu tests pass.