### PR TITLE
fix(langfuse): export canonical generation total

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -538,34 +538,29 @@ def _serialize_assistant_message(message: Any) -> dict[str, Any]:
     }
 
 
-def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, base_url: str) -> tuple[dict[str, int], dict[str, float]]:
-    usage_details: Dict[str, int] = {}
+def _canonical_usage_and_cost(
+    canonical: Any,
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+) -> tuple[dict[str, int], dict[str, float]]:
+    """Translate canonical Hermes usage into Langfuse usage and cost maps."""
+    usage_details: Dict[str, int] = {
+        "input": canonical.input_tokens,
+        "output": canonical.output_tokens,
+    }
+    if canonical.cache_read_tokens:
+        usage_details["cache_read_input_tokens"] = canonical.cache_read_tokens
+    if canonical.cache_write_tokens:
+        usage_details["cache_creation_input_tokens"] = canonical.cache_write_tokens
+    if canonical.reasoning_tokens:
+        usage_details["reasoning_tokens"] = canonical.reasoning_tokens
+
     cost_details: Dict[str, float] = {}
-    raw_usage = getattr(response, "usage", None)
-    if not raw_usage:
-        return usage_details, cost_details
-
     try:
-        from agent.usage_pricing import estimate_usage_cost, normalize_usage
+        from agent.usage_pricing import estimate_usage_cost
 
-        canonical = normalize_usage(raw_usage, provider=provider, api_mode=api_mode)
-        # Langfuse usage_details keys follow a naming convention:
-        #   - Dashboard sums all keys containing "input" as input total
-        #   - Dashboard sums all keys containing "output" as output total
-        #   - If no "total" key, Langfuse derives it from all usage types
-        # Use Anthropic-style key names so cache tokens roll into the
-        # dashboard input total automatically.
-        # Ref: https://langfuse.com/docs/model-usage-and-cost
-        usage_details = {
-            "input": canonical.input_tokens,
-            "output": canonical.output_tokens,
-        }
-        if canonical.cache_read_tokens:
-            usage_details["cache_read_input_tokens"] = canonical.cache_read_tokens
-        if canonical.cache_write_tokens:
-            usage_details["cache_creation_input_tokens"] = canonical.cache_write_tokens
-        if canonical.reasoning_tokens:
-            usage_details["reasoning_tokens"] = canonical.reasoning_tokens
         cost = estimate_usage_cost(
             model,
             canonical,
@@ -573,31 +568,83 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
             base_url=base_url,
             api_key="",
         )
