### PR TITLE
fix(kanban): block workers missing terminal handoff

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6567,75 +6567,49 @@ def _error_fingerprint(error_text: str) -> str:
     return fp.lower().strip()
 
 
-# Empirically ~96% of "clean exit without a terminal tool call" tasks complete
-# on a later run (a goal-mode finalize nudge, or the model simply emitting the
-# tool call next time), so a protocol violation is NOT deterministic — give it a
-# bounded retry before the breaker trips instead of blocking on the first hit.
-#
-# The budget is a violation-only STREAK, not a share of the unified
-# ``consecutive_failures`` counter: it counts consecutive clean-exit protocol
-# violations (derived from run history by ``_protocol_violation_streak``), so
-# earlier timeouts / nonzero exits neither consume nor extend it, and a
-# below-budget violation does not tick the unified counter either. A per-task
-# ``max_retries`` overrides this bound — the same "task override wins"
-# precedence ``_record_task_failure`` documents for every other failure kind.
-_PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
-
-# How far back to walk a task's closed runs when counting the violation
-# streak. The streak trips at a handful of violations, so anything beyond a
-# few dozen rows (violations interleaved with neutral rate-limited requeues)
-# can only mean "way past the bound" anyway.
-_PROTOCOL_VIOLATION_SCAN_LIMIT = 50
+_MISSING_HANDOFF_CLASSIFICATION = "protocol_violation_missing_handoff"
+_MISSING_HANDOFF_LOG_TAIL_BYTES = 4096
+_MISSING_HANDOFF_LOG_TAIL_LINES = 20
 
 
-def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
-    """Count the task's trailing run of clean-exit protocol violations.
+def _missing_handoff_log_evidence(task_id: str) -> dict:
+    """Return bounded, redacted stdout evidence for a missing handoff."""
+    path = worker_logs_dir() / f"{task_id}.log"
+    evidence = {"stdout_path": str(path)}
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as stream:
+            if size > _MISSING_HANDOFF_LOG_TAIL_BYTES:
+                stream.seek(-_MISSING_HANDOFF_LOG_TAIL_BYTES, os.SEEK_END)
+            raw = stream.read(_MISSING_HANDOFF_LOG_TAIL_BYTES)
+        text = raw.decode("utf-8", errors="replace")
+        if size > _MISSING_HANDOFF_LOG_TAIL_BYTES:
+            # The seek may land inside a credential. Discard that partial first
+            # line rather than asking the redactor to recognize a token suffix.
+            text = text.partition("\n")[2]
+        lines = text.splitlines()
+        tail = "\n".join(lines[-_MISSING_HANDOFF_LOG_TAIL_LINES:])
+        try:
+            from agent.redact import redact_sensitive_text
 
-    Walks the task's closed runs newest-first — including the violation run
-    ``detect_crashed_workers`` just closed — and counts how many in a row were
-    clean-exit protocol violations:
-
-    * ``rate_limited`` runs are neutral and skipped: a quota wall says nothing
-      about the task, exactly as it is neutral for the unified
-      ``consecutive_failures`` counter.
-    * Any other closed run (completed, plain crash, timeout, spawn failure,
-      reclaim, …) breaks the streak, so the bounded retry budget counts ONLY
-      protocol violations — mixed failure kinds can neither consume nor
-      extend it.
-
-    Violation runs are recognized by the ``protocol_violation`` marker that
-    ``detect_crashed_workers`` stamps into the run metadata; the violation
-    error text is matched as a fallback for runs recorded before the marker
-    existed.
-    """
-    streak = 0
-    rows = conn.execute(
-        "SELECT outcome, error, metadata FROM task_runs "
-        "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY id DESC LIMIT ?",
-        (task_id, _PROTOCOL_VIOLATION_SCAN_LIMIT),
-    ).fetchall()
-    for row in rows:
-        outcome = row["outcome"] or ""
-        if outcome == "rate_limited":
-            continue
-        if outcome == "crashed":
-            is_violation = False
-            raw_meta = row["metadata"]
-            if raw_meta:
-                try:
-                    is_violation = bool(
-                        json.loads(raw_meta).get("protocol_violation")
-                    )
-                except (ValueError, TypeError):
-                    is_violation = False
-            if not is_violation:
-                is_violation = "protocol violation" in (row["error"] or "")
-            if is_violation:
-                streak += 1
-                continue
-        break
-    return streak
+            tail = redact_sensitive_text(tail, force=True)
+        except Exception:
+            tail = "[log tail unavailable: redaction failed]"
+        tail_bytes = tail.encode("utf-8")
+        if len(tail_bytes) > _MISSING_HANDOFF_LOG_TAIL_BYTES:
+            tail = tail_bytes[-_MISSING_HANDOFF_LOG_TAIL_BYTES:].decode(
+                "utf-8", errors="replace",
+            )
+        evidence.update({
+            "final_log_tail": tail,
+            "log_tail_truncated": (
+                size > _MISSING_HANDOFF_LOG_TAIL_BYTES
+                or len(lines) > _MISSING_HANDOFF_LOG_TAIL_LINES
+            ),
+        })
+    except (OSError, ValueError) as exc:
+        evidence["log_tail_error"] = f"{type(exc).__name__}: {exc}"[:200]
+    return evidence
 
 
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
@@ -6651,11 +6625,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     dispatcher (the whole design is single-host).
 
     When the reap registry shows the worker exited cleanly (rc=0) but
