### PR TITLE
feat(api_server): reuse cached agents across chat-completions turns

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -570,6 +570,16 @@ The `_session_expiry_watcher` task runs in the gateway event loop every 300 seco
 The gateway maintains an LRU cache of `AIAgent` instances keyed by `session_key` to
 preserve prompt caching across turns.
 
+The API server platform applies the same pattern to `/v1/chat/completions`
+(`APIServerAdapter._acquire_agent` / `_release_agent` in
+`gateway/platforms/api_server.py`): agents are checked *out* of the cache for
+the duration of a run — concurrent requests on one session build a fresh
+instance instead of sharing one — and checked back *in* afterwards, validated
+by the same `_agent_config_signature`. Max 32 entries, 1h idle TTL, opt-out
+via `platforms.api_server` extra `agent_cache: false` or
+`API_SERVER_AGENT_CACHE=false`. The cache fails open: when config resolution
+errors, the request falls back to build-per-request.
+
 ### Cache Properties
 
 - **Max size:** 128 entries (`_AGENT_CACHE_MAX_SIZE`).

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -576,9 +576,11 @@ The API server platform applies the same pattern to `/v1/chat/completions`
 the duration of a run — concurrent requests on one session build a fresh
 instance instead of sharing one — and checked back *in* afterwards, validated
 by the same `_agent_config_signature`. Max 32 entries, 1h idle TTL, opt-out
-via `platforms.api_server` extra `agent_cache: false` or
-`API_SERVER_AGENT_CACHE=false`. The cache fails open: when config resolution
-errors, the request falls back to build-per-request.
+via `platforms.api_server` extra `agent_cache: false` (config.yaml). Eviction,
+invalidation and same-key displacement are soft (`release_clients()`, like
+`_release_evicted_agent_soft`); full teardown runs only at server shutdown.
+The cache fails open: when config resolution errors, the request falls back
+to build-per-request.
 
 ### Cache Properties
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -37,12 +37,14 @@ import hmac
 import json
 from contextlib import contextmanager
 from contextvars import ContextVar
+from collections import OrderedDict
 from functools import wraps
 import logging
 import os
 import socket as _socket
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -927,6 +929,18 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        # Reuse AIAgent instances across /v1/chat/completions turns of the
+        # same session (see "Agent cache" section below).  Opt-out via
+        # ``agent_cache: false`` in platforms.api_server extra config or
+        # API_SERVER_AGENT_CACHE=false.
+        _raw_agent_cache = extra.get(
+            "agent_cache", os.getenv("API_SERVER_AGENT_CACHE", "true")
+        )
+        self._agent_cache_enabled: bool = str(_raw_agent_cache).strip().lower() not in {
+            "0", "false", "no", "off",
+        }
+        self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
+        self._agent_cache_lock = threading.Lock()
         # model_routes: maps incoming ``model`` field values to specific
         # provider/model configs so one API server instance can serve
         # multiple clients on different backends.
@@ -1387,38 +1401,20 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return None
 
-    def _create_agent(
+    def _resolve_agent_runtime(
         self,
-        ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
-        stream_delta_callback=None,
-        tool_progress_callback=None,
-        tool_start_callback=None,
-        tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
-    ) -> Any:
+    ) -> Dict[str, Any]:
+        """Resolve the config an AIAgent for this request would be built from.
+
+        Extracted from ``_create_agent`` so the agent cache can compute a
+        config signature (and detect config changes) without paying for a
+        full AIAgent construction.  Returns a dict with ``model``,
+        ``runtime_kwargs``, ``enabled_toolsets``, ``max_iterations``,
+        ``fallback_model``, ``reasoning_config`` and ``user_config``.
         """
