### PR TITLE
fix(backup): retry SQLite safe copy read-write before raw-copy fallback

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -259,21 +259,34 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
     Handles WAL mode — produces a consistent snapshot even while
     the DB is being written to.  Falls back to raw copy on failure.
     """
-    try:
-        conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
-        backup_conn = sqlite3.connect(str(dst))
-        conn.backup(backup_conn)
-        backup_conn.close()
-        conn.close()
-        return True
-    except Exception as exc:
-        logger.warning("SQLite safe copy failed for %s: %s", src, exc)
+    # Prefer a read-only source connection, but retry read-write when it
+    # fails: a read-only client cannot open a WAL database whose -shm file
+    # is absent or needs recovery ("unable to open database file"), so DBs
+    # nothing currently holds open would otherwise degrade to the raw-copy
+    # fallback below. backup() over the read-write connection still
+    # produces a consistent snapshot.
+    last_exc: Optional[Exception] = None
+    for source, is_uri in ((f"file:{src}?mode=ro", True), (str(src), False)):
         try:
-            shutil.copy2(src, dst)
+            conn = sqlite3.connect(source, uri=is_uri)
+            try:
+                backup_conn = sqlite3.connect(str(dst))
+                try:
+                    conn.backup(backup_conn)
+                finally:
+                    backup_conn.close()
+            finally:
+                conn.close()
             return True
-        except Exception as exc2:
-            logger.error("Raw copy also failed for %s: %s", src, exc2)
-            return False
+        except Exception as exc:
+            last_exc = exc
+    logger.warning("SQLite safe copy failed for %s: %s", src, last_exc)
+    try:
+        shutil.copy2(src, dst)
+        return True
+    except Exception as exc2:
+        logger.error("Raw copy also failed for %s: %s", src, exc2)
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1369,6 +1369,70 @@ class TestSafeCopyDb:
         conn.close()
         assert rows == [("wal-test",)]
 
+    def test_ro_open_failure_falls_back_to_rw_backup(self, tmp_path, monkeypatch):
+        """A failed read-only open must retry via a read-write backup(),
+        not degrade straight to raw copy.
+
+        Read-only clients cannot open a WAL database whose -shm file is
+        absent or needs recovery ("unable to open database file"). The
+        read-write retry still snapshots consistently — including rows
+        that only live in the -wal, which a raw file copy would lose.
+        """
+        import hermes_cli.backup as backup_mod
+        from hermes_cli.backup import _safe_copy_db
+
+        src = tmp_path / "wal.db"
+        dst = tmp_path / "copy.db"
+
+        conn = sqlite3.connect(str(src))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE t (x INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1), (2)")
+        conn.commit()
+        # Keep the connection open so the rows live in the -wal file only.
+
+        real_connect = sqlite3.connect
+
+        def fail_ro_connect(database, *args, **kwargs):
+            if isinstance(database, str) and database.startswith("file:"):
+                raise sqlite3.OperationalError("unable to open database file")
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(backup_mod.sqlite3, "connect", fail_ro_connect)
+
+        def no_raw_copy(*args, **kwargs):
+            raise AssertionError("should not degrade to raw copy")
+
+        monkeypatch.setattr(backup_mod.shutil, "copy2", no_raw_copy)
+
+        assert _safe_copy_db(src, dst) is True
+        conn.close()
+
+        copy = real_connect(str(dst))
+        assert copy.execute("SELECT count(*) FROM t").fetchone() == (2,)
+        copy.close()
+
+    def test_raw_copy_when_backup_api_fails_entirely(self, tmp_path, monkeypatch):
+        """When both backup() attempts fail, the raw-copy fallback still runs."""
+        import hermes_cli.backup as backup_mod
+        from hermes_cli.backup import _safe_copy_db
+
+        src = tmp_path / "test.db"
+        dst = tmp_path / "copy.db"
+
+        conn = sqlite3.connect(str(src))
+        conn.execute("CREATE TABLE t (x INTEGER)")
+        conn.commit()
+        conn.close()
+
+        def always_fail(*args, **kwargs):
+            raise sqlite3.OperationalError("unable to open database file")
+
+        monkeypatch.setattr(backup_mod.sqlite3, "connect", always_fail)
+
+        assert _safe_copy_db(src, dst) is True
+        assert dst.read_bytes() == src.read_bytes()
+
 
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests


### PR DESCRIPTION
## Problem

`_safe_copy_db` opens the source database with `mode=ro`. A read-only client cannot open a WAL database whose `-shm` file is absent or needs recovery — SQLite raises `unable to open database file` — so the function skips the consistent `backup()` path and degrades straight to `shutil.copy2`. A raw file copy of a WAL database silently drops rows still living in the `-wal` file, so the "safe" copy can be stale or torn.

In production this fires on every pre-update quick snapshot (`create_quick_snapshot` → `_safe_copy_db`) for state DBs the gateway isn't currently holding open:

```
WARNING hermes_cli.backup: SQLite safe copy failed for /Users/.../verification_evidence.db: unable to open database file
WARNING hermes_cli.backup: SQLite safe copy failed for /Users/.../kanban.db: unable to open database file
```

(daily occurrences, one pair per `hermes update` run)

## Fix

If the read-only attempt fails, retry the `backup()` over a plain read-write connection before falling back to raw copy. `backup()` over a read-write connection still produces a consistent snapshot, and a read-write client is allowed to create/recover the `-shm`. Connections are now closed on all paths (`try/finally`) so a failed first attempt can't leak handles into the retry.

Behavior when the read-only open succeeds is unchanged; the raw-copy fallback is preserved as the last resort.

## Tests

- `test_ro_open_failure_falls_back_to_rw_backup` — forces the ro open to fail on a WAL DB whose rows live only in the `-wal`; asserts the copy is taken via `backup()` (raw copy asserted unreachable) and contains the WAL rows
- `test_raw_copy_when_backup_api_fails_entirely` — both attempts failing still degrades to raw copy
- Full file: 146 passed, 1 failed — `TestProfileRestoration::test_import_creates_profile_wrappers` fails identically on unmodified `main` in this environment (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)