### PR TITLE
feat(feishu): add FEISHU_IGNORE_AT_ALL env to skip @everyone triggers

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4333,9 +4333,16 @@ class FeishuAdapter(BasePlatformAdapter):
     # --- Mention detection ----------------------------------------------------
 
     def _mentions_self(self, message: Any) -> bool:
-        # @_all is Feishu's @everyone placeholder.
+        # @_all is Feishu's @everyone placeholder.  By default Hermes treats
+        # @everyone as a mention of the bot (so the bot responds in groups
+        # where someone @everyone's).  Set FEISHU_IGNORE_AT_ALL=true to make
+        # @everyone NOT trigger the bot — it will only respond to explicit
+        # @bot mentions.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:
+            ignore_at_all = os.getenv("FEISHU_IGNORE_AT_ALL", "false").strip().lower() in {"true", "1", "yes", "on"}
+            if ignore_at_all:
+                return False
             return True
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3567,6 +3567,35 @@ class TestGroupMentionAtAll(unittest.TestCase):
         allowed_sender = SimpleNamespace(open_id="ou_allowed", user_id=None)
         self.assertTrue(_admits_group(adapter, message, allowed_sender, ""))
 
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open", "FEISHU_IGNORE_AT_ALL": "true"}, clear=True)
+    def test_at_all_ignored_when_env_set(self):
+        """FEISHU_IGNORE_AT_ALL=true makes @_all NOT trigger the bot."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            content='{"text":"@_all 请注意"}',
+            mentions=[],
+        )
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        # Should be rejected — @_all is no longer treated as a mention.
+        self.assertFalse(_admits_group(adapter, message, sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open", "FEISHU_IGNORE_AT_ALL": "false"}, clear=True)
+    def test_at_all_still_triggers_when_env_unset_or_false(self):
+        """Default (env unset or false): @_all still triggers the bot."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            content='{"text":"@_all 请注意"}',
+            mentions=[],
+        )
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertTrue(_admits_group(adapter, message, sender_id, ""))
+
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestSenderNameResolution(unittest.TestCase):


### PR DESCRIPTION
 What does this PR do?

    Currently, Hermes' Feishu adapter treats @_all (Feishu's @everyone placeholder) as a mention of the bot. This means whenever someone uses    @everyone in a group chat, the bot wakes up and responds — which is rarely desired and can be noisy in busy groups.

    This PR adds a new environment variable FEISHU_IGNORE_AT_ALL (default: false, preserving existing behavior). When set to true, @_all no    longer triggers the bot — it only responds to explicit @bot mentions.

    This is the right approach because:

    • It's opt-in — default behavior is unchanged, so existing deployments are not affected
    • It's configurable per environment — via a simple env var, no code changes needed
    • It follows the same pattern as other Feishu env vars (FEISHU_GROUP_POLICY, FEISHU_REQUIRE_MENTION, etc.)

    Related Issue

    Fixes #

    Type of Change

    ☑ ✨ New feature (non-breaking change that adds functionality)

    Changes Made

    • plugins/platforms/feishu/adapter.py — Modified _mentions_self() to check FEISHU_IGNORE_AT_ALL env var; when true, @_all in message content    returns False instead of True, so @everyone no longer passes the mention gate
    • tests/gateway/test_feishu.py — Added 2 test cases to TestGroupMentionAtAll:
      • test_at_all_ignored_when_env_set — verifies FEISHU_IGNORE_AT_ALL=true rejects @everyone
      • test_at_all_still_triggers_when_env_unset_or_false — verifies default behavior is preserved

    How to Test

    1. Set FEISHU_IGNORE_AT_ALL=true in ~/.hermes/.env
    2. Restart the gateway: hermes gateway restart
    3. In a Feishu group where the bot is a member, send a message with @所有人 (@everyone) — the bot should not respond
    4. Now send a message explicitly @mentioning the bot — the bot should respond normally
    5. Run unit tests:

      ─ bash
         python3 -m pytest tests/gateway/test_feishu.py::TestGroupMentionAtAll -v -o addopts=""

       All 4 tests should pass (2 existing + 2 new).

    Checklist

Code

☑ I've read the hermes-agent/CONTRIBUTING.md at main · NousResearch/hermes-agent · GitHub
☑ My commit messages follow /en/ (feat(scope):, fix(scope):, etc.)
☑ I searched for existing PRs to make sure this isn't a duplicate
☑ My PR contains only changes related to this fix/feature (no unrelated commits)
☑ I've run pytest tests/ -q and all tests pass
☑ I've added tests for my changes (required for bug fixes, strongly encouraged for features)
☑ I've tested on my platform: WSL2 (Ubuntu 24.04)

Documentation & Housekeeping

☑ I've updated relevant documentation — or N/A
☑ I've updated cli-config.yaml.example if I added/changed config keys — or N/A
☑ I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
☑ I've considered cross-platform impact (Windows, macOS) per the hermes-agent/CONTRIBUTING.md at main · NousResearch/hermes-agent · GitHub —or N/A
☑ I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Screenshots / Logs

Gateway log before the fix (bot responds to @everyone):

[Lark] [INFO] connected to wss://msg-frontier.feishu.cn/ws/v2/...
[Feishu] Inbound group message received: ... text='@all 请注意'

After setting FEISHU_IGNORE_AT_ALL=true (bot ignores @everyone):

[Lark] [INFO] connected to wss://msg-frontier.feishu.cn/ws/v2/...
# No inbound log for @everyone messages — bot stays silent

Test output:

$ python3 -m pytest tests/gateway/test_feishu.py::TestGroupMentionAtAll -v -o addopts=""
test_at_all_in_content_accepts_without_explicit_bot_mention PASSED
test_at_all_still_requires_policy_gate PASSED
test_at_all_ignored_when_env_set PASSED
test_at_all_still_triggers_when_env_unset_or_false PASSED
======================== 4 passed, 10 warnings in 5.15s ========================