-        Create an AIAgent instance using the gateway's runtime config.
-
-        Uses _resolve_runtime_agent_kwargs() to pick up model, api_key,
-        base_url, etc. from config.yaml / env vars.  Toolsets are resolved
-        from config.yaml platform_toolsets.api_server (same as all other
-        gateway platforms), falling back to the hermes-api-server default.
-
-        ``gateway_session_key`` is a stable per-channel identifier supplied
-        by the client (via ``X-Hermes-Session-Key``).  Unlike ``session_id``
-        which scopes the short-term transcript and rotates on /new, this
-        key is meant to persist across transcripts so long-term memory
-        providers (e.g. Honcho) can scope their per-chat state correctly
-        — matching the semantics of the native gateway's ``session_key``.
-
-        ``route`` is an optional ``model_routes`` entry (per-client model
-        routing).  When set — and no session ``/model`` override exists for
-        this session — its model/provider/api_key/base_url override the
-        global defaults for this agent instance only.
-        """
-        from run_agent import AIAgent
         from gateway.run import (
             _current_max_iterations,
             _resolve_runtime_agent_kwargs,
@@ -1498,14 +1494,69 @@ class APIServerAdapter(BasePlatformAdapter):
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
         fallback_model = GatewayRunner._load_fallback_model()
 
+        return {
+            "model": model,
+            "runtime_kwargs": runtime_kwargs,
+            "enabled_toolsets": enabled_toolsets,
+            "max_iterations": max_iterations,
+            "fallback_model": fallback_model,
+            "reasoning_config": reasoning_config,
+            "user_config": user_config,
+        }
+
+    def _create_agent(
+        self,
+        ephemeral_system_prompt: Optional[str] = None,
+        session_id: Optional[str] = None,
+        stream_delta_callback=None,
+        tool_progress_callback=None,
+        tool_start_callback=None,
+        tool_complete_callback=None,
+        gateway_session_key: Optional[str] = None,
+        route: Optional[Dict[str, Any]] = None,
+        resolved: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """
+        Create an AIAgent instance using the gateway's runtime config.
+
+        Uses _resolve_agent_runtime() to pick up model, api_key, base_url,
+        etc. from config.yaml / env vars.  Toolsets are resolved from
+        config.yaml platform_toolsets.api_server (same as all other
+        gateway platforms), falling back to the hermes-api-server default.
+
+        ``gateway_session_key`` is a stable per-channel identifier supplied
+        by the client (via ``X-Hermes-Session-Key``).  Unlike ``session_id``
+        which scopes the short-term transcript and rotates on /new, this
+        key is meant to persist across transcripts so long-term memory
+        providers (e.g. Honcho) can scope their per-chat state correctly
+        — matching the semantics of the native gateway's ``session_key``.
+
+        ``route`` is an optional ``model_routes`` entry (per-client model
+        routing).  When set — and no session ``/model`` override exists for
+        this session — its model/provider/api_key/base_url override the
+        global defaults for this agent instance only.
+
+        ``resolved`` is an optional precomputed ``_resolve_agent_runtime()``
+        result, letting callers that already resolved the config (the agent
+        cache) avoid resolving it twice.
+        """
+        from run_agent import AIAgent
+
+        if resolved is None:
+            resolved = self._resolve_agent_runtime(
+                session_id=session_id,
+                gateway_session_key=gateway_session_key,
+                route=route,
+            )
+
         agent = AIAgent(
-            model=model,
-            **runtime_kwargs,
-            max_iterations=max_iterations,
+            model=resolved["model"],
+            **resolved["runtime_kwargs"],
+            max_iterations=resolved["max_iterations"],
             quiet_mode=True,
             verbose_logging=False,
             ephemeral_system_prompt=ephemeral_system_prompt or None,
-            enabled_toolsets=enabled_toolsets,
+            enabled_toolsets=resolved["enabled_toolsets"],
             session_id=session_id,
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
@@ -1513,11 +1564,195 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
             session_db=self._ensure_session_db(),
-            fallback_model=fallback_model,
-            reasoning_config=reasoning_config,
+            fallback_model=resolved["fallback_model"],
+            reasoning_config=resolved["reasoning_config"],
             gateway_session_key=gateway_session_key,
         )
         return agent
+
+    # ------------------------------------------------------------------
+    # Agent cache (chat completions)
+    # ------------------------------------------------------------------
+    #
+    # The native gateway reuses AIAgent instances per session_key so the
+    # frozen system prompt and tool schemas stay byte-identical across
+    # turns, preserving provider prompt caches (gateway/run.py
+    # ``_agent_cache``, docs/session-lifecycle.md §11).  The API server
+    # historically built a fresh AIAgent for every /v1/chat/completions
+    # request, which costs several hundred ms of pure construction
+    # (system prompt assembly, tool schema build, memory provider init)
+    # per turn and breaks local-backend prefix caches whenever the
+    # rebuilt prompt drifts.
+    #
+    # This cache extends the same pattern to the API server: agents are
+    # checked OUT of the cache for the duration of a run (so two
+    # concurrent requests for one session never share an instance — the
+    # second one just builds a fresh agent, i.e. the old behaviour) and
+    # checked back IN afterwards.  A config signature — the same
+    # ``GatewayRunner._agent_config_signature`` the gateway uses —
+    # invalidates entries when the model, provider, toolsets, ephemeral
+    # system prompt or cache-busting config keys change.
+
+    _AGENT_CACHE_MAX_SIZE = 32
+    _AGENT_CACHE_IDLE_TTL = 3600.0  # seconds; matches gateway agent cache
+
+    def _agent_cache_signature(
+        self,
+        resolved: Dict[str, Any],
+        ephemeral_system_prompt: Optional[str],
+    ) -> str:
+        """Config signature for cached agents (see gateway/run.py)."""
+        from gateway.run import GatewayRunner
+
+        return GatewayRunner._agent_config_signature(
+            resolved["model"],
+            resolved["runtime_kwargs"],
+            resolved["enabled_toolsets"],
+            ephemeral_system_prompt or "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(
+                resolved.get("user_config")
+            ),
+        )
+
+    def _acquire_agent(
+        self,
+        *,
+        ephemeral_system_prompt: Optional[str],
+        session_id: Optional[str],
+        stream_delta_callback=None,
+        tool_progress_callback=None,
+        tool_start_callback=None,
+        tool_complete_callback=None,
+        gateway_session_key: Optional[str] = None,
+        route: Optional[Dict[str, Any]] = None,
+    ) -> tuple:
+        """Return ``(agent, cache_key, signature)`` — cached when possible.
+
+        On a cache hit the per-request callbacks are rebound on the reused
+        instance (mirroring the gateway's cached-agent turn init) and
+        ``max_iterations`` is refreshed from current config.  Entries are
+        removed from the cache while in use; ``_release_agent`` puts them
+        back, so concurrent requests on one session degrade gracefully to
+        fresh construction instead of sharing an instance.
+        """
+        # The cache is an optimization: when config resolution or the
+        # signature computation fails for any reason, fall open to the
+        # historical build-per-request path instead of failing the turn.
+        resolved = None
+        signature = None
+        try:
+            resolved = self._resolve_agent_runtime(
+                session_id=session_id,
+                gateway_session_key=gateway_session_key,
+                route=route,
+            )
+            signature = self._agent_cache_signature(
+                resolved, ephemeral_system_prompt
+            )
+        except Exception:
+            logger.debug(
+                "api_server: agent cache signature unavailable; bypassing cache",
+                exc_info=True,
+            )
+        cache_key = gateway_session_key or session_id or ""
+        if signature is None:
+            cache_key = ""
+
+        agent = None
+        stale_agent = None
+        if self._agent_cache_enabled and cache_key:
+            now = time.time()
+            with self._agent_cache_lock:
+                entry = self._agent_cache.pop(cache_key, None)
+            if entry is not None:
+                cached_agent, cached_sig, last_used = entry
+                if cached_sig == signature and (
+                    now - last_used
+                ) < self._AGENT_CACHE_IDLE_TTL:
+                    agent = cached_agent
+                else:
+                    stale_agent = cached_agent
+        if stale_agent is not None:
+            # We are on the request's executor thread — blocking cleanup
+            # here is fine and keeps the eviction ordered before the
+            # replacement agent builds.
+            self._cleanup_cached_agent(stale_agent)
+
+        if agent is not None:
+            agent.stream_delta_callback = stream_delta_callback
+            agent.tool_progress_callback = tool_progress_callback
+            agent.tool_start_callback = tool_start_callback
+            agent.tool_complete_callback = tool_complete_callback
+            agent.max_iterations = resolved["max_iterations"]
+            try:
+                from gateway.run import GatewayRunner
+
+                GatewayRunner._init_cached_agent_for_turn(agent, 0)
+            except Exception:
+                logger.debug("cached agent turn init failed", exc_info=True)
+            logger.debug("api_server: reusing cached agent for %s", cache_key)
+        else:
+            agent = self._create_agent(
+                ephemeral_system_prompt=ephemeral_system_prompt,
+                session_id=session_id,
+                stream_delta_callback=stream_delta_callback,
+                tool_progress_callback=tool_progress_callback,
+                tool_start_callback=tool_start_callback,
+                tool_complete_callback=tool_complete_callback,
+                gateway_session_key=gateway_session_key,
+                route=route,
+                resolved=resolved,
+            )
+        return agent, cache_key, signature or ""
+
+    def _release_agent(
+        self,
+        cache_key: str,
+        agent: Any,
+        signature: str,
+        *,
+        discard: bool = False,
+    ) -> None:
+        """Return a checked-out agent to the cache (or clean it up)."""
+        if agent is None:
+            return
+        if discard or not self._agent_cache_enabled or not cache_key:
+            self._cleanup_cached_agent(agent)
+            return
+        evicted = []
+        with self._agent_cache_lock:
+            self._agent_cache[cache_key] = (agent, signature, time.time())
+            self._agent_cache.move_to_end(cache_key)
+            while len(self._agent_cache) > self._AGENT_CACHE_MAX_SIZE:
+                _, old_entry = self._agent_cache.popitem(last=False)
+                evicted.append(old_entry[0])
+        for old_agent in evicted:
+            self._cleanup_cached_agent(old_agent)
+
+    @staticmethod
+    def _cleanup_cached_agent(agent: Any) -> None:
+        """Best-effort resource cleanup for evicted/discarded agents.
+
+        Mirrors ``GatewayRunner._cleanup_agent_resources`` — memory provider
+        shutdown with the real transcript (#15165) and ``close()`` for tool
+        resources — without requiring a runner backref.
+        """
+        if agent is None:
+            return
+        try:
+            if hasattr(agent, "shutdown_memory_provider"):
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
+        except Exception:
+            pass
+        try:
+            if hasattr(agent, "close"):
+                agent.close()
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     # HTTP Handlers
@@ -4233,7 +4468,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id or "",
             )
             try:
-                agent = self._create_agent(
+                agent, cache_key, signature = self._acquire_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,
                     stream_delta_callback=stream_delta_callback,
@@ -4245,12 +4480,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent
-                effective_task_id = session_id or str(uuid.uuid4())
-                result = agent.run_conversation(
-                    user_message=user_message,
-                    conversation_history=conversation_history,
-                    task_id=effective_task_id,
-                )
+                run_ok = False
+                try:
+                    effective_task_id = session_id or str(uuid.uuid4())
+                    result = agent.run_conversation(
+                        user_message=user_message,
+                        conversation_history=conversation_history,
+                        task_id=effective_task_id,
+                    )
+                    run_ok = True
+                finally:
+                    # A turn that raised leaves the agent in an unknown
+                    # state — discard it instead of caching (next request
+                    # rebuilds, i.e. the historical behaviour).
+                    self._release_agent(
+                        cache_key, agent, signature, discard=not run_ok
+                    )
                 usage = {
                     "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                     "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
@@ -5086,6 +5331,18 @@ class APIServerAdapter(BasePlatformAdapter):
         (OSError: [Errno 24] Too many open files, #37011).
         """
         self._mark_disconnected()
+        # Drain the agent cache so memory providers flush and tool
+        # resources (sandboxes, browser daemons) shut down with the server.
+        with self._agent_cache_lock:
+            _cached_agents = [entry[0] for entry in self._agent_cache.values()]
+            self._agent_cache.clear()
+        for _agent in _cached_agents:
+            try:
+                await asyncio.get_running_loop().run_in_executor(
+                    None, self._cleanup_cached_agent, _agent
+                )
+            except Exception:
+                logger.debug("cached agent cleanup failed on disconnect", exc_info=True)
         if self._response_store is not None:
             try:
                 self._response_store.close()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -931,11 +931,8 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         # Reuse AIAgent instances across /v1/chat/completions turns of the
         # same session (see "Agent cache" section below).  Opt-out via
-        # ``agent_cache: false`` in platforms.api_server extra config or
-        # API_SERVER_AGENT_CACHE=false.
-        _raw_agent_cache = extra.get(
-            "agent_cache", os.getenv("API_SERVER_AGENT_CACHE", "true")
-        )
+        # ``agent_cache: false`` in platforms.api_server extra config.
+        _raw_agent_cache = extra.get("agent_cache", True)
         self._agent_cache_enabled: bool = str(_raw_agent_cache).strip().lower() not in {
             "0", "false", "no", "off",
         }
@@ -1673,10 +1670,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 else:
                     stale_agent = cached_agent
         if stale_agent is not None:
-            # We are on the request's executor thread — blocking cleanup
+            # We are on the request's executor thread — a blocking release
             # here is fine and keeps the eviction ordered before the
-            # replacement agent builds.
-            self._cleanup_cached_agent(stale_agent)
+            # replacement agent builds.  Soft: an invalidated (stale
+            # signature / idle TTL) session may resume at any time, and its
+            # task-scoped tool state must outlive the Python instance.
+            self._soft_release_agent(stale_agent)
 
         if agent is not None:
             agent.stream_delta_callback = stream_delta_callback
@@ -1713,29 +1712,68 @@ class APIServerAdapter(BasePlatformAdapter):
         *,
         discard: bool = False,
     ) -> None:
-        """Return a checked-out agent to the cache (or clean it up)."""
+        """Return a checked-out agent to the cache (or release it).
+
+        All release paths here are SOFT (``_soft_release_agent``): whether the
+        agent is discarded after an error, keyless, displaced by a concurrent
+        release on the same key, or LRU-evicted, its session may resume at
+        any time — full teardown is reserved for server shutdown
+        (``disconnect``).
+        """
         if agent is None:
             return
         if discard or not self._agent_cache_enabled or not cache_key:
-            self._cleanup_cached_agent(agent)
+            self._soft_release_agent(agent)
             return
-        evicted = []
+        released = []
         with self._agent_cache_lock:
+            # A concurrent request on the same session may have released its
+            # (fresher or older) agent already — replacing the entry must not
+            # leak the displaced instance (its clients, memory-provider state
+            # and tool resources are still live).
+            displaced = self._agent_cache.pop(cache_key, None)
+            if displaced is not None and displaced[0] is not agent:
+                released.append(displaced[0])
             self._agent_cache[cache_key] = (agent, signature, time.time())
-            self._agent_cache.move_to_end(cache_key)
             while len(self._agent_cache) > self._AGENT_CACHE_MAX_SIZE:
                 _, old_entry = self._agent_cache.popitem(last=False)
-                evicted.append(old_entry[0])
-        for old_agent in evicted:
-            self._cleanup_cached_agent(old_agent)
+                released.append(old_entry[0])
+        for old_agent in released:
+            self._soft_release_agent(old_agent)
+
+    @staticmethod
+    def _soft_release_agent(agent: Any) -> None:
+        """Soft release for evicted/displaced/discarded cache agents.
+
+        Mirrors ``GatewayRunner._release_evicted_agent_soft``: frees client
+        connections via ``release_clients()`` while preserving the session's
+        task-scoped tool state (terminal sandbox, browser daemon, tracked
+        background processes) so the next agent built for the same session
+        inherits them.  ``AIAgent.close()`` would end the session outright —
+        that is only correct at server shutdown (see ``disconnect``).
+        """
+        if agent is None:
+            return
+        try:
+            if hasattr(agent, "release_clients"):
+                agent.release_clients()
+            else:
+                # Legacy agent instance without the soft path — fall back to
+                # the full teardown rather than leaking clients.
+                APIServerAdapter._cleanup_cached_agent(agent)
+        except Exception:
+            pass
 
     @staticmethod
     def _cleanup_cached_agent(agent: Any) -> None:
-        """Best-effort resource cleanup for evicted/discarded agents.
+        """FULL teardown for cached agents at server shutdown.
 
         Mirrors ``GatewayRunner._cleanup_agent_resources`` — memory provider
         shutdown with the real transcript (#15165) and ``close()`` for tool
-        resources — without requiring a runner backref.
+        resources — without requiring a runner backref.  Not used for cache
+        eviction/invalidation (see ``_soft_release_agent``): ``close()`` kills
+        task-scoped processes and ends the session, which is only correct
+        when the server itself is going away.
         """
         if agent is None:
             return

--- a/tests/gateway/test_api_server_agent_cache.py
+++ b/tests/gateway/test_api_server_agent_cache.py
@@ -1,14 +1,20 @@
 """Tests for the API server agent cache (chat completions agent reuse).
 
 The cache mirrors the gateway's per-session AIAgent cache
-(gateway/run.py ``_agent_cache``): agents are checked OUT for the
-duration of a run and checked back IN afterwards, keyed by
+(gateway/run.py ``_agent_cache``): agents are checked OUT of the cache
+for the duration of a run and checked back IN afterwards, keyed by
 ``gateway_session_key or session_id`` and validated by a config
 signature.
+
+Release semantics mirror the gateway's too: eviction, invalidation,
+displacement and discard are SOFT (``release_clients()`` — the session
+may resume and must keep its task-scoped tool state); FULL teardown
+(``close()`` + memory-provider shutdown) happens only at server
+shutdown.
 """
 
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,9 +27,9 @@ def _make_adapter(**extra):
 
 
 def _instrument(adapter, signature="sig-1"):
-    """Stub config resolution / construction / cleanup on the adapter."""
+    """Stub config resolution / construction / release on the adapter."""
     created = []
-    cleaned = []
+    soft_released = []
 
     def _fake_create(**kwargs):
         agent = MagicMock(name=f"agent-{len(created)}")
@@ -35,8 +41,8 @@ def _instrument(adapter, signature="sig-1"):
     )
     adapter._agent_cache_signature = MagicMock(return_value=signature)
     adapter._create_agent = MagicMock(side_effect=_fake_create)
-    adapter._cleanup_cached_agent = MagicMock(side_effect=cleaned.append)
-    return created, cleaned
+    adapter._soft_release_agent = MagicMock(side_effect=soft_released.append)
+    return created, soft_released
 
 
 def _acquire(adapter, session_id="sess-1", **kwargs):
@@ -51,7 +57,7 @@ def _acquire(adapter, session_id="sess-1", **kwargs):
 class TestAgentReuse:
     def test_agent_reused_across_turns_of_same_session(self):
         adapter = _make_adapter()
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
 
         agent1, key, sig = _acquire(adapter)
         adapter._release_agent(key, agent1, sig)
@@ -60,7 +66,7 @@ class TestAgentReuse:
         assert agent2 is agent1
         assert key2 == key
         assert len(created) == 1
-        assert cleaned == []
+        assert soft_released == []
 
     def test_callbacks_rebound_on_cache_hit(self):
         adapter = _make_adapter()
@@ -103,9 +109,9 @@ class TestAgentReuse:
 
 
 class TestInvalidation:
-    def test_config_signature_change_rebuilds_agent(self):
+    def test_config_signature_change_soft_releases_stale_agent(self):
         adapter = _make_adapter()
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
 
         agent1, key, sig = _acquire(adapter)
         adapter._release_agent(key, agent1, sig)
@@ -114,11 +120,11 @@ class TestInvalidation:
         agent2, _, _ = _acquire(adapter)
 
         assert agent2 is not agent1
-        assert cleaned == [agent1]
+        assert soft_released == [agent1]
 
-    def test_idle_ttl_expiry_rebuilds_agent(self):
+    def test_idle_ttl_expiry_soft_releases_stale_agent(self):
         adapter = _make_adapter()
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
 
         agent1, key, sig = _acquire(adapter)
         adapter._release_agent(key, agent1, sig)
@@ -133,16 +139,16 @@ class TestInvalidation:
 
         agent2, _, _ = _acquire(adapter)
         assert agent2 is not agent1
-        assert cleaned == [agent1]
+        assert soft_released == [agent1]
 
-    def test_discard_on_release_cleans_up_and_skips_cache(self):
+    def test_discard_on_release_soft_releases_and_skips_cache(self):
         adapter = _make_adapter()
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
 
         agent1, key, sig = _acquire(adapter)
         adapter._release_agent(key, agent1, sig, discard=True)
 
-        assert cleaned == [agent1]
+        assert soft_released == [agent1]
         assert len(adapter._agent_cache) == 0
         agent2, _, _ = _acquire(adapter)
         assert agent2 is not agent1
@@ -159,17 +165,46 @@ class TestConcurrency:
         agent2, key2, sig2 = _acquire(adapter)
         assert agent2 is not agent1
 
+    def test_same_key_double_release_soft_releases_displaced_agent(self):
+        """Regression: two overlapping requests on one session release in
+        sequence — the entry replaced by the second release must be
+        deliberately soft-released, not silently overwritten (it still owns
+        clients, memory-provider state and tool resources)."""
+        adapter = _make_adapter()
+        created, soft_released = _instrument(adapter)
+
+        agent1, key1, sig1 = _acquire(adapter)
+        agent2, key2, sig2 = _acquire(adapter)  # concurrent, builds fresh
+        assert key1 == key2
+
         adapter._release_agent(key1, agent1, sig1)
         adapter._release_agent(key2, agent2, sig2)
-        # Last one released wins the cache slot; the earlier entry for the
-        # same key was overwritten, not leaked (single entry per key).
-        assert len(adapter._agent_cache) == 1
+
+        # agent1 was displaced by agent2's release and must be released.
+        assert soft_released == [agent1]
+        with adapter._agent_cache_lock:
+            assert len(adapter._agent_cache) == 1
+            assert adapter._agent_cache[key1][0] is agent2
+
+    def test_same_agent_double_release_does_not_self_release(self):
+        """Releasing the same instance twice (defensive) must not soft-release
+        the very agent that stays cached."""
+        adapter = _make_adapter()
+        created, soft_released = _instrument(adapter)
+
+        agent1, key, sig = _acquire(adapter)
+        adapter._release_agent(key, agent1, sig)
+        adapter._release_agent(key, agent1, sig)
+
+        assert soft_released == []
+        with adapter._agent_cache_lock:
+            assert adapter._agent_cache[key][0] is agent1
 
 
 class TestBounds:
-    def test_lru_cap_evicts_and_cleans_oldest(self):
+    def test_lru_cap_evicts_and_soft_releases_oldest(self):
         adapter = _make_adapter()
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
 
         agents = []
         for i in range(adapter._AGENT_CACHE_MAX_SIZE + 1):
@@ -179,41 +214,40 @@ class TestBounds:
             adapter._release_agent(key, agent, sig)
 
         assert len(adapter._agent_cache) == adapter._AGENT_CACHE_MAX_SIZE
-        # The first-released entry is the LRU one and must be cleaned up.
-        assert cleaned == [agents[0][1]]
+        # The first-released entry is the LRU one and must be soft-released.
+        assert soft_released == [agents[0][1]]
 
     def test_missing_cache_key_bypasses_cache(self):
         adapter = _make_adapter()
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
 
         agent1, key, sig = _acquire(adapter, session_id=None)
         assert key == ""
         adapter._release_agent(key, agent1, sig)
-        # Keyless agents are cleaned up, never cached.
-        assert cleaned == [agent1]
+        # Keyless agents are soft-released, never cached.
+        assert soft_released == [agent1]
         assert len(adapter._agent_cache) == 0
 
 
 class TestOptOut:
     def test_agent_cache_disabled_via_extra(self):
         adapter = _make_adapter(agent_cache=False)
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
 
         agent1, key, sig = _acquire(adapter)
         adapter._release_agent(key, agent1, sig)
         agent2, _, _ = _acquire(adapter)
 
         assert agent2 is not agent1
-        assert cleaned == [agent1]
-
-    def test_agent_cache_disabled_via_env(self, monkeypatch):
-        monkeypatch.setenv("API_SERVER_AGENT_CACHE", "false")
-        adapter = _make_adapter()
-        assert adapter._agent_cache_enabled is False
+        assert soft_released == [agent1]
 
     def test_agent_cache_enabled_by_default(self):
         adapter = _make_adapter()
         assert adapter._agent_cache_enabled is True
+
+    def test_agent_cache_extra_accepts_string_false(self):
+        adapter = _make_adapter(agent_cache="false")
+        assert adapter._agent_cache_enabled is False
 
 
 class TestFailOpen:
@@ -221,7 +255,7 @@ class TestFailOpen:
         """Cache is an optimization — a config-resolution error must fall
         back to the historical build-per-request path, not fail the turn."""
         adapter = _make_adapter()
-        created, cleaned = _instrument(adapter)
+        created, soft_released = _instrument(adapter)
         adapter._resolve_agent_runtime = MagicMock(
             side_effect=RuntimeError("no provider configured")
         )
@@ -231,13 +265,34 @@ class TestFailOpen:
         assert key == ""
         assert sig == ""
         adapter._release_agent(key, agent, sig)
-        # Bypassed agents are cleaned up, never cached.
-        assert cleaned == [agent]
+        # Bypassed agents are soft-released, never cached.
+        assert soft_released == [agent]
         assert len(adapter._agent_cache) == 0
 
 
-class TestCleanup:
-    def test_cleanup_calls_memory_shutdown_with_transcript(self):
+class TestReleaseSemantics:
+    def test_soft_release_frees_clients_but_preserves_session_state(self):
+        agent = MagicMock()
+        APIServerAdapter._soft_release_agent(agent)
+        agent.release_clients.assert_called_once_with()
+        agent.close.assert_not_called()
+        agent.shutdown_memory_provider.assert_not_called()
+
+    def test_soft_release_falls_back_to_full_cleanup_without_release_clients(self):
+        agent = MagicMock(spec=["close", "shutdown_memory_provider"])
+        agent._session_messages = None
+        APIServerAdapter._soft_release_agent(agent)
+        agent.close.assert_called_once()
+
+    def test_soft_release_survives_agent_errors(self):
+        agent = MagicMock()
+        agent.release_clients.side_effect = RuntimeError("boom")
+        APIServerAdapter._soft_release_agent(agent)  # must not raise
+
+    def test_soft_release_handles_none(self):
+        APIServerAdapter._soft_release_agent(None)
+
+    def test_full_cleanup_calls_memory_shutdown_with_transcript(self):
         agent = MagicMock()
         agent._session_messages = [{"role": "user", "content": "hi"}]
         APIServerAdapter._cleanup_cached_agent(agent)
@@ -246,12 +301,11 @@ class TestCleanup:
         )
         agent.close.assert_called_once()
 
-    def test_cleanup_survives_agent_errors(self):
+    def test_full_cleanup_survives_agent_errors(self):
         agent = MagicMock()
         agent.shutdown_memory_provider.side_effect = RuntimeError("boom")
         agent.close.side_effect = RuntimeError("boom")
-        # Must not raise.
-        APIServerAdapter._cleanup_cached_agent(agent)
+        APIServerAdapter._cleanup_cached_agent(agent)  # must not raise
 
-    def test_cleanup_handles_none(self):
+    def test_full_cleanup_handles_none(self):
         APIServerAdapter._cleanup_cached_agent(None)

--- a/tests/gateway/test_api_server_agent_cache.py
+++ b/tests/gateway/test_api_server_agent_cache.py
@@ -1,0 +1,257 @@
+"""Tests for the API server agent cache (chat completions agent reuse).
+
+The cache mirrors the gateway's per-session AIAgent cache
+(gateway/run.py ``_agent_cache``): agents are checked OUT for the
+duration of a run and checked back IN afterwards, keyed by
+``gateway_session_key or session_id`` and validated by a config
+signature.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter(**extra):
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra or None))
+
+
+def _instrument(adapter, signature="sig-1"):
+    """Stub config resolution / construction / cleanup on the adapter."""
+    created = []
+    cleaned = []
+
+    def _fake_create(**kwargs):
+        agent = MagicMock(name=f"agent-{len(created)}")
+        created.append(agent)
+        return agent
+
+    adapter._resolve_agent_runtime = MagicMock(
+        return_value={"max_iterations": 5}
+    )
+    adapter._agent_cache_signature = MagicMock(return_value=signature)
+    adapter._create_agent = MagicMock(side_effect=_fake_create)
+    adapter._cleanup_cached_agent = MagicMock(side_effect=cleaned.append)
+    return created, cleaned
+
+
+def _acquire(adapter, session_id="sess-1", **kwargs):
+    return adapter._acquire_agent(
+        ephemeral_system_prompt=kwargs.pop("ephemeral_system_prompt", None),
+        session_id=session_id,
+        stream_delta_callback=kwargs.pop("stream_delta_callback", None),
+        **kwargs,
+    )
+
+
+class TestAgentReuse:
+    def test_agent_reused_across_turns_of_same_session(self):
+        adapter = _make_adapter()
+        created, cleaned = _instrument(adapter)
+
+        agent1, key, sig = _acquire(adapter)
+        adapter._release_agent(key, agent1, sig)
+        agent2, key2, sig2 = _acquire(adapter)
+
+        assert agent2 is agent1
+        assert key2 == key
+        assert len(created) == 1
+        assert cleaned == []
+
+    def test_callbacks_rebound_on_cache_hit(self):
+        adapter = _make_adapter()
+        _instrument(adapter)
+
+        agent, key, sig = _acquire(adapter)
+        adapter._release_agent(key, agent, sig)
+
+        new_cb = MagicMock(name="delta-cb")
+        agent2, _, _ = _acquire(adapter, stream_delta_callback=new_cb)
+        assert agent2 is agent
+        assert agent2.stream_delta_callback is new_cb
+        assert agent2.max_iterations == 5
+
+    def test_different_sessions_get_different_agents(self):
+        adapter = _make_adapter()
+        created, _ = _instrument(adapter)
+
+        agent1, key1, sig1 = _acquire(adapter, session_id="sess-a")
+        adapter._release_agent(key1, agent1, sig1)
+        agent2, key2, sig2 = _acquire(adapter, session_id="sess-b")
+
+        assert agent2 is not agent1
+        assert len(created) == 2
+
+    def test_gateway_session_key_takes_precedence_in_cache_key(self):
+        adapter = _make_adapter()
+        _instrument(adapter)
+
+        agent1, key, sig = _acquire(
+            adapter, session_id="sess-a", gateway_session_key="chan-1"
+        )
+        assert key == "chan-1"
+        adapter._release_agent(key, agent1, sig)
+        # Same channel, different derived session id — still a hit.
+        agent2, _, _ = _acquire(
+            adapter, session_id="sess-b", gateway_session_key="chan-1"
+        )
+        assert agent2 is agent1
+
+
+class TestInvalidation:
+    def test_config_signature_change_rebuilds_agent(self):
+        adapter = _make_adapter()
+        created, cleaned = _instrument(adapter)
+
+        agent1, key, sig = _acquire(adapter)
+        adapter._release_agent(key, agent1, sig)
+
+        adapter._agent_cache_signature = MagicMock(return_value="sig-2")
+        agent2, _, _ = _acquire(adapter)
+
+        assert agent2 is not agent1
+        assert cleaned == [agent1]
+
+    def test_idle_ttl_expiry_rebuilds_agent(self):
+        adapter = _make_adapter()
+        created, cleaned = _instrument(adapter)
+
+        agent1, key, sig = _acquire(adapter)
+        adapter._release_agent(key, agent1, sig)
+        # Backdate the cached entry beyond the idle TTL.
+        with adapter._agent_cache_lock:
+            cached_agent, cached_sig, _ = adapter._agent_cache[key]
+            adapter._agent_cache[key] = (
+                cached_agent,
+                cached_sig,
+                time.time() - adapter._AGENT_CACHE_IDLE_TTL - 1,
+            )
+
+        agent2, _, _ = _acquire(adapter)
+        assert agent2 is not agent1
+        assert cleaned == [agent1]
+
+    def test_discard_on_release_cleans_up_and_skips_cache(self):
+        adapter = _make_adapter()
+        created, cleaned = _instrument(adapter)
+
+        agent1, key, sig = _acquire(adapter)
+        adapter._release_agent(key, agent1, sig, discard=True)
+
+        assert cleaned == [agent1]
+        assert len(adapter._agent_cache) == 0
+        agent2, _, _ = _acquire(adapter)
+        assert agent2 is not agent1
+
+
+class TestConcurrency:
+    def test_concurrent_checkout_never_shares_an_instance(self):
+        adapter = _make_adapter()
+        created, _ = _instrument(adapter)
+
+        agent1, key1, sig1 = _acquire(adapter)
+        # Second request for the SAME session before the first releases —
+        # must build fresh instead of sharing the checked-out agent.
+        agent2, key2, sig2 = _acquire(adapter)
+        assert agent2 is not agent1
+
+        adapter._release_agent(key1, agent1, sig1)
+        adapter._release_agent(key2, agent2, sig2)
+        # Last one released wins the cache slot; the earlier entry for the
+        # same key was overwritten, not leaked (single entry per key).
+        assert len(adapter._agent_cache) == 1
+
+
+class TestBounds:
+    def test_lru_cap_evicts_and_cleans_oldest(self):
+        adapter = _make_adapter()
+        created, cleaned = _instrument(adapter)
+
+        agents = []
+        for i in range(adapter._AGENT_CACHE_MAX_SIZE + 1):
+            agent, key, sig = _acquire(adapter, session_id=f"sess-{i}")
+            agents.append((key, agent, sig))
+        for key, agent, sig in agents:
+            adapter._release_agent(key, agent, sig)
+
+        assert len(adapter._agent_cache) == adapter._AGENT_CACHE_MAX_SIZE
+        # The first-released entry is the LRU one and must be cleaned up.
+        assert cleaned == [agents[0][1]]
+
+    def test_missing_cache_key_bypasses_cache(self):
+        adapter = _make_adapter()
+        created, cleaned = _instrument(adapter)
+
+        agent1, key, sig = _acquire(adapter, session_id=None)
+        assert key == ""
+        adapter._release_agent(key, agent1, sig)
+        # Keyless agents are cleaned up, never cached.
+        assert cleaned == [agent1]
+        assert len(adapter._agent_cache) == 0
+
+
+class TestOptOut:
+    def test_agent_cache_disabled_via_extra(self):
+        adapter = _make_adapter(agent_cache=False)
+        created, cleaned = _instrument(adapter)
+
+        agent1, key, sig = _acquire(adapter)
+        adapter._release_agent(key, agent1, sig)
+        agent2, _, _ = _acquire(adapter)
+
+        assert agent2 is not agent1
+        assert cleaned == [agent1]
+
+    def test_agent_cache_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_AGENT_CACHE", "false")
+        adapter = _make_adapter()
+        assert adapter._agent_cache_enabled is False
+
+    def test_agent_cache_enabled_by_default(self):
+        adapter = _make_adapter()
+        assert adapter._agent_cache_enabled is True
+
+
+class TestFailOpen:
+    def test_resolution_failure_bypasses_cache(self):
+        """Cache is an optimization — a config-resolution error must fall
+        back to the historical build-per-request path, not fail the turn."""
+        adapter = _make_adapter()
+        created, cleaned = _instrument(adapter)
+        adapter._resolve_agent_runtime = MagicMock(
+            side_effect=RuntimeError("no provider configured")
+        )
+
+        agent, key, sig = _acquire(adapter)
+        assert agent is created[0]
+        assert key == ""
+        assert sig == ""
+        adapter._release_agent(key, agent, sig)
+        # Bypassed agents are cleaned up, never cached.
+        assert cleaned == [agent]
+        assert len(adapter._agent_cache) == 0
+
+
+class TestCleanup:
+    def test_cleanup_calls_memory_shutdown_with_transcript(self):
+        agent = MagicMock()
+        agent._session_messages = [{"role": "user", "content": "hi"}]
+        APIServerAdapter._cleanup_cached_agent(agent)
+        agent.shutdown_memory_provider.assert_called_once_with(
+            agent._session_messages
+        )
+        agent.close.assert_called_once()
+
+    def test_cleanup_survives_agent_errors(self):
+        agent = MagicMock()
+        agent.shutdown_memory_provider.side_effect = RuntimeError("boom")
+        agent.close.side_effect = RuntimeError("boom")
+        # Must not raise.
+        APIServerAdapter._cleanup_cached_agent(agent)
+
+    def test_cleanup_handles_none(self):
+        APIServerAdapter._cleanup_cached_agent(None)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -481,7 +481,6 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |
 | `API_SERVER_MODEL_NAME` | Model name advertised on `/v1/models`. Defaults to the profile name (or `hermes-agent` for the default profile). Useful for multi-user setups where frontends like Open WebUI need distinct model names per connection. |
