### PR TITLE
fix(codex): strip `openai-codex:` colon prefix in model normalization

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -437,10 +437,27 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     # --- Copilot / Copilot ACP / openai-codex fallback:
     #     strip matching provider prefix, keep dots ---
     if provider in _STRIP_VENDOR_ONLY_PROVIDERS:
+        # Strip a matching ``provider:`` (colon) prefix as well as the
+        # ``provider/`` (slash) prefix handled by _strip_matching_provider_prefix.
+        # The ``provider:model`` colon syntax is Hermes's canonical runtime
+        # switch form (parse_model_input splits on the first colon), so
+        # ``openai-codex:gpt-5.6-sol`` must normalize to ``gpt-5.6-sol`` just
+        # like ``openai/gpt-5.6-sol`` does. Previously the colon prefix was
+        # left intact and the raw ``openai-codex:gpt-5.6-sol`` was sent to the
+        # Codex Responses API, which rejected it with HTTP 400
+        # "model is not supported when using Codex with a ChatGPT account".
         stripped = _strip_matching_provider_prefix(name, provider)
-        if stripped == name and name.startswith("openai/"):
-            # openai-codex maps openai/gpt-5.4 -> gpt-5.4
-            return name.split("/", 1)[1]
+        if stripped == name:
+            # Strip a leading ``<provider>:<model>`` or ``<provider>/<model>``
+            # prefix when the provider is literally ``openai-codex`` or
+            # ``openai`` (Copilot never uses these vendor prefixes). This keeps
+            # Hermes's canonical ``provider:model`` colon syntax working for
+            # the Codex backend, which rejects a raw ``openai-codex:gpt-5.6-sol``
+            # slug with HTTP 400.
+            for prefix in ("openai-codex", "openai"):
+                for sep in (":", "/"):
+                    if name.startswith(f"{prefix}{sep}"):
+                        return name.split(sep, 1)[1]
         return stripped
 
     # --- DeepSeek: map to one of two canonical names ---

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -146,6 +146,37 @@ class TestCopilotModelNormalization:
         assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"
 
 
+# ── openai-codex colon-prefix normalization (issue TBD) ────────────────
+
+class TestOpenAICodexColonPrefix:
+    """openai-codex must strip the canonical ``provider:model`` colon prefix.
+
+    Hermes's ``provider:model`` syntax (``parse_model_input`` splits on the
+    first colon) is the canonical way to switch providers at runtime, e.g.
+    ``hermes chat -m openai-codex:gpt-5.6-sol``. The Codex Responses API
+    rejects a raw ``openai-codex:gpt-5.6-sol`` slug with HTTP 400
+    "model is not supported when using Codex with a ChatGPT account", so the
+    colon prefix must be normalized away just like the slash prefix is.
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        ("openai-codex:gpt-5.6-sol", "gpt-5.6-sol"),
+        ("openai-codex:gpt-5.5",     "gpt-5.5"),
+        ("openai-codex:gpt-5.4-mini", "gpt-5.4-mini"),
+        ("openai/gpt-5.4",           "gpt-5.4"),
+        ("gpt-5.6-sol",              "gpt-5.6-sol"),
+    ])
+    def test_strips_provider_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "openai-codex") == expected
+
+    def test_preserves_colon_in_model_name(self):
+        """A colon inside a model name (not a provider prefix) is untouched."""
+        assert (
+            normalize_model_for_provider("anthropic/claude-3.5-sonnet:beta", "openai-codex")
+            == "anthropic/claude-3.5-sonnet:beta"
+        )
+
+
 # ── Aggregator providers (regression) ──────────────────────────────────
 
 class TestAggregatorProviders:


### PR DESCRIPTION
## What

`normalize_model_for_provider` left the `provider:model` colon prefix intact for `openai-codex`, so `hermes chat -m openai-codex:gpt-5.6-sol` sent the raw slug `openai-codex:gpt-5.6-sol` to the Codex Responses API, which rejected it with HTTP 400 *"model is not supported when using Codex with a ChatGPT account"*.

`parse_model_input` splits provider/model on the first colon, so `provider:model` is Hermes's canonical runtime switch syntax. The slash prefix (`openai/gpt-5.4`) was already stripped; the colon prefix was not.

## Change

For `_STRIP_VENDOR_ONLY_PROVIDERS` (`openai-codex`, `copilot`, `copilot-acp`) the code now strips a leading `openai-codex:<model>` / `openai/<model>` prefix in addition to the existing `_strip_matching_provider_prefix` slash handling. Copilot is unaffected (it never uses these vendor prefixes). A colon embedded **inside** a model name (e.g. `anthropic/claude-3.5-sonnet:beta`) is still preserved.

## Test

Adds `TestOpenAICodexColonPrefix` regression coverage. Full module `tests/hermes_cli/test_model_normalize.py` passes (86 cases, including the existing `openai/gpt-5.4` slash-prefix regression).

Fixes #64787
