### PR TITLE
fix(gateway): write restart-notification marker in all restart paths (launchd + systemd CLI + systemd direct)

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/.codegraph/daemon.pid
+++ b/.codegraph/daemon.pid
@@ -1,0 +1,6 @@
+{
+  "pid": 3340738,
+  "version": "0.9.5",
+  "socketPath": "/home/ubuntu/projects/src/hermes-agent/.codegraph/daemon.sock",
+  "startedAt": 1783452705128
+}

--- a/.codegraph/daemon.pid
+++ b/.codegraph/daemon.pid
@@ -1,6 +1,0 @@
-{
-  "pid": 3340738,
-  "version": "0.9.5",
-  "socketPath": "/home/ubuntu/projects/src/hermes-agent/.codegraph/daemon.sock",
-  "startedAt": 1783452705128
-}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20130,6 +20130,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             # marker first, land in the `planned_stop` branch above, and
             # leave this flag False so they DO persist "stopped".
             runner._signal_initiated_shutdown = True
+            # systemd SIGTERM: when INVOCATION_ID is set the signal came
+            # from the service manager (Restart=always or systemctl restart),
+            # not an external kill. Treat it as a planned service restart so
+            # the gateway writes .restart_pending.json and exits 0 instead
+            # of triggering an additional restart cycle.
+            if os.environ.get("INVOCATION_ID"):
+                runner._restart_requested = True
+                runner._restart_via_service = True
             logger.info(
                 "Received %s — initiating shutdown",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5744,6 +5744,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     e,
                 )
 
+        # Heuristic: write .restart_pending.json when a home channel is configured.
+        # The new gateway instance sends a "♻️ Gateway online" notification on
+        # startup.  This catches SIGTERM (kill PID) paths where INVOCATION_ID is
+        # not set and _restart_requested is False.  Not gated on active sessions —
+        # a quiet gateway that happens to have a home_channel should also notify
+        # on restart so the operator knows it came back.
+        _cfg = getattr(self, "config", None)
+        if _cfg is not None:
+            _has_active_home = False
+            for _platform in list(self.adapters.keys()):
+                _home = _cfg.get_home_channel(_platform)
+                if _home and _home.chat_id:
+                    _has_active_home = True
+                    break
+            if _has_active_home:
+                _marker = _planned_restart_notification_path()
+                try:
+                    import json as _json
+                    _data = {"reason": "shutdown", "pid": os.getpid(), "timestamp": time.time()}
+                    _marker.write_text(_json.dumps(_data, indent=None), encoding="utf-8")
+                    logger.debug("Wrote restart pending marker: %s", _marker)
+                except Exception as _me:
+                    logger.debug("Failed to write restart pending marker: %s", _me)
+
     async def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
             # Persist any in-flight transcript to the SQLite session store

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5744,14 +5744,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     e,
                 )
 
-        # Heuristic: write .restart_pending.json when a home channel is configured.
-        # The new gateway instance sends a "♻️ Gateway online" notification on
-        # startup.  This catches SIGTERM (kill PID) paths where INVOCATION_ID is
-        # not set and _restart_requested is False.  Not gated on active sessions —
-        # a quiet gateway that happens to have a home_channel should also notify
-        # on restart so the operator knows it came back.
+        # Gate on _restart_requested: this marker is only for planned restarts,
+        # not for every shutdown. When _restart_requested is True, the CLI
+        # fallback paths (launchd_restart / systemd_restart in hermes_cli/gateway.py)
+        # already wrote .restart_pending.json directly — this path handles the
+        # graceful SIGUSR1 path where the gateway writes the marker itself.
+        # A plain `systemctl stop` with no restart intent sets planned_stop above
+        # and never reaches this code, so the marker is never written spuriously.
         _cfg = getattr(self, "config", None)
-        if _cfg is not None:
+        if _cfg is not None and self._restart_requested:
             _has_active_home = False
             for _platform in list(self.adapters.keys()):
                 _home = _cfg.get_home_channel(_platform)
@@ -5762,7 +5763,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _marker = _planned_restart_notification_path()
                 try:
                     import json as _json