-| `API_SERVER_AGENT_CACHE` | Reuse `AIAgent` instances across `/v1/chat/completions` turns of the same session (default: `true`). Mirrors the gateway's per-session agent cache; set to `false` to rebuild the agent on every request. |
 | `GATEWAY_PROXY_URL` | URL of a remote Hermes API server to forward messages to ([proxy mode](/user-guide/messaging/matrix#proxy-mode-e2ee-on-macos)). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Also configurable via `gateway.proxy_url` in `config.yaml`. |
 | `GATEWAY_PROXY_KEY` | Bearer token for authenticating with the remote API server in proxy mode. Must match `API_SERVER_KEY` on the remote host. |
 | `MESSAGING_CWD` | Deprecated compatibility fallback for gateway working directory. Prefer `terminal.cwd` in `config.yaml`. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -481,6 +481,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |
 | `API_SERVER_MODEL_NAME` | Model name advertised on `/v1/models`. Defaults to the profile name (or `hermes-agent` for the default profile). Useful for multi-user setups where frontends like Open WebUI need distinct model names per connection. |
+| `API_SERVER_AGENT_CACHE` | Reuse `AIAgent` instances across `/v1/chat/completions` turns of the same session (default: `true`). Mirrors the gateway's per-session agent cache; set to `false` to rebuild the agent on every request. |
 | `GATEWAY_PROXY_URL` | URL of a remote Hermes API server to forward messages to ([proxy mode](/user-guide/messaging/matrix#proxy-mode-e2ee-on-macos)). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Also configurable via `gateway.proxy_url` in `config.yaml`. |
 | `GATEWAY_PROXY_KEY` | Bearer token for authenticating with the remote API server in proxy mode. Must match `API_SERVER_KEY` on the remote host. |
 | `MESSAGING_CWD` | Deprecated compatibility fallback for gateway working directory. Prefer `terminal.cwd` in `config.yaml`. |

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -59,6 +59,15 @@ Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI i
 
 Standard OpenAI Chat Completions format. Stateless — the full conversation is included in each request via the `messages` array.
 
+Although the endpoint is stateless, the server reuses the underlying
+`AIAgent` across turns of the same conversation (same derived session, or
+same `X-Hermes-Session-Id` / `X-Hermes-Session-Key`), so the system prompt
+and tool schemas stay byte-identical between requests — preserving provider
+prompt caches and skipping per-request agent construction. Reuse is
+transparent and invalidated automatically when the model, provider, toolsets
+or system prompt change; disable it with `API_SERVER_AGENT_CACHE=false` (or
+`agent_cache: false` in `platforms.api_server` extra config).
+
 **Request:**
 ```json
 {

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -65,8 +65,9 @@ same `X-Hermes-Session-Id` / `X-Hermes-Session-Key`), so the system prompt
 and tool schemas stay byte-identical between requests — preserving provider
 prompt caches and skipping per-request agent construction. Reuse is
 transparent and invalidated automatically when the model, provider, toolsets
-or system prompt change; disable it with `API_SERVER_AGENT_CACHE=false` (or
-`agent_cache: false` in `platforms.api_server` extra config).
+or system prompt change; evicted or invalidated agents are soft-released
+(session tool state survives for a resumed conversation). Disable reuse with
+`agent_cache: false` in `platforms.api_server` extra config.
 
 **Request:**
 ```json


### PR DESCRIPTION
## What does this PR do?

Extends the gateway's per-session `AIAgent` cache (docs/session-lifecycle.md §11) to the API server's `/v1/chat/completions` path.

Today every chat-completions request constructs a fresh `AIAgent` — system prompt assembly, tool schema build, memory provider init — even when the previous request of the same conversation built an identical one moments earlier. On my setup (a Home Assistant voice pipeline talking to the API server backed by a local llama.cpp model) that construction costs ~450 ms per turn, and the rebuilt prompt occasionally drifts, busting the local backend's prefix cache on top.

The gateway already solved this for messaging platforms with `_agent_cache`: reuse the agent per session so the frozen system prompt and tool schemas stay byte-identical across turns. This PR applies the same pattern to the API server:

- Agents are checked **out** of the cache for the duration of a run and checked back **in** afterwards. Two concurrent requests on one session never share an instance — the second one just builds fresh, i.e. the historical behaviour.
- Entries are keyed by `gateway_session_key or session_id` and validated with the same `GatewayRunner._agent_config_signature` the gateway uses, so model/provider/toolset/ephemeral-prompt/config changes invalidate cleanly.
- Per-request callbacks are rebound on reuse and `max_iterations` is refreshed, mirroring the gateway's cached-agent turn init.
- Bounded: max 32 entries (LRU) with a 1 h idle TTL; evicted/discarded agents get the same best-effort cleanup as the gateway (`shutdown_memory_provider` with the real transcript, `close()`).
- **Fail-open**: any error during config resolution/signature computation bypasses the cache and falls back to build-per-request. A turn that raises discards its agent instead of caching it.
- Opt-out: `agent_cache: false` in `platforms.api_server` extra config or `API_SERVER_AGENT_CACHE=false`.

Measured on the voice pipeline above: time-to-first-token through `/v1/chat/completions` (streaming) drops from ~0.9 s to ~0.4–0.5 s on cached turns, and local-backend prompt prefix reuse became deterministic across turns.

`/v1/runs` keeps its existing `_active_run_agents` lifecycle and is intentionally untouched.

## Related Issue

Related (adjacent but distinct): #37980 routes one-shot CLI through the already-hot API server; #57019 keeps local-backend prompt prefixes warm. Neither addresses the per-request `AIAgent` construction on the API server itself.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server.py`
  - extracted `_resolve_agent_runtime()` from `_create_agent()` (pure refactor) so the cache can compute a config signature without building an agent; `_create_agent()` accepts the precomputed result to avoid double resolution
  - new `_acquire_agent()` / `_release_agent()` / `_cleanup_cached_agent()` implementing the check-out/check-in cache; wired into `_run_agent()`
  - cache fields + `agent_cache` config/env toggle in `__init__`; cache drain in `disconnect()`
- `tests/gateway/test_api_server_agent_cache.py` — 17 tests: reuse, callback rebinding, key precedence, signature/TTL invalidation, concurrent checkout, LRU cap eviction, keyless bypass, opt-out, fail-open, cleanup
- `docs/session-lifecycle.md` — §11 note covering the API server variant
- `website/docs/user-guide/features/api-server.md`, `website/docs/reference/environment-variables.md` — user-facing docs for the toggle

## How to Test

1. `pytest tests/gateway/test_api_server_agent_cache.py -q` — 17 passed
2. `pytest tests/gateway/ -q` — full gateway suite passes (no regressions; the two suites that patch `_create_agent` still pass thanks to the fail-open path)
3. Manual: run the gateway with the API server enabled, send two streamed `/v1/chat/completions` requests for the same conversation (same first user message, or an explicit `X-Hermes-Session-Id`), and compare time-to-first-token; with `API_SERVER_AGENT_CACHE=false` the second request goes back to the old latency.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 12 (Linux 6.1), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (the toggle lives in `platforms.api_server` extra + env var, documented in the env-vars reference)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure-Python threading/OrderedDict, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
