### PR TITLE
fix(kanban): preserve initially blocked human gates

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3260,23 +3260,33 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       finish, transient infra error clears).
 
     The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    ``"blocked"`` / ``"unblocked"`` event for the task.  A ``"created"``
+    event whose payload records ``status="blocked"`` is also sticky: callers
+    use ``initial_status="blocked"`` specifically for immediate human gates,
+    and an empty parent set must not make those gates vacuously ready.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    Returns ``False`` when there is no explicit human-block signal at all
+    (e.g. the task was set to ``status='blocked'`` by the circuit breaker or
+    by direct DB manipulation) — preserves the pre-#28712 auto-recover
+    semantics for that path.
     """
     row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('created', 'blocked', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    if not row:
+        return False
+    if row["kind"] == "blocked":
+        return True
+    if row["kind"] != "created":
+        return False
+    try:
+        payload = json.loads(row["payload"] or "{}")
+    except (TypeError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and payload.get("status") == "blocked"
 
 
 def recompute_ready(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -324,6 +324,21 @@ def test_recompute_ready_cascades_through_chain(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
+def test_recompute_ready_preserves_initial_human_block(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="human gate",
+            assignee="main",
+            initial_status="blocked",
+        )
+
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+
+
 def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
     """blocked tasks with all parents done should be promoted to ready,
     unless the circuit-breaker failure limit has been reached."""


### PR DESCRIPTION
## Problem

`_has_sticky_block` decides whether a `blocked` task is a deliberate human gate
(which `recompute_ready` must not auto-promote) by inspecting the task's most
recent `blocked`/`unblocked` event. But a task created with
`--initial-status blocked` — the canonical way to stand up an *immediate* human
gate — emits only a `created` event (payload `status="blocked"`); it has no
`blocked` event yet.

So such a gate was treated as non-sticky. With no unfinished parents, the empty
parent set is vacuously satisfied and `recompute_ready` promotes the gate to
`ready`; the dispatcher then claims it and spawns a worker on a card that was
meant to wait for a human.

## Symptom

An initially-blocked human gate is silently promoted → dispatched → and if the
spawned worker re-blocks for input, the same-cause re-block trips
`BLOCK_RECURRENCE_LIMIT` → `block_loop_detected` → the card is routed out and
archived — instead of simply sitting `blocked` awaiting a human.

## Fix

Treat a `created` event whose payload records `status="blocked"` as a sticky
block, so `recompute_ready` leaves it blocked until an explicit `unblock`.
Behavior for circuit-breaker/direct-DB blocks (no explicit human-block signal)
is unchanged. Adds a regression test.
