### PR TITLE
feat(kanban): add read-only reliability report

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -19,6 +19,7 @@ import contextlib
 import json
 import os
 import shlex
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -690,6 +691,30 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_stats.add_argument("--json", action="store_true")
 
+    # --- reliability (bounded, read-only burn-down report) ---
+    p_reliability = sub.add_parser(
+        "reliability",
+        aliases=["burn-down"],
+        help="Read-only failure burn-down for the last 24h, 72h, or 7d",
+    )
+    p_reliability.add_argument(
+        "--window", choices=("24h", "72h", "7d"), default="72h",
+        help="Reporting window (default: 72h)",
+    )
+    p_reliability.add_argument(
+        "--limit", type=int, default=10,
+        help="Maximum rows per top/actionable section (default: 10)",
+    )
+    p_reliability.add_argument(
+        "--db", type=Path, default=None, metavar="PATH",
+        help="Existing kanban.db to inspect (default: current board)",
+    )
+    p_reliability.add_argument("--json", action="store_true")
+    p_reliability.add_argument(
+        "--output", type=Path, default=None, metavar="PATH",
+        help="Save the full report to a file instead of printing it",
+    )
+
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
@@ -929,6 +954,15 @@ def kanban_command(args: argparse.Namespace) -> int:
     # schema creation; `create` / `list` / every other command would
     # error out on a fresh install.
     with board_scope:
+        # Reliability reporting must remain genuinely read-only. In
+        # particular, do not call init_db(): it can create/migrate schemas and
+        # defeats SQLite mode=ro even when the report queries are SELECT-only.
+        if action in {"reliability", "burn-down"}:
+            try:
+                return int(_cmd_reliability(args) or 0)
+            except (OSError, sqlite3.Error, ValueError) as exc:
+                print(f"kanban reliability: {exc}", file=sys.stderr)
+                return 1
         try:
             kb.init_db()
         except Exception as exc:
@@ -963,6 +997,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "daemon":   _cmd_daemon,
             "watch":    _cmd_watch,
             "stats":    _cmd_stats,
+            "reliability": _cmd_reliability,
+            "burn-down": _cmd_reliability,
             "log":      _cmd_log,
             "runs":     _cmd_runs,
             "heartbeat": _cmd_heartbeat,
@@ -2428,6 +2464,40 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     age = stats["oldest_ready_age_seconds"]
     if age is not None:
         print(f"\nOldest ready task age: {int(age)}s")
+    return 0
+
+
+def _cmd_reliability(args: argparse.Namespace) -> int:
+    """Print or save a bounded report without mutating the board database."""
+    from hermes_cli.kanban_reliability import (
+        build_reliability_report,
+        open_readonly,
+        render_reliability_report,
+    )
+
+    windows = {"24h": 24 * 60 * 60, "72h": 72 * 60 * 60, "7d": 7 * 24 * 60 * 60}
+    label = getattr(args, "window", "72h")
+    db_path = getattr(args, "db", None) or kb.kanban_db_path()
+    with open_readonly(db_path) as conn:
+        report = build_reliability_report(
+            conn,
+            window_seconds=windows[label],
+            limit=int(getattr(args, "limit", 10)),
+        )
+    report["window"]["label"] = label
+    content = (
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+        if getattr(args, "json", False)
+        else render_reliability_report(report)
+    )
+    output = getattr(args, "output", None)
+    if output is None:
+        print(content, end="")
+        return 0
+    output = output.expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content, encoding="utf-8")
+    print(f"Saved Kanban reliability report to {output}")
     return 0
 
 

