### PR TITLE
fix(memory-display): broaden [full] detection to match 'full' keyword

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1291,9 +1291,14 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         return False, ""
 
     # Memory: distinguish "store full" from real errors.
+    # Match both the legacy "exceed the limit" wording and any newer variant
+    # that includes the literal word "full" (e.g. "memory store is full",
+    # "MemoryFullError"), case-insensitively. Keeps fixtures backward-compatible.
     if tool_name == "memory":
-        if isinstance(data, dict):
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+        if isinstance(data, dict) and data.get("success") is False:
+            err_msg = data.get("error", "") or ""
+            err_lower = err_msg.lower()
+            if "exceed the limit" in err_lower or "full" in err_lower:
                 return True, " [full]"
 
     # Structured error in JSON result (any tool that surfaces {"error": ...}).

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -260,8 +260,13 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     if tool_name == "memory":
         data = safe_json_loads(result)
         if isinstance(data, dict):
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
-                return True, " [full]"
+            # Mirror _detect_tool_failure: match the legacy "exceed the limit"
+            # wording and any newer variant containing the literal word
+            # "full", case-insensitively, so the two classifiers agree.
+            if data.get("success") is False:
+                err_lower = (data.get("error", "") or "").lower()
+                if "exceed the limit" in err_lower or "full" in err_lower:
+                    return True, " [full]"
 
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):

--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -67,6 +67,20 @@ class TestDetectToolFailureMemory:
         result = json.dumps({"success": False, "error": "would exceed the limit"})
         assert _detect_tool_failure("memory", result) == (True, " [full]")
 
+
+    def test_memory_full_keyword_returns_full_suffix(self):
+        # Broadened detection: any error message containing 'full' should
+        # collapse to ' [full]' too — covers MemoryFullError, 'store is
+        # full', etc. without needing the exact 'exceed the limit' phrase.
+        result = json.dumps({"success": False, "error": "memory store is full"})
+        assert _detect_tool_failure("memory", result) == (True, " [full]")
+
+    def test_memory_full_case_insensitive(self):
+        # Matching is case-insensitive so future LLM-formatted errors with
+        # different capitalisation also collapse cleanly.
+        result = json.dumps({"success": False, "error": "MEMORY STORE IS FULL"})
+        assert _detect_tool_failure("memory", result) == (True, " [full]")
+
     def test_memory_other_error_returns_specific_message(self):
         # An error that's NOT a "full" overflow falls through to the
         # structured-error path and surfaces the actual message.


### PR DESCRIPTION
## Summary

- Broaden CLI/TUI memory failure tagging so store-overflow errors collapse to ` [full]` when the error text contains the word `full` (case-insensitive), not only the legacy `exceed the limit` phrase.
- Keeps non-full memory errors on the structured path so they still show their real message.

## Motivation

Refs #2771.

`MemoryStore.add()` can surface capacity failures as messages that include `full` without the exact legacy phrase. Those currently fall through as long ` [error text]` suffixes instead of the compact ` [full]` tag the CLI already treats specially.

This is the **display-only** fragment of the earlier salvage #31861 by @leavedrop. Maintainers closed the broader salvage because auto-truncation was deliberately rejected as a silent data-loss path; this PR does **not** reintroduce truncation or lossy writes.

## Verification

- `pytest tests/agent/test_display_tool_failure.py -q` — 26 passed
- New coverage: `memory store is full` and `MEMORY STORE IS FULL` → ` [full]`
- Did NOT change: write path, auto-truncate, gateway warning side-channels

## Credit

Salvage fragment of #31861 by @leavedrop (display detector only).