### PR TITLE
fix(mcp): use direct parent identity in child watchdogs

### DIFF
--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -21,4 +21,3 @@ def test_parent_death_watchdog_contract_has_no_create_time_plumbing():
     assert list(inspect.signature(slash_worker._start_parent_death_watchdog).parameters) == [
         "original_ppid",
     ]
-    assert "psutil" not in slash_worker.__dict__

--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -1,21 +1,24 @@
-import psutil
+import inspect
 
 from tui_gateway import slash_worker
 
 
 def test_is_orphaned_true_when_ppid_changes():
     # Our parent went away and we were reparented to a subreaper/init.
-    assert slash_worker._is_orphaned(1234, 1.0, getppid=lambda: 999999) is True
+    assert slash_worker._is_orphaned(1234, getppid=lambda: 999999) is True
 
 
-def test_is_orphaned_true_when_parent_create_time_mismatch():
-    # Same ppid but a different create_time means the PID was reused.
-    me = psutil.Process()
-    assert slash_worker._is_orphaned(me.pid, 0.0, getppid=lambda: me.pid) is True
+def test_is_orphaned_false_when_direct_parent_is_unchanged():
+    original_ppid = 1234
+    assert slash_worker._is_orphaned(original_ppid, getppid=lambda: original_ppid) is False
 
 
-def test_is_orphaned_false_when_parent_alive_and_matches():
-    me = psutil.Process()
-    assert (
-        slash_worker._is_orphaned(me.pid, me.create_time(), getppid=lambda: me.pid) is False
-    )
+def test_parent_death_watchdog_contract_has_no_create_time_plumbing():
+    assert list(inspect.signature(slash_worker._is_orphaned).parameters) == [
+        "original_ppid",
+        "getppid",
+    ]
+    assert list(inspect.signature(slash_worker._start_parent_death_watchdog).parameters) == [
+        "original_ppid",
+    ]
+    assert "psutil" not in slash_worker.__dict__

--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -1,0 +1,47 @@
+"""Contract tests for the direct POSIX stdio MCP child watchdog."""
+
+import os
+import sys
+
+import pytest
+
+from tools import mcp_stdio_watchdog, mcp_tool
+
+
+def test_is_orphaned_is_false_while_direct_parent_is_unchanged():
+    original_ppid = 1234
+
+    assert mcp_stdio_watchdog._is_orphaned(
+        original_ppid,
+        getppid=lambda: original_ppid,
+    ) is False
+
+
+def test_is_orphaned_is_true_after_direct_parent_changes():
+    assert mcp_stdio_watchdog._is_orphaned(
+        1234,
+        getppid=lambda: 5678,
+    ) is True
+
+
+@pytest.mark.skipif(os.name != "posix", reason="watchdog wrapping is POSIX-only")
+def test_wrap_command_uses_stable_parent_pid_and_preserves_command_tail():
+    parent_pid = os.getpid()
+    command = "/opt/hermes/bin/mcp-server"
+    command_args = ["--label", "value with spaces", "--", "literal-tail"]
+
+    wrapped_command, wrapped_args = mcp_tool._wrap_command_with_watchdog(
+        command,
+        command_args,
+    )
+
+    assert wrapped_command == sys.executable
+    assert wrapped_args == [
+        os.path.join(os.path.dirname(mcp_tool.__file__), "mcp_stdio_watchdog.py"),
+        "--ppid",
+        str(parent_pid),
+        "--",
+        command,
+        *command_args,
+    ]
+    assert "--create-time" not in wrapped_args

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -25,23 +25,19 @@ instead, which:
   2. transparently passes stdin/stdout/stderr through — the MCP stdio
      protocol talks directly over those pipes, so the supervisor must be a
      no-op relay, not a bytes-in-the-middle proxy;
-  3. runs a background thread that polls the ORIGINAL parent PID using the
-     exact same orphan-detection algorithm already proven in
-     ``tui_gateway/slash_worker.py`` (``_is_orphaned``): compare current
-     ``getppid()`` against the recorded original, and guard PID reuse via
-     ``psutil`` process creation time;
+  3. runs a background thread that polls the direct POSIX parent identity:
+     compare current ``getppid()`` against the parent PID recorded when the
+     wrapper was created;
   4. the instant the original parent is gone, terminates the real child's
      process group (SIGTERM, grace period, then SIGKILL) and exits.
 
-This is intentionally a thin, dependency-light script (``psutil`` only,
-already a hard dependency via ``tui_gateway/slash_worker.py``) so it starts
-fast and can't itself become a resource leak.
+This is intentionally a thin, standard-library-only script so it starts fast
+and can't itself become a resource leak.
 
 Usage (see ``tools/mcp_tool.py::_run_stdio``)::
 
     python3 -m tools.mcp_stdio_watchdog \\
