### PR TITLE
fix(upstage): honor reasoning effort "none" instead of collapsing it to Solar's high

### DIFF
--- a/plugins/model-providers/upstage/__init__.py
+++ b/plugins/model-providers/upstage/__init__.py
@@ -76,7 +76,12 @@ class UpstageProfile(ProviderProfile):
             return {}, top_level
 
         # Map Hermes' effort vocabulary onto Solar's accepted set. xhigh/max/
-        # ultra collapse to high (Solar's strongest). minimal → off (omit).
+        # ultra collapse to high (Solar's strongest). none/minimal → off (omit).
+        # "none" must be listed explicitly: it arrives without `enabled: False`
+        # (batch_runner's --reasoning_disabled sends {"effort": "none"}, and
+        # --reasoning_effort none sends {"enabled": True, "effort": "none"}), so
+        # the disable guard above never sees it and the catch-all below would
+        # otherwise invert reasoning-off into Solar's strongest effort.
         # Unknown-but-enabled efforts (future vocabulary additions above
         # "high", per the max/ultra precedent in #62650) also collapse to
         # high rather than silently downgrading to the medium default.
@@ -85,6 +90,7 @@ class UpstageProfile(ProviderProfile):
             top_level["reasoning_effort"] = _DEFAULT_REASONING_EFFORT
             return {}, top_level
         mapped = {
+            "none": None,
             "minimal": None,
             "low": "low",
             "medium": "medium",

--- a/plugins/model-providers/upstage/__init__.py
+++ b/plugins/model-providers/upstage/__init__.py
@@ -76,14 +76,14 @@ class UpstageProfile(ProviderProfile):
             return {}, top_level
 
         # Map Hermes' effort vocabulary onto Solar's accepted set via the
-        # shared clamp (agent.reasoning_effort). minimal → omit (Solar's
+        # shared clamp (agent.reasoning_effort). none/minimal → omit (Solar's
         # minimal means off); unknown-but-enabled bespoke levels collapse to
         # high rather than silently downgrading (#62650 precedent).
         effort = (reasoning_config.get("effort") or "").strip().lower()
         if not effort:
             top_level["reasoning_effort"] = _DEFAULT_REASONING_EFFORT
             return {}, top_level
-        if effort == "minimal":
+        if effort in ("none", "minimal"):
             return {}, top_level
 
         from agent.reasoning_effort import EFFORT_LADDER, SOLAR_EFFORTS, clamp_effort

--- a/tests/plugins/model_providers/test_upstage_profile.py
+++ b/tests/plugins/model_providers/test_upstage_profile.py
@@ -111,6 +111,24 @@ class TestUpstageReasoning:
         )
         assert top_level == {}
 
+    def test_effort_none_omits_field(self, upstage_profile):
+        # "none" is documented-valid Hermes effort vocabulary, and neither shape
+        # it arrives in carries `enabled: False`, so the disable guard above
+        # can't catch either: batch_runner's --reasoning_disabled builds
+        # {"effort": "none"}, and --reasoning_effort none builds
+        # {"enabled": True, "effort": "none"}. A request to turn reasoning OFF
+        # must never reach the unknown-effort catch-all and become Solar's
+        # strongest effort.
+        _, top_level = upstage_profile.build_api_kwargs_extras(
+            reasoning_config={"effort": "none"}, model="solar-pro3"
+        )
+        assert top_level == {}
+
+        _, top_level = upstage_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"}, model="solar-pro3"
+        )
+        assert top_level == {}
+
     def test_disabled_omits_field(self, upstage_profile):
         # `/reasoning none` → enabled False → explicitly off.
         _, top_level = upstage_profile.build_api_kwargs_extras(

--- a/tests/plugins/model_providers/test_upstage_profile.py
+++ b/tests/plugins/model_providers/test_upstage_profile.py
@@ -202,3 +202,65 @@ def upstage_profile_singleton():
     import providers
 
     return providers.get_provider_profile("upstage")
+
+
+class TestUpstageFullKwargsIntegration:
+    """End-to-end: the transport's final kwargs honor reasoning off.
+
+    The profile-level tests above exercise ``build_api_kwargs_extras`` in
+    isolation, but the user-visible request contract is finalized when
+    ``ChatCompletionsTransport.build_kwargs`` merges the profile's top-level
+    fields into the API kwargs. These pin the wire contract for both
+    reasoning-off shapes batch_runner emits (--reasoning_disabled →
+    {"effort": "none"}, --reasoning_effort none → {"enabled": True,
+    "effort": "none"}): ``reasoning_effort`` must be absent from the final
+    kwargs. Mirrors TestOllamaCloudFullKwargsIntegration.
+    """
+
+    def test_full_kwargs_with_effort_none_reasoning_disabled_shape(self, upstage_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="solar-pro3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=upstage_profile,
+            reasoning_config={"effort": "none"},
+            base_url="https://api.upstage.ai/v1",
+            provider_name="upstage",
+        )
+        assert kwargs["model"] == "solar-pro3"
+        assert "reasoning_effort" not in kwargs
+        # Solar takes reasoning_effort top-level only — never via extra_body.
+        assert "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_full_kwargs_with_effort_none_enabled_true_shape(self, upstage_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="solar-pro3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=upstage_profile,
+            reasoning_config={"enabled": True, "effort": "none"},
+            base_url="https://api.upstage.ai/v1",
+            provider_name="upstage",
+        )
+        assert "reasoning_effort" not in kwargs
+        assert "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_full_kwargs_with_high_still_lands(self, upstage_profile):
+        # Positive control: the absence assertions above are only meaningful
+        # if the transport actually wires this profile's reasoning field.
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="solar-pro3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=upstage_profile,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="https://api.upstage.ai/v1",
+            provider_name="upstage",
+        )
+        assert kwargs["reasoning_effort"] == "high"

