### PR TITLE
fix(codex): send ChatGPT-Account-Id on /models probes

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -4,6 +4,7 @@ Pure utility functions with no AIAgent dependency. Used by ContextCompressor
 and run_agent.py for pre-flight context checks.
 """
 
+import base64
 import ipaddress
 import json
 import logging
@@ -1886,6 +1887,34 @@ _codex_oauth_context_cache_time: float = 0.0
 _CODEX_OAUTH_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
+def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
+    """Extract ``chatgpt_account_id`` from the Codex OAuth JWT.
+
+    The Codex ``/backend-api/codex/models`` endpoint returns the per-account
+    catalog only when the ``ChatGPT-Account-Id`` header is present; without
+    it, the endpoint returns ``{"models":[]}`` (HTTP 200) and the context
+    probe falls back to the hardcoded defaults — which can be stale or
+    wrong for the active account's plan. Mirrors the same extraction done
+    in ``auxiliary_client.py`` for the request path.
+
+    Returns ``None`` on any parse error rather than raising, so a bad
+    token still surfaces as a normal probe failure instead of crashing
+    the metadata resolver.
+    """
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        if not isinstance(claims, dict):
+            return None
+        acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+        return acct_id if isinstance(acct_id, str) and acct_id else None
+    except Exception:
+        return None
+
+
 def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
     """Probe the ChatGPT Codex /models endpoint for per-slug context windows.
 
@@ -1903,10 +1932,15 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
     ):
         return _codex_oauth_context_cache
 
+    headers = {"Authorization": f"Bearer {access_token}"}
+    acct_id = _extract_chatgpt_account_id(access_token)
+    if acct_id:
+        headers["ChatGPT-Account-Id"] = acct_id
+
     try:
         resp = requests.get(
             "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
-            headers={"Authorization": f"Bearer {access_token}"},
+            headers=headers,
             timeout=(5, 10),
             verify=_resolve_requests_verify(),
         )

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from pathlib import Path
@@ -93,13 +94,47 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
     return ordered
 
 
+def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
+    """Best-effort extraction of ``chatgpt_account_id`` from the OAuth JWT.
+
+    The Codex backend requires the ``ChatGPT-Account-Id`` header for the
+    per-account catalog. Without it, ``GET /backend-api/codex/models``
+    returns ``{"models":[]}`` (HTTP 200) — which masquerades as "no
+    models available" and silently degrades the picker to the curated
+    fallback list. The request-side path in ``auxiliary_client.py``
+    already extracts the same claim; this mirrors that logic here so the
+    probe sees the same catalog the request path will actually use.
+
+    Returns ``None`` on any parse error — the probe then degrades
+    gracefully to the unauthenticated fallback list instead of crashing.
+    """
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        acct_id = (
+            claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+            if isinstance(claims, dict)
+            else None
+        )
+        return acct_id if isinstance(acct_id, str) and acct_id else None
+    except Exception:
+        return None
+
+
 def _fetch_models_from_api(access_token: str) -> List[str]:
     """Fetch available models from the Codex API. Returns visible models sorted by priority."""
     try:
         import httpx
+        headers = {"Authorization": f"Bearer {access_token}"}
+        acct_id = _extract_chatgpt_account_id(access_token)
+        if acct_id:
+            headers["ChatGPT-Account-Id"] = acct_id
         resp = httpx.get(
             "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
-            headers={"Authorization": f"Bearer {access_token}"},
+            headers=headers,
             timeout=10,
         )
         if resp.status_code != 200:

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -113,6 +113,83 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5-internal" not in models
 
 
+def test_fetch_from_api_sends_chatgpt_account_id_header(monkeypatch):
+    """The Codex /models endpoint only returns the per-account catalog when
+    the ``ChatGPT-Account-Id`` header is present. Without it, the response
+    is ``{"models":[]}`` (HTTP 200), which makes the picker silently
+    degrade to the curated fallback list and send invalid slugs on later
+    requests. Regression test for the upstream bug behind slow first
+    responses and HTTP 520/120s SSE hangs.
+    """
+    import sys
+    from hermes_cli import codex_models
+
+    captured = {}
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"models": [{"slug": "gpt-5.6-sol", "priority": 0}]}
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            return _FakeResp()
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+    # Hand-crafted JWT carrying the chatgpt_account_id claim.
+    import base64
+    import json
+
+    payload = base64.urlsafe_b64encode(
+        json.dumps(
+            {"https://api.openai.com/auth": {"chatgpt_account_id": "acct-test-123"}}
+        ).encode()
+    ).rstrip(b"=").decode()
+    fake_jwt = f"header.{payload}.sig"
+
+    models = codex_models._fetch_models_from_api(access_token=fake_jwt)
+
+    assert captured["headers"]["Authorization"] == f"Bearer {fake_jwt}"
+    assert captured["headers"].get("ChatGPT-Account-Id") == "acct-test-123"
+    assert "gpt-5.6-sol" in models
+
+
+def test_fetch_from_api_omits_account_id_header_when_jwt_unparseable(monkeypatch):
+    """A malformed token must not crash the probe — it should still send the
+    bearer header and let the upstream decide. We just verify the probe
+    returns ``[]`` cleanly without the optional header.
+    """
+    import sys
+    from hermes_cli import codex_models
+
+    captured = {}
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"models": []}
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            captured["headers"] = dict(headers or {})
+            return _FakeResp()
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+    models = codex_models._fetch_models_from_api(access_token="not-a-jwt")
+
+    assert "ChatGPT-Account-Id" not in captured["headers"]
+    assert captured["headers"]["Authorization"] == "Bearer not-a-jwt"
+    assert models == []
+
+
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):
     from hermes_cli.main import _model_flow_openai_codex
 


