### PR TITLE
fix(terminal): skip local sudo prompt for SSH remote commands

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -323,3 +323,98 @@ def test_transform_sudo_command_pipes_one_password_line_per_invocation(monkeypat
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+# ── SSH remote sudo detection ──
+
+
+def test_ssh_remote_sudo_skips_local_prompt(monkeypatch):
+    """ssh host sudo cmd — sudo runs remotely, no local prompt."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "ssh host sudo whoami"
+    )
+
+    assert transformed == "ssh host sudo whoami"
+    assert sudo_stdin is None
+
+
+def test_ssh_remote_sudo_with_options_skips_local_prompt(monkeypatch):
+    """ssh -p 22 user@host sudo ls — flags and user@host handled."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "ssh -p 22 user@host sudo ls"
+    )
+
+    assert transformed == "ssh -p 22 user@host sudo ls"
+    assert sudo_stdin is None
+
+
+def test_ssh_remote_quoted_sudo_skips_local_prompt(monkeypatch):
+    """ssh host 'sudo a && sudo b' — && inside quotes is remote."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "ssh host 'sudo a && sudo b'"
+    )
+
+    assert transformed == "ssh host 'sudo a && sudo b'"
+    assert sudo_stdin is None
+
+
+def test_ssh_remote_then_semicolon_local_sudo_is_NOT_skipped(monkeypatch):
+    """ssh host remote ; sudo local — the local sudo MUST still trigger."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "ssh host remote ; sudo local"
+    )
+
+    # Local sudo after ; should be rewritten
+    assert "sudo -S -p ''" in transformed
+    assert sudo_stdin == "testpass\n"
+
+
+def test_ssh_remote_then_and_local_sudo_is_NOT_skipped(monkeypatch):
+    """ssh host cmd && sudo local — local sudo after && is NOT skipped."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "ssh host cmd && sudo local"
+    )
+
+    assert "sudo -S -p ''" in transformed
+    assert sudo_stdin == "testpass\n"
+
+
+def test_usr_bin_ssh_with_chained_local_sudo_is_NOT_skipped(monkeypatch):
+    """/usr/bin/ssh host remote && sudo local — local sudo after /usr/bin/ssh."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "/usr/bin/ssh host remote && sudo local"
+    )
+
+    assert "sudo -S -p ''" in transformed
+    assert sudo_stdin == "testpass\n"
+
+
+def test_normal_local_sudo_still_works(monkeypatch):
+    """sudo apt-get update — normal local sudo, no SSH involved."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo apt-get update"
+    )
+
+    assert transformed == "sudo -S -p '' apt-get update"
+    assert sudo_stdin == "testpass\n"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -868,6 +868,62 @@ def _rewrite_compound_background(command: str) -> str:
     return result
 
 
+# ── SSH remote command detection ──
+# SSH remote commands should not trigger local sudo password prompts.
+# Case-sensitive: only `ssh` (not SSH, sshd, ./ssh, ssh-keygen).
+_SSH_CMD_RE = re.compile(
+    r'(?:^|(?<=[;&|&(]))\s*(?:/usr/bin/)?ssh\s+'
+)
+
+
+def _has_chained_local_sudo(command: str) -> bool:
+    """True if command has a non-quoted ``&& sudo`` or ``|| sudo`` after SSH host.
+
+    Uses shlex (quote-aware) to avoid false positives on ``&&`` inside the
+    remote command string (e.g. ``ssh host 'sudo a && sudo b'``).
+    """
+    try:
+        import shlex
+        tokens = shlex.split(command)
+    except (ValueError, ImportError):
+        return False  # malformed quoting or no shlex → fail closed
+
+    in_ssh = False
+    past_host = False
+
+    for i, tok in enumerate(tokens):
+        if tok == "ssh" and not in_ssh:
+            in_ssh = True
+            continue
+        if in_ssh and not past_host:
+            if tok.startswith("-"):
+                continue  # SSH option (-p, -o, -J, etc.)
+            past_host = True  # This token is the [user@]host
+            continue
+        if past_host and tok in ("&&", "||"):
+            if i + 1 < len(tokens) and tokens[i + 1] == "sudo":
+                return True
+    return False
+
+
+def _is_ssh_remote_command(command: str) -> bool:
+    """Check if `command` is an SSH remote invocation.
+
+    Returns True only when the command invokes SSH with a remote command
+    and there is no chained local sudo (``&& sudo`` / ``|| sudo``) after
+    the SSH segment.
+
+    When True, the sudo password prompt is skipped — sudo runs on the
+    remote host, not locally.
+    """
+    if not _SSH_CMD_RE.search(command):
+        return False
+    # Fail-close: if a chained local sudo coexists with SSH, don't skip
+    if _has_chained_local_sudo(command):
+        return False
+    return True
+
+
 def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None]:
     """
     Transform sudo commands to use -S flag if SUDO_PASSWORD is available.
