### PR TITLE
fix(codex): trust response.status for reasoning-only turns on unrecognized Responses backends

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1382,10 +1382,11 @@ def _normalize_codex_response(
         # Response contains only reasoning (encrypted thinking state and/or
         # human-readable summary) with no visible content or tool calls.
         #
-        # For known Codex/xAI backends, reasoning-only with status="completed"
-        # means "the model is still thinking and needs another turn" — treat
-        # it as incomplete so the Codex continuation path retries instead of
-        # falling into the empty-content retry loop.
+        # For the specially-handled backends (Codex, xAI, GitHub/Copilot),
+        # reasoning-only with status="completed" means "the model is still
+        # thinking and needs another turn" — treat it as incomplete so the
+        # Codex continuation path retries instead of falling into the
+        # empty-content retry loop.
         #
         # For all other backends (other:<base_url>, etc.), trust the provider's
         # own response.status signal. When status == "completed" and no items
@@ -1393,7 +1394,11 @@ def _normalize_codex_response(
         # state — forcing "incomplete" causes multi-minute stalls as the
         # continuation path re-issues calls (3 retries × up to 240s each).
         # See https://github.com/NousResearch/hermes-agent/issues/64434
-        if response_status == "completed" and issuer_kind not in ("codex_backend", "xai_responses"):
+        if response_status == "completed" and issuer_kind not in (
+            "codex_backend",
+            "xai_responses",
+            "github_responses",
+        ):
             finish_reason = "stop"
         else:
             finish_reason = "incomplete"

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1380,12 +1380,23 @@ def _normalize_codex_response(
         finish_reason = "incomplete"
     elif (reasoning_items_raw or reasoning_parts or saw_reasoning_item) and not final_text:
         # Response contains only reasoning (encrypted thinking state and/or
-        # human-readable summary) with no visible content or tool calls. The
-        # model is still thinking and needs another turn to produce the actual
-        # answer. Marking this as "stop" would send it into the empty-content
-        # retry loop which burns retries then fails — treat it as incomplete so
-        # the Codex continuation path handles it correctly.
-        finish_reason = "incomplete"
+        # human-readable summary) with no visible content or tool calls.
+        #
+        # For known Codex/xAI backends, reasoning-only with status="completed"
+        # means "the model is still thinking and needs another turn" — treat
+        # it as incomplete so the Codex continuation path retries instead of
+        # falling into the empty-content retry loop.
+        #
+        # For all other backends (other:<base_url>, etc.), trust the provider's
+        # own response.status signal. When status == "completed" and no items
+        # are queued/in_progress/incomplete, reasoning alone is a valid final
+        # state — forcing "incomplete" causes multi-minute stalls as the
+        # continuation path re-issues calls (3 retries × up to 240s each).
+        # See https://github.com/NousResearch/hermes-agent/issues/64434
+        if response_status == "completed" and issuer_kind not in ("codex_backend", "xai_responses"):
+            finish_reason = "stop"
+        else:
+            finish_reason = "incomplete"
     else:
         finish_reason = "stop"
     return assistant_message, finish_reason

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -51,6 +51,12 @@ def test_normalize_codex_response_drops_transient_rs_tmp_reasoning_items():
 
 
 def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
+    """Summary-only reasoning keeps the continuation path for Codex backends.
+
+    Since #64434, an unrecognized issuer with ``response.status="completed"``
+    trusts the provider and returns ``stop`` — so this test pins the Codex
+    backend explicitly, where reasoning-only still means "still thinking".
+    """
     response = SimpleNamespace(
         status="completed",
         output=[
@@ -63,7 +69,9 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
         ],
     )
 
-    assistant_message, finish_reason = _normalize_codex_response(response)
+    assistant_message, finish_reason = _normalize_codex_response(
+        response, issuer_kind="codex_backend"
+    )
 
     assert finish_reason == "incomplete"
     assert assistant_message.content == ""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2359,15 +2359,16 @@ def _codex_reasoning_only_response(*, encrypted_content="enc_abc123", summary_te
 
 
 def test_normalize_codex_response_marks_reasoning_only_as_incomplete(monkeypatch):
-    """A response with only reasoning items and no content should be 'incomplete', not 'stop'.
+    """A response with only reasoning items and no content should be 'incomplete' for Codex backends.
 
-    Without this fix, reasoning-only responses get finish_reason='stop' which
-    sends them into the empty-content retry loop (3 retries then failure).
+    Codex CLI uses reasoning-only responses as a signal that the model is still
+    thinking and needs another turn. This test verifies the Codex-specific path
+    where issuer_kind="codex_backend" preserves the old behavior.
     """
     agent = _build_agent(monkeypatch)
     from agent.codex_responses_adapter import _normalize_codex_response
     assistant_message, finish_reason = _normalize_codex_response(
-        _codex_reasoning_only_response()
+        _codex_reasoning_only_response(), issuer_kind="codex_backend"
     )
 
     assert finish_reason == "incomplete"
@@ -2375,6 +2376,55 @@ def test_normalize_codex_response_marks_reasoning_only_as_incomplete(monkeypatch
     assert assistant_message.codex_reasoning_items is not None
     assert len(assistant_message.codex_reasoning_items) == 1
     assert assistant_message.codex_reasoning_items[0]["encrypted_content"] == "enc_abc123"
+
+
+def test_normalize_codex_response_reasoning_only_completed_is_stop_for_other_backends(monkeypatch):
+    """Reasoning-only with status='completed' should be 'stop' for non-Codex backends.
+
+    When response.status == "completed" and no items are queued/in_progress,
+    reasoning alone is a valid final state for non-Codex backends. Forcing
+    "incomplete" here causes multi-minute stalls (3 retries x up to 240s each).
+    See https://github.com/NousResearch/hermes-agent/issues/64434
+    """
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+    response = _codex_reasoning_only_response()
+    assistant_message, finish_reason = _normalize_codex_response(
+        response, issuer_kind="other:example-relay"
+    )
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == ""
+    assert assistant_message.codex_reasoning_items is not None
+    assert len(assistant_message.codex_reasoning_items) == 1
+
+
+def test_normalize_codex_response_reasoning_only_completed_is_stop_without_issuer(monkeypatch):
+    """Default issuer (None) should also trust response.status='completed' for reasoning-only.
+
+    When no issuer_kind is provided (test or default scenario) and the provider
+    says status='completed', reasoning-only should be treated as 'stop'.
+    """
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+    response = _codex_reasoning_only_response()
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == ""
+
+
+def test_normalize_codex_response_reasoning_only_is_stop_for_xai_backend(monkeypatch):
+    """xAI backend also preserves incomplete for reasoning-only (same as Codex)."""
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+    response = _codex_reasoning_only_response()
+    assistant_message, finish_reason = _normalize_codex_response(
+        response, issuer_kind="xai_responses"
+    )
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.content == ""
 
 
 def test_normalize_codex_response_reasoning_with_content_is_stop(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2414,13 +2414,32 @@ def test_normalize_codex_response_reasoning_only_completed_is_stop_without_issue
     assert assistant_message.content == ""
 
 
-def test_normalize_codex_response_reasoning_only_is_stop_for_xai_backend(monkeypatch):
+def test_normalize_codex_response_reasoning_only_stays_incomplete_for_xai_backend(monkeypatch):
     """xAI backend also preserves incomplete for reasoning-only (same as Codex)."""
     agent = _build_agent(monkeypatch)
     from agent.codex_responses_adapter import _normalize_codex_response
     response = _codex_reasoning_only_response()
     assistant_message, finish_reason = _normalize_codex_response(
         response, issuer_kind="xai_responses"
+    )
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.content == ""
+
+
+def test_normalize_codex_response_reasoning_only_stays_incomplete_for_github_backend(monkeypatch):
+    """GitHub/Copilot Responses backend preserves incomplete for reasoning-only.
+
+    Copilot fronts the same OpenAI model family as codex_backend and exhibits
+    the same reasoning-only "still thinking" degeneration mode, so it must
+    stay on the continuation path — only unrecognized (other:*) backends
+    trust response.status='completed' as terminal.
+    """
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+    response = _codex_reasoning_only_response()
+    assistant_message, finish_reason = _normalize_codex_response(
+        response, issuer_kind="github_responses"
     )
 
     assert finish_reason == "incomplete"


### PR DESCRIPTION
## Summary

Reasoning-only completed turns on `api_mode: codex_responses` no longer get force-classified as `incomplete` for unrecognized Responses backends — the provider's own `response.status="completed"` is trusted, eliminating ~12-minute silent continuation stalls (3 retries × up to 240s stale timeout each).

Salvages #64449 (@webtecnica, fixes #64434) with authorship preserved, plus one follow-up.

Root cause: `_normalize_codex_response` inferred "still thinking" purely from item-type composition (only a `reasoning` item present). That heuristic is correct for Codex/xAI backends where reasoning-only is a documented degeneration mode, but wrong for generic Responses-compatible relays (`other:<base_url>`), where a completed reasoning-only turn is a valid final state. The misfire drove the continuation path repeatedly and could burn the whole 150-iteration budget while showing only "Working — N min".

## Changes

- `agent/codex_responses_adapter.py`: when `response.status == "completed"`, only the specially-handled backends (`codex_backend`, `xai_responses`, `github_responses`) keep the reasoning-only → `incomplete` continuation heuristic; all other issuers get `stop` (@webtecnica)
- Follow-up (ours): added `github_responses` to the continuation set — the contributor's diff silently flipped Copilot to the `stop` side, but Copilot fronts the same OpenAI model family as `codex_backend` and shows the same reasoning-only degeneration; plus a pinning test

## Validation

| issuer_kind | status=completed, reasoning-only | Before | After |
|---|---|---|---|
| `other:<relay>` | | incomplete (3×240s stall) | **stop** |
| `codex_backend` | | incomplete | incomplete (unchanged) |
| `xai_responses` | | incomplete | incomplete (unchanged) |
| `github_responses` | | incomplete | incomplete (preserved by follow-up) |
| `other:<relay>` status=in_progress | | incomplete | incomplete (status trusted both ways) |

- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py`: 90/90 passed
- E2E repro of the issue's exact SimpleNamespace scenario with real imports: all five rows above verified

## Infographic

![finish-reason-trust-provider-status](https://v3b.fal.media/files/b/0aa24e85/1GCon0mNisI0TsKb8KDmd_ZWGxnGV6.png)
