### PR TITLE
fix(usage): accept Anthropic-style usage keys at normalization layer (salvage of #14903 by @hharry11)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -987,6 +987,26 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+_MISSING = object()
+
+
+def _first_present(usage: Any, primary: str, fallback: str) -> Any:
+    """Return usage[primary] when present (even if 0), else usage[fallback].
+
+    Presence-aware so a legitimate primary value of ``0`` is not silently
+    overridden by the fallback. Supports both attribute-style objects and
+    plain dicts.
+    """
+    if isinstance(usage, dict):
+        if primary in usage and usage[primary] is not None:
+            return usage[primary]
+        return usage.get(fallback, 0)
+    value = getattr(usage, primary, _MISSING)
+    if value is _MISSING or value is None:
+        return getattr(usage, fallback, 0)
+    return value
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,

--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)


### PR DESCRIPTION
Salvage of #14903 by @hharry11, re-targeted cleanly onto current `main` and relocated per the hermes-sweeper review on #53438 (which this supersedes — that branch had drifted far behind main and gone CONFLICTING).

## Problem
OpenAI-compatible servers and plugins (mlx_vlm, NVIDIA NIM, some proxies) emit Anthropic-style top-level `input_tokens`/`output_tokens` instead of `prompt_tokens`/`completion_tokens`. The chat-completions branch of `normalize_usage()` read only the OpenAI keys, so those responses were zeroed **at the normalization layer** — before `context_compressor` ever saw them, silently disabling context compression.

## Fix
Per @teknium1's review, the fallback belongs at the host-contract normalization layer (`agent/usage_pricing.py`), not in the compressor (which receives already-normalized legacy-key usage from `conversation_loop`). Changes:
- `normalize_usage()` chat-completions branch falls back to `input_tokens`/`output_tokens` when the OpenAI keys are **absent**.
- Fallback is **presence-aware** via a new `_first_present()` helper — a legitimate primary value of `0` is preserved rather than overridden by a truthiness `or`.
- OpenAI keys win when both are present.

## Tests
`tests/agent/test_usage_pricing.py`: Anthropic fallback, OpenAI priority, and zero-preservation. Full suite green.

Credit to original author @hharry11 (#14903).