### PR TITLE
fix(desktop): restore closed main window on second launch

### DIFF
--- a/apps/desktop/electron/main-window-lifecycle.test.ts
+++ b/apps/desktop/electron/main-window-lifecycle.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { ensureMainWindow } from './main-window-lifecycle'
+
+test('recreates a destroyed primary window without focusing it', () => {
+  const destroyedWindow = {
+    isDestroyed: () => true
+  }
+  let createCalls = 0
+  let focusCalls = 0
+
+  ensureMainWindow(destroyedWindow, {
+    isReady: true,
+    createWindow: () => {
+      createCalls += 1
+    },
+    focusWindow: () => {
+      focusCalls += 1
+    }
+  })
+
+  assert.equal(createCalls, 1)
+  assert.equal(focusCalls, 0)
+})
+
+test('waits for app readiness before recreating a primary window', () => {
+  let createCalls = 0
+
+  ensureMainWindow(null, {
+    isReady: false,
+    createWindow: () => {
+      createCalls += 1
+    },
+    focusWindow: () => assert.fail('missing window must not be focused')
+  })
+
+  assert.equal(createCalls, 0)
+})
+
+test('focuses a live primary window for a normal second launch', () => {
+  const liveWindow = {
+    isDestroyed: () => false
+  }
+  let focusedWindow = null
+
+  ensureMainWindow(liveWindow, {
+    isReady: true,
+    createWindow: () => assert.fail('live window must not be replaced'),
+    focusWindow: window => {
+      focusedWindow = window
+    }
+  })
+
+  assert.equal(focusedWindow, liveWindow)
+})
+
+test('leaves live-window focus to deep-link delivery', () => {
+  const liveWindow = {
+    isDestroyed: () => false
+  }
+
+  ensureMainWindow(liveWindow, {
+    isReady: true,
+    createWindow: () => assert.fail('live window must not be replaced'),
+    focusWindow: () => assert.fail('deep-link delivery owns focus'),
+    focusExisting: false
+  })
+})

--- a/apps/desktop/electron/main-window-lifecycle.ts
+++ b/apps/desktop/electron/main-window-lifecycle.ts
@@ -1,0 +1,28 @@
+type MainWindowLike = {
+  isDestroyed: () => boolean
+}
+
+type EnsureMainWindowOptions<T extends MainWindowLike> = {
+  isReady: boolean
+  createWindow: () => unknown
+  focusWindow: (window: T) => unknown
+  focusExisting?: boolean
+}
+
+export function ensureMainWindow<T extends MainWindowLike>(
+  window: T | null | undefined,
+  { isReady, createWindow, focusWindow, focusExisting = true }: EnsureMainWindowOptions<T>
+) {
+  if (!window || window.isDestroyed()) {
+    // a closed electron window stays truthy, so replace it before invoking native methods.
+    if (isReady) {
+      createWindow()
+    }
+
+    return
+  }
+
+  if (focusExisting) {
+    focusWindow(window)
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7242,6 +7242,8 @@ function createWindow() {
 
     if (mainWindow === createdMainWindow) {
       mainWindow = null
+      // the replacement renderer must register before queued links can be delivered.
+      _rendererReadyForDeepLink = false
     }
   })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -95,6 +95,7 @@ import {
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
+import { ensureMainWindow } from './main-window-lifecycle'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import {
@@ -7234,10 +7235,15 @@ function createWindow() {
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
 
-  // The overlay rides the main window — closing the app's primary window must
-  // tear it down too (otherwise it strands as an orphan that blocks
-  // window-all-closed from quitting on Windows/Linux).
-  mainWindow.on('closed', () => closePetOverlay())
+  // the closed wrapper remains truthy, so clear only the window this callback owns.
+  const createdMainWindow = mainWindow
+  mainWindow.on('closed', () => {
+    closePetOverlay()
+
+    if (mainWindow === createdMainWindow) {
+      mainWindow = null
+    }
+  })
 
   wireCommonWindowHandlers(mainWindow, zoomWiringForWindowKind('chat'))
 
@@ -8995,13 +9001,15 @@ if (!_gotSingleInstanceLock) {
 
     if (url) {
       handleDeepLink(url)
-    } else if (mainWindow) {
-      if (mainWindow.isMinimized()) {
-        mainWindow.restore()
-      }
-
-      mainWindow.focus()
     }
+
+    ensureMainWindow(mainWindow, {
+      isReady: app.isReady(),
+      createWindow,
+      focusWindow,
+      // deep-link delivery focuses a live window after its renderer is ready.
+      focusExisting: !url
+    })
   })
 }
 


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop from throwing `TypeError: Object has been destroyed` when `second-instance` fires after the primary macOS window was closed.

Electron keeps the destroyed `BrowserWindow` wrapper truthy. The old handler called `isMinimized()` directly on that stale wrapper. This change centralizes the lifecycle decision in an Electron-free helper: recreate a missing/destroyed window once the app is ready, focus a live window for a normal second launch, and leave live-window focus to deep-link delivery.

The primary window's `closed` handler also clears `mainWindow` identity-safely so a late callback cannot clear a replacement window.

This is the current-TypeScript implementation requested in the reviews on #50515 and #51756. Those PRs target the removed `main.cjs` entrypoint and no longer apply to current `main`.

## Related Issue

Fixes #50491

Related/supersedes the obsolete-file implementations in #50515 and #51756.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `apps/desktop/electron/main-window-lifecycle.ts` with an Electron-free `ensureMainWindow` helper.
- Update `apps/desktop/electron/main.ts` to recreate destroyed windows and reuse the guarded `focusWindow` path.
- Clear the primary-window reference safely from its owning `closed` callback.
- Add lifecycle regression coverage for destroyed, pre-ready, live, and deep-link cases.

## How to Test

1. Launch Hermes Desktop on macOS.
2. Close the primary window with Cmd-W without quitting the Electron process.
3. Launch Hermes again. A fresh primary window opens without an uncaught exception.
4. Run `npm exec vitest -- run electron/main-window-lifecycle.test.ts --project electron` from `apps/desktop`.
5. Run `npm run typecheck` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Electron/TypeScript-only change; targeted Vitest and desktop TypeScript checks pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: no user-facing API or configuration change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — behavior is lifecycle-safe on all Electron platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted regression test: 4 tests passed.

Desktop TypeScript check: `tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit` passed.

Manual macOS reproduction passed: after closing the primary window, launching a second instance recreated one live Hermes window without the uncaught exception.