### PR TITLE
test(agent): scope xai salvage regression test to codex_backend issuer

### DIFF
--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -500,7 +500,9 @@ def test_normalize_codex_response_salvage_is_xai_scoped():
         "Thinking.\n<response>The answer.</response>"
     )
 
-    assistant_message, finish_reason = _normalize_codex_response(response)
+    assistant_message, finish_reason = _normalize_codex_response(
+        response, issuer_kind="codex_backend"
+    )
 
     assert finish_reason == "incomplete"
     assert assistant_message.content == ""


### PR DESCRIPTION
## What does this PR do?

Test-only fix for the deterministic failure on current `main`:

```text
tests/agent/test_codex_responses_adapter.py::test_normalize_codex_response_salvage_is_xai_scoped
AssertionError: assert 'stop' == 'incomplete'
```

The test (added by #64768) asserts the Codex-backend reasoning-only → `incomplete` continuation behavior, but calls `_normalize_codex_response(response)` without `issuer_kind`. The default `None` lands in the generic-backend branch introduced by #64764, which intentionally trusts `response.status == "completed"` and returns `"stop"` for unrecognized issuers. The test therefore exercised a branch its docstring does not describe.

Passing `issuer_kind="codex_backend"` makes the test pin the behavior it documents (`agent/codex_responses_adapter.py` keeps `incomplete` only for `codex_backend`, `xai_responses`, `github_responses`), preserving both #64764's generic-backend `stop` behavior and #64768's xAI-only salvage scope. No production code changes.

## Related Issue

Fixes #64827

Interacting PRs: #64764, #64768.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/agent/test_codex_responses_adapter.py`: pass `issuer_kind="codex_backend"` in `test_normalize_codex_response_salvage_is_xai_scoped`, matching the sibling tests' explicit-issuer call style.

## How to Test

1. On `main` (verified at `569b912d7`): `uv run pytest "tests/agent/test_codex_responses_adapter.py::test_normalize_codex_response_salvage_is_xai_scoped" -q` → 1 failed (`'stop' == 'incomplete'`).
2. On this branch: same command → 1 passed.
3. `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_codex_responses_adapter.py` → 118 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched suites via `scripts/run_tests.sh` (118/118 passed)
- [x] I've added tests for my changes — the change IS the test correction
- [x] I've tested on my platform: macOS 15 arm64 (test is platform-independent)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (test-only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python unit test)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
before: 1 failed  (assert 'stop' == 'incomplete')
after:  26 passed (adapter file), 118 passed total with the companion run_agent suite
```