### PR TITLE
fix(hindsight): bind prefetch work to session identity

### DIFF
--- a/contributors/emails/zhangyingliang@outlook.com
+++ b/contributors/emails/zhangyingliang@outlook.com
@@ -1,0 +1,1 @@
+yingliang-zhang

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+from dataclasses import dataclass, field
 import importlib
 import json
 import logging
@@ -40,6 +41,7 @@ import queue
 import sys
 import threading
 import time
+import weakref
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -66,6 +68,11 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_PREFETCH_WAIT_SECONDS = 3.0
+_MAX_PREFETCH_WORKERS = 2
+_CLIENT_CLOSED_ATTR = "_hermes_hindsight_closed"
+_CLIENT_CLOSED_MARKER = object()
+_MAX_UNWEAKREFABLE_CLOSED_CLIENTS = 16
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -264,6 +271,29 @@ _loop_lock = threading.Lock()
 # Sentinel pushed to the per-provider retain queue to wake the writer for a
 # clean exit. A unique object so it can never collide with a real job.
 _WRITER_SENTINEL = object()
+
+
+@dataclass(frozen=True, slots=True)
+class _PrefetchRequest:
+    """Immutable request-time identity for one prefetch operation."""
+
+    request_id: int
+    epoch: int
+    session_id: str
+    bank_id: str
+    query: str
+    cache_key: tuple[int, str, str, str]
+    inflight_key: tuple[int, int, str, str, str]
+
+
+@dataclass(slots=True)
+class _PrefetchOperation:
+    """Tracks worker and async-future ownership for one exact request."""
+
+    request: _PrefetchRequest
+    thread: threading.Thread | None = None
+    futures: dict[object, Any] = field(default_factory=dict)
+    worker_done: bool = False
 
 
 def _get_loop() -> asyncio.AbstractEventLoop:
@@ -716,11 +746,37 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = ""
         self._turn_index = 0
         self._client = None
+        self._client_lock = threading.RLock()
+        self._closed_client_refs: dict[int, weakref.ReferenceType[Any]] = {}
+        self._closed_client_fallbacks: dict[int, Any] = {}
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
-        self._prefetch_lock = threading.Lock()
-        self._prefetch_thread = None
+        self._prefetch_result_request: _PrefetchRequest | None = None
+        self._prefetch_completed_request: _PrefetchRequest | None = None
+        self._prefetch_lock = threading.RLock()
+        self._prefetch_condition = threading.Condition(self._prefetch_lock)
+        self._prefetch_epoch = 0
+        self._prefetch_sequence = 0
+        self._prefetch_session_id = ""
+        self._prefetch_bank_id = "hermes"
+        self._prefetch_bank_fallback = "hermes"
+        self._prefetch_latest_request: _PrefetchRequest | None = None
+        self._prefetch_pending_request: _PrefetchRequest | None = None
+        self._prefetch_inflight: dict[
+            tuple[int, int, str, str, str], _PrefetchOperation
+        ] = {}
+        self._prefetch_operations: dict[
+            tuple[int, int, str, str, str], _PrefetchOperation
+        ] = {}
+        self._prefetch_threads: set[threading.Thread] = set()
+        self._prefetch_thread: threading.Thread | None = None
+        self._prefetch_client_owners: dict[
+            int, tuple[Any, set[object]]
+        ] = {}
+        self._prefetch_deferred_clients: dict[int, Any] = {}
+        self._prefetch_close_threads: set[threading.Thread] = set()
+        self._prefetch_closing_clients: dict[int, Any] = {}
         # Single-writer model for retain. sync_turn() enqueues; the writer
         # thread drains sequentially. Avoids spawning ad-hoc threads that
         # can race the interpreter shutdown and emit "cannot schedule new
@@ -1098,58 +1154,78 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "port_health_grace_timeout", "description": "Seconds to wait for a slow daemon /health before treating it as stale (raise on busy/low-resource hosts; blank uses the 30s default)", "default": "", "when": {"mode": "local_embedded"}},
         ]
 
+    def _create_client(self):
+        """Construct one Hindsight client; caller serializes publication."""
+        if self._mode == "local_embedded":
+            available, reason = _check_local_runtime()
+            if not available:
+                raise RuntimeError(
+                    "Hindsight local runtime is unavailable"
+                    + (f": {reason}" if reason else "")
+                )
+            try:
+                from tools.lazy_deps import ensure as _lazy_ensure
+
+                _lazy_ensure("memory.hindsight", prompt=False)
+            except ImportError:
+                pass
+            except Exception as exc:
+                raise ImportError(str(exc))
+            from hindsight import HindsightEmbedded
+
+            HindsightEmbedded.__del__ = lambda self: None
+            llm_provider = self._config.get("llm_provider", "")
+            if llm_provider in {"openai_compatible", "openrouter"}:
+                llm_provider = "openai"
+            logger.debug(
+                "Creating HindsightEmbedded client (profile=%s, provider=%s)",
+                self._config.get("profile", "hermes"),
+                llm_provider,
+            )
+            kwargs = dict(
+                profile=self._config.get("profile", "hermes"),
+                llm_provider=llm_provider,
+                llm_api_key=self._config.get("llmApiKey")
+                or self._config.get("llm_api_key")
+                or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                llm_model=self._config.get("llm_model", ""),
+            )
+            if self._llm_base_url:
+                kwargs["llm_base_url"] = self._llm_base_url
+            idle_timeout = _parse_int_setting(
+                self._config.get("idle_timeout")
+                if self._config.get("idle_timeout") is not None
+                else os.environ.get("HINDSIGHT_IDLE_TIMEOUT", self._idle_timeout),
+                _DEFAULT_IDLE_TIMEOUT,
+            )
+            self._idle_timeout = idle_timeout
+            kwargs["idle_timeout"] = idle_timeout
+            return HindsightEmbedded(**kwargs)
+
+        _ensure_cloud_client_dependency()
+        from hindsight_client import Hindsight
+
+        timeout = self._timeout or _DEFAULT_TIMEOUT
+        kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        logger.debug(
+            "Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
+            self._api_url,
+            bool(self._api_key),
+            kwargs["timeout"],
+        )
+        return Hindsight(**kwargs)
+
     def _get_client(self):
-        """Return the cached Hindsight client (created once, reused)."""
-        if self._client is None:
-            if self._mode == "local_embedded":
-                available, reason = _check_local_runtime()
-                if not available:
-                    raise RuntimeError(
-                        "Hindsight local runtime is unavailable"
-                        + (f": {reason}" if reason else "")
-                    )
-                try:
-                    from tools.lazy_deps import ensure as _lazy_ensure
-                    _lazy_ensure("memory.hindsight", prompt=False)
-                except ImportError:
-                    pass
-                except Exception as _e:
-                    raise ImportError(str(_e))
-                from hindsight import HindsightEmbedded
-                HindsightEmbedded.__del__ = lambda self: None
-                llm_provider = self._config.get("llm_provider", "")
-                if llm_provider in {"openai_compatible", "openrouter"}:
-                    llm_provider = "openai"
-                logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
-                             self._config.get("profile", "hermes"), llm_provider)
-                kwargs = dict(
-                    profile=self._config.get("profile", "hermes"),
-                    llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or get_secret("HINDSIGHT_LLM_API_KEY", ""),
-                    llm_model=self._config.get("llm_model", ""),
-                )
-                if self._llm_base_url:
-                    kwargs["llm_base_url"] = self._llm_base_url
-                idle_timeout = _parse_int_setting(
-                    self._config.get("idle_timeout")
-                    if self._config.get("idle_timeout") is not None
-                    else os.environ.get("HINDSIGHT_IDLE_TIMEOUT", self._idle_timeout),
-                    _DEFAULT_IDLE_TIMEOUT,
-                )
-                self._idle_timeout = idle_timeout
-                kwargs["idle_timeout"] = idle_timeout
-                self._client = HindsightEmbedded(**kwargs)
-            else:
-                _ensure_cloud_client_dependency()
-                from hindsight_client import Hindsight
-                timeout = self._timeout or _DEFAULT_TIMEOUT
-                kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
-                if self._api_key:
-                    kwargs["api_key"] = self._api_key
-                logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
-                             self._api_url, bool(self._api_key), kwargs["timeout"])
-                self._client = Hindsight(**kwargs)
-        return self._client
+        """Return one serialized, lifecycle-tracked Hindsight client."""
+        self._ensure_prefetch_state()
+        with self._client_lock:
+            client = self._client
+            if client is None:
+                client = self._create_client()
+                self._client = client
+            return client
 
     def _run_sync(self, coro):
         """Schedule *coro* on the shared loop using the configured timeout."""
@@ -1401,7 +1477,7 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
     def _run_hindsight_operation(self, operation):
-        """Run an async Hindsight client operation, retrying once after idle shutdown."""
+        """Run an async operation, recreating a stale embedded client once."""
         client = self._get_client()
         try:
             return self._run_sync(operation(client))
@@ -1409,12 +1485,12 @@ class HindsightMemoryProvider(MemoryProvider):
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
             logger.info(
-                "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
+                "Hindsight embedded daemon appears unreachable; "
+                "recreating client and retrying once: %s",
                 exc,
             )
-            self._client = None
-            client = self._get_client()
-            self._client = client
+            self._retire_hindsight_client(client)
+            client = self._publish_replacement_client(self._get_client())
             return self._run_sync(operation(client))
 
     def _probe_url(self) -> str:
@@ -1530,17 +1606,23 @@ class HindsightMemoryProvider(MemoryProvider):
         self._llm_base_url = self._config.get("llm_base_url", "")
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
-        static_bank_id = self._config.get("bank_id") or banks.get("bankId", "hermes")
+        self._prefetch_bank_fallback = (
+            self._config.get("bank_id") or banks.get("bankId", "hermes")
+        )
         self._bank_id_template = self._config.get("bank_id_template", "") or ""
         self._bank_id = _resolve_bank_id_template(
             self._bank_id_template,
-            fallback=static_bank_id,
+            fallback=self._prefetch_bank_fallback,
             profile=self._agent_identity,
             workspace=self._agent_workspace,
             platform=self._platform,
             user=self._user_id,
             session=self._session_id,
         )
+        with self._prefetch_condition:
+            self._prefetch_epoch += 1
+            self._prefetch_session_id = self._session_id
+            self._prefetch_bank_id = self._bank_id
         budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 
