### PR TITLE
fix: bound doctor state database health checks

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1730,17 +1730,20 @@ def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> str:
     ns = parser.parse_args(args)
 
     def _run() -> None:
-        from hermes_state import DEFAULT_DB_PATH, _db_opens_cleanly, repair_state_db_schema
+        from hermes_state import DEFAULT_DB_PATH, _probe_db_health, repair_state_db_schema
 
         db_path = DEFAULT_DB_PATH
         if not db_path.exists():
             print(f"No session database at {db_path} (nothing to repair).")
             return
-        reason = _db_opens_cleanly(db_path)
-        if reason is None:
+        health = _probe_db_health(db_path)
+        if health.status == "healthy":
             print(f"{db_path} opens cleanly; no repair needed.")
             return
-        print(f"{db_path} does not open cleanly: {reason}")
+        if health.status == "skipped":
+            print(f"{db_path} health check skipped: {health.reason}; no repair attempted.")
+            return
+        print(f"{db_path} does not open cleanly: {health.reason}")
         if ns.check_only:
             return
         report = repair_state_db_schema(db_path, backup=not ns.no_backup)
@@ -1749,6 +1752,9 @@ def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> str:
                 print(f"backup: {report['backup_path']}")
             print(f"strategy: {report.get('strategy')}")
             print("Repaired session database.")
+            return
+        if report.get("skipped"):
+            print(f"Repair verification skipped: {report.get('error')}")
             return
         raise ConsoleCommandError(f"Repair failed: {report.get('error')}")
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -510,6 +510,118 @@ def managed_scope_check() -> None:
         check_info(f"managed dir set via HERMES_MANAGED_DIR={managed_dir}")
 
 
+def _check_state_db(
+    state_db_path: Path,
+    *,
+    should_fix: bool,
+    full_integrity: bool,
+    issues: list[str],
+) -> int:
+    """Check state.db with bounded routine semantics and optional full mode."""
+    if not state_db_path.exists():
+        check_info(f"{_DHH}/state.db not created yet (will be created on first session)")
+        return 0
+
+    from hermes_state import _probe_db_health, repair_state_db_schema
+
+    if full_integrity:
+        check_info(
+            "Running full unbounded state.db integrity check "
+            "(operator requested; this may take a long time)"
+        )
+    health = _probe_db_health(state_db_path, full_integrity=full_integrity)
+    if health.status == "healthy":
+        count = health.session_count if health.session_count is not None else "?"
+        detail = "(full unbounded integrity check completed)" if full_integrity else ""
+        check_ok(f"{_DHH}/state.db exists ({count} sessions)", detail)
+        return 0
+
+    if health.status == "skipped":
+        check_warn(
+            f"{_DHH}/state.db health check skipped ({health.category})",
+            f"({health.reason})",
+        )
+        issues.append(
+            f"state.db health check skipped ({health.reason}) — retry when the "
+            "database is idle"
+        )
+        return 0
+
+    def _repair(repair_label: str, issue_label: str) -> int:
+        report = repair_state_db_schema(state_db_path)
+        if report.get("repaired"):
+            backup_name = (
+                Path(report["backup_path"]).name
+                if report.get("backup_path") else "n/a"
+            )
+            check_ok(
+                repair_label,
+                f"(strategy: {report.get('strategy')}; backup: {backup_name})",
+            )
+            return 1
+        if report.get("skipped"):
+            check_warn(
+                "state.db repair verification skipped",
+                f"({report.get('error')})",
+            )
+            issues.append(
+                f"{issue_label} repair could not be verified — {report.get('error')}"
+            )
+            return 0
+        check_warn(
+            f"{issue_label} repair did not recover automatically",
+            f"({report.get('error')}; backup: {report.get('backup_path')})",
+        )
+        issues.append(
+            f"{issue_label} and auto-repair failed — restore from the backup "
+            "copy beside state.db"
+        )
+        return 0
+
+    if health.category in {"fts_index", "fts_write"}:
+        check_warn(
+            f"{_DHH}/state.db fails an FTS health probe (FTS index may be corrupt)",
+            f"({health.reason})",
+        )
+        if should_fix:
+            return _repair("Repaired state.db FTS health", "state.db FTS corruption")
+        issues.append(
+            "state.db FTS corruption — run 'hermes doctor --fix' "
+            "(or 'hermes sessions repair') to rebuild the FTS index"
+        )
+        return 0
+
+    if health.category == "malformed_schema":
+        check_warn(
+            f"{_DHH}/state.db schema is malformed (sessions hidden until repaired)",
+            f"({health.reason})",
+        )
+        if should_fix:
+            return _repair("Repaired state.db schema", "state.db schema malformed")
+        issues.append(
+            "state.db schema malformed — run 'hermes doctor --fix' "
+            "(or 'hermes sessions repair') to recover hidden sessions"
+        )
+        return 0
+
+    if health.category == "integrity":
+        check_warn(
+            f"{_DHH}/state.db integrity check reports database corruption",
+            f"({health.reason})",
+        )
+        issues.append(
+            "state.db integrity check reports corruption — restore from a known-good "
+            "backup or use SQLite recovery tooling"
+        )
+    else:
+        check_warn(
+            f"{_DHH}/state.db health check failed",
+            f"({health.reason})",
+        )
+        issues.append(f"state.db is unreadable or corrupt — {health.reason}")
+    return 0
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -1228,106 +1340,15 @@ def run_doctor(args):
             check_ok(f"Created {_DHH}/memories/")
             fixed_count += 1
     
