### PR TITLE
feat(kanban): add structured task supersession

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -41,6 +41,7 @@ _STATUS_ICONS = {
     "blocked":  "⊘",
     "done":     "✓",
     "archived": "—",
+    "superseded": "⇢",
 }
 
 
@@ -51,10 +52,15 @@ def _fmt_ts(ts: Optional[int]) -> str:
 
 
 def _fmt_task_line(t: kb.Task) -> str:
-    icon = _STATUS_ICONS.get(t.status, "?")
+    display_status = "superseded" if t.superseded_by else t.status
+    icon = _STATUS_ICONS.get(display_status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    replacement = f" → {t.superseded_by}" if t.superseded_by else ""
+    return (
+        f"{icon} {t.id}  {display_status:10s}  "
+        f"{assignee:20s}{tenant}  {t.title}{replacement}"
+    )
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
@@ -80,6 +86,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "superseded_by": t.superseded_by,
     }
 
 
@@ -617,6 +624,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Emit machine-readable JSON result",
     )
 
+    p_supersede = sub.add_parser(
+        "supersede",
+        help="Mark an obsolete task as replaced by another task",
+    )
+    p_supersede.add_argument("task_id")
+    p_supersede.add_argument("replacement_id")
+
+    p_unsupersede = sub.add_parser(
+        "unsupersede",
+        help="Clear a task's supersession marker without re-queueing it",
+    )
+    p_unsupersede.add_argument("task_id")
+
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="*",
                            help="Task ids to archive (default mode)")
@@ -957,6 +977,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "schedule": _cmd_schedule,
             "unblock":  _cmd_unblock,
             "promote":  _cmd_promote,
+            "supersede": _cmd_supersede,
+            "unsupersede": _cmd_unsupersede,
             "archive":  _cmd_archive,
             "tail":     _cmd_tail,
             "dispatch": _cmd_dispatch,
@@ -1508,6 +1530,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
     print(f"Task {task.id}: {task.title}")
     print(f"  status:    {task.status}")
+    if task.superseded_by:
+        print(f"  superseded-by: {task.superseded_by} (not dispatchable)")
     print(f"  assignee:  {task.assignee or '-'}")
     if task.tenant:
         print(f"  tenant:    {task.tenant}")
@@ -2066,6 +2090,43 @@ def _cmd_promote(args: argparse.Namespace) -> int:
         else:
             print(f"cannot promote {r['task_id']}: {r['error']}", file=sys.stderr)
     return 0 if not failed else 1