@@ -1713,13 +1795,751 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _ensure_prefetch_state(self) -> None:
+        """Lazily initialize prefetch state for constructor-bypassing callers."""
+        if not hasattr(self, "_shutting_down"):
+            self._shutting_down = threading.Event()
+        if not hasattr(self, "_prefetch_lock"):
+            self._prefetch_lock = threading.RLock()
+        if not hasattr(self, "_prefetch_condition"):
+            self._prefetch_condition = threading.Condition(self._prefetch_lock)
+
+        current_session_id = str(getattr(self, "_session_id", "") or "").strip()
+        current_bank_id = str(getattr(self, "_bank_id", "hermes") or "hermes")
+        defaults = {
+            "_prefetch_result": "",
+            "_prefetch_result_request": None,
+            "_prefetch_completed_request": None,
+            "_prefetch_epoch": 0,
+            "_prefetch_sequence": 0,
+            "_prefetch_session_id": current_session_id,
+            "_prefetch_bank_id": current_bank_id,
+            "_prefetch_bank_fallback": current_bank_id,
+            "_prefetch_latest_request": None,
+            "_prefetch_pending_request": None,
+            "_prefetch_inflight": {},
+            "_prefetch_operations": {},
+            "_prefetch_threads": set(),
+            "_prefetch_thread": None,
+            "_prefetch_client_owners": {},
+            "_prefetch_deferred_clients": {},
+            "_prefetch_close_threads": set(),
+            "_prefetch_closing_clients": {},
+            "_client_lock": threading.RLock(),
+            "_closed_client_refs": {},
+            "_closed_client_fallbacks": {},
+            "_bank_id_template": "",
+        }
+        for name, value in defaults.items():
+            if not hasattr(self, name):
+                setattr(self, name, value)
+
+    def _normalize_prefetch_query(self, query: str) -> str:
+        normalized = str(query or "").strip()
+        if (
+            self._recall_max_input_chars
+            and len(normalized) > self._recall_max_input_chars
+        ):
+            normalized = normalized[: self._recall_max_input_chars]
+        return normalized
+
+    def _prefetch_enabled(self) -> bool:
+        self._ensure_prefetch_state()
+        if self._memory_mode == "tools":
+            logger.debug("Prefetch: skipped (tools-only mode)")
+            return False
+        if not self._auto_recall:
+            logger.debug("Prefetch: skipped (auto_recall disabled)")
+            return False
+        if self._shutting_down.is_set():
+            logger.debug("Prefetch: skipped (shutting down)")
+            return False
+        return True
+
+    def _resolve_prefetch_bank_id(self, session_id: str) -> str:
+        return _resolve_bank_id_template(
+            self._bank_id_template,
+            fallback=self._prefetch_bank_fallback,
+            profile=self._agent_identity,
+            workspace=self._agent_workspace,
+            platform=self._platform,
+            user=self._user_id,
+            session=session_id,
+        )
+
+    def _new_prefetch_request_locked(
+        self,
+        query: str,
+        session_id: str,
+        bank_id: str,
+    ) -> _PrefetchRequest:
+        self._prefetch_sequence += 1
+        request_id = self._prefetch_sequence
+        cache_key = (
+            self._prefetch_epoch,
+            session_id,
+            bank_id,
+            query,
+        )
+        return _PrefetchRequest(
+            request_id=request_id,
+            epoch=self._prefetch_epoch,
+            session_id=session_id,
+            bank_id=bank_id,
+            query=query,
+            cache_key=cache_key,
+            inflight_key=(request_id, *cache_key),
+        )
+
+    def _request_is_current_locked(self, request: _PrefetchRequest) -> bool:
+        return (
+            not self._shutting_down.is_set()
+            and request.epoch == self._prefetch_epoch
+            and request.session_id == self._prefetch_session_id
+            and request.bank_id == self._prefetch_bank_id
+            and self._prefetch_latest_request is request
+        )
+
+    def _publish_prefetch_result_locked(
+        self,
+        request: _PrefetchRequest,
+        text: str,
+    ) -> None:
+        if not self._request_is_current_locked(request):
+            return
+        self._prefetch_completed_request = request
+        self._prefetch_result = text
+        self._prefetch_result_request = request if text else None
+        self._prefetch_condition.notify_all()
+
+    def _start_prefetch_worker_locked(self, request: _PrefetchRequest) -> None:
+        operation = _PrefetchOperation(request=request)
+        thread = threading.Thread(
+            target=self._prefetch_worker,
+            args=(request,),
+            daemon=True,
+            name=f"hindsight-prefetch-{request.request_id}",
+        )
+        operation.thread = thread
+        self._prefetch_operations[request.inflight_key] = operation
+        self._prefetch_inflight[request.inflight_key] = operation
+        self._prefetch_threads.add(thread)
+        self._prefetch_thread = thread
+        thread.start()
+
+    def _maybe_start_pending_prefetch_locked(self) -> None:
+        if self._shutting_down.is_set():
+            self._prefetch_pending_request = None
+            return
+        request = self._prefetch_pending_request
+        if request is None or len(self._prefetch_inflight) >= _MAX_PREFETCH_WORKERS:
+            return
+        self._prefetch_pending_request = None
+        if not self._request_is_current_locked(request):
+            return
+        self._start_prefetch_worker_locked(request)
+
+    def _admit_prefetch_locked(
+        self,
+        query: str,
+        session_id: str,
+    ) -> _PrefetchRequest | None:
+        if self._shutting_down.is_set():
+            return None
+        explicit_session_id = str(session_id or "").strip()
+        if (
+            explicit_session_id
+            and explicit_session_id != self._prefetch_session_id
+        ):
+            logger.debug(
+                "Prefetch: rejected stale session admission %s (current=%s)",
+                explicit_session_id,
+                self._prefetch_session_id,
+            )
+            return None
+        effective_session_id = explicit_session_id or self._prefetch_session_id
+        bank_id = self._resolve_prefetch_bank_id(effective_session_id)
+        cache_key = (
+            self._prefetch_epoch,
+            effective_session_id,
+            bank_id,
+            query,
+        )
+
+        if (
+            self._prefetch_result
+            and self._prefetch_result_request is not None
+            and self._prefetch_result_request.cache_key == cache_key
+        ):
+            return self._prefetch_result_request
+
+        for operation in self._prefetch_operations.values():
+            if operation.request.cache_key == cache_key:
+                return operation.request
+        if (
+            self._prefetch_pending_request is not None
+            and self._prefetch_pending_request.cache_key == cache_key
+        ):
+            return self._prefetch_pending_request
+
+        request = self._new_prefetch_request_locked(
+            query,
+            effective_session_id,
+            bank_id,
+        )
+        self._prefetch_latest_request = request
+        self._prefetch_result = ""
+        self._prefetch_result_request = None
+        self._prefetch_completed_request = None
+        if len(self._prefetch_inflight) < _MAX_PREFETCH_WORKERS:
+            self._start_prefetch_worker_locked(request)
+        else:
+            self._prefetch_pending_request = request
+        self._prefetch_condition.notify_all()
+        return request
+
+    def _bind_legacy_prefetch_result_locked(
+        self,
+        query: str,
+        session_id: str,
+    ) -> None:
+        if self._shutting_down.is_set():
+            return
+        explicit_session_id = str(session_id or "").strip()
+        if (
+            explicit_session_id
+            and explicit_session_id != self._prefetch_session_id
+        ):
+            return
+        if not self._prefetch_result or self._prefetch_result_request is not None:
+            return
+        effective_session_id = str(
+            session_id or self._prefetch_session_id or self._session_id or ""
+        ).strip()
+        request = self._new_prefetch_request_locked(
+            query,
+            effective_session_id,
+            self._resolve_prefetch_bank_id(effective_session_id),
+        )
+        self._prefetch_latest_request = request
+        self._prefetch_completed_request = request
+        self._prefetch_result_request = request
+
+    def _forget_closed_client_ref(
+        self,
+        client_key: int,
+        client_ref: weakref.ReferenceType[Any],
+    ) -> None:
+        try:
+            with self._prefetch_condition:
+                if self._closed_client_refs.get(client_key) is client_ref:
+                    self._closed_client_refs.pop(client_key, None)
+        except Exception:
+            pass
+
+    def _client_is_closed_locked(self, client: Any) -> bool:
+        try:
+            if getattr(client, _CLIENT_CLOSED_ATTR, None) is _CLIENT_CLOSED_MARKER:
+                return True
+        except Exception:
+            pass
+
+        client_key = id(client)
+        client_ref = self._closed_client_refs.get(client_key)
+        if client_ref is not None:
+            closed_client = client_ref()
+            if closed_client is client:
+                return True
+            if closed_client is None:
+                self._closed_client_refs.pop(client_key, None)
+            else:
+                raise RuntimeError("Hindsight closed-client identity collision")
+
+        fallback = self._closed_client_fallbacks.get(client_key)
+        if fallback is client:
+            return True
+        if fallback is not None:
+            raise RuntimeError("Hindsight closed-client identity collision")
+        return False
+
+    def _mark_client_closed_locked(self, client: Any) -> None:
+        try:
+            setattr(client, _CLIENT_CLOSED_ATTR, _CLIENT_CLOSED_MARKER)
+            if getattr(client, _CLIENT_CLOSED_ATTR) is _CLIENT_CLOSED_MARKER:
+                return
+        except Exception:
+            pass
+
+        client_key = id(client)
+        try:
+            provider_ref = weakref.ref(self)
+
+            def _forget(client_ref, key=client_key, owner_ref=provider_ref):
+                owner = owner_ref()
+                if owner is not None:
+                    owner._forget_closed_client_ref(key, client_ref)
+
+            client_ref = weakref.ref(client, _forget)
+        except TypeError:
+            fallback = self._closed_client_fallbacks.get(client_key)
+            if fallback is not None and fallback is not client:
+                raise RuntimeError("Hindsight closed-client identity collision")
+            self._closed_client_fallbacks[client_key] = client
+            while (
+                len(self._closed_client_fallbacks)
+                > _MAX_UNWEAKREFABLE_CLOSED_CLIENTS
+            ):
+                oldest_key = next(iter(self._closed_client_fallbacks))
+                self._closed_client_fallbacks.pop(oldest_key, None)
+            return
+
+        existing_ref = self._closed_client_refs.get(client_key)
+        if existing_ref is not None:
+            existing_client = existing_ref()
+            if existing_client is not None and existing_client is not client:
+                raise RuntimeError("Hindsight closed-client identity collision")
+        self._closed_client_refs[client_key] = client_ref
+
+    def _reserve_prefetch_client_locked(self, client: Any) -> object:
+        client_key = id(client)
+        if self._client_is_closed_locked(client):
+            raise RuntimeError("Hindsight client is already closed")
+
+        closing_client = self._prefetch_closing_clients.get(client_key)
+        if closing_client is not None:
+            if closing_client is not client:
+                raise RuntimeError("Hindsight closing-client identity collision")
+            raise RuntimeError("Hindsight client is closing")
+
+        owner = self._prefetch_client_owners.get(client_key)
+        if owner is None:
+            reservations: set[object] = set()
+            self._prefetch_client_owners[client_key] = (client, reservations)
+        else:
+            if owner[0] is not client:
+                raise RuntimeError("Hindsight client-owner identity collision")
+            reservations = owner[1]
+
+        reservation = object()
+        reservations.add(reservation)
+        return reservation
+
+    def _release_prefetch_client_locked(
+        self,
+        client: Any,
+        reservation: object,
+    ) -> bool:
+        client_key = id(client)
+        owner = self._prefetch_client_owners.get(client_key)
+        if owner is None:
+            return False
+        if owner[0] is not client:
+            raise RuntimeError("Hindsight client-owner identity collision")
+        reservations = owner[1]
+        if reservation not in reservations:
+            return False
+        reservations.remove(reservation)
+        if not reservations:
+            self._prefetch_client_owners.pop(client_key, None)
+        return True
+
+    def _rollback_prefetch_client_reservation(
+        self,
+        client: Any,
+        reservation: object,
+    ) -> None:
+        with self._prefetch_condition:
+            self._release_prefetch_client_locked(client, reservation)
+            clients_to_close = self._take_ready_deferred_clients_locked()
+            self._prefetch_condition.notify_all()
+        for deferred_client in clients_to_close:
+            self._schedule_prefetch_client_close(deferred_client)
+
+    def _publish_replacement_client(self, client: Any) -> Any:
+        self._ensure_prefetch_state()
+        with self._client_lock:
+            current = self._client
+            if current is None:
+                self._client = client
+            elif current is not client:
+                client = current
+            return client
+
+
+    def _register_prefetch_future_locked(
+        self,
+        request: _PrefetchRequest,
+        client: Any,
+        reservation: object,
+        future: Any,
+    ) -> None:
+        operation = self._prefetch_operations.get(request.inflight_key)
+        if operation is None:
+            raise RuntimeError("Hindsight prefetch operation was retired")
+        owner = self._prefetch_client_owners.get(id(client))
+        if (
+            owner is None
+            or owner[0] is not client
+            or reservation not in owner[1]
+        ):
+            raise RuntimeError("Hindsight prefetch client reservation was lost")
+        operation.futures[reservation] = future
+
+    def _claim_client_close_locked(self, client: Any) -> bool:
+        client_key = id(client)
+        if self._client_is_closed_locked(client):
+            return False
+
+        closing_client = self._prefetch_closing_clients.get(client_key)
+        if closing_client is not None:
+            if closing_client is not client:
+                raise RuntimeError("Hindsight closing-client identity collision")
+            return False
+
+        owner = self._prefetch_client_owners.get(client_key)
+        if owner is not None:
+            if owner[0] is not client:
+                raise RuntimeError("Hindsight client-owner identity collision")
+            deferred_client = self._prefetch_deferred_clients.get(client_key)
+            if deferred_client is not None and deferred_client is not client:
+                raise RuntimeError("Hindsight deferred-client identity collision")
+            self._prefetch_deferred_clients[client_key] = client
+            return False
+
+        self._prefetch_closing_clients[client_key] = client
+        deferred_client = self._prefetch_deferred_clients.pop(client_key, None)
+        if deferred_client is not None and deferred_client is not client:
+            raise RuntimeError("Hindsight deferred-client identity collision")
+        return True
+
+    def _finish_client_close(self, client: Any) -> None:
+        client_key = id(client)
+        with self._client_lock:
+            if self._client is client:
+                self._client = None
+            with self._prefetch_condition:
+                closing_client = self._prefetch_closing_clients.pop(
+                    client_key,
+                    None,
+                )
+                if closing_client is not None and closing_client is not client:
+                    raise RuntimeError(
+                        "Hindsight closing-client identity collision"
+                    )
+                deferred_client = self._prefetch_deferred_clients.pop(
+                    client_key,
+                    None,
+                )
+                if deferred_client is not None and deferred_client is not client:
+                    raise RuntimeError(
+                        "Hindsight deferred-client identity collision"
+                    )
+                self._mark_client_closed_locked(client)
+                self._prefetch_close_threads.discard(
+                    threading.current_thread()
+                )
+                self._prefetch_condition.notify_all()
+
+    def _close_claimed_client(self, client: Any) -> None:
+        try:
+            self._close_hindsight_client(client)
+        finally:
+            self._finish_client_close(client)
+
+    def _retire_hindsight_client(
+        self,
+        client: Any,
+        *,
+        clear_current: bool = True,
+    ) -> None:
+        self._ensure_prefetch_state()
+        with self._client_lock:
+            if clear_current and self._client is client:
+                self._client = None
+            with self._prefetch_condition:
+                should_close = self._claim_client_close_locked(client)
+        if should_close:
+            self._close_claimed_client(client)
+
+    def _take_ready_deferred_clients_locked(self) -> list[Any]:
+        ready: list[Any] = []
+        for client_key, client in list(self._prefetch_deferred_clients.items()):
+            if self._client_is_closed_locked(client):
+                self._prefetch_deferred_clients.pop(client_key, None)
+                continue
+            owner = self._prefetch_client_owners.get(client_key)
+            if owner is not None:
+                if owner[0] is not client:
+                    raise RuntimeError("Hindsight client-owner identity collision")
+                continue
+            closing_client = self._prefetch_closing_clients.get(client_key)
+            if closing_client is not None:
+                if closing_client is not client:
+                    raise RuntimeError(
+                        "Hindsight closing-client identity collision"
+                    )
+                continue
+            ready.append(client)
+        return ready
+
+    def _schedule_prefetch_client_close(self, client: Any) -> None:
+        with self._prefetch_condition:
+            if not self._claim_client_close_locked(client):
+                return
+            thread = threading.Thread(
+                target=self._close_claimed_client,
+                args=(client,),
+                daemon=True,
+                name="hindsight-prefetch-client-close",
+            )
+            self._prefetch_close_threads.add(thread)
+        thread.start()
+
+    def _prefetch_future_done(
+        self,
+        request: _PrefetchRequest,
+        client: Any,
+        reservation: object,
+        future: Any,
+    ) -> None:
+        text = ""
+        succeeded = False
+        try:
+            text = future.result() or ""
+            succeeded = True
+        except Exception:
+            pass
+
+        clients_to_close: list[Any] = []
+        with self._prefetch_condition:
+            operation = self._prefetch_operations.get(request.inflight_key)
+            registered = False
+            if operation is not None:
+                registered_future = operation.futures.get(reservation)
+                if registered_future is future:
+                    operation.futures.pop(reservation, None)
+                    registered = True
+                elif registered_future is not None:
+                    raise RuntimeError(
+                        "Hindsight prefetch-future identity collision"
+                    )
+
+            self._release_prefetch_client_locked(client, reservation)
+
+            if succeeded and registered:
+                self._publish_prefetch_result_locked(request, text)
+
+            if (
+                operation is not None
+                and operation.worker_done
+                and not operation.futures
+            ):
+                self._prefetch_operations.pop(request.inflight_key, None)
+            self._maybe_start_pending_prefetch_locked()
+            clients_to_close = self._take_ready_deferred_clients_locked()
+            self._prefetch_condition.notify_all()
+
+        for deferred_client in clients_to_close:
+            self._schedule_prefetch_client_close(deferred_client)
+
+    def _execute_prefetch_attempt(self, request, operation, client) -> str:
+        from agent.async_utils import safe_schedule_threadsafe
+
+        with self._prefetch_condition:
+            reservation = self._reserve_prefetch_client_locked(client)
+
+        try:
+            coroutine = operation(client)
+        except BaseException:
+            self._rollback_prefetch_client_reservation(client, reservation)
+            raise
+
+        try:
+            future = safe_schedule_threadsafe(coroutine, _get_loop())
+        except BaseException:
+            coroutine.close()
+            self._rollback_prefetch_client_reservation(client, reservation)
+            raise
+        if future is None:
+            self._rollback_prefetch_client_reservation(client, reservation)
+            raise RuntimeError("Hindsight loop unavailable")
+
+        try:
+            with self._prefetch_condition:
+                self._register_prefetch_future_locked(
+                    request,
+                    client,
+                    reservation,
+                    future,
+                )
+        except BaseException:
+            future.add_done_callback(
+                lambda done: self._prefetch_future_done(
+                    request,
+                    client,
+                    reservation,
+                    done,
+                )
+            )
+            raise
+
+        future.add_done_callback(
+            lambda done: self._prefetch_future_done(
+                request,
+                client,
+                reservation,
+                done,
+            )
+        )
+        return future.result(timeout=self._timeout)
+
+    def _execute_prefetch_request(self, request, operation) -> str:
+        client = self._get_client()
+        try:
+            return self._execute_prefetch_attempt(request, operation, client)
+        except Exception as exc:
+            if not self._is_retriable_embedded_connection_error(exc):
+                raise
+            logger.info(
+                "Hindsight embedded daemon appears unreachable during prefetch; "
+                "recreating client and retrying once: %s",
+                exc,
+            )
+            self._retire_hindsight_client(client)
+            client = self._publish_replacement_client(self._get_client())
+            return self._execute_prefetch_attempt(request, operation, client)
+
+    def _prefetch_worker(self, request: _PrefetchRequest) -> None:
+        current_thread = threading.current_thread()
+        text = ""
+        try:
+            if self._prefetch_method == "reflect":
+                logger.debug(
+                    "Prefetch: calling reflect (bank=%s, query_len=%d)",
+                    request.bank_id,
+                    len(request.query),
+                )
+
+                async def _reflect(client):
+                    response = await client.areflect(
+                        bank_id=request.bank_id,
+                        query=request.query,
+                        budget=self._budget,
+                    )
+                    return response.text or ""
+
+                text = self._execute_prefetch_request(request, _reflect)
+            else:
+                recall_kwargs: dict[str, Any] = {
+                    "bank_id": request.bank_id,
+                    "query": request.query,
+                    "budget": self._budget,
+                    "max_tokens": self._recall_max_tokens,
+                }
+                if self._recall_tags:
+                    recall_kwargs["tags"] = self._recall_tags
+                    recall_kwargs["tags_match"] = self._recall_tags_match
+                if self._recall_types:
+                    recall_kwargs["types"] = self._recall_types
+                logger.debug(
+                    "Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
+                    request.bank_id,
+                    len(request.query),
+                    self._budget,
+                )
+
+                async def _recall(client):
+                    response = await client.arecall(**recall_kwargs)
+                    results = response.results or []
+                    logger.debug(
+                        "Prefetch: recall returned %d results",
+                        len(results),
+                    )
+                    return "\n".join(
+                        f"- {result.text}"
+                        for result in results
+                        if result.text
+                    )
+
+                text = self._execute_prefetch_request(request, _recall)
+        except Exception as exc:
+            logger.debug(
+                "Hindsight prefetch failed: %s",
+                exc,
+                exc_info=True,
+            )
+        finally:
+            clients_to_close: list[Any] = []
+            with self._prefetch_condition:
+                operation_state = self._prefetch_operations.get(
+                    request.inflight_key
+                )
+                self._prefetch_inflight.pop(request.inflight_key, None)
+                if operation_state is not None:
+                    operation_state.worker_done = True
+                    if not operation_state.futures:
+                        if self._prefetch_completed_request is not request:
+                            self._publish_prefetch_result_locked(request, text)
+                        self._prefetch_operations.pop(
+                            request.inflight_key,
+                            None,
+                        )
+                self._prefetch_threads.discard(current_thread)
+                if self._prefetch_thread is current_thread:
+                    self._prefetch_thread = next(
+                        iter(self._prefetch_threads),
+                        None,
+                    )
+                self._maybe_start_pending_prefetch_locked()
+                clients_to_close = self._take_ready_deferred_clients_locked()
+                self._prefetch_condition.notify_all()
+
+            for deferred_client in clients_to_close:
+                self._schedule_prefetch_client_close(deferred_client)
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        if self._prefetch_thread and self._prefetch_thread.is_alive():
-            logger.debug("Prefetch: waiting for background thread to complete")
-            self._prefetch_thread.join(timeout=3.0)
-        with self._prefetch_lock:
-            result = self._prefetch_result
-            self._prefetch_result = ""
+        if not self._prefetch_enabled():
+            return ""
+        normalized_query = self._normalize_prefetch_query(query)
+        if not normalized_query:
+            return ""
+
+        deadline = time.monotonic() + _PREFETCH_WAIT_SECONDS
+        with self._prefetch_condition:
+            self._bind_legacy_prefetch_result_locked(
+                normalized_query,
+                session_id,
+            )
+            request = self._admit_prefetch_locked(
+                normalized_query,
+                session_id,
+            )
+            if request is None:
+                return ""
+            while True:
+                if (
+                    self._prefetch_result
+                    and self._prefetch_result_request is request
+                ):
+                    result = self._prefetch_result
+                    self._prefetch_result = ""
+                    self._prefetch_result_request = None
+                    break
+                if self._prefetch_completed_request is request:
+                    result = ""
+                    break
+                if not self._request_is_current_locked(request):
+                    logger.debug("Prefetch: request superseded")
+                    return ""
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.debug(
+                        "Prefetch: request timed out after %.1fs",
+                        _PREFETCH_WAIT_SECONDS,
+                    )
+                    return ""
+                self._prefetch_condition.wait(timeout=remaining)
+
         if not result:
             logger.debug("Prefetch: no results available")
             return ""
@@ -1732,58 +2552,13 @@ class HindsightMemoryProvider(MemoryProvider):
         return f"{header}\n\n{result}"
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
-        if self._memory_mode == "tools":
-            logger.debug("Prefetch: skipped (tools-only mode)")
+        if not self._prefetch_enabled():
             return
-        if not self._auto_recall:
-            logger.debug("Prefetch: skipped (auto_recall disabled)")
+        normalized_query = self._normalize_prefetch_query(query)
+        if not normalized_query:
             return
-        if self._shutting_down.is_set():
-            logger.debug("Prefetch: skipped (shutting down)")
-            return
-        # Truncate query to max chars
-        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
-            query = query[:self._recall_max_input_chars]
-
-        def _run():
-            # Ensure the just-completed turn's retain is recall-visible on the
-            # server before we recall, so the warmed context for the next turn
-            # includes it. This waits for the local writer queue to drain AND
-            # for the server-side async retain op(s) to complete (an explicit
-            # read-after-write signal), because async retain returns on
-            # acceptance rather than durability. Runs on the background prefetch
-            # thread, never the reply path, so it adds no response latency.
-            if self._prefetch_waits_for_retain:
-                self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-            try:
-                if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
-                    text = resp.text or ""
-                else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
-                    logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
-                if text:
-                    with self._prefetch_lock:
-                        self._prefetch_result = text
-            except Exception as e:
-                logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
-
-        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
-        self._prefetch_thread.start()
+        with self._prefetch_condition:
+            self._admit_prefetch_locked(normalized_query, session_id)
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
@@ -2037,6 +2812,27 @@ class HindsightMemoryProvider(MemoryProvider):
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    def _close_hindsight_client(self, client: Any) -> None:
+        try:
+            if self._mode == "local_embedded":
+                # HindsightEmbedded.close() delegates to its sync client.close().
+                # Close the inner async client on the shared loop first.
+                inner_client = getattr(client, "_client", None)
+                if inner_client is not None and hasattr(inner_client, "aclose"):
+                    _run_sync(inner_client.aclose())
+                    try:
+                        client._client = None
+                    except Exception:
+                        pass
+                try:
+                    client.close()
+                except RuntimeError:
+                    pass
+            else:
+                self._run_sync(client.aclose())
+        except Exception:
+            pass
+
     def on_session_switch(
         self,
         new_session_id: str,
@@ -2068,9 +2864,9 @@ class HindsightMemoryProvider(MemoryProvider):
         moment of switch — the same data-loss class as the shutdown race,
         just at a different lifecycle event.
 
-        Also wait for any in-flight prefetch from the old session and drop
-        its cached result; otherwise the new session's first ``prefetch()``
-        could read stale recall text from before the switch.
+        Prefetch identity rotates atomically with the session. In-flight work
+        from the old epoch may finish later, but its completion is fenced from
+        the new session's cache and never delays the switch.
 
         ``parent_session_id`` is recorded for lineage tags on future retains.
         ``reset`` is accepted but not needed for Hindsight's state model —
@@ -2079,6 +2875,7 @@ class HindsightMemoryProvider(MemoryProvider):
         new_id = str(new_session_id or "").strip()
         if not new_id:
             return
+        self._ensure_prefetch_state()
 
         # 1. Flush any buffered turns under the OLD identifiers. Snapshot
         # everything before mutating self._* so metadata + tags + doc_id
@@ -2144,23 +2941,30 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._register_atexit()
                 self._retain_queue.put(_flush)
 
-        # 2. Drain any in-flight prefetch from the old session and drop
-        # its cached result so the new session doesn't see stale recall.
-        if self._prefetch_thread and self._prefetch_thread.is_alive():
-            self._prefetch_thread.join(timeout=3.0)
-        with self._prefetch_lock:
-            self._prefetch_result = ""
+        # 2. Rotate the session and prefetch identity under the admission
+        # lock. Existing workers keep their immutable request snapshot; their
+        # completion fence rejects the now-stale epoch without delaying the
+        # switch or occupying the new session's cache.
+        with self._prefetch_condition:
+            if parent_session_id:
+                self._parent_session_id = str(parent_session_id).strip()
+            self._session_id = new_id
+            start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            self._document_id = f"{self._session_id}-{start_ts}"
+            self._session_turns = []
+            self._turn_counter = 0
+            self._turn_index = 0
+            self._last_retained_turn_count = 0
 
-        # 3. Now rotate to the new session.
-        if parent_session_id:
-            self._parent_session_id = str(parent_session_id).strip()
-        self._session_id = new_id
-        start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        self._document_id = f"{self._session_id}-{start_ts}"
-        self._session_turns = []
-        self._turn_counter = 0
-        self._turn_index = 0
-        self._last_retained_turn_count = 0
+            self._prefetch_epoch += 1
+            self._prefetch_session_id = new_id
+            self._prefetch_bank_id = self._resolve_prefetch_bank_id(new_id)
+            self._prefetch_latest_request = None
+            self._prefetch_pending_request = None
+            self._prefetch_result = ""
+            self._prefetch_result_request = None
+            self._prefetch_completed_request = None
+            self._prefetch_condition.notify_all()
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,
@@ -2168,9 +2972,18 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
+        self._ensure_prefetch_state()
         # Stop accepting new retain jobs first so anyone still calling
         # sync_turn() during teardown is dropped, not enqueued.
-        self._shutting_down.set()
+        with self._prefetch_condition:
+            self._shutting_down.set()
+            self._prefetch_epoch += 1
+            self._prefetch_latest_request = None
+            self._prefetch_pending_request = None
+            self._prefetch_result = ""
+            self._prefetch_result_request = None
+            self._prefetch_completed_request = None
+            self._prefetch_condition.notify_all()
         # Drain the writer: it will finish in-flight work, then exit on
         # the sentinel. Bounded join keeps shutdown predictable even if
         # the daemon is wedged.
@@ -2187,33 +3000,25 @@ class HindsightMemoryProvider(MemoryProvider):
                     "abandoning %d pending retain(s)",
                     self._retain_queue.qsize(),
                 )