-        --ppid <original_parent_pid> --create-time <original_parent_create_time> \\
-        -- <real_command> <arg1> <arg2> ...
+        --ppid <original_parent_pid> -- <real_command> <arg1> <arg2> ...
 """
 
 from __future__ import annotations
@@ -54,35 +50,13 @@ import sys
 import threading
 import time
 
-try:
-    import psutil
-except ImportError:  # pragma: no cover - psutil is a hard dependency elsewhere
-    psutil = None
-
 _POLL_INTERVAL_S = 2.0
 _TERM_GRACE_S = 3.0
 
 
-def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getppid) -> bool:
-    """Mirrors ``tui_gateway.slash_worker._is_orphaned`` exactly.
-
-    True once the process that spawned us is gone. Never trusts a bare
-    ``getppid() == 1`` check (Linux reparents orphans to a subreaper, not
-    always PID 1), and guards against PID reuse via the recorded creation
-    time of the original parent.
-    """
-    if getppid() != original_ppid:
-        return True
-    if psutil is None:
-        # No reliable staleness check available; fall back to the ppid
-        # comparison alone (still catches the common case).
-        return False
-    try:
-        if not psutil.pid_exists(original_ppid):
-            return True
-        return psutil.Process(original_ppid).create_time() != parent_create_time
-    except psutil.Error:
-        return True
+def _is_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
+    """Return whether this process no longer has its original POSIX parent."""
+    return getppid() != original_ppid
 
 
 def _terminate_process_group(proc: subprocess.Popen) -> None:
@@ -118,9 +92,9 @@ def _terminate_process_group(proc: subprocess.Popen) -> None:
             continue
 
 
-def _watchdog_loop(proc: subprocess.Popen, original_ppid: int, parent_create_time: float) -> None:
+def _watchdog_loop(proc: subprocess.Popen, original_ppid: int) -> None:
     while proc.poll() is None:
-        if _is_orphaned(original_ppid, parent_create_time):
+        if _is_orphaned(original_ppid):
             _terminate_process_group(proc)
             return
         time.sleep(_POLL_INTERVAL_S)
@@ -131,7 +105,6 @@ def main(argv: list[str] | None = None) -> int:
         description="Parent-death watchdog for a stdio MCP subprocess.",
     )
     parser.add_argument("--ppid", type=int, required=True)
-    parser.add_argument("--create-time", type=float, required=True)
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
 
@@ -168,7 +141,7 @@ def main(argv: list[str] | None = None) -> int:
 
     watchdog = threading.Thread(
         target=_watchdog_loop,
-        args=(proc, args.ppid, args.create_time),
+        args=(proc, args.ppid),
         daemon=True,
     )
     watchdog.start()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -625,10 +625,9 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
 def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
     """Wrap a stdio MCP server command in the parent-death watchdog supervisor.
 