-    the task was still ``running`` in the DB, treat it as a protocol
-    violation (worker answered conversationally without calling
-    ``kanban_complete`` / ``kanban_block``) and trip the circuit breaker
-    on the first occurrence — retrying a worker whose CLI keeps
-    returning 0 without a terminal transition just loops forever.
+    the task was still ``running`` in the DB, block it immediately as a
+    missing-handoff protocol violation. A clean exit is not a crash, and
+    blindly rerunning already-completed work risks duplicate side effects.
 
     When the reap registry shows the worker exited with the rate-limit
     sentinel (``KANBAN_RATE_LIMIT_EXIT_CODE``), the worker bailed on a
@@ -6670,12 +6642,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     rate_limited: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
-    # write_txn so can't nest). ``protocol_violation`` flags the
-    # clean-exit-but-still-running case, which is accounted against its
-    # own bounded violation streak instead of the unified failure
-    # counter (see the post-txn loop below).
-    crash_details: list[tuple[str, int, str, bool, str]] = []
-    # (task_id, pid, claimer, protocol_violation, error_text)
+    # write_txn so can't nest). Missing-handoff exits are blocked inside the
+    # main transaction and never enter the genuine-crash accounting path.
+    crash_details: list[tuple[str, int, str, str]] = []
+    # (task_id, pid, claimer, error_text)
+    auto_blocked: list[str] = []
     with write_txn(conn):
         rows = conn.execute(
             "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
@@ -6702,31 +6673,24 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
             if kind == "clean_exit":
-                # Worker subprocess returned 0 but its task is still
-                # ``running`` in the DB — it exited without calling
-                # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
-                # work itself succeeded and only the paperwork was skipped, so
-                # a retry usually completes; the corrective sentence below is
-                # surfaced to the retry worker via the prior-attempt error in
-                # ``build_worker_context`` (guidance approach from #61817).
+                # Work may already have happened, so never retry it blindly.
                 protocol_violation = True
+                evidence = _missing_handoff_log_evidence(row["id"])
                 error_text = (
-                    "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation. "
-                    "If the prior run already did the work, verify it and "
-                    "report the result via kanban_complete; a run that ends "
-                    "without a terminal kanban call counts as failed no "
-                    "matter what it did."
+                    "Worker ended cleanly (rc=0) but omitted the required "
+                    "terminal board handoff (kanban_complete or kanban_block). "
+                    "Blocked automatically to avoid blindly rerunning work; "
+                    f"inspect stdout at {evidence['stdout_path']}."
                 )
                 event_kind = "protocol_violation"
                 event_payload = {
                     "pid": pid,
                     "claimer": row["claim_lock"],
                     "exit_code": code,
-                    # Durable marker for _protocol_violation_streak: _end_run
-                    # copies this payload into the run metadata, which is how
-                    # the violation-only retry budget is derived later.
                     "protocol_violation": True,
+                    "classification": _MISSING_HANDOFF_CLASSIFICATION,
+                    "reason": error_text,
+                    **evidence,
                 }
             elif kind == "rate_limited":
                 # Worker bailed because the provider rate-limited / exhausted
@@ -6762,18 +6726,33 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
-            cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
-                "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
-                (row["id"], pid, row["claim_lock"]),
-            )
+            if protocol_violation:
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, "
+                    "last_failure_error = ?, block_kind = 'capability', "
+                    "block_recurrences = 1 "
+                    "WHERE id = ? AND status = 'running' "
+                    "  AND worker_pid = ? AND claim_lock IS ?",
+                    (error_text[:500], row["id"], pid, row["claim_lock"]),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL "
+                    "WHERE id = ? AND status = 'running' "
+                    "  AND worker_pid = ? AND claim_lock IS ?",
+                    (row["id"], pid, row["claim_lock"]),
+                )
             if cur.rowcount == 1:
                 # Rate-limited requeues are a clean release, not a crash —
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                _run_outcome = (
+                    "blocked" if protocol_violation
+                    else "rate_limited" if rate_limited_exit
+                    else "crashed"
+                )
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -6785,7 +6764,15 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload,
                     run_id=run_id,
                 )
