### PR TITLE
docs(config): document terminal.shell_init_files + auto_source_bashrc in the terminal reference

### DIFF
--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -163,7 +163,7 @@ The installer handles this automatically — if you see this error during manual
 
 **Cause:** Hermes builds a per-session environment snapshot by running `bash -l` once at startup. A bash login shell reads `/etc/profile`, `~/.bash_profile`, and `~/.profile`, but **does not source `~/.bashrc`** — so tools that install themselves there (`nvm`, `asdf`, `pyenv`, `cargo`, custom `PATH` exports) stay invisible to the snapshot. This most commonly happens when Hermes runs under systemd or in a minimal shell where nothing has pre-loaded the interactive shell profile.
 
-**Solution:** Hermes auto-sources `~/.bashrc` by default. If that's not enough — e.g. you're a zsh user whose PATH lives in `~/.zshrc`, or you init `nvm` from a standalone file — list the extra files to source in `~/.hermes/config.yaml`:
+**Solution:** On non-Windows, Hermes auto-sources `~/.profile`, `~/.bash_profile`, then `~/.bashrc` by default. If that's not enough — e.g. you're a zsh user whose PATH lives in `~/.zshrc`, or you init `nvm` from a standalone file — list the extra files to source in `~/.hermes/config.yaml`:
 
 ```yaml
 terminal:
@@ -171,8 +171,10 @@ terminal:
     - ~/.zshrc                     # zsh users: pulls zsh-managed PATH into the bash snapshot
     - ~/.nvm/nvm.sh                # direct nvm init (works regardless of shell)
     - /etc/profile.d/cargo.sh      # system-wide rc files
-  # When this list is set, the default ~/.bashrc auto-source is NOT added —
-  # include it explicitly if you want both:
+  # When this list is set, the default auto-source list is NOT added.
+  # Include whichever of those you still want:
+  #   - ~/.profile
+  #   - ~/.bash_profile
   #   - ~/.bashrc
   #   - ~/.zshrc
 ```

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -117,10 +117,14 @@ terminal:
   timeout: 180      # Per-command timeout in seconds
   home_mode: auto   # auto | real | profile — subprocess HOME policy
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
+  shell_init_files: []      # Shell init files to source before the env snapshot (e.g. ~/.zshrc, ~/.nvm/nvm.sh); ~ and ${VAR} expand, missing files are skipped. Setting a list disables the default ~/.bashrc auto-source
+  auto_source_bashrc: true  # Auto-source ~/.bashrc / ~/.profile when shell_init_files is unset, so tools registered there (nvm, asdf, pyenv) stay visible (default: true)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
   modal_image: "nikolaik/python-nodejs:python3.11-nodejs20"                 # Container image for Modal backend
   daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"               # Container image for Daytona backend
 ```
+
+If terminal commands report `command not found` for tools like `nvm` or `pyenv`, see the FAQ entry on shell init files.
 
 For cloud sandboxes such as Modal and Daytona, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -117,14 +117,14 @@ terminal:
   timeout: 180      # Per-command timeout in seconds
   home_mode: auto   # auto | real | profile — subprocess HOME policy
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
-  shell_init_files: []      # Shell init files to source before the env snapshot (e.g. ~/.zshrc, ~/.nvm/nvm.sh); ~ and ${VAR} expand, missing files are skipped. Setting a list disables the default ~/.bashrc auto-source
-  auto_source_bashrc: true  # Auto-source ~/.bashrc / ~/.profile when shell_init_files is unset, so tools registered there (nvm, asdf, pyenv) stay visible (default: true)
+  shell_init_files: []      # Shell init files to source before the env snapshot (e.g. ~/.zshrc, ~/.nvm/nvm.sh); ~ and ${VAR} expand, missing files are skipped. Setting a list replaces the whole default list below, not just ~/.bashrc
+  auto_source_bashrc: true  # Non-Windows only: with shell_init_files unset, source ~/.profile, ~/.bash_profile, then ~/.bashrc so tools registered there (nvm, asdf, pyenv) stay visible (default: true)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
   modal_image: "nikolaik/python-nodejs:python3.11-nodejs20"                 # Container image for Modal backend
   daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"               # Container image for Daytona backend
 ```
 
-If terminal commands report `command not found` for tools like `nvm` or `pyenv`, see the FAQ entry on shell init files.
+If terminal commands report `command not found` for tools like `nvm` or `pyenv`, see the [FAQ](/reference/faq) entry on `node: command not found`.
 
 For cloud sandboxes such as Modal and Daytona, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 


### PR DESCRIPTION
`terminal.shell_init_files` and `terminal.auto_source_bashrc` are implemented (`tools/environments/local.py`, tests in `tests/tools/test_local_shell_init.py`) and documented in the FAQ, but missing from the configuration reference's `terminal:` section where every sibling key lives. this adds the two keys to the yaml block, matching the existing inline-comment style, and cross-links the FAQ entry.

provenance: #17799 asked for a convenient way to make Hermes aware of PATHs (closed, implemented on main); #14534 added the `~/.profile` auto-source. comment semantics verified against `_read_terminal_shell_init_config` / `_resolve_shell_init_files` in `tools/environments/local.py`.