--- a/tests/plugins/model_providers/test_upstage_profile.py
+++ b/tests/plugins/model_providers/test_upstage_profile.py
@@ -148,3 +148,65 @@ def upstage_profile_singleton():
     import providers
 
     return providers.get_provider_profile("upstage")
+
+
+class TestUpstageFullKwargsIntegration:
+    """End-to-end: the transport's final kwargs honor reasoning off.
+
+    The profile-level tests above exercise ``build_api_kwargs_extras`` in
+    isolation, but the user-visible request contract is finalized when
+    ``ChatCompletionsTransport.build_kwargs`` merges the profile's top-level
+    fields into the API kwargs. These pin the wire contract for both
+    reasoning-off shapes batch_runner emits (--reasoning_disabled →
+    {"effort": "none"}, --reasoning_effort none → {"enabled": True,
+    "effort": "none"}): ``reasoning_effort`` must be absent from the final
+    kwargs. Mirrors TestOllamaCloudFullKwargsIntegration.
+    """
+
+    def test_full_kwargs_with_effort_none_reasoning_disabled_shape(self, upstage_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="solar-pro3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=upstage_profile,
+            reasoning_config={"effort": "none"},
+            base_url="https://api.upstage.ai/v1",
+            provider_name="upstage",
+        )
+        assert kwargs["model"] == "solar-pro3"
+        assert "reasoning_effort" not in kwargs
+        # Solar takes reasoning_effort top-level only — never via extra_body.
+        assert "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_full_kwargs_with_effort_none_enabled_true_shape(self, upstage_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="solar-pro3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=upstage_profile,
+            reasoning_config={"enabled": True, "effort": "none"},
+            base_url="https://api.upstage.ai/v1",
+            provider_name="upstage",
+        )
+        assert "reasoning_effort" not in kwargs
+        assert "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_full_kwargs_with_high_still_lands(self, upstage_profile):
+        # Positive control: the absence assertions above are only meaningful
+        # if the transport actually wires this profile's reasoning field.
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="solar-pro3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=upstage_profile,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="https://api.upstage.ai/v1",
+            provider_name="upstage",
+        )
+        assert kwargs["reasoning_effort"] == "high"

--- a/tests/plugins/model_providers/test_upstage_profile.py
+++ b/tests/plugins/model_providers/test_upstage_profile.py
@@ -93,6 +93,24 @@ class TestUpstageReasoning:
         assert top_level == {"reasoning_effort": "high"}
 
 