-                if rate_limited_exit:
+                if protocol_violation:
+                    # Keep the automatic block sticky until an operator
+                    # explicitly unblocks it. Otherwise recompute_ready could
+                    # turn the next dispatcher tick into an accidental retry.
+                    _append_event(
+                        conn, row["id"], "blocked", event_payload, run_id=run_id,
+                    )
+                    auto_blocked.append(row["id"])
+                elif rate_limited_exit:
                     # Stamp the failure-error column so ``check_respawn_guard``
                     # recognizes this as a quota blocker and defers the
                     # respawn until the window clears — WITHOUT touching
@@ -6797,93 +6784,23 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     )
                     rate_limited.append(row["id"])
                 else:
-                    if protocol_violation:
-                        # Stamp the failure error now: a below-budget
-                        # violation never reaches ``_record_task_failure``
-                        # (which stamps this column for every other failure
-                        # kind), yet the board UI and the retry worker's
-                        # context still need the violation message + the
-                        # corrective guidance it carries.
-                        conn.execute(
-                            "UPDATE tasks SET last_failure_error = ? "
-                            "WHERE id = ?",
-                            (error_text[:500], row["id"]),
-                        )
                     crashed.append(row["id"])
                     crash_details.append(
-                        (row["id"], pid, row["claim_lock"],
-                         protocol_violation, error_text)
+                        (row["id"], pid, row["claim_lock"], error_text)
                     )
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the task transitions ready → blocked with a ``gave_up`` event
     # on top of the event we already emitted).
-    #
-    # Protocol-violation crashes (clean exit, no terminal tool call) get a
-    # BOUNDED retry, not an immediate trip: empirically ~96% of these tasks
-    # complete on a later run (a goal-mode finalize nudge, or the model simply
-    # emitting kanban_complete/kanban_block next time), so blocking on the first
-    # occurrence just churned them through the respawn cycle. The retry budget
-    # is a violation-only streak (``_protocol_violation_streak``): earlier
-    # timeouts / nonzero exits neither consume nor extend it, and a
-    # below-budget violation does not tick the unified
-    # ``consecutive_failures`` counter, so the two budgets stay independent.
-    # A per-task ``max_retries`` overrides the violation bound with the same
-    # top precedence it has for every other failure kind. Systemic same-error
-    # crashes still trip immediately.
-    auto_blocked: list[str] = []
+    # Clean missing-handoff exits were already blocked atomically above.
+    # Genuine crashes retain the existing failure-counter behavior; systemic
+    # same-error crashes still trip immediately.
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
+        for _, _, _, err_text in crash_details:
             fp = _error_fingerprint(err_text)
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
-            if protocol_violation:
-                streak = _protocol_violation_streak(conn, tid)
-                trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
-                ).fetchone()
-                if trow is None:
-                    continue  # task deleted mid-loop
-                task_override = (
-                    trow["max_retries"] if "max_retries" in trow.keys() else None
-                )
-                violation_limit = (
-                    int(task_override)
-                    if task_override is not None
-                    else _PROTOCOL_VIOLATION_FAILURE_LIMIT
-                )
-                if streak < violation_limit:
-                    # Below budget: the task is already back at ``ready``
-                    # (respawn allowed) with ``last_failure_error`` stamped.
-                    # Deliberately no ``_record_task_failure`` call — a
-                    # below-budget violation must not consume the unified
-                    # failure budget, just as other failure kinds don't
-                    # consume this one.
-                    continue
-                # Streak reached the bound: trip the breaker. ``force_trip``
-                # skips the threshold resolution inside
-                # ``_record_task_failure`` because the decision — including
-                # the per-task ``max_retries`` override — was already made
-                # against the violation streak above.
-                tripped = _record_task_failure(
-                    conn, tid,
-                    error=error_text,
-                    outcome="crashed",
-                    failure_limit=violation_limit,
-                    force_trip=True,
-                    release_claim=False,
-                    end_run=False,
-                    event_payload_extra={
-                        "pid": pid,
-                        "claimer": claimer,
-                        "protocol_violations": streak,
-                        "protocol_violation_limit": violation_limit,
-                    },
-                )
-                if tripped:
-                    auto_blocked.append(tid)
-                continue
+        for tid, pid, claimer, error_text in crash_details:
             fp = _error_fingerprint(error_text)
             is_systemic = _fp_counts.get(fp, 0) >= 3
             tripped = _record_task_failure(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6647,9 +6647,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     crash_details: list[tuple[str, int, str, str]] = []
     # (task_id, pid, claimer, error_text)
     auto_blocked: list[str] = []
+    protocol_blocks: list[tuple[str, Optional[int], str]] = []
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
+            "SELECT id, worker_pid, claim_lock, started_at, "
+            "       block_kind, block_recurrences FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -6727,14 +6729,27 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_code"] = code
 
             if protocol_violation:
