### PR TITLE
fix: encoding round-trip for skills_hub/skills_sync cache and lock reads (supersedes #62667)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1042,7 +1042,7 @@ class GitHubSource(SkillSource):
             stat = cache_file.stat()
             if time.time() - stat.st_mtime > INDEX_CACHE_TTL:
                 return None
-            return json.loads(cache_file.read_text())
+            return json.loads(cache_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return None
 
@@ -3231,7 +3231,7 @@ def _read_index_cache(key: str) -> Optional[Any]:
         stat = cache_file.stat()
         if time.time() - stat.st_mtime > INDEX_CACHE_TTL:
             return None
-        return json.loads(cache_file.read_text())
+        return json.loads(cache_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -3285,7 +3285,7 @@ class HubLockFile:
         if not self.path.exists():
             return {"version": 1, "installed": {}}
         try:
-            return json.loads(self.path.read_text())
+            return json.loads(self.path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             return {"version": 1, "installed": {}}
 
@@ -3357,7 +3357,7 @@ class TapsManager:
         if not self.path.exists():
             return []
         try:
-            data = json.loads(self.path.read_text())
+            data = json.loads(self.path.read_text(encoding="utf-8"))
             return data.get("taps", [])
         except (json.JSONDecodeError, OSError):
             return []
@@ -3675,7 +3675,7 @@ def _load_hermes_index() -> Optional[dict]:
         try:
             age = time.time() - hermes_index_cache_file.stat().st_mtime
             if age < HERMES_INDEX_TTL:
-                return json.loads(hermes_index_cache_file.read_text())
+                return json.loads(hermes_index_cache_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             pass
 
@@ -3741,7 +3741,7 @@ def _load_stale_index_cache() -> Optional[dict]:
     hermes_index_cache_file = _hermes_index_cache_file()
     if hermes_index_cache_file.exists():
         try:
-            return json.loads(hermes_index_cache_file.read_text())
+            return json.loads(hermes_index_cache_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             pass
     return None

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -402,7 +402,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
 
     lock_path = SKILLS_DIR / ".hub" / "lock.json"
     try:
-        data = json.loads(lock_path.read_text()) if lock_path.exists() else {"version": 1, "installed": {}}
+        data = json.loads(lock_path.read_text(encoding="utf-8")) if lock_path.exists() else {"version": 1, "installed": {}}
     except (json.JSONDecodeError, OSError):
         data = {"version": 1, "installed": {}}
     installed = data.setdefault("installed", {})


### PR DESCRIPTION
## Supersedes #62667

Addresses all issues raised by @teknium1 in the #62667 review:

### Problem

The write-side callers in `skills_hub.py` use `ensure_ascii=False` (UTF-8 output), but the paired read-side callers use `read_text()` without specifying encoding. On non-UTF-8 Windows locales (e.g. cp1252), this decodes UTF-8 bytes with the system default and corrupts non-ASCII skill names, descriptions, and metadata.

### Fixed read sites (7 total)

| File | Line | Paired write |
|------|------|-------------|
| `tools/skills_hub.py` | 1045 | :1055 `ensure_ascii=False` |
| `tools/skills_hub.py` | 3234 | :3254 `ensure_ascii=False` |
| `tools/skills_hub.py` | 3288 | :3294 HubLockFile `ensure_ascii=False` |
| `tools/skills_hub.py` | 3360 | HubLockFile taps read |
| `tools/skills_hub.py` | 3678 | :3732 hermes_index_cache write |
| `tools/skills_hub.py` | 3744 | :3732 hermes_index_cache write |
| `tools/skills_sync.py` | 405 | reads HubLockFile from skills_hub |

### What this does NOT change

- Read calls that already specify encoding (skills_sync.py:108, 141, 186) are untouched.
- The `ignore_file.write_text(...)` at :3249 writes ASCII-only content, no encoding needed.
- Binary mode reads/writes (`"rb"`/`"wb"`) are unaffected.