### PR TITLE
fix: replace all remaining assert guards with runtime checks (supersedes #62425)

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError('Codex session not initialised')
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4765,7 +4765,8 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
+            if self._app is None:
+                raise RuntimeError('API server application not initialised')
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -221,13 +221,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError('BlueBubbles client not initialised')
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError('BlueBubbles client not initialised')
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1335,7 +1335,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError('WeChat poll session not initialised')
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1401,7 +1402,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError('WeChat poll session not initialised')
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -1833,7 +1835,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        if last_error is None:
+            raise RuntimeError('WeChat connection failed with no error detail')
         raise last_error
 
     async def send(
@@ -2088,7 +2091,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+            raise RuntimeError('WeChat send session not initialised')
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2108,7 +2112,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+            raise RuntimeError('WeChat send session or token not initialised')
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -548,7 +548,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError('WebSocket not connected')
         buf = ""
         try:
             async for chunk in self._ws:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4661,7 +4661,8 @@ def _run_with_idle_timeout(
 
     def _reader() -> None:
         nonlocal last_output_ts
-        assert proc.stdout is not None
+        if proc.stdout is None:
+            raise RuntimeError('Subprocess stdout is None')
         for line in proc.stdout:
             try:
                 print(f"{indent}{line.rstrip()}", flush=True)

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -219,7 +219,8 @@ def _handle_row(row: _Row) -> None:
                 print(color(f"  '{row.name}' was not installed", Colors.DIM))
     elif choice == 3:
         try:
-            assert row.entry is not None
+            if row.entry is None:
+                raise RuntimeError('MCP picker row has no entry')
             install_entry(row.entry, enable=True)
         except CatalogError as exc:
             print(color(f"  ✗ reinstall failed: {exc}", Colors.RED))

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError('Google Meet WebSocket not connected')
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError('Google Meet WebSocket not connected')
         try:
             if timeout is None:
                 return self._ws.recv()

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -205,7 +205,8 @@ def _list_block(items: List[Tuple[int, bool, str]]) -> Block:
             }
             elements.append(cur)
             cur_key = key
-        assert cur is not None
+        if cur is None:
+            raise RuntimeError('Slack BlockKit traversal reached None')
         cur["elements"].append(
             {"type": "rich_text_section", "elements": _inline_elements(text)}
         )

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -928,7 +928,8 @@ def _patch_skill(
         target, err = _resolve_skill_target(skill_dir, file_path)
         if err:
             return {"success": False, "error": err}
-        assert target is not None
+        if target is None:
+            return {"success": False, "error": "skill target not found"}
     else:
         # Patching SKILL.md
         target = skill_dir / "SKILL.md"
@@ -1146,7 +1147,8 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "skill target not found"}
     if target.exists():
         read_guard = _background_review_read_before_write_guard(
             name, target, "write_file", file_path
@@ -1192,7 +1194,8 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "skill target not found"}
     if not target.exists():
         # List what's actually there for the model to see
         available = []


### PR DESCRIPTION
## Supersedes #62425

Addresses all issues raised by @teknium1 in the #62425 review:

### Problems fixed from #62425

1. **weixin.py:2116 was malformed** — `raise RuntimeError(...) and self._token is not None` attached the token check to the raise expression (evaluates to `None and ...`), so the raise always fired and the token check was lost. Now uses a proper `if self._send_session is None or self._token is None` guard.

2. **skill_manager_tool.py only covered :948** — #62425 missed asserts at :931, :1149, :1195. All three now covered.

3. **Test file imported non-existent `_safe_cute_tool_message`** — removed from this PR; should be scoped separately if the function is added.

### Full coverage (10 files, 18 assert sites)

| File | Lines | Fix |
|------|-------|-----|
| `agent/transports/codex_app_server_session.py` | 399 | RuntimeError |
| `gateway/platforms/api_server.py` | 4768 | RuntimeError |
| `gateway/platforms/bluebubbles.py` | 224, 230 | RuntimeError |
| `gateway/platforms/weixin.py` | 1338, 1404, 1836, 2091, 2111 | RuntimeError (5 sites) |
| `gateway/relay/ws_transport.py` | 551 | RuntimeError |
| `hermes_cli/main.py` | 4664 | RuntimeError |
| `hermes_cli/mcp_picker.py` | 222 | RuntimeError |
| `plugins/google_meet/realtime/openai_client.py` | 224, 229 | RuntimeError |
| `plugins/platforms/slack/block_kit.py` | 208 | RuntimeError |
| `tools/skill_manager_tool.py` | 931, 1149, 1195 | error dict return |

### Testing

All replacements follow the same pattern: `assert X is not None` → `if X is None: raise RuntimeError(msg)`. Runtime behaviour is identical under normal Python; the difference is these survive `python -O` where asserts are stripped.