+                same_cause = row["block_kind"] == _MISSING_HANDOFF_CLASSIFICATION
+                recurrences = (
+                    int(row["block_recurrences"] or 0) + 1 if same_cause else 1
+                )
+                target_status = (
+                    "triage" if recurrences >= BLOCK_RECURRENCE_LIMIT else "blocked"
+                )
                 cur = conn.execute(
-                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
-                    "last_failure_error = ?, block_kind = 'capability', "
-                    "block_recurrences = 1 "
+                    "last_failure_error = ?, block_kind = ?, "
+                    "block_recurrences = ? "
                     "WHERE id = ? AND status = 'running' "
                     "  AND worker_pid = ? AND claim_lock IS ?",
-                    (error_text[:500], row["id"], pid, row["claim_lock"]),
+                    (
+                        target_status,
+                        error_text[:500],
+                        _MISSING_HANDOFF_CLASSIFICATION,
+                        recurrences,
+                        row["id"], pid, row["claim_lock"],
+                    ),
                 )
             else:
                 cur = conn.execute(
@@ -6768,10 +6783,20 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     # Keep the automatic block sticky until an operator
                     # explicitly unblocks it. Otherwise recompute_ready could
                     # turn the next dispatcher tick into an accidental retry.
+                    block_payload = {
+                        **event_payload,
+                        "kind": _MISSING_HANDOFF_CLASSIFICATION,
+                        "recurrences": recurrences,
+                    }
+                    block_event = "blocked"
+                    if target_status == "triage":
+                        block_event = "block_loop_detected"
+                        block_payload["limit"] = BLOCK_RECURRENCE_LIMIT
                     _append_event(
-                        conn, row["id"], "blocked", event_payload, run_id=run_id,
+                        conn, row["id"], block_event, block_payload, run_id=run_id,
                     )
                     auto_blocked.append(row["id"])
+                    protocol_blocks.append((row["id"], run_id, error_text))
                 elif rate_limited_exit:
                     # Stamp the failure-error column so ``check_respawn_guard``
                     # recognizes this as a quota blocker and defers the
@@ -6788,6 +6813,19 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     crash_details.append(
                         (row["id"], pid, row["claim_lock"], error_text)
                     )
+    # Match block_task's lifecycle contract without invoking hooks while the
+    # crash-reaper write transaction is held.
+    for tid, run_id, reason in protocol_blocks:
+        blocked_task = get_task(conn, tid)
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_blocked",
+            tid,
+            board=get_current_board(),
+            assignee=blocked_task.assignee if blocked_task else None,
+            run_id=run_id,
+            reason=reason,
+        )
+
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the task transitions ready → blocked with a ``gave_up`` event
     # on top of the event we already emitted).

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4439,210 +4439,55 @@ def _drive_nonzero_crash(conn, tid, fake_pid):
     return _drive_worker_exit(conn, tid, fake_pid, 256)
 
 
