### PR TITLE
fix(gateway): allow bounded autonomous recovery restart

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -1,5 +1,11 @@
 """Shared gateway restart constants and parsing helpers."""
 
+import os
+import shlex
+import signal
+import sys
+import subprocess
+
 from hermes_cli.config import DEFAULT_CONFIG
 
 # EX_TEMPFAIL from sysexits.h — used to ask the service manager to restart
@@ -24,3 +30,89 @@ def parse_restart_drain_timeout(raw: object) -> float:
     except (TypeError, ValueError):
         return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     return max(0.0, value)
+
+
+def _service_names() -> tuple[str, str]:
+    from hermes_cli.gateway import get_launchd_label, get_service_name
+
+    return get_service_name(), get_launchd_label()
+
+
+def is_gateway_restart_command(command: str) -> bool:
+    """Return whether *command* is an exact gateway restart command."""
+    if not isinstance(command, str) or any(char in command for char in ";|&$`()<>"):
+        return False
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return False
+    if parts == ["hermes", "gateway", "restart"]:
+        return True
+    if not parts:
+        return False
+
+    service_name, launchd_label = _service_names()
+    executable = parts[0].rsplit("/", 1)[-1]
+    if executable == "systemctl" and "restart" in parts:
+        action = parts.index("restart")
+        return parts[action + 1:] in ([service_name], [f"{service_name}.service"])
+    if executable == "launchctl" and ("restart" in parts or "kickstart" in parts):
+        action = "restart" if "restart" in parts else "kickstart"
+        target = parts[parts.index(action) + 1:]
+        return len(target) == 1 and target[0].endswith(f"/{launchd_label}")
+    return False
+
+
+def _is_cron_session() -> bool | None:
+    try:
+        from gateway.session_context import get_session_env
+
+        return bool(get_session_env("HERMES_CRON_SESSION", ""))
+    except Exception:
+        return None
+
+
+def _is_current_supervisor() -> bool:
+    service_name, launchd_label = _service_names()
+    pid = str(os.getpid())
+    if sys.platform == "linux":
+        if not os.environ.get("INVOCATION_ID"):
+            return False
+        for scope in ([], ["--user"]):
+            try:
+                result = subprocess.run(
+                    ["systemctl", *scope, "show", service_name, "--property=MainPID", "--value"],
+                    capture_output=True, text=True, timeout=2, check=False,
+                )
+            except OSError:
+                continue
+            if result.returncode == 0 and result.stdout.strip() == pid:
+                return True
+        return False
+    if sys.platform == "darwin" and os.environ.get("XPC_SERVICE_NAME", "0") == launchd_label:
+        try:
+            result = subprocess.run(
+                ["launchctl", "list", launchd_label],
+                capture_output=True, text=True, timeout=2, check=False,
+            )
+        except OSError:
+            return False
+        return result.returncode == 0 and result.stdout.split(maxsplit=1)[0:1] == [pid]
+    return False
+
+
+def request_approved_gateway_restart_handoff() -> tuple[bool, str]:
+    """Deliver a restart request to the existing supervised gateway handler."""
+    cron_session = _is_cron_session()
+    if cron_session is not False:
+        return False, "Blocked: cron or unknown session context cannot restart the gateway."
+    if sys.platform not in {"darwin", "linux"} or not hasattr(signal, "SIGUSR1"):
+        return False, "Gateway self-restart handoff is supported only by launchd or systemd."
+    if not _is_current_supervisor():
+        return False, "Blocked: gateway self-restart requires its active launchd or systemd service."
+
+    try:
+        os.kill(os.getpid(), signal.SIGUSR1)
+    except OSError as exc:
+        return False, f"Could not deliver gateway restart request: {exc}"
+    return True, "Gateway restart request delivered to the supervised gateway."

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -1,12 +1,23 @@
-"""Shared gateway restart constants and parsing helpers."""
+"""Shared gateway restart constants and bounded recovery helpers."""
 
+import json
 import os
-import shlex
 import signal
-import sys
 import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # Windows imports this module but cannot use this handoff.
+    fcntl = None
 
 from hermes_cli.config import DEFAULT_CONFIG
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 
 # EX_TEMPFAIL from sysexits.h — used to ask the service manager to restart
 # the gateway after a graceful drain/reload path completes.
@@ -22,6 +33,12 @@ DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT = float(
     DEFAULT_CONFIG["agent"]["restart_drain_timeout"]
 )
 