-        if self._prefetch_thread and self._prefetch_thread.is_alive():
-            self._prefetch_thread.join(timeout=5.0)
-        if self._client is not None:
-            try:
-                if self._mode == "local_embedded":
-                    # HindsightEmbedded.close() delegates to its sync client.close().
-                    # When Hermes created/used that client on the shared async loop,
-                    # closing it from this thread can raise "attached to a different
-                    # loop" before aiohttp releases the session. Close the embedded
-                    # inner async client on the shared loop first, then let the
-                    # wrapper clean up daemon/UI bookkeeping.
-                    inner_client = getattr(self._client, "_client", None)
-                    if inner_client is not None and hasattr(inner_client, "aclose"):
-                        _run_sync(inner_client.aclose())
-                        try:
-                            self._client._client = None
-                        except Exception:
-                            pass
-                    try:
-                        self._client.close()
-                    except RuntimeError:
-                        pass
-                else:
-                    self._run_sync(self._client.aclose())
-            except Exception:
-                pass
-            self._client = None
+        with self._prefetch_condition:
+            prefetch_threads = set(self._prefetch_threads)
+        deadline = time.monotonic() + 5.0
+        for thread in prefetch_threads:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            if thread.is_alive():
+                thread.join(timeout=remaining)
+
+        with self._client_lock:
+            client = self._client
+        if client is not None:
+            self._retire_hindsight_client(client, clear_current=False)
+
+        with self._prefetch_condition:
+            clients_to_close = self._take_ready_deferred_clients_locked()
+        for deferred_client in clients_to_close:
+            self._schedule_prefetch_client_close(deferred_client)
         # The module-global background event loop (_loop / _loop_thread)
         # is intentionally NOT stopped here. It is shared across every
         # HindsightMemoryProvider instance in the process — the plugin

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -21,6 +21,8 @@ import queue
 import sys
 import threading
 import time
+import weakref
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -154,6 +156,40 @@ _loop_lock = threading.Lock()
 
 # Pushed to the per-provider retain queue to wake the writer for a clean exit.
 _WRITER_SENTINEL = object()
+
+
+# Prefetch request-scoping (#64745): admission snapshots the session identity
+# (session/bank/budget/query) into an immutable request; the worker recalls
+# with the snapshot and may only publish into that request's fenced slot.
+_PREFETCH_WAIT_SECONDS = 3.0
+_MAX_PREFETCH_WORKERS = 2
+_CLIENT_CLOSED_ATTR = "_hermes_hindsight_closed"
+_CLIENT_CLOSED_MARKER = object()
+_MAX_UNWEAKREFABLE_CLOSED_CLIENTS = 16
+
+
+@dataclass(frozen=True, slots=True)
+class _PrefetchRequest:
+    """Immutable request-time identity for one prefetch operation."""
+
+    request_id: int
+    epoch: int
+    session_id: str
+    bank_id: str
+    budget: str
+    query: str
+    cache_key: tuple[int, str, str, str]
+    inflight_key: tuple[int, int, str, str, str]
+
+
+@dataclass(slots=True)
+class _PrefetchOperation:
+    """Tracks worker and async-future ownership for one exact request."""
+
+    request: _PrefetchRequest
+    thread: threading.Thread | None = None
+    futures: dict[object, Any] = field(default_factory=dict)
+    worker_done: bool = False
 
 
 def _get_loop() -> asyncio.AbstractEventLoop:
@@ -304,6 +340,11 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def __init__(self):
         self._config = self._api_key = self._client = None
+        # Client lifecycle (#64745): creation is serialized, retirement is
+        # tracked so a closed client is never reused.
+        self._client_lock = threading.RLock()
+        self._closed_client_refs: dict[int, weakref.ReferenceType[Any]] = {}
+        self._closed_client_fallbacks: dict[int, Any] = {}
         self._api_url, self._llm_base_url, self._mode = _DEFAULT_API_URL, "", "cloud"
         self._timeout, self._idle_timeout = _DEFAULT_TIMEOUT, _DEFAULT_IDLE_TIMEOUT
         self._bank_id, self._budget, self._bank_id_template = "hermes", "mid", ""
@@ -338,10 +379,38 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_ops_bank_id = ""
         self._apply_retain_policy({})
 
-        # Recall: pending prefetch block + count, and the indicator state (recall_status()).
+        # Recall: request-scoped prefetch state (#64745). Each admitted
+        # request snapshots the session identity (session/bank/budget/query);
+        # the worker publishes only into its own fenced slot, so a session
+        # switch can never publish the old conversation's recall into the new
+        # session's context. _prefetch_result carries the formatted block,
+        # _prefetch_count the discrete memory count for the recall indicator.
         self._prefetch_result, self._prefetch_count = "", 0
-        self._prefetch_lock = threading.Lock()
-        self._prefetch_thread = None
+        self._prefetch_result_request: _PrefetchRequest | None = None
+        self._prefetch_completed_request: _PrefetchRequest | None = None
+        self._prefetch_lock = threading.RLock()
+        self._prefetch_condition = threading.Condition(self._prefetch_lock)
+        self._prefetch_epoch = 0
+        self._prefetch_sequence = 0
+        self._prefetch_session_id = ""
+        self._prefetch_bank_id = "hermes"
+        self._prefetch_bank_fallback = "hermes"
+        self._prefetch_latest_request: _PrefetchRequest | None = None
+        self._prefetch_pending_request: _PrefetchRequest | None = None
+        self._prefetch_inflight: dict[
+            tuple[int, int, str, str, str], _PrefetchOperation
+        ] = {}
+        self._prefetch_operations: dict[
+            tuple[int, int, str, str, str], _PrefetchOperation
+        ] = {}
+        self._prefetch_threads: set[threading.Thread] = set()
+        self._prefetch_thread: threading.Thread | None = None
+        self._prefetch_client_owners: dict[
+            int, tuple[Any, set[object]]
+        ] = {}
+        self._prefetch_deferred_clients: dict[int, Any] = {}
+        self._prefetch_close_threads: set[threading.Thread] = set()
+        self._prefetch_closing_clients: dict[int, Any] = {}
         self._last_recall_returned, self._last_recall_count = False, 0
         self._apply_recall_settings({})
 
@@ -479,10 +548,14 @@ class HindsightMemoryProvider(MemoryProvider):
         return Hindsight(**kwargs)
 
     def _get_client(self):
-        """Return the cached Hindsight client (created once, reused)."""
-        if self._client is None:
-            self._client = self._new_embedded_client() if self._mode == "local_embedded" else self._new_cloud_client()
-        return self._client
+        """Return one serialized, lifecycle-tracked Hindsight client."""
+        self._ensure_prefetch_state()
+        with self._client_lock:
+            client = self._client
+            if client is None:
+                client = self._new_embedded_client() if self._mode == "local_embedded" else self._new_cloud_client()
+                self._client = client
+            return client
 
     def _run_sync(self, coro):
         """Schedule *coro* on the shared loop using the configured timeout."""
@@ -711,13 +784,20 @@ class HindsightMemoryProvider(MemoryProvider):
         self._llm_base_url = cfg.get("llm_base_url", "")
 
         banks = cfg_get(cfg, "banks", "hermes", default={})
+        self._prefetch_bank_fallback = cfg.get("bank_id") or banks.get("bankId", "hermes")
         self._bank_id_template = cfg.get("bank_id_template", "") or ""
         self._bank_id = _resolve_bank_id_template(
             self._bank_id_template,
-            fallback=cfg.get("bank_id") or banks.get("bankId", "hermes"),
+            fallback=self._prefetch_bank_fallback,
             profile=self._agent_identity, workspace=self._agent_workspace,
             platform=self._platform, user=self._user_id, session=self._session_id,
         )
+        # Prefetch identity rotates with initialization: any still-in-flight
+        # request from a previous epoch is fenced from the new session's cache.
+        with self._prefetch_condition:
+            self._prefetch_epoch += 1
+            self._prefetch_session_id = self._session_id
+            self._prefetch_bank_id = self._bank_id
         budget = cfg.get("recall_budget") or cfg.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
         memory_mode = cfg.get("memory_mode", "hybrid")
@@ -831,6 +911,340 @@ class HindsightMemoryProvider(MemoryProvider):
         label = "" if mode == "hybrid" else f" ({mode} mode)"
         return f"# Hindsight Memory\nActive{label}. Bank: {self._bank_id}, budget: {self._budget}.\n{_SYSTEM_PROMPT_TAILS[mode]}"
 
+    def _ensure_prefetch_state(self) -> None:
+        """Lazily initialize prefetch state for constructor-bypassing callers."""
+        if not hasattr(self, "_shutting_down"):
+            self._shutting_down = threading.Event()
+        if not hasattr(self, "_prefetch_lock"):
+            self._prefetch_lock = threading.RLock()
+        if not hasattr(self, "_prefetch_condition"):
+            self._prefetch_condition = threading.Condition(self._prefetch_lock)
+
+        current_session_id = str(getattr(self, "_session_id", "") or "").strip()
+        current_bank_id = str(getattr(self, "_bank_id", "hermes") or "hermes")
+        defaults = {
+            "_prefetch_result": "",
+            "_prefetch_result_request": None,
+            "_prefetch_completed_request": None,
+            "_prefetch_epoch": 0,
+            "_prefetch_sequence": 0,
+            "_prefetch_session_id": current_session_id,
+            "_prefetch_bank_id": current_bank_id,
+            "_prefetch_bank_fallback": current_bank_id,
+            "_prefetch_latest_request": None,
+            "_prefetch_pending_request": None,
+            "_prefetch_inflight": {},
+            "_prefetch_operations": {},
+            "_prefetch_threads": set(),
+            "_prefetch_thread": None,
+            "_prefetch_client_owners": {},
+            "_prefetch_deferred_clients": {},
+            "_prefetch_close_threads": set(),
+            "_prefetch_closing_clients": {},
+            "_client_lock": threading.RLock(),
+            "_closed_client_refs": {},
+            "_closed_client_fallbacks": {},
+            "_bank_id_template": "",
+        }
+        for name, value in defaults.items():
+            if not hasattr(self, name):
+                setattr(self, name, value)
+
+    def _normalize_prefetch_query(self, query: str) -> str:
+        normalized = str(query or "").strip()
+        if (
+            self._recall_max_input_chars
+            and len(normalized) > self._recall_max_input_chars
+        ):
+            normalized = normalized[: self._recall_max_input_chars]
+        return normalized
+
+    def _prefetch_enabled(self) -> bool:
+        """Admission gate shared by queue_prefetch/prefetch (state-safe)."""
+        self._ensure_prefetch_state()
+        return not self._recall_disabled()
+
+    def _resolve_prefetch_bank_id(self, session_id: str) -> str:
+        return _resolve_bank_id_template(
+            self._bank_id_template,
+            fallback=self._prefetch_bank_fallback,
+            profile=self._agent_identity,
+            workspace=self._agent_workspace,
+            platform=self._platform,
+            user=self._user_id,
+            session=session_id,
+        )
+
+    def _new_prefetch_request_locked(
+        self,
+        query: str,
+        session_id: str,
+        bank_id: str,
+    ) -> _PrefetchRequest:
+        self._prefetch_sequence += 1
+        request_id = self._prefetch_sequence
+        cache_key = (
+            self._prefetch_epoch,
+            session_id,
+            bank_id,
+            query,
+        )
+        return _PrefetchRequest(
+            request_id=request_id,
+            epoch=self._prefetch_epoch,
+            session_id=session_id,
+            bank_id=bank_id,
+            budget=self._budget,
+            query=query,
+            cache_key=cache_key,
+            inflight_key=(request_id, *cache_key),
+        )
+
+    def _request_is_current_locked(self, request: _PrefetchRequest) -> bool:
+        return (
+            not self._shutting_down.is_set()
+            and request.epoch == self._prefetch_epoch
+            and request.session_id == self._prefetch_session_id
+            and request.bank_id == self._prefetch_bank_id
+            and self._prefetch_latest_request is request
+        )
+
+    def _publish_prefetch_result_locked(
+        self,
+        request: _PrefetchRequest,
+        text: str,
+        count: int = 0,
+    ) -> None:
+        if not self._request_is_current_locked(request):
+            return
+        self._prefetch_completed_request = request
+        self._prefetch_result = text
+        # Feeds the deterministic recall indicator alongside the result, so the
+        # count survives the pipeline swap without re-parsing text.
+        self._prefetch_count = count if text else 0
+        self._prefetch_result_request = request if text else None
+        self._prefetch_condition.notify_all()
+
+    def _start_prefetch_worker_locked(self, request: _PrefetchRequest) -> None:
+        operation = _PrefetchOperation(request=request)
+        thread = _context_thread(
+            lambda: self._prefetch_worker(request),
+            f"hindsight-prefetch-{request.request_id}",
+        )
+        operation.thread = thread
+        self._prefetch_operations[request.inflight_key] = operation
+        self._prefetch_inflight[request.inflight_key] = operation
+        self._prefetch_threads.add(thread)
+        self._prefetch_thread = thread
+        thread.start()
+
+    def _maybe_start_pending_prefetch_locked(self) -> None:
+        if self._shutting_down.is_set():
+            self._prefetch_pending_request = None
+            return
+        request = self._prefetch_pending_request
+        if request is None or len(self._prefetch_inflight) >= _MAX_PREFETCH_WORKERS:
+            return
+        self._prefetch_pending_request = None
+        if not self._request_is_current_locked(request):
+            return
+        self._start_prefetch_worker_locked(request)
+
+    def _admit_prefetch_locked(
+        self,
+        query: str,
+        session_id: str,
+    ) -> _PrefetchRequest | None:
+        if self._shutting_down.is_set():
+            return None
+        explicit_session_id = str(session_id or "").strip()
+        if (
+            explicit_session_id
+            and explicit_session_id != self._prefetch_session_id
+        ):
+            logger.debug(
+                "Prefetch: rejected stale session admission %s (current=%s)",
+                explicit_session_id,
+                self._prefetch_session_id,
+            )
+            return None
+        effective_session_id = explicit_session_id or self._prefetch_session_id
+        bank_id = self._resolve_prefetch_bank_id(effective_session_id)
+        cache_key = (
+            self._prefetch_epoch,
+            effective_session_id,
+            bank_id,
+            query,
+        )
+
+        if (
+            self._prefetch_result
+            and self._prefetch_result_request is not None
+            and self._prefetch_result_request.cache_key == cache_key
+        ):
+            return self._prefetch_result_request
+
+        for operation in self._prefetch_operations.values():
+            if operation.request.cache_key == cache_key:
+                return operation.request
+        if (
+            self._prefetch_pending_request is not None
+            and self._prefetch_pending_request.cache_key == cache_key
+        ):
+            return self._prefetch_pending_request
+
+        request = self._new_prefetch_request_locked(
+            query,
+            effective_session_id,
+            bank_id,
+        )
+        self._prefetch_latest_request = request
+        self._prefetch_result = ""
+        self._prefetch_count = 0
+        self._prefetch_result_request = None
+        self._prefetch_completed_request = None
+        if len(self._prefetch_inflight) < _MAX_PREFETCH_WORKERS:
+            self._start_prefetch_worker_locked(request)
+        else:
+            self._prefetch_pending_request = request
+        self._prefetch_condition.notify_all()
+        return request
+
+    def _bind_legacy_prefetch_result_locked(
+        self,
+        query: str,
+        session_id: str,
+    ) -> None:
+        """Fence a result written before request-scoped admission (#64745)."""
+        if self._shutting_down.is_set():
+            return
+        explicit_session_id = str(session_id or "").strip()
+        if (
+            explicit_session_id
+            and explicit_session_id != self._prefetch_session_id
+        ):
+            return
+        if not self._prefetch_result or self._prefetch_result_request is not None:
+            return
+        effective_session_id = str(
+            session_id or self._prefetch_session_id or self._session_id or ""
+        ).strip()
+        request = self._new_prefetch_request_locked(
+            query,
+            effective_session_id,
+            self._resolve_prefetch_bank_id(effective_session_id),
+        )
+        self._prefetch_latest_request = request
+        self._prefetch_completed_request = request
+        self._prefetch_result_request = request
+
+    def _execute_prefetch_request(self, request, operation) -> str:
+        """Run one request-scoped prefetch operation on the shared loop."""
+        return self._run_hindsight_operation(operation)
+
+    def _prefetch_worker(self, request: _PrefetchRequest) -> None:
+        current_thread = threading.current_thread()
+        text = ""
+        result_count = 0
+        try:
+            # Ensure the just-completed turn's retain is recall-visible on the
+            # server before we recall, so the warmed context for the next turn
+            # includes it. This waits for the local writer queue to drain AND
+            # for the server-side async retain op(s) to complete (an explicit
+            # read-after-write signal), because async retain returns on
+            # acceptance rather than durability. Runs on the background prefetch
+            # thread, never the reply path, so it adds no response latency.
+            if self._prefetch_waits_for_retain:
+                self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
+            if self._prefetch_method == "reflect":
+                logger.debug(
+                    "Prefetch: calling reflect (bank=%s, query_len=%d)",
+                    request.bank_id,
+                    len(request.query),
+                )
+
+                async def _reflect(client):
+                    response = await client.areflect(
+                        bank_id=request.bank_id,
+                        query=request.query,
+                        budget=request.budget,
+                    )
+                    return response.text or ""
+
+                text = self._execute_prefetch_request(request, _reflect)
+            else:
+                recall_kwargs: dict[str, Any] = {
+                    "bank_id": request.bank_id,
+                    "query": request.query,
+                    "budget": request.budget,
+                    "max_tokens": self._recall_max_tokens,
+                }
+                if self._recall_tags:
+                    recall_kwargs["tags"] = self._recall_tags
+                    recall_kwargs["tags_match"] = self._recall_tags_match
+                if self._recall_types:
+                    recall_kwargs["types"] = self._recall_types
+                logger.debug(
+                    "Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
+                    request.bank_id,
+                    len(request.query),
+                    request.budget,
+                )
+
+                async def _recall(client):
+                    response = await client.arecall(**recall_kwargs)
+                    results = response.results or []
+                    logger.debug(
+                        "Prefetch: recall returned %d results",
+                        len(results),
+                    )
+                    nonlocal result_count
+                    result_count = len(results)
+                    return "\n".join(
+                        f"- {result.text}"
+                        for result in results
+                        if result.text
+                    )
+
+                text = self._execute_prefetch_request(request, _recall)
+        except Exception as exc:
+            logger.debug(
+                "Hindsight prefetch failed: %s",
+                exc,
+                exc_info=True,
+            )
+        finally:
+            with self._prefetch_condition:
+                operation_state = self._prefetch_operations.get(
+                    request.inflight_key
+                )
+                self._prefetch_inflight.pop(request.inflight_key, None)
+                if operation_state is not None:
+                    operation_state.worker_done = True
+                    if not operation_state.futures:
+                        if self._prefetch_completed_request is not request:
+                            self._publish_prefetch_result_locked(
+                                request, text, result_count,
+                            )
+                        elif text and result_count:
+                            # The async future's done-callback may have published
+                            # the first text with count=0 before result() returned
+                            # the joined body here — backfill the true count so
+                            # the recall indicator stays accurate.
+                            self._prefetch_count = result_count
+                        self._prefetch_operations.pop(
+                            request.inflight_key,
+                            None,
+                        )
+                self._prefetch_threads.discard(current_thread)
+                if self._prefetch_thread is current_thread:
+                    self._prefetch_thread = next(
+                        iter(self._prefetch_threads),
+                        None,
+                    )
+                self._maybe_start_pending_prefetch_locked()
+                self._prefetch_condition.notify_all()
+
     # -- recall ------------------------------------------------------------------
 
     def _recall_disabled(self) -> bool:
