### PR TITLE
fix(desktop): handle Windows simple-git binary paths with spaces

### DIFF
--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -43,7 +43,11 @@ function runGh(args, cwd, ghBin): Promise<{ ok: boolean; stdout: string }> {
 }
 
 function gitFor(cwd, gitBin) {
-  return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
+  // simple-git rejects Windows binary paths containing spaces (e.g.
+  // C:\Program Files\Git\cmd\git.exe — the default Git for Windows install
+  // path). Fall back to bare 'git' which Node resolves via PATH.
+  const binary = gitBin && !gitBin.includes(' ') ? gitBin : 'git'
+  return simpleGit({ baseDir: cwd, binary, maxConcurrentProcesses: 4, trimmed: false })
 }
 
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only bug where the desktop review pane shows "No diff to show" because `simple-git` rejects binary paths containing spaces (e.g. `C:\Program Files\Git\cmd\git.exe` — the default Git for Windows install path).

`resolveGitBinary()` in `main.ts` correctly resolves the git binary to an absolute path. When that path contains spaces, `simple-git`'s internal spawn fails silently — every `git.status()`, `git.diffSummary()`, etc. call throws, and the review pane's catch blocks return empty results.

## Root Cause

`gitFor()` in `apps/desktop/electron/git-review-ops.ts` passes the resolved binary path directly to `simpleGit()`:

```ts
// Before
function gitFor(cwd, gitBin) {
  return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
}
```

`simple-git` does not quote the binary path when spawning, so a space in `C:\Program Files\Git\...` breaks the spawn.

## Fix

Guard against spaces in the binary path — fall back to bare `'git'` (which Node resolves via PATH):

```ts
// After
function gitFor(cwd, gitBin) {
  const binary = gitBin && !gitBin.includes(' ') ? gitBin : 'git'
  return simpleGit({ baseDir: cwd, binary, maxConcurrentProcesses: 4, trimmed: false })
}
```

On Windows, `git` is always on PATH regardless of install location (the installer adds it), so the fallback is safe. On macOS/Linux, `resolveGitBinary()` returns a PATH-resolved `'git'` (no spaces), so behavior is unchanged.

Note: the two `execFile(gitBin || 'git', ...)` calls in the same file are **not** affected — Node's `execFile` properly quotes arguments with spaces.

## Related Issue

Closes #64810

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test

**Reproduction (Windows, before fix):**
1. Install Git for Windows to the default path (`C:\Program Files\Git\`)
2. Open Hermes Desktop, open a git repo workspace
3. Press `Ctrl+G` to open the review pane
4. Observe: "No diff to show" for all files

**After fix:**
- Review pane shows files and diffs normally.

**Non-Windows / PATH-only:** No change in behavior — `git` is still resolved from PATH.

## Checklist

- [x] Code follows the style guide (single-word names, no `else`, early returns)
- [x] Change is surgical — one function, one guard clause
- [x] No new env vars or config surface