@@ -905,6 +961,12 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     """
     if command is None:
         return None, None
+
+    # SSH remote command: sudo is on the remote host, not local.
+    # Skip local sudo password prompt entirely.
+    if _is_ssh_remote_command(command):
+        return command, None
+
     transformed, sudo_count = _rewrite_real_sudo_invocations(command)
     if sudo_count == 0:
         return command, None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -877,10 +877,11 @@ _SSH_CMD_RE = re.compile(
 
 
 def _has_chained_local_sudo(command: str) -> bool:
-    """True if command has a non-quoted ``&& sudo`` or ``|| sudo`` after SSH host.
+    """True if command has a non-quoted ``&& sudo``, ``|| sudo`` or ``; sudo`` after SSH host.
 
     Uses shlex (quote-aware) to avoid false positives on ``&&`` inside the
     remote command string (e.g. ``ssh host 'sudo a && sudo b'``).
+    Also handles ``/usr/bin/ssh`` (not just bare ``ssh``).
     """
     try:
         import shlex
@@ -892,7 +893,7 @@ def _has_chained_local_sudo(command: str) -> bool:
     past_host = False
 
     for i, tok in enumerate(tokens):
-        if tok == "ssh" and not in_ssh:
+        if tok in ("ssh", "/usr/bin/ssh") and not in_ssh:
             in_ssh = True
             continue
         if in_ssh and not past_host:
@@ -900,7 +901,7 @@ def _has_chained_local_sudo(command: str) -> bool:
                 continue  # SSH option (-p, -o, -J, etc.)
             past_host = True  # This token is the [user@]host
             continue
-        if past_host and tok in ("&&", "||"):
+        if past_host and tok in ("&&", "||", ";"):
             if i + 1 < len(tokens) and tokens[i + 1] == "sudo":
                 return True
     return False


### PR DESCRIPTION
## Summary

Fixes a false positive where `terminal("ssh user@host sudo cmd")` pops the Desktop
sudo password dialog ("管理员密码 — Hermes needs your sudo password") even though
the `sudo` executes on the **remote** host via SSH, not locally.

### Root Cause

`_transform_sudo_command()` scans every terminal command for `sudo` tokens and
asks for the local sudo password when it finds one. SSH remote commands like
`ssh host sudo cmd` were incorrectly triggering this check, because the token
parser sees `sudo` as a command token (even though it's part of the SSH remote
command argument).

### Fix

Detect SSH remote command invocations at the `_transform_sudo_command` entry
point and skip local sudo password prompting. The detection is:

- **Case-sensitive**: matches `ssh` and `/usr/bin/ssh`, excludes `SSH`, `sshd`,
  `./ssh`, `ssh-keygen`, `python3 ssh.py`
- **Quote-aware**: uses `shlex` to avoid false positives on `&&` inside quoted
  remote commands (e.g. `ssh host 'sudo a && sudo b'`)
- **Fail-close**: if the SSH command has a chained `&& sudo` or `|| sudo` after
  the remote segment, the local sudo IS counted (not skipped)

### Test Matrix

| Command | Behavior |
|---------|----------|
| `ssh host sudo whoami` | ✅ skip (remote sudo) |
| `ssh -p 22 user@host sudo ls` | ✅ skip |
| `ssh host 'sudo a && sudo b'` | ✅ skip (&& inside quotes) |
| `ssh host cmd && sudo local` | ✅ no-skip (local sudo) |
| `ssh host cmd \|\| sudo local` | ✅ no-skip |
| `SSH host sudo cmd` | ✅ no-skip (case) |
| `sshd -D sudo cmd` | ✅ no-skip (not ssh) |
| `./ssh user@host sudo cmd` | ✅ no-skip |
| `sudo apt-get update` | ✅ no-skip (local) |

## Related

- No existing community issue found (first report)
- Related PRs: #52569 (same area), #52483 (desktop sudo UX)