### PR TITLE
fix: display layers never crash on non-string tool-call arguments

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -13,6 +14,8 @@ from acp.schema import (
     ToolCallProgress,
     ToolKind,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Map hermes tool names -> ACP ToolKind
@@ -1026,7 +1029,37 @@ def build_tool_start(
     *,
     edit_diff: Any = None,
 ) -> ToolCallStart:
-    """Create a ToolCallStart event for the given hermes tool invocation."""
+    """Create a ToolCallStart event for the given hermes tool invocation.
+
+    A malformed tool argument (e.g. a non-string ``command``/``path`` from a
+    model that ignores the schema) must never abort the ACP tool-call render —
+    ``build_tool_start`` runs on the live tool-progress callback and during
+    session history replay. On any failure in the title/content/location
+    builders, fall back to a minimal, valid start event. Mirrors
+    ``get_cute_tool_message`` in ``agent/display.py``, wrapped for the same
+    reason on the CLI side.
+    """
+    try:
+        return _build_tool_start(
+            tool_call_id, tool_name, arguments, edit_diff=edit_diff
+        )
+    except Exception as exc:  # noqa: BLE001 — a tool-call render must never abort the turn
+        logger.debug("ACP tool-start render failed for %r: %s", tool_name, exc)
+        safe_name = tool_name if isinstance(tool_name, str) and tool_name else "tool"
+        return acp.start_tool_call(
+            tool_call_id, safe_name, kind=get_tool_kind(safe_name),
+            content=None, locations=[], raw_input=None,
+        )
+
+
+def _build_tool_start(
+    tool_call_id: str,
+    tool_name: str,
+    arguments: Dict[str, Any],
+    *,
+    edit_diff: Any = None,
+) -> ToolCallStart:
+    """Build the ToolCallStart event (unguarded; see ``build_tool_start``)."""
     kind = get_tool_kind(tool_name)
     title = build_tool_title(tool_name, arguments)
     locations = extract_locations(arguments)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -613,10 +613,29 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         [terminal] ran `npm test` -> exit 0, 47 lines output
         [read_file] read config.py from line 1 (1,200 chars)
         [search_files] content search for 'compress' in agent/ -> 12 matches
+
+    Never raises: models sometimes emit non-string argument values (bool,
+    int, None) and the args here come from persisted session history, so a
+    single malformed historical call must not crash compression — which
+    retries on the same history and would crash-loop. Individual branches
+    coerce the values they slice/measure (keeping summaries informative);
+    this wrapper is the backstop for anything they miss.
     """
+    try:
+        return _summarize_tool_result_unguarded(tool_name, tool_args, tool_content)
+    except Exception as exc:  # noqa: BLE001 — a summary must never crash compression
+        logger.debug("Tool-result summary failed for %s: %s", tool_name, exc)
+        _len = len(tool_content) if isinstance(tool_content, str) else 0
+        return f"[{tool_name}] ({_len:,} chars result)"
+
+
+def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_content: str) -> str:
+    """Build the summary line (unguarded; see ``_summarize_tool_result``)."""
     try:
         args = json.loads(tool_args) if tool_args else {}
     except (json.JSONDecodeError, TypeError):
+        args = {}
+    if not isinstance(args, dict):
         args = {}
 
     content = tool_content or ""

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -586,6 +586,21 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     return result if changed else messages
 
 
+def _str_arg(args: dict, key: str, default: str = "") -> str:
+    """Safely get a string argument from parsed tool args.
+
+    LLMs sometimes return non-string parameter values (e.g. bool, int) for
+    tool calls.  Calling ``len()`` / ``.count()`` / slicing on those causes
+    ``TypeError`` / ``AttributeError`` which crashes context compression.
+    This helper coerces any value to ``str`` so downstream code can assume
+    a string is always returned.
+    """
+    val = args.get(key, default)
+    if isinstance(val, str):
+        return val
+    return str(val) if val is not None else default
+
+
 def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) -> str:
     """Create an informative 1-line summary of a tool call + result.
 
@@ -609,7 +624,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
     line_count = content.count("\n") + 1 if content.strip() else 0
 
     if tool_name == "terminal":
-        cmd = args.get("command", "")
+        cmd = _str_arg(args, "command")
         if len(cmd) > 80:
             cmd = cmd[:77] + "..."
         exit_match = re.search(r'"exit_code"\s*:\s*(-?\d+)', content)
@@ -623,7 +638,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
 
     if tool_name == "write_file":
         path = args.get("path", "?")
-        written_lines = args.get("content", "").count("\n") + 1 if args.get("content") else "?"
+        written_lines = _str_arg(args, "content").count("\n") + 1 if args.get("content") else "?"
         return f"[write_file] wrote to {path} ({written_lines} lines)"
 
     if tool_name == "search_files":
@@ -658,14 +673,15 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[web_extract] {url_desc} ({content_len:,} chars)"
 
     if tool_name == "delegate_task":
-        goal = args.get("goal", "")
+        goal = _str_arg(args, "goal")
         if len(goal) > 60:
             goal = goal[:57] + "..."
         return f"[delegate_task] '{goal}' ({content_len:,} chars result)"
 
     if tool_name == "execute_code":
-        code_preview = (args.get("code") or "")[:60].replace("\n", " ")
-        if len(args.get("code", "")) > 60:
+        code_str = _str_arg(args, "code")
+        code_preview = code_str[:60].replace("\n", " ")
+        if len(code_str) > 60:
             code_preview += "..."
         return f"[execute_code] `{code_preview}` ({line_count} lines output)"
 
@@ -674,7 +690,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         return f"[{tool_name}] name={name} ({content_len:,} chars)"
 
     if tool_name == "vision_analyze":
-        question = args.get("question", "")[:50]
+        question = _str_arg(args, "question")[:50]
         return f"[vision_analyze] '{question}' ({content_len:,} chars)"
 
     if tool_name == "memory":

--- a/agent/display.py
+++ b/agent/display.py
@@ -462,13 +462,14 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         sid = args.get("session_id", "")
         data = args.get("data", "")
         timeout_val = args.get("timeout")
-        parts = [action]
+        parts = [str(action) if action else ""]
         if sid:
-            parts.append(sid[:16])
+            parts.append(str(sid)[:16])
         if data:
-            parts.append(f'"{_oneline(data[:20])}"')
+            parts.append(f'"{_oneline(str(data)[:20])}"')
         if timeout_val and action == "wait":
             parts.append(f"{timeout_val}s")
+        parts = [p for p in parts if p]
         return " ".join(parts) if parts else None
 
     if tool_name == "todo":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -332,6 +332,8 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "liuwei666888@users.noreply.github.com": "liuwei666888",
+    "527711370@qq.com": "liuwei666888",
     "217401759+justinschille@users.noreply.github.com": "justinschille",
     "theoldwizard123@pm.me": "unsupportedpastels",
     "johnmlussier@gmail.com": "John-Lussier",

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -227,6 +227,26 @@ class TestBuildToolStart:
         assert result.content is None
         assert result.raw_input is None
 
+    def test_build_tool_start_survives_non_string_command(self):
+        """A malformed (non-string) terminal command previously raised
+        TypeError in build_tool_title (len(None)) and aborted the render."""
+        result = build_tool_start("tc-bad-cmd", "terminal", {"command": None})
+        assert isinstance(result, ToolCallStart)
+        assert result.kind == "execute"  # tool identity preserved in the fallback
+
+    def test_build_tool_start_survives_non_string_path(self):
+        """A non-string read_file path previously raised a ToolCallLocation
+        pydantic ValidationError in extract_locations and aborted the render."""
+        result = build_tool_start("tc-bad-path", "read_file", {"path": {"p": "x"}})
+        assert isinstance(result, ToolCallStart)
+        assert result.kind == "read"
+
+    def test_build_tool_start_survives_non_string_goal(self):
+        """A non-string delegate_task goal previously raised TypeError
+        (len(123)) in build_tool_title and aborted the render."""
+        result = build_tool_start("tc-bad-goal", "delegate_task", {"goal": 123})
+        assert isinstance(result, ToolCallStart)
+
     def test_build_tool_start_for_web_extract_is_compact(self):
         """web_extract start should stay compact; title identifies URLs."""
         args = {"urls": ["https://example.com/docs"]}

--- a/tests/agent/test_summarize_tool_result_type_safety.py
+++ b/tests/agent/test_summarize_tool_result_type_safety.py
@@ -187,6 +187,13 @@ class TestEdgeCases:
         result = _summarize_tool_result("terminal", None, "output")
         assert "terminal" in result
 
+    def test_non_dict_json_args(self):
+        """Args that parse to a non-dict (list/scalar) should not crash."""
+        result = _summarize_tool_result("terminal", json.dumps([1, 2]), "output")
+        assert "terminal" in result
+        result = _summarize_tool_result("terminal", json.dumps("bare"), "output")
+        assert "terminal" in result
+
     def test_unknown_tool_name(self):
         """Unknown tool name should return generic summary."""
         args = json.dumps({"foo": "bar"})
@@ -205,3 +212,75 @@ class TestEdgeCases:
         result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
         assert "terminal" in result
         assert "ls" in result
+
+
+class TestBackstopWrapper:
+    """The outer guard: NO input shape may raise out of _summarize_tool_result.
+
+    Compression retries on the same persisted history, so an escaping
+    exception here becomes a crash loop. The wrapper returns a minimal
+    '[tool] (N chars result)' summary when a branch fails.
+    """
+
+    def test_never_raises_matrix(self):
+        """Fuzz the per-tool branches with hostile value shapes."""
+        hostile_values = [None, True, 42, 3.14, ["a"], {"k": "v"}]
+        tools = [
+            "terminal", "read_file", "write_file", "search_files", "patch",
+            "browser_navigate", "web_search", "web_extract", "delegate_task",
+            "execute_code", "skill_view", "vision_analyze", "memory",
+            "cronjob", "process", "totally_unknown_tool",
+        ]
+        keys = ["command", "path", "content", "pattern", "url", "query",
+                "urls", "goal", "code", "name", "question", "action",
+                "target", "session_id", "mode", "offset", "ref"]
+        for tool in tools:
+            for value in hostile_values:
+                args = json.dumps({k: value for k in keys})
+                result = _summarize_tool_result(tool, args, "x" * 250)
+                assert isinstance(result, str) and result, (tool, value)
+
+    def test_backstop_fallback_shape(self):
+        """When a branch does fail, the fallback names the tool and size."""
+        from unittest.mock import patch as _patch
+        with _patch(
+            "agent.context_compressor._summarize_tool_result_unguarded",
+            side_effect=TypeError("boom"),
+        ):
+            result = _summarize_tool_result("terminal", "{}", "y" * 300)
+        assert result == "[terminal] (300 chars result)"
+
+    def test_backstop_handles_non_string_content(self):
+        from unittest.mock import patch as _patch
+        with _patch(
+            "agent.context_compressor._summarize_tool_result_unguarded",
+            side_effect=TypeError("boom"),
+        ):
+            result = _summarize_tool_result("terminal", "{}", None)
+        assert result == "[terminal] (0 chars result)"
+
+
+class TestDisplayPreviewTypeSafety:
+    """Sibling site: agent/display.py previews run on the live
+    tool-progress callback and crashed on non-string process args."""
+
+    def test_process_preview_non_string_session_id(self):
+        from agent.display import build_tool_preview
+        assert build_tool_preview("process", {"action": "poll", "session_id": 123}) == "poll 123"
+
+    def test_process_preview_non_string_data(self):
+        from agent.display import build_tool_preview
+        result = build_tool_preview(
+            "process", {"action": "submit", "session_id": "abc", "data": 42}
+        )
+        assert result == 'submit abc "42"'
+
+    def test_process_preview_none_action(self):
+        from agent.display import build_tool_preview
+        result = build_tool_preview("process", {"action": None, "session_id": "abc"})
+        assert isinstance(result, str)
+
+    def test_process_label_non_string_session_id(self):
+        from agent.display import build_tool_label
+        result = build_tool_label("process", {"action": "poll", "session_id": 123})
+        assert isinstance(result, str)

--- a/tests/agent/test_summarize_tool_result_type_safety.py
+++ b/tests/agent/test_summarize_tool_result_type_safety.py
@@ -1,0 +1,207 @@
+"""Type safety tests for _summarize_tool_result.
+
+When LLMs return non-string parameter values (e.g. bool, int, None) in tool
+call arguments, _summarize_tool_result() must not crash with TypeError or
+AttributeError. This caused an infinite TUI crash loop in production.
+"""
+import json
+import pytest
+from agent.context_compressor import _summarize_tool_result
+
+
+class TestTypeSafety:
+    """Non-string tool arguments must not crash _summarize_tool_result."""
+
+    def test_terminal_command_bool(self):
+        """bool value for 'command' should not raise TypeError."""
+        args = json.dumps({"command": True})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "True" in result or "exit" in result
+
+    def test_terminal_command_int(self):
+        """int value for 'command' should not raise TypeError."""
+        args = json.dumps({"command": 42})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "42" in result
+
+    def test_terminal_command_none(self):
+        """None value for 'command' should not raise TypeError."""
+        args = json.dumps({"command": None})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+
+    def test_write_file_content_bool(self):
+        """bool value for 'content' should not raise AttributeError."""
+        args = json.dumps({"path": "test.txt", "content": False})
+        result = _summarize_tool_result("write_file", args, "OK")
+        assert "write_file" in result
+        assert "test.txt" in result
+
+    def test_write_file_content_int(self):
+        """int value for 'content' should not raise AttributeError."""
+        args = json.dumps({"path": "test.txt", "content": 123})
+        result = _summarize_tool_result("write_file", args, "OK")
+        assert "write_file" in result
+
+    def test_delegate_task_goal_bool(self):
+        """bool value for 'goal' should not raise TypeError."""
+        args = json.dumps({"goal": False})
+        result = _summarize_tool_result("delegate_task", args, "result")
+        assert "delegate_task" in result
+        assert "False" in result
+
+    def test_delegate_task_goal_int(self):
+        """int value for 'goal' should not raise TypeError."""
+        args = json.dumps({"goal": 999})
+        result = _summarize_tool_result("delegate_task", args, "result")
+        assert "delegate_task" in result
+        assert "999" in result
+
+    def test_execute_code_code_bool(self):
+        """bool value for 'code' should not raise TypeError."""
+        args = json.dumps({"code": True})
+        result = _summarize_tool_result("execute_code", args, "output")
+        assert "execute_code" in result
+        assert "True" in result
+
+    def test_execute_code_code_int(self):
+        """int value for 'code' should not raise TypeError."""
+        args = json.dumps({"code": 0})
+        result = _summarize_tool_result("execute_code", args, "output")
+        assert "execute_code" in result
+
+    def test_vision_analyze_question_bool(self):
+        """bool value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": True})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+        assert "True" in result
+
+    def test_vision_analyze_question_int(self):
+        """int value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": 123})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+        assert "123" in result
+
+    def test_vision_analyze_question_list(self):
+        """list value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": ["a", "b"]})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+
+    def test_vision_analyze_question_dict(self):
+        """dict value for 'question' should not raise TypeError."""
+        args = json.dumps({"question": {"key": "value"}})
+        result = _summarize_tool_result("vision_analyze", args, "analysis")
+        assert "vision_analyze" in result
+
+
+class TestNormalStringArguments:
+    """Normal string arguments should continue to work as before."""
+
+    def test_terminal_normal_command(self):
+        """Normal string command should be summarized correctly."""
+        args = json.dumps({"command": "ls -la"})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "ls -la" in result
+        assert "exit 0" in result
+
+    def test_terminal_long_command_truncated(self):
+        """Long commands should be truncated."""
+        long_cmd = "a" * 100
+        args = json.dumps({"command": long_cmd})
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "..." in result
+        assert len(result) < 150
+
+    def test_write_file_normal_content(self):
+        """Normal string content should count lines correctly."""
+        args = json.dumps({"path": "test.py", "content": "line1\nline2\nline3"})
+        result = _summarize_tool_result("write_file", args, "OK")
+        assert "write_file" in result
+        assert "test.py" in result
+        assert "3 lines" in result
+
+    def test_delegate_task_normal_goal(self):
+        """Normal string goal should be summarized correctly."""
+        args = json.dumps({"goal": "Fix the bug"})
+        result = _summarize_tool_result("delegate_task", args, "done")
+        assert "delegate_task" in result
+        assert "Fix the bug" in result
+
+    def test_delegate_task_long_goal_truncated(self):
+        """Long goals should be truncated."""
+        long_goal = "x" * 100
+        args = json.dumps({"goal": long_goal})
+        result = _summarize_tool_result("delegate_task", args, "done")
+        assert "..." in result
+
+    def test_execute_code_normal_code(self):
+        """Normal code should be previewed correctly."""
+        args = json.dumps({"code": "print('hello')"})
+        result = _summarize_tool_result("execute_code", args, "hello")
+        assert "execute_code" in result
+        assert "print" in result
+
+    def test_execute_code_long_code_truncated(self):
+        """Long code should be truncated."""
+        long_code = "a = 1\n" * 20
+        args = json.dumps({"code": long_code})
+        result = _summarize_tool_result("execute_code", args, "output")
+        assert "..." in result
+
+    def test_vision_analyze_normal_question(self):
+        """Normal question should be included."""
+        args = json.dumps({"question": "What is this?"})
+        result = _summarize_tool_result("vision_analyze", args, "It's a cat")
+        assert "vision_analyze" in result
+        assert "What is this?" in result
+
+    def test_vision_analyze_long_question_truncated(self):
+        """Long questions should be truncated."""
+        long_q = "?" * 100
+        args = json.dumps({"question": long_q})
+        result = _summarize_tool_result("vision_analyze", args, "answer")
+        assert len(result) < 150
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_empty_args(self):
+        """Empty JSON object should not crash."""
+        result = _summarize_tool_result("terminal", "{}", "output")
+        assert "terminal" in result
+
+    def test_invalid_json(self):
+        """Invalid JSON should not crash."""
+        result = _summarize_tool_result("terminal", "not json", "output")
+        assert "terminal" in result
+
+    def test_null_args(self):
+        """None/null args should not crash."""
+        result = _summarize_tool_result("terminal", None, "output")
+        assert "terminal" in result
+
+    def test_unknown_tool_name(self):
+        """Unknown tool name should return generic summary."""
+        args = json.dumps({"foo": "bar"})
+        result = _summarize_tool_result("unknown_tool", args, "output")
+        # Should return some fallback, not crash
+        assert isinstance(result, str)
+
+    def test_mixed_types_in_args(self):
+        """Args with mixed types should not crash."""
+        args = json.dumps({
+            "command": "ls",
+            "background": True,
+            "timeout": 30,
+            "extra": None
+        })
+        result = _summarize_tool_result("terminal", args, '{"exit_code": 0}')
+        assert "terminal" in result
+        assert "ls" in result


### PR DESCRIPTION
## Summary

Display layers no longer crash on non-string tool-call argument values (bool, int, None, list, dict). Consolidates @liuwei666888's #52431 (context-compressor summaries — reported as an infinite TUI crash loop) and @Frowtek's #62588 (ACP tool-call render) into one class fix, plus a third crash site found during the sweep (CLI tool-progress previews).

The class: models sometimes emit non-string argument values, and those values get persisted into session history. Any display-layer code that slices/`len()`s/`.count()`s an arg value crashes — and because compression and history replay re-read the same persisted history, the crash repeats forever. Dispatch-layer handling landed in #64634; this completes the display layer.

The rule applied consistently: **display layers never raise on model-shaped data, and coerce for preview — never repair for dispatch.** Each surface gets informative per-branch coercion plus a never-raises guard, mirroring the existing `get_cute_tool_message` pattern.

## Changes

- `agent/context_compressor.py` (@liuwei666888, cherry-picked + follow-up): `_str_arg` coercion at the 5 slicing branches; consolidation adds a never-raises backstop wrapper around `_summarize_tool_result` (fallback: `[tool] (N chars result)`) and rejects non-dict parsed args (a JSON list would crash every `args.get`).
- `acp_adapter/tools.py` (@Frowtek, cherry-picked as-is): `build_tool_start` guarded; on any title/location builder failure emits a minimal valid start event preserving tool identity, instead of aborting the editor render / session replay.
- `agent/display.py` (follow-up): `build_tool_preview`'s process branch sliced `session_id`/`data` uncoerced — crashed `build_tool_preview` and `build_tool_label` on the live tool-progress callback (probed live on main: `TypeError: 'int' object is not subscriptable`). Coerced like sibling branches.
- Tests: contributors' 20 + 3 tests kept; consolidation adds a fuzz matrix (16 tools × 6 hostile value shapes → zero raises), backstop fallback-shape contracts, and display process-preview regressions.

## Validation

| | Result |
|---|---|
| Crash repro on main | compressor: 6/6 variants raise; ACP: 3/3 raise; display: 2 preview fns raise |
| Post-fix probe | all variants return valid summaries/events/previews |
| E2E: real `_prune_old_tool_results` over poisoned history (non-string args, >200-char results) | prunes 4/4, no exception |
| Targeted suites (type-safety + ACP tools + display + context compressor) | 318/318 |
| Full `tests/acp/` + compressor | 460/460 |
| ruff + windows-footgun | clean |

Originals #52431 and #62588 will be closed with credit after merge; both contributor emails are already in AUTHOR_MAP.

## Infographic

![display-layer-hardening](https://v3b.fal.media/files/b/0aa24f1f/v7qaMhw_p8FDQGuPiUA7v_4TOEcLH4.png)