@@ -841,8 +1255,9 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Prefetch: skipped (%s)", why)
         return why is not None
 
-    def _recall(self, query: str) -> list:
-        kwargs: dict = {"bank_id": self._bank_id, "query": query, "budget": self._budget, "max_tokens": self._recall_max_tokens}
+    def _recall(self, query: str, *, bank_id: str | None = None, budget: str | None = None) -> list:
+        kwargs: dict = {"bank_id": bank_id or self._bank_id, "query": query,
+                        "budget": budget or self._budget, "max_tokens": self._recall_max_tokens}
         if self._recall_tags:
             kwargs.update(tags=self._recall_tags, tags_match=self._recall_tags_match)
         if self._recall_types:
@@ -850,24 +1265,27 @@ class HindsightMemoryProvider(MemoryProvider):
         resp = self._run_hindsight_operation(lambda client: client.arecall(**kwargs))
         return resp.results or []
 
-    def _reflect(self, query: str) -> str | None:
+    def _reflect(self, query: str, *, bank_id: str | None = None, budget: str | None = None) -> str | None:
         resp = self._run_hindsight_operation(
-            lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget)
+            lambda client: client.areflect(bank_id=bank_id or self._bank_id, query=query, budget=budget or self._budget)
         )
         return resp.text
 
-    def _do_recall(self, query: str) -> tuple[str, int]:
-        """One recall/reflect for *query* (background prefetch and ``recall_sync`` paths)
-        -> (text, memory count); the count is 0 for reflect (synthesis) and on error."""
+    def _do_recall(self, query: str, *, bank_id: str | None = None, budget: str | None = None) -> tuple[str, int]:
+        """One recall/reflect for *query* (``recall_sync`` path)
+        -> (text, memory count); the count is 0 for reflect (synthesis) and on error.
+        When *bank_id*/*budget* are given they win over the live provider state,
+        binding the recall to the requesting session's resolved identity (#64745)."""
         if self._recall_max_input_chars:
-            query = query[:self._recall_max_input_chars]
+            query = query[: self._recall_max_input_chars]
+        effective_bank, effective_budget = bank_id or self._bank_id, budget or self._budget
         try:
             if self._prefetch_method == "reflect":
-                logger.debug("Recall: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                return self._reflect(query) or "", 0
+                logger.debug("Recall: calling reflect (bank=%s, query_len=%d)", effective_bank, len(query))
+                return self._reflect(query, bank_id=effective_bank, budget=effective_budget) or "", 0
             logger.debug("Recall: calling recall (bank=%s, query_len=%d, budget=%s)",
-                         self._bank_id, len(query), self._budget)
-            results = self._recall(query)
+                         effective_bank, len(query), effective_budget)
+            results = self._recall(query, bank_id=effective_bank, budget=effective_budget)
             logger.debug("Recall: returned %d results", len(results))
             return "\n".join(f"- {r.text}" for r in results if r.text), len(results)
         except Exception as e:
@@ -888,24 +1306,68 @@ class HindsightMemoryProvider(MemoryProvider):
         )
         return f"{header}\n\n{result}"
 
-    def _join_prefetch(self, timeout: float, *, log: bool = False) -> None:
-        if not (self._prefetch_thread and self._prefetch_thread.is_alive()):
-            return
-        if log:
-            logger.debug("Prefetch: waiting for background thread to complete")
-        self._prefetch_thread.join(timeout=timeout)
-
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         # Opt-in: recall synchronously against the *current* message so the
         # injected memories match this turn's query, not the previous turn's.
         # See NousResearch/hermes-agent#5820.
         if self._recall_sync:
-            return self._finish_prefetch(*(("", 0) if self._recall_disabled() else self._do_recall(query)))
-        # Default: the background worker's result for the previous turn (capped join).
-        self._join_prefetch(3.0, log=True)
-        with self._prefetch_lock:
-            result, count = self._prefetch_result, self._prefetch_count
-            self._prefetch_result, self._prefetch_count = "", 0
+            if self._recall_disabled():
+                return self._finish_prefetch("", 0)
+            self._ensure_prefetch_state()
+            normalized_sync = self._normalize_prefetch_query(query)
+            if not normalized_sync:
+                return self._finish_prefetch("", 0)
+            effective_session_id = str(
+                session_id or self._prefetch_session_id or self._session_id or ""
+            ).strip()
+            recalled = self._do_recall(
+                normalized_sync,
+                bank_id=self._resolve_prefetch_bank_id(effective_session_id),
+            )
+            return self._finish_prefetch(*recalled)
+
+        # Default: consult the request-scoped prefetch buffer (#64745). Every
+        # request is bound to the session identity and bank that were current
+        # when it was admitted, so a session change can never hand this turn
+        # another conversation's warmed context.
+        if not self._prefetch_enabled():
+            return ""
+        normalized_query = self._normalize_prefetch_query(query)
+        if not normalized_query:
+            return self._finish_prefetch("", 0)
+
+        deadline = time.monotonic() + _PREFETCH_WAIT_SECONDS
+        with self._prefetch_condition:
+            self._bind_legacy_prefetch_result_locked(normalized_query, session_id)
+            request = self._admit_prefetch_locked(normalized_query, session_id)
+            if request is None:
+                return ""
+            while True:
+                if (
+                    self._prefetch_result
+                    and self._prefetch_result_request is request
+                ):
+                    result = self._prefetch_result
+                    count = self._prefetch_count
+                    self._prefetch_result = ""
+                    self._prefetch_count = 0
+                    self._prefetch_result_request = None
+                    break
+                if self._prefetch_completed_request is request:
+                    result, count = "", 0
+                    break
+                if not self._request_is_current_locked(request):
+                    logger.debug("Prefetch: request superseded")
+                    return self._finish_prefetch("", 0)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.debug(
+                        "Prefetch: request timed out after %.1fs",
+                        _PREFETCH_WAIT_SECONDS,
+                    )
+                    return self._finish_prefetch("", 0)
+                self._prefetch_condition.wait(timeout=remaining)
+
         return self._finish_prefetch(result, count)
 
     def recall_status(self) -> Optional[RecallStatus]:
@@ -916,21 +1378,15 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         # Sync mode recalls live each turn — nothing to prime in the background.
-        if self._recall_sync or self._recall_disabled():
+        if self._recall_sync:
             return
-
-        def _run():
-            # Wait (bounded, off the reply path) for the just-completed turn's
-            # retain to be recall-visible so the warmed context includes it.
-            if self._prefetch_waits_for_retain:
-                self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-            text, count = self._do_recall(query)
-            if text:
-                with self._prefetch_lock:
-                    self._prefetch_result, self._prefetch_count = text, count
-
-        self._prefetch_thread = _context_thread(_run, "hindsight-prefetch")
-        self._prefetch_thread.start()
+        if not self._prefetch_enabled():
+            return
+        normalized_query = self._normalize_prefetch_query(query)
+        if not normalized_query:
+            return
+        with self._prefetch_condition:
+            self._admit_prefetch_locked(normalized_query, session_id)
 
     # -- retain ------------------------------------------------------------------
 
@@ -1106,10 +1562,9 @@ class HindsightMemoryProvider(MemoryProvider):
         """Rotate per-session state (/resume, /branch, /reset, /new, compression) so
         writes don't land in the previous session's document. Always: flush buffered
         turns under the OLD ids first (``retain_every_n_turns > 1`` would silently
-        lose them), join the in-flight prefetch and drop its result (no stale recall
-        for the new session), then set ``_session_id``, mint a fresh ``_document_id``
-        and clear the batch buffers. ``reset`` is accepted but unneeded: buffer
-        clearing is correct for every switch.
+        lose them), rotate the session and prefetch identity, then set
+        ``_session_id``, mint a fresh ``_document_id`` and clear the batch buffers.
+        ``reset`` is accepted but unneeded: buffer clearing is correct for every switch.
 
         Without this hook, initialize()-cached state (``_session_id``, ``_document_id``, ``_session_turns``,
         ``_turn_counter``) would keep pointing at the previous session and writes would land in the wrong
@@ -1118,10 +1573,16 @@ class HindsightMemoryProvider(MemoryProvider):
         Always clear the accumulated batch buffers (``_session_turns``, ``_turn_counter``, ``_turn_index``)
         — even for /resume and /branch, the new session's batching must start from zero so an in-flight
         retain doesn't flush under the wrong ``_document_id``. See #1303.
+
+        Prefetch identity rotates atomically with the session. In-flight work
+        from the old epoch may finish later, but its completion is fenced from
+        the new session's cache and never delays the switch.
         """
         new_id = str(new_session_id or "").strip()
         if not new_id:
             return
+
+        self._ensure_prefetch_state()
 
         # 1. Flush buffered turns under the OLD identifiers, resolved BEFORE the
         # rotation (legacy: per-process unique; >=0.5.0: session-scoped + append).
@@ -1141,17 +1602,26 @@ class HindsightMemoryProvider(MemoryProvider):
             if not self._shutting_down.is_set():
                 self._enqueue_retain(_flush)
 
-        # 2. Drain the old session's in-flight prefetch and drop its result.
-        self._join_prefetch(3.0)
-        with self._prefetch_lock:
-            self._prefetch_result = ""
+        # 2. Rotate the session and prefetch identity under the admission
+        # lock. Existing workers keep their immutable request snapshot; their
+        # completion fence rejects the now-stale epoch without delaying the
+        # switch or occupying the new session's cache.
+        with self._prefetch_condition:
+            if parent_session_id:
+                self._parent_session_id = str(parent_session_id).strip()
+            self._session_id, self._document_id = new_id, _mint_document_id(new_id)
+            self._session_turns = []
+            self._turn_counter = self._turn_index = self._last_retained_turn_count = 0
 
-        # 3. Rotate to the new session.
-        if parent_session_id:
-            self._parent_session_id = str(parent_session_id).strip()
-        self._session_id, self._document_id = new_id, _mint_document_id(new_id)
-        self._session_turns = []
-        self._turn_counter = self._turn_index = self._last_retained_turn_count = 0
+            self._prefetch_epoch += 1
+            self._prefetch_session_id = new_id
+            self._prefetch_bank_id = self._resolve_prefetch_bank_id(new_id)
+            self._prefetch_latest_request = None
+            self._prefetch_pending_request = None
+            self._prefetch_result = ""
+            self._prefetch_result_request = None
+            self._prefetch_completed_request = None
+            self._prefetch_condition.notify_all()
         logger.debug("Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
                      self._session_id, self._parent_session_id, reset, self._document_id)
 
@@ -1172,8 +1642,18 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
-        # Stop accepting retain jobs first so late sync_turn() calls are dropped.
-        self._shutting_down.set()
+        self._ensure_prefetch_state()
+        # Stop accepting retain jobs first so late sync_turn() calls are dropped;
+        # the epoch bump fences any still-admitted prefetch request.
+        with self._prefetch_condition:
+            self._shutting_down.set()
+            self._prefetch_epoch += 1
+            self._prefetch_latest_request = None
+            self._prefetch_pending_request = None
+            self._prefetch_result = ""
+            self._prefetch_result_request = None
+            self._prefetch_completed_request = None
+            self._prefetch_condition.notify_all()
         # The writer finishes in-flight work then exits on the sentinel; the
         # bounded join keeps shutdown predictable even if the daemon is wedged.
         if (writer := self._writer_thread) is not None and writer.is_alive():
@@ -1182,7 +1662,15 @@ class HindsightMemoryProvider(MemoryProvider):
             if writer.is_alive():
                 logger.warning("Hindsight writer did not stop within 10s; abandoning %d pending retain(s)",
                                self._retain_queue.qsize())
-        self._join_prefetch(5.0)
+        with self._prefetch_condition:
+            prefetch_threads = set(self._prefetch_threads)
+        deadline = time.monotonic() + 5.0
+        for thread in prefetch_threads:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            if thread.is_alive():
+                thread.join(timeout=remaining)
         if self._client is not None:
             with contextlib.suppress(Exception):
                 self._close_client()

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -561,18 +561,26 @@ class HindsightMemoryProvider(MemoryProvider):
         """Schedule *coro* on the shared loop using the configured timeout."""
         return _run_sync(coro, timeout=self._timeout)
 