-    # Check SQLite session store
+    # Check SQLite session store. Routine doctor is bounded to five seconds;
+    # operators can explicitly opt into the unbounded full scan.
     state_db_path = hermes_home / "state.db"
-    if state_db_path.exists():
-        try:
-            import sqlite3
-            conn = sqlite3.connect(str(state_db_path))
-            cursor = conn.execute("SELECT COUNT(*) FROM sessions")
-            count = cursor.fetchone()[0]
-            conn.close()
-            check_ok(f"{_DHH}/state.db exists ({count} sessions)")
-
-            # FTS write-health probe (#50502): `SELECT COUNT(*)` above succeeds
-            # even when the FTS index is corrupt and every message write fails
-            # through the triggers. `_db_opens_cleanly` now drives a rolled-back
-            # write so this otherwise-silent corruption class is surfaced (and
-            # repaired in place with --fix).
-            from hermes_state import _db_opens_cleanly, repair_state_db_schema
-
-            _write_reason = _db_opens_cleanly(state_db_path)
-            if _write_reason is not None:
-                check_warn(
-                    f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)",
-                    f"({_write_reason})",
-                )
-                if should_fix:
-                    report = repair_state_db_schema(state_db_path)
-                    if report.get("repaired"):
-                        backup_name = (
-                            Path(report["backup_path"]).name
-                            if report.get("backup_path") else "n/a"
-                        )
-                        check_ok(
-                            "Repaired state.db FTS write health",
-                            f"(strategy: {report.get('strategy')}; backup: {backup_name})",
-                        )
-                        fixed_count += 1
-                    else:
-                        check_warn(
-                            "state.db FTS write-health repair did not recover automatically",
-                            f"({report.get('error')}; backup: {report.get('backup_path')})",
-                        )
-                        issues.append(
-                            "state.db FTS write corruption and auto-repair failed — "
-                            "restore from the backup copy beside state.db"
-                        )
-                else:
-                    issues.append(
-                        "state.db FTS write corruption — run 'hermes doctor --fix' "
-                        "(or 'hermes sessions repair') to rebuild the FTS index"
-                    )
-        except Exception as e:
-            from hermes_state import is_malformed_db_error, repair_state_db_schema
-
-            if is_malformed_db_error(e):
-                # sqlite_master itself is malformed (e.g. duplicate
-                # messages_fts) — every statement fails before it runs, so
-                # this is NOT a plain FTS-index rebuild. Repair sqlite_master
-                # in place (backup first; sessions/messages preserved).
-                check_warn(
-                    f"{_DHH}/state.db schema is malformed (sessions hidden until repaired)",
-                    f"({e})",
-                )
-                if should_fix:
-                    report = repair_state_db_schema(state_db_path)
-                    if report.get("repaired"):
-                        try:
-                            conn = sqlite3.connect(str(state_db_path))
-                            count = conn.execute(
-                                "SELECT COUNT(*) FROM sessions"
-                            ).fetchone()[0]
-                            conn.close()
-                        except Exception:
-                            count = "?"
-                        backup_name = (
-                            Path(report["backup_path"]).name
-                            if report.get("backup_path") else "n/a"
-                        )
-                        check_ok(
-                            f"Repaired state.db schema ({count} sessions recovered)",
-                            f"(strategy: {report.get('strategy')}; backup: {backup_name})",
-                        )
-                        fixed_count += 1
-                    else:
-                        check_warn(
-                            "state.db schema repair did not recover automatically",
-                            f"({report.get('error')}; backup: {report.get('backup_path')})",
-                        )
-                        issues.append(
-                            "state.db schema malformed and auto-repair failed — "
-                            "restore from the backup copy beside state.db"
-                        )
-                else:
-                    issues.append(
-                        "state.db schema malformed — run 'hermes doctor --fix' "
-                        "(or 'hermes sessions repair') to recover hidden sessions"
-                    )
-            else:
-                check_warn(f"{_DHH}/state.db exists but has issues: {e}")
-    else:
-        check_info(f"{_DHH}/state.db not created yet (will be created on first session)")
+    fixed_count += _check_state_db(
+        state_db_path,
+        should_fix=should_fix,
+        full_integrity=getattr(args, "full_state_db_check", False),
+        issues=issues,
+    )
 
     # Check WAL file size (unbounded growth indicates missed checkpoints)
     wal_path = hermes_home / "state.db-wal"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13910,7 +13910,7 @@ def main():
         if action == "repair":
             from hermes_state import (
                 DEFAULT_DB_PATH,
-                _db_opens_cleanly,
+                _probe_db_health,
                 repair_state_db_schema,
             )
 
@@ -13918,11 +13918,17 @@ def main():
             if not db_path.exists():
                 print(f"No session database at {db_path} (nothing to repair).")
                 return
