### PR TITLE
fix(gateway): preserve reply anchors across queued turns

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2092,6 +2092,31 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+class AnchoredReply(str):
+    """Normal reply whose delivery anchor differs from the trigger event.
+
+    Queue-mode agent runs may drain several user turns inside one handler
+    invocation.  The returned text then belongs to the last drained turn, not
+    necessarily to the event that originally entered the platform adapter.
+    Carrying the resolved reply anchor with the text lets the adapter preserve
+    that association without mutating the original inbound event.
+    """
+
+    reply_to_message_id: Optional[str]
+    event: Optional[MessageEvent]
+
+    def __new__(
+        cls,
+        text: str,
+        reply_to_message_id: Optional[str],
+        event: Optional[MessageEvent] = None,
+    ):
+        instance = super().__new__(cls, text)
+        instance.reply_to_message_id = reply_to_message_id
+        instance.event = event
+        return instance
+
+
 def merge_pending_message_event(
     pending_messages: Dict[str, MessageEvent],
     session_key: str,
@@ -2175,9 +2200,13 @@ _RETRYABLE_ERROR_PATTERNS = (
 
 
 # Type for message handlers.  Handlers may return a plain string (normal
-# reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
-# ``None`` when the response was already delivered (e.g. via streaming).
-MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+# reply), an ``EphemeralReply`` to opt the reply into auto-deletion, an
+# ``AnchoredReply`` when a queued turn changed the delivery anchor, or ``None``
+# when the response was already delivered (e.g. via streaming).
+MessageHandler = Callable[
+    [MessageEvent],
+    Awaitable[Optional[Union[str, "EphemeralReply", "AnchoredReply"]]],
+]
 
 
 def resolve_channel_prompt(
@@ -3240,7 +3269,8 @@ class BasePlatformAdapter(ABC):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send a batch of images.
 
         Accepts ``http(s)://``, ``file://`` URIs in the first tuple
@@ -3255,6 +3285,9 @@ class BasePlatformAdapter(ABC):
         """
         from urllib.parse import unquote as _unquote
 
+        remaining_reply_to = reply_to
+        reply_to_all_parts = getattr(self, "_reply_to_mode", None) == "all"
+        delivered = False
         for image_url, alt_text in images:
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
@@ -3266,30 +3299,76 @@ class BasePlatformAdapter(ABC):
                     alt_text[:30] if alt_text else "",
                 )
                 if image_url.startswith("file://"):
-                    img_result = await self.send_image_file(
+                    kwargs = dict(
                         chat_id=chat_id,
                         image_path=_unquote(image_url[7:]),
                         caption=alt_text if alt_text else None,
                         metadata=metadata,
                     )
+                    if remaining_reply_to is not None:
+                        kwargs["reply_to"] = remaining_reply_to
+                    img_result = await self.send_image_file(**kwargs)
                 elif self._is_animation_url(image_url):
-                    img_result = await self.send_animation(
+                    kwargs = dict(
                         chat_id=chat_id,
                         animation_url=image_url,
                         caption=alt_text if alt_text else None,
                         metadata=metadata,
                     )
+                    if remaining_reply_to is not None:
+                        kwargs["reply_to"] = remaining_reply_to
+                    img_result = await self.send_animation(**kwargs)
                 else:
-                    img_result = await self.send_image(
+                    kwargs = dict(
                         chat_id=chat_id,
                         image_url=image_url,
                         caption=alt_text if alt_text else None,
                         metadata=metadata,
                     )
+                    if remaining_reply_to is not None:
+                        kwargs["reply_to"] = remaining_reply_to
+                    img_result = await self.send_image(**kwargs)
                 if not img_result.success:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                elif not reply_to_all_parts:
+                    remaining_reply_to = None
+                if img_result.success:
+                    delivered = True
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+        return delivered
+
+    async def _send_multiple_images_compat(
+        self,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+        reply_to: Optional[str] = None,
+    ) -> bool:
+        """Call batch-image overrides without breaking legacy plugins."""
+        kwargs: Dict[str, Any] = {
+            "chat_id": chat_id,
+            "images": images,
+            "metadata": metadata,
+            "human_delay": human_delay,
+        }
+        if reply_to is not None:
+            try:
+                params = inspect.signature(self.send_multiple_images).parameters
+                accepts_reply_to = "reply_to" in params or any(
+                    param.kind is inspect.Parameter.VAR_KEYWORD
+                    for param in params.values()
+                )
+            except (TypeError, ValueError):
+                accepts_reply_to = False
+            if accepts_reply_to:
+                kwargs["reply_to"] = reply_to
+        result = await self.send_multiple_images(**kwargs)
+        # Legacy overrides used the historical ``None`` return contract after
+        # a successful send. Treat that as delivered; new implementations
+        # return an explicit bool so failures can preserve the anchor.
+        return True if result is None else bool(result)
 
     async def send_image(
         self,
@@ -4915,6 +4994,19 @@ class BasePlatformAdapter(ABC):
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
             is_ephemeral_response = isinstance(response, EphemeralReply)
+            is_anchored_response = isinstance(response, AnchoredReply)
+            response_event = (
+                response.event
+                if is_anchored_response and response.event is not None
+                else event
+            )
+            response_source = getattr(response_event, "source", None) or event.source
+            response_chat_id = response_source.chat_id
+            response_reply_anchor = (
+                response.reply_to_message_id
+                if is_anchored_response
+                else _reply_anchor_for_event(response_event)
+            )
 
             # Slash-command handlers may return an EphemeralReply sentinel to
             # request that their reply message auto-delete after a TTL (used
@@ -4996,7 +5088,7 @@ class BasePlatformAdapter(ABC):
                             "[%s] response_delivery_recovered: extract pipeline "
                             "reduced a non-empty response (%d chars) to empty with "
                             "no attachment; delivering recovered original to %s",
-                            self.name, len(_response_pre_extract), event.source.chat_id,
+                            self.name, len(_response_pre_extract), response_chat_id,
                         )
                         text_content = _recovered
 
@@ -5004,15 +5096,29 @@ class BasePlatformAdapter(ABC):
                 # the existing notify=True marker. Clone once so typing/status
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
-                _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _final_thread_metadata = _mark_notify_metadata(
+                    _thread_metadata_for_source(
+                        response_source,
+                        response_reply_anchor,
+                    )
+                )
+                anchored_reply_remaining = (
+                    response_reply_anchor if is_anchored_response else None
+                )
+                reply_to_all_parts = getattr(self, "_reply_to_mode", None) == "all"
+
+                def _consume_anchored_reply() -> None:
+                    nonlocal anchored_reply_remaining
+                    if not reply_to_all_parts:
+                        anchored_reply_remaining = None
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
                 # True globally and no ``/voice off`` has been issued.
                 _tts_path = None
-                if (self._should_auto_tts_for_chat(event.source.chat_id)
-                        and event.message_type == MessageType.VOICE
+                if (self._should_auto_tts_for_chat(response_chat_id)
+                        and response_event.message_type == MessageType.VOICE
                         and text_content
                         and not media_files):
                     try:
@@ -5041,15 +5147,20 @@ class BasePlatformAdapter(ABC):
                             and text_content[:1024] == text_content
                         ):
                             telegram_tts_caption = text_content
-                        tts_result = await self.play_tts(
-                            chat_id=event.source.chat_id,
+                        tts_kwargs = dict(
+                            chat_id=response_chat_id,
                             audio_path=_tts_path,
                             caption=telegram_tts_caption,
                             metadata=_final_thread_metadata,
                         )
+                        if telegram_tts_caption and anchored_reply_remaining is not None:
+                            tts_kwargs["reply_to"] = anchored_reply_remaining
+                        tts_result = await self.play_tts(**tts_kwargs)
                         _tts_caption_delivered = bool(
                             telegram_tts_caption and getattr(tts_result, "success", False)
                         )
+                        if _tts_caption_delivered:
+                            _consume_anchored_reply()
                     finally:
                         try:
                             os.remove(_tts_path)
@@ -5058,15 +5169,21 @@ class BasePlatformAdapter(ABC):
 
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
-                    logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
-                    _reply_anchor = _reply_anchor_for_event(event)
+                    logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), response_chat_id)
+                    text_reply_anchor = (
+                        anchored_reply_remaining
+                        if is_anchored_response
+                        else response_reply_anchor
+                    )
                     result = await self._send_with_retry(
-                        chat_id=event.source.chat_id,
+                        chat_id=response_chat_id,
                         content=text_content,
-                        reply_to=_reply_anchor,
+                        reply_to=text_reply_anchor,
                         metadata=_final_thread_metadata,
                     )
                     _record_delivery(result)
+                    if result.success and anchored_reply_remaining is not None:
+                        _consume_anchored_reply()
 
                     # Schedule auto-deletion of system-notice replies.
                     # Detached so the handler returns immediately; errors
@@ -5078,7 +5195,7 @@ class BasePlatformAdapter(ABC):
                         and result.message_id
                     ):
                         self._schedule_ephemeral_delete(
-                            chat_id=event.source.chat_id,
+                            chat_id=response_chat_id,
                             message_id=result.message_id,
                             ttl_seconds=_ephemeral_ttl,
                         )
@@ -5090,12 +5207,15 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
-                        await self.send_multiple_images(
-                            chat_id=event.source.chat_id,
+                        batch_delivered = await self._send_multiple_images_compat(
+                            chat_id=response_chat_id,
                             images=images,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
+                            reply_to=anchored_reply_remaining,
                         )
+                        if batch_delivered and anchored_reply_remaining is not None:
+                            _consume_anchored_reply()
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
@@ -5132,12 +5252,15 @@ class BasePlatformAdapter(ABC):
                 if _image_paths:
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
-                            chat_id=event.source.chat_id,
+                        batch_delivered = await self._send_multiple_images_compat(
+                            chat_id=response_chat_id,
                             images=_batch,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
+                            reply_to=anchored_reply_remaining,
                         )
+                        if batch_delivered and anchored_reply_remaining is not None:
+                            _consume_anchored_reply()
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
@@ -5146,27 +5269,37 @@ class BasePlatformAdapter(ABC):
                         await asyncio.sleep(human_delay)
                     try:
                         ext = Path(media_path).suffix.lower()
+                        media_reply_kwargs = (
+                            {"reply_to": anchored_reply_remaining}
+                            if anchored_reply_remaining is not None
+                            else {}
+                        )
                         if should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
                             media_result = await self.send_voice(
-                                chat_id=event.source.chat_id,
+                                chat_id=response_chat_id,
                                 audio_path=media_path,
                                 metadata=_final_thread_metadata,
+                                **media_reply_kwargs,
                             )
                         elif ext in _VIDEO_EXTS:
                             media_result = await self.send_video(
-                                chat_id=event.source.chat_id,
+                                chat_id=response_chat_id,
                                 video_path=media_path,
                                 metadata=_final_thread_metadata,
+                                **media_reply_kwargs,
                             )
                         else:
                             media_result = await self.send_document(
-                                chat_id=event.source.chat_id,
+                                chat_id=response_chat_id,
                                 file_path=media_path,
                                 metadata=_final_thread_metadata,
+                                **media_reply_kwargs,
                             )
 
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
+                        elif anchored_reply_remaining is not None:
+                            _consume_anchored_reply()
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
 
@@ -5176,18 +5309,30 @@ class BasePlatformAdapter(ABC):
                         await asyncio.sleep(human_delay)
                     try:
                         ext = Path(file_path).suffix.lower()
+                        local_reply_kwargs = (
+                            {"reply_to": anchored_reply_remaining}
+                            if anchored_reply_remaining is not None
+                            else {}
+                        )
                         if ext in _VIDEO_EXTS:
-                            await self.send_video(
-                                chat_id=event.source.chat_id,
+                            local_result = await self.send_video(
+                                chat_id=response_chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
+                                **local_reply_kwargs,
                             )
                         else:
-                            await self.send_document(
-                                chat_id=event.source.chat_id,
+                            local_result = await self.send_document(
+                                chat_id=response_chat_id,
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
+                                **local_reply_kwargs,
                             )
+                        if (
+                            getattr(local_result, "success", False)
+                            and anchored_reply_remaining is not None
+                        ):
+                            _consume_anchored_reply()
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 
@@ -5202,7 +5347,7 @@ class BasePlatformAdapter(ABC):
                         "[%s] response_delivery_dropped: non-empty response "
                         "(%d chars) produced no delivered message or attachment "
                         "for %s (empty after extract, recovery yielded nothing).",
-                        self.name, len(_response_pre_extract), event.source.chat_id,
+                        self.name, len(_response_pre_extract), response_chat_id,
                     )
 
             # Determine overall success for the processing hook

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1173,7 +1173,8 @@ class SignalAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send a batch of images via chunked Signal RPC calls.
 
         Per-image alt texts are dropped — Signal's send RPC only carries
@@ -1183,7 +1184,7 @@ class SignalAdapter(BasePlatformAdapter):
         the rate-limit scheduler handles inter-batch pacing.
         """
         if not images:
-            return
+            return False
 
         scheduler = get_scheduler()
         logger.info(
@@ -1230,7 +1231,7 @@ class SignalAdapter(BasePlatformAdapter):
                 "(download=%d missing=%d oversize=%d)",
                 len(images), skipped_download, skipped_missing, skipped_oversize,
             )
-            return
+            return False
 
         logger.info(
             "Signal send_multiple_images: %d/%d images valid, sending in chunks",
@@ -1250,6 +1251,7 @@ class SignalAdapter(BasePlatformAdapter):
             attachments[i:i + SIGNAL_MAX_ATTACHMENTS_PER_MSG]
             for i in range(0, len(attachments), SIGNAL_MAX_ATTACHMENTS_PER_MSG)
         ]
+        delivered = False
 
         for idx, att_batch in enumerate(att_batches):
             n = len(att_batch)
@@ -1277,6 +1279,7 @@ class SignalAdapter(BasePlatformAdapter):
                     if result is not None:
                         success, err_msg = self._validate_send_result(result)
                         if success:
+                            delivered = True
                             self._track_sent_timestamp(result)
                             await scheduler.report_rpc_duration(_rpc_duration, n)
                             logger.info(
@@ -1339,6 +1342,7 @@ class SignalAdapter(BasePlatformAdapter):
                         attempt, SIGNAL_RATE_LIMIT_MAX_ATTEMPTS,
                         f"{e.retry_after:.0f}s" if e.retry_after else "unknown",
                     )
+        return delivered
 
     async def _notify_batch_pacing(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1786,6 +1786,7 @@ from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.platforms.base import (
+    AnchoredReply,
     BasePlatformAdapter,
     EphemeralReply,
     MessageEvent,
@@ -12275,10 +12276,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
+            queued_delivery_event = agent_result.get("delivery_event")
+            delivery_event = (
+                queued_delivery_event
+                if isinstance(queued_delivery_event, MessageEvent)
+                else event
+            )
+            delivery_source = getattr(delivery_event, "source", None) or source
+            delivery_reply_to = (
+                agent_result.get("delivery_reply_to_message_id")
+                if "delivery_reply_to_message_id" in agent_result
+                else self._reply_anchor_for_event(delivery_event)
+            )
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
-            if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
-                await self._send_voice_reply(event, response)
+            if self._should_send_voice_reply(delivery_event, response, agent_messages, already_sent=_already_sent):
+                await self._send_voice_reply(delivery_event, response)
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -12293,10 +12306,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # users see the agent "stop responding without explanation."
             if agent_result.get("already_sent") and not agent_result.get("failed"):
                 if response:
-                    _media_adapter = self._adapter_for_source(source)
+                    _media_adapter = self._adapter_for_source(delivery_source)
                     if _media_adapter:
+                        media_kwargs = {}
+                        if getattr(_media_adapter, "_reply_to_mode", None) == "all":
+                            media_kwargs["reply_to"] = delivery_reply_to
                         await self._deliver_media_from_response(
-                            response, event, _media_adapter,
+                            response,
+                            delivery_event,
+                            _media_adapter,
+                            **media_kwargs,
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
@@ -12304,17 +12323,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # still surface the runtime metadata on the final reply.
                 if _footer_line:
                     try:
-                        _foot_adapter = self._adapter_for_source(source)
+                        _foot_adapter = self._adapter_for_source(delivery_source)
                         if _foot_adapter:
+                            footer_kwargs = {
+                                "metadata": self._thread_metadata_for_source(
+                                    delivery_source,
+                                    delivery_reply_to,
+                                )
+                            }
+                            if getattr(_foot_adapter, "_reply_to_mode", None) == "all":
+                                footer_kwargs["reply_to"] = delivery_reply_to
                             await _foot_adapter.send(
-                                source.chat_id,
+                                delivery_source.chat_id,
                                 _footer_line,
-                                metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
+                                **footer_kwargs,
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
 
+            if (
+                delivery_event is not event
+                or (
+                    "delivery_reply_to_message_id" in agent_result
+                    and delivery_reply_to != self._reply_anchor_for_event(event)
+                )
+            ):
+                return AnchoredReply(
+                    response,
+                    delivery_reply_to,
+                    delivery_event,
+                )
             return response
             
         except Exception as e:
@@ -13351,6 +13390,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         response: str,
         event: MessageEvent,
         adapter,
+        reply_to: Optional[str] = None,
     ) -> None:
         """Extract MEDIA: tags and local file paths from a response and deliver them.
 
@@ -13383,7 +13423,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             local_files, _ = adapter.extract_local_files(cleaned)
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+            _thread_meta = self._thread_metadata_for_source(
+                event.source,
+                self._reply_anchor_for_event(event),
+            )
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -13414,10 +13457,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
+                    await adapter._send_multiple_images_compat(
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
+                        reply_to=reply_to,
                     )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
@@ -13425,23 +13469,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             for media_path, is_voice in non_image_media:
                 try:
                     ext = Path(media_path).suffix.lower()
+                    media_reply_kwargs = (
+                        {"reply_to": reply_to}
+                        if reply_to is not None
+                        else {}
+                    )
                     if should_send_media_as_audio(event.source.platform, ext, is_voice=is_voice):
                         await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
+                            **media_reply_kwargs,
                         )
                     elif ext in _VIDEO_EXTS:
                         await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
+                            **media_reply_kwargs,
                         )
                     else:
                         await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
+                            **media_reply_kwargs,
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
@@ -13449,17 +13501,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             for file_path in non_image_local:
                 try:
                     ext = Path(file_path).suffix.lower()
+                    local_reply_kwargs = (
+                        {"reply_to": reply_to}
+                        if reply_to is not None
+                        else {}
+                    )
                     if ext in _VIDEO_EXTS:
                         await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=file_path,
                             metadata=_thread_meta,
+                            **local_reply_kwargs,
                         )
                     else:
                         await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=file_path,
                             metadata=_thread_meta,
+                            **local_reply_kwargs,
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
@@ -20104,6 +20163,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             await adapter.send(
                                 source.chat_id,
                                 first_response,
+                                reply_to=event_message_id,
                                 metadata=_status_thread_metadata,
                             )
                         except Exception as e:
@@ -20221,6 +20281,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
                 )
+                if isinstance(followup_result, dict) and pending_event is not None:
+                    # The recursive result's final response belongs to this
+                    # queued event. Preserve a deeper delivery context if that
+                    # recursive run drained another queued turn of its own.
+                    followup_result.setdefault(
+                        "delivery_reply_to_message_id",
+                        next_message_id,
+                    )
+                    followup_result.setdefault("delivery_event", pending_event)
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2425,12 +2425,31 @@ class DiscordAdapter(BasePlatformAdapter):
             continuation_message_ids=tuple(continuation_ids),
         )
 
+    async def _reply_reference_for_channel(
+        self,
+        channel,
+        reply_to: Optional[str],
+    ):
+        if not reply_to or self._reply_to_mode == "off":
+            return None
+        try:
+            ref_msg = await channel.fetch_message(int(reply_to))
+            return (
+                ref_msg.to_reference(fail_if_not_exists=False)
+                if hasattr(ref_msg, "to_reference")
+                else ref_msg
+            )
+        except Exception as exc:
+            logger.debug("Could not fetch attachment reply target: %s", exc)
+            return None
+
     async def _send_file_attachment(
         self,
         chat_id: str,
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
@@ -2455,7 +2474,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     content=(caption or "").strip(),
                     file=file,
                 )
-            msg = await channel.send(content=caption if caption else None, file=file)
+            reference = await self._reply_reference_for_channel(channel, reply_to)
+            send_kwargs = {"content": caption if caption else None, "file": file}
+            if reference is not None:
+                send_kwargs["reference"] = reference
+            msg = await channel.send(**send_kwargs)
         return SendResult(success=True, message_id=str(msg.id))
 
     async def send_multiple_images(
@@ -2464,7 +2487,8 @@ class DiscordAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send a batch of images as a single Discord message with multiple attachments.
 
         Discord permits up to 10 file attachments per message. Batches are
@@ -2475,17 +2499,18 @@ class DiscordAdapter(BasePlatformAdapter):
         fall back to the base per-image loop.
         """
         if not self._client:
-            return
+            return False
         if not images:
-            return
+            return False
 
         try:
             import discord as _discord_mod
             import io as _io
             from urllib.parse import unquote as _unquote
         except Exception:  # pragma: no cover
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(
+                chat_id, images, metadata, human_delay, reply_to
+            )
 
         try:
             channel = self._client.get_channel(int(chat_id))
@@ -2493,19 +2518,38 @@ class DiscordAdapter(BasePlatformAdapter):
                 channel = await self._client.fetch_channel(int(chat_id))
             if not channel:
                 logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
-                return
+                return False
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(
+                chat_id, images, metadata, human_delay, reply_to
+            )
+
+        reference = None
+        if reply_to and self._reply_to_mode != "off" and not self._is_forum_parent(channel):
+            try:
+                ref_msg = await channel.fetch_message(int(reply_to))
+                reference = (
+                    ref_msg.to_reference(fail_if_not_exists=False)
+                    if hasattr(ref_msg, "to_reference")
+                    else ref_msg
+                )
+            except Exception as exc:
+                logger.debug("Could not fetch multi-image reply target: %s", exc)
 
         CHUNK = 10
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
+        delivered = False
 
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
 
+            chunk_reply_to = (
+                reply_to
+                if self._reply_to_mode == "all" or not delivered
+                else None
+            )
             files: List[Any] = []
             captions: List[str] = []
             aiohttp_session = None
@@ -2571,20 +2615,37 @@ class DiscordAdapter(BasePlatformAdapter):
                         files=files,
                     )
                 else:
-                    await channel.send(content=content, files=files)
+                    chunk_reference = (
+                        reference
+                        if chunk_reply_to is not None
+                        else None
+                    )
+                    send_kwargs = {"content": content, "files": files}
+                    if chunk_reference is not None:
+                        send_kwargs["reference"] = chunk_reference
+                    await channel.send(**send_kwargs)
+                    delivered = True
             except Exception as e:
                 logger.warning(
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",
                     self.name, chunk_idx + 1, len(chunks), e,
                     exc_info=True,
                 )
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback_delivered = await super().send_multiple_images(
+                    chat_id,
+                    chunk,
+                    metadata,
+                    human_delay=human_delay,
+                    reply_to=chunk_reply_to,
+                )
+                delivered = delivered or fallback_delivered
             finally:
                 if aiohttp_session is not None:
                     try:
                         await aiohttp_session.close()
                     except Exception:
                         pass
+        return delivered
 
     async def play_tts(
         self,
@@ -2659,7 +2720,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 waveform_b64 = base64.b64encode(waveform_bytes).decode()
 
                 import json as _json
-                payload = _json.dumps({
+                payload_data = {
                     "flags": 8192,
                     "attachments": [{
                         "id": "0",
@@ -2667,7 +2728,13 @@ class DiscordAdapter(BasePlatformAdapter):
                         "duration_secs": round(duration_secs, 2),
                         "waveform": waveform_b64,
                     }],
-                })
+                }
+                if reply_to and self._reply_to_mode != "off":
+                    payload_data["message_reference"] = {
+                        "message_id": str(reply_to),
+                        "fail_if_not_exists": False,
+                    }
+                payload = _json.dumps(payload_data)
                 form = [
                     {"name": "payload_json", "value": payload},
                     {
@@ -2685,7 +2752,13 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as voice_err:
                 logger.debug("Voice message flag failed, falling back to file: %s", voice_err)
                 file = discord.File(io.BytesIO(file_data), filename=filename)
-                msg = await channel.send(file=file)
+                reference = await self._reply_reference_for_channel(
+                    channel, reply_to
+                )
+                send_kwargs = {"file": file}
+                if reference is not None:
+                    send_kwargs["reference"] = reference
+                msg = await channel.send(**send_kwargs)
                 return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send audio, falling back to base adapter: %s", self.name, e, exc_info=True)
@@ -3628,7 +3701,9 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(
+                chat_id, image_path, caption, reply_to=reply_to
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -3692,10 +3767,16 @@ class DiscordAdapter(BasePlatformAdapter):
                             file=file,
                         )
 
-                    msg = await channel.send(
-                        content=caption if caption else None,
-                        file=file,
+                    reference = await self._reply_reference_for_channel(
+                        channel, reply_to
                     )
+                    send_kwargs = {
+                        "content": caption if caption else None,
+                        "file": file,
+                    }
+                    if reference is not None:
+                        send_kwargs["reference"] = reference
+                    msg = await channel.send(**send_kwargs)
                     return SendResult(success=True, message_id=str(msg.id))
 
         except ImportError:
@@ -3761,10 +3842,16 @@ class DiscordAdapter(BasePlatformAdapter):
                             file=file,
                         )
 
-                    msg = await channel.send(
-                        content=caption if caption else None,
-                        file=file,
+                    reference = await self._reply_reference_for_channel(
+                        channel, reply_to
                     )
+                    send_kwargs = {
+                        "content": caption if caption else None,
+                        "file": file,
+                    }
+                    if reference is not None:
+                        send_kwargs["reference"] = reference
+                    msg = await channel.send(**send_kwargs)
                     return SendResult(success=True, message_id=str(msg.id))
 
         except ImportError:
@@ -3793,7 +3880,9 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(
+                chat_id, video_path, caption, reply_to=reply_to
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -3811,7 +3900,13 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(
+                chat_id,
+                file_path,
+                caption,
+                file_name=file_name,
+                reply_to=reply_to,
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -987,7 +987,8 @@ class EmailAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send a batch of images as a single email with multiple MIME attachments.
 
         Local files are attached directly. URL images have their URL
@@ -996,7 +997,7 @@ class EmailAdapter(BasePlatformAdapter):
         attachments fine, subject to SMTP message size limits.
         """
         if not images:
-            return
+            return False
 
         from urllib.parse import unquote as _unquote
 
@@ -1016,28 +1017,31 @@ class EmailAdapter(BasePlatformAdapter):
                 body_parts.append(f"Image: {image_url}")
 
         if not local_paths and not body_parts:
-            return
+            return False
 
         body = "\n\n".join(body_parts)
 
         try:
             loop = asyncio.get_running_loop()
+            send_args = (chat_id, body, local_paths)
+            if reply_to is not None:
+                send_args += (reply_to,)
             await loop.run_in_executor(
-                None,
-                self._send_email_with_attachments,
-                chat_id,
-                body,
-                local_paths,
+                None, self._send_email_with_attachments, *send_args
             )
+            return True
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            return await super().send_multiple_images(
+                chat_id, images, metadata, human_delay, reply_to
+            )
 
     def _send_email_with_attachments(
         self,
         to_addr: str,
         body: str,
         file_paths: List[str],
+        reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -1050,7 +1054,7 @@ class EmailAdapter(BasePlatformAdapter):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
+        original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1323,6 +1323,7 @@ class LineAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         path = Path(image_path)
         if not path.exists() or not path.is_file():
@@ -1353,6 +1354,7 @@ class LineAdapter(BasePlatformAdapter):
         audio_path: str,
         duration_ms: int = 1000,
         metadata: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         path = Path(audio_path)
         if not path.exists() or not path.is_file():
@@ -1377,6 +1379,7 @@ class LineAdapter(BasePlatformAdapter):
         video_path: str,
         preview_path: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         path = Path(video_path)
         if not path.exists() or not path.is_file():

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1917,13 +1917,17 @@ class MatrixAdapter(BasePlatformAdapter):
         images: list[tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send multiple Matrix images as one ordered logical batch."""
         if not images:
-            return
+            return False
         from urllib.parse import unquote as _unquote
 
         total = len(images)
+        remaining_reply_to = reply_to
+        reply_to_all_parts = getattr(self, "_reply_to_mode", None) == "all"
+        delivered = False
         for idx, (image_url, alt_text) in enumerate(images, start=1):
             if human_delay > 0 and idx > 1:
                 await asyncio.sleep(human_delay)
@@ -1935,6 +1939,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     chat_id=chat_id,
                     image_path=_unquote(image_url[7:]),
                     caption=caption,
+                    reply_to=remaining_reply_to,
                     metadata=metadata,
                 )
             else:
@@ -1942,10 +1947,16 @@ class MatrixAdapter(BasePlatformAdapter):
                     chat_id=chat_id,
                     image_url=image_url,
                     caption=caption,
+                    reply_to=remaining_reply_to,
                     metadata=metadata,
                 )
             if not result.success:
                 logger.warning("Matrix: failed to send image %d/%d: %s", idx, total, result.error)
+            elif not reply_to_all_parts:
+                remaining_reply_to = None
+            if result.success:
+                delivered = True
+        return delivered
 
     async def send_document(
         self,

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -598,7 +598,8 @@ class MattermostAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send a batch of images as a single Mattermost post with multiple attachments.
 
         Mattermost supports up to 5 ``file_ids`` per post. Each image is
@@ -608,7 +609,7 @@ class MattermostAdapter(BasePlatformAdapter):
         base per-image loop on total failure.
         """
         if not images:
-            return
+            return False
 
         import mimetypes
         import aiohttp
@@ -616,6 +617,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         CHUNK = 5  # Mattermost post file_ids cap
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
+        delivered = False
 
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
@@ -671,7 +673,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 }
-                resolved_root = await self._thread_root_for_send(None, metadata)
+                resolved_root = await self._thread_root_for_send(reply_to, metadata)
                 if resolved_root:
                     payload["root_id"] = resolved_root
                 logger.info(
@@ -681,13 +683,30 @@ class MattermostAdapter(BasePlatformAdapter):
                 data = await self._post_preserving_thread(chat_id, payload, metadata)
                 if not data or "id" not in data:
                     logger.warning("Mattermost: multi-image post failed, falling back")
-                    await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                    fallback_delivered = await super().send_multiple_images(
+                        chat_id,
+                        chunk,
+                        metadata,
+                        human_delay=human_delay,
+                        reply_to=reply_to,
+                    )
+                    delivered = delivered or fallback_delivered
+                else:
+                    delivered = True
             except Exception as e:
                 logger.warning(
                     "Mattermost: multi-image send failed (chunk %d/%d), falling back: %s",
                     chunk_idx + 1, len(chunks), e, exc_info=True,
                 )
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback_delivered = await super().send_multiple_images(
+                    chat_id,
+                    chunk,
+                    metadata,
+                    human_delay=human_delay,
+                    reply_to=reply_to,
+                )
+                delivered = delivered or fallback_delivered
+        return delivered
 
     # ------------------------------------------------------------------
     # WebSocket

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1817,7 +1817,8 @@ class SlackAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send a batch of images as a single Slack message with multiple file uploads.
 
         Uses ``files_upload_v2`` with its ``file_uploads`` parameter so all
@@ -1828,22 +1829,24 @@ class SlackAdapter(BasePlatformAdapter):
         The batch limit is 10 file uploads per call (Slack server-side cap).
         """
         if not self._app:
-            return
+            return False
         if not images:
-            return
+            return False
 
         try:
             import httpx as _httpx
             from urllib.parse import unquote as _unquote
             from tools.url_safety import is_safe_url as _is_safe_url
         except Exception:
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(
+                chat_id, images, metadata, human_delay, reply_to
+            )
 
-        thread_ts = self._resolve_thread_ts(None, metadata)
+        thread_ts = self._resolve_thread_ts(reply_to, metadata)
 
         CHUNK = 10
         chunks = [images[i : i + CHUNK] for i in range(0, len(images), CHUNK)]
+        delivered = False
 
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
@@ -1925,6 +1928,7 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 self._record_uploaded_file_thread(chat_id, thread_ts)
                 _ = result
+                delivered = True
             except Exception as e:
                 logger.warning(
                     "[Slack] Multi-image files_upload_v2 failed (chunk %d/%d), falling back to per-image: %s",
@@ -1933,9 +1937,15 @@ class SlackAdapter(BasePlatformAdapter):
                     e,
                     exc_info=True,
                 )
-                await super().send_multiple_images(
-                    chat_id, chunk, metadata, human_delay=human_delay
+                fallback_delivered = await super().send_multiple_images(
+                    chat_id,
+                    chunk,
+                    metadata,
+                    human_delay=human_delay,
+                    reply_to=reply_to,
                 )
+                delivered = delivered or fallback_delivered
+        return delivered
 
     def _record_uploaded_file_thread(
         self, chat_id: str, thread_ts: Optional[str]

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6202,7 +6202,8 @@ class TelegramAdapter(BasePlatformAdapter):
         images: List[tuple],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+        reply_to: Optional[str] = None,
+    ) -> bool:
         """Send a batch of images natively via Telegram's media group API.
 
         Telegram's ``send_media_group`` bundles up to 10 photos/videos into
@@ -6215,9 +6216,9 @@ class TelegramAdapter(BasePlatformAdapter):
         the base adapter's per-image loop.
         """
         if not self._bot:
-            return
+            return False
         if not images:
-            return
+            return False
 
         try:
             from telegram import InputMediaPhoto
@@ -6226,8 +6227,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] InputMediaPhoto unavailable, falling back to per-image send: %s",
                 self.name, exc,
             )
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(
+                chat_id, images, metadata, human_delay, reply_to
+            )
 
         # Peel off animations — they need send_animation, not send_media_group
         animations: List[tuple] = []
@@ -6239,13 +6241,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 photos.append((image_url, alt_text))
 
         # Animations: route through the base default (per-image send_animation)
+        delivered = False
         if animations:
-            await super().send_multiple_images(
-                chat_id, animations, metadata, human_delay=human_delay,
+            delivered = await super().send_multiple_images(
+                chat_id,
+                animations,
+                metadata,
+                human_delay=human_delay,
+                reply_to=reply_to,
             )
 
+        photo_reply_to = (
+            reply_to
+            if not delivered or self._reply_to_mode == "all"
+            else None
+        )
+
         if not photos:
-            return
+            return delivered
 
         from urllib.parse import unquote as _unquote
         _thread = self._metadata_thread_id(metadata)
@@ -6258,6 +6271,11 @@ class TelegramAdapter(BasePlatformAdapter):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
 
+            chunk_reply_to = (
+                photo_reply_to
+                if self._reply_to_mode == "all" or not delivered
+                else None
+            )
             media: List[Any] = []
             opened_files: List[Any] = []
             try:
@@ -6284,7 +6302,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Sending media group of %d photo(s) (chunk %d/%d)",
                     self.name, len(media), chunk_idx + 1, len(chunks),
                 )
-                reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+                reply_to_id = self._reply_to_message_id_for_send(
+                    chunk_reply_to,
+                    metadata,
+                    reply_to_mode=self._reply_to_mode,
+                )
                 thread_kwargs = self._thread_kwargs_for_send(
                     chat_id,
                     _thread,
@@ -6314,6 +6336,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "media group",
                     reset_media=_reset_opened_files,
                 )
+                delivered = True
             except Exception as e:
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s",
@@ -6321,15 +6344,21 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
                 # Fallback: send each photo in this chunk individually
-                await super().send_multiple_images(
-                    chat_id, chunk, metadata, human_delay=human_delay,
+                fallback_delivered = await super().send_multiple_images(
+                    chat_id,
+                    chunk,
+                    metadata,
+                    human_delay=human_delay,
+                    reply_to=chunk_reply_to,
                 )
+                delivered = delivered or fallback_delivered
             finally:
                 for fh in opened_files:
                     try:
                         fh.close()
                     except Exception:
                         pass
+        return delivered
 
     async def send_image_file(
         self,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "hansnow2012@gmail.com": "hansnow",  # PR #64752 (gateway: preserve reply anchors across queued turns)
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)
     "neo@neodeMac-mini.local": "neo-claw-bot",  # PR #58465 salvage (moa: drop empty user turns from advisory view)
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)

--- a/tests/gateway/test_queued_reply_anchor.py
+++ b/tests/gateway/test_queued_reply_anchor.py
@@ -1,0 +1,526 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    AnchoredReply,
+    BasePlatformAdapter,
+    MessageEvent,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class CaptureFeishuAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.FEISHU)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"sent-{len(self.sent)}")
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class TwoTurnAgent:
+    calls = []
+    on_turn = None
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls.append(message)
+        turn = len(type(self).calls)
+        if type(self).on_turn is not None:
+            type(self).on_turn(turn)
+        prior = list(conversation_history or [])
+        return {
+            "final_response": f"answer-{turn}",
+            "messages": prior
+            + [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": f"answer-{turn}"},
+            ],
+            "api_calls": 1,
+        }
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        multiplex_profiles=False,
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_queued_feishu_turns_keep_their_own_reply_anchors(monkeypatch, tmp_path):
+    TwoTurnAgent.calls = []
+    TwoTurnAgent.on_turn = None
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TwoTurnAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+
+    adapter = CaptureFeishuAdapter()
+    runner = _make_runner(adapter)
+    source_a = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+        user_name="A",
+    )
+    source_b = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_b",
+        user_name="B",
+    )
+    session_key = build_session_key(source_a, group_sessions_per_user=False)
+    pending_event = MessageEvent(
+        text="question-b",
+        source=source_b,
+        message_id="om_b",
+    )
+    adapter._pending_messages[session_key] = pending_event
+
+    result = await runner._run_agent(
+        message="question-a",
+        context_prompt="",
+        history=[],
+        source=source_a,
+        session_id="sess-feishu-shared",
+        session_key=session_key,
+        event_message_id="om_a",
+    )
+
+    assert [call["content"] for call in adapter.sent] == ["answer-1"]
+    assert adapter.sent[0]["reply_to"] == "om_a"
+    assert result["final_response"] == "answer-2"
+    assert result["delivery_reply_to_message_id"] == "om_b"
+    assert result["delivery_event"] is pending_event
+
+
+@pytest.mark.asyncio
+async def test_three_queued_feishu_turns_keep_each_reply_anchor(monkeypatch, tmp_path):
+    TwoTurnAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TwoTurnAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+
+    adapter = CaptureFeishuAdapter()
+    runner = _make_runner(adapter)
+    source_a = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+    )
+    source_b = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_b",
+    )
+    source_c = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_c",
+    )
+    session_key = build_session_key(source_a, group_sessions_per_user=False)
+    event_b = MessageEvent(text="question-b", source=source_b, message_id="om_b")
+    event_c = MessageEvent(text="question-c", source=source_c, message_id="om_c")
+    adapter._pending_messages[session_key] = event_b
+
+    def queue_third_turn(turn):
+        if turn == 2:
+            adapter._pending_messages[session_key] = event_c
+
+    TwoTurnAgent.on_turn = queue_third_turn
+    try:
+        result = await runner._run_agent(
+            message="question-a",
+            context_prompt="",
+            history=[],
+            source=source_a,
+            session_id="sess-feishu-three-turns",
+            session_key=session_key,
+            event_message_id="om_a",
+        )
+    finally:
+        TwoTurnAgent.on_turn = None
+
+    assert [(call["content"], call["reply_to"]) for call in adapter.sent] == [
+        ("answer-1", "om_a"),
+        ("answer-2", "om_b"),
+    ]
+    assert result["final_response"] == "answer-3"
+    assert result["delivery_reply_to_message_id"] == "om_c"
+    assert result["delivery_event"] is event_c
+
+
+@pytest.mark.asyncio
+async def test_base_delivery_uses_queued_turn_reply_anchor():
+    adapter = CaptureFeishuAdapter()
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+    )
+    event = MessageEvent(
+        text="question-a",
+        source=source,
+        message_id="om_a",
+    )
+
+    async def handler(_event):
+        return AnchoredReply("answer-b", "om_b")
+
+    adapter.set_message_handler(handler)
+    await adapter._process_message_background(
+        event,
+        build_session_key(source, group_sessions_per_user=False),
+    )
+
+    assert adapter.sent == [
+        {
+            "chat_id": "oc_group",
+            "content": "answer-b",
+            "reply_to": "om_b",
+            "metadata": {"notify": True},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_base_media_delivery_uses_queued_turn_event_and_anchor():
+    adapter = CaptureFeishuAdapter()
+    source_a = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+    )
+    source_b = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_b",
+    )
+    event_a = MessageEvent(text="question-a", source=source_a, message_id="om_a")
+    event_b = MessageEvent(text="question-b", source=source_b, message_id="om_b")
+
+    async def handler(_event):
+        return AnchoredReply(
+            "![plot](https://example.com/plot.png)",
+            "om_b",
+            event_b,
+        )
+
+    adapter.set_message_handler(handler)
+    await adapter._process_message_background(
+        event_a,
+        build_session_key(source_a, group_sessions_per_user=False),
+    )
+
+    assert adapter.sent == [
+        {
+            "chat_id": "oc_group",
+            "content": "plot\nhttps://example.com/plot.png",
+            "reply_to": "om_b",
+            "metadata": {"notify": True},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_text_claims_anchor_before_following_image():
+    adapter = CaptureFeishuAdapter()
+    source_a = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+    )
+    event_a = MessageEvent(text="question-a", source=source_a, message_id="om_a")
+    event_b = MessageEvent(
+        text="question-b",
+        source=SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type="group",
+            user_id="ou_b",
+        ),
+        message_id="om_b",
+    )
+
+    async def handler(_event):
+        return AnchoredReply(
+            "answer-b\n![plot](https://example.com/plot.png)",
+            "om_b",
+            event_b,
+        )
+
+    adapter.set_message_handler(handler)
+    await adapter._process_message_background(
+        event_a,
+        build_session_key(source_a, group_sessions_per_user=False),
+    )
+
+    assert [sent["reply_to"] for sent in adapter.sent] == ["om_b", None]
+
+
+@pytest.mark.asyncio
+async def test_legacy_batch_override_remains_compatible():
+    adapter = CaptureFeishuAdapter()
+    batch_calls = []
+
+    async def legacy_send_multiple_images(
+        chat_id,
+        images,
+        metadata=None,
+        human_delay=0.0,
+    ):
+        batch_calls.append((chat_id, images, metadata, human_delay))
+
+    adapter.send_multiple_images = legacy_send_multiple_images
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+    )
+    event = MessageEvent(text="question-a", source=source, message_id="om_a")
+
+    async def handler(_event):
+        return AnchoredReply(
+            "![plot](https://example.com/plot.png)",
+            "om_b",
+            event,
+        )
+
+    adapter.set_message_handler(handler)
+    await adapter._process_message_background(
+        event,
+        build_session_key(source, group_sessions_per_user=False),
+    )
+
+    assert len(batch_calls) == 1
+    assert batch_calls[0][0] == "oc_group"
+
+
+@pytest.mark.asyncio
+async def test_gateway_handler_routes_final_text_to_last_queued_turn(
+    monkeypatch,
+    tmp_path,
+):
+    from tests.gateway.test_gateway_silence_tokens import _runner
+
+    runner = _runner(monkeypatch, tmp_path)
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+    )
+    event = MessageEvent(
+        text="question-a",
+        source=source,
+        message_id="om_a",
+    )
+    delivery_event = MessageEvent(
+        text="question-b",
+        source=SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type="group",
+            user_id="ou_b",
+        ),
+        message_id="om_b",
+    )
+    runner._reply_anchor_for_event = lambda evt: evt.message_id
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "answer-b",
+            "messages": [
+                {"role": "user", "content": "question-a"},
+                {"role": "assistant", "content": "answer-a"},
+                {"role": "user", "content": "question-b"},
+                {"role": "assistant", "content": "answer-b"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 2,
+            "failed": False,
+            "delivery_reply_to_message_id": "om_b",
+            "delivery_event": delivery_event,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        event,
+        source,
+        "agent:main:feishu:group:oc_group",
+        1,
+    )
+
+    assert isinstance(response, AnchoredReply)
+    assert response == "answer-b"
+    assert response.reply_to_message_id == "om_b"
+    assert response.event is delivery_event
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reply_mode", "expected_ancillary_reply_to"),
+    [("first", None), ("all", "om_b")],
+)
+async def test_streaming_ancillary_delivery_uses_last_queued_event(
+    monkeypatch,
+    tmp_path,
+    reply_mode,
+    expected_ancillary_reply_to,
+):
+    from tests.gateway.test_gateway_silence_tokens import _runner
+
+    runner = _runner(monkeypatch, tmp_path)
+    adapter = CaptureFeishuAdapter()
+    adapter._reply_to_mode = reply_mode
+    runner.adapters = {Platform.FEISHU: adapter}
+    runner._adapter_for_source = lambda _source: adapter
+    runner._should_send_voice_reply = MagicMock(return_value=True)
+    runner._send_voice_reply = AsyncMock()
+    runner._deliver_media_from_response = AsyncMock()
+    monkeypatch.setenv("FEISHU_HOME_CHAT", "oc_group")
+    monkeypatch.setattr(
+        "gateway.runtime_footer.build_footer_line",
+        lambda **_kwargs: "runtime-footer",
+    )
+
+    source_a = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_a",
+    )
+    source_b = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        user_id="ou_b",
+    )
+    event_a = MessageEvent(text="question-a", source=source_a, message_id="om_a")
+    event_b = MessageEvent(text="question-b", source=source_b, message_id="om_b")
+    runner._reply_anchor_for_event = lambda evt: evt.message_id
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "answer-b",
+            "messages": [
+                {"role": "user", "content": "question-b"},
+                {"role": "assistant", "content": "answer-b"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+            "failed": False,
+            "already_sent": True,
+            "delivery_reply_to_message_id": "om_b",
+            "delivery_event": event_b,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        event_a,
+        source_a,
+        "agent:main:feishu:group:oc_group",
+        1,
+    )
+
+    assert response is None
+    runner._send_voice_reply.assert_awaited_once_with(event_b, "answer-b")
+    expected_media_kwargs = (
+        {"reply_to": expected_ancillary_reply_to}
+        if expected_ancillary_reply_to is not None
+        else {}
+    )
+    runner._deliver_media_from_response.assert_awaited_once_with(
+        "answer-b", event_b, adapter, **expected_media_kwargs
+    )
+    assert adapter.sent[-1]["content"] == "runtime-footer"
+    assert adapter.sent[-1]["reply_to"] == expected_ancillary_reply_to


### PR DESCRIPTION
## Summary

Fix reply anchoring when multiple messages are queued into the same shared group session.

When two group members mention the agent while a turn is already running, the queued turn's final response could be delivered using the original event. This caused the later answer to quote the earlier member's message instead of the message that produced that answer.

## Root cause

`_run_agent()` recursively processed queued follow-ups but returned only the final response text to the outer delivery layer. The outer layer therefore still held the first event's chat and message context.

Intermediate queued replies also did not explicitly bind delivery to the message ID for the turn being completed.

## Solution

- Carry the deepest queued turn's `MessageEvent` and reply anchor back to the delivery layer with `AnchoredReply`.
- Bind intermediate queued responses to their own event message IDs.
- Route final text, images, files, voice/TTS, streaming media, and footer content through the final queued event.
- Preserve native multi-image batching while forwarding the correct reply anchor.
- Keep compatibility with third-party adapters that implement the older batch-image signature.
- Consume `reply_to_mode=first` only after the first successful visible delivery, while preserving `reply_to_mode=all` for every delivered part.
- Add regression coverage for queued delivery context, failed delivery attempts, multipart output, streaming ancillary media, and adapter batch paths.

## Validation

- Focused gateway/platform regression suite: 383 passed, 22 skipped, 4 deselected.
- New queued-reply regression tests: 9 passed.
- Ruff checks passed.
- `git diff --check` passed.
- Independent `codex -m gpt-5.6-sol review --uncommitted` completed with no actionable findings.