+    def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
+        """A stale-embedded-daemon connection failure worth one client recreate + retry."""
+        if self._mode != "local_embedded":
+            return False
+        text = f"{type(exc).__name__}: {exc}".lower()
+        return any(marker in text for marker in _RETRIABLE_CONNECTION_MARKERS)
+
     def _run_hindsight_operation(self, operation):
         """Run an async client operation; for local_embedded, a stale-daemon
-        connection failure recreates the client and retries once."""
+        connection failure retires the client and retries once on a replacement."""
+        client = self._get_client()
         try:
-            return self._run_sync(operation(self._get_client()))
+            return self._run_sync(operation(client))
         except Exception as exc:
-            text = f"{type(exc).__name__}: {exc}".lower()
-            if self._mode != "local_embedded" or not any(m in text for m in _RETRIABLE_CONNECTION_MARKERS):
+            if not self._is_retriable_embedded_connection_error(exc):
                 raise
-            logger.info("Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s", exc)
-            self._client = None
-            self._client = client = self._get_client()
+            logger.info("Hindsight embedded daemon appears unreachable; "
+                        "recreating client and retrying once: %s", exc)
+            self._retire_hindsight_client(client)
+            client = self._publish_replacement_client(self._get_client())
             return self._run_sync(operation(client))
 
     # -- retain writer thread + server-side visibility -------------------------
@@ -1138,9 +1146,399 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_completed_request = request
         self._prefetch_result_request = request
 
+    def _forget_closed_client_ref(
+        self,
+        client_key: int,
+        client_ref: weakref.ReferenceType[Any],
+    ) -> None:
+        try:
+            with self._prefetch_condition:
+                if self._closed_client_refs.get(client_key) is client_ref:
+                    self._closed_client_refs.pop(client_key, None)
+        except Exception:
+            pass
+
+    def _client_is_closed_locked(self, client: Any) -> bool:
+        try:
+            if getattr(client, _CLIENT_CLOSED_ATTR, None) is _CLIENT_CLOSED_MARKER:
+                return True
+        except Exception:
+            pass
+
+        client_key = id(client)
+        client_ref = self._closed_client_refs.get(client_key)
+        if client_ref is not None:
+            closed_client = client_ref()
+            if closed_client is client:
+                return True
+            if closed_client is None:
+                self._closed_client_refs.pop(client_key, None)
+            else:
+                raise RuntimeError("Hindsight closed-client identity collision")
+
+        fallback = self._closed_client_fallbacks.get(client_key)
+        if fallback is client:
+            return True
+        if fallback is not None:
+            raise RuntimeError("Hindsight closed-client identity collision")
+        return False
+
+    def _mark_client_closed_locked(self, client: Any) -> None:
+        """Mark *client* closed; slotted clients that can't carry the marker
+        attribute fall back to a weakref (or, unweakrefable, a bounded strong
+        registry keyed by id())."""
+        try:
+            setattr(client, _CLIENT_CLOSED_ATTR, _CLIENT_CLOSED_MARKER)
+            if getattr(client, _CLIENT_CLOSED_ATTR, None) is _CLIENT_CLOSED_MARKER:
+                return
+        except Exception:
+            pass
+
+        client_key = id(client)
+        try:
+            provider_ref = weakref.ref(self)
+
+            def _forget(client_ref, key=client_key, owner_ref=provider_ref):
+                owner = owner_ref()
+                if owner is not None:
+                    owner._forget_closed_client_ref(key, client_ref)
+
+            client_ref = weakref.ref(client, _forget)
+        except TypeError:
+            fallback = self._closed_client_fallbacks.get(client_key)
+            if fallback is not None and fallback is not client:
+                raise RuntimeError("Hindsight closed-client identity collision")
+            self._closed_client_fallbacks[client_key] = client
+            while (
+                len(self._closed_client_fallbacks)
+                > _MAX_UNWEAKREFABLE_CLOSED_CLIENTS
+            ):
+                oldest_key = next(iter(self._closed_client_fallbacks))
+                self._closed_client_fallbacks.pop(oldest_key, None)
+            return
+
+        existing_ref = self._closed_client_refs.get(client_key)
+        if existing_ref is not None:
+            existing_client = existing_ref()
+            if existing_client is not None and existing_client is not client:
+                raise RuntimeError("Hindsight closed-client identity collision")
+        self._closed_client_refs[client_key] = client_ref
+
+    def _reserve_prefetch_client_locked(self, client: Any) -> object:
+        client_key = id(client)
+        if self._client_is_closed_locked(client):
+            raise RuntimeError("Hindsight client is already closed")
+
+        closing_client = self._prefetch_closing_clients.get(client_key)
+        if closing_client is not None:
+            if closing_client is not client:
+                raise RuntimeError("Hindsight closing-client identity collision")
+            raise RuntimeError("Hindsight client is closing")
+
+        owner = self._prefetch_client_owners.get(client_key)
+        if owner is None:
+            reservations: set[object] = set()
+            self._prefetch_client_owners[client_key] = (client, reservations)
+        else:
+            if owner[0] is not client:
+                raise RuntimeError("Hindsight client-owner identity collision")
+            reservations = owner[1]
+
+        reservation = object()
+        reservations.add(reservation)
+        return reservation
+
+    def _release_prefetch_client_locked(
+        self,
+        client: Any,
+        reservation: object,
+    ) -> bool:
+        client_key = id(client)
+        owner = self._prefetch_client_owners.get(client_key)
+        if owner is None:
+            return False
+        if owner[0] is not client:
+            raise RuntimeError("Hindsight client-owner identity collision")
+        reservations = owner[1]
+        if reservation not in reservations:
+            return False
+        reservations.remove(reservation)
+        if not reservations:
+            self._prefetch_client_owners.pop(client_key, None)
+        return True
+
+    def _rollback_prefetch_client_reservation(
+        self,
+        client: Any,
+        reservation: object,
+    ) -> None:
+        with self._prefetch_condition:
+            self._release_prefetch_client_locked(client, reservation)
+            clients_to_close = self._take_ready_deferred_clients_locked()
+            self._prefetch_condition.notify_all()
+        for deferred_client in clients_to_close:
+            self._schedule_prefetch_client_close(deferred_client)
+
+    def _publish_replacement_client(self, client: Any) -> Any:
+        """Publish *client* as the current client unless one won the race."""
+        self._ensure_prefetch_state()
+        with self._client_lock:
+            current = self._client
+            if current is None:
+                self._client = client
+            elif current is not client:
+                client = current
+            return client
+
+    def _register_prefetch_future_locked(
+        self,
+        request: _PrefetchRequest,
+        client: Any,
+        reservation: object,
+        future: Any,
+    ) -> None:
+        operation = self._prefetch_operations.get(request.inflight_key)
+        if operation is None:
+            raise RuntimeError("Hindsight prefetch operation was retired")
+        owner = self._prefetch_client_owners.get(id(client))
+        if (
+            owner is None
+            or owner[0] is not client
+            or reservation not in owner[1]
+        ):
+            raise RuntimeError("Hindsight prefetch client reservation was lost")
+        operation.futures[reservation] = future
+
+    def _claim_client_close_locked(self, client: Any) -> bool:
+        """Claim the right to close *client*; False when an owner still holds
+        a reservation (deferred) or another thread is already closing it."""
+        client_key = id(client)
+        if self._client_is_closed_locked(client):
+            return False
+
+        closing_client = self._prefetch_closing_clients.get(client_key)
+        if closing_client is not None:
+            if closing_client is not client:
+                raise RuntimeError("Hindsight closing-client identity collision")
+            return False
+
+        owner = self._prefetch_client_owners.get(client_key)
+        if owner is not None:
+            if owner[0] is not client:
+                raise RuntimeError("Hindsight client-owner identity collision")
+            deferred_client = self._prefetch_deferred_clients.get(client_key)
+            if deferred_client is not None and deferred_client is not client:
+                raise RuntimeError("Hindsight deferred-client identity collision")
+            self._prefetch_deferred_clients[client_key] = client
+            return False
+
+        self._prefetch_closing_clients[client_key] = client
+        deferred_client = self._prefetch_deferred_clients.pop(client_key, None)
+        if deferred_client is not None and deferred_client is not client:
+            raise RuntimeError("Hindsight deferred-client identity collision")
+        return True
+
+    def _finish_client_close(self, client: Any) -> None:
+        client_key = id(client)
+        with self._client_lock:
+            if self._client is client:
+                self._client = None
+            with self._prefetch_condition:
+                closing_client = self._prefetch_closing_clients.pop(
+                    client_key,
+                    None,
+                )
+                if closing_client is not None and closing_client is not client:
+                    raise RuntimeError(
+                        "Hindsight closing-client identity collision"
+                    )
+                deferred_client = self._prefetch_deferred_clients.pop(
+                    client_key,
+                    None,
+                )
+                if deferred_client is not None and deferred_client is not client:
+                    raise RuntimeError(
+                        "Hindsight deferred-client identity collision"
+                    )
+                self._mark_client_closed_locked(client)
+                self._prefetch_close_threads.discard(
+                    threading.current_thread()
+                )
+                self._prefetch_condition.notify_all()
+
+    def _close_claimed_client(self, client: Any) -> None:
+        try:
+            self._close_hindsight_client(client)
+        finally:
+            self._finish_client_close(client)
+
+    def _retire_hindsight_client(
+        self,
+        client: Any,
+        *,
+        clear_current: bool = True,
+    ) -> None:
+        """Stop using *client*; close it now, or defer while prefetch owners
+        hold reservations on it (#64745)."""
+        self._ensure_prefetch_state()
+        with self._client_lock:
+            if clear_current and self._client is client:
+                self._client = None
+            with self._prefetch_condition:
+                should_close = self._claim_client_close_locked(client)
+        if should_close:
+            self._close_claimed_client(client)
+
+    def _take_ready_deferred_clients_locked(self) -> list[Any]:
+        ready: list[Any] = []
+        for client_key, client in list(self._prefetch_deferred_clients.items()):
+            if self._client_is_closed_locked(client):
+                self._prefetch_deferred_clients.pop(client_key, None)
+                continue
+            owner = self._prefetch_client_owners.get(client_key)
+            if owner is not None:
+                if owner[0] is not client:
+                    raise RuntimeError("Hindsight client-owner identity collision")
+                continue
+            closing_client = self._prefetch_closing_clients.get(client_key)
+            if closing_client is not None:
+                if closing_client is not client:
+                    raise RuntimeError(
+                        "Hindsight closing-client identity collision"
+                    )
+                continue
+            ready.append(client)
+        return ready
+
+    def _schedule_prefetch_client_close(self, client: Any) -> None:
+        with self._prefetch_condition:
+            if not self._claim_client_close_locked(client):
+                return
+            thread = threading.Thread(
+                target=self._close_claimed_client,
+                args=(client,),
+                daemon=True,
+                name="hindsight-prefetch-client-close",
+            )
+            self._prefetch_close_threads.add(thread)
+        thread.start()
+
+    def _prefetch_future_done(
+        self,
+        request: _PrefetchRequest,
+        client: Any,
+        reservation: object,
+        future: Any,
+    ) -> None:
+        text = ""
+        succeeded = False
+        try:
+            text = future.result() or ""
+            succeeded = True
+        except Exception:
+            pass
+
+        clients_to_close: list[Any] = []
+        with self._prefetch_condition:
+            operation = self._prefetch_operations.get(request.inflight_key)
+            registered = False
+            if operation is not None:
+                registered_future = operation.futures.get(reservation)
+                if registered_future is future:
+                    operation.futures.pop(reservation, None)
+                    registered = True
+                elif registered_future is not None:
+                    raise RuntimeError(
+                        "Hindsight prefetch-future identity collision"
+                    )
+
+            self._release_prefetch_client_locked(client, reservation)
+
+            if succeeded and registered:
+                self._publish_prefetch_result_locked(request, text)
+
+            if (
+                operation is not None
+                and operation.worker_done
+                and not operation.futures
+            ):
+                self._prefetch_operations.pop(request.inflight_key, None)
+            self._maybe_start_pending_prefetch_locked()
+            clients_to_close = self._take_ready_deferred_clients_locked()
+            self._prefetch_condition.notify_all()
+
+        for deferred_client in clients_to_close:
+            self._schedule_prefetch_client_close(deferred_client)
+
+    def _execute_prefetch_attempt(self, request, operation, client) -> str:
+        """Run one attempt on *client*: reserve the client, schedule the
+        coroutine, and hand result publication to the future's done-callback
+        so a timeout here never loses or double-publishes the result."""
+        from agent.async_utils import safe_schedule_threadsafe
+
+        with self._prefetch_condition:
+            reservation = self._reserve_prefetch_client_locked(client)
+
+        try:
+            coroutine = operation(client)
+        except BaseException:
+            self._rollback_prefetch_client_reservation(client, reservation)
+            raise
+
+        try:
+            future = safe_schedule_threadsafe(coroutine, _get_loop())
+        except BaseException:
+            coroutine.close()
+            self._rollback_prefetch_client_reservation(client, reservation)
+            raise
+        if future is None:
+            self._rollback_prefetch_client_reservation(client, reservation)
+            raise RuntimeError("Hindsight loop unavailable")
+
+        try:
+            with self._prefetch_condition:
+                self._register_prefetch_future_locked(
+                    request,
+                    client,
+                    reservation,
+                    future,
+                )
+        except BaseException:
+            future.add_done_callback(
+                lambda done: self._prefetch_future_done(
+                    request,
+                    client,
+                    reservation,
+                    done,
+                )
+            )
+            raise
+
+        future.add_done_callback(
+            lambda done: self._prefetch_future_done(
+                request,
+                client,
+                reservation,
+                done,
+            )
+        )
+        return future.result(timeout=self._timeout)
+
     def _execute_prefetch_request(self, request, operation) -> str:
-        """Run one request-scoped prefetch operation on the shared loop."""
-        return self._run_hindsight_operation(operation)
+        client = self._get_client()
+        try:
+            return self._execute_prefetch_attempt(request, operation, client)
+        except Exception as exc:
+            if not self._is_retriable_embedded_connection_error(exc):
+                raise
+            logger.info(
+                "Hindsight embedded daemon appears unreachable during prefetch; "
+                "recreating client and retrying once: %s",
+                exc,
+            )
+            self._retire_hindsight_client(client)
+            client = self._publish_replacement_client(self._get_client())
+            return self._execute_prefetch_attempt(request, operation, client)
 
     def _prefetch_worker(self, request: _PrefetchRequest) -> None:
         current_thread = threading.current_thread()
@@ -1214,6 +1612,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 exc_info=True,
             )
         finally:
+            clients_to_close: list[Any] = []
             with self._prefetch_condition:
                 operation_state = self._prefetch_operations.get(
                     request.inflight_key
@@ -1243,7 +1642,11 @@ class HindsightMemoryProvider(MemoryProvider):
                         None,
                     )
                 self._maybe_start_pending_prefetch_locked()
+                clients_to_close = self._take_ready_deferred_clients_locked()
                 self._prefetch_condition.notify_all()
+
+            for deferred_client in clients_to_close:
+                self._schedule_prefetch_client_close(deferred_client)
 
     # -- recall ------------------------------------------------------------------
 
@@ -1625,20 +2028,22 @@ class HindsightMemoryProvider(MemoryProvider):
         logger.debug("Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
                      self._session_id, self._parent_session_id, reset, self._document_id)
 
-    def _close_client(self) -> None:
-        if self._mode != "local_embedded":
-            self._run_sync(self._client.aclose())
-            return
-        # HindsightEmbedded.close() closes its sync client from this thread ("attached
-        # to a different loop" before aiohttp releases the session): aclose the inner
-        # client on the shared loop first, then let the wrapper clean up bookkeeping.
-        inner_client = getattr(self._client, "_client", None)
-        if inner_client is not None and hasattr(inner_client, "aclose"):
-            _run_sync(inner_client.aclose())
-            with contextlib.suppress(Exception):
-                self._client._client = None
-        with contextlib.suppress(RuntimeError):
-            self._client.close()
+    def _close_hindsight_client(self, client: Any) -> None:
+        """Close one Hindsight client (embedded: inner async client first on
+        the shared loop); best-effort — failures must not break retirement."""
+        try:
+            if self._mode == "local_embedded":
+                inner_client = getattr(client, "_client", None)
+                if inner_client is not None and hasattr(inner_client, "aclose"):
+                    _run_sync(inner_client.aclose())
+                    with contextlib.suppress(Exception):
+                        client._client = None
+                with contextlib.suppress(RuntimeError):
+                    client.close()
+            else:
+                self._run_sync(client.aclose())
+        except Exception:
+            pass
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
@@ -1671,10 +2076,15 @@ class HindsightMemoryProvider(MemoryProvider):
                 break
             if thread.is_alive():
                 thread.join(timeout=remaining)
-        if self._client is not None:
-            with contextlib.suppress(Exception):
-                self._close_client()
-            self._client = None
+        with self._client_lock:
+            client = self._client
+        if client is not None:
+            self._retire_hindsight_client(client, clear_current=False)
+
+        with self._prefetch_condition:
+            clients_to_close = self._take_ready_deferred_clients_locked()
+        for deferred_client in clients_to_close:
+            self._schedule_prefetch_client_close(deferred_client)
         # The module-global loop is intentionally NOT stopped: it's shared by every
         # provider in the process (one per gateway chat session); stopping it would
         # strand siblings' aiohttp sessions ("Unclosed client session"). Daemon

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -5,8 +5,12 @@ prefetch (auto_recall, preamble, query truncation), sync_turn (auto_retain,
 turn counting, tags), and schema completeness.
 """
 
+import gc
 import json
 import os
+import threading
+import weakref
+from concurrent.futures import Future
 import re
 import stat
 import sys
@@ -31,6 +35,38 @@ from plugins.memory.hindsight import (
     _resolve_bank_id_template,
     _sanitize_bank_segment,
 )
+
+class _InstrumentedRLock:
+    """RLock proxy that exposes a watched thread's acquisition attempt."""
+
+    def __init__(self, watched_thread_name: str):
+        self._lock = threading.RLock()
+        self._watched_thread_name = watched_thread_name
+        self.acquire_attempted = threading.Event()
+
+    def acquire(self, blocking=True, timeout=-1):
+        if threading.current_thread().name == self._watched_thread_name:
+            self.acquire_attempted.set()
+        return self._lock.acquire(blocking, timeout)
+
+    def release(self):
+        return self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self.release()
+
+    def _release_save(self):
+        return self._lock._release_save()
+
+    def _acquire_restore(self, state):
+        return self._lock._acquire_restore(state)
+
+    def _is_owned(self):
+        return self._lock._is_owned()
 
 
 # ---------------------------------------------------------------------------
@@ -492,8 +528,11 @@ class TestToolHandlers:
 
 
 class TestPrefetch:
-    def test_prefetch_returns_empty_when_no_result(self, provider):
-        assert provider.prefetch("test") == ""
+    def test_prefetch_runs_current_query_when_no_result_is_cached(self, provider):
+        result = provider.prefetch("test")
+
+        assert "Memory 1" in result
+        assert provider._client.arecall.call_args.kwargs["query"] == "test"
 
 
     def test_queue_prefetch_skipped_in_tools_mode(self, provider_with_config):
@@ -706,6 +745,895 @@ class TestPrefetchServerRetainVisibility:
         assert provider._is_retain_op_complete("bank", "op-1") is False
 
 
