### PR TITLE
fix(agent): guard against LM Studio silently serving a different model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,18 @@
 # UPSTAGE_BASE_URL=https://api.upstage.ai/v1
 
 # =============================================================================
+# LM STUDIO (LOCAL) WRONG-MODEL GUARD
+# =============================================================================
+# LM Studio answers chat requests naming an unloaded model id with whichever
+# model IS loaded, so Hermes verifies serving state at startup and asserts
+# response identity at runtime (provider=lmstudio only; both fail open when
+# the server is unreachable).
+# HERMES_LMSTUDIO_ALLOW_UNLOADED=1      # Skip the startup loaded-model preflight
+# HERMES_SKIP_MODEL_IDENTITY_CHECK=1    # Skip the runtime response-identity assertion
+# HERMES_WRONG_MODEL_HARD_ABORT=1       # Abort instead of walking the configured
+#                                       # fallback chain when the wrong model answered
+
+# =============================================================================
 # TOOL API KEYS
 # =============================================================================
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -35,6 +35,8 @@ from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
+    check_lmstudio_model_served,
+    detect_local_server_type,
     fetch_model_metadata,
     is_local_endpoint,
     query_ollama_num_ctx,
@@ -1946,6 +1948,46 @@ def init_agent(
             f"model.context_length in config.yaml to the real value "
             f"(this must be at least {MINIMUM_CONTEXT_LENGTH // 1000}K)."
         )
