### PR TITLE
docs: document htui/hgui worktree UI dev helpers

### DIFF
--- a/website/docs/developer-guide/worktree-ui-dev.md
+++ b/website/docs/developer-guide/worktree-ui-dev.md
@@ -1,0 +1,145 @@
+---
+sidebar_position: 5
+title: "TUI & Desktop from Worktrees"
+description: "Run the Ink TUI and Electron desktop app from a git worktree without a full npm install per checkout"
+---
+
+# TUI & Desktop from Worktrees
+
+The Python core runs fine from any [git worktree](../user-guide/git-worktrees.md) — `cd` in and `hermes` just works. The two TypeScript surfaces do not: `ui-tui/` and `apps/desktop/` each need a populated `node_modules`, and a fresh `npm ci` per worktree is slow and duplicates gigabytes across every branch you have checked out.
+
+`htui` and `hgui` are two shell helpers that close that gap. Each launches its surface **from the current worktree** while borrowing `node_modules` from one canonical checkout — so a throwaway branch costs a symlink, not an install.
+
+They're developer conveniences, not shipped commands. Drop them in `~/.zshrc`; adapt paths to taste.
+
+## The deps-sharing model
+
+One checkout is the **deps checkout** — the one place you actually run `npm install`. Every other worktree links against it, and only re-installs locally when its lockfile diverges (a branch that bumps a dependency must not silently run against stale packages).
+
+```mermaid
+flowchart TD
+    A[htui / hgui in a worktree] --> B{package-lock.json<br/>matches deps checkout?}
+    B -- yes --> C[symlink node_modules<br/>from deps checkout]
+    B -- no --> D[local npm ci<br/>in this worktree]
+    C --> E[launch surface]
+    D --> E
+```
+
+Two env vars name the canonical checkout:
+
+| Variable | Meaning |
+|----------|---------|
+| `HERMES_MAIN_CHECKOUT` | The deps checkout — where `node_modules` really lives, and whose `.venv/bin/python` runs the backend. |
+| `HERMES_GUI_DEPS_CHECKOUT` | Where the desktop deps (`apps/desktop/node_modules`) live. Defaults to `HERMES_MAIN_CHECKOUT`; override only if you keep desktop deps elsewhere. |
+
+Neither is read by Hermes itself — they're private to these helpers. The variables Hermes *does* read are covered in [Environment Variables](../reference/environment-variables.md).
+
+## `htui` — TUI from the worktree
+
+The Ink TUI has a dev path already: `hermes --tui --dev` runs the TypeScript sources via `tsx` instead of the prebuilt bundle. `htui` is a one-liner over it that also points the run at the current worktree's `ui-tui/`:
+
+```bash
+htui() {
+  local root
+  root="$(_hermes_root)" || { echo "htui: not in a Hermes checkout" >&2; return 1; }
+  ( cd "$root" && PYTHONPATH="$root" \
+      "$HERMES_MAIN_CHECKOUT/.venv/bin/python" -m hermes_cli.main --tui --dev "$@" )
+}
+```
+
+`--dev` compiles from source, so it links `ui-tui/node_modules` from `HERMES_MAIN_CHECKOUT` when the root lockfile matches and installs locally otherwise (see [`_hermes_root` / linking helpers](#shared-helpers)).
+
+:::warning `--dev` and `HERMES_TUI_DIR` are mutually exclusive
+`HERMES_TUI_DIR` points Hermes at a *prebuilt* bundle (Nix, system packages), which has no source to hot-reload. If it's set in your shell, `hermes --tui --dev` exits with an error. Run `unset HERMES_TUI_DIR` before `htui`.
+:::
+
+## `hgui` — desktop app from the worktree
+
+The desktop app is heavier: it needs `node_modules` at both the repo root and `apps/desktop/`, a Vite dev server pinned to port `5174`, and a Python backend. `hgui` wires all of it against the current worktree:
+
+```bash
+hgui() {
+  local root deps desktop
+  root="$(_hermes_root)" || { echo "hgui: not in a Hermes checkout" >&2; return 1; }
+  deps="${HERMES_GUI_DEPS_CHECKOUT:-$HERMES_MAIN_CHECKOUT}"
+  desktop="$root/apps/desktop"
+
+  # Borrow deps when locks match; otherwise install locally in the worktree.
+  if cmp -s "$root/package-lock.json" "$deps/package-lock.json"; then
+    _hermes_link_deps "$desktop" "$deps/apps/desktop"
+    _hermes_link_deps "$root" "$deps"
+  else
+    ( cd "$root" && npm ci ) || return 1
+  fi
+
+  # Vite is fixed at 5174 — evict a stale session from another hgui.
+  lsof -t -i:5174 >/dev/null 2>&1 && killport 5174
+
+  # Electron often survives Ctrl+C without reaping its ephemeral backends.
+  trap '_hermes_gui_cleanup "$root"' INT TERM EXIT
+
+  ( cd "$desktop"
+    export PATH="$root/node_modules/.bin:$PATH"
+    HERMES_DESKTOP_HERMES_ROOT="$root" \
+    HERMES_DESKTOP_PYTHON="$HERMES_MAIN_CHECKOUT/.venv/bin/python" \
+    HERMES_DESKTOP_IGNORE_EXISTING=1 \
+    HERMES_DESKTOP_CWD="$root" \
+    npm run dev )
+}
+```
+
+The desktop env vars it sets are all real backend-resolution knobs:
+
+| Variable | Role in `hgui` |
+|----------|----------------|
+| `HERMES_DESKTOP_HERMES_ROOT` | Runs the backend from **this worktree**, not the packaged/PATH `hermes`. |
+| `HERMES_DESKTOP_PYTHON` | Reuses the deps checkout's venv instead of re-resolving a Python. |
+| `HERMES_DESKTOP_IGNORE_EXISTING` | Ignores any `hermes` on `PATH` so it can't shadow the worktree. |
+| `HERMES_DESKTOP_CWD` | Opens the desktop chat rooted at the worktree. |
+
+Two footguns `hgui` handles that a bare `npm run dev` does not:
+
+- **Port `5174` is fixed.** A second `hgui` collides with the first's Vite server; the helper kills the stale one first.
+- **Orphaned children.** Electron frequently survives `Ctrl+C` through `concurrently` without reaping the ephemeral `dashboard --port 0` backend or the Vite process. The `EXIT`/`INT`/`TERM` trap runs a cleanup that terminates the Electron shell, the `:5174` listener, and any `--port 0` dashboard it spawned.
+
+## Shared helpers
+
+Both functions resolve the enclosing checkout and link deps the same way:
+
+```bash
+# The enclosing worktree, verified as a real Hermes checkout.
+_hermes_root() {
+  local root
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [[ -f "$root/hermes_cli/main.py" && -d "$root/ui-tui" ]] && print -r "$root"
+}
+
+# Symlink node_modules from the deps checkout — never over an existing tree.
+_hermes_link_deps() {
+  local target="${1%/}" source="${2%/}"
+  [[ -d "$source/node_modules" ]] || return 1
+  [[ -e "$target/node_modules" ]] || ln -s "$source/node_modules" "$target/node_modules"
+}
+
+# Reap ephemeral backends Electron leaves behind on exit.
+_hermes_gui_cleanup() {
+  local root="$1"
+  [[ -n "$root" ]] && pkill -TERM -f "${root}/apps/desktop/node_modules/electron" 2>/dev/null
+  lsof -t -i:5174 >/dev/null 2>&1 && killport 5174
+  pgrep -f 'hermes_cli\.main.*dashboard.*--port 0' 2>/dev/null | xargs -r kill -TERM 2>/dev/null
+}
+```
+
+`killport` is a small helper of your own (`lsof -ti:$1 | xargs kill`); substitute your preferred incantation.
+
+:::info Why link only when locks match
+A symlink to a divergent `node_modules` is worse than no install — the worktree would build against packages its own lockfile never declared. Byte-comparing `package-lock.json` is the cheap, exact guard: same lock ⇒ safe to borrow; different lock ⇒ `npm ci` locally. Vite realpaths symlinks before enforcing `server.fs.allow`, which is why `apps/desktop/vite.config.ts` whitelists the real `node_modules` location.
+:::
+
+## See also
+
+- [Git Worktrees](../user-guide/git-worktrees.md) — the isolation model these helpers build on
+- [TUI](../user-guide/tui.md) — `hermes --tui --dev` and the `HERMES_TUI_DIR` prebuild path
+- [Desktop App](../user-guide/desktop.md) — building from source and the backend resolution ladder
+- [`apps/desktop/README.md`](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/README.md) — dev server, sandbox script, and packaging
+- [Environment Variables](../reference/environment-variables.md) — every `HERMES_*` variable Hermes reads

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -510,6 +510,8 @@ Three dashboard-auth providers ship in the box. For a remote Hermes Desktop conn
 | `HERMES_DESKTOP_HERMES_ROOT` | Desktop source-checkout override used by `hermes desktop --hermes-root`; checked before the packaged first-launch install or an existing `hermes` on `PATH`. |
 | `HERMES_DESKTOP_IGNORE_EXISTING` | Set to `1` to make Desktop ignore an existing `hermes` on `PATH` during backend resolution. Equivalent to `hermes desktop --ignore-existing`. |
 | `HERMES_DESKTOP_CWD` | Initial project directory for Desktop chat sessions. Set by `hermes desktop --cwd`. |
+| `HERMES_DESKTOP_PYTHON` | Absolute path to a Python interpreter for the backend, checked before Electron auto-resolves one for the source checkout. Used by worktree dev helpers (see [TUI & Desktop from Worktrees](../developer-guide/worktree-ui-dev.md)) to reuse a shared venv. |
+| `HERMES_DESKTOP_DEV_SERVER` | Vite dev-server URL the Electron shell loads instead of the packaged bundle (e.g. `http://127.0.0.1:5174`). Set automatically by `npm run dev`; only relevant when hacking on the app. |
 
 ### Microsoft Graph (Teams Meetings)
 

--- a/website/docs/user-guide/git-worktrees.md
+++ b/website/docs/user-guide/git-worktrees.md
@@ -171,3 +171,7 @@ This combination gives you:
 - Strong guarantees that different agents and experiments do not step on each other.
 - Fast iteration cycles with easy recovery from bad edits.
 - Clean, reviewable pull requests.
+
+## Developing the UI surfaces across worktrees
+
+The TypeScript surfaces (`ui-tui/`, `apps/desktop/`) each need a `node_modules`, which a fresh `npm ci` per worktree duplicates across every branch. If you hack on the TUI or desktop app from multiple worktrees, see [TUI & Desktop from Worktrees](../developer-guide/worktree-ui-dev.md) for the `htui` / `hgui` helpers that share one install by symlink.

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -79,6 +79,10 @@ Click anywhere on a section header (or its chevron) to toggle it. The Tools list
 
 On first launch Hermes installs the TUI's Node dependencies into `ui-tui/node_modules` (one-time, a few seconds). Subsequent launches are fast. If you pull a new Hermes version, the TUI bundle is rebuilt automatically when sources are newer than the dist.
 
+:::tip Working across git worktrees?
+Contributors who run `hermes --tui --dev` from many worktrees can share one `node_modules` instead of installing per checkout — see [TUI & Desktop from Worktrees](../developer-guide/worktree-ui-dev.md).
+:::
+
 ### External prebuild
 
 Distributions that ship a prebuilt bundle (Nix, system packages) can point Hermes at it:

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -715,6 +715,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'developer-guide/contributing',
+        'developer-guide/worktree-ui-dev',
         {
           type: 'category',
           label: 'Architecture',


### PR DESCRIPTION
## What

Documents `htui` and `hgui` — two `~/.zshrc` helpers for running the Ink TUI (`ui-tui/`) and Electron desktop app (`apps/desktop/`) **from any git worktree** without a full `npm install` per checkout. New developer-guide page + sidebar entry + cross-links, and fills two undocumented desktop env vars.

## The problem they solve

The Python core runs fine from any worktree — `cd` in, `hermes` works. The two TypeScript surfaces don't: each needs a populated `node_modules`, and a fresh `npm ci` per worktree is slow and duplicates gigabytes across every branch you have checked out. That friction is why nobody dev's the UI from throwaway branches.

## The model

One checkout is the **deps checkout** (`HERMES_MAIN_CHECKOUT`) — the single place you actually `npm install`. Every other worktree borrows its `node_modules` by symlink **iff its `package-lock.json` is byte-identical** (`_hermes_locks_match` → `cmp -s`); a branch that bumps a dep diverges and gets a local `npm ci` instead (`_hermes_local_install`, stamped by lock hash so it only reinstalls when the lock actually changes). A symlink to divergent deps is worse than none — you'd build against packages your own lockfile never declared.

## `htui` — TUI from the worktree

`htui` is one line over the `hermes` wrapper's `--dev` path (runs TS sources via `tsx`, skips the prebuilt bundle). The wrapper resolves the enclosing worktree, links/repairs `ui-tui/node_modules`, and — crucially — `env -u HERMES_TUI_DIR` for the `--dev` flow, since `--dev` and `HERMES_TUI_DIR` (a *prebuilt* bundle with no source to hot-reload) are mutually exclusive.

```bash
htui                          # TUI from this worktree, source-compiled
htui -r 20260409_000000_aa    # args forward → resume a session
```

## `hgui` — desktop app from the worktree

Heavier: needs `node_modules` at both the repo root and `apps/desktop/`, a Vite server on the fixed port 5174, and a Python backend. `hgui` resolves the checkout (arg or `$PWD`), links-or-installs deps, evicts a stale Vite session on 5174, launches `npm run dev`, and traps `EXIT`/`INT`/`TERM` to reap the ephemeral `dashboard --port 0` backend + Electron shell that survive Ctrl+C through `concurrently`.

```bash
hgui                          # desktop dev against the enclosing worktree
hgui ../hermes-agent-other    # or an explicit checkout
```

Four real backend-resolution knobs make the app run *this* worktree, not the packaged/PATH `hermes`: `HERMES_DESKTOP_HERMES_ROOT` (backend = this worktree), `HERMES_DESKTOP_PYTHON` (reuse the deps-checkout venv), `HERMES_DESKTOP_IGNORE_EXISTING` (no PATH shadowing), `HERMES_DESKTOP_CWD` (chat rooted at the worktree).

## The actual `~/.zshrc` functions

<details>
<summary><code>htui</code>, <code>hgui</code>, the <code>hermes</code> wrapper, and their helpers (verbatim)</summary>

```bash
# Hermes worktree-aware launcher.
export HERMES_MAIN_CHECKOUT="$HOME/www/hermes-agent"

_hermes_root() {
  local root
  root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
  [[ -f "$root/hermes_cli/main.py" && -d "$root/ui-tui" ]] || return 1
  print -r "$root"
}

hermes() {
  local root arg use_tui_dir
  use_tui_dir=1
  root="$(_hermes_root)" || {
    command hermes "$@"
    return
  }

  for arg in "$@"; do
    case "$arg" in
      --dev|--dev=*)
        use_tui_dir=0
        break
        ;;
    esac
  done

  # ui-tui is a root workspace, so its deps track the root lock. Link main's
  # tree only when locks match; a stale link to divergent deps is repaired.
  if [[ -L "$root/ui-tui/node_modules" ]] && ! _hermes_locks_match "$root" "$HERMES_MAIN_CHECKOUT"; then
    rm -f "$root/ui-tui/node_modules"
  fi
  if [[ ! -e "$root/ui-tui/node_modules" ]]; then
    if _hermes_locks_match "$root" "$HERMES_MAIN_CHECKOUT" && [[ -d "$HERMES_MAIN_CHECKOUT/ui-tui/node_modules" ]]; then
      ln -s "$HERMES_MAIN_CHECKOUT/ui-tui/node_modules" "$root/ui-tui/node_modules"
    else
      _hermes_local_install "$root" || true
    fi
  fi

  if (( use_tui_dir )); then
    PYTHONPATH="$root" \
    HERMES_TUI_DIR="$root/ui-tui" \
    "$HERMES_MAIN_CHECKOUT/.venv/bin/python" -m hermes_cli.main "$@"
  else
    # Force-disable prebuilt override for --dev flow.
    env -u HERMES_TUI_DIR \
      PYTHONPATH="$root" \
      "$HERMES_MAIN_CHECKOUT/.venv/bin/python" -m hermes_cli.main "$@"
  fi
}

htui() {
  hermes --tui --dev "$@"
}

_hermes_npm_root_ok() {
  local root="$1"
  [[ -f "${root%/}/node_modules/vite/package.json" ]]
}

# Symlink node_modules from deps checkout when missing or a broken partial install.
_hermes_link_node_modules() {
  local target="$1" source="$2"
  local dest="${target%/}/node_modules" src="${source%/}/node_modules"

  [[ -d "$src" ]] || return 1

  if [[ -L "$dest" ]]; then
    return 0
  fi

  if [[ -e "$dest" ]]; then
    if _hermes_npm_root_ok "$target"; then
      return 0
    fi
    if _hermes_npm_root_ok "$source"; then
      rm -rf "$dest"
    else
      return 1
    fi
  fi

  ln -s "$src" "$dest"
}

# A deps checkout only stands in for another when their locks are byte-identical.
_hermes_locks_match() {
  cmp -s "${1%/}/package-lock.json" "${2%/}/package-lock.json"
}

# Real (non-symlinked) install in the worktree, stamped against its own lock so
# we reinstall only when the lock actually changes.
_hermes_local_install() {
  local root="${1%/}" stamp hash
  stamp="$root/node_modules/.hgui-lock"
  hash="${$(shasum "$root/package-lock.json" 2>/dev/null)%% *}"

  if [[ -d "$root/node_modules" && ! -L "$root/node_modules" \
        && -f "$stamp" && "$(<$stamp)" == "$hash" ]]; then
    return 0
  fi

  echo "hgui: worktree deps diverge from deps checkout; installing locally (npm ci)…" >&2
  [[ -L "$root/node_modules" ]] && rm -f "$root/node_modules"
  [[ -L "$root/apps/desktop/node_modules" ]] && rm -f "$root/apps/desktop/node_modules"
  [[ -L "$root/ui-tui/node_modules" ]] && rm -f "$root/ui-tui/node_modules"

  ( cd "$root" && npm ci ) || return 1
  print -r -- "$hash" > "$stamp"
}

_hermes_resolve_checkout() {
  local arg="$1" root

  if [[ -n "$arg" ]]; then
    root="$(cd "$arg" 2>/dev/null && pwd)" || return 1
    [[ -f "$root/hermes_cli/main.py" ]] || return 1
    print -r "$root"
    return 0
  fi

  _hermes_root
}

# Desktop dev spawns ephemeral `dashboard --port 0` backends; Electron often
# survives a Ctrl+C through concurrently without reaping them.
_hermes_gui_cleanup() {
  local root="$1" pid cmdline dashboard_pids vite_pids

  if [[ -n "$root" ]]; then
    pkill -TERM -f "${root}/apps/desktop/node_modules/electron/dist/Electron" 2>/dev/null
    pkill -TERM -f "wait-on http://127.0.0.1:5174" 2>/dev/null
  fi

  dashboard_pids=("${(@f)$(pgrep -f 'hermes_cli\.main.*dashboard' 2>/dev/null)}")
  for pid in $dashboard_pids; do
    cmdline="$(ps -p "$pid" -o command= 2>/dev/null)" || continue
    [[ "$cmdline" == *"--port 0"* || "$cmdline" == *"--port=0"* ]] || continue
    kill -TERM "$pid" 2>/dev/null
  done

  if lsof -t -i:5174 >/dev/null 2>&1; then
    vite_pids=("${(@f)$(lsof -t -i:5174 2>/dev/null)}")
    for pid in $vite_pids; do kill -TERM "$pid" 2>/dev/null; done
    sleep 0.5
    killport 5174
  fi

  sleep 0.5
  if [[ -n "$root" ]]; then
    pkill -KILL -f "${root}/apps/desktop/node_modules/electron/dist/Electron" 2>/dev/null
  fi
  for pid in $dashboard_pids; do
    cmdline="$(ps -p "$pid" -o command= 2>/dev/null)" || continue
    [[ "$cmdline" == *"--port 0"* || "$cmdline" == *"--port=0"* ]] || continue
    kill -KILL "$pid" 2>/dev/null
  done
}

hgui() {
  local root deps desktop deps_desktop py arg cleanup_done=0

  arg="$1"
  root="$(_hermes_resolve_checkout "$arg")" || {
    if [[ -n "$arg" ]]; then
      echo "hgui: $arg is not a Hermes checkout" >&2
    else
      echo "hgui: not inside a Hermes checkout (usage: hgui [path])" >&2
    fi
    return 1
  }

  deps="${HERMES_GUI_DEPS_CHECKOUT:-$HERMES_MAIN_CHECKOUT}"
  desktop="$root/apps/desktop"
  deps_desktop="$deps/apps/desktop"

  if [[ ! -d "$desktop" ]]; then
    echo "hgui: $root does not have apps/desktop" >&2
    return 1
  fi

  if [[ ! -d "$deps_desktop" ]]; then
    echo "hgui: set HERMES_GUI_DEPS_CHECKOUT to a checkout with apps/desktop deps" >&2
    return 1
  fi

  # Link main's tree only when this worktree's lock matches; otherwise a branch
  # that bumps a dep would silently run against stale packages. On divergence,
  # install locally instead.
  if _hermes_locks_match "$root" "$deps"; then
    _hermes_link_node_modules "$desktop" "$deps_desktop" || true
    _hermes_link_node_modules "$root" "$deps" || true
  elif ! _hermes_local_install "$root"; then
    echo "hgui: dependency install failed" >&2
    return 1
  fi

  if ! _hermes_npm_root_ok "$root"; then
    echo "hgui: run once: cd $deps && npm ci" >&2
    return 1
  fi

  py="$HERMES_MAIN_CHECKOUT/.venv/bin/python"
  [[ -x "$py" ]] || py="$(command -v python3)"

  # Vite dev server is fixed at 5174; clear a stale session from another hgui.
  if lsof -t -i:5174 >/dev/null 2>&1; then
    echo "hgui: stopping process on port 5174" >&2
    killport 5174
  fi

  _hgui_cleanup_trap() {
    (( cleanup_done )) && return
    cleanup_done=1
    _hermes_gui_cleanup "$root"
  }

  trap '_hgui_cleanup_trap' INT TERM EXIT

  (
    cd "$desktop" || exit 1
    export PATH="$root/node_modules/.bin:$PATH"
    HERMES_DESKTOP_HERMES_ROOT="$root" \
    HERMES_DESKTOP_PYTHON="$py" \
    HERMES_DESKTOP_IGNORE_EXISTING=1 \
    HERMES_DESKTOP_CWD="$root" \
    npm run dev
  )
  local rc=$?

  trap - INT TERM EXIT
  _hgui_cleanup_trap
  return $rc
}
```

`killport` is a personal helper (`lsof -ti:$1 | xargs kill`). Only the `HERMES_MAIN_CHECKOUT` export path is genericized to `$HOME`; everything else is verbatim.

</details>

## Changes

- **New** `website/docs/developer-guide/worktree-ui-dev.md` — model, distilled `htui`/`hgui`/shared helpers, footguns, port-5174 + orphan-reaping notes. Mermaid diagram (passes `lint:diagrams`).
- **Sidebar** — under Developer Guide, after Contributing.
- **Cross-links** — `user-guide/tui.md`, `user-guide/git-worktrees.md`.
- **Env-var reference** — adds `HERMES_DESKTOP_PYTHON` (`electron/main.ts` `findPythonForRoot`) and `HERMES_DESKTOP_DEV_SERVER` (`electron/main.ts` / `package.json`), both read by the desktop backend but never documented.

`HERMES_MAIN_CHECKOUT` / `HERMES_GUI_DEPS_CHECKOUT` are documented only in the new page — Hermes core never reads them, so they don't belong in the env-var reference.

## Test plan

- [x] `ascii-guard lint --exclude-code-blocks` clean on all changed docs
- [x] Mermaid enabled in `docusaurus.config.ts`; diagram in a fenced block
- [x] Internal relative links resolve; sidebar id matches file path
- [ ] `cd website && npm ci && npm run build` in CI