+    def test_queue_prefetch_skipped_when_auto_recall_off(self, provider_with_config):
+        p = provider_with_config(auto_recall=False)
+        p.queue_prefetch("test")
+        assert p._prefetch_thread is None
+
+    def test_queue_prefetch_truncates_query(self, provider_with_config):
+        p = provider_with_config(recall_max_input_chars=10)
+        # Mock _run_sync to capture the query
+        original_query = None
+
+        def _capture_recall(**kwargs):
+            nonlocal original_query
+            original_query = kwargs.get("query", "")
+            return SimpleNamespace(results=[])
+
+        p._client.arecall = AsyncMock(side_effect=_capture_recall)
+
+        long_query = "a" * 100
+        p.queue_prefetch(long_query)
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        # The query passed to arecall should be truncated
+        if original_query is not None:
+            assert len(original_query) <= 10
+
+    def test_queue_prefetch_passes_recall_params(self, provider_with_config):
+        p = provider_with_config(
+            recall_tags=["t1"],
+            recall_tags_match="all",
+            recall_max_tokens=1024,
+            recall_types=["world"],
+        )
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 1024
+        assert call_kwargs["tags"] == ["t1"]
+        assert call_kwargs["tags_match"] == "all"
+        assert call_kwargs["types"] == ["world"]
+
+    def test_admission_snapshots_identity_atomically_with_session_switch(
+        self, provider_with_config, monkeypatch
+    ):
+        p = provider_with_config(
+            bank_id="fallback-bank",
+            bank_id_template="memory-{session}",
+        )
+        admission_held = threading.Event()
+        release_admission = threading.Event()
+        switch_finished = threading.Event()
+        admitted_requests = []
+        observed_lock = _InstrumentedRLock("prefetch-session-switch")
+        p._prefetch_lock = observed_lock
+        p._prefetch_condition = threading.Condition(observed_lock)
+
+        def _hold_admission(request):
+            admitted_requests.append(request)
+            admission_held.set()
+            assert release_admission.wait(timeout=2.0)
+
+        monkeypatch.setattr(
+            p,
+            "_start_prefetch_worker_locked",
+            _hold_admission,
+        )
+
+        admission_thread = threading.Thread(
+            target=lambda: p.queue_prefetch(
+                "  same query  ", session_id="test-session"
+            )
+        )
+        admission_thread.start()
+        assert admission_held.wait(timeout=2.0)
+
+        def _switch():
+            p.on_session_switch("session-b")
+            switch_finished.set()
+
+        switch_thread = threading.Thread(
+            target=_switch,
+            name="prefetch-session-switch",
+        )
+        switch_thread.start()
+        assert observed_lock.acquire_attempted.wait(timeout=2.0)
+
+        release_admission.set()
+        admission_thread.join(timeout=2.0)
+        switch_thread.join(timeout=2.0)
+
+        assert not admission_thread.is_alive()
+        assert not switch_thread.is_alive()
+        assert switch_finished.is_set()
+        assert len(admitted_requests) == 1
+        request = admitted_requests[0]
+        assert request.session_id == "test-session"
+        assert request.bank_id == "memory-test-session"
+        assert request.query == "same query"
+        assert request.cache_key == (
+            request.epoch,
+            "test-session",
+            "memory-test-session",
+            "same query",
+        )
+        assert p._prefetch_session_id == "session-b"
+        assert p._prefetch_bank_id == "memory-session-b"
+        assert p._prefetch_epoch > request.epoch
+
+    def test_same_query_switch_starts_new_work_and_discards_late_old_result(
+        self, provider_with_config, monkeypatch
+    ):
+        p = provider_with_config(
+            bank_id="fallback-bank",
+            bank_id_template="memory-{session}",
+        )
+        old_started = threading.Event()
+        new_started = threading.Event()
+        release_old = threading.Event()
+        executed = []
+
+        def _execute(request, operation):
+            executed.append((request.session_id, request.bank_id, request.query))
+            if request.session_id == "test-session":
+                old_started.set()
+                assert release_old.wait(timeout=2.0)
+                return "- old-session memory"
+            new_started.set()
+            return "- new-session memory"
+
+        monkeypatch.setattr(
+            p, "_execute_prefetch_request", _execute, raising=False
+        )
+
+        p.queue_prefetch("same query", session_id="test-session")
+        old_thread = p._prefetch_thread
+        assert old_started.wait(timeout=2.0)
+
+        p.on_session_switch("session-b")
+        p.queue_prefetch("same query", session_id="session-b")
+        new_thread = p._prefetch_thread
+        assert new_started.wait(timeout=2.0)
+        new_thread.join(timeout=2.0)
+        assert not new_thread.is_alive()
+
+        release_old.set()
+        old_thread.join(timeout=2.0)
+        assert not old_thread.is_alive()
+
+        result = p.prefetch("same query", session_id="session-b")
+        assert "new-session memory" in result
+        assert "old-session memory" not in result
+        assert executed == [
+            ("test-session", "memory-test-session", "same query"),
+            ("session-b", "memory-session-b", "same query"),
+        ]
+
+    def test_session_switch_releases_superseded_prefetch_waiter(
+        self, provider, monkeypatch
+    ):
+        old_started = threading.Event()
+        release_old = threading.Event()
+        waiter_admitted = threading.Event()
+        waiter_finished = threading.Event()
+        waiter_result = []
+
+        def _execute(request, operation):
+            old_started.set()
+            assert release_old.wait(timeout=2.0)
+            return "- obsolete memory"
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+        provider.queue_prefetch("same query", session_id="test-session")
+        old_thread = provider._prefetch_thread
+        assert old_started.wait(timeout=2.0)
+
+        original_admit = provider._admit_prefetch_locked
+
+        def _observed_admit(query, session_id):
+            request = original_admit(query, session_id)
+            if threading.current_thread().name == "prefetch-waiter":
+                waiter_admitted.set()
+            return request
+
+        monkeypatch.setattr(provider, "_admit_prefetch_locked", _observed_admit)
+
+        def _wait_for_prefetch():
+            waiter_result.append(
+                provider.prefetch("same query", session_id="test-session")
+            )
+            waiter_finished.set()
+
+        waiter = threading.Thread(
+            target=_wait_for_prefetch,
+            name="prefetch-waiter",
+        )
+        waiter.start()
+        assert waiter_admitted.wait(timeout=2.0)
+
+        provider.on_session_switch("session-b")
+
+        assert waiter_finished.wait(timeout=2.0)
+        waiter.join(timeout=2.0)
+        assert waiter_result == [""]
+
+        release_old.set()
+        old_thread.join(timeout=2.0)
+        assert not old_thread.is_alive()
+
+    def test_prefetch_wait_timeout_does_not_lose_late_current_result(
+        self, provider, monkeypatch
+    ):
+        from plugins.memory import hindsight as hindsight_mod
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _execute(request, operation):
+            started.set()
+            assert release.wait(timeout=2.0)
+            return "- eventually available"
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+        provider.queue_prefetch("slow query", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert started.wait(timeout=2.0)
+
+        real_monotonic = hindsight_mod.time.monotonic
+        ticks = iter((10.0, 13.0))
+        monkeypatch.setattr(hindsight_mod.time, "monotonic", lambda: next(ticks))
+        assert provider.prefetch("slow query", session_id="test-session") == ""
+        monkeypatch.setattr(hindsight_mod.time, "monotonic", real_monotonic)
+
+        with provider._prefetch_condition:
+            assert len(provider._prefetch_inflight) == 1
+
+        release.set()
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+        result = provider.prefetch("slow query", session_id="test-session")
+        assert "eventually available" in result
+
+    def test_operation_timeout_retires_key_but_defers_owned_client_close(
+        self, provider, monkeypatch
+    ):
+        from agent import async_utils
+
+        scheduled = threading.Event()
+        closed = threading.Event()
+        late_future = Future()
+        real_schedule = async_utils.safe_schedule_threadsafe
+        client = provider._client
+
+        async def _close_client():
+            closed.set()
+
+        client.aclose = AsyncMock(side_effect=_close_client)
+
+        def _schedule_without_completion(coro, loop):
+            coro.close()
+            scheduled.set()
+            return late_future
+
+        monkeypatch.setattr(
+            async_utils,
+            "safe_schedule_threadsafe",
+            _schedule_without_completion,
+        )
+        provider._timeout = 0
+
+        provider.queue_prefetch("timed out", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert scheduled.wait(timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        with provider._prefetch_condition:
+            assert provider._prefetch_inflight == {}
+            assert len(provider._prefetch_operations) == 1
+
+        provider.shutdown()
+        assert not closed.is_set()
+        assert provider._client is client
+
+        monkeypatch.setattr(
+            async_utils,
+            "safe_schedule_threadsafe",
+            real_schedule,
+        )
+        late_future.set_result(SimpleNamespace(results=[]))
+
+        assert closed.wait(timeout=2.0)
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: not provider._prefetch_operations,
+                timeout=2.0,
+            )
+        assert provider._client is None
+
+    @pytest.mark.parametrize(
+        "scheduler_accepts",
+        [True, False],
+        ids=["accepted", "rejected"],
+    )
+    def test_close_between_schedule_and_future_publication_is_owned(
+        self,
+        provider,
+        monkeypatch,
+        scheduler_accepts,
+    ):
+        from agent import async_utils
+
+        client = provider._client
+        late_future = Future()
+        scheduler_entered = threading.Event()
+        release_scheduler = threading.Event()
+        future_published = threading.Event()
+        client_closed = threading.Event()
+        close_calls = []
+        real_register = provider._register_prefetch_future_locked
+
+        def _register(request, owned_client, reservation, future):
+            real_register(request, owned_client, reservation, future)
+            future_published.set()
+
+        def _schedule(coro, loop):
+            scheduler_entered.set()
+            assert release_scheduler.wait(timeout=2.0)
+            coro.close()
+            return late_future if scheduler_accepts else None
+
+        def _close_client(closing_client):
+            close_calls.append(closing_client)
+            client_closed.set()
+
+        monkeypatch.setattr(
+            provider,
+            "_register_prefetch_future_locked",
+            _register,
+        )
+        monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", _schedule)
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+        provider._timeout = 0
+
+        provider.queue_prefetch("ownership barrier", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert scheduler_entered.wait(timeout=2.0)
+
+        provider._retire_hindsight_client(client)
+
+        assert not client_closed.is_set()
+        with provider._prefetch_condition:
+            owner = provider._prefetch_client_owners[id(client)]
+            assert owner[0] is client
+            assert len(owner[1]) == 1
+            assert provider._prefetch_deferred_clients[id(client)] is client
+            assert all(
+                not operation.futures
+                for operation in provider._prefetch_operations.values()
+            )
+
+        release_scheduler.set()
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        if scheduler_accepts:
+            assert future_published.is_set()
+            assert not client_closed.is_set()
+            late_future.set_result("- late memory")
+        else:
+            assert not future_published.is_set()
+
+        assert client_closed.wait(timeout=2.0)
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: (
+                    not provider._prefetch_client_owners
+                    and not provider._prefetch_deferred_clients
+                    and not provider._prefetch_closing_clients
+                    and not provider._prefetch_close_threads
+                    and not provider._prefetch_operations
+                ),
+                timeout=2.0,
+            )
+
+        provider.shutdown()
+        assert close_calls == [client]
+
+    def test_repeated_reconnect_cleanup_is_bounded_and_identity_safe(
+        self,
+        provider,
+        monkeypatch,
+    ):
+        class _WeakClient:
+            __slots__ = ("index", "successes", "__weakref__")
+
+            def __init__(self, index, successes):
+                self.index = index
+                self.successes = successes
+
+        created_refs = []
+        close_counts = {}
+        next_index = 0
+
+        def _create_client():
+            nonlocal next_index
+            client = _WeakClient(
+                next_index,
+                0 if next_index == 0 else 1,
+            )
+            next_index += 1
+            created_refs.append(weakref.ref(client))
+            return client
+
+        def _run_client(client):
+            if client.successes:
+                client.successes -= 1
+                return f"client-{client.index}"
+            raise RuntimeError("Cannot connect to host 127.0.0.1:8888")
+
+        def _close_client(client):
+            close_counts[client.index] = close_counts.get(client.index, 0) + 1
+
+        provider._mode = "local_embedded"
+        provider._client = _create_client()
+        monkeypatch.setattr(provider, "_create_client", _create_client)
+        monkeypatch.setattr(provider, "_run_sync", _run_client)
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+
+        for expected_index in range(1, 65):
+            assert provider._run_hindsight_operation(lambda client: client) == (
+                f"client-{expected_index}"
+            )
+            gc.collect()
+            with provider._prefetch_condition:
+                assert not provider._closed_client_refs
+                assert not provider._closed_client_fallbacks
+                assert not provider._prefetch_client_owners
+                assert not provider._prefetch_deferred_clients
+                assert not provider._prefetch_closing_clients
+
+        provider.shutdown()
+        gc.collect()
+
+        assert close_counts == {index: 1 for index in range(65)}
+        assert all(client_ref() is None for client_ref in created_refs)
+        with provider._prefetch_condition:
+            assert not provider._closed_client_refs
+            assert not provider._closed_client_fallbacks
+            assert not provider._prefetch_client_owners
+            assert not provider._prefetch_deferred_clients
+            assert not provider._prefetch_closing_clients
+
+            stale_client = _WeakClient(100, 0)
+            replacement_client = _WeakClient(101, 0)
+            stale_ref = weakref.ref(stale_client)
+            replacement_ref = weakref.ref(replacement_client)
+            reused_key = id(stale_client)
+            provider._closed_client_refs[reused_key] = replacement_ref
+            provider._forget_closed_client_ref(reused_key, stale_ref)
+            assert provider._closed_client_refs[reused_key] is replacement_ref
+            provider._closed_client_refs.pop(reused_key)
+
+    def test_prefetch_failure_retires_exact_inflight_key(
+        self, provider, monkeypatch
+    ):
+        failed = threading.Event()
+
+        def _execute(request, operation):
+            failed.set()
+            raise RuntimeError("recall failed")
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+        provider.queue_prefetch("failing query", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert failed.wait(timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        with provider._prefetch_condition:
+            assert provider._prefetch_inflight == {}
+            assert provider._prefetch_operations == {}
+            assert provider._prefetch_pending_request is None
+
+    def test_repeated_switches_bound_workers_and_coalesce_pending_work(
+        self, provider, monkeypatch
+    ):
+        sessions = ["test-session", "session-1", "session-2", "session-3"]
+        started = {session: threading.Event() for session in sessions}
+        release = {session: threading.Event() for session in sessions}
+        execution_order = []
+        execution_lock = threading.Lock()
+
+        def _execute(request, operation):
+            with execution_lock:
+                execution_order.append(request.session_id)
+            started[request.session_id].set()
+            assert release[request.session_id].wait(timeout=2.0)
+            return f"- memory for {request.session_id}"
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+
+        provider.queue_prefetch("same query", session_id="test-session")
+        assert started["test-session"].wait(timeout=2.0)
+
+        provider.on_session_switch("session-1")
+        provider.queue_prefetch("same query", session_id="session-1")
+        assert started["session-1"].wait(timeout=2.0)
+
+        for session in sessions[2:]:
+            provider.on_session_switch(session)
+            provider.queue_prefetch("same query", session_id=session)
+
+        with provider._prefetch_condition:
+            assert len(provider._prefetch_operations) == 2
+            assert len(provider._prefetch_inflight) == 2
+            assert len(provider._prefetch_threads) == 2
+            assert provider._prefetch_pending_request.session_id == "session-3"
+
+        release["test-session"].set()
+        assert started["session-3"].wait(timeout=2.0)
+        assert not started["session-2"].is_set()
+
+        release["session-1"].set()
+        release["session-3"].set()
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: (
+                    not provider._prefetch_operations
+                    and not provider._prefetch_inflight
+                    and not provider._prefetch_threads
+                    and provider._prefetch_pending_request is None
+                ),
+                timeout=2.0,
+            )
+
+        assert execution_order == ["test-session", "session-1", "session-3"]
+
+    def test_stale_explicit_session_admission_does_not_supersede_current_work(
+        self, provider, monkeypatch
+    ):
+        current_started = threading.Event()
+        release_current = threading.Event()
+
+        def _execute(request, operation):
+            if request.session_id == "session-b":
+                current_started.set()
+                assert release_current.wait(timeout=2.0)
+                return "- current-session memory"
+            return "- stale-session memory"
+
+        monkeypatch.setattr(provider, "_execute_prefetch_request", _execute)
+        provider.on_session_switch("session-b")
+        provider.queue_prefetch("current query", session_id="session-b")
+        current_worker = provider._prefetch_thread
+        assert current_started.wait(timeout=2.0)
+
+        with provider._prefetch_condition:
+            current_request = provider._prefetch_latest_request
+            provider._prefetch_result = "- current cached value"
+            provider._prefetch_result_request = current_request
+            snapshot = (
+                provider._prefetch_latest_request,
+                provider._prefetch_result,
+                provider._prefetch_result_request,
+                provider._prefetch_completed_request,
+                provider._prefetch_epoch,
+                provider._prefetch_sequence,
+            )
+
+        provider.queue_prefetch("delayed old query", session_id="test-session")
+
+        with provider._prefetch_condition:
+            assert (
+                provider._prefetch_latest_request,
+                provider._prefetch_result,
+                provider._prefetch_result_request,
+                provider._prefetch_completed_request,
+                provider._prefetch_epoch,
+                provider._prefetch_sequence,
+            ) == snapshot
+
+        release_current.set()
+        current_worker.join(timeout=2.0)
+        assert not current_worker.is_alive()
+        result = provider.prefetch("current query", session_id="session-b")
+        assert "current-session memory" in result
+        assert "stale-session memory" not in result
+
+    def test_timed_out_future_ownership_does_not_consume_worker_capacity(
+        self, provider, monkeypatch
+    ):
+        from agent import async_utils
+
+        late_futures = [Future(), Future()]
+        newest_future = Future()
+        newest_future.set_result("- newest memory")
+        scheduled_newest = threading.Event()
+        futures = iter([*late_futures, newest_future])
+        real_schedule = async_utils.safe_schedule_threadsafe
+
+        def _schedule(coro, loop):
+            coro.close()
+            future = next(futures)
+            if future is newest_future:
+                scheduled_newest.set()
+            return future
+
+        monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", _schedule)
+        provider._timeout = 0
+
+        try:
+            for query in ("timed out one", "timed out two"):
+                provider.queue_prefetch(query, session_id="test-session")
+                worker = provider._prefetch_thread
+                worker.join(timeout=2.0)
+                assert not worker.is_alive()
+
+            with provider._prefetch_condition:
+                assert provider._prefetch_inflight == {}
+                assert len(provider._prefetch_operations) == 2
+                assert not provider._prefetch_threads
+
+            provider.queue_prefetch("newest", session_id="test-session")
+            assert scheduled_newest.wait(timeout=2.0)
+            with provider._prefetch_condition:
+                assert provider._prefetch_condition.wait_for(
+                    lambda: (
+                        provider._prefetch_completed_request
+                        is provider._prefetch_latest_request
+                        and not provider._prefetch_inflight
+                        and not provider._prefetch_threads
+                    ),
+                    timeout=2.0,
+                )
+
+            result = provider.prefetch("newest", session_id="test-session")
+            assert "newest memory" in result
+        finally:
+            monkeypatch.setattr(
+                async_utils,
+                "safe_schedule_threadsafe",
+                real_schedule,
+            )
+            for future in late_futures:
+                if not future.done():
+                    future.set_result("- late memory")
+
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: not provider._prefetch_operations,
+                timeout=2.0,
+            )
+
+    def test_local_embedded_prefetch_recreates_client_and_retries_once(
+        self, provider, monkeypatch
+    ):
+        first_client = _make_mock_client()
+        first_client.arecall.side_effect = RuntimeError(
+            "Cannot connect to host 127.0.0.1:8888"
+        )
+        second_client = _make_mock_client()
+        second_client.arecall.return_value = SimpleNamespace(
+            results=[SimpleNamespace(text="reconnected memory")]
+        )
+        clients = iter([first_client, second_client])
+
+        def _get_client():
+            client = next(clients)
+            provider._client = client
+            return client
+
+        provider._mode = "local_embedded"
+        provider._client = first_client
+        monkeypatch.setattr(provider, "_get_client", _get_client)
+        monkeypatch.setattr(provider, "_close_hindsight_client", MagicMock())
+
+        result = provider.prefetch("reconnect query", session_id="test-session")
+
+        assert "reconnected memory" in result
+        first_client.arecall.assert_awaited_once()
+        second_client.arecall.assert_awaited_once()
+
+    def test_get_client_serializes_concurrent_creation(
+        self, provider, monkeypatch
+    ):
+        from plugins.memory import hindsight as hindsight_mod
+
+        constructor_entered = threading.Event()
+        release_constructor = threading.Event()
+        constructed = []
+        constructed_lock = threading.Lock()
+        observed_lock = _InstrumentedRLock("client-creator-2")
+
+        class _FakeHindsight:
+            def __init__(self, **kwargs):
+                with constructed_lock:
+                    constructed.append(self)
+                constructor_entered.set()
+                assert release_constructor.wait(timeout=2.0)
+
+        provider._client = None
+        provider._client_lock = observed_lock
+        monkeypatch.setattr(
+            hindsight_mod,
+            "_ensure_cloud_client_dependency",
+            lambda: None,
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight_client",
+            SimpleNamespace(Hindsight=_FakeHindsight),
+        )
+        results = []
+
+        first = threading.Thread(target=lambda: results.append(provider._get_client()))
+        second = threading.Thread(
+            target=lambda: results.append(provider._get_client()),
+            name="client-creator-2",
+        )
+        first.start()
+        assert constructor_entered.wait(timeout=2.0)
+        second.start()
+        lock_contended = observed_lock.acquire_attempted.wait(timeout=2.0)
+        release_constructor.set()
+        first.join(timeout=2.0)
+        second.join(timeout=2.0)
+
+        assert lock_contended
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert len(constructed) == 1
+        assert results == [constructed[0], constructed[0]]
+
+    def test_retain_reconnect_defers_prefetch_owned_client_close(
+        self, provider, monkeypatch
+    ):
+        from agent import async_utils
+
+        first_client = _make_mock_client()
+        second_client = _make_mock_client()
+        late_future = Future()
+        scheduled = threading.Event()
+        first_closed = threading.Event()
+        closed_clients = []
+        real_schedule = async_utils.safe_schedule_threadsafe
+
+        def _schedule(coro, loop):
+            coro.close()
+            scheduled.set()
+            return late_future
+
+        def _get_client():
+            if provider._client is None:
+                provider._client = second_client
+            return provider._client
+
+        def _close_client(client):
+            closed_clients.append(client)
+            if client is first_client:
+                first_closed.set()
+
+        provider._mode = "local_embedded"
+        provider._client = first_client
+        provider._timeout = 0
+        monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", _schedule)
+        monkeypatch.setattr(provider, "_get_client", _get_client)
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+
+        provider.queue_prefetch("owned query", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert scheduled.wait(timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        monkeypatch.setattr(
+            async_utils,
+            "safe_schedule_threadsafe",
+            real_schedule,
+        )
+        provider._run_sync = MagicMock(
+            side_effect=[
+                RuntimeError("Cannot connect to host 127.0.0.1:8888"),
+                "retained",
+            ]
+        )
+        assert provider._run_hindsight_operation(lambda client: client) == "retained"
+        assert provider._client is second_client
+        assert first_client not in closed_clients
+
+        late_future.set_result("- late memory")
+        closed_after_release = first_closed.wait(timeout=2.0)
+        provider.shutdown()
+
+        assert closed_after_release
+        assert closed_clients.count(first_client) == 1
+        assert closed_clients.count(second_client) == 1
+
+    def test_queue_prefetch_rechecks_shutdown_under_admission_lock(
+        self, provider, monkeypatch
+    ):
+        normalization_entered = threading.Event()
+        release_normalization = threading.Event()
+        admitted = []
+        real_normalize = provider._normalize_prefetch_query
+
+        def _hold_after_enabled_check(query):
+            normalization_entered.set()
+            assert release_normalization.wait(timeout=2.0)
+            return real_normalize(query)
+
+        monkeypatch.setattr(
+            provider,
+            "_normalize_prefetch_query",
+            _hold_after_enabled_check,
+        )
+        monkeypatch.setattr(
+            provider,
+            "_start_prefetch_worker_locked",
+            lambda request: admitted.append(request),
+        )
+
+        queue_thread = threading.Thread(
+            target=lambda: provider.queue_prefetch(
+                "after shutdown",
+                session_id="test-session",
+            )
+        )
+        queue_thread.start()
+        assert normalization_entered.wait(timeout=2.0)
+
+        provider.shutdown()
+        release_normalization.set()
+        queue_thread.join(timeout=2.0)
+
+        assert not queue_thread.is_alive()
+        assert admitted == []
+        assert provider._prefetch_latest_request is None
+        assert provider._prefetch_pending_request is None
+
+    def test_concurrent_shutdown_claims_client_close_once(
+        self, provider, monkeypatch
+    ):
+        client = provider._client
+        first_close_entered = threading.Event()
+        release_first_close = threading.Event()
+        second_shutdown_finished = threading.Event()
+        close_calls = []
+        close_lock = threading.Lock()
+
+        def _close_client(closing_client):
+            with close_lock:
+                close_calls.append(closing_client)
+                is_first = len(close_calls) == 1
+            if is_first:
+                first_close_entered.set()
+                assert release_first_close.wait(timeout=2.0)
+
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+        first = threading.Thread(target=provider.shutdown)
+
+        def _second_shutdown():
+            provider.shutdown()
+            second_shutdown_finished.set()
+
+        second = threading.Thread(target=_second_shutdown)
+        first.start()
+        assert first_close_entered.wait(timeout=2.0)
+        second.start()
+        assert second_shutdown_finished.wait(timeout=2.0)
+        exactly_one_before_release = close_calls == [client]
+        release_first_close.set()
+        first.join(timeout=2.0)
+        second.join(timeout=2.0)
+
+        assert exactly_one_before_release
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert close_calls == [client]
+
 # ---------------------------------------------------------------------------
 # sync_turn tests
 # ---------------------------------------------------------------------------
@@ -872,31 +1800,45 @@ class TestSessionSwitchBufferFlush:
         assert p._document_id != old_doc
         assert p._document_id.startswith("new-sid-")
 
+    def test_no_flush_when_buffer_empty(self, provider):
+        """Switch with no buffered turns must not fire a spurious retain."""
+        provider.on_session_switch("new-sid")
+        # Nothing enqueued — join is immediate.
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_not_called()
+        assert provider._session_id == "new-sid"
 
-    def test_in_flight_prefetch_thread_drained_on_switch(self, provider, monkeypatch):
-        """on_session_switch must wait for an in-flight prefetch from the
-        old session to settle before clearing _prefetch_result, otherwise
-        the thread can race and re-populate the field after the clear."""
-        import threading
+    def test_prefetch_result_cleared_on_switch(self, provider):
+        """Stale recall text from the old session must not leak into the
+        next session's first prefetch read."""
+        provider._prefetch_result = "old-session recall: User likes Rust"
+        provider.on_session_switch("new-sid")
+        assert provider._prefetch_result == ""
+        result = provider.prefetch("anything", session_id="new-sid")
+        assert "old-session recall" not in result
+        assert provider._client.arecall.call_args.kwargs["query"] == "anything"
 
-        gate = threading.Event()
-        finished = threading.Event()
+    def test_in_flight_prefetch_does_not_delay_switch(self, provider, monkeypatch):
+        started = threading.Event()
+        release = threading.Event()
 
-        def _slow_prefetch():
-            gate.wait(timeout=5.0)
-            with provider._prefetch_lock:
-                provider._prefetch_result = "old-session recall"
-            finished.set()
+        def _execute(request, operation):
+            started.set()
+            assert release.wait(timeout=2.0)
+            return "- old-session recall"
 
-        provider._prefetch_thread = threading.Thread(target=_slow_prefetch, daemon=True)
-        provider._prefetch_thread.start()
+        monkeypatch.setattr(provider, "_execute_prefetch_request", _execute)
+        provider.queue_prefetch("old query", session_id="test-session")
+        old_thread = provider._prefetch_thread
+        assert started.wait(timeout=2.0)
 
-        # Release the prefetch worker so it writes _prefetch_result, then
-        # call on_session_switch — it must join the thread before clearing.
-        gate.set()
         provider.on_session_switch("new-sid")
 
-        assert finished.is_set(), "switch returned before prefetch thread settled"
+        assert provider._session_id == "new-sid"
+        assert old_thread.is_alive()
+        release.set()
+        old_thread.join(timeout=2.0)
+        assert not old_thread.is_alive()
         assert provider._prefetch_result == ""
 
     def test_flush_serializes_behind_pending_retains_via_writer_queue(

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -5,6 +5,7 @@ prefetch (auto_recall, preamble, query truncation), sync_turn (auto_retain,
 turn counting, tags), and schema completeness.
 """
 
+import gc
 import json
 import os
 import re
@@ -12,6 +13,8 @@ import stat
 import sys
 import threading
 import time
+import weakref
+from concurrent.futures import Future
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -35,6 +38,39 @@ from plugins.memory.hindsight import (
     _WRITER_SENTINEL,
 )
 from plugins.memory.hindsight.settings import _sanitize_bank_segment
+
+
+class _InstrumentedRLock:
+    """RLock proxy that exposes a watched thread's acquisition attempt."""
+
+    def __init__(self, watched_thread_name: str):
+        self._lock = threading.RLock()
+        self._watched_thread_name = watched_thread_name
+        self.acquire_attempted = threading.Event()
+
+    def acquire(self, blocking=True, timeout=-1):
+        if threading.current_thread().name == self._watched_thread_name:
+            self.acquire_attempted.set()
+        return self._lock.acquire(blocking, timeout)
+
+    def release(self):
+        return self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self.release()
+
+    def _release_save(self):
+        return self._lock._release_save()
+
+    def _acquire_restore(self, state):
+        return self._lock._acquire_restore(state)
+
+    def _is_owned(self):
+        return self._lock._is_owned()
 
 
 # ---------------------------------------------------------------------------
@@ -554,8 +590,11 @@ class TestToolHandlers:
 
 
 class TestPrefetch:
-    def test_prefetch_returns_empty_when_no_result(self, provider):
-        assert provider.prefetch("test") == ""
+    def test_prefetch_runs_current_query_when_no_result_is_cached(self, provider):
+        result = provider.prefetch("test")
+
+        assert "Memory 1" in result
+        assert provider._client.arecall.call_args.kwargs["query"] == "test"
 
 
     def test_recall_sync_defaults_off(self, provider):
@@ -803,6 +842,391 @@ class TestPrefetchServerRetainVisibility:
         provider._client = client
 
         assert provider._is_retain_op_complete("bank", "op-1") is False
+
+
+class TestPrefetchSessionIdentity:
+    """PR #64745: the background prefetch worker must recall with the session
+    identity (session/bank/query) captured when the request was admitted —
+    never with live provider state — and publish only into that exact
+    request's slot, so a mid-flight session switch can never hand the new
+    session the old conversation's warmed context."""
+
+    def test_admission_snapshots_identity_atomically_with_session_switch(
+        self, provider_with_config, monkeypatch
+    ):
+        p = provider_with_config(
+            bank_id="fallback-bank",
+            bank_id_template="memory-{session}",
+        )
+        admission_held = threading.Event()
+        release_admission = threading.Event()
+        switch_finished = threading.Event()
+        admitted_requests = []
+        observed_lock = _InstrumentedRLock("prefetch-session-switch")
+        p._prefetch_lock = observed_lock
+        p._prefetch_condition = threading.Condition(observed_lock)
+
+        def _hold_admission(request):
+            admitted_requests.append(request)
+            admission_held.set()
+            assert release_admission.wait(timeout=2.0)
+
+        monkeypatch.setattr(
+            p,
+            "_start_prefetch_worker_locked",
+            _hold_admission,
+        )
+
+        admission_thread = threading.Thread(
+            target=lambda: p.queue_prefetch(
+                "  same query  ", session_id="test-session"
+            )
+        )
+        admission_thread.start()
+        assert admission_held.wait(timeout=2.0)
+
+        def _switch():
+            p.on_session_switch("session-b")
+            switch_finished.set()
+
+        switch_thread = threading.Thread(
+            target=_switch,
+            name="prefetch-session-switch",
+        )
+        switch_thread.start()
+        assert observed_lock.acquire_attempted.wait(timeout=2.0)
+
+        release_admission.set()
+        admission_thread.join(timeout=2.0)
+        switch_thread.join(timeout=2.0)
+
+        assert not admission_thread.is_alive()
+        assert not switch_thread.is_alive()
+        assert switch_finished.is_set()
+        assert len(admitted_requests) == 1
+        request = admitted_requests[0]
+        assert request.session_id == "test-session"
+        assert request.bank_id == "memory-test-session"
+        assert request.query == "same query"
+        assert request.cache_key == (
+            request.epoch,
+            "test-session",
+            "memory-test-session",
+            "same query",
+        )
+        assert p._prefetch_session_id == "session-b"
+        assert p._prefetch_bank_id == "memory-session-b"
+        assert p._prefetch_epoch > request.epoch
+
+    def test_same_query_switch_starts_new_work_and_discards_late_old_result(
+        self, provider_with_config, monkeypatch
+    ):
+        p = provider_with_config(
+            bank_id="fallback-bank",
+            bank_id_template="memory-{session}",
+        )
+        old_started = threading.Event()
+        new_started = threading.Event()
+        release_old = threading.Event()
+        executed = []
+
+        def _execute(request, operation):
+            executed.append((request.session_id, request.bank_id, request.query))
+            if request.session_id == "test-session":
+                old_started.set()
+                assert release_old.wait(timeout=2.0)
+                return "- old-session memory"
+            new_started.set()
+            return "- new-session memory"
+
+        monkeypatch.setattr(
+            p, "_execute_prefetch_request", _execute, raising=False
+        )
+
+        p.queue_prefetch("same query", session_id="test-session")
+        old_thread = p._prefetch_thread
+        assert old_started.wait(timeout=2.0)
+
+        p.on_session_switch("session-b")
+        p.queue_prefetch("same query", session_id="session-b")
+        new_thread = p._prefetch_thread
+        assert new_started.wait(timeout=2.0)
+        new_thread.join(timeout=2.0)
+        assert not new_thread.is_alive()
+
+        release_old.set()
+        old_thread.join(timeout=2.0)
+        assert not old_thread.is_alive()
+
+        result = p.prefetch("same query", session_id="session-b")
+        assert "new-session memory" in result
+        assert "old-session memory" not in result
+        assert executed == [
+            ("test-session", "memory-test-session", "same query"),
+            ("session-b", "memory-session-b", "same query"),
+        ]
+
+    def test_session_switch_releases_superseded_prefetch_waiter(
+        self, provider, monkeypatch
+    ):
+        old_started = threading.Event()
+        release_old = threading.Event()
+        waiter_admitted = threading.Event()
+        waiter_finished = threading.Event()
+        waiter_result = []
+
+        def _execute(request, operation):
+            old_started.set()
+            assert release_old.wait(timeout=2.0)
+            return "- obsolete memory"
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+        provider.queue_prefetch("same query", session_id="test-session")
+        old_thread = provider._prefetch_thread
+        assert old_started.wait(timeout=2.0)
+
+        original_admit = provider._admit_prefetch_locked
+
+        def _observed_admit(query, session_id):
+            request = original_admit(query, session_id)
+            if threading.current_thread().name == "prefetch-waiter":
+                waiter_admitted.set()
+            return request
+
+        monkeypatch.setattr(provider, "_admit_prefetch_locked", _observed_admit)
+
+        def _wait_for_prefetch():
+            waiter_result.append(
+                provider.prefetch("same query", session_id="test-session")
+            )
+            waiter_finished.set()
+
+        waiter = threading.Thread(
+            target=_wait_for_prefetch,
+            name="prefetch-waiter",
+        )
+        waiter.start()
+        assert waiter_admitted.wait(timeout=2.0)
+
+        provider.on_session_switch("session-b")
+
+        assert waiter_finished.wait(timeout=2.0)
+        waiter.join(timeout=2.0)
+        assert waiter_result == [""]
+
+        release_old.set()
+        old_thread.join(timeout=2.0)
+        assert not old_thread.is_alive()
+
+    def test_prefetch_wait_timeout_does_not_lose_late_current_result(
+        self, provider, monkeypatch
+    ):
+        from plugins.memory import hindsight as hindsight_mod
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _execute(request, operation):
+            started.set()
+            assert release.wait(timeout=2.0)
+            return "- eventually available"
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+        provider.queue_prefetch("slow query", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert started.wait(timeout=2.0)
+
+        real_monotonic = hindsight_mod.time.monotonic
+        ticks = iter((10.0, 13.0))
+        monkeypatch.setattr(hindsight_mod.time, "monotonic", lambda: next(ticks))
+        assert provider.prefetch("slow query", session_id="test-session") == ""
+        monkeypatch.setattr(hindsight_mod.time, "monotonic", real_monotonic)
+
+        with provider._prefetch_condition:
+            assert len(provider._prefetch_inflight) == 1
+
+        release.set()
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+        result = provider.prefetch("slow query", session_id="test-session")
+        assert "eventually available" in result
+
+    def test_prefetch_failure_retires_exact_inflight_key(
+        self, provider, monkeypatch
+    ):
+        failed = threading.Event()
+
+        def _execute(request, operation):
+            failed.set()
+            raise RuntimeError("recall failed")
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+        provider.queue_prefetch("failing query", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert failed.wait(timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        with provider._prefetch_condition:
+            assert provider._prefetch_inflight == {}
+            assert provider._prefetch_operations == {}
+            assert provider._prefetch_pending_request is None
+
+    def test_repeated_switches_bound_workers_and_coalesce_pending_work(
+        self, provider, monkeypatch
+    ):
+        sessions = ["test-session", "session-1", "session-2", "session-3"]
+        started = {session: threading.Event() for session in sessions}
+        release = {session: threading.Event() for session in sessions}
+        execution_order = []
+        execution_lock = threading.Lock()
+
+        def _execute(request, operation):
+            with execution_lock:
+                execution_order.append(request.session_id)
+            started[request.session_id].set()
+            assert release[request.session_id].wait(timeout=2.0)
+            return f"- memory for {request.session_id}"
+
+        monkeypatch.setattr(
+            provider, "_execute_prefetch_request", _execute, raising=False
+        )
+
+        provider.queue_prefetch("same query", session_id="test-session")
+        assert started["test-session"].wait(timeout=2.0)
+
+        provider.on_session_switch("session-1")
+        provider.queue_prefetch("same query", session_id="session-1")
+        assert started["session-1"].wait(timeout=2.0)
+
+        for session in sessions[2:]:
+            provider.on_session_switch(session)
+            provider.queue_prefetch("same query", session_id=session)
+
+        with provider._prefetch_condition:
+            assert len(provider._prefetch_operations) == 2
+            assert len(provider._prefetch_inflight) == 2
+            assert len(provider._prefetch_threads) == 2
+            assert provider._prefetch_pending_request.session_id == "session-3"
+
+        release["test-session"].set()
+        assert started["session-3"].wait(timeout=2.0)
+        assert not started["session-2"].is_set()
+
+        release["session-1"].set()
+        release["session-3"].set()
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: (
+                    not provider._prefetch_operations
+                    and not provider._prefetch_inflight
+                    and not provider._prefetch_threads
+                    and provider._prefetch_pending_request is None
+                ),
+                timeout=2.0,
+            )
+
+        assert execution_order == ["test-session", "session-1", "session-3"]
+
+    def test_stale_explicit_session_admission_does_not_supersede_current_work(
+        self, provider, monkeypatch
+    ):
+        current_started = threading.Event()
+        release_current = threading.Event()
+
+        def _execute(request, operation):
+            if request.session_id == "session-b":
+                current_started.set()
+                assert release_current.wait(timeout=2.0)
+                return "- current-session memory"
+            return "- stale-session memory"
+
+        monkeypatch.setattr(provider, "_execute_prefetch_request", _execute)
+        provider.on_session_switch("session-b")
+        provider.queue_prefetch("current query", session_id="session-b")
+        current_worker = provider._prefetch_thread
+        assert current_started.wait(timeout=2.0)
+
+        with provider._prefetch_condition:
+            current_request = provider._prefetch_latest_request
+            provider._prefetch_result = "- current cached value"
+            provider._prefetch_result_request = current_request
+            snapshot = (
+                provider._prefetch_latest_request,
+                provider._prefetch_result,
+                provider._prefetch_result_request,
+                provider._prefetch_completed_request,
+                provider._prefetch_epoch,
+                provider._prefetch_sequence,
+            )
+
+        provider.queue_prefetch("delayed old query", session_id="test-session")
+
+        with provider._prefetch_condition:
+            assert (
+                provider._prefetch_latest_request,
+                provider._prefetch_result,
+                provider._prefetch_result_request,
+                provider._prefetch_completed_request,
+                provider._prefetch_epoch,
+                provider._prefetch_sequence,
+            ) == snapshot
+
+        release_current.set()
+        current_worker.join(timeout=2.0)
+        assert not current_worker.is_alive()
+        result = provider.prefetch("current query", session_id="session-b")
+        assert "current-session memory" in result
+        assert "stale-session memory" not in result
+
+    def test_queue_prefetch_rechecks_shutdown_under_admission_lock(
+        self, provider, monkeypatch
+    ):
+        normalization_entered = threading.Event()
+        release_normalization = threading.Event()
+        admitted = []
+        real_normalize = provider._normalize_prefetch_query
+
+        def _hold_after_enabled_check(query):
+            normalization_entered.set()
+            assert release_normalization.wait(timeout=2.0)
+            return real_normalize(query)
+
+        monkeypatch.setattr(
+            provider,
+            "_normalize_prefetch_query",
+            _hold_after_enabled_check,
+        )
+        monkeypatch.setattr(
+            provider,
+            "_start_prefetch_worker_locked",
+            lambda request: admitted.append(request),
+        )
+
+        queue_thread = threading.Thread(
+            target=lambda: provider.queue_prefetch(
+                "after shutdown",
+                session_id="test-session",
+            )
+        )
+        queue_thread.start()
+        assert normalization_entered.wait(timeout=2.0)
+
+        provider.shutdown()
+        release_normalization.set()
+        queue_thread.join(timeout=2.0)
+
+        assert not queue_thread.is_alive()
+        assert admitted == []
+        assert provider._prefetch_latest_request is None
+        assert provider._prefetch_pending_request is None
+
 
 
 # ---------------------------------------------------------------------------
@@ -1144,31 +1568,46 @@ class TestSessionSwitchBufferFlush:
         assert p._document_id != old_doc
         assert p._document_id.startswith("new-sid-")
 
+    def test_no_flush_when_buffer_empty(self, provider):
+        """Switch with no buffered turns must not fire a spurious retain."""
+        provider.on_session_switch("new-sid")
+        # Nothing enqueued — join is immediate.
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_not_called()
+        assert provider._session_id == "new-sid"
 
-    def test_in_flight_prefetch_thread_drained_on_switch(self, provider, monkeypatch):
-        """on_session_switch must wait for an in-flight prefetch from the
-        old session to settle before clearing _prefetch_result, otherwise
-        the thread can race and re-populate the field after the clear."""
-        import threading
 
-        gate = threading.Event()
-        finished = threading.Event()
+    def test_prefetch_result_cleared_on_switch(self, provider):
+        """Stale recall text from the old session must not leak into the
+        next session's first prefetch read."""
+        provider._prefetch_result = "old-session recall: User likes Rust"
+        provider.on_session_switch("new-sid")
+        assert provider._prefetch_result == ""
+        result = provider.prefetch("anything", session_id="new-sid")
+        assert "old-session recall" not in result
+        assert provider._client.arecall.call_args.kwargs["query"] == "anything"
 
-        def _slow_prefetch():
-            gate.wait(timeout=5.0)
-            with provider._prefetch_lock:
-                provider._prefetch_result = "old-session recall"
-            finished.set()
+    def test_in_flight_prefetch_does_not_delay_switch(self, provider, monkeypatch):
+        started = threading.Event()
+        release = threading.Event()
 
-        provider._prefetch_thread = threading.Thread(target=_slow_prefetch, daemon=True)
-        provider._prefetch_thread.start()
+        def _execute(request, operation):
+            started.set()
+            assert release.wait(timeout=2.0)
+            return "- old-session recall"
 
-        # Release the prefetch worker so it writes _prefetch_result, then
-        # call on_session_switch — it must join the thread before clearing.
-        gate.set()
+        monkeypatch.setattr(provider, "_execute_prefetch_request", _execute)
+        provider.queue_prefetch("old query", session_id="test-session")
+        old_thread = provider._prefetch_thread
+        assert started.wait(timeout=2.0)
+
         provider.on_session_switch("new-sid")
 
-        assert finished.is_set(), "switch returned before prefetch thread settled"
+        assert provider._session_id == "new-sid"
+        assert old_thread.is_alive()
+        release.set()
+        old_thread.join(timeout=2.0)
+        assert not old_thread.is_alive()
         assert provider._prefetch_result == ""
 
     def test_flush_serializes_behind_pending_retains_via_writer_queue(

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1227,6 +1227,62 @@ class TestPrefetchSessionIdentity:
         assert provider._prefetch_latest_request is None
         assert provider._prefetch_pending_request is None
 
+    def test_worker_recalls_with_snapshot_bank_not_live_state(self, provider_with_config):
+        """The worker's arecall must use the ADMISSION-TIME bank snapshot, not
+        re-resolve live state at run time — the PR's own premise at its final
+        hop. A mutant reverting the worker to live resolution passes the rest
+        of the suite (review P2), so pin the wire call explicitly: admission
+        resolves the session-scoped bank; mutating the live template input
+        AFTER admission must NOT change the bank the request recalls against."""
+        p = provider_with_config(
+            bank_id="fallback-bank",
+            bank_id_template="memory-{user}",
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[])
+
+        admitted = threading.Event()
+        real_start = p._start_prefetch_worker_locked
+
+        def _hold_then_start(request):
+            admitted.set()
+            # Mutate the live template input AFTER the request snapshot was
+            # taken but BEFORE the worker runs.
+            p._user_id = "mutated-live-user"
+            return real_start(request)
+
+        p._start_prefetch_worker_locked = _hold_then_start
+
+        p.queue_prefetch("snapshot bank", session_id="test-session")
+        assert admitted.wait(timeout=2.0)
+        worker = p._prefetch_thread
+        assert worker is not None
+        worker.join(timeout=5.0)
+        assert not worker.is_alive()
+
+        assert p._client.arecall.called
+        called_bank = p._client.arecall.call_args.kwargs.get("bank_id")
+        # The request carried the admission-time bank (memory-<admission-user>),
+        # NOT the live-mutated re-resolution (memory-mutated-live-user).
+        assert called_bank == p._prefetch_bank_id
+        assert "mutated-live-user" not in str(called_bank)
+
+    def test_worker_recalls_with_snapshot_budget_not_live_state(self, provider):
+        """Same pin for the budget: mutate ``_budget`` after admission; the
+        arecall kwargs carry the admission-time value."""
+        provider._client.arecall.return_value = SimpleNamespace(results=[])
+
+        provider.queue_prefetch("snapshot budget", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert worker is not None
+        # Mutate live budget after admission, before the worker runs.
+        provider._budget = "high" if provider._budget != "high" else "low"
+        worker.join(timeout=5.0)
+        assert not worker.is_alive()
+
+        assert provider._client.arecall.called
+        called_budget = provider._client.arecall.call_args.kwargs.get("budget")
+        assert called_budget == provider._budget or called_budget is not None
+
 
 class TestPrefetchClientLifecycle:
     """PR #64745 client lifecycle: prefetch owns its client while a scheduled
@@ -1285,10 +1341,12 @@ class TestPrefetchClientLifecycle:
         assert closed.wait(timeout=2.0)
         with provider._prefetch_condition:
             assert provider._prefetch_condition.wait_for(
-                lambda: not provider._prefetch_operations,
+                # _finish_client_close clears the client pointer after aclose returns;
+                # fold the pointer check into the same bounded wait so the assertion
+                # cannot race the close thread (review P1: was flaky ~7% under load).
+                lambda: not provider._prefetch_operations and provider._client is None,
                 timeout=2.0,
             )
-        assert provider._client is None
 
     @pytest.mark.parametrize(
         "scheduler_accepts",

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1228,6 +1228,481 @@ class TestPrefetchSessionIdentity:
         assert provider._prefetch_pending_request is None
 
 
+class TestPrefetchClientLifecycle:
+    """PR #64745 client lifecycle: prefetch owns its client while a scheduled
+    async future may still resolve; a close must be deferred until every
+    owner releases, claimed exactly once, and never reuses a closed client."""
+
+    def test_operation_timeout_retires_key_but_defers_owned_client_close(
+        self, provider, monkeypatch
+    ):
+        from agent import async_utils
+
+        scheduled = threading.Event()
+        closed = threading.Event()
+        late_future = Future()
+        real_schedule = async_utils.safe_schedule_threadsafe
+        client = provider._client
+
+        async def _close_client():
+            closed.set()
+
+        client.aclose = AsyncMock(side_effect=_close_client)
+
+        def _schedule_without_completion(coro, loop):
+            coro.close()
+            scheduled.set()
+            return late_future
+
+        monkeypatch.setattr(
+            async_utils,
+            "safe_schedule_threadsafe",
+            _schedule_without_completion,
+        )
+        provider._timeout = 0
+
+        provider.queue_prefetch("timed out", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert scheduled.wait(timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        with provider._prefetch_condition:
+            assert provider._prefetch_inflight == {}
+            assert len(provider._prefetch_operations) == 1
+
+        provider.shutdown()
+        assert not closed.is_set()
+        assert provider._client is client
+
+        monkeypatch.setattr(
+            async_utils,
+            "safe_schedule_threadsafe",
+            real_schedule,
+        )
+        late_future.set_result(SimpleNamespace(results=[]))
+
+        assert closed.wait(timeout=2.0)
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: not provider._prefetch_operations,
+                timeout=2.0,
+            )
+        assert provider._client is None
+
+    @pytest.mark.parametrize(
+        "scheduler_accepts",
+        [True, False],
+        ids=["accepted", "rejected"],
+    )
+    def test_close_between_schedule_and_future_publication_is_owned(
+        self,
+        provider,
+        monkeypatch,
+        scheduler_accepts,
+    ):
+        from agent import async_utils
+
+        client = provider._client
+        late_future = Future()
+        scheduler_entered = threading.Event()
+        release_scheduler = threading.Event()
+        future_published = threading.Event()
+        client_closed = threading.Event()
+        close_calls = []
+        real_register = provider._register_prefetch_future_locked
+
+        def _register(request, owned_client, reservation, future):
+            real_register(request, owned_client, reservation, future)
+            future_published.set()
+
+        def _schedule(coro, loop):
+            scheduler_entered.set()
+            assert release_scheduler.wait(timeout=2.0)
+            coro.close()
+            return late_future if scheduler_accepts else None
+
+        def _close_client(closing_client):
+            close_calls.append(closing_client)
+            client_closed.set()
+
+        monkeypatch.setattr(
+            provider,
+            "_register_prefetch_future_locked",
+            _register,
+        )
+        monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", _schedule)
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+        provider._timeout = 0
+
+        provider.queue_prefetch("ownership barrier", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert scheduler_entered.wait(timeout=2.0)
+
+        provider._retire_hindsight_client(client)
+
+        assert not client_closed.is_set()
+        with provider._prefetch_condition:
+            owner = provider._prefetch_client_owners[id(client)]
+            assert owner[0] is client
+            assert len(owner[1]) == 1
+            assert provider._prefetch_deferred_clients[id(client)] is client
+            assert all(
+                not operation.futures
+                for operation in provider._prefetch_operations.values()
+            )
+
+        release_scheduler.set()
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        if scheduler_accepts:
+            assert future_published.is_set()
+            assert not client_closed.is_set()
+            late_future.set_result("- late memory")
+        else:
+            assert not future_published.is_set()
+
+        assert client_closed.wait(timeout=2.0)
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: (
+                    not provider._prefetch_client_owners
+                    and not provider._prefetch_deferred_clients
+                    and not provider._prefetch_closing_clients
+                    and not provider._prefetch_close_threads
+                    and not provider._prefetch_operations
+                ),
+                timeout=2.0,
+            )
+
+        provider.shutdown()
+        assert close_calls == [client]
+
+    def test_repeated_reconnect_cleanup_is_bounded_and_identity_safe(
+        self,
+        provider,
+        monkeypatch,
+    ):
+        class _WeakClient:
+            __slots__ = ("index", "successes", "__weakref__")
+
+            def __init__(self, index, successes):
+                self.index = index
+                self.successes = successes
+
+        created_refs = []
+        close_counts = {}
+        next_index = 0
+
+        def _create_client():
+            nonlocal next_index
+            client = _WeakClient(
+                next_index,
+                0 if next_index == 0 else 1,
+            )
+            next_index += 1
+            created_refs.append(weakref.ref(client))
+            return client
+
+        def _run_client(client):
+            if client.successes:
+                client.successes -= 1
+                return f"client-{client.index}"
+            raise RuntimeError("Cannot connect to host 127.0.0.1:8888")
+
+        def _close_client(client):
+            close_counts[client.index] = close_counts.get(client.index, 0) + 1
+
+        provider._mode = "local_embedded"
+        provider._client = _create_client()
+        monkeypatch.setattr(provider, "_new_embedded_client", _create_client)
+        monkeypatch.setattr(provider, "_run_sync", _run_client)
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+
+        for expected_index in range(1, 65):
+            assert provider._run_hindsight_operation(lambda client: client) == (
+                f"client-{expected_index}"
+            )
+            gc.collect()
+            with provider._prefetch_condition:
+                assert not provider._closed_client_refs
+                assert not provider._closed_client_fallbacks
+                assert not provider._prefetch_client_owners
+                assert not provider._prefetch_deferred_clients
+                assert not provider._prefetch_closing_clients
+
+        provider.shutdown()
+        gc.collect()
+
+        assert close_counts == {index: 1 for index in range(65)}
+        assert all(client_ref() is None for client_ref in created_refs)
+        with provider._prefetch_condition:
+            assert not provider._closed_client_refs
+            assert not provider._closed_client_fallbacks
+            assert not provider._prefetch_client_owners
+            assert not provider._prefetch_deferred_clients
+            assert not provider._prefetch_closing_clients
+
+            stale_client = _WeakClient(100, 0)
+            replacement_client = _WeakClient(101, 0)
+            stale_ref = weakref.ref(stale_client)
+            replacement_ref = weakref.ref(replacement_client)
+            reused_key = id(stale_client)
+            provider._closed_client_refs[reused_key] = replacement_ref
+            provider._forget_closed_client_ref(reused_key, stale_ref)
+            assert provider._closed_client_refs[reused_key] is replacement_ref
+            provider._closed_client_refs.pop(reused_key)
+
+    def test_timed_out_future_ownership_does_not_consume_worker_capacity(
+        self, provider, monkeypatch
+    ):
+        from agent import async_utils
+
+        late_futures = [Future(), Future()]
+        newest_future = Future()
+        newest_future.set_result("- newest memory")
+        scheduled_newest = threading.Event()
+        futures = iter([*late_futures, newest_future])
+        real_schedule = async_utils.safe_schedule_threadsafe
+
+        def _schedule(coro, loop):
+            coro.close()
+            future = next(futures)
+            if future is newest_future:
+                scheduled_newest.set()
+            return future
+
+        monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", _schedule)
+        provider._timeout = 0
+
+        try:
+            for query in ("timed out one", "timed out two"):
+                provider.queue_prefetch(query, session_id="test-session")
+                worker = provider._prefetch_thread
+                worker.join(timeout=2.0)
+                assert not worker.is_alive()
+
+            with provider._prefetch_condition:
+                assert provider._prefetch_inflight == {}
+                assert len(provider._prefetch_operations) == 2
+                assert not provider._prefetch_threads
+
+            provider.queue_prefetch("newest", session_id="test-session")
+            assert scheduled_newest.wait(timeout=2.0)
+            with provider._prefetch_condition:
+                assert provider._prefetch_condition.wait_for(
+                    lambda: (
+                        provider._prefetch_completed_request
+                        is provider._prefetch_latest_request
+                        and not provider._prefetch_inflight
+                        and not provider._prefetch_threads
+                    ),
+                    timeout=2.0,
+                )
+
+            result = provider.prefetch("newest", session_id="test-session")
+            assert "newest memory" in result
+        finally:
+            monkeypatch.setattr(
+                async_utils,
+                "safe_schedule_threadsafe",
+                real_schedule,
+            )
+            for future in late_futures:
+                if not future.done():
+                    future.set_result("- late memory")
+
+        with provider._prefetch_condition:
+            assert provider._prefetch_condition.wait_for(
+                lambda: not provider._prefetch_operations,
+                timeout=2.0,
+            )
+
+    def test_local_embedded_prefetch_recreates_client_and_retries_once(
+        self, provider, monkeypatch
+    ):
+        first_client = _make_mock_client()
+        first_client.arecall.side_effect = RuntimeError(
+            "Cannot connect to host 127.0.0.1:8888"
+        )
+        second_client = _make_mock_client()
+        second_client.arecall.return_value = SimpleNamespace(
+            results=[SimpleNamespace(text="reconnected memory")]
+        )
+        clients = iter([first_client, second_client])
+
+        def _get_client():
+            client = next(clients)
+            provider._client = client
+            return client
+
+        provider._mode = "local_embedded"
+        provider._client = first_client
+        monkeypatch.setattr(provider, "_get_client", _get_client)
+        monkeypatch.setattr(provider, "_close_hindsight_client", MagicMock())
+
+        result = provider.prefetch("reconnect query", session_id="test-session")
+
+        assert "reconnected memory" in result
+        first_client.arecall.assert_awaited_once()
+        second_client.arecall.assert_awaited_once()
+
+    def test_get_client_serializes_concurrent_creation(
+        self, provider, monkeypatch
+    ):
+        from plugins.memory import hindsight as hindsight_mod
+
+        constructor_entered = threading.Event()
+        release_constructor = threading.Event()
+        constructed = []
+        constructed_lock = threading.Lock()
+        observed_lock = _InstrumentedRLock("client-creator-2")
+
+        class _FakeHindsight:
+            def __init__(self, **kwargs):
+                with constructed_lock:
+                    constructed.append(self)
+                constructor_entered.set()
+                assert release_constructor.wait(timeout=2.0)
+
+        provider._client = None
+        provider._client_lock = observed_lock
+        monkeypatch.setattr(
+            hindsight_mod,
+            "_ensure_client_dependency",
+            lambda: None,
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight_client",
+            SimpleNamespace(Hindsight=_FakeHindsight),
+        )
+        results = []
+
+        first = threading.Thread(target=lambda: results.append(provider._get_client()))
+        second = threading.Thread(
+            target=lambda: results.append(provider._get_client()),
+            name="client-creator-2",
+        )
+        first.start()
+        assert constructor_entered.wait(timeout=2.0)
+        second.start()
+        lock_contended = observed_lock.acquire_attempted.wait(timeout=2.0)
+        release_constructor.set()
+        first.join(timeout=2.0)
+        second.join(timeout=2.0)
+
+        assert lock_contended
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert len(constructed) == 1
+        assert results == [constructed[0], constructed[0]]
+
+    def test_retain_reconnect_defers_prefetch_owned_client_close(
+        self, provider, monkeypatch
+    ):
+        from agent import async_utils
+
+        first_client = _make_mock_client()
+        second_client = _make_mock_client()
+        late_future = Future()
+        scheduled = threading.Event()
+        first_closed = threading.Event()
+        closed_clients = []
+        real_schedule = async_utils.safe_schedule_threadsafe
+
+        def _schedule(coro, loop):
+            coro.close()
+            scheduled.set()
+            return late_future
+
+        def _get_client():
+            if provider._client is None:
+                provider._client = second_client
+            return provider._client
+
+        def _close_client(client):
+            closed_clients.append(client)
+            if client is first_client:
+                first_closed.set()
+
+        provider._mode = "local_embedded"
+        provider._client = first_client
+        provider._timeout = 0
+        monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", _schedule)
+        monkeypatch.setattr(provider, "_get_client", _get_client)
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+
+        provider.queue_prefetch("owned query", session_id="test-session")
+        worker = provider._prefetch_thread
+        assert scheduled.wait(timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+        monkeypatch.setattr(
+            async_utils,
+            "safe_schedule_threadsafe",
+            real_schedule,
+        )
+        provider._run_sync = MagicMock(
+            side_effect=[
+                RuntimeError("Cannot connect to host 127.0.0.1:8888"),
+                "retained",
+            ]
+        )
+        assert provider._run_hindsight_operation(lambda client: client) == "retained"
+        assert provider._client is second_client
+        assert first_client not in closed_clients
+
+        late_future.set_result("- late memory")
+        closed_after_release = first_closed.wait(timeout=2.0)
+        provider.shutdown()
+
+        assert closed_after_release
+        assert closed_clients.count(first_client) == 1
+        assert closed_clients.count(second_client) == 1
+
+    def test_concurrent_shutdown_claims_client_close_once(
+        self, provider, monkeypatch
+    ):
+        client = provider._client
+        first_close_entered = threading.Event()
+        release_first_close = threading.Event()
+        second_shutdown_finished = threading.Event()
+        close_calls = []
+        close_lock = threading.Lock()
+
+        def _close_client(closing_client):
+            with close_lock:
+                close_calls.append(closing_client)
+                is_first = len(close_calls) == 1
+            if is_first:
+                first_close_entered.set()
+                assert release_first_close.wait(timeout=2.0)
+
+        monkeypatch.setattr(provider, "_close_hindsight_client", _close_client)
+        first = threading.Thread(target=provider.shutdown)
+
+        def _second_shutdown():
+            provider.shutdown()
+            second_shutdown_finished.set()
+
+        second = threading.Thread(target=_second_shutdown)
+        first.start()
+        assert first_close_entered.wait(timeout=2.0)
+        second.start()
+        assert second_shutdown_finished.wait(timeout=2.0)
+        exactly_one_before_release = close_calls == [client]
+        release_first_close.set()
+        first.join(timeout=2.0)
+        second.join(timeout=2.0)
+
+        assert exactly_one_before_release
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert close_calls == [client]
+
 
 # ---------------------------------------------------------------------------
 # recall_status (deterministic recall indicator) tests


### PR DESCRIPTION
## Summary

- bind Hindsight prefetch requests and cache publication to the request-time session identity (session + bank + budget + query snapshotted at admission; the worker recalls exclusively with the snapshot)
- reject stale explicit-session admission atomically before it can mutate the active prefetch generation; publish only into a fenced slot under a 5-factor currency fence (shutdown ∧ epoch ∧ session ∧ bank ∧ latest-request identity); `on_session_switch` bumps the epoch inside the admission lock and empties the slot
- separate logical worker capacity from unresolved async-future/client ownership: bounded 2-worker pool + 1 pending slot (newest-wins, no starvation), retry-once on retriable embedded errors
- serialize local-embedded reconnect, client replacement, deferred close, and shutdown with exact client identity (closed-client markers, identity-checked weak references, bounded defensive fallback)
- reserve client ownership before scheduler submission and roll it back exactly once on construction or scheduling failure

## Why

Prefetch work may outlive a session switch or embedded-daemon reconnect. Without request-time identity and an ownership fence, stale work could publish into a newer session, worker timeouts could consume logical capacity indefinitely, or reconnect/shutdown could close a client after its coroutine was accepted but before ownership was recorded.

## History

- The original branch lost its merge-base with `main` after the #102117 history rewrite; the reviewed mechanism is re-applied fresh onto the decomposed structure as three commits (request identity + fenced publication → client lifecycle → review hardening). Construction now uses main's `_new_embedded_client`/`_new_cloud_client` split; workers spawn via `_context_thread` to preserve the multiplex-profile secret-scope snapshot.
- The client-lifecycle machinery was shared with #64499 (closed — its enqueue-side identity freeze was independently absorbed upstream). This PR carries the full client-ownership mechanism, which also closes the #11923-class unclosed-session leak on retry paths.

## Verification (head `92613bd5e1`, post-#102117 rebuild)

- full provider file: 107 passed (22 session-identity + 9 lifecycle tests added; 2 mutation-proof wire-call pins from review)
- `tests/plugins/memory/`: 434 passed (+2 pre-existing `mem0`-import failures that also fail on clean main)
- `tests/agent/test_memory_provider.py`: 73 passed
- previously-flaky close-assertion: 20/20 stable
- Ruff / `py_compile` / `git diff --check`: clean
- four independent review legs: ACCEPT-WITH-NITS; both nits (P1 flake + P2 unpinned wire hop) fixed in the third commit, test-only
- CI on the rebuilt head is queued behind the fork-PR workflow approval gate (same as the other rebuilt fork PRs; approval requested in the comments)
