### PR TITLE
feat(launchd): add Umask=077 to generated plist for owner-only file creation

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2834,6 +2834,7 @@ KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
+UMask=0077
 StandardOutput=journal
 StandardError=journal
 
@@ -2872,6 +2873,7 @@ KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
+UMask=0077
 StandardOutput=journal
 StandardError=journal
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4044,6 +4044,9 @@ def generate_launchd_plist() -> str:
     <key>ExitTimeOut</key>
     <integer>25</integer>
 
+    <key>Umask</key>
+    <integer>63</integer>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -505,6 +505,13 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_plist_includes_umask_077(self):
+        """SEC-04A: generated plist must set Umask=63 (octal 077) so all
+        files created by the gateway process are owner-only."""
+        plist = gateway_cli.generate_launchd_plist()
+        assert "<key>Umask</key>" in plist
+        assert "<integer>63</integer>" in plist
+
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
         monkeypatch.setenv(

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -512,6 +512,24 @@ class TestGeneratedSystemdUnits:
         assert "<key>Umask</key>" in plist
         assert "<integer>63</integer>" in plist
 
+    def test_system_user_unit_includes_umask_0077(self, monkeypatch):
+        """SEC-04A: generated system systemd unit must set UMask=0077 so all
+        files created by the gateway process are owner-only."""
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("hermes", "hermes", "/home/hermes"),
+        )
+        monkeypatch.setattr(gateway_cli, "_hermes_home_for_target_user", lambda home: "/home/hermes/.hermes")
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="hermes")
+        assert "UMask=0077" in unit
+
+    def test_user_unit_includes_umask_0077(self):
+        """SEC-04A: generated user systemd unit must set UMask=0077 so all
+        files created by the gateway process are owner-only."""
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        assert "UMask=0077" in unit
+
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
         monkeypatch.setenv(


### PR DESCRIPTION
## Problem

The gateway service generators (launchd and systemd) do not set a umask, so the gateway process inherits the default 022. This creates `state.db`, WAL, and SHM files as world-readable (0644). On hosts without FileVault, these files are accessible to any local user.

## Solution

Sets `Umask=0077` on all gateway service templates so all files created by the gateway process are owner-only by default:

- **launchd (macOS):** `Umask=63` (decimal for octal 077) in the generated plist
- **systemd system unit (Linux):** `UMask=0077` in the `[Service]` section
- **systemd user unit (Linux):** `UMask=0077` in the `[Service]` section

## Changes

- `hermes_cli/gateway.py`:
  - Add `<key>Umask</key><integer>63</integer>` to `generate_launchd_plist()`
  - Add `UMask=0077` to both `generate_systemd_unit(system=True)` and `generate_systemd_unit(system=False)` templates
- `tests/hermes_cli/test_gateway_service.py`:
  - `test_launchd_plist_includes_umask_077` — launchd regression test
  - `test_system_user_unit_includes_umask_0077` — system unit regression test
  - `test_user_unit_includes_umask_0077` — user unit regression test

## Testing

```
$ python -m pytest tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits -k "umask" -xvs
PASSED test_launchd_plist_includes_umask_077
PASSED test_system_user_unit_includes_umask_0077
PASSED test_user_unit_includes_umask_0077
```

## Notes

- The umask only affects newly created files; existing files need a one-time `chmod 600`
- This is a defense-in-depth measure — the `.hermes` parent directory is typically 0700, but the umask ensures files are protected even if the parent permissions change
- No behavioral change to the gateway's functionality