### PR TITLE
fix(guardrails): mutation-aware no-progress reset scoped by observation domain

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -59,6 +59,38 @@ MUTATING_TOOL_NAMES = frozenset(
     }
 )
 
+# Groups tools by the world state they observe or change. A successful
+# mutating call invalidates no-progress tracking only for reads in its own
+# domain: a browser click legitimately changes what the next snapshot
+# returns, but a todo or memory write says nothing about a stuck page.
+# Mutating tools without a domain (todo, memory, send_message, ...) reset
+# nothing; reads without a mutating counterpart (web_search, session_search)
+# are never reset — nothing the agent does changes what they observe.
+_OBSERVATION_DOMAINS = {
+    "browser_click": "browser",
+    "browser_type": "browser",
+    "browser_press": "browser",
+    "browser_scroll": "browser",
+    "browser_navigate": "browser",
+    "browser_snapshot": "browser",
+    "browser_console": "browser",
+    "browser_get_images": "browser",
+    "terminal": "workspace",
+    "execute_code": "workspace",
+    "write_file": "workspace",
+    "patch": "workspace",
+    "read_file": "workspace",
+    "search_files": "workspace",
+    "mcp_filesystem_read_file": "workspace",
+    "mcp_filesystem_read_text_file": "workspace",
+    "mcp_filesystem_read_multiple_files": "workspace",
+    "mcp_filesystem_list_directory": "workspace",
+    "mcp_filesystem_list_directory_with_sizes": "workspace",
+    "mcp_filesystem_directory_tree": "workspace",
+    "mcp_filesystem_get_file_info": "workspace",
+    "mcp_filesystem_search_files": "workspace",
+}
+
 
 @dataclass(frozen=True)
 class ToolCallGuardrailConfig:
@@ -411,6 +443,27 @@ class ToolCallGuardrailController:
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
+
+        # A successful state-changing call invalidates "same result = no
+        # progress" for reads in its own observation domain: the world those
+        # reads observe just changed, so an identical re-read is legitimate
+        # once more (slow SPAs often lag one interaction behind). Without
+        # this, a browser session interleaving click/type/press with
+        # browser_snapshot accumulates snapshot repeats across the whole turn
+        # and hard-blocks the model's only way to observe the page. Reads in
+        # unrelated domains keep counting — a todo or memory write says
+        # nothing about a stuck page — as do tight read-read-read loops with
+        # no mutation in between. Failed mutations changed nothing and never
+        # reach this point (the failure branch above returns first).
+        if tool_name in self.config.mutating_tools:
+            domain = _OBSERVATION_DOMAINS.get(tool_name)
+            if domain is not None:
+                for stale in [
+                    sig
+                    for sig in self._no_progress
+                    if _OBSERVATION_DOMAINS.get(sig.tool_name) == domain
+                ]:
+                    self._no_progress.pop(stale, None)
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -106,6 +106,39 @@ def is_stall_guard_repeatable(tool_name: str) -> bool:
     return tool_name.endswith(_STALL_GUARD_REPEATABLE_SUFFIXES)
 
 