+# A resumed recovery turn must not immediately restart the gateway again.
+GATEWAY_RECOVERY_RESTART_COOLDOWN_SECONDS = 300.0
+_RECOVERY_RESTART_STATE_FILE = ".gateway_recovery_restart.json"
+_RECOVERY_RESTART_LOCK_FILE = ".gateway_recovery_restart.lock"
+_recovery_restart_lock = threading.Lock()
+
 
 def parse_restart_drain_timeout(raw: object) -> float:
     """Parse a configured drain timeout, falling back to the shared default."""
@@ -32,35 +49,9 @@ def parse_restart_drain_timeout(raw: object) -> float:
     return max(0.0, value)
 
 
-def _service_names() -> tuple[str, str]:
-    from hermes_cli.gateway import get_launchd_label, get_service_name
-
-    return get_service_name(), get_launchd_label()
-
-
 def is_gateway_restart_command(command: str) -> bool:
-    """Return whether *command* is an exact gateway restart command."""
-    if not isinstance(command, str) or any(char in command for char in ";|&$`()<>"):
-        return False
-    try:
-        parts = shlex.split(command)
-    except ValueError:
-        return False
-    if parts == ["hermes", "gateway", "restart"]:
-        return True
-    if not parts:
-        return False
-
-    service_name, launchd_label = _service_names()
-    executable = parts[0].rsplit("/", 1)[-1]
-    if executable == "systemctl" and "restart" in parts:
-        action = parts.index("restart")
-        return parts[action + 1:] in ([service_name], [f"{service_name}.service"])
-    if executable == "launchctl" and ("restart" in parts or "kickstart" in parts):
-        action = "restart" if "restart" in parts else "kickstart"
-        target = parts[parts.index(action) + 1:]
-        return len(target) == 1 and target[0].endswith(f"/{launchd_label}")
-    return False
+    """Return whether *command* is the literal supported recovery intent."""
+    return isinstance(command, str) and command.strip(" ") == "hermes gateway restart"
 
 
 def _is_cron_session() -> bool | None:
@@ -70,6 +61,12 @@ def _is_cron_session() -> bool | None:
         return bool(get_session_env("HERMES_CRON_SESSION", ""))
     except Exception:
         return None
+
+
+def _service_names() -> tuple[str, str]:
+    from hermes_cli.gateway import get_launchd_label, get_service_name
+
+    return get_service_name(), get_launchd_label()
 
 
 def _is_current_supervisor() -> bool:
@@ -101,18 +98,89 @@ def _is_current_supervisor() -> bool:
     return False
 
 
-def request_approved_gateway_restart_handoff() -> tuple[bool, str]:
-    """Deliver a restart request to the existing supervised gateway handler."""
-    cron_session = _is_cron_session()
-    if cron_session is not False:
+def _recovery_state_path() -> Path:
+    return get_hermes_home() / _RECOVERY_RESTART_STATE_FILE
+
+
+def _recovery_lock_path() -> Path:
+    return get_hermes_home() / _RECOVERY_RESTART_LOCK_FILE
+
+
+@contextmanager
+def _locked_recovery_state():
+    """Serialize admission across gateway threads and sibling processes."""
+    with _recovery_restart_lock:
+        lock_path = _recovery_lock_path()
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _load_recovery_state() -> dict[str, object]:
+    try:
+        with _recovery_state_path().open(encoding="utf-8") as state_file:
+            state = json.load(state_file)
+        return state if isinstance(state, dict) else {}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def _is_cooldown_active(state: dict[str, object], session_id: str, now: float) -> bool:
+    if state.get("session_id") != session_id or state.get("outcome") != "scheduled":
+        return False
+    try:
+        scheduled_at = float(state["scheduled_at"])
+    except (KeyError, TypeError, ValueError):
+        return True  # Malformed successful state fails closed rather than looping.
+    return now - scheduled_at < GATEWAY_RECOVERY_RESTART_COOLDOWN_SECONDS
+
+
+def request_gateway_recovery_restart(
+    *, session_id: str | None, task_id: str | None, reason: str = "agent_recovery"
+) -> tuple[bool, str]:
+    """Schedule one audited, supervised recovery restart for an active session.
+
+    This receives metadata from the terminal tool invocation, not from prompt
+    text. Only the literal canonical command can reach this helper.
+    """
+    if not isinstance(session_id, str) or not session_id:
+        return False, "Blocked: gateway recovery restart requires an active session."
+    if _is_cron_session() is not False:
         return False, "Blocked: cron or unknown session context cannot restart the gateway."
     if sys.platform not in {"darwin", "linux"} or not hasattr(signal, "SIGUSR1"):