-            reason = _db_opens_cleanly(db_path)
-            if reason is None:
+            health = _probe_db_health(db_path)
+            if health.status == "healthy":
                 print(f"✓ {db_path} opens cleanly — no repair needed.")
                 return
-            print(f"✗ {db_path} does not open cleanly: {reason}")
+            if health.status == "skipped":
+                print(
+                    f"⚠ {db_path} health check skipped: {health.reason}; "
+                    "no repair attempted."
+                )
+                return
+            print(f"✗ {db_path} does not open cleanly: {health.reason}")
             if getattr(args, "check_only", False):
                 return
             print("Repairing (a backup copy is made first)…")
@@ -13943,6 +13949,9 @@ def main():
                 except Exception:
                     print("✓ Repaired.")
             else:
+                if report.get("skipped"):
+                    print(f"⚠ Repair verification skipped: {report.get('error')}")
+                    return
                 print(f"✗ Repair failed: {report.get('error')}")
                 if report.get("backup_path"):
                     print(f"  A backup is preserved at: {report['backup_path']}")

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -23,6 +23,14 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
         "--fix", action="store_true", help="Attempt to fix issues automatically"
     )
     doctor_parser.add_argument(
+        "--full-state-db-check",
+        action="store_true",
+        help=(
+            "Run the full unbounded state.db integrity check (may take a long "
+            "time on large databases; routine doctor uses a 5-second budget)"
+        ),
+    )
+    doctor_parser.add_argument(
         "--ack",
         metavar="ADVISORY_ID",
         default=None,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,6 +23,7 @@ import sqlite3
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -495,6 +496,10 @@ _MALFORMED_SCHEMA_MARKERS = (
 _repair_attempted_paths: set[str] = set()
 _repair_attempt_lock = threading.Lock()
 
+_DB_HEALTH_BUDGET_SECONDS = 5.0
+_DB_HEALTH_PROGRESS_OPS = 1_000
+_DB_HEALTH_BUSY_TIMEOUT_SECONDS = 0.1
+
 
 def is_malformed_db_error(exc: BaseException) -> bool:
     """True if *exc* is a SQLite 'malformed schema / disk image' error.
@@ -547,25 +552,112 @@ def _backup_db_file(db_path: Path) -> Optional[Path]:
         return None
 
 
-def _db_opens_cleanly(db_path: Path) -> Optional[str]:
-    """Probe a DB on a fresh connection. Returns None if healthy, else a reason.
+@dataclass(frozen=True)
+class DBHealthResult:
+    """Structured result from a state database health probe."""
 
-    Runs the same first-statement (``PRAGMA journal_mode``) that trips the
-    malformed-schema parse, then ``PRAGMA integrity_check`` and a canonical
-    ``sessions`` read, and finally a rolled-back ``messages`` write so that
-    FTS5 index corruption — which leaves base-table reads and
-    ``integrity_check`` passing while every ``INSERT INTO messages`` fails
-    through the FTS triggers — is reported as unhealthy rather than slipping
-    past as a false "ok" (#50502).
+    status: str
+    category: Optional[str] = None
+    reason: Optional[str] = None
+    session_count: Optional[int] = None
+    check_mode: str = "bounded"
+
+
+def _probe_db_health(
+    db_path: Path,
+    *,
+    full_integrity: bool = False,
+    budget_seconds: float = _DB_HEALTH_BUDGET_SECONDS,
+    _clock: Optional[Callable[[], float]] = None,
+    _progress_ops: int = _DB_HEALTH_PROGRESS_OPS,
+    _busy_timeout_seconds: float = _DB_HEALTH_BUSY_TIMEOUT_SECONDS,
+) -> DBHealthResult:
+    """Probe state.db without mistaking contention or cancellation for damage.
+
+    Routine probes run ``PRAGMA integrity_check`` behind a SQLite progress
+    handler with a five-second wall-clock budget. ``full_integrity=True`` is
+    the explicit operator opt-in to the same complete scan without a progress
+    deadline. Both modes retain the rolled-back FTS-trigger write probe.
     """
-    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    check_mode = "full" if full_integrity else "bounded"
+    clock = _clock or time.monotonic
+    deadline = None if full_integrity else clock() + max(0.0, budget_seconds)
+    timed_out = False
+    conn: Optional[sqlite3.Connection] = None
+    progress_handler_installed = False
+
+    def _result_for_error(exc: sqlite3.DatabaseError) -> DBHealthResult:
+        message = str(exc)
+        lowered = message.lower()
+        error_code = getattr(exc, "sqlite_errorcode", None)
+        primary_code = error_code & 0xFF if isinstance(error_code, int) else None
+        if timed_out:
+            return DBHealthResult(
+                status="skipped",
+                category="timeout",
+                reason=f"health check exceeded {budget_seconds:g}s budget",
+                check_mode=check_mode,
+            )
+        busy_code = getattr(sqlite3, "SQLITE_BUSY", 5)
+        locked_code = getattr(sqlite3, "SQLITE_LOCKED", 6)
+        if primary_code in (busy_code, locked_code) or (
+            "database is locked" in lowered
+            or "database table is locked" in lowered
+            or "database is busy" in lowered
+        ):
+            return DBHealthResult(
+                status="skipped",
+                category="locked",
+                reason=message,
+                check_mode=check_mode,
+            )
+        category = (
+            "malformed_schema"
+            if "malformed database schema" in lowered
+            else "database_error"
+        )
+        return DBHealthResult(
+            status="unhealthy",
+            category=category,
+            reason=message,
+            check_mode=check_mode,
+        )
+
     try:
+        conn = sqlite3.connect(
+            str(db_path),
+            isolation_level=None,
+            timeout=max(0.0, _busy_timeout_seconds),
+        )
+        if deadline is not None:
+
+            def _cancel_after_budget() -> int:
+                nonlocal timed_out
+                if clock() >= deadline:
+                    timed_out = True
+                    return 1
+                return 0
+
+            conn.set_progress_handler(_cancel_after_budget, max(1, _progress_ops))
+            progress_handler_installed = True
+
         conn.execute("PRAGMA journal_mode").fetchone()
         rows = conn.execute("PRAGMA integrity_check").fetchall()
         problems = [str(r[0]) for r in rows if r and str(r[0]).lower() != "ok"]
         if problems:
-            return "; ".join(problems[:3])
-        conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+            reason = "; ".join(problems[:3])
+            lowered_reason = reason.lower()
+            return DBHealthResult(
+                status="unhealthy",
+                category=(
+                    "fts_index"
+                    if "fts5" in lowered_reason or "messages_fts" in lowered_reason
+                    else "integrity"
+                ),
+                reason=reason,
+                check_mode=check_mode,
+            )
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
 
         # FTS write probe: drive a row through the messages_fts* triggers in a
         # transaction that is always rolled back, so a corrupt FTS index that
@@ -586,21 +678,51 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 (probe_session_id, "user", "_fts_health_probe", time.time()),
             )
             conn.execute("ROLLBACK")
-        except sqlite3.OperationalError as exc:
+        except sqlite3.DatabaseError as exc:
             # Missing tables / FTS disabled — not the corruption class we probe.
-            try:
-                conn.execute("ROLLBACK")
-            except sqlite3.Error:
-                pass
             msg = str(exc).lower()
             if "no such table" in msg or "no such column" in msg:
-                return None
-            return str(exc)
-        return None
+                return DBHealthResult(
+                    status="healthy",
+                    session_count=session_count,
+                    check_mode=check_mode,
+                )
+            transient = _result_for_error(exc)
+            if transient.status == "skipped":
+                return transient
+            return DBHealthResult(
+                status="unhealthy",
+                category="fts_write",
+                reason=str(exc),
+                session_count=session_count,
+                check_mode=check_mode,
+            )
+        return DBHealthResult(
+            status="healthy",
+            session_count=session_count,
+            check_mode=check_mode,
+        )
     except sqlite3.DatabaseError as exc:
-        return str(exc)
+        return _result_for_error(exc)
     finally:
-        conn.close()
+        if conn is not None:
+            try:
+                if progress_handler_installed:
+                    conn.set_progress_handler(None, 0)
+            finally:
+                try:
+                    if conn.in_transaction:
+                        conn.rollback()
+                except sqlite3.Error:
+                    pass
+                finally:
+                    conn.close()
+
+
+def _db_opens_cleanly(db_path: Path) -> Optional[str]:
+    """Compatibility wrapper: None when healthy, otherwise the probe reason."""
+    result = _probe_db_health(db_path)
+    return None if result.status == "healthy" else result.reason
 
 
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:
@@ -627,11 +749,12 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     Canonical ``sessions`` / ``messages`` rows are never modified. A
     timestamped raw backup is taken first unless ``backup=False``.
 
-    Returns a report dict: ``{repaired: bool, strategy: str|None,
-    backup_path: str|None, error: str|None}``.
+    Returns a report dict: ``{repaired: bool, skipped: bool,
+    strategy: str|None, backup_path: str|None, error: str|None}``.
     """
     report: Dict[str, Any] = {
         "repaired": False,
+        "skipped": False,
         "strategy": None,
         "backup_path": None,
         "error": None,
@@ -642,9 +765,20 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
         report["error"] = f"{db_path} does not exist"
         return report
 
-    if _db_opens_cleanly(db_path) is None:
+    health = _probe_db_health(db_path)
+    if health.status == "healthy":
         report["repaired"] = True
         report["strategy"] = "already_healthy"
+        return report
+    if health.status == "skipped":
+        report["skipped"] = True
+        report["error"] = f"health check skipped: {health.reason}"
+        return report
+    if health.category == "integrity":
+        report["error"] = (
+            f"{health.reason} (not an FTS/schema repair target; restore from "
+            "a known-good backup or use SQLite recovery tooling)"
+        )
         return report
 
     if backup:
@@ -668,13 +802,18 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                     continue
         finally:
             conn.close()
-        if _db_opens_cleanly(db_path) is None:
+        health = _probe_db_health(db_path)
+        if health.status == "healthy":
             report["repaired"] = True
             report["strategy"] = "rebuild_fts"
             logger.warning(
                 "state.db FTS indexes rebuilt in place (schema preserved): %s",
                 db_path,
             )
+            return report
+        if health.status == "skipped":
+            report["skipped"] = True
+            report["error"] = f"post-repair verification skipped: {health.reason}"
             return report
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db FTS in-place rebuild pass failed: %s", exc)
@@ -698,13 +837,18 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             conn.commit()
         finally:
             conn.close()
-        if _db_opens_cleanly(db_path) is None:
+        health = _probe_db_health(db_path)
+        if health.status == "healthy":
             report["repaired"] = True
             report["strategy"] = "dedup_schema"
             logger.warning(
                 "state.db schema repaired by de-duplicating sqlite_master "
                 "(FTS index preserved): %s", db_path
             )
+            return report
+        if health.status == "skipped":
+            report["skipped"] = True
+            report["error"] = f"post-repair verification skipped: {health.reason}"
             return report
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db dedup repair pass failed: %s", exc)
@@ -720,8 +864,8 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             conn.execute("VACUUM")
         finally:
             conn.close()
-        reason = _db_opens_cleanly(db_path)
-        if reason is None:
+        health = _probe_db_health(db_path)
+        if health.status == "healthy":
             report["repaired"] = True
             report["strategy"] = "drop_fts_rebuild"
             logger.warning(
@@ -729,7 +873,11 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                 "will rebuild from messages on next open: %s", db_path
             )
             return report
-        report["error"] = reason
+        if health.status == "skipped":
+            report["skipped"] = True
+            report["error"] = f"post-repair verification skipped: {health.reason}"
+            return report
+        report["error"] = health.reason
     except sqlite3.DatabaseError as exc:
         report["error"] = str(exc)
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -855,6 +855,169 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
     assert not any("opencode" in url.lower() and "models" in url.lower() for url, _, _ in calls)
 
 
+class TestDoctorStateDBHealth:
+    @staticmethod
+    def _state_db(tmp_path):
+        import sqlite3
+
+        path = tmp_path / "state.db"
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "CREATE TABLE sessions ("
+            "id TEXT PRIMARY KEY, source TEXT NOT NULL, started_at REAL NOT NULL)"
+        )
+        conn.commit()
+        conn.close()
+        return path
+
+    def test_routine_and_full_modes_are_forwarded_to_probe(self, monkeypatch, tmp_path):
+        import hermes_state
+
+        state_db = self._state_db(tmp_path)
+        calls = []
+
+        def fake_probe(path, *, full_integrity=False):
+            calls.append((path, full_integrity))
+            return hermes_state.DBHealthResult(
+                status="healthy", session_count=12,
+                check_mode="full" if full_integrity else "bounded",
+            )
+
+        monkeypatch.setattr(hermes_state, "_probe_db_health", fake_probe)
+
+        routine_out = io.StringIO()
+        with contextlib.redirect_stdout(routine_out):
+            fixed = doctor_mod._check_state_db(
+                state_db,
+                should_fix=False,
+                full_integrity=False,
+                issues=[],
+            )
+        full_out = io.StringIO()
+        with contextlib.redirect_stdout(full_out):
+            doctor_mod._check_state_db(
+                state_db,
+                should_fix=False,
+                full_integrity=True,
+                issues=[],
+            )
+
+        assert fixed == 0
+        assert calls == [(state_db, False), (state_db, True)]
+        assert "12 sessions" in routine_out.getvalue()
+        assert "full" in full_out.getvalue().lower()
+        assert "unbounded" in full_out.getvalue().lower()
+
+    @pytest.mark.parametrize(
+        ("category", "reason"),
+        (("timeout", "health check exceeded 5s budget"), ("locked", "database is locked")),
+    )
+    def test_skipped_probe_warns_without_repair(
+        self, monkeypatch, tmp_path, category, reason
+    ):
+        import hermes_state
+
+        state_db = self._state_db(tmp_path)
+        monkeypatch.setattr(
+            hermes_state,
+            "_probe_db_health",
+            lambda *_args, **_kwargs: hermes_state.DBHealthResult(
+                status="skipped", category=category, reason=reason
+            ),
+        )
+        monkeypatch.setattr(
+            hermes_state,
+            "repair_state_db_schema",
+            lambda *_args, **_kwargs: pytest.fail("skipped probe must not be repaired"),
+        )
+        issues = []
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            fixed = doctor_mod._check_state_db(
+                state_db,
+                should_fix=True,
+                full_integrity=False,
+                issues=issues,
+            )
+
+        rendered = output.getvalue().lower()
+        assert fixed == 0
+        assert "skipped" in rendered
+        assert category in rendered or reason.lower() in rendered
+        assert "corrupt" not in rendered
+        assert any("skipped" in issue.lower() for issue in issues)
+
+    def test_general_integrity_failure_is_not_labeled_fts_or_auto_repaired(
+        self, monkeypatch, tmp_path
+    ):
+        import hermes_state
+
+        state_db = self._state_db(tmp_path)
+        monkeypatch.setattr(
+            hermes_state,
+            "_probe_db_health",
+            lambda *_args, **_kwargs: hermes_state.DBHealthResult(
+                status="unhealthy", category="integrity", reason="page 7 is corrupt"
+            ),
+        )
+        monkeypatch.setattr(
+            hermes_state,
+            "repair_state_db_schema",
+            lambda *_args, **_kwargs: pytest.fail("general corruption is not FTS repair"),
+        )
+        issues = []
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            doctor_mod._check_state_db(
+                state_db,
+                should_fix=True,
+                full_integrity=False,
+                issues=issues,
+            )
+
+        rendered = output.getvalue().lower()
+        assert "integrity" in rendered
+        assert "corrupt" in rendered
+        assert "fts" not in rendered
+        assert issues
+
+    @pytest.mark.parametrize(
+        ("category", "reason", "expected"),
+        (
+            ("fts_index", "malformed inverted index", "fts"),
+            ("malformed_schema", "malformed database schema", "schema is malformed"),
+        ),
+    )
+    def test_repairable_corruption_classes_keep_specific_reporting(
+        self, monkeypatch, tmp_path, category, reason, expected
+    ):
+        import hermes_state
+
+        state_db = self._state_db(tmp_path)
+        monkeypatch.setattr(
+            hermes_state,
+            "_probe_db_health",
+            lambda *_args, **_kwargs: hermes_state.DBHealthResult(
+                status="unhealthy", category=category, reason=reason
+            ),
+        )
+        issues = []
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            doctor_mod._check_state_db(
+                state_db,
+                should_fix=False,
+                full_integrity=False,
+                issues=issues,
+            )
+
+        assert expected in output.getvalue().lower()
+        assert any(expected.split()[0] in issue.lower() for issue in issues)
+
+
 class TestGitHubTokenCheck:
     """Tests for GitHub token / gh auth detection in doctor."""
 

--- a/tests/test_state_db_health_probe.py
+++ b/tests/test_state_db_health_probe.py
@@ -1,0 +1,369 @@
+"""Bounded health probing for the SQLite session store."""
+
+import argparse
+import sqlite3
+
+import pytest
+
+import hermes_state
+
+
+def _build_minimal_state_db(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE sessions ("
+            "id TEXT PRIMARY KEY, source TEXT NOT NULL, started_at REAL NOT NULL)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_routine_probe_installs_and_clears_progress_handler(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+
+    events = []
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def set_progress_handler(self, progress_handler, n):
+            events.append(("progress", progress_handler, n))
+            return super().set_progress_handler(progress_handler, n)
+
+        def close(self):
+            events.append(("close",))
+            return super().close()
+
+    def tracking_connect(*args, **kwargs):
+        return real_connect(*args, factory=TrackingConnection, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", tracking_connect)
+
+    assert hermes_state._db_opens_cleanly(db_path) is None
+    assert [event[0] for event in events] == ["progress", "progress", "close"]
+    assert callable(events[0][1]) and events[0][2] > 0
+    assert events[1] == ("progress", None, 0)
+
+
+def test_simulated_slow_integrity_check_is_cancelled_without_waiting(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    phase = {"sql": None}
+    real_connect = sqlite3.connect
+
+    class SlowIntegrityConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=(), /):
+            phase["sql"] = sql
+            return super().execute(sql, parameters)
+
+    def tracking_connect(*args, **kwargs):
+        return real_connect(*args, factory=SlowIntegrityConnection, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", tracking_connect)
+
+    def clock():
+        return 106.0 if phase["sql"] == "PRAGMA integrity_check" else 100.0
+
+    result = hermes_state._probe_db_health(
+        db_path,
+        budget_seconds=5.0,
+        _clock=clock,
+        _progress_ops=1,
+    )
+
+    assert result.status == "skipped"
+    assert result.category == "timeout"
+    assert "5" in result.reason
+
+
+def test_timeout_clears_handler_before_closing_connection(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+
+    events = []
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def set_progress_handler(self, progress_handler, n):
+            events.append(("progress", progress_handler, n))
+            return super().set_progress_handler(progress_handler, n)
+
+        def close(self):
+            events.append(("close",))
+            return super().close()
+
+    def tracking_connect(*args, **kwargs):
+        return real_connect(*args, factory=TrackingConnection, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", tracking_connect)
+    ticks = iter((0.0, 6.0))
+
+    result = hermes_state._probe_db_health(
+        db_path,
+        budget_seconds=5.0,
+        _clock=lambda: next(ticks, 6.0),
+        _progress_ops=1,
+    )
+
+    assert result.status == "skipped"
+    assert [event[0] for event in events] == ["progress", "progress", "close"]
+    assert events[1] == ("progress", None, 0)
+
+
+def test_locked_database_is_skipped_not_corrupt(tmp_path):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    locker = sqlite3.connect(str(db_path), isolation_level=None)
+    locker.execute("BEGIN EXCLUSIVE")
+    try:
+        result = hermes_state._probe_db_health(
+            db_path,
+            _busy_timeout_seconds=0.01,
+        )
+    finally:
+        locker.execute("ROLLBACK")
+        locker.close()
+
+    assert result.status == "skipped"
+    assert result.category == "locked"
+    assert "locked" in result.reason.lower()
+
+
+def test_locked_classification_supports_python_without_sqlite_error_constants(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    locker = sqlite3.connect(str(db_path), isolation_level=None)
+    locker.execute("BEGIN EXCLUSIVE")
+    monkeypatch.delattr(hermes_state.sqlite3, "SQLITE_BUSY", raising=False)
+    monkeypatch.delattr(hermes_state.sqlite3, "SQLITE_LOCKED", raising=False)
+    try:
+        result = hermes_state._probe_db_health(
+            db_path,
+            _busy_timeout_seconds=0.01,
+        )
+    finally:
+        locker.execute("ROLLBACK")
+        locker.close()
+
+    assert result.status == "skipped"
+    assert result.category == "locked"
+
+
+def test_corrupt_database_is_reported_unhealthy(tmp_path):
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"not a sqlite database")
+
+    result = hermes_state._probe_db_health(db_path)
+
+    assert result.status == "unhealthy"
+    assert result.category == "database_error"
+    assert "not a database" in result.reason.lower()
+
+
+def test_malformed_schema_is_reported_unhealthy(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = hermes_state.SessionDB(db_path=db_path)
+    db.close()
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "INSERT INTO sqlite_master (type, name, tbl_name, rootpage, sql) "
+        "SELECT type, name, tbl_name, rootpage, sql FROM sqlite_master "
+        "WHERE name='messages_fts'"
+    )
+    conn.commit()
+    conn.close()
+
+    result = hermes_state._probe_db_health(db_path)
+
+    assert result.status == "unhealthy"
+    assert result.category == "malformed_schema"
+    assert "malformed database schema" in result.reason.lower()
+
+
+def test_fts_trigger_corruption_is_reported_unhealthy(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = hermes_state.SessionDB(db_path=db_path)
+    session_id = db.create_session(session_id="health-probe", source="cli")
+    db.append_message(session_id, role="user", content="health probe")
+    db.close()
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.execute("UPDATE messages_fts_data SET block = X'DEADBEEFDEADBEEF'")
+    conn.close()
+
+    result = hermes_state._probe_db_health(db_path)
+
+    assert result.status == "unhealthy"
+    assert result.category in {"fts_index", "fts_write"}
+    assert result.reason
+
+
+def test_database_error_from_fts_write_probe_keeps_fts_classification(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    real_connect = sqlite3.connect
+
+    class FailingFTSConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=(), /):
+            if sql.startswith("INSERT INTO messages "):
+                raise sqlite3.DatabaseError("database disk image is malformed")
+            return super().execute(sql, parameters)
+
+    def failing_connect(*args, **kwargs):
+        return real_connect(*args, factory=FailingFTSConnection, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", failing_connect)
+
+    result = hermes_state._probe_db_health(db_path)
+
+    assert result.status == "unhealthy"
+    assert result.category == "fts_write"
+    assert "malformed" in result.reason
+
+
+def test_explicit_full_probe_runs_without_a_progress_budget(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    events = []
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def set_progress_handler(self, progress_handler, n):
+            events.append((progress_handler, n))
+            return super().set_progress_handler(progress_handler, n)
+
+    def tracking_connect(*args, **kwargs):
+        return real_connect(*args, factory=TrackingConnection, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", tracking_connect)
+
+    result = hermes_state._probe_db_health(db_path, full_integrity=True)
+
+    assert result.status == "healthy"
+    assert result.check_mode == "full"
+    assert events == []
+
+
+def test_repair_does_not_touch_database_when_health_probe_is_skipped(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    monkeypatch.setattr(
+        hermes_state,
+        "_probe_db_health",
+        lambda _path: hermes_state.DBHealthResult(
+            status="skipped", category="timeout", reason="budget expired"
+        ),
+    )
+    monkeypatch.setattr(
+        hermes_state,
+        "_backup_db_file",
+        lambda _path: pytest.fail("skipped health checks must not start repair"),
+    )
+
+    report = hermes_state.repair_state_db_schema(db_path)
+
+    assert report["repaired"] is False
+    assert report["skipped"] is True
+    assert "budget expired" in report["error"]
+    assert report["backup_path"] is None
+
+
+def test_repair_stops_when_post_strategy_verification_is_skipped(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    results = iter(
+        (
+            hermes_state.DBHealthResult(
+                status="unhealthy", category="fts_write", reason="bad FTS index"
+            ),
+            hermes_state.DBHealthResult(
+                status="skipped", category="locked", reason="database is locked"
+            ),
+        )
+    )
+    monkeypatch.setattr(hermes_state, "_probe_db_health", lambda _path: next(results))
+
+    report = hermes_state.repair_state_db_schema(db_path, backup=False)
+
+    assert report["repaired"] is False
+    assert report["skipped"] is True
+    assert "verification" in report["error"]
+    assert "locked" in report["error"]
+
+
+def test_repair_does_not_treat_general_integrity_failure_as_fts_damage(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    monkeypatch.setattr(
+        hermes_state,
+        "_probe_db_health",
+        lambda _path: hermes_state.DBHealthResult(
+            status="unhealthy", category="integrity", reason="page 7 is corrupt"
+        ),
+    )
+    monkeypatch.setattr(
+        hermes_state,
+        "_backup_db_file",
+        lambda _path: pytest.fail("unsupported corruption must not start FTS repair"),
+    )
+
+    report = hermes_state.repair_state_db_schema(db_path)
+
+    assert report["repaired"] is False
+    assert report["skipped"] is False
+    assert "not an FTS/schema repair target" in report["error"]
+
+
+def test_doctor_parser_exposes_explicit_full_state_db_check():
+    from hermes_cli.subcommands.doctor import build_doctor_parser
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_doctor_parser(subparsers, cmd_doctor=lambda _args: None)
+
+    assert parser.parse_args(["doctor"]).full_state_db_check is False
+    assert parser.parse_args(["doctor", "--full-state-db-check"]).full_state_db_check is True
+    doctor_help = parser._subparsers._group_actions[0].choices["doctor"].format_help()
+    assert "unbounded" in doctor_help.lower()
+    assert "state.db" in doctor_help
+
+
+def test_console_sessions_repair_does_not_repair_a_skipped_probe(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.console_engine import _sessions_repair
+
+    db_path = tmp_path / "state.db"
+    _build_minimal_state_db(db_path)
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(
+        hermes_state,
+        "_probe_db_health",
+        lambda _path: hermes_state.DBHealthResult(
+            status="skipped", category="locked", reason="database is locked"
+        ),
+    )
+    monkeypatch.setattr(
+        hermes_state,
+        "repair_state_db_schema",
+        lambda *_args, **_kwargs: pytest.fail("skipped probe must not invoke repair"),
+    )
+
+    output = _sessions_repair(None, [])
+
+    assert "health check skipped" in output.lower()
+    assert "locked" in output.lower()

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -172,7 +172,7 @@ def test_strategy_b_rebuild_when_dedup_insufficient(tmp_path, monkeypatch):
     # + VACUUM) and runs its real SQL against the file. Keyed on whether the FTS
     # schema is still present rather than a call counter, so it stays correct as
     # earlier verification call sites are added/removed.
-    real_check = hermes_state._db_opens_cleanly
+    real_check = hermes_state._probe_db_health
     calls = {"n": 0}
 
     def flaky_check(path):
@@ -186,12 +186,20 @@ def test_strategy_b_rebuild_when_dedup_insufficient(tmp_path, monkeypatch):
             probe.close()
         except sqlite3.DatabaseError:
             # sqlite_master still malformed (pre-dedup) — treat as broken.
-            return "pretend still broken (schema unreadable)"
+            return hermes_state.DBHealthResult(
+                status="unhealthy",
+                category="malformed_schema",
+                reason="pretend still broken (schema unreadable)",
+            )
         if still_has_fts:
-            return "pretend in-place/dedup passes were insufficient"
+            return hermes_state.DBHealthResult(
+                status="unhealthy",
+                category="fts_index",
+                reason="pretend in-place/dedup passes were insufficient",
+            )
         return real_check(path)
 
-    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", flaky_check)
+    monkeypatch.setattr(hermes_state, "_probe_db_health", flaky_check)
     report = repair_state_db_schema(db_path)
     monkeypatch.undo()
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -678,12 +678,17 @@ Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-relo
 ## `hermes doctor`
 
 ```bash
-hermes doctor [--fix]
+hermes doctor [--fix] [--full-state-db-check]
 ```
+
+Routine doctor runs the `state.db` integrity probe with a five-second budget.
+If the database is busy, locked, or exceeds that budget, doctor reports the
+check as skipped instead of calling the database corrupt.
 
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+| `--full-state-db-check` | Opt into the full unbounded `state.db` integrity scan. This can take a long time on large databases. |
 
 ## `hermes dump`
 


### PR DESCRIPTION
## Summary

- bound the routine `hermes doctor` state database integrity probe to five seconds with SQLite progress-handler cancellation
- classify timeout, busy, and locked outcomes as skipped warnings rather than corruption, and prevent repair escalation on skipped/general-integrity results
- add an explicit `--full-state-db-check` opt-in for an unbounded scan, preserve malformed-schema and FTS repair paths, and update every sessions-repair caller
- document the operator-facing behavior and add direct real-SQLite coverage for cleanup, contention, corruption classes, repair gating, CLI routing, and full mode

## Validation

- `scripts/run_tests.sh tests/test_state_db_health_probe.py tests/test_state_db_malformed_repair.py tests/hermes_cli/test_doctor.py -q` — 101 passed
- affected state/doctor/console/readiness suites — 685 passed
- Ruff on all changed Python files — green
- `compileall` on changed modules/tests — green
- `git diff --check` — green
- frozen patch SHA-256 `0e66a30521b39e6cbe852aa730e603d4fb7ac938320fe28336473c504c7b4583`

## Independent review

Claude Fable 5 high-effort review blocked the first frozen artifact because the new direct test file was omitted from plain `git diff`. One bounded fix pass added the file to the frozen unit without changing content. The single final re-review returned `VERDICT: APPROVE` with no blockers and confirmed the nine-file patch matches the approved frozen artifact.

## Safety

- no live `state.db` was opened or copied
- large/slow behavior was exercised at the real SQLite progress-handler seam using disposable databases
- timeout/lock/busy paths fail closed and never auto-repair