+# Groups tools by the world state they observe or change. A successful
+# mutating call invalidates no-progress tracking only for reads in its own
+# domain: a browser click legitimately changes what the next snapshot
+# returns, but a todo or memory write says nothing about a stuck page.
+# Mutating tools without a domain (todo, memory, send_message, ...) reset
+# nothing; reads without a mutating counterpart (web_search, session_search)
+# are never reset — nothing the agent does changes what they observe.
+_OBSERVATION_DOMAINS = {
+    "browser_click": "browser",
+    "browser_type": "browser",
+    "browser_press": "browser",
+    "browser_scroll": "browser",
+    "browser_navigate": "browser",
+    "browser_snapshot": "browser",
+    "browser_console": "browser",
+    "browser_get_images": "browser",
+    "terminal": "workspace",
+    "execute_code": "workspace",
+    "write_file": "workspace",
+    "patch": "workspace",
+    "read_file": "workspace",
+    "search_files": "workspace",
+    "mcp_filesystem_read_file": "workspace",
+    "mcp_filesystem_read_text_file": "workspace",
+    "mcp_filesystem_read_multiple_files": "workspace",
+    "mcp_filesystem_list_directory": "workspace",
+    "mcp_filesystem_list_directory_with_sizes": "workspace",
+    "mcp_filesystem_directory_tree": "workspace",
+    "mcp_filesystem_get_file_info": "workspace",
+    "mcp_filesystem_search_files": "workspace",
+}
+
+
 @dataclass(frozen=True)
 class ToolCallGuardrailConfig:
     """Thresholds for per-turn tool-call loop detection.
@@ -492,6 +525,27 @@ class ToolCallGuardrailController:
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
+
+        # A successful state-changing call invalidates "same result = no
+        # progress" for reads in its own observation domain: the world those
+        # reads observe just changed, so an identical re-read is legitimate
+        # once more (slow SPAs often lag one interaction behind). Without
+        # this, a browser session interleaving click/type/press with
+        # browser_snapshot accumulates snapshot repeats across the whole turn
+        # and hard-blocks the model's only way to observe the page. Reads in
+        # unrelated domains keep counting — a todo or memory write says
+        # nothing about a stuck page — as do tight read-read-read loops with
+        # no mutation in between. Failed mutations changed nothing and never
+        # reach this point (the failure branch above returns first).
+        if tool_name in self.config.mutating_tools:
+            domain = _OBSERVATION_DOMAINS.get(tool_name)
+            if domain is not None:
+                for stale in [
+                    sig
+                    for sig in self._no_progress
+                    if _OBSERVATION_DOMAINS.get(sig.tool_name) == domain
+                ]:
+                    self._no_progress.pop(stale, None)
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -119,6 +119,99 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
+def test_successful_mutating_call_resets_no_progress_in_its_domain():
+    """Interleaved page interactions must not accumulate snapshot repeats.
+
+    Regression for the browser false-positive: a session alternating
+    browser_click and browser_snapshot on a slow SPA reached the no-progress
+    block even though every snapshot legitimately followed a state-changing
+    action. A successful mutating call resets no-progress tracking for reads
+    in its observation domain.
+    """
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    snapshot_result = "same accessibility tree"
+
+    for _ in range(5):
+        assert controller.before_call("browser_snapshot", {}).action == "allow"
+        controller.after_call("browser_snapshot", {}, snapshot_result, failed=False)
+        controller.after_call("browser_click", {"ref": "@e5"}, '{"success": true}', failed=False)
+
+    assert controller.before_call("browser_snapshot", {}).action == "allow"
+    assert controller.halt_decision is None
+
+
+def test_failed_mutating_call_does_not_reset_no_progress_counts():
+    """A mutating call that failed changed nothing — repeats keep counting."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    snapshot_result = "same accessibility tree"
+
+    for _ in range(2):
+        assert controller.before_call("browser_snapshot", {}).action == "allow"
+        controller.after_call("browser_snapshot", {}, snapshot_result, failed=False)
+        controller.after_call(
+            "browser_click", {"ref": "@e5"}, '{"success": false, "error": "no such ref"}',
+            failed=True,
+        )
+
+    blocked = controller.before_call("browser_snapshot", {})
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+
+
+def test_unrelated_successful_mutation_does_not_reset_no_progress_counts():
+    """A successful mutating call outside the read's observation domain (a
+    todo or memory write while a page is stuck) says nothing about the page —
+    the ledger for browser reads must keep counting."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    snapshot_result = "same accessibility tree"
+
+    for i in range(2):
+        assert controller.before_call("browser_snapshot", {}).action == "allow"
+        controller.after_call("browser_snapshot", {}, snapshot_result, failed=False)
+        controller.after_call("todo", {"add": f"item-{i}"}, '{"success": true}', failed=False)
+        controller.after_call("memory", {"action": "add"}, '{"success": true}', failed=False)
+
+    blocked = controller.before_call("browser_snapshot", {})
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+
+
+def test_mutation_reset_is_scoped_to_its_own_domain():
+    """A successful terminal command resets workspace reads (it can change
+    files) but leaves browser read progress untouched."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=5)
+    )
+    controller.after_call("read_file", {"path": "/tmp/x"}, "same file contents", failed=False)
+    controller.after_call("browser_snapshot", {}, "same accessibility tree", failed=False)
+
+    controller.after_call("terminal", {"command": "make build"}, '{"exit_code": 0}', failed=False)
+
+    reread = controller.after_call("read_file", {"path": "/tmp/x"}, "same file contents", failed=False)
+    assert reread.action == "allow"
+    resnap = controller.after_call("browser_snapshot", {}, "same accessibility tree", failed=False)
+    assert resnap.action == "warn"
+    assert resnap.code == "idempotent_no_progress_warning"
+
+
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)


### PR DESCRIPTION
## What does this PR do?

Fixes the browser-session false positive in the idempotent no-progress guardrail (#64804, first half).

The no-progress tracker counts identical results per signature across the whole turn, so a session interleaving `browser_click`/`browser_type` with `browser_snapshot` on a slow SPA (page lags one interaction behind) accumulates snapshot repeats until `idempotent_no_progress_block` fires — blocking the model's only way to observe the page. In a replay of 20 unattended sessions from 2026-07-12, 16 died at this block.

A successful mutating call now clears no-progress tracking **for reads in its own observation domain only** (browser interactions invalidate browser reads; terminal/file writes invalidate file reads). The reset is deliberately narrow:

- Failed mutations do not reset.
- Mutations without an observation domain (`todo`, `memory`, `send_message`, …) reset nothing — an unrelated write says nothing about a stuck page.
- Reads with no mutating counterpart (`web_search`, `session_search`) are never reset.
- Tight read-read-read loops with no mutation in between still count.

## What this PR no longer does

The first revision also gave the model a tool-free wrap-up call after a halt (suppressing tools for one call + injecting a synthetic user steer). Both mechanisms conflict with AGENTS.md invariants (toolset stability mid-conversation; no synthetic user messages mid-loop), so that half is withdrawn here. The halt-recovery problem — the canned "I stopped retrying X" response discarding partial results (#64804, second half) — remains real and is better solved on the existing tool-result path, coordinating with #64363.

## Tests

`tests/agent/test_tool_guardrails.py`: interleaved click/snapshot stays unblocked; failed mutations don't reset; unrelated mutations (todo/memory) don't reset; terminal resets workspace reads but not browser reads. Green via `scripts/run_tests.sh`.

Fixes #64804 (guardrail half).