### PR TITLE
fix(setup): add timeout and stdin=DEVNULL to espeak-ng install subprocess.run

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -810,13 +810,22 @@ def _install_neutts_deps() -> bool:
         if prompt_yes_no("Install espeak-ng now?", True):
             try:
                 if sys.platform == "darwin":
-                    subprocess.run(["brew", "install", "espeak-ng"], check=True)
+                    subprocess.run(
+                        ["brew", "install", "espeak-ng"], check=True,
+                        timeout=300, stdin=subprocess.DEVNULL,
+                    )
                 elif sys.platform == "win32":
-                    subprocess.run(["choco", "install", "espeak-ng", "-y"], check=True)
+                    subprocess.run(
+                        ["choco", "install", "espeak-ng", "-y"], check=True,
+                        timeout=300, stdin=subprocess.DEVNULL,
+                    )
                 else:
-                    subprocess.run(["sudo", "apt", "install", "-y", "espeak-ng"], check=True)
+                    subprocess.run(
+                        ["sudo", "apt", "install", "-y", "espeak-ng"], check=True,
+                        timeout=300, stdin=subprocess.DEVNULL,
+                    )
                 print_success("espeak-ng installed")
-            except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
                 print_warning(f"Could not install espeak-ng automatically: {e}")
                 print_info("Please install it manually and re-run setup.")
                 return False

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -540,3 +540,102 @@ def test_prompt_yes_no_keyboard_interrupt_still_exits(monkeypatch):
     with pytest.raises(SystemExit):
         setup_mod.prompt_yes_no("Install it now?", True)
 
