### PR TITLE
fix: classify streaming render errors as format_error + tests (supersedes #62673)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -741,6 +741,28 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # ── 1b. Streaming render/format errors (no status code) ────────
+    # OpenAI-compatible providers (LM Studio, llama.cpp) can raise a
+    # bare ``APIError`` with no ``status_code`` when a chat-template
+    # Jinja render fails during streaming.  These are deterministic —
+    # the provider cannot serve the request regardless of retries.
+    # Classify as ``format_error`` so the fallback chain fires instead
+    # of retrying on the same backend until max_retries.  See #62662.
+    if status_code is None and any(
+        p in error_msg
+        for p in (
+            "error rendering",
+            "rendering prompt",
+            "jinja template",
+            "jinja render",
+        )
+    ):
+        return _result(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # ── 2. HTTP status code classification ──────────────────────────
 
     if status_code is not None:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1953,3 +1953,46 @@ class TestOpenRouterUpstreamRateLimit:
         # Overload disambiguation runs first; the outer message is the overload
         # phrase, so this is an overload, not an upstream rate-limit.
         assert result.reason == FailoverReason.overloaded
+
+
+class TestStreamingRenderFormatError:
+    """Jinja template render failures during streaming are format_error, not retryable.
+
+    LM Studio / llama.cpp can raise a bare APIError with no status_code when
+    a chat-template Jinja render fails.  These are deterministic — retrying
+    on the same backend will always fail.  Classify as format_error so the
+    fallback chain fires immediately.  See #62662, #62673.
+    """
+
+    def test_error_rendering_no_status_is_format_error(self):
+        e = MockAPIError("Error rendering prompt with jinja template: ...")
+        result = classify_api_error(e, provider="lm-studio", model="x")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_rendering_prompt_no_status_is_format_error(self):
+        e = MockAPIError("rendering prompt failed: undefined variable 'foo'")
+        result = classify_api_error(e, provider="llamacpp", model="x")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_jinja_template_no_status_is_format_error(self):
+        e = MockAPIError("jinja template error at line 3")
+        result = classify_api_error(e, provider="lm-studio", model="x")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_jinja_render_no_status_is_format_error(self):
+        e = MockAPIError("jinja render failure: unexpected token")
+        result = classify_api_error(e, provider="lm-studio", model="x")
+        assert result.reason == FailoverReason.format_error
+        assert result.should_fallback is True
+
+    def test_render_error_with_status_code_not_format_error(self):
+        """If status_code is present, let normal HTTP classification handle it."""
+        e = MockAPIError("Error rendering prompt", status_code=500)
+        result = classify_api_error(e, provider="lm-studio", model="x")
+        # With a 500 status, this should go through the HTTP classification path
+        assert result.reason != FailoverReason.format_error


### PR DESCRIPTION
## Supersedes #62673

Addresses all issues raised by @teknium1 in the #62673 review:

### Changes

1. **agent/error_classifier.py**: Classify status-less Jinja render errors as `format_error` with `retryable=False`, `should_fallback=True`. Four trigger phrases: "error rendering", "rendering prompt", "jinja template", "jinja render". Only fires when `status_code is None` — if a status code is present, normal HTTP classification handles it.

2. **tests/agent/test_error_classifier.py**: Add `TestStreamingRenderFormatError` class with 5 regression tests covering all four trigger phrases plus a negative test (same message with status_code=500 should NOT classify as format_error).

### Clarification on summary

As teknium1 noted, the gateway loop already calls `_try_activate_fallback()` at `conversation_loop.py:3898-3925` after retries are exhausted. This change is an eager-failover optimization: the classifier tells the loop "don't bother retrying this on the same provider" so fallback activates on the first failure instead of after max_retries.