--- a/hermes_cli/kanban_reliability.py
+++ b/hermes_cli/kanban_reliability.py
@@ -1,0 +1,290 @@
+"""Read-only Kanban burn-down reliability reporting.
+
+The report deliberately opens an existing board database with SQLite
+``mode=ro`` and ``query_only``.  It is safe to run from cron or the gateway
+while the dispatcher is active: no schema initialization, migrations, or
+board mutations are performed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+from collections import Counter
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+
+_SUCCESS_OUTCOMES = {"completed"}
+_STALE_LOCK_RE = re.compile(r"\bstale_lock=([^\s,;]+)", re.IGNORECASE)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _metadata(run: Mapping[str, Any]) -> dict[str, Any]:
+    value = run.get("metadata")
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+    return _as_dict(value)
+
+
+def categorize_failure(run: Mapping[str, Any]) -> str:
+    """Map a failed run to a stable operator-facing failure category."""
+    metadata = _metadata(run)
+    failure_category = str(metadata.get("failure_category") or "").lower()
+    outcome = str(run.get("outcome") or "").lower()
+    text = " ".join(
+        str(value or "")
+        for value in (
+            failure_category,
+            metadata.get("error"),
+            metadata.get("exit_kind"),
+            run.get("error"),
+            run.get("summary"),
+        )
+    ).lower()
+
+    if "heartbeat" in text and ("reclaim" in text or outcome == "reclaimed"):
+        return "heartbeat_reclaim"
+    if "completion" in text and any(
+        marker in text for marker in ("gate", "evidence", "contract", "rejected", "blocked")
+    ):
+        return "completion_gate"
+    if "protocol violation" in text or "protocol_violation" in text:
+        return "protocol_violation"
+    if any(marker in text for marker in ("iteration budget", "iteration limit", "max iterations")):
+        return "iteration_exhaustion"
+    if any(marker in text for marker in ("pid not alive", "pid is not alive", "worker pid", "process not alive")):
+        return "pid_not_alive"
+    if any(marker in text for marker in ("workspace", "artifact guard", "missing artifact", "worktree")):
+        return "workspace_or_artifact"
+    if any(
+        marker in text
+        for marker in (
+            "auth",
+            "credential",
+            "missing token",
+            "token is missing",
+            "command not found",
+            "no such executable",
+            "tooling missing",
+        )
+    ):
+        return "auth_or_tooling"
+    if outcome == "blocked":
+        return "blocked"
+    return failure_category or outcome or "unknown"
+
+
+def _parse_json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(str(value))
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _reason_from_payload(value: Any) -> str:
+    payload = _parse_json_object(value)
+    reason = payload.get("reason") or payload.get("error") or payload.get("message") or "unspecified"
+    return " ".join(str(reason).split())[:240]
+
+
+def _stale_lock(run: Mapping[str, Any]) -> str | None:
+    error = str(run.get("error") or "")
+    match = _STALE_LOCK_RE.search(error)
+    if match:
+        return match.group(1)
+    metadata = _metadata(run)
+    value = metadata.get("stale_lock")
+    return str(value) if value else None
+
+
+@contextmanager
+def open_readonly(path: Path | str) -> Iterator[sqlite3.Connection]:
+    """Open an existing SQLite database without permitting writes."""
+    resolved = Path(path).expanduser().resolve(strict=True)
+    conn = sqlite3.connect(f"file:{resolved.as_posix()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _sorted_counts(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
+
+
+def build_reliability_report(
+    conn: sqlite3.Connection,
+    *,
+    window_seconds: int,
+    now: int | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Build a bounded reliability summary from a read-only connection."""
+    if window_seconds <= 0:
+        raise ValueError("window_seconds must be positive")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    now_ts = int(time.time()) if now is None else int(now)
+    since = now_ts - int(window_seconds)
+
+    rows = [
+        dict(row)
+        for row in conn.execute(
+            "SELECT id, task_id, profile, status, outcome, summary, metadata, error, "
+            "started_at, ended_at FROM task_runs "
+            "WHERE COALESCE(ended_at, started_at) >= ? "
+            "ORDER BY COALESCE(ended_at, started_at), id",
+            (since,),
+        )
+    ]
+    outcome_counts = Counter(str(row.get("outcome") or "running") for row in rows)
+    profile_counts = Counter(str(row.get("profile") or "(unassigned)") for row in rows)
+    failures = [
+        row for row in rows
+        if row.get("outcome") and str(row["outcome"]) not in _SUCCESS_OUTCOMES
+    ]
+    category_counts = Counter(categorize_failure(row) for row in failures)
+
+    bursts: dict[str, dict[str, Any]] = {}
+    for row in failures:
+        lock = _stale_lock(row)
+        if not lock:
+            continue
+        timestamp = int(row.get("ended_at") or row.get("started_at") or 0)
+        burst = bursts.setdefault(
+            lock,
+            {"stale_lock": lock, "count": 0, "first_at": timestamp, "last_at": timestamp},
+        )
+        burst["count"] += 1
+        burst["first_at"] = min(burst["first_at"], timestamp)
+        burst["last_at"] = max(burst["last_at"], timestamp)
+    recurring_bursts = [item for item in bursts.values() if item["count"] > 1]
+    stale_lock_bursts = sorted(
+        recurring_bursts,
+        key=lambda item: (-item["count"], -item["last_at"], item["stale_lock"]),
+    )[:limit]
+
+    blocked_reasons = Counter(
+        _reason_from_payload(row["payload"])
+        for row in conn.execute(
+            "SELECT payload FROM task_events WHERE kind IN ('blocked', 'spawn_auto_blocked') "
+            "AND created_at >= ?",
+            (since,),
+        )
+    )
+    top_blocked_reasons = [
+        {"reason": reason, "count": count}
+        for reason, count in sorted(blocked_reasons.items(), key=lambda item: (-item[1], item[0]))[:limit]
+    ]
+
+    blocker_rows = list(
+        conn.execute(
+            "SELECT t.id, t.title, t.assignee, t.status, t.block_kind, "
+            "(SELECT e.payload FROM task_events e "
+            " WHERE e.task_id=t.id AND e.kind IN ('blocked', 'spawn_auto_blocked') "
+            " ORDER BY e.id DESC LIMIT 1) AS block_payload, "
+            "t.last_failure_error "
+            "FROM tasks t WHERE t.status='blocked' OR "
+            "(t.status='triage' AND (t.block_kind IS NOT NULL OR t.last_failure_error IS NOT NULL)) "
+            "ORDER BY COALESCE(t.started_at, t.created_at) ASC, t.id ASC LIMIT ?",
+            (limit + 1,),
+        )
+    )
+    active_blockers = []
+    for row in blocker_rows[:limit]:
+        reason = _reason_from_payload(row["block_payload"])
+        if reason == "unspecified" and row["last_failure_error"]:
+            reason = " ".join(str(row["last_failure_error"]).split())[:240]
+        active_blockers.append(
+            {
+                "task_id": row["id"],
+                "title": row["title"],
+                "assignee": row["assignee"],
+                "status": row["status"],
+                "block_kind": row["block_kind"],
+                "reason": reason,
+            }
+        )
+
+    return {
+        "generated_at": now_ts,
+        "window": {"seconds": int(window_seconds), "since": since},
+        "runs": {
+            "total": len(rows),
+            "by_outcome": _sorted_counts(outcome_counts),
+            "by_profile": _sorted_counts(profile_counts),
+        },
+        "failures": {
+            "total": len(failures),
+            "by_category": _sorted_counts(category_counts),
+        },
+        "stale_lock_bursts": stale_lock_bursts,
+        "top_blocked_reasons": top_blocked_reasons,
+        "active_actionable_blockers": active_blockers,
+        "truncated": {
+            "stale_lock_bursts": len(recurring_bursts) > limit,
+            "top_blocked_reasons": len(blocked_reasons) > limit,
+            "active_actionable_blockers": len(blocker_rows) > limit,
+        },
+    }
+
+
+def render_reliability_report(report: Mapping[str, Any]) -> str:
+    """Render a compact terminal-friendly report."""
+    window = _as_dict(report.get("window"))
+    runs = _as_dict(report.get("runs"))
+    failures = _as_dict(report.get("failures"))
+    lines = [
+        f"Kanban reliability ({window.get('label') or window.get('seconds', '?')}): "
+        f"{runs.get('total', 0)} runs, {failures.get('total', 0)} non-success",
+        "",
+        "By outcome: " + ", ".join(f"{k}={v}" for k, v in _as_dict(runs.get("by_outcome")).items()),
+        "By profile: " + ", ".join(f"{k}={v}" for k, v in _as_dict(runs.get("by_profile")).items()),
+        "By failure category: "
+        + (", ".join(f"{k}={v}" for k, v in _as_dict(failures.get("by_category")).items()) or "none"),
+        "",
+        "Top stale_lock bursts:",
+    ]
+    bursts = report.get("stale_lock_bursts") or []
+    lines.extend(
+        f"  {item['stale_lock']}: {item['count']} runs "
+        f"({time.strftime('%Y-%m-%d %H:%M', time.localtime(item['first_at']))} → "
+        f"{time.strftime('%Y-%m-%d %H:%M', time.localtime(item['last_at']))})"
+        for item in bursts
+    )
+    if not bursts:
+        lines.append("  none")
+    lines.append("\nTop blocked reasons:")
+    reasons = report.get("top_blocked_reasons") or []
+    lines.extend(f"  {item['count']}× {item['reason']}" for item in reasons)
+    if not reasons:
+        lines.append("  none")
+    lines.append("\nActive actionable blockers:")
+    blockers = report.get("active_actionable_blockers") or []
+    lines.extend(
+        f"  {item['task_id']} [{item['status']}] @{item['assignee'] or '-'} "
+        f"{item['title']} — {item['reason']}"
+        for item in blockers
+    )
+    if not blockers:
+        lines.append("  none")
+    return "\n".join(lines) + "\n"