-                    _data = {"reason": "shutdown", "pid": os.getpid(), "timestamp": time.time()}
+                    _data = {"reason": "restart", "pid": os.getpid(), "timestamp": time.time()}
                     _marker.write_text(_json.dumps(_data, indent=None), encoding="utf-8")
                     logger.debug("Wrote restart pending marker: %s", _marker)
                 except Exception as _me:
@@ -20146,22 +20147,21 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",
             )
         else:
-            _signal_initiated_shutdown = True
-            # Mirror onto the runner so _stop_impl can suppress the
-            # gateway_state=stopped persist for unexpected signals
-            # (container/s6 SIGTERM on restart, OOM, bare kill) — see
-            # issue #42675. Operator-initiated stops set a planned-stop
-            # marker first, land in the `planned_stop` branch above, and
-            # leave this flag False so they DO persist "stopped".
+            # Signal-initiated shutdown: no planned-stop marker was found, so
+            # this is either an unexpected external kill, a container/s6 SIGTERM,
+            # or an OOM. Set the flag so _stop_impl suppresses gateway_state=stopped
+            # persist (issue #42675). Operator-initiated stops go through
+            # planned-stop and leave this flag False, so they DO persist "stopped".
             runner._signal_initiated_shutdown = True
-            # systemd SIGTERM: when INVOCATION_ID is set the signal came
-            # from the service manager (Restart=always or systemctl restart),
-            # not an external kill. Treat it as a planned service restart so
-            # the gateway writes .restart_pending.json and exits 0 instead
-            # of triggering an additional restart cycle.
-            if os.environ.get("INVOCATION_ID"):
-                runner._restart_requested = True
-                runner._restart_via_service = True
+            # NOTE: we no longer infer restart intent from INVOCATION_ID.
+            # INVOCATION_ID only tells us the process was started by systemd —
+            # it does NOT tell us this particular SIGTERM is a restart trigger.
+            # A plain `systemctl stop` (not restart) sets INVOCATION_ID too,
+            # and treating it as a restart would trigger RestartForceExitStatus=75
+            # restart loops for operators who just want to stop the gateway.
+            # Restart intent is now carried exclusively through the explicit
+            # CLI fallback paths (launchd_restart / systemd_restart in
+            # hermes_cli/gateway.py) which write .restart_pending.json directly.
             logger.info(
                 "Received %s — initiating shutdown",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3257,6 +3257,11 @@ def systemd_restart(system: bool = False):
             if _systemd_service_is_start_limited(system=system):
                 return
 
+        # SIGUSR1 timed out — the gateway didn't exit gracefully in time.
+        # Write the planned-restart marker so the next startup sends the
+        # "♻️ Gateway online" home-channel notification.  (On the graceful
+        # path the gateway writes this itself; here it didn't complete.)
+        _write_planned_restart_marker()
         print(
             f"⚠ Graceful restart did not complete within {int(drain_timeout + 5)}s; "
             "forcing a service restart..."
@@ -3289,6 +3294,10 @@ def systemd_restart(system: bool = False):
     if _recover_pending_systemd_restart(system=system, previous_pid=pid):
         return
 
+    # No running PID and no pending restart to recover — this is a cold
+    # `systemctl restart` with no gateway running.  Write the marker so the
+    # freshly started gateway sends the "♻️ Gateway online" notification.
+    _write_planned_restart_marker()
     _run_systemctl(
         ["reset-failed", get_service_name()],
         system=system,
@@ -4248,6 +4257,30 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _write_planned_restart_marker() -> None:
+    """Write .restart_pending.json so the next gateway startup sends the
+    "♻️ Gateway online" notification to home channels.
+
+    Mirrors the marker written by the graceful SIGUSR1 path inside the
+    gateway process (gateway/run.py, ``_planned_restart_notification_path``).
+    Called from the SIGTERM fallback paths in ``launchd_restart()`` and
+    ``systemd_restart()`` where the gateway process cannot write the marker
+    itself because ``_restart_requested`` is never set.
+    """
+    try:
+        import json as _json
+
+        marker = get_hermes_home() / ".restart_pending.json"
+        data = {
+            "requested_at": time.time(),
+            "via_service": True,
+            "detached": False,
+        }
+        marker.write_text(_json.dumps(data, indent=None), encoding="utf-8")
+    except Exception as e:
+        print(f"⚠ Failed to write restart notification marker: {e}")
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -4260,6 +4293,11 @@ def launchd_restart():
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()
             return
+        # SIGUSR1 path failed (terminal is not a gateway child) or no PID was
+        # found.  Write the planned-restart marker now so the next gateway
+        # startup sends "♻️ Gateway online" to home channels — mirroring what
+        # the graceful SIGUSR1 path does inside the gateway process.
+        _write_planned_restart_marker()
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -178,6 +178,7 @@ AUTHOR_MAP = {
     "46495124+yungchentang@users.noreply.github.com": "yungchentang",  # PR #53622 salvage (drain Telegram general send pool on pool timeout before retry; #53524)
     "15205536+595650661@users.noreply.github.com": "595650661",  # PR #37851 salvage (classify MiniMax new_sensitive content filter → content_policy_blocked; #32421)
     "qWaitCrypto@users.noreply.github.com": "qWaitCrypto",  # PR #52534 salvage (preserve assistant tool_use cache_control marker in Anthropic conversion so cache breakpoints aren't dropped from the wire)
+    "emarrero@emarreros-Mac-mini.local": "emarrero",  # PR #43199 (launchd restart-notification marker)
     "benbenwyb@gmail.com": "benbenlijie",  # PR #47205 salvage (named custom-provider extra_body + Z.AI Coding overload adaptive backoff; #50663)
     "dana@added-value.co.il": "Danamove",  # PR #46726 salvage (kill venv-resident pythonw gateway before recreating venv on Windows; #47036/#47557/#47910)
     "rcint@klaith.com": "rc-int",  # PR #9126 salvage / co-author (cap subagent summary size vs parent context overflow)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3590,3 +3590,76 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
             deadline=gateway_cli.time.monotonic() - 1,
         )
         assert ok is False
+
+
+class TestWritePlannedRestartMarker:
+    """_write_planned_restart_marker() writes .restart_pending.json with the
+    right shape, and is called from both SIGTERM fallback paths."""
+
+    def test_writes_marker_file(self, tmp_path, monkeypatch):
+        """Helper creates .restart_pending.json in HERMES_HOME."""
+        import json
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        gateway_cli._write_planned_restart_marker()
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+        assert data["detached"] is False
+        assert isinstance(data["requested_at"], float)
+
+    def test_swallows_write_error(self, tmp_path, monkeypatch, capsys):
+        """A filesystem error must NOT raise — only print a warning."""
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path / "missing")
+        gateway_cli._write_planned_restart_marker()  # must not raise
+        out = capsys.readouterr().out
+        assert "⚠" in out
+
+    def test_launchd_restart_writes_marker_on_sigusr1_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """launchd_restart() writes the marker when SIGUSR1 is unavailable."""
+        import json
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            gateway_cli, "get_launchd_label", lambda: "com.hermes.gateway"
+        )
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/1000")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda: None
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess, "run",
+            lambda *a, **kw: SimpleNamespace(returncode=0, stdout="", stderr="")
+        )
+        gateway_cli.launchd_restart()
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+
+    def test_systemd_restart_writes_marker_on_no_pid(self, tmp_path, monkeypatch):
+        """systemd_restart() writes the marker when no gateway PID is found."""
+        import json
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda s: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+        monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda *a, **kw: None)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda **kw: None)
+        monkeypatch.setattr(gateway_cli, "_sync_hermes_home_from_systemd_unit", lambda **kw: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway_cli, "_systemd_main_pid", lambda **kw: None)
+        monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda **kw: False)
+        monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway.service")
+        monkeypatch.setattr(gateway_cli, "_wait_for_systemd_service_restart", lambda **kw: True)
+        monkeypatch.setattr(
+            gateway_cli, "_run_systemctl",
+            lambda cmd, system=False, check=True, timeout=30: SimpleNamespace(returncode=0)
+        )
+        gateway_cli.systemd_restart()
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["via_service"] is True
+


### PR DESCRIPTION
Recreated from #59079 — that PR was accidentally auto-closed by GitHub when its source branch (`fix/restart-notification-marker-launchd-systemd`) was deleted during branch cleanup. Same commits, same content (head sha `0ce3d6c49444fd7185dd50bcf6a92fa4fab2ccb2`), just renamed to include the PR number per our branch naming convention.

Original PR: #59079

Refs: NousResearch/hermes-agent#47179