### PR TITLE
fix(mcp_catalog): add timeout and stdin=DEVNULL to _run_bootstrap subprocess.run

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -364,7 +364,10 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(
+            cmd, cwd=str(cwd), shell=True, timeout=300,
+            stdin=subprocess.DEVNULL,
+        )
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"


### PR DESCRIPTION
## Summary

Add timeout=300 and stdin=DEVNULL to the subprocess.run call in _run_bootstrap within hermes_cli/mcp_catalog.py.

## Problem

_run_bootstrap executes arbitrary shell commands from MCP catalog bootstrap configs via subprocess.run(cmd, shell=True) with no timeout and no stdin=DEVNULL. If a bootstrap command prompts for user input or stalls, the entire agent turn blocks forever.

## Fix

Minimal 3-line addition: timeout=300 (5 min is generous for a bootstrap step) and stdin=subprocess.DEVNULL (prevents TTY hangs on prompts).

## Testing
- Syntax check passed (py_compile)
- Behavior verified