-def test_detect_crashed_workers_protocol_violation_first_occurrence_retries(kanban_home):
-    """A first clean-exit protocol violation gets a retry, not a block.
+def test_clean_exit_without_handoff_blocks_with_bounded_log_evidence(kanban_home):
+    """rc=0 without a terminal board handoff is actionable, not retried."""
+    import hermes_cli.kanban_db as _kb
 
-    A worker that exited rc=0 while its task was still ``running`` skipped
-    the terminal kanban call (model answered conversationally, transient tool
-    wedge). Empirically these overwhelmingly complete on respawn, so the
-    first violation must leave the task ``ready`` with corrective guidance
-    stamped in ``last_failure_error`` — not trip the breaker like the pre-fix
-    behavior did. The violation is accounted against its own violation-only
-    streak, so it must NOT tick the unified ``consecutive_failures`` counter.
-    """
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="quiet", assignee="worker")
+        log_dir = _kb.worker_logs_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        sensitive_value = "sk-test-sensitive-value-that-must-not-survive"
+        lines = [f"line {i} {'x' * 240}" for i in range(30)]
+        lines.extend([f"OPENAI_API_KEY={sensitive_value}", "FINAL WORKER OUTPUT"])
+        log_path = log_dir / f"{tid}.log"
+        log_path.write_text("\n".join(lines), encoding="utf-8")
+
         result_crashed = _drive_protocol_violation(conn, tid, 999998)
-        assert tid in result_crashed, "should be detected as crashed"
 
-        task = kb.get_task(conn, tid)
-        assert task.status == "ready", (
-            f"first protocol violation should retry, got status={task.status}"
-        )
-        assert task.consecutive_failures == 0, (
-            "a below-budget violation must not consume the unified failure "
-            f"budget, got consecutive_failures={task.consecutive_failures}"
-        )
-        assert "kanban_complete" in (task.last_failure_error or ""), (
-            f"expected protocol-violation message, got {task.last_failure_error!r}"
-        )
-
-        events = kb.list_events(conn, tid)
-        kinds = [e.kind for e in events]
-        assert "protocol_violation" in kinds, (
-            f"expected 'protocol_violation' event, got {kinds}"
-        )
-        # The ``crashed`` event would be misleading here — the worker
-        # didn't crash, it returned 0.
-        assert "crashed" not in kinds, (
-            f"should NOT emit 'crashed' event on clean exit, got {kinds}"
-        )
-        assert "gave_up" not in kinds, (
-            f"breaker must not trip on the first violation, got {kinds}"
-        )
-    finally:
-        conn.close()
-
-
-def test_detect_crashed_workers_protocol_violation_streak_trips_at_limit(kanban_home):
-    """The violation streak trips the terminal path exactly at the bound.
-
-    Genuine repeat offenders (a worker whose CLI keeps returning 0 without a
-    terminal transition) must still surface to a human: the
-    ``_PROTOCOL_VIOLATION_FAILURE_LIMIT``-th consecutive violation blocks the
-    task with a ``gave_up`` event carrying the streak accounting.
-    """
-    import hermes_cli.kanban_db as _kb
-    conn = kb.connect()
-    try:
-        tid = kb.create_task(conn, title="quiet", assignee="worker")
-        limit = _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
-        for i in range(limit - 1):
-            _drive_protocol_violation(conn, tid, 990000 + i)
-            assert kb.get_task(conn, tid).status == "ready", (
-                f"violation {i + 1}/{limit} should still retry"
-            )
-
-        _drive_protocol_violation(conn, tid, 990900)
-
-        task = kb.get_task(conn, tid)
-        assert task.status == "blocked", (
-            f"violation streak at the bound must block, got {task.status}"
-        )
-        events = kb.list_events(conn, tid)
-        kinds = [e.kind for e in events]
-        assert kinds.count("protocol_violation") == limit
-        assert "crashed" not in kinds
-        gave_up = [e for e in events if e.kind == "gave_up"]
-        assert len(gave_up) == 1, f"expected exactly one gave_up, got {kinds}"
-        payload = gave_up[0].payload or {}
-        assert payload.get("protocol_violations") == limit
-        assert payload.get("protocol_violation_limit") == limit
-        # Side channel consumed by dispatch_once — read through the same
-        # (current) module object the reaper ran in, see _drive_worker_exit.
-        assert tid in _kb.detect_crashed_workers._last_auto_blocked
-    finally:
-        conn.close()
-
-
-def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
-    """Mixed failure kinds must not consume the violation retry budget.
-
-    Regression for the #61233 review finding: expressed as a plain
-    ``failure_limit`` over the unified ``consecutive_failures`` counter, the
-    violation budget was consumed by earlier timeouts / nonzero exits. As a
-    violation-only streak, a prior real crash must not eat violation
-    retries, and below-budget violations must leave the unified counter
-    untouched (so the two budgets stay independent).
-    """
-    import hermes_cli.kanban_db as _kb
-    conn = kb.connect()
-    try:
-        tid = kb.create_task(conn, title="mixed", assignee="worker")
-
-        # One real crash: unified counter ticks to 1 (below
-        # DEFAULT_FAILURE_LIMIT=2 — task stays ready).
-        _drive_nonzero_crash(conn, tid, 991000)
-        task = kb.get_task(conn, tid)
-        assert task.status == "ready"
-        assert task.consecutive_failures == 1
-
-        # Two violations after it: streak 1 and 2 — both retry, unified
-        # counter untouched. (Pre-fix: the crash consumed the budget and the
-        # violations blocked well before three of them happened.)
-        for i, pid in enumerate((991001, 991002)):
-            _drive_protocol_violation(conn, tid, pid)
-            task = kb.get_task(conn, tid)
-            assert task.status == "ready", (
-                f"violation {i + 1} after a crash must still retry, "
-                f"got {task.status}"
-            )
-            assert task.consecutive_failures == 1, (
-                "below-budget violations must not tick the unified counter"
-            )
-
-        # Third consecutive violation: streak hits the bound — blocked.
-        _drive_protocol_violation(conn, tid, 991003)
+        assert tid not in result_crashed, "a clean exit must not be a crash"
         task = kb.get_task(conn, tid)
         assert task.status == "blocked"