-        if cost.amount_usd is not None:
-            # Langfuse cost_details keys must match usage_details keys.
-            # Provide per-type breakdown so dashboard can show cost by type.
-            try:
-                from agent.usage_pricing import get_pricing_entry
-                from decimal import Decimal
-                _ONE_M = Decimal("1000000")
-                entry = get_pricing_entry(model, provider=provider, base_url=base_url)
-                if entry:
-                    if entry.input_cost_per_million is not None and canonical.input_tokens:
-                        cost_details["input"] = float(Decimal(canonical.input_tokens) * entry.input_cost_per_million / _ONE_M)
-                    if entry.output_cost_per_million is not None and canonical.output_tokens:
-                        cost_details["output"] = float(Decimal(canonical.output_tokens) * entry.output_cost_per_million / _ONE_M)
-                    if entry.cache_read_cost_per_million is not None and canonical.cache_read_tokens:
-                        cost_details["cache_read_input_tokens"] = float(Decimal(canonical.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_M)
-                    if entry.cache_write_cost_per_million is not None and canonical.cache_write_tokens:
-                        cost_details["cache_creation_input_tokens"] = float(Decimal(canonical.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_M)
-                else:
-                    cost_details["total"] = float(cost.amount_usd)
-            except Exception:
-                cost_details["total"] = float(cost.amount_usd)
     except Exception as exc:  # pragma: no cover - fail-open
-        _debug(f"usage normalization failed: {exc}")
+        _debug(f"usage pricing failed: {exc}")
+        return usage_details, cost_details
+
+    # A partial component breakdown is not a valid request total.  In
+    # particular, cache pricing may be unavailable even when input/output
+    # rates are known.  Leave all costs absent so Langfuse cannot mistake a
+    # partial subtotal for the full generation cost.
+    if cost.amount_usd is None:
+        return usage_details, cost_details
+
+    # Langfuse only derives a total for the built-in input/output cost keys.
+    # Cache/custom keys therefore need an explicit canonical total.  Use the
+    # Hermes estimate rather than summing components because it also includes
+    # request-level pricing.  Preserve the existing component-only payload for
+    # subscription-included routes; their export policy is handled separately.
+    if cost.status != "included":
+        cost_details["total"] = float(cost.amount_usd)
+
+    # Langfuse cost_details keys match usage_details keys.  Keep the per-type
+    # breakdown for dashboards in addition to the authoritative request total.
+    try:
+        from decimal import Decimal
+
+        from agent.usage_pricing import get_pricing_entry
+
+        one_million = Decimal("1000000")
+        entry = get_pricing_entry(model, provider=provider, base_url=base_url)
+        if entry:
+            if entry.input_cost_per_million is not None and canonical.input_tokens:
+                cost_details["input"] = float(
+                    Decimal(canonical.input_tokens)
+                    * entry.input_cost_per_million
+                    / one_million
+                )
+            if entry.output_cost_per_million is not None and canonical.output_tokens:
+                cost_details["output"] = float(
+                    Decimal(canonical.output_tokens)
+                    * entry.output_cost_per_million
+                    / one_million
+                )
+            if entry.cache_read_cost_per_million is not None and canonical.cache_read_tokens:
+                cost_details["cache_read_input_tokens"] = float(
+                    Decimal(canonical.cache_read_tokens)
+                    * entry.cache_read_cost_per_million
+                    / one_million
+                )
+            if entry.cache_write_cost_per_million is not None and canonical.cache_write_tokens:
+                cost_details["cache_creation_input_tokens"] = float(
+                    Decimal(canonical.cache_write_tokens)
+                    * entry.cache_write_cost_per_million
+                    / one_million
+                )
+    except Exception:  # pragma: no cover - canonical total remains usable
+        pass
 
     return usage_details, cost_details
+
+
+def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, base_url: str) -> tuple[dict[str, int], dict[str, float]]:
+    raw_usage = getattr(response, "usage", None)
+    if not raw_usage:
+        return {}, {}
+
+    try:
+        from agent.usage_pricing import normalize_usage
+
+        canonical = normalize_usage(raw_usage, provider=provider, api_mode=api_mode)
+        return _canonical_usage_and_cost(
+            canonical,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+        )
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"usage normalization failed: {exc}")
+        return {}, {}
 
 
 def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
@@ -969,53 +1016,30 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
         )
     elif isinstance(usage, dict) and usage:
         # post_api_request passes a pre-built CanonicalUsage summary dict.
-        # Use Langfuse-convention key names: "input", "output", and
-        # "cache_read_input_tokens" / "cache_creation_input_tokens" so the
-        # dashboard sums cache tokens into the input total automatically.
         _input = usage.get("input_tokens", 0)
         _output = usage.get("output_tokens", 0) or usage.get("completion_tokens", 0)
         _cache_read = usage.get("cache_read_tokens", 0)
         _cache_write = usage.get("cache_write_tokens", 0)
         _reasoning = usage.get("reasoning_tokens", 0)
-        usage_details = {
-            "input": _input,
-            "output": _output,
-        }
-        if _cache_read:
-            usage_details["cache_read_input_tokens"] = _cache_read
-        if _cache_write:
-            usage_details["cache_creation_input_tokens"] = _cache_write
-        if _reasoning:
-            usage_details["reasoning_tokens"] = _reasoning
-        cost_details = {}
-        # Estimate per-type cost from the summary if possible
         try:
-            from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, get_pricing_entry
-            from decimal import Decimal
-            _ONE_M = Decimal("1000000")
+            from agent.usage_pricing import CanonicalUsage
+
             _cu = CanonicalUsage(
                 input_tokens=_input,
                 output_tokens=_output,
                 cache_read_tokens=_cache_read,
                 cache_write_tokens=_cache_write,
                 reasoning_tokens=_reasoning,
+                request_count=usage.get("request_count", 1),
             )