### PR DESCRIPTION
## Summary

The Codex OAuth `/backend-api/codex/models` endpoint returns the per-account model catalog only when the `ChatGPT-Account-Id` header is present. Without it, the response is `200 OK` with `{"models":[]}` — the picker silently degrades to the curated fallback list, which is stale for the active plan and was the upstream cause of slow first responses and HTTP 520 / 120s SSE hangs on `gpt-5.6-sol` and other GPT-5.6 family slugs.

## Root cause

`hermes_cli/codex_models.py::_fetch_models_from_api` and `agent/model_metadata.py::_fetch_codex_oauth_context_lengths` both probed `https://chatgpt.com/backend-api/codex/models?client_version=1.0.0` with only the `Authorization: Bearer …` header. The Codex backend's request-side path (`agent/auxiliary_client.py`) already extracts `chatgpt_account_id` from the JWT and sends `ChatGPT-Account-Id` — but the two probe-side paths did not, so the catalog they saw did not match the catalog the request side was actually using.

Symptoms observed on a ChatGPT Pro account:

- `_fetch_models_from_api` returned `{"models":[]}` despite the account having 10+ models.
- `_fetch_codex_oauth_context_lengths` resolved no slugs, so model metadata fell back to hardcoded defaults — including a stale 372K value that was the original subject of PR #64760.
- Subsequent `/responses` calls landed on a backend that didn't recognise the slug and failed with `HTTP 520 — HTML error page` (Cloudflare origin error) or `120s SSE silence timeout`. Hermes retried 3× per its policy, giving the observed 9-minute cumulative hang.

## Fix

Mirror the existing JWT-claim extraction from `auxiliary_client.py` into the two probe-side paths: decode the access token's middle segment, pull `https://api.openai.com/auth.chatgpt_account_id`, and send it as `ChatGPT-Account-Id` on the probe request. Bad/unparseable tokens fall back to the existing unauthenticated probe rather than crashing.

Same class of bug as #64760.

## Verification

Live verification against the active ChatGPT Pro account (account_id `e5d82550-…`):

- `_fetch_models_from_api` now returns 10 models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, plus the three `-pro` forward-compat variants.
- `_fetch_codex_oauth_context_lengths` now resolves 8 slugs to 272K context, matching the live API.
- End-to-end: `hermes chat -Q -m gpt-5.6-sol --provider openai-codex -q "Reply with one word: pong"` returns `pong` cleanly (previously hung or returned 520).

Tests:

- 21/21 `tests/hermes_cli/test_codex_models.py` pass (19 existing + 2 new regression tests covering the new header behaviour).
- 164/164 across the full Codex/auth test suite pass (`test_codex_models`, `test_auth_codex_provider`, `test_auth_codex_self_heal`, `test_codex_cli_model_picker`, `test_codex_runtime_switch`, `test_codex_runtime_plugin_migration`, `test_openai_codex_model_validation_fallback`).

## Diff stat

```
agent/model_metadata.py                 | 36 +++++++++++++++++++++++++++++++++++-
hermes_cli/codex_models.py              | 37 ++++++++++++++++++++++++++++++++++++-
tests/hermes_cli/test_codex_models.py   | 77 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
3 files changed, 148 insertions(+), 2 deletions(-)
```

Local commit: `5597b2fd1` (on top of `d97898f8` + `3f0b0e20e`).