+    def test_effort_none_omits_field(self, upstage_profile):
+        # "none" is documented-valid Hermes effort vocabulary, and neither shape
+        # it arrives in carries `enabled: False`, so the disable guard above
+        # can't catch either: batch_runner's --reasoning_disabled builds
+        # {"effort": "none"}, and --reasoning_effort none builds
+        # {"enabled": True, "effort": "none"}. A request to turn reasoning OFF
+        # must never reach the unknown-effort catch-all and become Solar's
+        # strongest effort.
+        _, top_level = upstage_profile.build_api_kwargs_extras(
+            reasoning_config={"effort": "none"}, model="solar-pro3"
+        )
+        assert top_level == {}
+
+        _, top_level = upstage_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"}, model="solar-pro3"
+        )
+        assert top_level == {}
+
     def test_disabled_omits_field(self, upstage_profile):
         # `/reasoning none` → enabled False → explicitly off.
         _, top_level = upstage_profile.build_api_kwargs_extras(


### PR DESCRIPTION
## What does this PR do?

A request to turn reasoning **off** is silently inverted into Solar's **strongest** reasoning effort.

`"none"` is documented-valid effort vocabulary in Hermes (`batch_runner.py:1264` lists it first in `valid_efforts`), but `UpstageProfile.build_api_kwargs_extras` never maps it. It falls through to the unknown-effort catch-all and becomes `"high"`:

```
{"effort": "none"}                  -> {'reasoning_effort': 'high'}
{"enabled": True, "effort": "none"} -> {'reasoning_effort': 'high'}
```

**Both reasoning-off entry points are affected** (`batch_runner.py:1256-1268`):

| Flag | Config built | Why the guards miss it |
|---|---|---|
| `--reasoning_disabled` | `{"effort": "none"}` | no `"enabled"` key, so the `enabled is False` guard doesn't fire |
| `--reasoning_effort none` | `{"enabled": True, "effort": "none"}` | explicitly sets `enabled: True` — the guard can *never* catch this one |

The effort is non-empty, so the empty-effort early return misses too, and `.get(effort, "high")` does the rest. The config is passed to the profile unchanged (`agent/transports/chat_completions.py:580`), then `api_kwargs.update(...)` puts `reasoning_effort: high` on the wire.

**User-visible cost:** the console prints `Reasoning: DISABLED (effort=none)` while every request in the batch carries `reasoning_effort: high` — inflated thinking-token spend and latency on every task, silently, with no error. The one signal the user gets says the opposite of what happens.

`1f41bdbec` made this maximal: it changed the fallback from `_DEFAULT_REASONING_EFFORT` to `"high"`, so `"none"` went from wrongly yielding `medium` to wrongly yielding `high`.

**upstage is the sole provider profile missing this guard.** The siblings all handle it explicitly:

- `plugins/model-providers/ollama-cloud/__init__.py:52` — `if effort == "none":`
- `plugins/model-providers/zai/__init__.py:76` — `if not effort or effort == "none":`
- `plugins/model-providers/opencode-zen/__init__.py:74` — `if not effort or effort == "none":`

Three profiles carrying an explicit `"none"` branch is direct evidence the shape is expected input at this layer, so the fix belongs in the profile rather than in `batch_runner`.

## Related Issue

None — found by reading the provider profiles against `batch_runner`'s effort vocabulary.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/upstage/__init__.py` — add `"none": None` to the effort map. It routes through the existing `if mapped:` guard, so the field is omitted and Solar applies its own default (`minimal` = off), matching the siblings. The deliberate unknown → `"high"` catch-all for future vocabulary above `high` (per #62650) is preserved.
- `tests/plugins/model_providers/test_upstage_profile.py` — regression test covering **both** shapes.

## How to Test

1. Reproduce on `main` — both shapes return Solar's strongest effort:
   ```
   {'effort': 'none'}                  -> {'reasoning_effort': 'high'}
   {'enabled': True, 'effort': 'none'} -> {'reasoning_effort': 'high'}
   ```
2. `pytest tests/plugins/model_providers/test_upstage_profile.py -q` on unpatched code → `test_effort_none_omits_field` fails with `assert {'reasoning_effort': 'high'} == {}`.
3. Apply the one-line fix → both shapes return `{}`; **41 passed** across `test_upstage_profile.py` + `tests/hermes_cli/test_upstage_provider.py`, **206 passed** across `tests/plugins/model_providers/`.
4. `test_unknown_future_effort_collapses_to_high` and the `xhigh`/`max`/`ultra` collapse tests stay green — the catch-all is untouched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the provider lane: 206 passed in tests/plugins/model_providers/, plus tests/hermes_cli/test_upstage_provider.py — not the full suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- comment above the effort map updated to record why "none" must be explicit -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure dict-lookup logic, no platform surface -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

**Invariant:** a documented reasoning-**off** request must never emit a `reasoning_effort` that turns reasoning **on** — least of all Solar's strongest level.

- **Known-bad inputs now covered:** `{"effort": "none"}` (the `--reasoning_disabled` shape) and `{"enabled": True, "effort": "none"}` (the `--reasoning_effort none` shape). Both previously emitted `reasoning_effort: high`; both now omit the field.
- **Future-input coverage:** the unknown-effort catch-all still collapses to `"high"`, so a future level *above* `high` won't silently downgrade — `test_unknown_future_effort_collapses_to_high` pins this and stays green. Only the one documented off-value is carved out.
- **Negative case:** `test_pro_explicit_effort_passes_through` (`low`/`medium`/`high`) and the `xhigh`/`max`/`ultra` collapse tests confirm the fix doesn't over-suppress — reasoning-on requests are unchanged.