### PR TITLE
fix(tui): preserve explicit Markdown URL labels over page titles

### DIFF
--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -2,7 +2,7 @@ import { PassThrough } from 'stream'
 
 import { Box, renderSync } from '@hermes/ink'
 import React from 'react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, pickFallbackLabel, preferLinkDisplayLabel, stripInlineMarkup } from '../components/markdown.js'
 import { stripAnsi } from '../lib/text.js'
@@ -349,5 +349,39 @@ describe('explicit Markdown link labels (#64795)', () => {
     expect(preferLinkDisplayLabel(undefined, 'Fetched Page Title', url)).toBe('Fetched Page Title')
     expect(pickFallbackLabel(undefined, url)).toBeUndefined()
     expect(pickFallbackLabel('   ', url)).toBeUndefined()
+  })
+
+  // Regression for hermes-sweeper review on PR #64820: the `<https://…>`
+  // autolink parser branch passes the URL text itself as the "label".
+  // Treating that as an explicit author label made autolinks render the
+  // literal URL instead of a fetched title, breaking the auto-link
+  // title-resolution contract. Autolinks must keep fetched-title display.
+  it('prefers fetched titles for angle-bracket autolinks (no explicit label)', async () => {
+    vi.resetModules()
+    vi.doMock('../lib/externalLink.js', async () => {
+      const actual = await vi.importActual<typeof import('../lib/externalLink.js')>('../lib/externalLink.js')
+
+      return { ...actual, useLinkTitle: () => 'Fetched Autolink Title' }
+    })
+
+    const { Md: MdMocked } = await import('../components/markdown.js')
+    const lines = renderPlain(
+      React.createElement(
+        Box,
+        { width: 120 },
+        React.createElement(MdMocked, {
+          t: DEFAULT_THEME,
+          text: 'see <https://www.example.test/some/deep/path> now'
+        })
+      )
+    )
+
+    const rendered = lines.join('\n')
+
+    expect(rendered).toContain('Fetched Autolink Title')
+    expect(rendered).not.toContain('https://www.example.test/some/deep/path')
+
+    vi.doUnmock('../lib/externalLink.js')
+    vi.resetModules()
   })
 })

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -5,6 +5,7 @@ import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, pickFallbackLabel, preferLinkDisplayLabel, stripInlineMarkup } from '../components/markdown.js'
+import type * as ExternalLinkModule from '../lib/externalLink.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -359,7 +360,7 @@ describe('explicit Markdown link labels (#64795)', () => {
   it('prefers fetched titles for angle-bracket autolinks (no explicit label)', async () => {
     vi.resetModules()
     vi.doMock('../lib/externalLink.js', async () => {
-      const actual = await vi.importActual<typeof import('../lib/externalLink.js')>('../lib/externalLink.js')
+      const actual = await vi.importActual<typeof ExternalLinkModule>('../lib/externalLink.js')
 
       return { ...actual, useLinkTitle: () => 'Fetched Autolink Title' }
     })

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -4,7 +4,7 @@ import { Box, renderSync } from '@hermes/ink'
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, stripInlineMarkup } from '../components/markdown.js'
+import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, pickFallbackLabel, preferLinkDisplayLabel, stripInlineMarkup } from '../components/markdown.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -327,5 +327,27 @@ describe('renderTable CJK width alignment', () => {
     // The CJK row is the one that drifted before the fix.  It must
     // align with the rest now.
     expect(qwenCol2).toBe(headerCol2)
+  })
+})
+
+
+describe('explicit Markdown link labels (#64795)', () => {
+  it('preserves a label that normalizes equal to the destination URL', () => {
+    const url = 'https://example.test/path'
+    expect(pickFallbackLabel(url, url)).toBe(url)
+    expect(pickFallbackLabel(`  ${url}  `, url)).toBe(url)
+  })
+
+  it('prefers explicit labels over fetched page titles', () => {
+    const url = 'https://example.test/path'
+    expect(preferLinkDisplayLabel(url, 'Fetched Page Title', url)).toBe(url)
+    expect(preferLinkDisplayLabel('docs home', 'Fetched Page Title', url)).toBe('docs home')
+  })
+
+  it('uses fetched titles only when no explicit label was supplied', () => {
+    const url = 'https://example.test/path'
+    expect(preferLinkDisplayLabel(undefined, 'Fetched Page Title', url)).toBe('Fetched Page Title')
+    expect(pickFallbackLabel(undefined, url)).toBeUndefined()
+    expect(pickFallbackLabel('   ', url)).toBeUndefined()
   })
 })

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -153,15 +153,20 @@ const autolinkUrl = (raw: string) =>
 const defaultLinkLabel = (url: string) =>
   url.startsWith('mailto:') ? url.replace(/^mailto:/, '') : /^https?:\/\//i.test(url) ? urlSlugTitleLabel(url) : url
 
