### PR TITLE
fix(cli): native Google AI Studio model probing via ?key= query auth (salvage of #13550 by @killeress, supersedes #52865)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3441,6 +3441,60 @@ def _is_github_models_base_url(base_url: Optional[str]) -> bool:
     )
 
 
+def _is_native_gemini_base_url(base_url: Optional[str]) -> bool:
+    """True only for Google's *native* Generative Language API base URLs.
+
+    Google AI Studio's native endpoint authenticates with a ``?key=`` query
+    parameter and returns ``models[].name`` shaped as ``models/<id>``. Its
+    OpenAI-compatibility endpoint (``.../v1beta/openai``) is intentionally
+    treated as OpenAI-shaped elsewhere (Bearer auth + ``data[].id`` with the
+    ``models/`` prefix stripped), so it must be excluded here to avoid routing
+    it through the native ``models[].name`` parser.
+    """
+    normalized = (base_url or "").strip().rstrip("/").lower()
+    if not normalized:
+        return False
+    parsed = urllib.parse.urlparse(normalized)
+    if parsed.hostname != "generativelanguage.googleapis.com":
+        return False
+    # Exclude the OpenAI-compat surface (.../v1beta/openai[/...]).
+    if "/openai" in parsed.path:
+        return False
+    return True
+
+
+def _fetch_native_gemini_models(
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    timeout: float = 5.0,
+) -> Optional[list[str]]:
+    """Fetch model IDs from Google's native Generative Language API.
+
+    Uses ``?key=`` query auth (not ``Authorization: Bearer``) and parses the
+    ``models[].name`` shape, stripping the ``models/`` prefix. Routed through
+    ``_urlopen_model_catalog_request`` so the shared redirect
+    credential-hardening contract is preserved for query-auth probing.
+    """
+    if not api_key:
+        return None
+    normalized = (base_url or "").strip().rstrip("/")
+    if not normalized:
+        normalized = "https://generativelanguage.googleapis.com/v1beta"
+    url = f"{normalized}/models?key={urllib.parse.quote(api_key, safe='')}"
+    req = urllib.request.Request(url, headers={"User-Agent": _HERMES_USER_AGENT})
+    try:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception:
+        return None
+    models = data.get("models", [])
+    return [
+        m["name"].split("/")[-1]
+        for m in models
+        if isinstance(m, dict) and m.get("name")
+    ]
+
+
 def _lmstudio_server_root(base_url: Optional[str]) -> Optional[str]:
     """Return the LM Studio server root for native ``/api/v1`` endpoints.
 
@@ -4167,6 +4221,21 @@ def probe_api_models(
             "models": models,
             "probed_url": COPILOT_MODELS_URL,
             "resolved_base_url": COPILOT_BASE_URL,
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+
+    # Google AI Studio's *native* API uses ?key= query auth (not Bearer) and
+    # returns models[].name. The OpenAI-compat surface (.../v1beta/openai) is
+    # deliberately excluded so it keeps flowing through the generic Bearer path.
+    if _is_native_gemini_base_url(normalized):
+        models = _fetch_native_gemini_models(
+            api_key=api_key, base_url=normalized, timeout=timeout,
+        )
+        return {
+            "models": models,
+            "probed_url": f"{normalized}/models",
+            "resolved_base_url": normalized,
             "suggested_base_url": None,
             "used_fallback": False,
         }

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -202,3 +202,133 @@ class TestGeminiModelsDev:
         assert "gemini-live-2.5-flash" not in result     # noise: live-
         assert "gemini-2.5-flash-preview-04-17" not in result  # noise: dated preview
 
+    def test_list_provider_models_hides_low_tpm_google_gemmas(self):
+        mock_data = {
+            "google": {
+                "models": {
+                    "gemini-2.5-pro": {},
+                    "gemma-4-31b-it": {},
+                    "gemma-3-27b-it": {},
+                    "gemini-1.5-pro": {},
+                    "gemini-2.0-flash": {},
+                }
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_data):
+            from agent.models_dev import list_provider_models
+
+            result = list_provider_models("gemini")
+
+        assert "gemini-2.5-pro" in result
+        assert "gemma-4-31b-it" not in result
+        assert "gemma-3-27b-it" not in result
+        assert "gemini-1.5-pro" not in result
+        assert "gemini-2.0-flash" not in result
+
+
+# ── Native Gemini model probing (?key= query auth) ──
+
+class TestNativeGeminiProbe:
+    """probe_api_models must route Google's *native* Generative Language API
+    through ?key= query auth + models[].name parsing, while leaving the
+    OpenAI-compat surface (.../v1beta/openai) on the generic Bearer path."""
+
+    def test_native_base_url_detected(self):
+        from hermes_cli.models import _is_native_gemini_base_url
+
+        assert _is_native_gemini_base_url(
+            "https://generativelanguage.googleapis.com/v1beta"
+        )
+        assert _is_native_gemini_base_url(
+            "https://generativelanguage.googleapis.com/v1beta/"
+        )
+
+    def test_openai_compat_surface_excluded(self):
+        from hermes_cli.models import _is_native_gemini_base_url
+
+        assert not _is_native_gemini_base_url(
+            "https://generativelanguage.googleapis.com/v1beta/openai"
+        )
+        assert not _is_native_gemini_base_url(
+            "https://generativelanguage.googleapis.com/v1beta/openai/"
+        )
+
+    def test_non_google_host_excluded(self):
+        from hermes_cli.models import _is_native_gemini_base_url
+
+        assert not _is_native_gemini_base_url("https://api.openai.com/v1")
+        assert not _is_native_gemini_base_url("")
+        assert not _is_native_gemini_base_url(None)
+
+    def test_probe_uses_query_auth_and_catalog_urlopen(self):
+        """The fix routes native probing through _urlopen_model_catalog_request
+        (the redirect credential-hardening path) with a ?key= URL and parses
+        models[].name -> stripped id."""
+        import hermes_cli.models as models
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return (
+                    b'{"models": [{"name": "models/gemini-2.5-pro"},'
+                    b' {"name": "models/gemini-2.0-flash"}]}'
+                )
+
+        def _fake_urlopen(req, timeout=5.0):
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            return _Resp()
+
+        with patch.object(models, "_urlopen_model_catalog_request", _fake_urlopen):
+            result = models.probe_api_models(
+                api_key="secret-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            )
+
+        # Query auth, not Bearer.
+        assert "?key=secret-key" in captured["url"]
+        assert not any(
+            k.lower() == "authorization" for k in captured["headers"]
+        )
+        # models[].name parsed with models/ prefix stripped.
+        assert result["models"] == ["gemini-2.5-pro", "gemini-2.0-flash"]
+
+    def test_probe_openai_compat_uses_generic_bearer_path(self):
+        """The OpenAI-compat endpoint must NOT hit the native ?key= branch;
+        it flows through the generic data[].id + Bearer probing path."""
+        import hermes_cli.models as models
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "models/gemini-2.5-pro"}]}'
+
+        def _fake_urlopen(req, timeout=5.0):
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            return _Resp()
+
+        with patch.object(models, "_urlopen_model_catalog_request", _fake_urlopen):
+            result = models.probe_api_models(
+                api_key="secret-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            )
+
+        # Generic path: Bearer header present, no ?key= in URL.
+        assert "?key=" not in captured["url"]
+        assert captured["headers"].get("Authorization") == "Bearer secret-key"
+        assert result["models"] == ["models/gemini-2.5-pro"]


### PR DESCRIPTION
Clean rebuild of #52865 against current main (old branch was ~2500 commits behind and un-rebasable). Salvage of #13550 by @killeress.

## Problem
Google's native Generative Language API authenticates with a `?key=` query parameter (not `Authorization: Bearer`) and returns `models[].name` shaped as `models/<id>`. `probe_api_models` sent it through the generic Bearer + `data[].id` path, so it discovered no models.

## Fix (addresses maintainer review on #52865)
- **Route only exact native Gemini hosts; exclude the OpenAI-compat surface.** `_is_native_gemini_base_url` matches only `generativelanguage.googleapis.com` and explicitly excludes `.../v1beta/openai`, which current main intentionally treats as OpenAI-shaped (Bearer + `data[].id` with the `models/` prefix stripped).
- **Preserve the catalog redirect-security contract.** Native probing routes through `_urlopen_model_catalog_request` (the shared redirect credential-hardening path) rather than a raw `urllib.request.urlopen`, and the api key is URL-quoted.

## Tests
Added to `tests/hermes_cli/test_gemini_provider.py`:
- native base-url detection + OpenAI-compat/non-Google exclusion
- native probe uses `?key=` query auth (no Bearer) and parses `models[].name`
- **OpenAI-compat regression**: `.../v1beta/openai` keeps the generic Bearer + `data[].id` path

Full attribution to original @killeress (#13550). Closing #52865 in favor of this.

Co-authored-by: killeress <killeress0425@gmail.com>