-        gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
-        assert len(gave_up) == 1
-        assert (gave_up[0].payload or {}).get("protocol_violations") == \
-            _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
-    finally:
-        conn.close()
+        assert task.block_kind == "capability"
+        assert task.consecutive_failures == 0
+        assert "ended cleanly (rc=0)" in (task.last_failure_error or "")
+        assert "inspect stdout" in (task.last_failure_error or "")
 
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        assert "protocol_violation" in kinds
+        assert "blocked" in kinds
+        assert "crashed" not in kinds
+        assert "gave_up" not in kinds
+        payload = [e.payload for e in events if e.kind == "protocol_violation"][-1]
+        assert payload["classification"] == "protocol_violation_missing_handoff"
+        assert payload["stdout_path"] == str(log_path)
+        assert payload["log_tail_truncated"] is True
+        assert "FINAL WORKER OUTPUT" in payload["final_log_tail"]
+        assert sensitive_value not in payload["final_log_tail"]
+        assert len(payload["final_log_tail"].encode("utf-8")) <= 4096
 
-def test_protocol_violation_streak_resets_on_other_failure_kind(kanban_home):
-    """A non-violation failure between violations resets the streak.
-
-    The budget counts CONSECUTIVE clean-exit violations: two violations, a
-    real crash, then two more violations is a streak of 2 — not 4 — so the
-    fourth violation must still retry; only a third consecutive one blocks.
-    """
-    conn = kb.connect()
-    try:
-        tid = kb.create_task(conn, title="reset", assignee="worker")
-
-        _drive_protocol_violation(conn, tid, 993000)
-        _drive_protocol_violation(conn, tid, 993001)
-        assert kb.get_task(conn, tid).status == "ready"
-
-        # Real crash breaks the streak (and ticks the unified counter to 1).
-        _drive_nonzero_crash(conn, tid, 993002)
-        assert kb.get_task(conn, tid).status == "ready"
-
-        # Streak restarts at 1, 2 — the pre-crash violations no longer count.
-        _drive_protocol_violation(conn, tid, 993003)
-        assert kb.get_task(conn, tid).status == "ready", (
-            "violation streak must reset after a non-violation failure"
-        )
-        _drive_protocol_violation(conn, tid, 993004)
-        assert kb.get_task(conn, tid).status == "ready"
-
-        # Third consecutive violation since the crash: blocked.
-        _drive_protocol_violation(conn, tid, 993005)
+        run = conn.execute(
+            "SELECT outcome, metadata FROM task_runs WHERE task_id = ?",
+            (tid,),
+        ).fetchone()
+        assert run["outcome"] == "blocked"
+        assert json.loads(run["metadata"])["classification"] == \
+            "protocol_violation_missing_handoff"
+        assert tid in _kb.detect_crashed_workers._last_auto_blocked
+        assert kb.recompute_ready(conn) == 0
         assert kb.get_task(conn, tid).status == "blocked"