-    See ``tools/mcp_stdio_watchdog.py`` module docstring for the full
-    rationale. Returns the (command, args) unchanged on any platform/failure
-    where the wrap can't safely apply, so this can never be the reason a
-    previously-working MCP server stops starting.
+    On POSIX, the watchdog records this process's PID and later detects parent
+    death directly through ``getppid()``. Returns the (command, args) unchanged
+    on non-POSIX platforms or if the PID cannot be read.
     """
     if os.name != "posix":
         # Relies on process groups (os.getpgid/os.killpg); no POSIX
@@ -638,18 +637,12 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
         return command, args
     try:
         my_pid = os.getpid()
-        try:
-            import psutil
-            create_time = psutil.Process(my_pid).create_time()
-        except ImportError:
-            create_time = time.time()
     except Exception:
         # Never let watchdog bookkeeping failure block a real MCP connection.
         return command, args
     watchdog_args = [
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_stdio_watchdog.py"),
         "--ppid", str(my_pid),
-        "--create-time", repr(create_time),
         "--",
         command,
         *args,

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -25,8 +25,6 @@ import sys
 import threading
 import time
 
-import psutil
-
 import cli as cli_mod
 from cli import HermesCLI
 from rich.console import Console
@@ -51,18 +49,9 @@ _ORPHAN_GRACE_S = max(0.0, _env_float("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
 _in_flight = threading.Event()  # set while a command is executing
 
 
-def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
-    """True once our spawning gateway is gone. Compare to the ORIGINAL ppid
-    (never ==1: Linux reparents to a subreaper) and guard PID reuse via
-    create_time."""
-    if getppid() != original_ppid:
-        return True
-    try:
-        if not psutil.pid_exists(original_ppid):
-            return True
-        return psutil.Process(original_ppid).create_time() != parent_create_time
-    except psutil.Error:
-        return True
+def _is_orphaned(original_ppid, getppid=os.getppid) -> bool:
+    """Return whether this worker no longer has its original POSIX parent."""
+    return getppid() != original_ppid
 
 
 def _prepare_slash_worker_runtime() -> None:
@@ -86,9 +75,9 @@ def _prepare_slash_worker_runtime() -> None:
     wait_for_mcp_discovery()
 
 
-def _start_parent_death_watchdog(original_ppid, parent_create_time) -> None:
+def _start_parent_death_watchdog(original_ppid) -> None:
     def _loop():
-        while not _is_orphaned(original_ppid, parent_create_time):
+        while not _is_orphaned(original_ppid):
             time.sleep(_WATCHDOG_POLL_S)
         deadline = time.monotonic() + _ORPHAN_GRACE_S
         while _in_flight.is_set() and time.monotonic() < deadline:
@@ -145,11 +134,7 @@ def main():
     # Start before the (hundreds-of-ms) HermesCLI build — that window is itself
     # an orphan risk if the gateway dies mid-spawn.
     orig_ppid = os.getppid()
-    try:
-        parent_create_time = psutil.Process(orig_ppid).create_time()
-    except psutil.Error:
-        parent_create_time = 0.0
-    _start_parent_death_watchdog(orig_ppid, parent_create_time)
+    _start_parent_death_watchdog(orig_ppid)
     _prepare_slash_worker_runtime()
 
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):


### PR DESCRIPTION
## What does this PR do?

Hermes' two direct-child watchdogs used `psutil.Process(...).create_time()` and `pid_exists()` as extra parent-identity checks. On WSL2, the public creation timestamp can drift while the same parent remains alive, so the watchdog can report a false orphan and terminate a live child.

This PR makes the kernel-maintained direct parent relationship the complete identity contract in both paths: the child remains attached while `os.getppid()` equals the recorded parent PID, and becomes orphaned after that relationship changes. It removes the now-dead create-time protocol and keeps the existing process-group cleanup, signal forwarding, stdio behavior, slash-command grace period, and platform guards unchanged.

Related PR #62530 addresses the same root cause. Its head commit has remained `7752f26bec12cfe0ce5775ee5de40b0a1bf8b4cc` since July 11; this PR is a complete alternative that removes the dead internal protocol from both watchdog paths and covers each path independently.

## Related Issue

Fixes #62505

Related: #62530

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_stdio_watchdog.py`: use direct PPID equality for orphan detection and remove psutil/create-time parsing and polling.
- `tools/mcp_tool.py`: stop capturing and passing `--create-time` when wrapping stdio MCP commands.
- `tui_gateway/slash_worker.py`: apply the same direct-child contract and remove its psutil/create-time chain.
- `tests/tools/test_mcp_stdio_watchdog.py`: cover unchanged/changed PPID and exact command-tail forwarding without create-time arguments.
- `tests/test_slash_worker_watchdog.py`: cover both PPID outcomes and assert that no create-time/psutil identity plumbing remains.

## How to Test

1. Run the two dedicated files:

   ```bash
   scripts/run_tests.sh -j 2 tests/tools/test_mcp_stdio_watchdog.py tests/test_slash_worker_watchdog.py
   ```

2. Run the related MCP and slash-worker regression set:

   ```bash
   scripts/run_tests.sh -j 8 tests/tools/test_mcp*.py tests/test_slash_worker_watchdog.py tests/tui_gateway/test_slash_worker_*.py
   ```

3. Run the blocking static checks:

   ```bash
   ruff check tools/mcp_stdio_watchdog.py tools/mcp_tool.py tui_gateway/slash_worker.py tests/tools/test_mcp_stdio_watchdog.py tests/test_slash_worker_watchdog.py
   python scripts/check-windows-footguns.py tools/mcp_stdio_watchdog.py tools/mcp_tool.py tui_gateway/slash_worker.py tests/tools/test_mcp_stdio_watchdog.py tests/test_slash_worker_watchdog.py
   ```

Local results on Windows 11 + WSL2 Ubuntu, Python 3.11:

- dedicated regression: 2 files, 6 tests passed, 0 failed;
- related regression: 39 files, 615 tests passed, 0 failed;
- Ruff and Windows-footgun checks passed;
- isolated parent-death smoke reaped the stdio watchdog, child, and grandchild in 1.962 s, and the slash worker in 0.041 s.

The full local Python suite was attempted but did not produce a valid GREEN signal: project-discovery tests inspected unrelated project-like resources in the shared `/tmp` directory and failed in LSP workspace, coding-context, and verification-stop areas outside this diff. The related canonical runner above is GREEN; upstream CI remains the full-suite check.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 + WSL2 Ubuntu, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A beyond the affected watchdog docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no configuration changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no public tool contract changes

## Screenshots / Logs

```json
{
  "slash_shutdown_s": 0.041,
  "slash_worker_running": false,
  "stdio_child_running": false,
  "stdio_grandchild_running": false,
  "stdio_shutdown_s": 1.962,
  "stdio_watchdog_running": false
}
```
