### PR TITLE
fix(slack): stop double-decoding HTML entities when escaping message text

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2108,7 +2108,14 @@ class SlackAdapter(BasePlatformAdapter):
 
         # 6) Escape Slack control characters in remaining plain text.
         # Unescape first so already-escaped input doesn't get double-escaped.
-        text = text.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+        # Single pass: sequential str.replace would re-scan its own output, so
+        # the & from "&amp;" could pair with a following "lt;" and decode twice
+        # ("&amp;lt;" → "&lt;" → "<"), destroying literal entity text.
+        text = re.sub(
+            r"&(amp|lt|gt);",
+            lambda m: {"amp": "&", "lt": "<", "gt": ">"}[m.group(1)],
+            text,
+        )
         text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
         # 7) Convert headers (## Title) → *Title* (bold)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2519,6 +2519,16 @@ class TestFormatMessage:
         """Already-escaped &gt; in plain text must not become &amp;gt;."""
         assert adapter.format_message("5 &gt; 3") == "5 &gt; 3"
 
+    def test_escaped_entity_text_not_double_decoded(self, adapter):
+        """&amp;lt; is the wire form of the literal text &lt; — it must survive.
+
+        The unescape pass must not re-scan its own output: decoding &amp; to &
+        first must not let the resulting & combine with a following lt; into a
+        second decode, or the literal text is silently destroyed.
+        """
+        assert adapter.format_message("&amp;lt;") == "&amp;lt;"
+        assert adapter.format_message("&amp;gt;") == "&amp;gt;"
+
     def test_mixed_raw_and_escaped_entities(self, adapter):
         """Raw & and pre-escaped &amp; coexist correctly."""
         result = adapter.format_message("AT&T and &amp; entity")


### PR DESCRIPTION
## What does this PR do?

`format_message` silently destroys literal HTML-entity text before it reaches Slack.

Step 6 unescapes already-escaped input so it doesn't get double-escaped — a real invariant the test suite already guards. But the unescape is three **sequential** `str.replace` calls, and each re-scans the previous one's output:

```
"&amp;lt;"  --(&amp; → &)-->  "&lt;"  --(&lt; → <)-->  "<"
```

The `&` produced by the first replace pairs with the following `lt;` and decodes a **second** time. `&amp;lt;` is the wire form of the literal text `&lt;` — so Slack receives `&lt;` and renders `<`. The user's literal text is gone, with no error.

Observed on `main` (buggy) vs. patched (fixed):

| input | on `main` | patched | |
|---|---|---|---|
| `&amp;lt;` | `&lt;` | `&amp;lt;` | ⬅ the bug |
| `&amp;gt;` | `&gt;` | `&amp;gt;` | ⬅ the bug |
| `&amp;lt;b&amp;gt;` | `&lt;b&gt;` → renders `<b>` | `&amp;lt;b&amp;gt;` | ⬅ the bug |
| `&amp;amp;` | `&amp;amp;` | `&amp;amp;` | already correct |
| `&lt;` / `&gt;` / `&amp;` | unchanged | unchanged | already correct |
| `a & b` / `<x>` / `AT&T < 5 > 3` | unchanged | unchanged | already correct |

Anyone writing *about* markup — a code review comment, a docs snippet, an agent explaining HTML — hits this. Reaches Slack via `send()` (L1414), `edit_message()` (L1531), and Block Kit sections (L2046 routes section text through `format_message`), so both the plain mrkdwn and Block Kit paths are affected.

`re.sub` scans left-to-right and never re-scans its own replacements, so a single pass fixes it. **Only the double-decode cases change; every other input is byte-identical before and after.**

This is not a new invariant. It's the same contract `test_pre_escaped_ampersand_not_double_escaped`, `test_pre_escaped_lt_not_double_escaped`, and `test_pre_escaped_gt_not_double_escaped` already assert (L2510-2520) — extended to the case they miss.

## Related Issue

None — found by reading the escaping passes in `format_message` against the round-trip invariant its own tests assert.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py` — replace the three chained `str.replace` unescape calls with a single `re.sub` pass over `&(amp|lt|gt);`. The escape line below is deliberately left as-is: it's correctly ordered (`&` first, so the `&`s it inserts aren't re-escaped). `re` is already imported (L16).
- `tests/gateway/test_slack.py` — regression test alongside the three existing pre-escape tests in `TestFormatMessage`.

## How to Test

1. On `main`: `adapter.format_message("&amp;lt;")` returns `'&lt;'` instead of `'&amp;lt;'`.
2. `pytest tests/gateway/test_slack.py -k escaped_entity_text_not_double_decoded` on unpatched code → fails with `assert '&lt;' == '&amp;lt;'`.
3. Apply the fix → passes. **240 passed** in `tests/gateway/test_slack.py`; **400 passed** across the Slack surface (`test_slack.py`, `test_slack_block_kit.py`, `test_slack_block_kit_adapter.py`, `test_slack_approval_buttons.py`, `test_slack_mention.py`, `test_slack_plugin_action_handlers.py`, `test_slack_channel_skills.py`).
4. The three existing `test_pre_escaped_*_not_double_escaped` tests and `test_mixed_raw_and_escaped_entities` stay green — the fix doesn't over-correct.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the full Slack surface: 400 passed — not the entire suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- comment above the unescape updated to record why the single pass is required -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure string logic, no platform surface -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

**Invariant:** unescaping already-escaped input must decode each entity exactly once — an escaped entity's own text must round-trip intact.

- **Known-bad inputs now covered:** `&amp;lt;` and `&amp;gt;` (the wire forms of the literal texts `&lt;` and `&gt;`). Both previously decoded twice and lost their literal meaning.
- **Future-input coverage:** the cascade is structural, not enumerable — any `&amp;` immediately followed by `lt;`/`gt;` triggers it. `re.sub`'s single left-to-right pass removes the class of bug rather than the two instances, so a future entity added to the map can't reintroduce it.
- **Negative case:** the three existing `test_pre_escaped_*_not_double_escaped` tests plus `test_mixed_raw_and_escaped_entities` and `test_escapes_control_characters` confirm the fix doesn't under-decode — genuinely pre-escaped single entities and raw `&`/`<`/`>` are handled exactly as before.