### PR TITLE
fix(kanban): heartbeat workers during silent turns

### DIFF
--- a/agent/kanban_worker_heartbeat.py
+++ b/agent/kanban_worker_heartbeat.py
@@ -1,0 +1,134 @@
+"""Process-side heartbeat keepalive for dispatcher-spawned workers.
+
+The agent's normal activity bridge only runs when model chunks or tools make
+foreground progress. A provider request can remain silent longer than the
+kanban stale-heartbeat threshold, so workers also need a liveness signal from
+a thread that is independent of the model turn.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import threading
+from collections.abc import Callable, Iterator
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+WORKER_HEARTBEAT_INTERVAL_SECONDS = 5 * 60.0
+
+
+def _heartbeat_current_run() -> bool:
+    """Refresh the current run and return whether this process still owns it.
+
+    The dispatcher injects all three identity values. Requiring the run id and
+    claim lock prevents a delayed thread from touching a task that has already
+    been reclaimed and assigned to another worker.
+    """
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    run_id_raw = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    claim_lock = (os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+    if not task_id or not run_id_raw or not claim_lock:
+        return False
+    try:
+        run_id = int(run_id_raw)
+    except ValueError:
+        return False
+
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect_closing() as conn:
+        if not kb.heartbeat_worker(
+            conn,
+            task_id,
+            expected_run_id=run_id,
+        ):
+            return False
+        return kb.heartbeat_claim(conn, task_id, claimer=claim_lock)
+
+
+class KanbanWorkerHeartbeat:
+    """Run a heartbeat callback periodically on a daemon thread."""
+
+    def __init__(
+        self,
+        heartbeat_fn: Callable[[], bool],
+        *,
+        interval_seconds: float = WORKER_HEARTBEAT_INTERVAL_SECONDS,
+    ) -> None:
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        self._heartbeat_fn = heartbeat_fn
+        self._interval_seconds = float(interval_seconds)
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="hermes-kanban-worker-heartbeat",
+            daemon=True,
+        )
+
+    @property
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not threading.current_thread():
+            self._thread.join(timeout=2.0)
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                still_active = self._heartbeat_fn()
+            except Exception:
+                # A transient DB lock or filesystem error must not kill either
+                # the worker or its keepalive. The next interval retries.
+                logger.debug("kanban worker heartbeat failed", exc_info=True)
+            else:
+                if not still_active:
+                    self._stop_event.set()
+                    return
+            if self._stop_event.wait(self._interval_seconds):
+                return
+
+
+@contextlib.contextmanager
+def worker_heartbeat_keepalive(
+    *,
+    interval_seconds: Optional[float] = None,
+    heartbeat_fn: Optional[Callable[[], bool]] = None,
+) -> Iterator[Optional[KanbanWorkerHeartbeat]]:
+    """Keep a dispatched worker alive for the duration of the process scope.
+
+    Outside a fully identified dispatcher worker this is a no-op. Tests may
+    inject ``heartbeat_fn`` to exercise lifecycle behavior without board state.
+    """
+    if heartbeat_fn is None:
+        required = (
+            os.environ.get("HERMES_KANBAN_TASK"),
+            os.environ.get("HERMES_KANBAN_RUN_ID"),
+            os.environ.get("HERMES_KANBAN_CLAIM_LOCK"),
+        )
+        if not all(value and value.strip() for value in required):
+            yield None
+            return
+        heartbeat_fn = _heartbeat_current_run
+
+    keepalive = KanbanWorkerHeartbeat(
+        heartbeat_fn,
+        interval_seconds=(
+            WORKER_HEARTBEAT_INTERVAL_SECONDS
+            if interval_seconds is None
+            else interval_seconds
+        ),
+    )
+    keepalive.start()
+    try:
+        yield keepalive
+    finally:
+        keepalive.stop()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2487,11 +2487,18 @@ def cmd_chat(args):
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
-    try:
-        cli_main(**kwargs)
-    except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+    # A model request may remain completely silent for longer than the
+    # dispatcher's stale-heartbeat threshold. Keep dispatcher-spawned workers
+    # alive from a process-side daemon thread, independent of model chunks and
+    # tool calls. The context always stops the thread on normal return or error.
+    from agent.kanban_worker_heartbeat import worker_heartbeat_keepalive
+
+    with worker_heartbeat_keepalive():
+        try:
+            cli_main(**kwargs)
+        except ValueError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
 
 
 def cmd_gateway(args):

--- a/tests/agent/test_kanban_worker_heartbeat.py
+++ b/tests/agent/test_kanban_worker_heartbeat.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent.kanban_worker_heartbeat import (
+    KanbanWorkerHeartbeat,
+    worker_heartbeat_keepalive,
+)
+from hermes_cli import kanban_db as kb
+
+
+def _wait_until(predicate, *, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+def test_keepalive_heartbeats_without_foreground_activity():
+    calls = 0
+
+    def heartbeat() -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    keepalive = KanbanWorkerHeartbeat(heartbeat, interval_seconds=0.01)
+    keepalive.start()
+    try:
+        assert _wait_until(lambda: calls >= 3)
+    finally:
+        keepalive.stop()
+
+    stopped_at = calls
+    time.sleep(0.05)
+    assert calls == stopped_at
+    assert not keepalive.is_alive
+
+
+def test_keepalive_stops_when_task_is_no_longer_running():
+    results = iter((True, False))
+    calls = 0
+
+    def heartbeat() -> bool:
+        nonlocal calls
+        calls += 1
+        return next(results)
+
+    keepalive = KanbanWorkerHeartbeat(heartbeat, interval_seconds=0.01)
+    keepalive.start()
+
+    assert _wait_until(lambda: not keepalive.is_alive)
+    assert calls == 2
+
+
+def test_keepalive_stops_when_worker_scope_errors():
+    keepalive = None
+
+    with pytest.raises(RuntimeError, match="model failed"):
+        with worker_heartbeat_keepalive(
+            interval_seconds=0.01,
+            heartbeat_fn=lambda: True,
+        ) as active_keepalive:
+            keepalive = active_keepalive
+            assert keepalive is not None
+            assert _wait_until(lambda: keepalive.is_alive)
+            raise RuntimeError("model failed")
+
+    assert keepalive is not None
+    assert not keepalive.is_alive
+
+
+def test_chat_process_wraps_agent_run_in_worker_keepalive(monkeypatch):
+    from agent import kanban_worker_heartbeat as heartbeat_module
+    from hermes_cli import main
+
+    events = []
+
+    @contextmanager
+    def fake_keepalive():
+        events.append("heartbeat-started")
+        try:
+            yield None
+        finally:
+            events.append("heartbeat-stopped")
+
+    def fake_cli_main(**_kwargs):
+        events.append("agent-run")
+
+    monkeypatch.setattr(heartbeat_module, "worker_heartbeat_keepalive", fake_keepalive)
+    monkeypatch.setattr(main, "_resolve_use_tui", lambda _args: False)
+    monkeypatch.setattr(main, "_apply_safe_mode", lambda _args: None)
+    monkeypatch.setattr(main, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(main, "_termux_should_prefetch_update_check", lambda: False)
+    monkeypatch.setattr(main, "_sync_bundled_skills_for_startup", lambda: None)
+    monkeypatch.setattr(main, "_pin_kanban_board_env", lambda: None)
+    monkeypatch.setitem(sys.modules, "cli", types.SimpleNamespace(main=fake_cli_main))
+
+    args = SimpleNamespace(model=None, toolsets=None, query="work kanban task t_test")
+    main.cmd_chat(args)
+
+    assert events == ["heartbeat-started", "agent-run", "heartbeat-stopped"]
+
+
+@pytest.fixture
+def running_worker(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db(board="default")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="long model turn", assignee="worker")
+        assert kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        kb._set_worker_pid(conn, task_id, os.getpid())
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", str(task.claim_lock))
+    return task_id
+
+
+def test_real_keepalive_refreshes_claim_and_prevents_stale_reclaim(
+    running_worker, monkeypatch
+):
+    task_id = running_worker
+    old = int(time.time()) - (kb.DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS + 60)
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
+            (int(time.time()) - 1, old, task_id),
+        )
+        conn.commit()
+
+    with worker_heartbeat_keepalive(interval_seconds=0.01):
+        def refreshed() -> bool:
+            with kb.connect() as conn:
+                task = kb.get_task(conn, task_id)
+                return bool(task and task.last_heartbeat_at and task.last_heartbeat_at > old)
+
+        assert _wait_until(refreshed)
+        with kb.connect() as conn:
+            assert kb.release_stale_claims(conn) == 0
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.status == "running"
+
+
+@pytest.mark.parametrize("final_status", ["blocked", "done"])
+def test_real_keepalive_self_stops_after_task_finalization(
+    running_worker, final_status
+):
+    task_id = running_worker
+    with worker_heartbeat_keepalive(interval_seconds=0.01) as keepalive:
+        assert keepalive is not None
+        assert _wait_until(lambda: keepalive.is_alive)
+        with kb.connect() as conn:
+            conn.execute(
+                "UPDATE tasks SET status = ? WHERE id = ?", (final_status, task_id)
+            )
+            conn.commit()
+        assert _wait_until(lambda: not keepalive.is_alive)


### PR DESCRIPTION
## Summary
- start a process-side 5-minute heartbeat for dispatcher-spawned workers before the one-shot agent loop
- pin each heartbeat to the task's run ID and claim lock so a delayed thread cannot keep a reclaimed/reassigned task alive
- stop automatically on completion, block, model/CLI error, or process exit while preserving stale/dead-worker reclaim

## Incident
Addresses live workers such as `t_b70ebfd1` and `t_e93313bf` being reclaimed after ~30 minutes without foreground tool/model activity even though useful work resumed afterward.

## Verification
- `scripts/run_tests.sh tests/agent/test_kanban_worker_heartbeat.py -q` (7 passed)
- focused DB/tool/dispatcher suite (357 passed)
- all Kanban Python tests (869 passed)
- post-rebase focused lifecycle/reclaim suite (9 passed)
- `python3 -m ruff check agent/kanban_worker_heartbeat.py tests/agent/test_kanban_worker_heartbeat.py hermes_cli/main.py`
- `python3 -m compileall -q agent/kanban_worker_heartbeat.py hermes_cli/main.py tests/agent/test_kanban_worker_heartbeat.py`
- `git diff --check`

## Behavior
The daemon thread emits liveness independent of model chunks and tool calls. It immediately self-stops when the task/run is no longer active, and process death removes the daemon with the worker so genuinely stale locks remain reclaimable.
