### PR TITLE
fix(ci): route root npm manifest changes into the Python lane

### DIFF
--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -56,7 +56,11 @@ def _is_docs(p: str) -> bool:
 
 
 def _py_irrelevant(p: str) -> bool:
-    return _is_docs(p) or p in _ROOT_NPM or p.startswith(_PY_SKIP) or p.startswith(_DOCKER_META)
+    # Root npm manifests are NOT python-irrelevant: several Python invariant
+    # tests read package.json / package-lock.json (tap-cluster, electron pin,
+    # lazy-deps, lockfile churn), so a lockfile-only change can break the Python
+    # suite. Omitting them here is what let #63970 merge green then redden main.
+    return _is_docs(p) or p.startswith(_PY_SKIP) or p.startswith(_DOCKER_META)
 
 
 def _is_scan(p: str) -> bool:

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -50,8 +50,10 @@ CASES = {
     "uv.lock → python": (["uv.lock"], _lanes(python=True)),
     "ts package → frontend": (["apps/desktop/src/app.tsx"], _lanes(frontend=True)),
     "ui-tui → frontend": (["ui-tui/src/entry.ts"], _lanes(frontend=True)),
-    # Lockfile bump shifts every TS package's tree, but not the Python suite.
-    "root lockfile → frontend, not python": (["package-lock.json"], _lanes(frontend=True)),
+    # Lockfile bump shifts every TS package's tree AND feeds Python invariant
+    # tests that read package-lock.json (tap-cluster, electron pin, lazy-deps).
+    "root lockfile → frontend + python": (["package-lock.json"], _lanes(frontend=True, python=True)),
+    "root package.json → frontend + python": (["package.json"], _lanes(frontend=True, python=True)),
     "website → site": (["website/docs/intro.md"], _lanes(site=True)),
     # SKILL.md reads like docs, but the skill-doc tests read skills/, so a
     # skill edit must still run Python.


### PR DESCRIPTION
## Summary

Closes the CI blind spot that let #63970 merge green then redden `main`.

The change classifier (`scripts/ci/classify_changes.py`) marked `package.json` / `package-lock.json` as **python-irrelevant**, so a PR touching only `apps/desktop/**` + the root lockfile skipped the Python lane. But several Python invariant tests read those exact files:

- `test_assistant_ui_tap_compat.py` (tap-cluster resolution)
- `test_desktop_electron_pin.py`
- `test_package_json_lazy_deps.py`
- `test_install_lockfile_churn.py`

On a PR the classifier skipped Python; on push to `main` it fails open and runs everything — so the tap regression only surfaced post-merge.

## What changed

- Drop root npm manifests from the `_py_irrelevant` denylist so a lockfile change runs the Python lane. This honors the classifier's own stated contract: *"never skip a lane a change could break."*
- Root npm still triggers the `frontend` lane unchanged.
- Flip the stale test case that encoded the bug (`root lockfile → frontend, not python`) and add a `package.json` case.

Tradeoff: lockfile-only PRs (dep bumps) now run the Python suite. That's the intended safety — those PRs can break Python invariant tests, and over-running a lane is explicitly acceptable per the contract; false-greening main is not.

## Test plan

- [x] `pytest tests/ci/test_classify_changes.py -q` → `22 passed`
- [x] Classifier on #63970's exact file set now emits `python=true` (was `false`):
  ```
  apps/desktop/package.json, .../markdown-text.tsx, package.json, package-lock.json
  → python=true  frontend=true
  ```

Pairs with #64799 (the tap-compat test fix). Independent — either can merge first.