### PR TITLE
fix(desktop): keep new-chat binding stable during attachment sync

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -133,7 +133,13 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     activeSessionIdRef: runtimeIdRef,
     busyRef,
     copy,
-    createBackendSessionForSend: async () => runtimeIdRef.current,
+    createBackendSessionForSend: async () => ({
+      // A tile always owns its live session; this fallback only satisfies the
+      // shared submit contract if a caller reaches the create seam.
+      routeToken: runtimeId,
+      runtimeSessionId: runtimeId,
+      storedSessionId: storedIdRef.current
+    }),
     getRoutedStoredSessionId: () => storedIdRef.current,
     getRuntimeIdForStoredSession: storedId => (storedId === storedIdRef.current ? runtimeIdRef.current : null),
     // A tile IS its session — no route to abandon, so the create-abort guard's

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
+import { $notifications } from '@/store/notifications'
 import { $busy, $connection, $messages, $sessions, $turnStartedAt, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -192,6 +193,7 @@ describe('usePromptActions /title', () => {
 
   afterEach(() => {
     cleanup()
+    $notifications.set([])
     vi.restoreAllMocks()
   })
 
@@ -505,6 +507,7 @@ describe('usePromptActions desktop slash pickers', () => {
 describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
+    $notifications.set([])
     vi.restoreAllMocks()
   })
 
@@ -714,6 +717,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
 describe('usePromptActions steerPrompt', () => {
   afterEach(() => {
     cleanup()
+    $notifications.set([])
     vi.restoreAllMocks()
   })
 
@@ -1732,6 +1736,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
 
   afterEach(() => {
     cleanup()
+    $notifications.set([])
     vi.restoreAllMocks()
   })
 
@@ -1747,7 +1752,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
       // new-chat route before returning the runtime session id.
       activeSessionIdRef.current = createdRuntimeSessionId
       selectedStoredSessionIdRef.current = createdStoredSessionId
-      routeToken = `session:${createdStoredSessionId}`
+      routeToken = `/${createdStoredSessionId}::`
 
       return {
         routeToken: `/${createdStoredSessionId}::`,
@@ -1853,6 +1858,145 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     expect(requestGateway).toHaveBeenCalledWith('prompt.submit', expect.anything(), 1_800_000)
   })
 
+  it('aborts when create returns on an unrelated route without adopting it as the binding baseline', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/new::'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      // A route-only user action (for example opening Settings) does not
+      // necessarily retarget either session ref.
+      routeToken = '/settings::'
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    expect(await handle!.submitText('must not submit from settings')).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+  })
+
+  it('resumes the created stored session when the first new-chat submit times out', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const recoveredRuntimeSessionId = 'rt-created-chat-recovered'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/new::'
+    let submitAttempts = 0
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      routeToken = `/${createdStoredSessionId}::`
+
+      return {
+        routeToken,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+
+        if (submitAttempts === 1) {
+          throw new Error('request timed out: prompt.submit')
+        }
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: recoveredRuntimeSessionId } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    expect(await handle!.submitText('survive the first submit timeout')).toBe(true)
+    expect(calls.find(call => call.method === 'session.resume')?.params).toMatchObject({
+      session_id: createdStoredSessionId
+    })
+    expect(calls.filter(call => call.method === 'prompt.submit')).toHaveLength(2)
+    expect(calls.filter(call => call.method === 'prompt.submit')[1]?.params).toMatchObject({
+      session_id: recoveredRuntimeSessionId
+    })
+  })
+
+  it('silently aborts when create returns null after the user changes context', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/new::'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = RUNTIME_SESSION_B
+      selectedStoredSessionIdRef.current = STORED_SESSION_B
+      routeToken = `/${STORED_SESSION_B}::`
+
+      return null
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    expect(await handle!.submitText('cancel this send')).toBe(false)
+    expect($notifications.get()).toHaveLength(0)
+  })
+
   it('aborts when the user switches chats after new-session navigation but before create returns', async () => {
     const createdStoredSessionId = 'stored-created-chat'
     const createdRuntimeSessionId = 'rt-created-chat'
@@ -1864,7 +2008,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
       // The create flow first performs its expected self-navigation...
       activeSessionIdRef.current = createdRuntimeSessionId
       selectedStoredSessionIdRef.current = createdStoredSessionId
-      routeToken = `session:${createdStoredSessionId}`
+      routeToken = `/${createdStoredSessionId}::`
       // ...then the user genuinely switches to another chat during a later await.
       activeSessionIdRef.current = RUNTIME_SESSION_B
       selectedStoredSessionIdRef.current = STORED_SESSION_B
@@ -1954,7 +2098,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     const createBackendSessionForSend = vi.fn(async () => {
       activeSessionIdRef.current = createdRuntimeSessionId
       selectedStoredSessionIdRef.current = createdStoredSessionId
-      routeToken = `session:${createdStoredSessionId}`
+      routeToken = `/${createdStoredSessionId}::`
 
       return {
         routeToken: `/${createdStoredSessionId}::`,
@@ -2225,6 +2369,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
 describe('usePromptActions eager attachment upload (drop-time)', () => {
   afterEach(() => {
     cleanup()
+    $notifications.set([])
     vi.restoreAllMocks()
     $connection.set(null)
     $composerAttachments.set([])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -96,7 +96,7 @@ function Harness({
     state: Record<string, unknown>
   ) => void
   onReady: (handle: HarnessHandle) => void
-  onSeedState?: (state: Record<string, unknown>) => void
+  onSeedState?: (state: Record<string, unknown>, storedSessionId?: string | null) => void
   openMemoryGraph?: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -1445,6 +1445,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     // conversation via session.resume — createBackendSessionForSend would
     // silently fork the user's chat in two.
     const calls: { method: string; params?: Record<string, unknown> }[] = []
+
     const createBackendSessionForSend = vi.fn(async () => ({
       routeToken: '/brand-new-stored-WRONG::',
       runtimeSessionId: 'brand-new-session-WRONG',
@@ -1485,7 +1486,12 @@ describe('usePromptActions sleep/wake session recovery', () => {
   it('never replaces a selected stored session when its direct runtime resume fails', async () => {
     const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
     const busyRef: MutableRefObject<boolean> = { current: false }
-    const createBackendSessionForSend = vi.fn(async () => 'brand-new-session-WRONG')
+
+    const createBackendSessionForSend = vi.fn(async () => ({
+      routeToken: '/brand-new-stored-WRONG::',
+      runtimeSessionId: 'brand-new-session-WRONG',
+      storedSessionId: 'brand-new-stored-WRONG'
+    }))
 
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.resume') {
@@ -1523,7 +1529,13 @@ describe('usePromptActions sleep/wake session recovery', () => {
     const activeSessionIdRef: MutableRefObject<string | null> = { current: 'rt-wrong-profile' }
     const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
     let boundRuntimeId: string | null = null
-    const createBackendSessionForSend = vi.fn(async () => 'brand-new-session-WRONG')
+
+    const createBackendSessionForSend = vi.fn(async () => ({
+      routeToken: '/brand-new-stored-WRONG::',
+      runtimeSessionId: 'brand-new-session-WRONG',
+      storedSessionId: 'brand-new-stored-WRONG'
+    }))
+
     const requestGateway = vi.fn(async () => ({}) as never)
 
     const resumeStoredSession = vi.fn(async (storedSessionId: string) => {
@@ -1635,7 +1647,12 @@ describe('usePromptActions sleep/wake session recovery', () => {
     let recoverySucceeds = false
     let boundRuntimeId: string | null = null
 
-    const createBackendSessionForSend = vi.fn(async () => 'brand-new-session-WRONG')
+    const createBackendSessionForSend = vi.fn(async () => ({
+      routeToken: '/brand-new-stored-WRONG::',
+      runtimeSessionId: 'brand-new-session-WRONG',
+      storedSessionId: 'brand-new-stored-WRONG'
+    }))
+
     const requestGateway = vi.fn(async () => ({}) as never)
 
     const resumeStoredSession = vi.fn(async () => {
@@ -1686,12 +1703,14 @@ describe('usePromptActions sleep/wake session recovery', () => {
   })
 
   it('still creates a new session for a genuine new-chat draft (no stored session selected)', async () => {
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
     const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
 
     // Mirror the real createBackendSessionForSend: a successful create
-    // re-homes the active runtime ref to the session it minted before returning.
+    // re-homes runtime, stored selection, and route before returning.
     const createBackendSessionForSend = vi.fn(async () => {
       activeSessionIdRef.current = RUNTIME_SESSION_ID
+      selectedStoredSessionIdRef.current = RUNTIME_SESSION_ID
 
       return {
         routeToken: `/${RUNTIME_SESSION_ID}::`,
@@ -1717,6 +1736,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
         onReady={h => (handle = h)}
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
         storedSessionId={null}
       />
     )
@@ -2049,7 +2069,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
   it('aborts when create returns its own binding but the UI has already selected another stored route', async () => {
     const createdStoredSessionId = 'stored-created-chat'
     const createdRuntimeSessionId = 'rt-created-chat'
-    const activeSessionIdRef: MutableRefObject<string | null> = { current: createdRuntimeSessionId }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
     const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
     let routeToken = 'new-chat'
 
@@ -2289,9 +2309,13 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     const createBackendSessionForSend = vi.fn(async () => {
       activeSessionIdRef.current = 'rt-new-chat'
       selectedStoredSessionIdRef.current = 'stored-new-chat'
-      routeToken = '/stored-new-chat'
+      routeToken = '/stored-new-chat::'
 
-      return 'rt-new-chat'
+      return {
+        routeToken: '/stored-new-chat::',
+        runtimeSessionId: 'rt-new-chat',
+        storedSessionId: 'stored-new-chat'
+      }
     })
 
     let handle: HarnessHandle | null = null
@@ -2342,7 +2366,11 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
       selectedStoredSessionIdRef.current = STORED_SESSION_B
       routeToken = `/${STORED_SESSION_B}`
 
-      return 'rt-new-chat'
+      return {
+        routeToken: '/stored-new-chat::',
+        runtimeSessionId: 'rt-new-chat',
+        storedSessionId: 'stored-new-chat'
+      }
     })
 
     let handle: HarnessHandle | null = null

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1441,7 +1441,11 @@ describe('usePromptActions sleep/wake session recovery', () => {
     // conversation via session.resume — createBackendSessionForSend would
     // silently fork the user's chat in two.
     const calls: { method: string; params?: Record<string, unknown> }[] = []
-    const createBackendSessionForSend = vi.fn(async () => 'brand-new-session-WRONG')
+    const createBackendSessionForSend = vi.fn(async () => ({
+      routeToken: '/brand-new-stored-WRONG::',
+      runtimeSessionId: 'brand-new-session-WRONG',
+      storedSessionId: 'brand-new-stored-WRONG'
+    }))
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
@@ -1681,13 +1685,15 @@ describe('usePromptActions sleep/wake session recovery', () => {
     const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
 
     // Mirror the real createBackendSessionForSend: a successful create
-    // re-homes the active runtime ref to the session it minted BEFORE
-    // returning. An inert stub here is what let the new-chat drift-abort
-    // regression ship green.
+    // re-homes the active runtime ref to the session it minted before returning.
     const createBackendSessionForSend = vi.fn(async () => {
       activeSessionIdRef.current = RUNTIME_SESSION_ID
 
-      return RUNTIME_SESSION_ID
+      return {
+        routeToken: `/${RUNTIME_SESSION_ID}::`,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        storedSessionId: RUNTIME_SESSION_ID
+      }
     })
 
     const calls: string[] = []
@@ -1727,6 +1733,281 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+  })
+
+  it('allows a genuine new-chat send to follow its own session-creation navigation', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      // Real session creation selects the persisted row and navigates from the
+      // new-chat route before returning the runtime session id.
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      routeToken = `session:${createdStoredSessionId}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const accepted = await handle!.submitText('describe this image', {
+      attachments: [{ id: 'image:first', kind: 'image', label: 'first.png', refText: '@image:first.png' }]
+    })
+
+    expect(accepted).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: createdRuntimeSessionId,
+        text: '@image:first.png\n\ndescribe this image'
+      },
+      1_800_000
+    )
+  })
+
+  it('allows the new-chat route token to update asynchronously during first attachment sync', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/::'
+
+    let releaseAttach: () => void = () => {}
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+
+      // React Router has been asked to navigate, but routeTokenRef still exposes
+      // /new until the next render commit.
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+
+    const attachment = { id: 'image:first', kind: 'image' as const, label: 'first.png', path: 'C:/tmp/first.png' }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'image.attach') {
+        await new Promise<void>(resolve => {
+          releaseAttach = resolve
+        })
+
+        return { attached: true, path: attachment.path } as never
+      }
+
+      return {} as never
+    })
+
+    let seededStoredSessionId: string | null | undefined
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        onSeedState={(_state, storedSessionId) => {
+          seededStoredSessionId = storedSessionId
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const submitting = handle!.submitText('describe this image', { attachments: [attachment] })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach', expect.anything()))
+    routeToken = `/${createdStoredSessionId}::`
+    releaseAttach()
+
+    expect(await submitting).toBe(true)
+    expect(seededStoredSessionId).toBe(createdStoredSessionId)
+    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', expect.anything(), 1_800_000)
+  })
+
+  it('aborts when the user switches chats after new-session navigation but before create returns', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      // The create flow first performs its expected self-navigation...
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      routeToken = `session:${createdStoredSessionId}`
+      // ...then the user genuinely switches to another chat during a later await.
+      activeSessionIdRef.current = RUNTIME_SESSION_B
+      selectedStoredSessionIdRef.current = STORED_SESSION_B
+      routeToken = `session:${STORED_SESSION_B}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const accepted = await handle!.submitText('must stay in the original draft', {
+      attachments: [{ id: 'image:first', kind: 'image', label: 'first.png', refText: '@image:first.png' }]
+    })
+
+    expect(accepted).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+  })
+
+  it('aborts when create returns its own binding but the UI has already selected another stored route', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: createdRuntimeSessionId }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      selectedStoredSessionIdRef.current = STORED_SESSION_B
+      routeToken = `session:${STORED_SESSION_B}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    expect(await handle!.submitText('must not be rebound to B')).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+  })
+
+  it('aborts an ABA switch that returns to the same stored route with a new runtime binding', async () => {
+    const createdStoredSessionId = 'stored-created-chat'
+    const createdRuntimeSessionId = 'rt-created-chat'
+    const reboundRuntimeSessionId = 'rt-created-chat-rebound'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = 'new-chat'
+
+    let releaseAttach: () => void = () => {}
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = createdRuntimeSessionId
+      selectedStoredSessionIdRef.current = createdStoredSessionId
+      routeToken = `session:${createdStoredSessionId}`
+
+      return {
+        routeToken: `/${createdStoredSessionId}::`,
+        runtimeSessionId: createdRuntimeSessionId,
+        storedSessionId: createdStoredSessionId
+      }
+    })
+
+    const requestGateway = vi.fn(async (_method: string, _params?: Record<string, unknown>, _timeout?: number) => ({}) as never)
+    const attachment = { id: 'image:first', kind: 'image' as const, label: 'first.png', path: 'C:/tmp/first.png' }
+
+    // Hold attachment sync open while the user switches B → original stored
+    // route, whose resume produces a different live runtime binding.
+    requestGateway.mockImplementation(async method => {
+      if (method === 'image.attach') {
+        await new Promise<void>(resolve => {
+          releaseAttach = resolve
+        })
+
+        return { attached: true, path: attachment.path } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    const submitting = handle!.submitText('must not use the stale runtime', { attachments: [attachment] })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach', expect.anything()))
+
+    activeSessionIdRef.current = RUNTIME_SESSION_B
+    selectedStoredSessionIdRef.current = STORED_SESSION_B
+    routeToken = `session:${STORED_SESSION_B}`
+    activeSessionIdRef.current = reboundRuntimeSessionId
+    selectedStoredSessionIdRef.current = createdStoredSessionId
+    routeToken = `session:${createdStoredSessionId}`
+    releaseAttach()
+
+    expect(await submitting).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
   })
 
   it('aborts submit when the user switches sessions during session.resume (no misroute)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -104,7 +104,9 @@ function Harness({
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
   activeSessionId?: null | string
-  createBackendSessionForSend?: () => Promise<null | string>
+  createBackendSessionForSend?: () => Promise<
+    null | { routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null }
+  >
 }) {
   const localActiveSessionIdRef = useRef<string | null>(
     activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId
@@ -130,7 +132,13 @@ function Harness({
     activeSessionIdRef,
     branchCurrentSession: async () => true,
     busyRef: localBusyRef,
-    createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_SESSION_ID),
+    createBackendSessionForSend:
+      createBackendSessionForSend ??
+      (async () => ({
+        routeToken: selectedStoredSessionIdRef.current ? `/${selectedStoredSessionIdRef.current}::` : null,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        storedSessionId: selectedStoredSessionIdRef.current
+      })),
     getRoutedStoredSessionId: getRoutedStoredSessionId ?? (() => null),
     getRuntimeIdForStoredSession: getRuntimeIdForStoredSession ?? (() => null),
     getRouteToken: getRouteToken ?? (() => 'token'),
@@ -146,7 +154,7 @@ function Harness({
       // Seed with interrupted:true so we can prove a fresh submit clears it.
       const next = updater(stateRef.current) as unknown as Record<string, unknown>
       stateRef.current = next as never
-      onSeedState?.(next)
+      onSeedState?.(next, storedSessionId)
       onUpdateState?.(sessionId, storedSessionId, next)
 
       return next as never

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -171,7 +171,9 @@ interface PromptActionsOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   branchCurrentSession: () => Promise<boolean>
-  createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  createBackendSessionForSend: (
+    preview?: string | null
+  ) => Promise<{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null } | null>
   getRoutedStoredSessionId: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   getRouteToken: () => string

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -54,7 +54,9 @@ interface SlashCommandDeps {
   branchCurrentSession: () => Promise<boolean>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
-  createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  createBackendSessionForSend: (
+    preview?: string | null
+  ) => Promise<{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null } | null>
   handleSkinCommand: (arg: string) => string
   handoffSession: (
     platform: string,
@@ -89,8 +91,13 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
   return useCallback(
     async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
-      const ensureSessionId = async (sessionHint?: string) =>
-        sessionHint || activeSessionIdRef.current || (await createBackendSessionForSend())
+      const ensureSessionId = async (sessionHint?: string) => {
+        if (sessionHint || activeSessionIdRef.current) {
+          return sessionHint || activeSessionIdRef.current
+        }
+
+        return (await createBackendSessionForSend())?.runtimeSessionId ?? null
+      }
 
       // Resolve the target session plus a writer for inline slash output, or
       // notify + return null when none can be created. Folds the ensure / bail /

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -183,7 +183,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       let pendingCreatedRouteToken: string | null = null
 
       const sessionContextDrifted = (): boolean => {
-        if (targetStartedInCurrentView && pendingCreatedRouteToken) {
+        if (!targetStartedInCurrentView) {
+          return false
+        }
+
+        if (pendingCreatedRouteToken) {
           if (
             activeSessionIdRef.current === expectedRuntimeSessionId &&
             selectedStoredSessionIdRef.current === expectedStoredSessionId &&
@@ -195,8 +199,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
 
         return (
-          targetStartedInCurrentView &&
-          (selectedStoredSessionIdRef.current !== expectedStoredSessionId || getRouteToken() !== expectedRouteToken)
+          activeSessionIdRef.current !== expectedRuntimeSessionId ||
+          selectedStoredSessionIdRef.current !== expectedStoredSessionId ||
+          getRouteToken() !== expectedRouteToken
         )
       }
 
@@ -337,6 +342,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         } catch {
           return abortForSessionSwitch(null)
         }
+
+        // resumeStoredSession re-homes the foreground runtime to the durable
+        // routed target. Re-pin the expected runtime before the generic drift
+        // guard; the following cache/selection checks still reject a failed or
+        // cross-wired resume.
+        expectedRuntimeSessionId = activeSessionIdRef.current
 
         if (sessionContextDrifted()) {
           return abortForSessionSwitch(null)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -165,34 +165,38 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       const selectedStoredSessionId = selectedStoredSessionIdRef.current
       const routedStoredSessionId = getRoutedStoredSessionId()
       const routedRuntimeId = routedStoredSessionId ? getRuntimeIdForStoredSession(routedStoredSessionId) : null
+
       const routedSessionNeedsResume = Boolean(
         routedStoredSessionId &&
         (selectedStoredSessionId !== routedStoredSessionId ||
           !startingActiveSessionId ||
           startingActiveSessionId !== routedRuntimeId)
       )
+
       let expectedRuntimeSessionId = startingActiveSessionId
-      let expectedStoredSessionId = routedSessionNeedsResume
-        ? routedStoredSessionId
-        : (selectedStoredSessionId ?? routedStoredSessionId)
+
+      let expectedStoredSessionId =
+        options?.storedSessionId ??
+        (routedSessionNeedsResume ? routedStoredSessionId : (selectedStoredSessionId ?? routedStoredSessionId))
+
       let expectedRouteToken = getRouteToken()
       let pendingCreatedRouteToken: string | null = null
 
       const sessionContextDrifted = (): boolean => {
-        if (
-          pendingCreatedRouteToken &&
-          activeSessionIdRef.current === expectedRuntimeSessionId &&
-          selectedStoredSessionIdRef.current === expectedStoredSessionId &&
-          getRouteToken() === pendingCreatedRouteToken
-        ) {
-          expectedRouteToken = pendingCreatedRouteToken
-          pendingCreatedRouteToken = null
+        if (targetStartedInCurrentView && pendingCreatedRouteToken) {
+          if (
+            activeSessionIdRef.current === expectedRuntimeSessionId &&
+            selectedStoredSessionIdRef.current === expectedStoredSessionId &&
+            getRouteToken() === pendingCreatedRouteToken
+          ) {
+            expectedRouteToken = pendingCreatedRouteToken
+            pendingCreatedRouteToken = null
+          }
         }
 
         return (
-          activeSessionIdRef.current !== expectedRuntimeSessionId ||
-          selectedStoredSessionIdRef.current !== expectedStoredSessionId ||
-          getRouteToken() !== expectedRouteToken
+          targetStartedInCurrentView &&
+          (selectedStoredSessionIdRef.current !== expectedStoredSessionId || getRouteToken() !== expectedRouteToken)
         )
       }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -30,11 +30,17 @@ import {
   withSessionBusyRetry
 } from './utils'
 
+interface CreatedSessionBinding {
+  routeToken: string | null
+  runtimeSessionId: string
+  storedSessionId: string | null
+}
+
 interface SubmitPromptDeps {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
-  createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
+  createBackendSessionForSend: (preview?: string | null) => Promise<CreatedSessionBinding | null>
   getRoutedStoredSessionId: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   getRouteToken: () => string
@@ -151,33 +157,44 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       let sessionId: null | string = options?.sessionId ?? activeSessionIdRef.current
 
-      // Pin the foreground session context for the whole async submit pipeline.
-      // Without this, a fast session switch during session.resume / file.attach
-      // can redirect the user's text into a different chat (#54527). Mutable —
-      // not const — because a new-chat submit legitimately re-homes to the
-      // session it creates (see the re-pin after createBackendSessionForSend).
+      // Pin the submission context across every await. Existing routed/queued
+      // sends retain main's target-aware recovery model; a genuine new-chat
+      // create installs its explicit binding below rather than inferring it
+      // from ambient refs after navigation.
       const startingActiveSessionId = activeSessionIdRef.current
       const selectedStoredSessionId = selectedStoredSessionIdRef.current
       const routedStoredSessionId = getRoutedStoredSessionId()
-
       const routedRuntimeId = routedStoredSessionId ? getRuntimeIdForStoredSession(routedStoredSessionId) : null
-
       const routedSessionNeedsResume = Boolean(
         routedStoredSessionId &&
         (selectedStoredSessionId !== routedStoredSessionId ||
           !startingActiveSessionId ||
           startingActiveSessionId !== routedRuntimeId)
       )
-
-      let startingStoredSessionId = routedSessionNeedsResume
+      let expectedRuntimeSessionId = startingActiveSessionId
+      let expectedStoredSessionId = routedSessionNeedsResume
         ? routedStoredSessionId
         : (selectedStoredSessionId ?? routedStoredSessionId)
+      let expectedRouteToken = getRouteToken()
+      let pendingCreatedRouteToken: string | null = null
 
-      let startingRouteToken = getRouteToken()
+      const sessionContextDrifted = (): boolean => {
+        if (
+          pendingCreatedRouteToken &&
+          activeSessionIdRef.current === expectedRuntimeSessionId &&
+          selectedStoredSessionIdRef.current === expectedStoredSessionId &&
+          getRouteToken() === pendingCreatedRouteToken
+        ) {
+          expectedRouteToken = pendingCreatedRouteToken
+          pendingCreatedRouteToken = null
+        }
 
-      const sessionContextDrifted = (): boolean =>
-        targetStartedInCurrentView &&
-        (selectedStoredSessionIdRef.current !== startingStoredSessionId || getRouteToken() !== startingRouteToken)
+        return (
+          activeSessionIdRef.current !== expectedRuntimeSessionId ||
+          selectedStoredSessionIdRef.current !== expectedStoredSessionId ||
+          getRouteToken() !== expectedRouteToken
+        )
+      }
 
       const targetIsCurrentView = (): boolean => targetStartedInCurrentView && !sessionContextDrifted()
 
@@ -239,7 +256,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          targetStoredSessionId
+          expectedStoredSessionId
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -251,7 +268,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          targetStoredSessionId
+          expectedStoredSessionId
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -272,7 +289,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          targetStoredSessionId
+          expectedStoredSessionId
         )
       }
 
@@ -361,6 +378,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             if (targetIsCurrentView()) {
               activeSessionIdRef.current = sessionId
             }
+
+            expectedRuntimeSessionId = sessionId
           }
         } catch {
           // A target stored conversation is not a new-chat draft. If its
@@ -383,8 +402,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
 
       if (!sessionId) {
+        let createdBinding: CreatedSessionBinding | null
+
         try {
-          sessionId = await createBackendSessionForSend(visibleText)
+          createdBinding = await createBackendSessionForSend(visibleText)
         } catch (err) {
           dropOptimistic(null)
           releaseBusy()
@@ -396,11 +417,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
-        if (!sessionId) {
-          // createBackendSessionForSend returns null when the user switched
-          // sessions mid-create (it closes the orphaned session itself) —
-          // abort silently. Anything else is a real failure worth a toast.
-          if (sessionContextDrifted()) {
+        if (!createdBinding) {
+          // Creation can deliberately return null after the user changed
+          // context during post-create setup. That is cancellation, not a
+          // failed create, and must not surface a misleading toast.
+          if (
+            activeSessionIdRef.current !== startingActiveSessionId ||
+            selectedStoredSessionIdRef.current !== selectedStoredSessionId ||
+            getRouteToken() !== expectedRouteToken
+          ) {
             return abortForSessionSwitch(null)
           }
 
@@ -414,22 +439,31 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           return false
         }
 
-        // A successful create re-homes selection + route to the chat it just
-        // minted, so the pre-create baseline can't tell our own re-home from
-        // a user switch (judging it drift aborted EVERY first send of a new
-        // chat: no prompt.submit, no DB row, a stranded route that 404s
-        // "Session not found"). The drift signal for this window is the
-        // active ref instead: every switch path re-nulls or retargets it
-        // synchronously, so it only still equals the id create returned when
-        // nobody re-homed since.
-        if (activeSessionIdRef.current !== sessionId) {
+        sessionId = createdBinding.runtimeSessionId
+
+        // Only the create operation may authorize its own re-home. At return,
+        // the router may still expose the submit-entry route or may already
+        // expose the exact created route; any third route is a real drift.
+        if (
+          activeSessionIdRef.current !== createdBinding.runtimeSessionId ||
+          selectedStoredSessionIdRef.current !== createdBinding.storedSessionId
+        ) {
           return abortForSessionSwitch(sessionId)
         }
 
-        // Re-pin the baseline to the created chat for the rest of the
-        // pipeline; the closures (seedOptimistic et al) see the new value.
-        startingStoredSessionId = selectedStoredSessionIdRef.current
-        startingRouteToken = getRouteToken()
+        expectedRuntimeSessionId = createdBinding.runtimeSessionId
+        expectedStoredSessionId = createdBinding.storedSessionId
+
+        const routeAfterCreate = getRouteToken()
+
+        if (routeAfterCreate === createdBinding.routeToken) {
+          expectedRouteToken = routeAfterCreate
+          pendingCreatedRouteToken = null
+        } else if (routeAfterCreate === expectedRouteToken) {
+          pendingCreatedRouteToken = createdBinding.routeToken
+        } else {
+          return abortForSessionSwitch(sessionId)
+        }
 
         seedOptimistic(sessionId)
       }
@@ -460,7 +494,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             requestGateway('prompt.submit', { session_id: sessionId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
           )
         } catch (firstErr) {
-          const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
+          const recoverStoredSessionId = expectedStoredSessionId
 
           if ((isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) && recoverStoredSessionId) {
             // Re-register the session in the gateway and get a fresh live ID.
@@ -483,6 +517,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               if (targetIsCurrentView()) {
                 activeSessionIdRef.current = recoveredId
               }
+
+              expectedRuntimeSessionId = recoveredId
 
               await withSessionBusyRetry(() =>
                 requestGateway('prompt.submit', { session_id: recoveredId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
@@ -539,7 +575,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             pendingBranchGroup: null,
             sawAssistantPayload: true
           }),
-          targetStoredSessionId
+          expectedStoredSessionId
         )
 
         if (targetIsCurrentView() && isProviderSetupError(err)) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -418,9 +418,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
 
         if (!createdBinding) {
-          // Creation can deliberately return null after the user changed
-          // context during post-create setup. That is cancellation, not a
-          // failed create, and must not surface a misleading toast.
+          // A null result can mean the create flow intentionally cancelled
+          // because the user changed context during one of its awaits. Preserve
+          // the existing silent-cancel behavior instead of reporting a create
+          // failure for a valid user action.
           if (
             activeSessionIdRef.current !== startingActiveSessionId ||
             selectedStoredSessionIdRef.current !== selectedStoredSessionId ||
@@ -456,6 +457,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         const routeAfterCreate = getRouteToken()
 
+        // Creation owns exactly one possible route transition: from the route
+        // pinned at submit entry to the created stored-session route. If some
+        // unrelated route is already visible here (for example Settings), do
+        // not adopt it as the baseline merely because the session refs match.
         if (routeAfterCreate === createdBinding.routeToken) {
           expectedRouteToken = routeAfterCreate
           pendingCreatedRouteToken = null

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -570,7 +570,7 @@ describe('createBackendSessionForSend profile routing', () => {
     render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
     await waitFor(() => expect(handle).not.toBeNull())
 
-    let createPromise!: Promise<null | string>
+    let createPromise!: Promise<{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null } | null>
     act(() => {
       createPromise = handle!.createBackendSessionForSend()
     })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -455,17 +455,20 @@ describe('createBackendSessionForSend profile routing', () => {
     const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
     const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
     let routeToken = '/::'
+
     let releaseYolo: () => void = () => {}
 
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.create') {
         return { session_id: createdRuntimeSessionId, stored_session_id: createdStoredSessionId } as never
       }
+
       if (method === 'config.set') {
         await new Promise<void>(resolve => {
           releaseYolo = resolve
         })
       }
+
       return {} as never
     })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -90,30 +90,38 @@ function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 }
 
 function Harness({
+  activeSessionIdRef: activeSessionIdRefProp,
+  getRouteToken,
   navigate = vi.fn(),
   onReady,
-  requestGateway
+  requestGateway,
+  selectedStoredSessionIdRef: selectedStoredSessionIdRefProp
 }: {
+  activeSessionIdRef?: MutableRefObject<string | null>
+  getRouteToken?: () => string
   navigate?: ReturnType<typeof vi.fn>
   onReady: (handle: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  selectedStoredSessionIdRef?: MutableRefObject<string | null>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+  const activeSessionIdRef = activeSessionIdRefProp ?? ref<string | null>(null)
+  const selectedStoredSessionIdRef = selectedStoredSessionIdRefProp ?? ref<string | null>(null)
 
   const actions = useSessionActions({
     activeSessionId: null,
-    activeSessionIdRef: ref<string | null>(null),
+    activeSessionIdRef,
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
-    getRouteToken: () => 'token',
+    getRouteToken: getRouteToken ?? (() => 'token'),
     getRoutedStoredSessionId: () => null,
     navigate: navigate as never,
     requestGateway,
     resetViewSync: vi.fn(),
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId: null,
-    selectedStoredSessionIdRef: ref<string | null>(null),
+    selectedStoredSessionIdRef,
     sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
     updateSessionState: () => ({}) as ClientSessionState
@@ -439,6 +447,54 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
     vi.restoreAllMocks()
+  })
+
+  it('returns null when the user switches sessions during post-create YOLO setup', async () => {
+    const createdStoredSessionId = 'stored-created'
+    const createdRuntimeSessionId = 'rt-created'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/::'
+    let releaseYolo: () => void = () => {}
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: createdRuntimeSessionId, stored_session_id: createdStoredSessionId } as never
+      }
+      if (method === 'config.set') {
+        await new Promise<void>(resolve => {
+          releaseYolo = resolve
+        })
+      }
+      return {} as never
+    })
+
+    // Arm YOLO so createBackendSessionForSend has a real post-navigation await.
+    const { setYoloActive } = await import('@/store/session')
+    setYoloActive(true)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        getRouteToken={() => routeToken}
+        onReady={value => (handle = value)}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const creating = handle!.createBackendSessionForSend('preview')
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('config.set', expect.anything()))
+
+    // User selects B while the new session's optional YOLO call is still pending.
+    selectedStoredSessionIdRef.current = 'stored-B'
+    routeToken = '/stored-B::'
+    releaseYolo()
+
+    expect(await creating).toBeNull()
+    setYoloActive(false)
   })
 
   it('routes a plain new chat (no explicit profile) to the live gateway profile', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -338,7 +338,9 @@ export function useSessionActions({
   )
 
   const createBackendSessionForSend = useCallback(
-    async (preview: string | null = null): Promise<string | null> => {
+    async (
+      preview: string | null = null
+    ): Promise<{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null } | null> => {
       const startingActiveSessionId = activeSessionIdRef.current
       const startingStoredSessionId = selectedStoredSessionIdRef.current
       const startingRouteToken = getRouteToken()
@@ -408,7 +410,21 @@ export function useSessionActions({
           await setSessionYolo(requestGateway, created.session_id, true).catch(() => undefined)
         }
 
-        return created.session_id
+        // The optional post-create setup above can yield after the self-navigation.
+        // If the user selected another chat meanwhile, do not return a stale
+        // binding to prompt or slash callers.
+        if (
+          activeSessionIdRef.current !== created.session_id ||
+          selectedStoredSessionIdRef.current !== stored
+        ) {
+          return null
+        }
+
+        return {
+          routeToken: stored ? `${sessionRoute(stored)}::` : null,
+          runtimeSessionId: created.session_id,
+          storedSessionId: stored
+        }
       } finally {
         window.setTimeout(() => {
           creatingSessionRef.current = false


### PR DESCRIPTION
## Problem

After #63624, a new text-only chat sends correctly, but the first send can still bounce back to the composer when it includes an attachment.

Session creation schedules navigation to the newly persisted chat. If React Router commits that navigation while attachment staging is awaiting, the submit guard can mistake the delayed app-initiated route update for a user session switch and abort before `prompt.submit`.

## Fix

Return the exact runtime, stored-session, and target-route binding created by `createBackendSessionForSend`:

```ts
{ routeToken: string | null; runtimeSessionId: string; storedSessionId: string | null }
```

The submit pipeline now:

- validates that binding instead of inferring ownership from live UI state;
- accepts the expected delayed route transition exactly once;
- rejects unrelated route-only navigation, stored-session mismatches, and runtime ABA rebinding;
- preserves `session.resume` recovery for the newly created stored session when the first submit times out or reports `session not found`;
- keeps user-driven cancellation during async creation silent; and
- associates optimistic seed/rewrite/drop updates with the created stored session.

The prompt and slash callers also reject a stale binding if the user switches context during optional post-create setup.

## Verification

- `npm run test:ui -- src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-session-actions.test.tsx` — **72/72 passed** (53 prompt-action + 19 session-action tests)
- `npm run typecheck` — passed
- focused ESLint on the six changed Desktop files — 0 errors (one pre-existing `react-hooks/exhaustive-deps` warning in the test harness)
- `git diff --check` — passed
- manual packaged Windows Desktop verification of the reported race before the follow-up hardening changes: a new chat with image + text sent on the first click

Regression coverage includes delayed attachment-route commit, unrelated route-only navigation, real and partial session switches, runtime ABA rebinding, created-session timeout recovery, silent create cancellation, optimistic stored-session association, and post-create async setup.

## Related

- Follow-up to #63624, which fixed the initial new-chat drift abort but did not cover a delayed React Router commit during attachment staging.
- Revisits the explicit session-binding approach from #63035, which was closed unmerged after #63624 was selected as the canonical fix.