-    finally:
-        conn.close()
-
-
-def test_protocol_violation_respects_max_retries_precedence(kanban_home):
-    """Per-task ``max_retries`` overrides the violation bound, both ways.
-
-    Same top precedence it has for every other failure kind in
-    ``_record_task_failure``: ``max_retries=1`` blocks on the FIRST violation
-    (zero retries — the pre-fix behavior, now opt-in per task);
-    ``max_retries=5`` keeps retrying past the default bound of 3 and blocks
-    on the 5th consecutive violation.
-    """
-    conn = kb.connect()
-    try:
-        strict = kb.create_task(
-            conn, title="strict", assignee="worker", max_retries=1,
-        )
-        _drive_protocol_violation(conn, strict, 992000)
-        task = kb.get_task(conn, strict)
-        assert task.status == "blocked", (
-            f"max_retries=1 must block on the first violation, got {task.status}"
-        )
-        gave_up = [e for e in kb.list_events(conn, strict) if e.kind == "gave_up"]
-        assert len(gave_up) == 1
-        payload = gave_up[0].payload or {}
-        assert payload.get("protocol_violations") == 1
-        assert payload.get("protocol_violation_limit") == 1
-
-        lenient = kb.create_task(
-            conn, title="lenient", assignee="worker", max_retries=5,
-        )
-        for i in range(4):
-            _drive_protocol_violation(conn, lenient, 992100 + i)
-            assert kb.get_task(conn, lenient).status == "ready", (
-                f"violation {i + 1}/5 should retry under max_retries=5"
-            )
-        _drive_protocol_violation(conn, lenient, 992104)
-        assert kb.get_task(conn, lenient).status == "blocked"
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4459,7 +4459,8 @@ def test_clean_exit_without_handoff_blocks_with_bounded_log_evidence(kanban_home
         assert tid not in result_crashed, "a clean exit must not be a crash"
         task = kb.get_task(conn, tid)
         assert task.status == "blocked"
-        assert task.block_kind == "capability"
+        assert task.block_kind == "protocol_violation_missing_handoff"
+        assert task.block_recurrences == 1
         assert task.consecutive_failures == 0
         assert "ended cleanly (rc=0)" in (task.last_failure_error or "")
         assert "inspect stdout" in (task.last_failure_error or "")
@@ -4488,6 +4489,28 @@ def test_clean_exit_without_handoff_blocks_with_bounded_log_evidence(kanban_home
         assert tid in _kb.detect_crashed_workers._last_auto_blocked
         assert kb.recompute_ready(conn) == 0
         assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_repeated_missing_handoff_after_unblock_routes_to_triage(kanban_home):
+    """A manual unblock cannot create an unbounded clean-exit loop."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="quiet loop", assignee="worker")
+        _drive_protocol_violation(conn, tid, 999996)
+        assert kb.unblock_task(conn, tid) is True
+
+        _drive_protocol_violation(conn, tid, 999995)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "triage"
+        assert task.block_kind == "protocol_violation_missing_handoff"
+        assert task.block_recurrences == kb.BLOCK_RECURRENCE_LIMIT
+        events = kb.list_events(conn, tid)
+        loop_event = [e for e in events if e.kind == "block_loop_detected"][-1]
+        assert loop_event.payload["kind"] == "protocol_violation_missing_handoff"
+        assert loop_event.payload["recurrences"] == kb.BLOCK_RECURRENCE_LIMIT
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
- immediately block rc=0 workers that exit without `kanban_complete` or `kanban_block`
- classify the violation as `protocol_violation_missing_handoff` and attach a bounded, redacted worker log tail plus stdout path
- preserve missing-handoff recurrence tracking so repeated unblock/re-block cycles route to triage, while rc!=0 crash accounting remains unchanged
- fire the standard blocked-task lifecycle hook after the reaper transaction

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_blocked_sticky.py -q` (406 passed)
- `uvx ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py`
- `git diff --check`