### PR TITLE
fix(telegram): catch AttributeError from PTB python-3.11 __slots__ conflict with actionable message

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3251,6 +3251,20 @@ class TelegramAdapter(BasePlatformAdapter):
                         raise
                 except Exception as init_err:
                     if not self._looks_like_network_error(init_err):
+                        # Capture known non-retryable errors with a clear message.
+                        if (
+                            isinstance(init_err, AttributeError)
+                            and "do_request" in str(init_err)
+                            and "read-only" in str(init_err)
+                        ):
+                            raise OSError(
+                                f"Telegram PTB version conflict: {init_err}. "
+                                "This is caused by a CPython / python-telegram-bot "
+                                "incompatibility with __slots__ and abc.abstractmethod "
+                                "on some Python 3.11 builds. Ensure the pinned version "
+                                "is installed: pip install 'python-telegram-bot[webhooks]==22.6'. "
+                                "Upgrading to Python 3.12+ also resolves this."
+                            ) from init_err
                         raise
                     if _attempt < _max_connect - 1:
                         wait = min(2 ** _attempt, 15)


### PR DESCRIPTION
Fixes #64730

## Summary

On Python 3.11, a CPython interaction between `abc.abstractmethod` and `__slots__` in PTB's `HTTPXRequest` class makes the `do_request` attribute read-only. When the Telegram adapter's `connect()` calls `Application.initialize()`, the abstract-method/slots conflict raises:

> 'HTTPXRequest' object attribute 'do_request' is read-only

This is a closed issue in CPython resolved in Python 3.12+, but users on Python 3.11 (especially Windows) hit it when running the Telegram gateway.

## Fix

Convert the opaque `AttributeError` into a clear `OSError` with an actionable message suggesting:
- Ensuring the pinned PTB version (`==22.6`) is installed
- Upgrading to Python 3.12+

## Test Plan

- `test_telegram_start_polling_timeout.py`: 4/4 passed
- `test_telegram_init_deadline.py`: 6/6 passed
- `test_telegram_closewait_limits_31599.py` + `test_telegram_conflict.py` + `test_telegram_network.py`: 63/63 passed