### PR TITLE
fix: retain {10,} floor for ElevenLabs sk_ regex (supersedes #62415)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -96,7 +96,7 @@ _PREFIX_PATTERNS = [
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
     r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
-    r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
+    r"sk_[A-Za-z0-9]{10,}",             # ElevenLabs TTS key (sk_ prefix, no underscore in body to avoid snake_case false positives)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
     r"gsk_[A-Za-z0-9]{10,}",            # Groq Cloud API key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -445,6 +445,20 @@ class TestElevenLabsTavilyExaKeys:
         assert "HOME=/home/user" in result
         assert "SHELL=/bin/bash" in result
 
+    def test_snake_case_identifier_not_falsely_redacted(self):
+        """sk_ followed by snake_case words must not be redacted (false positive guard)."""
+        text = "Call sk_compute_embedding(input_tensor) and sk_normalize_output(result)"
+        result = redact_sensitive_text(text)
+        assert "sk_compute_embedding" in result
+        assert "sk_normalize_output" in result
+
+    def test_elevenlabs_key_10_chars_redacted(self):
+        """Real ElevenLabs key with 10+ alphanumeric chars after sk_ is redacted."""
+        text = "key=sk_a1b2c3d4e5f6g7h8i9j0"
+        result = redact_sensitive_text(text)
+        assert "a1b2c3d4e5f6g7h8i9j0" not in result
+        assert "REDACTED" in result or "***" in result
+
 
 class TestJWTTokens:
     """JWT tokens start with eyJ (base64 for '{') and have dot-separated parts."""


### PR DESCRIPTION
## Supersedes #62415

Addresses @teknium1 review on #62415:

### Problem with #62415

The original PR changed `sk_[A-Za-z0-9_]{10,}` to `sk_[A-Za-z0-9]{20,}` — both removing `_` AND raising the floor from 10 to 20. teknium1 pointed out:

1. Removing `_` alone already prevents the snake_case false positive (`sk_compute_embedding` no longer matches because `_` is not in the character class).
2. Raising to `{20,}` unnecessarily narrows redaction coverage for real 10–19 character ElevenLabs keys.

### Fix

Keep `[A-Za-z0-9]` (no underscore) with `{10,}` minimum:
```python
r"sk_[A-Za-z0-9]{10,}",  # ElevenLabs TTS key
```

### Tests added

- `test_snake_case_identifier_not_falsely_redacted`: `sk_compute_embedding` and `sk_normalize_output` pass through unredacted
- `test_elevenlabs_key_10_chars_redacted`: real 20-char key `sk_a1b2c3d4e5f6g7h8i9j0` is caught