-        return False, "Gateway self-restart handoff is supported only by launchd or systemd."
+        return False, "Gateway recovery restart is supported only by launchd or systemd."
     if not _is_current_supervisor():
-        return False, "Blocked: gateway self-restart requires its active launchd or systemd service."
+        return False, "Blocked: gateway recovery restart requires its active launchd or systemd service."
 
+    now = time.time()
+    state = {
+        "reason": reason,
+        "session_id": session_id,
+        "task_id": task_id or None,
+        "attempted_at": now,
+        "outcome": "pending",
+    }
     try:
-        os.kill(os.getpid(), signal.SIGUSR1)
+        with _locked_recovery_state():
+            if _is_cooldown_active(_load_recovery_state(), session_id, now):
+                return False, "Blocked: gateway recovery restart cooldown is active for this session."
+            atomic_json_write(_recovery_state_path(), state, indent=None, mode=0o600)
+            try:
+                os.kill(os.getpid(), signal.SIGUSR1)
+            except OSError as exc:
+                state["outcome"] = "delivery_failed"
+                state["failure"] = str(exc)
+                atomic_json_write(_recovery_state_path(), state, indent=None, mode=0o600)
+                return False, f"Could not deliver gateway recovery restart request: {exc}"
+            state["outcome"] = "scheduled"
+            state["scheduled_at"] = time.time()
+            atomic_json_write(_recovery_state_path(), state, indent=None, mode=0o600)
     except OSError as exc:
-        return False, f"Could not deliver gateway restart request: {exc}"
-    return True, "Gateway restart request delivered to the supervised gateway."
+        return False, f"Could not record gateway recovery restart: {exc}"
+    return True, "Gateway recovery restart accepted and scheduled through its supervisor."

--- a/tests/gateway/test_restart_handoff.py
+++ b/tests/gateway/test_restart_handoff.py
@@ -1,5 +1,6 @@
-"""Regression coverage for approved gateway restart handoff."""
+"""Regression coverage for bounded autonomous gateway recovery restarts."""
 
+import json
 import signal
 
 import pytest
@@ -7,88 +8,128 @@ import pytest
 import gateway.restart as restart
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "hermes gateway restart",
-        "systemctl --user restart hermes-gateway",
-        "launchctl kickstart gui/501/ai.hermes.gateway",
-    ],
-)
-def test_recognizes_standalone_gateway_restart_commands(command):
+@pytest.mark.parametrize("command", ["hermes gateway restart", "  hermes gateway restart  "])
+def test_recognizes_only_canonical_gateway_restart_command(command):
     assert restart.is_gateway_restart_command(command)
 
 
 @pytest.mark.parametrize(
     "command",
     [
-        "systemctl stop hermes-gateway",
+        "systemctl --user restart hermes-gateway",
+        "launchctl kickstart gui/501/ai.hermes.gateway",
+        "hermes gateway restart --force",
+        "hermes gateway 'restart'",
+        "hermes gateway re\\start",
+        "hermes gateway restart\n",
+        "echo hermes gateway restart",
+        "hermes gateway restart; rm -rf /",
         "pkill -f hermes.*gateway",
-        "systemctl restart nginx",
-        "systemctl restart hermes-gateway; rm -rf /",
-        "systemctl restart hermes-gateway-backup",
-        "launchctl kickstart gui/501/ai.hermes.gateway-backup",
     ],
 )
-def test_rejects_non_restart_or_compound_commands(command):
+def test_rejects_raw_commands_and_source_text(command):
     assert not restart.is_gateway_restart_command(command)
 
 