-            entry = get_pricing_entry(model, provider=provider, base_url=base_url)
-            if entry:
-                if entry.input_cost_per_million is not None and _input:
-                    cost_details["input"] = float(Decimal(_input) * entry.input_cost_per_million / _ONE_M)
-                if entry.output_cost_per_million is not None and _output:
-                    cost_details["output"] = float(Decimal(_output) * entry.output_cost_per_million / _ONE_M)
-                if entry.cache_read_cost_per_million is not None and _cache_read:
-                    cost_details["cache_read_input_tokens"] = float(Decimal(_cache_read) * entry.cache_read_cost_per_million / _ONE_M)
-                if entry.cache_write_cost_per_million is not None and _cache_write:
-                    cost_details["cache_creation_input_tokens"] = float(Decimal(_cache_write) * entry.cache_write_cost_per_million / _ONE_M)
-            else:
-                _cost = estimate_usage_cost(model, _cu, provider=provider, base_url=base_url, api_key="")
-                if _cost.amount_usd is not None:
-                    cost_details["total"] = float(_cost.amount_usd)
+            usage_details, cost_details = _canonical_usage_and_cost(
+                _cu,
+                provider=provider,
+                model=model,
+                base_url=base_url,
+            )
         except Exception:
-            pass
+            usage_details, cost_details = {}, {}
     else:
         usage_details, cost_details = {}, {}
 

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+from decimal import Decimal
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -1021,3 +1023,232 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+class TestCanonicalCostExport:
+    """Both supported response paths must export the same complete cost."""
+
+    @staticmethod
+    def _response(input_tokens, output_tokens, cache_read=0, cache_write=0):
+        cache_details = SimpleNamespace(
+            cached_tokens=cache_read,
+            cache_write_tokens=cache_write,
+        )
+        usage = SimpleNamespace(
+            # Anthropic response shape.
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_write,
+            # OpenAI chat response shape used by the included-route case.
+            prompt_tokens=input_tokens + cache_read + cache_write,
+            completion_tokens=output_tokens,
+            prompt_tokens_details=cache_details,
+        )
+        return SimpleNamespace(usage=usage)
+
+    @staticmethod
+    def _summary(input_tokens, output_tokens, cache_read=0, cache_write=0, request_count=1):
+        return {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_read_tokens": cache_read,
+            "cache_write_tokens": cache_write,
+            "reasoning_tokens": 0,
+            "request_count": request_count,
+        }
+
+    @staticmethod
+    def _capture_summary_path(mod, monkeypatch, usage, *, provider, model, api_mode):
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        observation = object()
+        state = mod.TraceState(trace_id="trace-cost", root_ctx=None, root_span=None)
+        state.generations[mod._request_key(1)] = observation
+        task_key = mod._trace_key("task-cost", "session-cost")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+        captured = {}
+
+        def fake_end_observation(
+            obs,
+            *,
+            output=None,
+            metadata=None,
+            usage_details=None,
+            cost_details=None,
+        ):
+            captured["usage_details"] = usage_details
+            captured["cost_details"] = cost_details
+
+        monkeypatch.setattr(mod, "_end_observation", fake_end_observation)
+        mod.on_post_llm_call(
+            task_id="task-cost",
+            session_id="session-cost",
+            api_call_count=1,
+            model=model,
+            provider=provider,
+            api_mode=api_mode,
+            response={"model": model},
+            usage=usage,
+        )
+        return captured["usage_details"], captured["cost_details"]
+
+    def _run_both_paths(
+        self,
+        mod,
+        monkeypatch,
+        usage,
+        *,
+        provider="anthropic",
+        model="priced-model",
+        api_mode="anthropic_messages",
+    ):
+        response_result = mod._usage_and_cost(
+            self._response(
+                usage["input_tokens"],
+                usage["output_tokens"],
+                usage.get("cache_read_tokens", 0),
+                usage.get("cache_write_tokens", 0),
+            ),
+            provider=provider,
+            api_mode=api_mode,
+            model=model,
+            base_url="",
+        )
+        summary_result = self._capture_summary_path(
+            mod,
+            monkeypatch,
+            usage,
+            provider=provider,
+            model=model,
+            api_mode=api_mode,
+        )
+        assert response_result[0] == summary_result[0]
+        return response_result[1], summary_result[1]
+
+    @pytest.mark.parametrize(
+        ("cache_read", "cache_write", "expected_total"),
+        [
+            (0, 0, 0.00002),
+            (2, 3, 0.0000255),
+        ],
+        ids=("no-cache", "cached"),
+    )
+    def test_known_costs_include_canonical_total_on_both_paths(
+        self,
+        monkeypatch,
+        cache_read,
+        cache_write,
+        expected_total,
+    ):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            input_cost_per_million=Decimal("1"),
+            output_cost_per_million=Decimal("2"),
+            cache_read_cost_per_million=Decimal("0.5"),
+            cache_write_cost_per_million=Decimal("1.5"),
+            source="custom_contract",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(10, 5, cache_read, cache_write)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        expected = {
+            "total": expected_total,
+            "input": 0.00001,
+            "output": 0.00001,
+        }
+        if cache_read:
+            expected["cache_read_input_tokens"] = 0.000001
+        if cache_write:
+            expected["cache_creation_input_tokens"] = 0.0000045
+        assert response_cost == pytest.approx(expected)
+        assert summary_cost == pytest.approx(expected)
+
+    def test_total_uses_request_cost_instead_of_component_sum(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            input_cost_per_million=Decimal("1"),
+            output_cost_per_million=Decimal("2"),
+            cache_read_cost_per_million=Decimal("0.5"),
+            cache_write_cost_per_million=Decimal("1.5"),
+            request_cost=Decimal("0.01"),
+            source="provider_models_api",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(10, 5, cache_read=2, cache_write=3)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        for cost_details in (response_cost, summary_cost):
+            component_sum = sum(
+                value for key, value in cost_details.items() if key != "total"
+            )
+            assert cost_details["total"] == pytest.approx(0.0100255)
+            assert component_sum == pytest.approx(0.0000255)
+
+    def test_request_only_price_still_exports_total(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            request_cost=Decimal("0.01"),
+            source="provider_models_api",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(0, 0)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        assert response_cost == {"total": 0.01}
+        assert summary_cost == {"total": 0.01}
+
+    def test_partial_cache_pricing_exports_no_costs(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            input_cost_per_million=Decimal("1"),
+            output_cost_per_million=Decimal("2"),
+            cache_read_cost_per_million=None,
+            source="provider_models_api",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(10, 5, cache_read=2)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        assert response_cost == {}
+        assert summary_cost == {}
+
+    def test_unknown_pricing_exports_no_costs(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: None)
+        usage = self._summary(10, 5)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        assert response_cost == {}
+        assert summary_cost == {}
+
+    def test_included_route_does_not_pin_total(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        usage = self._summary(10, 5, cache_read=2)
+
+        response_cost, summary_cost = self._run_both_paths(
+            mod,
+            monkeypatch,
+            usage,
+            provider="openai-codex",
+            model="gpt-5.3-codex",
+            api_mode="chat_completions",
+        )
+        assert response_cost == summary_cost
+        assert "total" not in response_cost


### PR DESCRIPTION
## What does this PR do?

Fixes Langfuse generation/trace/session cost rollups when Hermes exports cache or other custom cost buckets.

The bug was reproduced on unchanged `main` at `d2c81eb681dea1382fbd1ed403f58320d5aef575`; the branch is now rebased onto current `main` at `9baa7d4673ce89f09378daa3660530f8bf142708`. Hermes already computes the right request-level total, but both Langfuse export paths discard it and send only component buckets. Current Langfuse ingestion treats any supplied `cost_details` as authoritative and skips model-price inference. It derives `total` only for the exact built-in `input` + `output` case; adding `cache_read_input_tokens` leaves `total` absent. Downstream generation conversion treats an absent total as zero, and trace/session aggregation consumes that total.

The contract was verified against the current [ingestion schema](https://github.com/langfuse/langfuse/blob/b445e2ff64141a5eab928122405c24f0576f8106/fern/apis/server/definition/ingestion.yml#L207-L229), [ingestion implementation](https://github.com/langfuse/langfuse/blob/b445e2ff64141a5eab928122405c24f0576f8106/worker/src/services/IngestionService/index.ts#L1457-L1482), [Python SDK serialization](https://github.com/langfuse/langfuse-python/blob/85208902bad63899352742bb85103ac97983b012/langfuse/_client/attributes.py#L116-L165), [observation conversion](https://github.com/langfuse/langfuse/blob/b445e2ff64141a5eab928122405c24f0576f8106/packages/shared/src/server/repositories/observations_converters.ts#L443-L464), [trace rollup](https://github.com/langfuse/langfuse/blob/b445e2ff64141a5eab928122405c24f0576f8106/packages/shared/src/server/services/traces-ui-table-service.ts#L293-L317), and [session rollup](https://github.com/langfuse/langfuse/blob/b445e2ff64141a5eab928122405c24f0576f8106/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts#L1363-L1389).

This patch exports Hermes's canonical `estimate_usage_cost(...).amount_usd` as `cost_details.total` in both the response-object and sanitized-summary paths. It deliberately does not sum component buckets: the canonical amount also includes per-request pricing (`request_count * request_cost`). Unknown or partially priced usage still emits no guessed cost, and subscription-included routes retain their existing component-only semantics without an explicit total.

This cannot be repaired reliably with Langfuse model-price configuration or Hermes environment settings. Once Hermes supplies any cost bucket, current Langfuse ingestion does not run model inference; removing all supplied costs would also discard Hermes-specific cache/custom/request pricing and is not equivalent to completing the payload.

### Reproduction on unchanged main

Local Langfuse server 3.178.0 with Python SDK 4.7.1:

| Runtime path | Case | Hermes canonical total | Cost payload before | Stored generation total | Trace rollup |
| --- | --- | ---: | --- | ---: | ---: |
| response object | no cache | $1.60 | input=$1.00, output=$0.60 | $1.60 | $1.60 |
| response object | cache | $0.88 | input=$0.20, output=$0.60, cache=$0.08 | $0.00 / absent | $0.00 |
| sanitized summary | no cache | $1.60 | input=$1.00, output=$0.60 | $1.60 | $1.60 |
| sanitized summary | cache | $0.88 | input=$0.20, output=$0.60, cache=$0.08 | $0.00 / absent | $0.00 |

After this patch, the same four calls export explicit totals of $1.60, $0.88, $1.60, and $0.88. Each generation and trace stores the matching value, and the session metrics roll up to $4.96.

## Related Issue

Related: #49932, #43130

Credit to @rdguidry: draft PR #49932 first identified the missing-explicit-total problem. This is a separate, provider-agnostic plugin-only fix because #49932 also owns Venice pricing/catalog changes and derives total by summing buckets, which omits request-level pricing. No code was copied from #49932; its Venice work remains there.

#43130 is orthogonal subscription-included policy work: it removes all explicit cost details so Langfuse may estimate nominal list price. This patch is behaviorally compatible because it never adds `total` for an `included` result. If #43130 lands first, only a mechanical rebase around the shared helper may be needed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/observability/langfuse/__init__.py`: share canonical usage/cost export between both call paths and include the authoritative request-level total only when pricing is complete and not subscription-included.
- `tests/plugins/test_langfuse_plugin.py`: cover cache/no-cache, request-priced, request-only, partial/unknown pricing, and included-route parity through both real exporter paths.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py tests/agent/test_usage_pricing.py -q`.
2. Run `python -m ruff check plugins/observability/langfuse/__init__.py tests/plugins/test_langfuse_plugin.py` and `python scripts/check-windows-footguns.py plugins/observability/langfuse/__init__.py tests/plugins/test_langfuse_plugin.py`.
3. Point the plugin at a Langfuse v3 instance and compare otherwise identical calls with and without cached input tokens across the response-object and sanitized-summary hooks. Generation, trace, and session totals should match Hermes's canonical amount.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64

Full wrapper run: 41,121 passed and 39 failed in unrelated host/environment-sensitive tests (live credential guards, Linux service/systemd assumptions, macOS `/tmp` path normalization, AWS credentials, and gateway SDK/race tests). The changed Langfuse tests passed in the full run. Focused wrapper: 70 passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public configuration or API change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows footgun check passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Focused tests: 70 passed.
- Langfuse plugin tests: 55 passed.
- Ruff, Python compile, `git diff --check`, and Windows footgun checks: passed.
- Before-fix E2E run: `codex-langfuse-rollup-1784094329-099614`.
- After-fix E2E run: `codex-langfuse-fix-1784095229-0cbc8f`.