+
+
+def _cmd_supersede(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        try:
+            ok = kb.supersede_task(
+                conn,
+                args.task_id,
+                args.replacement_id,
+                actor=_profile_author(),
+            )
+        except (RuntimeError, ValueError) as exc:
+            print(f"cannot supersede {args.task_id}: {exc}", file=sys.stderr)
+            return 1
+    if not ok:
+        print(f"cannot supersede {args.task_id}: task not found", file=sys.stderr)
+        return 1
+    print(f"Superseded {args.task_id} by {args.replacement_id}")
+    return 0
+
+
+def _cmd_unsupersede(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        ok = kb.clear_supersession(
+            conn,
+            args.task_id,
+            actor=_profile_author(),
+        )
+    if not ok:
+        print(
+            f"cannot clear supersession for {args.task_id} "
+            "(task not found or not superseded)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Cleared supersession for {args.task_id}; task remains blocked")
+    return 0
 
 
 def _cmd_archive(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -915,6 +915,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Replacement task that made this card obsolete. Superseded cards remain
+    # visible for audit/history but are never auto-promoted or dispatched.
+    superseded_by: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1001,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            superseded_by=(
+                row["superseded_by"]
+                if "superseded_by" in keys and row["superseded_by"]
+                else None
             ),
         )
 
@@ -1176,7 +1184,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Structured duplicate/replacement marker. A non-NULL target makes this
+    -- task terminal for dispatcher purposes while preserving its history.
+    superseded_by        TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1985,6 +1996,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "superseded_by" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "superseded_by", "superseded_by TEXT"
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -3315,12 +3331,14 @@ def recompute_ready(
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, status, consecutive_failures, max_retries, superseded_by "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
+            if row["superseded_by"]:
+                continue
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
                 # Worker / operator asked for human review — do not
                 # silently auto-recover.  ``unblock_task`` is the only
@@ -3441,6 +3459,7 @@ def claim_task(
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
+               AND superseded_by IS NULL
             """,
             (lock, expires, now, task_id),
         )
@@ -4977,6 +4996,120 @@ def block_task(
     return True
 
 
+_SUPERSEDED_BY_RE = re.compile(
+    r"\bsuperseded\s+by\s+(t_[0-9a-f]+)\b", re.IGNORECASE
+)
+
+
+def supersede_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    replacement_id: str,
+    *,
+    actor: str,
+) -> bool:
+    """Mark ``task_id`` as obsolete in favor of ``replacement_id``.
+
+    Active queue states are parked in ``blocked`` but retain a structured
+    marker so operators and dispatchers can distinguish them from actionable
+    blocked work. Running tasks must be stopped or blocked first.
+    """
+    if task_id == replacement_id:
+        raise ValueError("a task cannot supersede itself")
+    with write_txn(conn):
+        rows = conn.execute(
+            "SELECT id, status FROM tasks WHERE id IN (?, ?)",
+            (task_id, replacement_id),
+        ).fetchall()
+        by_id = {row["id"]: row for row in rows}
+        if task_id not in by_id:
+            return False
+        if replacement_id not in by_id:
+            raise ValueError(f"replacement task {replacement_id} not found")
+        if by_id[task_id]["status"] == "running":
+            raise RuntimeError(
+                f"cannot supersede running task {task_id}; block or stop it first"
+            )
+        conn.execute(
+            "UPDATE tasks SET superseded_by = ?, "
+            "status = CASE WHEN status IN "
+            "('triage', 'todo', 'scheduled', 'ready', 'blocked', 'review') "
+            "THEN 'blocked' ELSE status END, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ?",
+            (replacement_id, task_id),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "superseded",
+            {"superseded_by": replacement_id, "actor": actor},
+        )
+    return True
+
+
+def clear_supersession(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: str,
+) -> bool:
+    """Clear a supersession marker without implicitly re-queueing the task."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT superseded_by FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None or not row["superseded_by"]:
+            return False
+        previous = row["superseded_by"]
+        conn.execute(
+            "UPDATE tasks SET superseded_by = NULL WHERE id = ?", (task_id,)
+        )
+        _append_event(
+            conn,
+            task_id,
+            "supersession_cleared",
+            {"previous": previous, "actor": actor},
+        )
+    return True
+
+
+def find_supersession_candidates(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Report legacy run summaries containing ``Superseded by t_<id>``.
+
+    The newest matching summary per task is returned. This is deliberately
+    read-only: operators must review the target and apply ``supersede_task``.
+    """
+    rows = conn.execute(
+        "SELECT r.task_id, r.summary, t.superseded_by "
+        "FROM task_runs r JOIN tasks t ON t.id = r.task_id "
+        "WHERE r.summary IS NOT NULL ORDER BY r.id DESC"
+    ).fetchall()
+    existing_ids = {
+        row["id"] for row in conn.execute("SELECT id FROM tasks").fetchall()
+    }
+    seen: set[str] = set()
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        task_id = row["task_id"]
+        if task_id in seen:
+            continue
+        match = _SUPERSEDED_BY_RE.search(row["summary"] or "")
+        if not match:
+            continue
+        seen.add(task_id)
+        replacement_id = match.group(1).lower()
+        candidates.append(
+            {
+                "task_id": task_id,
+                "superseded_by": replacement_id,
+                "summary": row["summary"],
+                "already_structured": row["superseded_by"] == replacement_id,
+                "replacement_exists": replacement_id in existing_ids,
+            }
+        )
+    return candidates
+
 
 def promote_task(
     conn: sqlite3.Connection,
@@ -4998,12 +5131,17 @@ def promote_task(
     promotion would succeed without mutating state.
     """
     row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        "SELECT status, superseded_by FROM tasks WHERE id = ?", (task_id,)
     ).fetchone()
     if row is None:
         return False, f"task {task_id} not found"
 
     cur_status = row["status"]
+    if row["superseded_by"]:
+        return False, (
+            f"task {task_id} is superseded by {row['superseded_by']}; "
+            "clear the supersession marker before promoting it"
+        )
     if cur_status not in ("todo", "blocked"):
         return False, (
             f"task {task_id} is {cur_status!r}; promote only applies to "
@@ -5061,9 +5199,12 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
+            "SELECT current_run_id, superseded_by FROM tasks "
+            "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
         ).fetchone()
+        if stale and stale["superseded_by"]:
+            return False
         if stale and stale["current_run_id"]:
             conn.execute(
                 """
@@ -7285,7 +7426,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
         "WHERE status = 'ready' AND assignee IS NOT NULL "
-        "    AND claim_lock IS NULL"
+        "    AND claim_lock IS NULL AND superseded_by IS NULL"
     ).fetchall()
     if not rows:
         return False
@@ -7480,6 +7621,7 @@ def _dispatch_once_locked(
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
+        "AND superseded_by IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2662,12 +2662,13 @@
       "data-task-id": t.id,
       className: cn(
         "hermes-kanban-card",
+        t.superseded_by ? "hermes-kanban-card--superseded" : "",
         props.selected ? "hermes-kanban-card--selected" : "",
         props.failed ? "hermes-kanban-card--failed" : "",
         props.draggingSource ? "hermes-kanban-card--dragging-source" : "",
         stalenessClass(t),
       ),
-      draggable: true,
+      draggable: !t.superseded_by,
       tabIndex: 0,
       role: "button",
       "aria-label": `${t.title || "untitled"} — ${t.id} — ${t.status}`,
@@ -2731,6 +2732,13 @@
                   className: "hermes-kanban-needs-assignee",
                   title: tx(i18n, "needsAssigneeHint", "Dependencies are satisfied, but the dispatcher skips this task until you assign a profile."),
                 }, tx(i18n, "needsAssignee", "Needs assignee"))
+              : null,
+            t.superseded_by
+              ? h(Badge, {
+                  variant: "outline",
+                  className: "hermes-kanban-superseded",
+                  title: `This task is obsolete and will not be dispatched. Replacement: ${t.superseded_by}`,
+                }, `Superseded → ${t.superseded_by}`)
               : null,
           ),
           h("div", { className: "hermes-kanban-card-title" },

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -244,6 +244,16 @@
   transform: scale(0.995);
 }
 
+.hermes-kanban-card--superseded {
+  cursor: default;
+  opacity: 0.62;
+}
+
+.hermes-kanban-card--superseded :where(.hermes-kanban-card-content) {
+  border-left: 3px solid var(--color-muted-foreground, #6b7280);
+  filter: grayscale(0.35);
+}
+
 .hermes-kanban-card-content {
   padding: 0.5rem 0.6rem !important;
   display: flex;
@@ -298,6 +308,12 @@
   background: color-mix(in srgb, var(--color-warning, #d4b348) 16%, transparent);
   border-color: color-mix(in srgb, var(--color-warning, #d4b348) 45%, var(--color-border));
   color: var(--color-foreground);
+}
+
+.hermes-kanban-superseded {
+  font-size: 0.6rem !important;
+  padding: 0.05rem 0.3rem !important;
+  color: var(--color-muted-foreground, #6b7280) !important;
 }
 
 .hermes-kanban-assignee {

--- a/scripts/report_kanban_superseded.py
+++ b/scripts/report_kanban_superseded.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Dry-run report for legacy Kanban summaries that mention supersession."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from hermes_cli import kanban_db as kb  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Report tasks whose run summaries contain 'Superseded by t_<id>'. "
+            "This command never changes task state."
+        )
+    )
+    parser.add_argument(
+        "--board",
+        default=None,
+        help="Board slug (default: active board)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    kb.init_db(board=args.board)
+    with kb.connect_closing(board=args.board) as conn:
+        candidates = kb.find_supersession_candidates(conn)
+
+    board = args.board or kb.get_current_board()
+    report = {
+        "board": board,
+        "dry_run": True,
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return 0
+
+    print(f"Board: {board}")
+    print("Dry run: no task state was changed.")
+    if not candidates:
+        print("No legacy supersession summaries found.")
+        return 0
+    for candidate in candidates:
+        task_id = candidate["task_id"]
+        replacement_id = candidate["superseded_by"]
+        state = (
+            "already structured"
+            if candidate["already_structured"]
+            else "candidate"
+        )
+        target = (
+            "target exists"
+            if candidate["replacement_exists"]
+            else "TARGET MISSING"
+        )
+        print(f"- {task_id} -> {replacement_id} [{state}; {target}]")
+        if candidate["replacement_exists"] and not candidate["already_structured"]:
+            print(
+                f"  suggested: hermes kanban supersede "
+                f"{task_id} {replacement_id}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_kanban_superseded.py
+++ b/tests/hermes_cli/test_kanban_superseded.py
@@ -1,0 +1,160 @@
+"""Superseded Kanban tasks are terminal for dispatcher purposes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+from scripts import report_kanban_superseded
+
+
+@pytest.fixture
+def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    with kb.connect_closing() as connection:
+        yield connection
+
+
+def test_superseded_ready_task_is_blocked_and_never_dispatched(conn, monkeypatch):
+    replacement = kb.create_task(conn, title="clean replacement")
+    original = kb.create_task(conn, title="stale rescue", assignee="coder")
+
+    assert kb.supersede_task(conn, original, replacement, actor="operator")
+    task = kb.get_task(conn, original)
+    assert task.status == "blocked"
+    assert task.superseded_by == replacement
+    assert kb.claim_task(conn, original) is None
+
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    result = kb.dispatch_once(conn, dry_run=True)
+    assert original not in {task_id for task_id, *_ in result.spawned}
+
+
+def test_superseded_todo_task_is_not_promoted_when_parent_finishes(conn):
+    parent = kb.create_task(conn, title="parent")
+    replacement = kb.create_task(conn, title="replacement")
+    original = kb.create_task(
+        conn,
+        title="old child",
+        assignee="coder",
+        parents=[parent],
+    )
+
+    assert kb.supersede_task(conn, original, replacement, actor="operator")
+    kb.complete_task(conn, parent, result="done")
+
+    assert kb.recompute_ready(conn) == 0
+    task = kb.get_task(conn, original)
+    assert task.status == "blocked"
+    assert task.superseded_by == replacement
+
+
+def test_superseded_task_must_be_cleared_before_unblock(conn):
+    replacement = kb.create_task(conn, title="replacement")
+    original = kb.create_task(conn, title="old card")
+    assert kb.supersede_task(conn, original, replacement, actor="operator")
+
+    assert kb.unblock_task(conn, original) is False
+    assert kb.get_task(conn, original).status == "blocked"
+
+    assert kb.clear_supersession(conn, original, actor="operator")
+    assert kb.unblock_task(conn, original)
+    task = kb.get_task(conn, original)
+    assert task.status == "ready"
+    assert task.superseded_by is None
+
+
+def test_ordinary_blocked_task_behavior_is_unchanged(conn):
+    parent = kb.create_task(conn, title="parent")
+    child = kb.create_task(conn, title="child", parents=[parent])
+    kb.complete_task(conn, parent, result="done")
+    conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (child,))
+    conn.commit()
+
+    assert kb.recompute_ready(conn) == 1
+    task = kb.get_task(conn, child)
+    assert task.status == "ready"
+    assert task.superseded_by is None
+
+
+def test_legacy_tasks_table_gains_superseded_by_without_data_loss(conn):
+    original = kb.create_task(conn, title="legacy card")
+    conn.execute("ALTER TABLE tasks DROP COLUMN superseded_by")
+    conn.commit()
+
+    kb._migrate_add_optional_columns(conn)
+
+    columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
+    }
+    assert "superseded_by" in columns
+    assert kb.get_task(conn, original).title == "legacy card"
+
+
+def test_cli_listing_labels_superseded_task(conn):
+    replacement = kb.create_task(conn, title="replacement")
+    original = kb.create_task(conn, title="old card", assignee="coder")
+    assert kb.supersede_task(conn, original, replacement, actor="operator")
+    task = kb.get_task(conn, original)
+
+    line = kanban_cli._fmt_task_line(task)
+    cli_payload = kanban_cli._task_to_dict(task)
+
+    assert "superseded" in line
+    assert f"→ {replacement}" in line
+    assert cli_payload["superseded_by"] == replacement
+
+
+def test_supersession_candidates_are_reported_without_mutation(conn):
+    replacement = kb.create_task(conn, title="replacement")
+    original = kb.create_task(conn, title="old card", assignee="coder")
+    claimed = kb.claim_task(conn, original)
+    assert claimed is not None
+    summary = f"Superseded by {replacement}; keep blocked to avoid retry churn."
+    assert kb.block_task(
+        conn,
+        original,
+        reason=summary,
+        expected_run_id=claimed.current_run_id,
+    )
+
+    candidates = kb.find_supersession_candidates(conn)
+
+    assert candidates == [
+        {
+            "task_id": original,
+            "superseded_by": replacement,
+            "summary": summary,
+            "already_structured": False,
+            "replacement_exists": True,
+        }
+    ]
+    assert kb.get_task(conn, original).superseded_by is None
+
+
+def test_report_script_is_explicitly_dry_run(conn, capsys):
+    replacement = kb.create_task(conn, title="replacement")
+    original = kb.create_task(conn, title="old card", assignee="coder")
+    claimed = kb.claim_task(conn, original)
+    assert claimed is not None
+    assert kb.block_task(
+        conn,
+        original,
+        reason=f"Superseded by {replacement}",
+        expected_run_id=claimed.current_run_id,
+    )
+
+    assert report_kanban_superseded.main(["--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["dry_run"] is True
+    assert report["candidate_count"] == 1
+    assert kb.get_task(conn, original).superseded_by is None


### PR DESCRIPTION
## Summary
- add a structured `superseded_by` marker and audited supersede/unsupersede transitions
- keep superseded cards visible but terminal for promotion, claiming, and dispatcher selection
- label superseded cards in CLI and dashboard UI, with disabled dragging and muted styling
- add a dry-run report for legacy run summaries containing `Superseded by t_<id>`
- cover schema migration, dispatcher guards, ordinary blocked-task behavior, CLI display, and report safety

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/plugins/test_kanban_dashboard_plugin.py -q` (849 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_superseded.py -q` (8 passed)
- `.venv/bin/ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py scripts/report_kanban_superseded.py tests/hermes_cli/test_kanban_superseded.py`
- `node --check plugins/kanban/dashboard/dist/index.js`
- isolated CLI E2E: create two tasks, supersede one, show/list confirms `blocked`, `not dispatchable`, and `superseded → <replacement>`

## Local environment notes
- The full Python suite was attempted; unrelated files require optional host dependencies unavailable in this worker (`acp`, `systemctl`, `ssh`, browser/audio support).
- Root `npm run check` was attempted; unrelated workspaces have missing local Node modules. The web workspace portion completed with 72 passing tests.
