### PR TITLE
fix(codex): refresh persisted context windows from live catalog

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1937,6 +1937,26 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
     return result
 
 
+def _resolve_codex_oauth_live_context_length(
+    model: str, access_token: str = ""
+) -> Optional[int]:
+    """Return the live Codex context window, or ``None`` if unavailable."""
+    model_bare = _strip_provider_prefix(model).strip()
+    if not model_bare or not access_token:
+        return None
+
+    live = _fetch_codex_oauth_context_lengths(access_token)
+    if model_bare in live:
+        return live[model_bare]
+
+    # Case-insensitive match in case casing drifts.
+    model_lower = model_bare.lower()
+    for slug, ctx in live.items():
+        if slug.lower() == model_lower:
+            return ctx
+    return None
+
+
 def _resolve_codex_oauth_context_length(
     model: str, access_token: str = ""
 ) -> Optional[int]:
@@ -1949,15 +1969,9 @@ def _resolve_codex_oauth_context_length(
     if not model_bare:
         return None
 
-    if access_token:
-        live = _fetch_codex_oauth_context_lengths(access_token)
-        if model_bare in live:
-            return live[model_bare]
-        # Case-insensitive match in case casing drifts
-        model_lower = model_bare.lower()
-        for slug, ctx in live.items():
-            if slug.lower() == model_lower:
-                return ctx
+    live_ctx = _resolve_codex_oauth_live_context_length(model_bare, access_token)
+    if live_ctx:
+        return live_ctx
 
     # Fallback: longest-key-first substring match over hardcoded defaults.
     model_lower = model_bare.lower()
@@ -2139,10 +2153,8 @@ def get_model_context_length(
         if cached is not None:
             # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
             # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
-            # models.dev and persisted it. Codex OAuth caps at 272K for every
-            # slug, so any cached Codex entry at or above 400K is a leftover
-            # from the old resolution path. Drop it and fall through to the
-            # live /models probe in step 5 below.
+            # models.dev and persisted it. Values at or above 400K are known
+            # to come from that old path, so drop them before probing Codex.
             if provider == "openai-codex" and cached >= 400_000:
                 logger.info(
                     "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "
@@ -2150,6 +2162,26 @@ def get_model_context_length(
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
+            # Codex's enforced context window can change in either direction
+            # while remaining below 400K (for example gpt-5.6-sol moved from
+            # 372K to 272K). When OAuth is available, refresh from the live,
+            # authoritative catalog instead of letting the persistent cache
+            # mask provider-side changes forever. The in-process live catalog
+            # has a one-hour TTL, so repeated resolutions do not add requests.
+            # If the probe is unavailable, retain the last known cached value.
+            elif provider == "openai-codex" and api_key:
+                live_codex_ctx = _resolve_codex_oauth_live_context_length(
+                    model, access_token=api_key
+                )
+                if live_codex_ctx:
+                    if live_codex_ctx != cached:
+                        logger.info(
+                            "Refreshing Codex context cache %s@%s: %s -> %s",
+                            model, base_url, f"{cached:,}", f"{live_codex_ctx:,}",
+                        )
+                        save_context_length(model, base_url, live_codex_ctx)
+                    return live_codex_ctx
+                return cached
             # Invalidate stale 32k cache entries for Kimi-family models.
             elif cached <= 32768 and _model_name_suggests_kimi(model):
                 logger.info(

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -520,9 +520,48 @@ class TestCodexOAuthContextLength:
         assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
         assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
 
-    def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
-        """Codex entries at the correct 272k must NOT be invalidated —
-        only stale pre-fix values (>= 400k) get dropped."""
+    def test_codex_cache_is_refreshed_from_live_probe_when_token_available(
+        self, tmp_path, monkeypatch
+    ):
+        """Codex can change a model's enforced window below the old 400k stale
+        guard. A cached 372k value must not mask a newer authoritative 272k
+        response when an OAuth token is available.
+        """
+        from agent import model_metadata as mm
+
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        base_url = "https://chatgpt.com/backend-api/codex"
+        import yaml as _yaml
+        cache_file.write_text(_yaml.dump({"context_lengths": {
+            f"gpt-5.6-sol@{base_url}": 372_000,
+        }}))
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{"slug": "gpt-5.6-sol", "context_window": 272_000}]
+        }
+
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.6-sol",
+                base_url=base_url,
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+
+        assert ctx == 272_000
+        mock_save.assert_called_with("gpt-5.6-sol", base_url, 272_000)
+
+    def test_codex_cache_is_respected_when_live_probe_is_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        """Without a usable live response, keep the last known Codex value
+        rather than replacing it with a potentially stale hardcoded fallback.
+        """
         from agent import model_metadata as mm
 
         cache_file = tmp_path / "context_length_cache.yaml"
@@ -534,8 +573,9 @@ class TestCodexOAuthContextLength:
             f"gpt-5.5@{base_url}": 272_000,
         }}))
 
-        # If the invalidation incorrectly fired, this would be called; assert it isn't.
-        with patch("agent.model_metadata.requests.get") as mock_get:
+        fake_response = MagicMock()
+        fake_response.status_code = 503
+        with patch("agent.model_metadata.requests.get", return_value=fake_response) as mock_get:
             ctx = mm.get_model_context_length(
                 model="gpt-5.5",
                 base_url=base_url,
@@ -543,7 +583,7 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
         assert ctx == 272_000
-        mock_get.assert_not_called()
+        mock_get.assert_called_once()
 
     def test_stale_invalidation_scoped_to_codex_provider(self, tmp_path, monkeypatch):
         """A cached 1M entry for a non-Codex provider (e.g. Anthropic opus on


### PR DESCRIPTION
## Summary

- refresh persisted Codex OAuth context-window values from the authoritative live `/models` catalog whenever an OAuth token is available
- update the persistent cache when the provider value changes in either direction
- retain the last known cached value when the live probe is unavailable
- preserve the existing `>=400K` invalidation for known pre-provider-aware direct-API cache entries

## Root cause

Hermes returned persistent `model@base_url` values before reaching the provider-aware Codex resolver. The existing guard only invalidated values at or above 400K, so plausible sub-400K values could remain stale forever.

Observed on 2026-07-15:

- local cache: `gpt-5.6-sol = 372000`
- authenticated live Codex `/models`: `gpt-5.6-sol = 272000`
- TUI therefore displayed `31.3K/372K` even though the current provider limit was 272K

This is the inverse of the stale-lower-cache case in #61910 and demonstrates why neither 272K nor 372K should be treated as permanently authoritative. The provider catalog has changed in both directions within days. This PR keeps the existing fallbacks but reconciles any cached value against the live catalog.

## Verification

- regression test reproduces cached 372K → live 272K
- outage test verifies the last known cache survives a failed probe
- `165 passed`: model metadata suites
- `153 passed`: context compressor and context breakdown suites
- `9 passed, 313 deselected`: TUI gateway context/usage tests
- `py_compile` and `git diff --check` pass
- real authenticated resolution returned and persisted `272000`