+
+# ---------------------------------------------------------------------------
+# NeuTTS espeak-ng setup helpers — regression coverage for timeout /
+# stdin=DEVNULL subprocess kwargs and TimeoutExpired fallback.
+# ---------------------------------------------------------------------------
+
+
+class TestNeuTTSSetup:
+    """_install_neutts_deps / _check_espeak_ng subprocess safety."""
+
+    def test_check_espeak_ng_found(self, monkeypatch):
+        from hermes_cli.setup import _check_espeak_ng
+        monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/espeak-ng" if x == "espeak-ng" else None)
+        assert _check_espeak_ng() is True
+
+    def test_check_espeak_ng_not_found(self, monkeypatch):
+        from hermes_cli.setup import _check_espeak_ng
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        assert _check_espeak_ng() is False
+
+    def test_install_espeak_ng_macos_timeout_returns_false(self, monkeypatch, tmp_path):
+        import subprocess
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.platform", "darwin", raising=False)
+        monkeypatch.setattr("hermes_cli.setup._check_espeak_ng", lambda: False)
+
+        called = {}
+
+        def _fake_run(*a, **kw):
+            called["kwargs"] = kw
+            raise subprocess.TimeoutExpired(cmd=a[0], timeout=300)
+
+        monkeypatch.setattr("subprocess.run", _fake_run)
+        monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *a, **kw: True)
+
+        from hermes_cli.setup import _install_neutts_deps
+        result = _install_neutts_deps()
+        assert result is False
+        assert called["kwargs"].get("timeout") == 300
+        assert called["kwargs"].get("stdin") == subprocess.DEVNULL
+
+    def test_install_espeak_ng_linux_timeout_returns_false(self, monkeypatch, tmp_path):
+        import subprocess
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.platform", "linux", raising=False)
+        monkeypatch.setattr("hermes_cli.setup._check_espeak_ng", lambda: False)
+
+        called = {}
+
+        def _fake_run(*a, **kw):
+            called["kwargs"] = kw
+            raise subprocess.TimeoutExpired(cmd=a[0], timeout=300)
+
+        monkeypatch.setattr("subprocess.run", _fake_run)
+        monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *a, **kw: True)
+
+        from hermes_cli.setup import _install_neutts_deps
+        result = _install_neutts_deps()
+        assert result is False
+        assert called["kwargs"].get("timeout") == 300
+        assert called["kwargs"].get("stdin") == subprocess.DEVNULL
+
+    def test_install_espeak_ng_windows_timeout_returns_false(self, monkeypatch, tmp_path):
+        import subprocess
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.platform", "win32", raising=False)
+        monkeypatch.setattr("hermes_cli.setup._check_espeak_ng", lambda: False)
+
+        called = {}
+
+        def _fake_run(*a, **kw):
+            called["kwargs"] = kw
+            raise subprocess.TimeoutExpired(cmd=a[0], timeout=300)
+
+        monkeypatch.setattr("subprocess.run", _fake_run)
+        monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *a, **kw: True)
+
+        from hermes_cli.setup import _install_neutts_deps
+        result = _install_neutts_deps()
+        assert result is False
+        assert called["kwargs"].get("timeout") == 300
+        assert called["kwargs"].get("stdin") == subprocess.DEVNULL
+
+    def test_install_espeak_ng_user_declines_continues_to_pip(self, monkeypatch, tmp_path):
+        """When user declines espeak-ng, the function continues to the pip install step."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("hermes_cli.setup._check_espeak_ng", lambda: False)
+        monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *a, **kw: False)
+
+        import subprocess
+        from unittest.mock import MagicMock
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        monkeypatch.setattr("hermes_cli.tools_config._pip_install", lambda *a, **kw: fake_result)
+
+        from hermes_cli.setup import _install_neutts_deps
+        result = _install_neutts_deps()
+        # pip install succeeds → True
+        assert result is True

--- a/tests/hermes_cli/test_setup_espeak_ng.py
+++ b/tests/hermes_cli/test_setup_espeak_ng.py
@@ -1,0 +1,163 @@
+"""Tests for espeak-ng installation subprocess handling in setup.py.
+
+These tests verify the regression contract for PR #64802:
+- timeout=300 and stdin=subprocess.DEVNULL are passed to every platform
+  branch's subprocess.run call.
+- subprocess.TimeoutExpired is caught alongside CalledProcessError /
+  FileNotFoundError and causes _install_neutts_deps to return False.
+"""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _stub_setup_helpers(monkeypatch):
+    """Stub out helpers that would otherwise prompt or print during tests."""
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "_check_espeak_ng", lambda: False)
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: True)
+    monkeypatch.setattr(setup_mod, "print_success", lambda *a: None)
+    monkeypatch.setattr(setup_mod, "print_warning", lambda *a: None)
+    monkeypatch.setattr(setup_mod, "print_info", lambda *a: None)
+    monkeypatch.setattr(setup_mod, "print_error", lambda *a: None)
+
+
+# ---------------------------------------------------------------------------
+# Platform-branch subprocess.kwargs tests
+# ---------------------------------------------------------------------------
+
+
+def _install_for_platform(platform):
+    """Patch sys.platform and subprocess.run globally, capturing all calls,
+    then call _install_neutts_deps."""
+    captured = []
+
+    def _fake_run(*args, **kwargs):
+        captured.append({"args": list(args), "kwargs": dict(kwargs)})
+        return SimpleNamespace(returncode=0)
+
+    with (
+        patch("subprocess.run", _fake_run),
+        patch("sys.platform", platform),
+    ):
+        from hermes_cli.setup import _install_neutts_deps
+        result = _install_neutts_deps()
+
+    return result, captured
+
+
+def _find_espeak_call(captured):
+    """Find the subprocess.run call that installs espeak-ng."""
+    for call in captured:
+        cmd = call["args"][0] if call["args"] else []
+        if "espeak-ng" in str(cmd):
+            return call
+    return None
+
+
+class TestEspeakNgSubprocessKwargs:
+    """Verify each platform branch calls subprocess.run with timeout=300
+    and stdin=subprocess.DEVNULL."""
+
+    def test_darwin_branch_has_timeout_and_devnull(self):
+        """macOS (darwin) brew install gets timeout=300 and stdin=DEVNULL."""
+        result, captured = _install_for_platform("darwin")
+        assert result is True
+        espeak_call = _find_espeak_call(captured)
+        assert espeak_call is not None
+        assert espeak_call["kwargs"]["timeout"] == 300
+        assert espeak_call["kwargs"]["stdin"] is subprocess.DEVNULL
+        assert espeak_call["args"][0] == ["brew", "install", "espeak-ng"]
+
+    def test_win32_branch_has_timeout_and_devnull(self):
+        """Windows (win32) choco install gets timeout=300 and stdin=DEVNULL."""
+        result, captured = _install_for_platform("win32")
+        assert result is True
+        espeak_call = _find_espeak_call(captured)
+        assert espeak_call is not None
+        assert espeak_call["kwargs"]["timeout"] == 300
+        assert espeak_call["kwargs"]["stdin"] is subprocess.DEVNULL
+        assert espeak_call["args"][0] == ["choco", "install", "espeak-ng", "-y"]
+
+    def test_linux_branch_has_timeout_and_devnull(self):
+        """Linux (generic) apt install gets timeout=300 and stdin=DEVNULL."""
+        result, captured = _install_for_platform("linux")
+        assert result is True
+        espeak_call = _find_espeak_call(captured)
+        assert espeak_call is not None
+        assert espeak_call["kwargs"]["timeout"] == 300
+        assert espeak_call["kwargs"]["stdin"] is subprocess.DEVNULL
+        assert espeak_call["args"][0] == ["sudo", "apt", "install", "-y", "espeak-ng"]
+
+
+# ---------------------------------------------------------------------------
+# TimeoutExpired handling
+# ---------------------------------------------------------------------------
+
+
+class TestEspeakNgTimeoutExpired:
+    """subprocess.TimeoutExpired must be caught and _install_neutts_deps
+    returns False without raising."""
+
+    def _timeout_run(self, *args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=300)
+
+    def test_timeout_returns_false_no_raise(self):
+        """TimeoutExpired is caught; _install_neutts_deps returns False."""
+        with (
+            patch("subprocess.run", self._timeout_run),
+            patch("sys.platform", "darwin"),
+        ):
+            from hermes_cli.setup import _install_neutts_deps
+            result = _install_neutts_deps()
+        assert result is False
+
+    def test_timeout_warned(self):
+        """A warning is printed when timeout occurs."""
+        warnings = []
+        from hermes_cli import setup as setup_mod
+        orig_warn = setup_mod.print_warning
+        setup_mod.print_warning = lambda *a: warnings.append(a)
+        try:
+            with (
+                patch("subprocess.run", self._timeout_run),
+                patch("sys.platform", "linux"),
+            ):
+                from hermes_cli.setup import _install_neutts_deps
+                result = _install_neutts_deps()
+            assert result is False
+            assert any("Could not install espeak-ng" in str(w) for w in warnings)
+        finally:
+            setup_mod.print_warning = orig_warn
+
+
+# ---------------------------------------------------------------------------
+# CalledProcessError handling (existing behaviour, sanity check)
+# ---------------------------------------------------------------------------
+
+
+class TestEspeakNgCalledProcessError:
+    """Non-zero exit code from the package manager is caught gracefully."""
+
+    def _failing_run(self, *args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0])
+
+    def test_called_process_error_returns_false(self):
+        with (
+            patch("subprocess.run", self._failing_run),
+            patch("sys.platform", "darwin"),
+        ):
+            from hermes_cli.setup import _install_neutts_deps
+            result = _install_neutts_deps()
+        assert result is False


### PR DESCRIPTION
## Summary

Add timeout (300s) and stdin=DEVNULL to the three subprocess.run calls that install espeak-ng via brew/choco/apt in the NeuTTS setup flow.

## Problem

The espeak-ng installation subprocess calls in `_install_neutts_deps()` (hermes_cli/setup.py lines 813-817) had no `timeout` parameter. If brew, choco, or apt hangs (e.g., due to a package lock, network issue, or unexpected user prompt), the entire setup process would block forever. Additionally, the except clause only caught `CalledProcessError` and `FileNotFoundError` — not `TimeoutExpired` — so a timeout would crash rather than produce a helpful error message.

## Fix

- Added `timeout=300` and `stdin=subprocess.DEVNULL` to all three `subprocess.run()` calls
- Added `subprocess.TimeoutExpired` to the existing except clause so timeouts produce the same user-friendly error message as other failures

## Testing
- Syntax check passed (py_compile)
- Behavior verified