--- a/tests/hermes_cli/test_kanban_reliability.py
+++ b/tests/hermes_cli/test_kanban_reliability.py
@@ -1,0 +1,119 @@
+"""Behavior tests for the read-only Kanban reliability report."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_reliability import (
+    build_reliability_report,
+    categorize_failure,
+    open_readonly,
+)
+
+
+@pytest.mark.parametrize(
+    ("run", "expected"),
+    [
+        (
+            {"outcome": "reclaimed", "metadata": {"failure_category": "heartbeat_stale_reclaimed"}},
+            "heartbeat_reclaim",
+        ),
+        ({"outcome": "failed", "error": "completion gate rejected: missing PR evidence"}, "completion_gate"),
+        ({"outcome": "spawn_failed", "error": "GitHub authentication token is missing"}, "auth_or_tooling"),
+        ({"outcome": "crashed", "error": "worker pid is not alive"}, "pid_not_alive"),
+        ({"outcome": "failed", "error": "protocol violation: kanban_complete was not called"}, "protocol_violation"),
+        ({"outcome": "timed_out", "error": "Iteration budget exhausted (90/90)"}, "iteration_exhaustion"),
+        ({"outcome": "spawn_failed", "error": "workspace parent artifact guard found missing files"}, "workspace_or_artifact"),
+        ({"outcome": "blocked", "error": None}, "blocked"),
+    ],
+)
+def test_categorize_failure_groups_operator_failure_classes(run, expected):
+    assert categorize_failure(run) == expected
+
+
+@pytest.fixture
+def report_db(tmp_path: Path) -> Path:
+    path = tmp_path / "kanban.db"
+    kb.init_db(path)
+    now = 2_000_000_000
+    with kb.connect(path) as conn:
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, assignee, created_at, workspace_kind, "
+            "block_kind, last_failure_error) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("t_blocked", "Needs credentials", "blocked", "coder", now - 500, "scratch", "needs_input", "missing token"),
+        )
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, assignee, created_at, workspace_kind) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("t_done", "Recovered", "done", "researcher", now - 700, "scratch"),
+        )
+        runs = [
+            ("t_blocked", "coder", "reclaimed", "reclaimed", now - 400, now - 300,
+             json.dumps({"failure_category": "heartbeat_stale_reclaimed", "stale_lock_host": "host-a"}), "stale_lock=host-a:1"),
+            ("t_done", "researcher", "reclaimed", "reclaimed", now - 390, now - 290,
+             json.dumps({"failure_category": "heartbeat_stale_reclaimed", "stale_lock_host": "host-a"}), "stale_lock=host-a:1"),
+            ("t_done", "researcher", "done", "completed", now - 200, now - 100, None, None),
+        ]
+        conn.executemany(
+            "INSERT INTO task_runs (task_id, profile, status, outcome, started_at, ended_at, metadata, error) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            runs,
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, ?, ?, ?)",
+            ("t_blocked", "blocked", json.dumps({"reason": "missing deploy credential"}), now - 250),
+        )
+        conn.commit()
+    return path
+
+
+def test_report_has_bounded_counts_bursts_reasons_and_active_blockers(report_db: Path):
+    with open_readonly(report_db) as conn:
+        report = build_reliability_report(conn, window_seconds=86_400, now=2_000_000_000, limit=1)
+
+    assert report["runs"]["by_outcome"] == {"completed": 1, "reclaimed": 2}
+    assert report["runs"]["by_profile"] == {"coder": 1, "researcher": 2}
+    assert report["failures"]["by_category"] == {"heartbeat_reclaim": 2}
+    assert report["stale_lock_bursts"] == [
+        {"stale_lock": "host-a:1", "count": 2, "first_at": 1_999_999_700, "last_at": 1_999_999_710}
+    ]
+    assert report["top_blocked_reasons"] == [{"reason": "missing deploy credential", "count": 1}]
+    assert report["active_actionable_blockers"] == [
+        {
+            "task_id": "t_blocked",
+            "title": "Needs credentials",
+            "assignee": "coder",
+            "status": "blocked",
+            "block_kind": "needs_input",
+            "reason": "missing deploy credential",
+        }
+    ]
+    assert report["truncated"]["active_actionable_blockers"] is False
+
+
+def test_open_readonly_enables_sqlite_query_only(report_db: Path):
+    with open_readonly(report_db) as conn:
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            conn.execute("UPDATE tasks SET title='mutated'")
+
+
+def test_reliability_cli_accepts_window_and_saves_output_without_initializing(
+    report_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(report_db))
+    monkeypatch.setattr(kb, "init_db", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must stay read-only")))
+    output = tmp_path / "report.json"
+
+    result = kc.run_slash(f"reliability --window 24h --json --output {output}")
+
+    assert "Saved Kanban reliability report" in result
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["window"]["label"] == "24h"
+    assert payload["runs"]["total"] == 3

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -675,6 +675,8 @@ hermes kanban dispatch [--dry-run] [--max N]           # one-shot pass
 hermes kanban daemon --force                           # DEPRECATED — standalone dispatcher (use `hermes gateway start` instead)
         [--failure-limit N] [--pidfile PATH] [-v]
 hermes kanban stats [--json]                           # per-status + per-assignee counts
+hermes kanban reliability [--window 24h|72h|7d]        # read-only failure burn-down
+        [--limit N] [--db PATH] [--json] [--output PATH]
 hermes kanban log <id> [--tail BYTES]                  # worker log from ~/.hermes/kanban/logs/
 hermes kanban notify-subscribe <id>                    # gateway bridge hook (used by /kanban in the gateway)
         --platform <name> --chat-id <id> [--thread-id <id>] [--user-id <id>]
@@ -689,6 +691,19 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 ```
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
+
+`hermes kanban reliability` summarizes run outcomes by profile and failure
+category, recurring `stale_lock` bursts, blocked reasons, and currently
+actionable blocked/triage tasks. It opens the existing database with SQLite
+`mode=ro` plus `query_only`; unlike normal board commands, it never initializes
+or migrates the schema. Use `--db /persisted/.hermes/kanban.db` to inspect an
+explicit deployment database. For cron or gateway automation, pass `--output`
+so the bounded terminal response only reports the saved file path:
+
+```bash
+hermes kanban reliability --window 72h --json \
+  --output ~/.hermes/reports/kanban-reliability.json
+```
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 


### PR DESCRIPTION
## Summary
- add `hermes kanban reliability` with bounded 24h/72h/7d windows
- categorize run failures and surface stale-lock bursts, blocked reasons, and actionable blockers
- keep the report genuinely read-only with SQLite `mode=ro` + `query_only`, with JSON/file output for cron and gateway use
- document the CLI and add behavior-focused tests

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_reliability.py tests/hermes_cli/test_kanban_cli.py -q` (58 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban*.py -q` (848 passed)
- `ruff check` + `py_compile` + `git diff --check`
- live smoke test against `/persisted/.hermes/kanban.db`; database mtime and size unchanged