-def test_systemd_handoff_signals_gateway_process(monkeypatch):
+def _enable_systemd_handoff(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(restart, "_is_cron_session", lambda: False)
     monkeypatch.setattr(restart.sys, "platform", "linux")
-    monkeypatch.setenv("INVOCATION_ID", "unit-invocation")
     monkeypatch.setattr(restart, "_is_current_supervisor", lambda: True)
+    monkeypatch.setattr(restart, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(restart.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+    return calls
 
-    accepted, message = restart.request_approved_gateway_restart_handoff()
+
+def test_autonomous_handoff_records_origin_and_signals_gateway(monkeypatch, tmp_path):
+    calls = _enable_systemd_handoff(monkeypatch, tmp_path)
+
+    accepted, message = restart.request_gateway_recovery_restart(
+        session_id="telegram:chat:42", task_id="turn-7"
+    )
 
     assert accepted is True
-    assert "request delivered" in message
+    assert "accepted and scheduled" in message
     assert calls == [(restart.os.getpid(), signal.SIGUSR1)]
+    state = json.loads((tmp_path / ".gateway_recovery_restart.json").read_text())
+    assert state["reason"] == "agent_recovery"
+    assert state["session_id"] == "telegram:chat:42"
+    assert state["task_id"] == "turn-7"
+    assert isinstance(state["attempted_at"], float)
 
 
-def test_launchd_handoff_signals_gateway_process(monkeypatch):
+def test_launchd_handoff_signals_gateway_process(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(restart, "_is_cron_session", lambda: False)
     monkeypatch.setattr(restart.sys, "platform", "darwin")
-    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
     monkeypatch.setattr(restart, "_is_current_supervisor", lambda: True)
+    monkeypatch.setattr(restart, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(restart.os, "kill", lambda pid, sig: calls.append((pid, sig)))
 
-    accepted, _message = restart.request_approved_gateway_restart_handoff()
+    accepted, _message = restart.request_gateway_recovery_restart(
+        session_id="session", task_id=None
+    )
 
     assert accepted is True
     assert calls == [(restart.os.getpid(), signal.SIGUSR1)]
 
 
-def test_manual_gateway_fails_closed_without_supervisor(monkeypatch):
-    monkeypatch.setattr(restart, "_is_cron_session", lambda: False)
-    monkeypatch.setattr(restart, "_is_current_supervisor", lambda: False)
-    monkeypatch.setattr(restart.sys, "platform", "linux")
-    monkeypatch.delenv("INVOCATION_ID", raising=False)
+def test_cooldown_blocks_recursive_recovery_restart(monkeypatch, tmp_path):
+    calls = _enable_systemd_handoff(monkeypatch, tmp_path)
+    monkeypatch.setattr(restart.time, "time", lambda: 1000.0)
+
+    assert restart.request_gateway_recovery_restart(session_id="session", task_id="turn")[0]
+    accepted, message = restart.request_gateway_recovery_restart(session_id="session", task_id="resumed-turn")
+
+    assert accepted is False
+    assert "cooldown" in message
+    assert len(calls) == 1
+
+
+def test_different_session_is_not_blocked_by_prior_recovery(monkeypatch, tmp_path):
+    calls = _enable_systemd_handoff(monkeypatch, tmp_path)
+    monkeypatch.setattr(restart.time, "time", lambda: 1000.0)
+
+    assert restart.request_gateway_recovery_restart(session_id="first", task_id=None)[0]
+    assert restart.request_gateway_recovery_restart(session_id="second", task_id=None)[0]
+    assert len(calls) == 2
+
+
+def test_cron_session_cannot_schedule_restart(monkeypatch, tmp_path):
+    monkeypatch.setattr(restart, "_is_cron_session", lambda: True)
+    monkeypatch.setattr(restart, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(restart.os, "kill", lambda *_args: pytest.fail("must not signal"))
 
-    accepted, message = restart.request_approved_gateway_restart_handoff()
+    accepted, message = restart.request_gateway_recovery_restart(session_id="session", task_id=None)
+
+    assert accepted is False
+    assert "cron or unknown session context" in message
+
+
+def test_manual_gateway_fails_closed_without_supervisor(monkeypatch, tmp_path):
+    monkeypatch.setattr(restart, "_is_cron_session", lambda: False)
+    monkeypatch.setattr(restart, "_is_current_supervisor", lambda: False)
+    monkeypatch.setattr(restart, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(restart.os, "kill", lambda *_args: pytest.fail("must not signal"))
+
+    accepted, message = restart.request_gateway_recovery_restart(session_id="session", task_id=None)
 
     assert accepted is False
     assert "active launchd or systemd service" in message
 
 
-def test_cron_session_cannot_schedule_restart(monkeypatch):
-    monkeypatch.setattr(restart, "_is_cron_session", lambda: True)
-    monkeypatch.setattr(restart.os, "kill", lambda *_args: pytest.fail("must not signal"))
+def test_signal_failure_is_reported_truthfully_without_consuming_cooldown(monkeypatch, tmp_path):
+    _enable_systemd_handoff(monkeypatch, tmp_path)
+    monkeypatch.setattr(restart.os, "kill", lambda *_args: (_ for _ in ()).throw(OSError("denied")))
 
-    accepted, message = restart.request_approved_gateway_restart_handoff()
-
-    assert accepted is False
-    assert "cron or unknown session context" in message
-def test_unknown_session_context_cannot_schedule_restart(monkeypatch):
-    monkeypatch.setattr(restart, "_is_cron_session", lambda: None)
-    monkeypatch.setattr(restart.os, "kill", lambda *_args: pytest.fail("must not signal"))
-
-    accepted, message = restart.request_approved_gateway_restart_handoff()
+    accepted, message = restart.request_gateway_recovery_restart(session_id="session", task_id=None)
 
     assert accepted is False
-    assert "cron or unknown session context" in message
+    assert "Could not deliver" in message
+
+    calls = []
+    monkeypatch.setattr(restart.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+    accepted, _message = restart.request_gateway_recovery_restart(session_id="session", task_id=None)
+
+    assert accepted is True
+    assert calls == [(restart.os.getpid(), signal.SIGUSR1)]

--- a/tests/gateway/test_restart_handoff.py
+++ b/tests/gateway/test_restart_handoff.py
@@ -1,0 +1,94 @@
+"""Regression coverage for approved gateway restart handoff."""
+
+import signal
+
+import pytest
+
+import gateway.restart as restart
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "hermes gateway restart",
+        "systemctl --user restart hermes-gateway",
+        "launchctl kickstart gui/501/ai.hermes.gateway",
+    ],
+)
+def test_recognizes_standalone_gateway_restart_commands(command):
+    assert restart.is_gateway_restart_command(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "systemctl stop hermes-gateway",
+        "pkill -f hermes.*gateway",
+        "systemctl restart nginx",
+        "systemctl restart hermes-gateway; rm -rf /",
+        "systemctl restart hermes-gateway-backup",
+        "launchctl kickstart gui/501/ai.hermes.gateway-backup",
+    ],
+)
+def test_rejects_non_restart_or_compound_commands(command):
+    assert not restart.is_gateway_restart_command(command)
+
+
+def test_systemd_handoff_signals_gateway_process(monkeypatch):
+    calls = []
+    monkeypatch.setattr(restart, "_is_cron_session", lambda: False)
+    monkeypatch.setattr(restart.sys, "platform", "linux")
+    monkeypatch.setenv("INVOCATION_ID", "unit-invocation")
+    monkeypatch.setattr(restart, "_is_current_supervisor", lambda: True)
+    monkeypatch.setattr(restart.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+
+    accepted, message = restart.request_approved_gateway_restart_handoff()
+
+    assert accepted is True
+    assert "request delivered" in message
+    assert calls == [(restart.os.getpid(), signal.SIGUSR1)]
+
+
+def test_launchd_handoff_signals_gateway_process(monkeypatch):
+    calls = []
+    monkeypatch.setattr(restart, "_is_cron_session", lambda: False)
+    monkeypatch.setattr(restart.sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+    monkeypatch.setattr(restart, "_is_current_supervisor", lambda: True)
+    monkeypatch.setattr(restart.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+
+    accepted, _message = restart.request_approved_gateway_restart_handoff()
+
+    assert accepted is True
+    assert calls == [(restart.os.getpid(), signal.SIGUSR1)]
+
+
+def test_manual_gateway_fails_closed_without_supervisor(monkeypatch):
+    monkeypatch.setattr(restart, "_is_cron_session", lambda: False)
+    monkeypatch.setattr(restart, "_is_current_supervisor", lambda: False)
+    monkeypatch.setattr(restart.sys, "platform", "linux")
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(restart.os, "kill", lambda *_args: pytest.fail("must not signal"))
+
+    accepted, message = restart.request_approved_gateway_restart_handoff()
+
+    assert accepted is False
+    assert "active launchd or systemd service" in message
+
+
+def test_cron_session_cannot_schedule_restart(monkeypatch):
+    monkeypatch.setattr(restart, "_is_cron_session", lambda: True)
+    monkeypatch.setattr(restart.os, "kill", lambda *_args: pytest.fail("must not signal"))
+
+    accepted, message = restart.request_approved_gateway_restart_handoff()
+
+    assert accepted is False
+    assert "cron or unknown session context" in message
+def test_unknown_session_context_cannot_schedule_restart(monkeypatch):
+    monkeypatch.setattr(restart, "_is_cron_session", lambda: None)
+    monkeypatch.setattr(restart.os, "kill", lambda *_args: pytest.fail("must not signal"))
+
+    accepted, message = restart.request_approved_gateway_restart_handoff()
+
+    assert accepted is False
+    assert "cron or unknown session context" in message

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -280,13 +280,7 @@ class TestGatewaySelfTargetingGuard:
 # ---------------------------------------------------------------------------
 
 class TestTerminalToolGatewayLifecycleGuard:
-    """terminal_tool must refuse gateway lifecycle commands when _HERMES_GATEWAY=1.
-
-    Issue #37453: systemctl --user restart hermes-gateway runs as a child of the
-    gateway process.  When systemd delivers SIGTERM the gateway kills its own
-    restart command mid-execution — the service may never restart.  The guard
-    must fire before execution, unconditionally (force=True cannot bypass it).
-    """
+    """Terminal lifecycle commands are blocked except approved safe handoffs."""
 
     def _make_fake_env(self):
         class _FakeEnv:
@@ -307,6 +301,8 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
         if inside_gateway:
             monkeypatch.setenv("_HERMES_GATEWAY", "1")
+            monkeypatch.delenv("INVOCATION_ID", raising=False)
+            monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
         else:
             monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
 
@@ -337,6 +333,55 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
+    def test_approved_restart_uses_safe_handoff(self, monkeypatch):
+        import gateway.restart as restart
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        monkeypatch.setattr(
+            restart,
+            "request_approved_gateway_restart_handoff",
+            lambda: (True, "Gateway restart accepted and scheduled through its supervisor."),
+        )
+
+        monkeypatch.setattr(
+            tt,
+            "_check_all_guards",
+            lambda *_args, **_kwargs: {"approved": True, "user_approved": True},
+        )
+        result = json.loads(tt.terminal_tool(
+            command="systemctl --user restart hermes-gateway"
+        ))
+
+        assert result == {
+            "output": "Gateway restart accepted and scheduled through its supervisor.",
+            "exit_code": 0,
+            "error": "",
+            "status": "completed",
+            "restart_scheduled": True,
+        }
+    def test_smart_approval_cannot_schedule_restart(self, monkeypatch):
+        import gateway.restart as restart
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt,
+            "_check_all_guards",
+            lambda *_args, **_kwargs: {"approved": True, "smart_approved": True},
+        )
+        monkeypatch.setattr(
+            restart.os,
+            "kill",
+            lambda *_args: pytest.fail("must not schedule"),
+        )
+
+        result = json.loads(tt.terminal_tool(
+            command="systemctl restart hermes-gateway"
+        ))
+
+        assert result["exit_code"] == 1
+        assert result.get("restart_scheduled") is not True
 
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
         """Non-hermes systemctl commands must not be blocked by this guard."""

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -310,66 +310,74 @@ class TestTerminalToolGatewayLifecycleGuard:
         "systemctl restart hermes-gateway",
         "systemctl --user restart hermes-gateway",
         "systemctl stop hermes-gateway.service",
-        "hermes gateway restart",
         "launchctl kickstart gui/501/ai.hermes.gateway",
         "pkill -f hermes.*gateway",
     ])
-    def test_blocks_lifecycle_commands_inside_gateway(self, monkeypatch, cmd):
+    def test_blocks_raw_lifecycle_commands_inside_gateway(self, monkeypatch, cmd):
         import tools.terminal_tool as tt
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
-        result = json.loads(tt.terminal_tool(command=cmd))
+        result = json.loads(tt.terminal_tool(command=cmd, session_id="session"))
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
 
-    def test_force_true_cannot_bypass_block(self, monkeypatch):
+    def test_force_cannot_bypass_raw_lifecycle_block(self, monkeypatch):
         import tools.terminal_tool as tt
-        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
         result = json.loads(tt.terminal_tool(
-            command="systemctl restart hermes-gateway", force=True
+            command="systemctl restart hermes-gateway", session_id="session", force=True
         ))
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
-    def test_approved_restart_uses_safe_handoff(self, monkeypatch):
+    def test_autonomous_canonical_restart_uses_safe_handoff(self, monkeypatch):
+        import gateway.restart as restart
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        calls = []
+        monkeypatch.setattr(
+            restart,
+            "request_gateway_recovery_restart",
+            lambda **kwargs: (calls.append(kwargs) or (True, "Gateway recovery restart accepted and scheduled through its supervisor.")),
+        )
+        monkeypatch.setattr(
+            tt,
+            "_check_all_guards",
+            lambda *_args, **_kwargs: pytest.fail("recovery handoff must not require approval"),
+        )
+
+        result = json.loads(tt.terminal_tool(
+            command="hermes gateway restart", session_id="gateway-session", task_id="turn-1"
+        ))
+
+        assert result["restart_scheduled"] is True
+        assert calls == [{"session_id": "gateway-session", "task_id": "turn-1"}]
+
+    def test_canonical_restart_without_active_session_fails_closed(self, monkeypatch):
         import gateway.restart as restart
         import tools.terminal_tool as tt
 
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
         monkeypatch.setattr(
             restart,
-            "request_approved_gateway_restart_handoff",
-            lambda: (True, "Gateway restart accepted and scheduled through its supervisor."),
+            "request_gateway_recovery_restart",
+            lambda **kwargs: (False, "Blocked: gateway recovery restart requires an active session."),
         )
 
-        monkeypatch.setattr(
-            tt,
-            "_check_all_guards",
-            lambda *_args, **_kwargs: {"approved": True, "user_approved": True},
-        )
-        result = json.loads(tt.terminal_tool(
-            command="systemctl --user restart hermes-gateway"
-        ))
+        result = json.loads(tt.terminal_tool(command="hermes gateway restart"))
 
-        assert result == {
-            "output": "Gateway restart accepted and scheduled through its supervisor.",
-            "exit_code": 0,
-            "error": "",
-            "status": "completed",
-            "restart_scheduled": True,
-        }
-    def test_smart_approval_cannot_schedule_restart(self, monkeypatch):
+        assert result["exit_code"] == 1
+        assert result["restart_scheduled"] is False
+        assert "active session" in result["error"]
+
+    def test_source_text_cannot_schedule_restart(self, monkeypatch):
         import gateway.restart as restart
         import tools.terminal_tool as tt
 
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
-        monkeypatch.setattr(
-            tt,
-            "_check_all_guards",
-            lambda *_args, **_kwargs: {"approved": True, "smart_approved": True},
-        )
         monkeypatch.setattr(
             restart.os,
             "kill",
@@ -377,12 +385,10 @@ class TestTerminalToolGatewayLifecycleGuard:
         )
 
         result = json.loads(tt.terminal_tool(
-            command="systemctl restart hermes-gateway"
+            command="echo hermes gateway restart", session_id="gateway-session"
         ))
 
-        assert result["exit_code"] == 1
-        assert result.get("restart_scheduled") is not True
-
+        assert result["exit_code"] != 0
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
         """Non-hermes systemctl commands must not be blocked by this guard."""
         import tools.terminal_tool as tt

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2081,6 +2081,29 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
+        # Only a live gateway agent tool call of this exact canonical command
+        # reaches the supervised recovery handoff. It is deliberately before
+        # command approval and environment creation: recovery is not authorized
+        # by prompt text or a user approval for a raw service-manager command.
+        if os.environ.get("_HERMES_GATEWAY") == "1":
+            from gateway.restart import (
+                is_gateway_restart_command,
+                request_gateway_recovery_restart,
+            )
+
+            if is_gateway_restart_command(command):
+                accepted, message = request_gateway_recovery_restart(
+                    session_id=session_id,
+                    task_id=task_id,
+                )
+                return json.dumps({
+                    "output": message,
+                    "exit_code": 0 if accepted else 1,
+                    "error": "" if accepted else message,
+                    "status": "completed" if accepted else "error",
+                    "restart_scheduled": accepted,
+                }, ensure_ascii=False)
+
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]
@@ -2318,34 +2341,17 @@ def terminal_tool(
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
 
-        # Lifecycle commands cannot run as child processes: service-manager
-        # termination kills the child before it can report completion. A fresh
-        # owner approval can request a supervised POSIX gateway restart by
-        # signalling the existing in-process graceful-restart handler instead.
+        # Gateway lifecycle commands cannot run as child processes: service-
+        # manager termination kills the child before it can report completion.
+        # The only recovery exception was handled above for the canonical
+        # Hermes command; raw service-manager and kill commands stay blocked.
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from hermes_cli.cron import _contains_gateway_lifecycle_command
             if _contains_gateway_lifecycle_command(command):
-                from gateway.restart import (
-                    is_gateway_restart_command,
-                    request_approved_gateway_restart_handoff,
-                )
-
-                if _user_approved_run and is_gateway_restart_command(command):
-                    accepted, message = request_approved_gateway_restart_handoff()
-                    return json.dumps({
-                        "output": message,
-                        "exit_code": 0 if accepted else 1,
-                        "error": "" if accepted else message,
-                        "status": "completed" if accepted else "error",
-                        "restart_scheduled": accepted,
-                    }, ensure_ascii=False)
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,
-                    "error": (
-                        "Blocked: gateway lifecycle commands require a fresh owner "
-                        "approval and a supported supervisor handoff."
-                    ),
+                    "error": "Blocked: gateway lifecycle commands cannot run inside the gateway.",
                     "status": "error",
                 }, ensure_ascii=False)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2265,28 +2265,6 @@ def terminal_tool(
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
-        # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
-        # restart|stop targeting hermes-gateway) must never run inside the
-        # gateway process itself. The restart would SIGTERM the gateway, which
-        # kills this very subprocess before it can complete — the service may
-        # never restart. This mirrors the `hermes gateway restart` guard in
-        # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
-        # but applies unconditionally (force=True cannot help here).
-        if os.environ.get("_HERMES_GATEWAY") == "1":
-            from hermes_cli.cron import _contains_gateway_lifecycle_command
-            if _contains_gateway_lifecycle_command(command):
-                return json.dumps({
-                    "output": "",
-                    "exit_code": 1,
-                    "error": (
-                        "Blocked: cannot restart or stop the gateway from inside the "
-                        "gateway process. The gateway would kill this command before "
-                        "it could complete (SIGTERM propagates to child processes). "
-                        "Run `hermes gateway restart` from a separate shell outside "
-                        "the running gateway."
-                    ),
-                    "status": "error",
-                }, ensure_ascii=False)
 
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
@@ -2296,6 +2274,7 @@ def terminal_tool(
         # an approved command can't be SIGINT-killed by a bit that landed during
         # the approval-wait (see clear_current_thread_interrupt).
         _approved_run = bool(force)
+        _user_approved_run = False
         if not force:
             approval = _check_all_guards(
                 command, env_type,
@@ -2333,9 +2312,42 @@ def terminal_tool(
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command required approval ({desc}) and was approved by the user."
                 _approved_run = True
+                _user_approved_run = True
+
             elif approval.get("smart_approved"):
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
+
+        # Lifecycle commands cannot run as child processes: service-manager
+        # termination kills the child before it can report completion. A fresh
+        # owner approval can request a supervised POSIX gateway restart by
+        # signalling the existing in-process graceful-restart handler instead.
+        if os.environ.get("_HERMES_GATEWAY") == "1":
+            from hermes_cli.cron import _contains_gateway_lifecycle_command
+            if _contains_gateway_lifecycle_command(command):
+                from gateway.restart import (
+                    is_gateway_restart_command,
+                    request_approved_gateway_restart_handoff,
+                )
+
+                if _user_approved_run and is_gateway_restart_command(command):
+                    accepted, message = request_approved_gateway_restart_handoff()
+                    return json.dumps({
+                        "output": message,
+                        "exit_code": 0 if accepted else 1,
+                        "error": "" if accepted else message,
+                        "status": "completed" if accepted else "error",
+                        "restart_scheduled": accepted,
+                    }, ensure_ascii=False)
+                return json.dumps({
+                    "output": "",
+                    "exit_code": 1,
+                    "error": (
+                        "Blocked: gateway lifecycle commands require a fresh owner "
+                        "approval and a supported supervisor handoff."
+                    ),
+                    "status": "error",
+                }, ensure_ascii=False)
 
         # Validate workdir against shell injection
         if workdir:


### PR DESCRIPTION
## Summary
- permit only literal `hermes gateway restart` from a live gateway terminal tool call to schedule a supervised recovery restart
- serialize the recovery admission decision, persist the recovery reason, session, task, outcome, and attempt time, and reject successful repeat attempts for that session during the cooldown
- keep raw `systemctl`, `launchctl`, kill, and stop commands blocked, including when forced

This restores the bounded autonomous recovery capability described in #37453 after 245b95b hard-blocked gateway lifecycle subprocesses. User-explicit restart uses the same handoff but is not a prerequisite: authorization comes from the active tool call, never prompt, web, file, or source text. Cron and unknown contexts fail closed. The existing SIGUSR1 drain, supervisor restart, and pending-session resume path provide the single restart/resume handoff.

## Verification
- `scripts/run_tests.sh tests/gateway/test_restart_handoff.py tests/hermes_cli/test_gateway_restart_loop.py tests/gateway/test_restart_drain.py tests/gateway/test_restart_notification.py tests/gateway/test_clean_shutdown_marker.py -q`
- 147 passed
- `git diff --check`