### PR TITLE
fix(agent): harden loopback proxy and compression retries

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3123,6 +3123,7 @@ def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
         "unrecognized request argument",
         "unrecognized parameter",
         "invalid parameter",
+        "may only be set to",
     ))
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,7 +29,7 @@ from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.gemini_native_adapter import is_native_gemini_base_url
-from agent.model_metadata import is_local_endpoint
+from agent.model_metadata import is_explicit_local_runtime
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -2202,7 +2202,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # prefill on large contexts before producing the first token.
             # Auto-increase the httpx read timeout unless the user explicitly
             # overrode HERMES_STREAM_READ_TIMEOUT.
-            if _stream_read_timeout == 120.0 and agent.base_url and is_local_endpoint(agent.base_url):
+            if _stream_read_timeout == 120.0 and is_explicit_local_runtime(
+                agent.provider, agent.base_url
+            ):
                 _stream_read_timeout = _base_timeout
                 logger.debug(
                     "Local provider detected (%s) — stream read timeout raised to %.0fs",
@@ -3021,7 +3023,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
+    if _stream_stale_timeout_base == 180.0 and is_explicit_local_runtime(
+        agent.provider, agent.base_url
+    ):
         _stream_stale_timeout = float("inf")
         logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
     else:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -546,14 +546,6 @@ def compress_context(
     # Set True once the in-place DB write actually completes (the DB block can
     # raise and skip it). Surfaced to the gateway via agent._last_compaction_in_place.
     compacted_in_place = False
-    logger.info(
-        "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
-        agent.session_id or "none", _pre_msg_count,
-        f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
-        focus_topic,
-    )
-    agent._emit_status(COMPACTION_STATUS)
-
     # ── Compression lock ────────────────────────────────────────────────
     # Atomic, state.db-backed lock per session_id.  Without this, two
     # AIAgent instances that share the same session_id (most commonly the
@@ -699,6 +691,17 @@ def compress_context(
                 _lock_ttl,
                 _lock_refresh_interval,
             ).start()
+
+    # Only the lock winner is genuinely compacting. Emitting this status before
+    # acquisition made every contender look active in gateway UIs even though
+    # losing paths immediately returned unchanged messages.
+    logger.info(
+        "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
+        agent.session_id or "none", _pre_msg_count,
+        f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
+        focus_topic,
+    )
+    agent._emit_status(COMPACTION_STATUS)
 
     def _release_lock() -> None:
         """Release the lock keyed on the OLD session_id (before rotation)."""

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -657,6 +657,30 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
+_EXPLICIT_LOCAL_RUNTIME_PROVIDERS = frozenset({
+    "ollama",
+    "lmstudio",
+    "vllm",
+    "llamacpp",
+    "llama.cpp",
+    "llama-cpp",
+})
+
+
+def is_explicit_local_runtime(provider: Optional[str], base_url: str) -> bool:
+    """Return whether provider explicitly identifies local inference.
+
+    Endpoint locality alone is insufficient: loopback aggregators and reverse
+    proxies can forward requests to remote models. Generic ``custom`` and
+    ``local`` providers are therefore intentionally excluded.
+    """
+    provider_id = (provider or "").strip().lower()
+    return (
+        provider_id in _EXPLICIT_LOCAL_RUNTIME_PROVIDERS
+        and is_local_endpoint(base_url)
+    )
+
+
 def _localhost_to_ipv4(url: str) -> str:
     """Rewrite a ``localhost`` HOST to ``127.0.0.1`` in a probe URL.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1285,7 +1285,24 @@ class AIAgent:
         """
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
-        if uses_implicit_default and base_url and is_local_endpoint(base_url):
+        # A loopback URL does not prove inference is local. Aggregators and
+        # reverse proxies commonly listen on localhost while forwarding to a
+        # remote model; disabling the stale watchdog for those routes turns an
+        # upstream hang into an unbounded wait. Exempt only runtimes we can
+        # positively identify as local inference backends.
+        provider_lower = (getattr(self, "provider", "") or "").strip().lower()
+        base_url_lower = base_url.lower()
+        genuine_local_inference = (
+            provider_lower in {"ollama", "lmstudio"}
+            or "ollama" in base_url_lower
+            or ":11434" in base_url_lower
+        )
+        if (
+            uses_implicit_default
+            and base_url
+            and is_local_endpoint(base_url)
+            and genuine_local_inference
+        ):
             return float("inf")
 
         from agent.chat_completion_helpers import estimate_request_context_tokens

--- a/run_agent.py
+++ b/run_agent.py
@@ -150,7 +150,7 @@ from agent.error_classifier import FailoverReason
 from agent.redact import redact_sensitive_text
 from agent.model_metadata import (
     estimate_request_tokens_rough,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.estimate_request_tokens_rough")
-    is_local_endpoint,
+    is_explicit_local_runtime,
 )
 from agent.usage_pricing import normalize_usage
 # Re-exported for tests that monkeypatch these symbols on run_agent.
@@ -1285,23 +1285,9 @@ class AIAgent:
         """
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
-        # A loopback URL does not prove inference is local. Aggregators and
-        # reverse proxies commonly listen on localhost while forwarding to a
-        # remote model; disabling the stale watchdog for those routes turns an
-        # upstream hang into an unbounded wait. Exempt only runtimes we can
-        # positively identify as local inference backends.
-        provider_lower = (getattr(self, "provider", "") or "").strip().lower()
-        base_url_lower = base_url.lower()
-        genuine_local_inference = (
-            provider_lower in {"ollama", "lmstudio"}
-            or "ollama" in base_url_lower
-            or ":11434" in base_url_lower
-        )
         if (
             uses_implicit_default
-            and base_url
-            and is_local_endpoint(base_url)
-            and genuine_local_inference
+            and is_explicit_local_runtime(self.provider, base_url)
         ):
             return float("inf")
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -192,9 +192,18 @@ def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     assert held is True
 
     agent = _build_agent_with_db(db, parent_sid)
+    agent._emit_status = MagicMock()
+    agent._emit_status.reset_mock()
     messages = [{"role": "user", "content": "m1"}, {"role": "user", "content": "m2"}]
 
     compressed, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    # Lock losers may emit feasibility warnings, but they are not actually
+    # compacting and must not advertise a compaction lifecycle to clients.
+    from agent.conversation_compression import COMPACTION_STATUS
+
+    emitted = [call.args[0] for call in agent._emit_status.call_args_list]
+    assert COMPACTION_STATUS not in emitted
 
     # Skipped: messages returned verbatim, no rotation
     assert compressed is messages or compressed == messages

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -10,31 +10,43 @@ import os
 import pytest
 from unittest.mock import patch
 
-from agent.model_metadata import is_local_endpoint
+from agent.model_metadata import is_explicit_local_runtime, is_local_endpoint
 
 
 class TestLocalStreamReadTimeout:
     """Verify stream read timeout auto-detection logic."""
 
-    @pytest.mark.parametrize("base_url", [
-        "http://localhost:11434",
-        "http://127.0.0.1:8080",
-        "http://0.0.0.0:5000",
-        "http://192.168.1.100:8000",
-        "http://10.0.0.5:1234",
-        "http://host.docker.internal:11434",
-        "http://host.containers.internal:11434",
-        "http://host.lima.internal:11434",
+    @pytest.mark.parametrize("provider,base_url", [
+        ("ollama", "http://localhost:11434"),
+        ("lmstudio", "http://127.0.0.1:1234"),
+        ("vllm", "http://192.168.1.100:8000"),
+        ("llamacpp", "http://10.0.0.5:8080"),
+        ("llama.cpp", "http://host.docker.internal:8080"),
+        ("llama-cpp", "http://host.lima.internal:8080"),
     ])
-    def test_local_endpoint_bumps_read_timeout(self, base_url):
-        """Local endpoint + default timeout -> bumps to base_timeout."""
+    def test_explicit_local_runtime_bumps_read_timeout(self, provider, base_url):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
             _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
             _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
+            if _stream_read_timeout == 120.0 and is_explicit_local_runtime(provider, base_url):
                 _stream_read_timeout = _base_timeout
             assert _stream_read_timeout == 1800.0
+
+    @pytest.mark.parametrize("provider,base_url", [
+        ("9router", "http://localhost:20128/v1"),
+        ("9router", "http://localhost:11434/v1"),
+        ("9router", "http://localhost:20128/ollama/v1"),
+        ("custom", "http://localhost:11434/v1"),
+        ("local", "http://localhost:11434/v1"),
+    ])
+    def test_loopback_proxy_keeps_default_read_timeout(self, provider, base_url):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
+            if _stream_read_timeout == 120.0 and is_explicit_local_runtime(provider, base_url):
+                _stream_read_timeout = 1800.0
+            assert _stream_read_timeout == 120.0
 
     def test_user_override_respected_for_local(self):
         """User sets HERMES_STREAM_READ_TIMEOUT -> keep their value even for local."""
@@ -42,7 +54,7 @@ class TestLocalStreamReadTimeout:
             _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
             _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
             base_url = "http://localhost:11434"
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
+            if _stream_read_timeout == 120.0 and is_explicit_local_runtime("ollama", base_url):
                 _stream_read_timeout = _base_timeout
             assert _stream_read_timeout == 300.0
 
@@ -57,7 +69,7 @@ class TestLocalStreamReadTimeout:
             os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
             _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
             _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
+            if _stream_read_timeout == 120.0 and is_explicit_local_runtime("ollama", base_url):
                 _stream_read_timeout = _base_timeout
             assert _stream_read_timeout == 120.0
 
@@ -68,7 +80,7 @@ class TestLocalStreamReadTimeout:
             _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
             _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
             base_url = ""
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
+            if _stream_read_timeout == 120.0 and is_explicit_local_runtime("ollama", base_url):
                 _stream_read_timeout = _base_timeout
             assert _stream_read_timeout == 120.0
 

--- a/tests/agent/test_non_stream_stale_timeout.py
+++ b/tests/agent/test_non_stream_stale_timeout.py
@@ -100,6 +100,43 @@ def test_estimator_unknown_dict_fallback():
 # ── default base + tier scaling ────────────────────────────────────────────
 
 
+def test_loopback_aggregator_keeps_stale_watchdog(monkeypatch, tmp_path):
+    """A loopback proxy to remote models is not a local inference backend."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    agent = _make_agent(
+        tmp_path,
+        provider="9router",
+        model="cx/gpt-5.6-sol",
+        base_url="http://localhost:20128/v1",
+    )
+    payload = {
+        "model": agent.model,
+        "messages": [{"role": "user", "content": "x" * 500_000}],
+    }
+
+    assert agent._compute_non_stream_stale_timeout(payload) == 240.0
+
+
+def test_genuine_local_inference_keeps_unlimited_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    agent = _make_agent(
+        tmp_path,
+        provider="ollama",
+        model="llama3.2",
+        base_url="http://localhost:11434/v1",
+    )
+
+    assert agent._compute_non_stream_stale_timeout({"messages": []}) == float("inf")
+
+
 def test_default_base_is_90s(monkeypatch, tmp_path):
     """Default base stale timeout dropped from 300s to 90s (May 2026)."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_non_stream_stale_timeout.py
+++ b/tests/agent/test_non_stream_stale_timeout.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
+import pytest
 
 def _write_config(tmp_path: Path, body: str) -> None:
     hermes_home = tmp_path
@@ -121,7 +121,10 @@ def test_loopback_aggregator_keeps_stale_watchdog(monkeypatch, tmp_path):
     assert agent._compute_non_stream_stale_timeout(payload) == 240.0
 
 
-def test_genuine_local_inference_keeps_unlimited_default(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "provider", ["ollama", "lmstudio", "vllm", "llamacpp", "llama.cpp", "llama-cpp"]
+)
+def test_genuine_local_inference_keeps_unlimited_default(monkeypatch, tmp_path, provider):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / ".env").write_text("", encoding="utf-8")
     monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
@@ -129,12 +132,34 @@ def test_genuine_local_inference_keeps_unlimited_default(monkeypatch, tmp_path):
 
     agent = _make_agent(
         tmp_path,
-        provider="ollama",
+        provider=provider,
         model="llama3.2",
         base_url="http://localhost:11434/v1",
     )
 
     assert agent._compute_non_stream_stale_timeout({"messages": []}) == float("inf")
+
+
+@pytest.mark.parametrize("base_url", [
+    "http://localhost:11434/v1",
+    "http://localhost:20128/ollama/v1",
+])
+def test_loopback_proxy_ollama_markers_do_not_disable_watchdog(
+    monkeypatch, tmp_path, base_url
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    agent = _make_agent(
+        tmp_path,
+        provider="9router",
+        model="cx/gpt-5.6-sol",
+        base_url=base_url,
+    )
+
+    assert agent._compute_non_stream_stale_timeout({"messages": []}) == 90.0
 
 
 def test_default_base_is_90s(monkeypatch, tmp_path):

--- a/tests/agent/test_unsupported_parameter_retry.py
+++ b/tests/agent/test_unsupported_parameter_retry.py
@@ -36,6 +36,10 @@ class TestIsUnsupportedParameterError:
         ("temperature", "HTTP 400: Unsupported parameter: temperature"),
         ("temperature", "Error code: 400 - {'error': {'code': 'unsupported_parameter', 'param': 'temperature'}}"),
         ("temperature", "this model does not support temperature"),
+        (
+            "temperature",
+            "temperature may only be set to 1 when thinking is enabled",
+        ),
         # max_tokens phrasings
         ("max_tokens", "HTTP 400: Unsupported parameter: max_tokens"),
         ("max_tokens", "Unknown parameter: max_tokens — use max_completion_tokens"),
@@ -139,4 +143,57 @@ class TestMaxTokensRetryHardening:
                 )
 
         assert client.chat.completions.create.call_count == 1
+
+
+class TestFixedTemperatureContractRetry:
+    """Thinking gateways may require a server-managed temperature value."""
+
+    @pytest.mark.parametrize("async_mode", [False, True])
+    @pytest.mark.asyncio
+    async def test_retries_without_temperature_when_gateway_requires_one(
+        self, async_mode
+    ):
+        client = MagicMock()
+        client.base_url = "https://compatible.example/v1"
+        rejected = RuntimeError(
+            "temperature may only be set to 1 when thinking is enabled"
+        )
+        accepted = _dummy_response()
+        if async_mode:
+            client.chat.completions.create = AsyncMock(
+                side_effect=[rejected, accepted]
+            )
+        else:
+            client.chat.completions.create.side_effect = [rejected, accepted]
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("custom", "stable-alias", None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(client, "stable-alias"),
+            ),
+            patch(
+                "agent.auxiliary_client._validate_llm_response",
+                side_effect=lambda response, _task: response,
+            ),
+        ):
+            kwargs = dict(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                temperature=0.3,
+            )
+            if async_mode:
+                result = await async_call_llm(**kwargs)
+            else:
+                result = call_llm(**kwargs)
+
+        assert result is accepted
+        assert client.chat.completions.create.call_count == 2
+        first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
+        retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        assert first_kwargs["temperature"] == 0.3
+        assert "temperature" not in retry_kwargs
 


### PR DESCRIPTION
## Summary

- keep stale-call protection enabled for loopback aggregators and reverse proxies that route to remote models
- retry auxiliary calls without `temperature` when thinking gateways reject fixed temperature contracts such as `temperature may only be set to 1`
- emit compaction lifecycle status only after the caller wins the per-session compression lock

## Problem

A provider can expose an OpenAI-compatible API on `localhost` while forwarding requests to remote inference. Hermes currently treats every local endpoint as genuine local inference and disables the implicit stale watchdog. If the remote upstream stalls, the request can wait without the normal 90–240 second stale protection.

Compression also retries without `temperature` for unsupported-parameter errors, but some thinking gateways phrase the contract as `temperature may only be set to 1 when thinking is enabled`. That wording was not recognized, so compression failed instead of retrying with the server-managed default.

Finally, concurrent compression contenders emitted `COMPACTION_STATUS` before acquiring the session lock. Lock losers then appeared to clients as actively compacting even though they immediately returned unchanged messages.

## Changes

- exempt only positively identified local inference runtimes (`ollama`, `lmstudio`, or Ollama's default port) from the implicit stale watchdog
- recognize `may only be set to` as an unsupported/fixed parameter contract and retry without `temperature`
- move compaction status emission after successful lock acquisition
- add behavior tests for loopback proxies, genuine local inference, fixed-temperature retries, and lock-loser status

## Tests

```text
scripts/run_tests.sh \
  tests/agent/test_non_stream_stale_timeout.py \
  tests/agent/test_compression_concurrent_fork.py \
  tests/agent/test_unsupported_parameter_retry.py -q

58 passed
```