-const pickFallbackLabel = (label: string | undefined, target: string): string | undefined => {
+export const pickFallbackLabel = (label: string | undefined, _target: string): string | undefined => {
+  // Preserve any explicit Markdown label the author supplied — including labels
+  // that normalize to the same string as the target URL. Callers only omit the
+  // argument for bare/auto-linked URLs that never had an author label.
   const trimmed = label?.trim()
 
-  if (!trimmed) {
-    return undefined
-  }
-
-  return normalizeExternalUrl(trimmed) === target ? undefined : trimmed
+  return trimmed || undefined
 }
+
+export const preferLinkDisplayLabel = (
+  fallbackLabel: string | undefined,
+  fetched: string | undefined,
+  url: string
+): string => fallbackLabel || fetched || defaultLinkLabel(url)
 
 interface ResolvedLinkProps {
   fallbackLabel?: string
@@ -171,7 +176,10 @@ interface ResolvedLinkProps {
 
 function ResolvedLink({ fallbackLabel, t, url }: ResolvedLinkProps) {
   const fetched = useLinkTitle(url)
-  const display = fetched || fallbackLabel || defaultLinkLabel(url)
+  // Explicit Markdown link labels win over fetched page titles. Title
+  // resolution remains the preferred display only for bare/auto-linked URLs
+  // that have no author-supplied label (fallbackLabel is undefined then).
+  const display = preferLinkDisplayLabel(fallbackLabel, fetched, url)
 
   return (
     <Link url={url}>

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -190,10 +190,21 @@ function ResolvedLink({ fallbackLabel, t, url }: ResolvedLinkProps) {
   )
 }
 
-const renderResolvedLink = (k: number, t: Theme, rawUrl: string, label?: string) => {
+const renderResolvedLink = (
+  k: number,
+  t: Theme,
+  rawUrl: string,
+  label?: string,
+  // Autolinks (`<https://…>`) and bare URLs never carry an author-supplied
+  // label — the "label" is just the URL text itself. Only explicit
+  // `[label](url)` links should suppress fetched-title resolution, so
+  // autolink/bare callers pass isAutolink=true to keep title fetching.
+  isAutolink = false
+) => {
   const target = normalizeExternalUrl(rawUrl)
+  const fallbackLabel = isAutolink ? undefined : pickFallbackLabel(label, target)
 
-  return <ResolvedLink fallbackLabel={pickFallbackLabel(label, target)} key={k} t={t} url={target} />
+  return <ResolvedLink fallbackLabel={fallbackLabel} key={k} t={t} url={target} />
 }
 
 export const stripInlineMarkup = (v: string) =>
@@ -569,7 +580,7 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
     } else if (m[3] && m[4]) {
       parts.push(renderResolvedLink(parts.length, t, m[4], m[3]))
     } else if (m[5]) {
-      parts.push(renderResolvedLink(parts.length, t, autolinkUrl(m[5]), m[5].replace(/^mailto:/, '')))
+      parts.push(renderResolvedLink(parts.length, t, autolinkUrl(m[5]), m[5].replace(/^mailto:/, ''), true))
     } else if (m[6]) {
       parts.push(
         <Text key={parts.length} strikethrough>


### PR DESCRIPTION
## Summary

- Preserve explicit Markdown link labels in the TUI renderer, including when the label normalizes to the same string as the target URL.
- Prefer author-supplied labels over fetched HTML page titles; title resolution remains for bare/auto-linked URLs only.

## Motivation

Closes #64795.

For workflows where the literal URL matters (copy, dictation, handoff to another tool), `[https://example.test/path](https://example.test/path)` was treated like an unlabeled autolink: `pickFallbackLabel()` discarded the label and `ResolvedLink` preferred `useLinkTitle()`.

## Verification

- `cd ui-tui && npm test -- src/__tests__/markdown.test.ts` — 31 passed
- Pure helpers cover: URL-equals-label preservation, explicit label wins over fetched title, bare links still use title fallback

## Did NOT change

- Bare URL slug/title behavior for unlabeled links
- Network title fetching itself (only precedence when a label exists)