+
+    # Fail fast when LM Studio is not actually serving the configured model.
+    # LM Studio answers chat requests for unknown model ids with whichever
+    # model IS loaded (verified live, 0.4.19) — without this check a
+    # mis-targeted session runs on the wrong weights/context window and
+    # surfaces only as a baffling downstream error (context overflow), or
+    # worse, succeeds silently on the wrong model.
+    # Fails OPEN on "unknown" (server down → the connection error that follows
+    # is already a clear symptom). Escape hatch: HERMES_LMSTUDIO_ALLOW_UNLOADED=1.
+    _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio" or (
+        agent.base_url
+        and is_local_endpoint(agent.base_url)
+        and detect_local_server_type(
+            agent.base_url, api_key=getattr(agent, "api_key", "") or ""
+        ) == "lm-studio"
+    )
+    if _is_lmstudio and os.getenv("HERMES_LMSTUDIO_ALLOW_UNLOADED", "") != "1":
+        _served_status, _served_ids = check_lmstudio_model_served(
+            agent.model or "",
+            agent.base_url or "",
+            api_key=getattr(agent, "api_key", "") or "",
+        )
+        if _served_status == "missing":
+            _served_str = ", ".join(_served_ids) if _served_ids else "(none)"
+            raise ValueError(
+                f"Model {agent.model!r} is not currently loaded in LM Studio at "
+                f"{agent.base_url} (unloaded or replaced by another process?). "
+                f"LM Studio would "
+                f"silently serve this chat with a different loaded model. "
+                f"Currently serving: {_served_str}. Load the model (e.g. "
+                f"`lms load <model-key> --identifier {agent.model}`) or switch "
+                f"models. Set HERMES_LMSTUDIO_ALLOW_UNLOADED=1 to bypass."
+            )
+        if _served_status == "fuzzy":
+            _ra().logger.warning(
+                "LM Studio at %s serves %s but not the exact id %r — LM Studio "
+                "routes by exact identifier, so requests may be answered by a "
+                "different loaded model.",
+                agent.base_url, _served_ids, agent.model,
+            )
 
     # Nous Hermes 3/4 are chat models, not tool-call-tuned. The interactive
     # CLI already warns via cli.py show_banner() (richer output + /model hint),

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1563,6 +1563,41 @@ def run_conversation(
                         else:
                             error_details.append("response.choices is empty")
 
+                # LM Studio wrong-model guard: LM Studio serves requests naming
+                # an unloaded id with whichever model IS loaded (verified live,
+                # 0.4.19). If the response says a different model answered,
+                # abort loudly instead of continuing on the wrong weights.
+                # Scoped to lmstudio; fails open when the response carries no
+                # model field. Escape hatch: HERMES_SKIP_MODEL_IDENTITY_CHECK=1.
+                if (
+                    not response_invalid
+                    and (agent.provider or "").strip().lower() == "lmstudio"
+                    and os.getenv("HERMES_SKIP_MODEL_IDENTITY_CHECK", "") != "1"
+                ):
+                    _served_model = str(getattr(response, "model", "") or "")
+                    if _served_model and agent.model:
+                        from agent.model_metadata import (
+                            _model_id_matches,
+                            _strip_provider_prefix,
+                        )
+                        _req_model = _strip_provider_prefix(agent.model)
+                        if not (
+                            _served_model == _req_model
+                            or _model_id_matches(_served_model, _req_model)
+                            or _model_id_matches(_req_model, _served_model)
+                        ):
+                            from agent.errors import WrongModelServedError
+                            raise WrongModelServedError(
+                                f"LM Studio served this request with "
+                                f"{_served_model!r} instead of the requested "
+                                f"{_req_model!r} — the requested model is not "
+                                f"loaded (unloaded or replaced by another "
+                                f"process?). Refusing "
+                                f"to continue on the wrong model. Load it with "
+                                f"`lms load <model-key> --identifier {_req_model}` "
+                                f"or switch models."
+                            )
+
                 if response_invalid:
                     agent._invoke_api_request_error_hook(
                         task_id=effective_task_id,
@@ -3918,6 +3953,8 @@ def run_conversation(
                             agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
                         elif classified.reason == FailoverReason.ssl_cert_verification:
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
+                        elif type(api_error).__name__ == "WrongModelServedError":
+                            agent._buffer_status("⚠️ LM Studio served a different model than requested — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                     if agent._try_activate_fallback():

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3942,13 +3942,19 @@ def run_conversation(
                 ) and not is_context_length_error
 
                 if is_client_error:
+                    # Opt-in hard abort for wrong-model-served (see
+                    # agent/errors.py): with HERMES_WRONG_MODEL_HARD_ABORT=1
+                    # the guard aborts with its own actionable message instead
+                    # of walking the configured fallback chain.
+                    from agent.errors import should_hard_abort_wrong_model
+                    _wrong_model_abort = should_hard_abort_wrong_model(api_error)
                     # Try fallback before aborting — a different provider may
                     # not have the same issue (rate limit, auth, etc.). Only
                     # announce the attempt when a fallback chain actually
                     # exists; otherwise "trying fallback..." is a lie and the
                     # session looks like it's recovering when it's about to
                     # abort silently (#35314, #17446).
-                    if agent._has_pending_fallback():
+                    if not _wrong_model_abort and agent._has_pending_fallback():
                         if classified.reason == FailoverReason.content_policy_blocked:
                             agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
                         elif classified.reason == FailoverReason.ssl_cert_verification:
@@ -3957,7 +3963,7 @@ def run_conversation(
                             agent._buffer_status("⚠️ LM Studio served a different model than requested — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if not _wrong_model_abort and agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -582,6 +582,23 @@ def classify_api_error(
     Returns:
         ClassifiedError with reason and recovery action hints.
     """
+    # Wrong-model-served (LM Studio guard) — deterministic per request:
+    # retrying reproduces the identical misroute, and model-fallback would
+    # substitute yet another unrequested model. Fail fast with the guard's
+    # own actionable message. Matched by type name (not import) to keep this
+    # module free of agent.* imports, consistent with its pattern style.
+    if type(error).__name__ == "WrongModelServedError":
+        return ClassifiedError(
+            reason=FailoverReason.model_not_found,
+            provider=provider,
+            model=model,
+            message=str(error),
+            retryable=False,
+            should_compress=False,
+            should_rotate_credential=False,
+            should_fallback=False,
+        )
+
     status_code = _extract_status_code(error)
     error_type = type(error).__name__
     # Copilot/GitHub Models RateLimitError may not set .status_code; force 429

--- a/agent/errors.py
+++ b/agent/errors.py
@@ -11,3 +11,14 @@ class EmptyStreamError(RuntimeError):
 
 class MoAPresetNotFoundError(ValueError):
     """Raised when a persisted MoA preset no longer exists in config."""
+
+
+class WrongModelServedError(Exception):
+    """The provider answered with a different model than the one requested.
+
+    Deterministic per request (LM Studio serves whatever is loaded when the
+    requested identifier isn't) — retrying reproduces it, and falling back
+    would just pick ANOTHER unrequested model, so the classifier marks this
+    non-retryable with no fallback.
+    """
+    pass

--- a/agent/errors.py
+++ b/agent/errors.py
@@ -22,3 +22,22 @@ class WrongModelServedError(Exception):
     non-retryable with no fallback.
     """
     pass
+
+
+def should_hard_abort_wrong_model(error: BaseException) -> bool:
+    """True when a wrong-model-served error should abort the session instead
+    of walking the configured fallback chain.
+
+    Default is False: a fallback the user explicitly configured, announced
+    with a truthful status line, is a visible recovery — not the silent
+    substitution the guard exists to stop. Opt in with
+    HERMES_WRONG_MODEL_HARD_ABORT=1 for setups where model identity is part
+    of the session's contract (per-model task gating, privacy posture) and
+    finishing on ANY substitute model is worse than stopping.
+    """
+    import os
+
+    return (
+        isinstance(error, WrongModelServedError)
+        and os.getenv("HERMES_WRONG_MODEL_HARD_ABORT", "") == "1"
+    )

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1477,6 +1477,87 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
     return False
 
 
+def fetch_lmstudio_serving_state(
+    base_url: str, api_key: str = ""
+) -> Optional[Tuple[List[str], List[str]]]:
+    """Return (loaded_instance_ids, downloaded_keys) from LM Studio's native API.
+
+    Uses ``/api/v1/models`` because the OpenAI-compat ``/v1/models`` listing
+    merges downloaded catalog keys with loaded-instance identifiers and cannot
+    distinguish them (verified live on 0.4.19) — but only LOADED instance ids
+    are what chat POSTs actually route to. Deliberately uncached: this is live
+    serving state, and a stale answer defeats the wrong-model guard.
+
+    Returns None when the endpoint can't be queried (offline / not LM Studio);
+    callers must treat None as "unknown", never as "nothing loaded".
+    """
+    import httpx
+
+    server_url = _lmstudio_server_root(base_url)
+    if not server_url:
+        return None
+    try:
+        with httpx.Client(timeout=3.0, headers=_auth_headers(api_key)) as client:
+            resp = client.get(server_url.rstrip("/") + "/api/v1/models")
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+    except Exception:
+        return None
+    loaded: List[str] = []
+    keys: List[str] = []
+    for m in data.get("models", []):
+        if not isinstance(m, dict):
+            continue
+        for field in ("key", "id"):
+            value = m.get(field)
+            if isinstance(value, str) and value and value not in keys:
+                keys.append(value)
+        for inst in m.get("loaded_instances", []) or []:
+            if not isinstance(inst, dict):
+                continue
+            inst_id = inst.get("id") or inst.get("identifier")
+            if isinstance(inst_id, str) and inst_id and inst_id not in loaded:
+                loaded.append(inst_id)
+    return loaded, keys
+
+
+def check_lmstudio_model_served(
+    model: str, base_url: str, api_key: str = ""
+) -> Tuple[str, List[str]]:
+    """Check whether *model* will actually be served by the LM Studio at *base_url*.
+
+    LM Studio (verified live on 0.4.19) answers /v1/chat/completions requests
+    naming an UNKNOWN model id with whichever model IS loaded — only
+    GET /v1/models/{id} 404s. A mis-targeted chat therefore doesn't fail; it
+    silently runs on the wrong weights and the wrong context window. Routing
+    is by exact loaded-instance identifier: in the 2026-07-14 incident the
+    requested id basename-matched a *downloaded* catalog key and LM Studio
+    still served the request with the unrelated loaded model, so a
+    downloaded-but-not-loaded basename match is a misroute, not a pass.
+
+    Returns (status, loaded_instance_ids):
+      "ok"      — exact match on a loaded instance identifier
+      "jit"     — exact match on a downloaded catalog key (JIT will load it)
+      "fuzzy"   — basename match on a LOADED instance id; may or may not route
+      "missing" — neither loaded nor an exact downloaded key; a chat POST WILL
+                  be answered by whichever model is loaded
+      "unknown" — endpoint unreachable / not LM Studio; can't tell
+    """
+    bare = _strip_provider_prefix(model)
+    state = fetch_lmstudio_serving_state(base_url, api_key=api_key)
+    if state is None:
+        return "unknown", []
+    loaded, keys = state
+    if any(inst_id == bare for inst_id in loaded):
+        return "ok", loaded
+    if any(key == bare for key in keys):
+        return "jit", loaded
+    if any(_model_id_matches(inst_id, bare) for inst_id in loaded):
+        return "fuzzy", loaded
+    return "missing", loaded
+
+
 def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query an Ollama server for the model's context length.
 

--- a/tests/agent/test_wrong_model_guard.py
+++ b/tests/agent/test_wrong_model_guard.py
@@ -1,0 +1,118 @@
+"""Tests for the LM Studio wrong-model guard.
+
+Regression context (live incident, 2026-07-14): LM Studio 0.4.19 answers
+``POST /v1/chat/completions`` naming an UNLOADED model identifier with
+whichever model IS loaded — only ``GET /v1/models/{id}`` 404s. A Hermes
+session configured for a pinned identifier that a concurrent batch run had
+swapped out was silently served by a 16K-context A/B instance and died with
+a baffling "context length exceeded" at chat start. Empirically verified in
+the same incident: the response body's ``model`` field reports the SERVED
+instance id (e.g. ``ab-qwen3-32b``), not an echo of the requested id, and
+the OpenAI-compat ``/v1/models`` listing merges downloaded catalog keys with
+loaded-instance ids (so only the native ``/api/v1/models`` "loaded_instances"
+data distinguishes what a POST will actually route to).
+
+Guard layers under test:
+  1. ``check_lmstudio_model_served`` — startup preflight verdicts.
+  2. ``WrongModelServedError`` classification — terminal: no retry, no
+     compression, no credential rotation, no model fallback hint.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import agent.model_metadata as mm
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.errors import WrongModelServedError
+
+
+def _mock_state(loaded, keys):
+    return patch.object(
+        mm, "fetch_lmstudio_serving_state", lambda *a, **k: (loaded, keys)
+    )
+
+
+# Serving states replicated from the observed incident:
+#   PINNED   — the configured identifier is loaded (healthy state).
+#   INCIDENT — the configured model was unloaded by a concurrent process;
+#              only an unrelated instance under a different identifier is
+#              resident (the observed failure state, byte-for-byte).
+PINNED = (["nemotron-3-nano"], ["nvidia/nemotron-3-nano", "qwen3-32b"])
+INCIDENT = (["ab-qwen3-32b"], ["nvidia/nemotron-3-nano", "qwen3-32b"])
+BASE = "http://127.0.0.1:1234/v1"
+
+
+def test_loaded_identifier_is_ok():
+    with _mock_state(*PINNED):
+        status, loaded = mm.check_lmstudio_model_served("nemotron-3-nano", BASE)
+    assert status == "ok"
+    assert loaded == ["nemotron-3-nano"]
+
+
+def test_incident_state_is_missing():
+    """The exact 2026-07-14 state must BLOCK: the requested id basename-matches
+    a *downloaded* key, but LM Studio provably routed the request to the
+    unrelated loaded model, so a downloaded-only match is a misroute."""
+    with _mock_state(*INCIDENT):
+        status, loaded = mm.check_lmstudio_model_served("nemotron-3-nano", BASE)
+    assert status == "missing"
+    assert loaded == ["ab-qwen3-32b"]
+
+
+def test_exact_downloaded_key_is_jit():
+    with _mock_state(*INCIDENT):
+        status, _ = mm.check_lmstudio_model_served("nvidia/nemotron-3-nano", BASE)
+    assert status == "jit"
+
+
+def test_provider_prefix_is_stripped():
+    with _mock_state(*PINNED):
+        status, _ = mm.check_lmstudio_model_served("local:nemotron-3-nano", BASE)
+    assert status == "ok"
+
+
+def test_basename_match_on_loaded_instance_is_fuzzy():
+    with _mock_state(["nvidia/nemotron-3-nano"], []):
+        status, _ = mm.check_lmstudio_model_served("nemotron-3-nano", BASE)
+    assert status == "fuzzy"
+
+
+def test_unreachable_endpoint_is_unknown():
+    """Fail OPEN when serving state can't be read — the ordinary connection
+    error that follows is already a clear symptom."""
+    with patch.object(mm, "fetch_lmstudio_serving_state", lambda *a, **k: None):
+        status, loaded = mm.check_lmstudio_model_served("nemotron-3-nano", BASE)
+    assert status == "unknown"
+    assert loaded == []
+
+
+def test_wrong_model_served_error_is_terminal():
+    """Deterministic misroute: retrying reproduces it, compression can't fix
+    it, and a model fallback would substitute yet another unrequested model."""
+    classified = classify_api_error(
+        WrongModelServedError("LM Studio served 'ab-qwen3-32b' instead of 'nemotron-3-nano'"),
+        provider="lmstudio",
+        model="nemotron-3-nano",
+    )
+    assert classified.reason == FailoverReason.model_not_found
+    assert classified.retryable is False
+    assert classified.should_compress is False
+    assert classified.should_rotate_credential is False
+    assert classified.should_fallback is False
+    assert "ab-qwen3-32b" in classified.message
+
+
+def test_runtime_guard_comparison_semantics():
+    """The conversation-loop guard accepts exact and basename matches in
+    either direction, and rejects genuinely different served models."""
+    def accepted(served, requested):
+        return (
+            served == requested
+            or mm._model_id_matches(served, requested)
+            or mm._model_id_matches(requested, served)
+        )
+
+    assert accepted("nemotron-3-nano", "nemotron-3-nano")
+    assert accepted("nvidia/nemotron-3-nano", "nemotron-3-nano")
+    assert not accepted("ab-qwen3-32b", "nemotron-3-nano")
+    assert not accepted("qwen3-coder-next-mlx", "nemotron-3-nano")

--- a/tests/agent/test_wrong_model_guard.py
+++ b/tests/agent/test_wrong_model_guard.py
@@ -16,6 +16,9 @@ Guard layers under test:
   1. ``check_lmstudio_model_served`` — startup preflight verdicts.
   2. ``WrongModelServedError`` classification — terminal: no retry, no
      compression, no credential rotation, no model fallback hint.
+  3. ``should_hard_abort_wrong_model`` — opt-in hard abort: default walks
+     the configured fallback chain (with a truthful status line); with
+     HERMES_WRONG_MODEL_HARD_ABORT=1 the session aborts instead.
 """
 from __future__ import annotations
 
@@ -23,7 +26,7 @@ from unittest.mock import patch
 
 import agent.model_metadata as mm
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.errors import WrongModelServedError
+from agent.errors import WrongModelServedError, should_hard_abort_wrong_model
 
 
 def _mock_state(loaded, keys):
@@ -100,6 +103,21 @@ def test_wrong_model_served_error_is_terminal():
     assert classified.should_rotate_credential is False
     assert classified.should_fallback is False
     assert "ab-qwen3-32b" in classified.message
+
+
+def test_hard_abort_is_off_by_default(monkeypatch):
+    """Without the opt-in, a configured fallback chain is still walked —
+    announced with a truthful status line, not silently."""
+    monkeypatch.delenv("HERMES_WRONG_MODEL_HARD_ABORT", raising=False)
+    assert should_hard_abort_wrong_model(WrongModelServedError("x")) is False
+
+
+def test_hard_abort_opt_in(monkeypatch):
+    """HERMES_WRONG_MODEL_HARD_ABORT=1 aborts wrong-model-served sessions
+    instead of falling back, and affects ONLY that error type."""
+    monkeypatch.setenv("HERMES_WRONG_MODEL_HARD_ABORT", "1")
+    assert should_hard_abort_wrong_model(WrongModelServedError("x")) is True
+    assert should_hard_abort_wrong_model(ValueError("x")) is False
 
 
 def test_runtime_guard_comparison_semantics():


### PR DESCRIPTION
## What does this PR do?

LM Studio (verified on 0.4.19) answers `POST /v1/chat/completions` requests that name an
**unloaded** model identifier with whichever model **is** currently loaded. Only
`GET /v1/models/{id}` returns 404 — the chat POST never fails on the name. Verified live:
a request naming `nemotron-3-nano` (not loaded) returned HTTP 200 with
`"model": "ab-qwen3-32b"` — the response's `model` field carries the **served** instance
id, not an echo of the request.

For Hermes this plays out badly whenever the configured model isn't resident (e.g.
another process swapped models on a shared LM Studio):

1. The context-length probe 404s → Hermes logs "probe-down" and falls back to a hardcoded
   catalog match, proceeding as if the configured model (and its context window) were fine.
2. The chat is served by the *loaded* model. If its context is smaller, the session dies at
   start with a misleading `Context length exceeded … cannot compress further` — three
   layers away from the real cause ("your model isn't loaded").
3. Worse: if the prompt *fits*, the session **runs to completion on the wrong model with no
   error at all**.

This PR adds two guard layers, both scoped to `provider == "lmstudio"` (plus detected LM
Studio servers), both **failing open** when the server is unreachable (the ordinary
connection error is already a clear symptom):

**1. Startup preflight** (`agent_init`): `check_lmstudio_model_served()` reads the
**native** `/api/v1/models` `loaded_instances` data. The OpenAI-compat `/v1/models`
listing cannot be used: it merges *downloaded catalog keys* with *loaded-instance ids*,
so a downloaded-but-unloaded model is indistinguishable from a loaded one (with it, the
incident state above basename-matches a downloaded key and slips through). Verdicts:

| Verdict | Meaning | Action |
|---|---|---|
| `ok` | configured id is a loaded-instance identifier (exact) | pass |
| `jit` | exact downloaded catalog key — LM Studio JIT-loads it on POST | pass (keeps headless/JIT setups working, cf. #35163) |
| `fuzzy` | basename match against a *loaded* id | warn, don't block |
| `missing` | anything else — a chat POST **will** be answered by a different model | raise at init with an actionable message naming what is actually loaded |
| `unknown` | endpoint unreachable / not listing models | pass (fail open) |

Escape hatch: `HERMES_LMSTUDIO_ALLOW_UNLOADED=1`.

**2. Runtime identity assertion** (`conversation_loop`): if a response's `model` field
names a different model than requested (exact and basename matches accepted in both
directions via the existing `_model_id_matches`), raise `WrongModelServedError`. The
classifier marks it terminal — no retry (a deterministic misroute reproduces identically),
no compression, no credential rotation. If the user has a fallback chain configured, the
loop announces the real reason ("LM Studio served a different model than requested —
trying fallback...") instead of a generic banner, then proceeds down the chain as usual.
This layer covers the two cases the preflight can't see: the model being unloaded
**mid-session**, and the silent wrong-model success. Escape hatch:
`HERMES_SKIP_MODEL_IDENTITY_CHECK=1`.

**Opt-in strict mode** (second commit): some deployments treat model identity as part of
the session's contract (per-model task gating, privacy posture) — for them, completing
the session on *any* substitute model is worse than stopping.
`HERMES_WRONG_MODEL_HARD_ABORT=1` makes wrong-model-served abort immediately with the
guard's actionable message instead of activating a fallback. Default behavior is
unchanged from commit 1 (announced fallback walk).

Cloud providers are untouched (dated-snapshot ids like `gpt-x` → `gpt-x-2026-04-23`
never reach either check). Other local servers (Ollama, vLLM, llama.cpp) are out of
scope: they either JIT-load by name or hard-fail on unknown names — only LM Studio has
the proven silent-substitution behavior. Extending the gate later is a one-line change.

## Related Issue

No existing issue describes the silent substitution itself (happy to file one if
preferred). Related: #47678 (context-length probe returns `None` when the model isn't
loaded — same underlying state, this PR makes it fail fast instead of guessing),
#35163 (headless/JIT startup — the `jit` verdict deliberately passes exact downloaded
keys so JIT setups keep working).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — `fetch_lmstudio_serving_state()` +
  `check_lmstudio_model_served()` (native-API serving-state readers; deliberately
  uncached — stale serving state would defeat the guard)
- `agent/agent_init.py` — startup preflight next to the existing
  `MINIMUM_CONTEXT_LENGTH` init-time rejection
- `agent/errors.py` — `WrongModelServedError`; `should_hard_abort_wrong_model()`
- `agent/conversation_loop.py` — response-identity assertion inside the API-call try;
  truthful fallback banner; opt-in hard-abort gate
- `agent/error_classifier.py` — terminal classification (no retry / compress / rotate /
  fallback hint), reusing `model_not_found` with explicit overrides (smallest safe diff)
- `tests/agent/test_wrong_model_guard.py` — verdict matrix (incl. the exact observed
  incident state), classifier terminality, matcher semantics, hard-abort knob (10 tests)
- `.env.example` — documents the three toggles

## How to Test

1. `pytest tests/agent/test_wrong_model_guard.py -q` (10 tests, no server needed).
2. Live repro: in LM Studio, load any model under identifier B; configure Hermes for a
   different identifier A (`provider: lmstudio`). Start a session → init aborts with
   `Model 'A' is not currently loaded in LM Studio at <url> (unloaded or replaced by
   another process?) … Currently serving: B …` before any chat POST reaches the server
   (server log shows probe GETs only).
3. Runtime leg: same setup with `HERMES_LMSTUDIO_ALLOW_UNLOADED=1` → first response
   triggers `WrongModelServedError`; with a fallback chain configured the session
   announces "LM Studio served a different model than requested — trying fallback...";
   with `HERMES_WRONG_MODEL_HARD_ABORT=1` it aborts with the guard message instead.
4. Regression: with the configured model actually loaded, sessions run normally; cloud
   provider sessions are unaffected.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the touched-package suite (`tests/agent/`, per-file isolation via
  `scripts/run_tests.sh`) and `tests/agent/test_wrong_model_guard.py`
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon), LM Studio 0.4.19

### Documentation & Housekeeping

- [x] Docstrings + `.env.example` updated; no config keys added (env toggles only) — cli-config.yaml.example N/A
- [x] No architecture/workflow change — CONTRIBUTING/AGENTS N/A
- [x] Cross-platform: pure-Python httpx GETs against localhost; no platform-specific code
- [x] No tool behavior changed — schemas N/A

## Screenshots / Logs

Observed behavior this PR guards against (LM Studio 0.4.19, sanitized):

```
# Requested model not loaded; a different model is. The POST succeeds anyway:
POST /v1/chat/completions {"model": "nemotron-3-nano", ...}
→ HTTP 200 {"model": "ab-qwen3-32b", ...}   # served instance id, not an echo

# What the user saw before this guard (prompt > loaded model's context):
Context length exceeded: 1,380 tokens. Cannot compress further.

# With the guard (at init, before any chat POST):
Model 'nemotron-3-nano' is not currently loaded in LM Studio at
http://127.0.0.1:1234/v1 (unloaded or replaced by another process?). LM Studio
would silently serve this chat with a different loaded model. Currently
serving: ab-qwen3-32b. Load the model (e.g. `lms load <model-key> --identifier
nemotron-3-nano`) or switch models. Set HERMES_LMSTUDIO_ALLOW_UNLOADED=1 to bypass.
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
