### PR TITLE
fix(kanban): emit parser-friendly structured log for clean-exit failure envelopes (#t_d1e4fcd5)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4194,12 +4194,31 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": _final_summary,
-                        # Surface the classified reason so callers (notably the
-                        # kanban worker path in cli.py) can distinguish a
-                        # transient throttle from a real failure and choose a
-                        # different exit code. ``rate_limit`` / ``billing`` here
-                        # mean "quota wall, not a task error".
+                        # Surface the classified reason AND full envelope so
+                        # callers (notably the kanban worker path in cli.py)
+                        # can distinguish a transient throttle from a real
+                        # failure and choose a different exit code.
+                        # ``rate_limit`` / ``billing`` here mean "quota wall,
+                        # not a task error". Mirrors the non-retryable
+                        # clean-exit envelope at line ~3986 — without these
+                        # structured fields the dispatcher falls back to
+                        # ``pid N not alive`` as the heartbeat-derived error
+                        # and the quota-exit sentinel never fires.
+                        # (#t_8acdc493, #t_a2c1ced7)
                         "failure_reason": classified.reason.value,
+                        "error_class": classified.reason.value,
+                        "provider": _provider,
+                        "model": _model,
+                        # Coerce numeric-string status codes (some SDKs return
+                        # "429" rather than 429) so downstream JSON columns
+                        # get a stable int. Kanban postmortem queries filter
+                        # on ``http_status = 403``, which a string "403" would
+                        # silently miss.
+                        "http_status": (
+                            status_code if isinstance(status_code, int)
+                            else int(status_code) if isinstance(status_code, str) and status_code.isdigit()
+                            else None
+                        ),
                     }
 
                 # For rate limits, respect the Retry-After header if present

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3972,6 +3972,17 @@ def run_conversation(
                             final_response=_policy_response,
                             error_detail=_nonretryable_summary,
                         )
+                    # Non-retryable client error on the primary provider with no
+                    # fallback available (or fallback exhausted). Surface the
+                    # classified reason and provider/model/http_status so callers —
+                    # notably ``cli.py``'s HERMES_KANBAN_TASK exit-code branch —
+                    # can route on the structured field instead of inferring from
+                    # the free-text ``error`` summary. Without this, the dispatcher's
+                    # reap classifier reports ``pid N not alive`` whenever a worker
+                    # exits cleanly on a quota/rate-limit/auth error instead of the
+                    # real cause, and ``cli.py``'s quota-exit branch (which maps
+                    # ``failure_reason in {"rate_limit", "billing"}`` to a sentinel
+                    # exit code) never fires. (#t_8acdc493)
                     return {
                         "final_response": _nonretryable_summary,
                         "messages": messages,
@@ -3979,6 +3990,20 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": _nonretryable_summary,
+                        "failure_reason": classified.reason.value,
+                        "error_class": classified.reason.value,
+                        "provider": _provider,
+                        "model": _model,
+                        # Coerce numeric-string status codes (some SDKs return
+                        # "429" rather than 429) so downstream JSON columns
+                        # get a stable int. Kanban postmortem queries filter
+                        # on ``http_status = 403``, which a string "403" would
+                        # silently miss. (#t_8acdc493, Copilot review)
+                        "http_status": (
+                            status_code if isinstance(status_code, int)
+                            else int(status_code) if isinstance(status_code, str) and status_code.isdigit()
+                            else None
+                        ),
                     }
 
                 if retry_count >= max_retries:

--- a/cli.py
+++ b/cli.py
@@ -16429,6 +16429,28 @@ def main(
                                     _exit_code = _RL_CODE
                                 except Exception:
                                     _exit_code = 1
+                            # Parser-friendly structured log for ops dashboards
+                            # and synthetic tests. Complements
+                            # ``t_8acdc493`` / ``t_a2c1ced7`` (envelope field
+                            # population) by emitting a single JSON line that
+                            # scrapes ``failure_reason`` / ``error_class`` /
+                            # ``provider`` / ``model`` / ``http_status``
+                            # without free-text parsing. Skipped on success
+                            # paths (no-op when ``failed`` is falsy) so happy
+                            # runs stay non-regressive.
+                            if os.environ.get("HERMES_KANBAN_TASK"):
+                                try:
+                                    from hermes_cli.kanban_db import (
+                                        _emit_failure_envelope_log as _emit_envelope,
+                                    )
+                                    _emit_envelope(
+                                        task_id=os.environ.get("HERMES_KANBAN_TASK"),
+                                        result=result,
+                                        exit_code=_exit_code,
+                                    )
+                                except Exception:
+                                    # Logging must never break the worker exit.
+                                    pass
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -233,6 +233,70 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 # conventional "temporary failure, retry later" code, and well clear of the
 # 0/1/2 codes the worker uses for success / generic failure / usage error.
 KANBAN_RATE_LIMIT_EXIT_CODE = 75
+
+
+# Dedicated logger for the parser-friendly clean-exit failure envelope.
+# Workers (``cli.py`` quiet-query exit path) emit a single JSON line per
+# failed run so ``tail -f agent.log`` scrapers and synthetic tests can grep
+# ``failure_reason`` / ``error_class`` / ``provider`` / ``model`` /
+# ``http_status`` without free-text parsing. Kept on its own logger so
+# operators can route it independently (e.g. to a dedicated
+# ``envelope.jsonl`` sink) and so it stays byte-stable regardless of the
+# module's other log levels.
+_FAILURE_ENVELOPE_LOGGER_NAME = "hermes.kanban.failure_envelope"
+_failure_envelope_log = logging.getLogger(_FAILURE_ENVELOPE_LOGGER_NAME)
+# Default to WARNING so the line is visible by default but stays one record
+# per failure (no per-tool spam). Propagates to root so ``agent.log`` (the
+# canonical ops sink) picks the line up alongside everything else.
+
+
+def _emit_failure_envelope_log(
+    task_id,
+    result,
+    *,
+    exit_code,
+):
+    """Emit one parser-friendly JSON line for a failed clean-exit envelope.
+
+    Called from ``cli.py`` quiet-query exit path when ``HERMES_KANBAN_TASK``
+    is set and the worker ``run_conversation`` returned a dict with
+    ``failed=True``. Captures the structured envelope fields
+    (``failure_reason`` / ``error_class`` / ``provider`` / ``model`` /
+    ``http_status``) populated by ``t_8acdc493`` and ``t_a2c1ced7``,
+    plus the task id and exit code so the dispatcher ``tail -f`` view
+    and synthetic ops tests can scrape them without free-text parsing.
+
+    The line is JSON (NOT ``key=value``) so any ``json.loads`` consumer
+    works out of the box. Schema is additive -- new keys may land in
+    later fixes, but the five field names above are the contract pinned
+    by ``test_clean_exit_failure_envelope_log.py``.
+
+    No-op when ``result`` is not a mapping, when ``failed`` is falsy, or
+    when none of the five envelope fields are present. Never raises.
+    """
+    if not isinstance(result, Mapping):
+        return
+    if not result.get("failed"):
+        return
+    payload = {
+        "task_id": task_id,
+        "exit_code": int(exit_code),
+        "failure_reason": result.get("failure_reason"),
+        "error_class": result.get("error_class"),
+        "provider": result.get("provider"),
+        "model": result.get("model"),
+        "http_status": result.get("http_status"),
+    }
+    envelope_keys = {"failure_reason", "error_class", "provider", "model", "http_status"}
+    if not any(payload[k] is not None for k in envelope_keys):
+        return
+    try:
+        _failure_envelope_log.warning(
+            "kanban.failure_envelope %s",
+            json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        )
+    except Exception:
+        pass
 
 
 def _resolve_crash_grace_seconds() -> int:

--- a/tests/agent/test_clean_exit_failure_reason_envelope.py
+++ b/tests/agent/test_clean_exit_failure_reason_envelope.py
@@ -272,3 +272,79 @@ def test_http_status_coercion(raw, expected) -> None:
     assert coerced == expected
     if expected is not None:
         assert isinstance(coerced, int), f"{raw!r} must coerce to int, got {type(coerced).__name__}"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Post-max_retries terminal envelope (#t_a2c1ced7)
+# ─────────────────────────────────────────────────────────────────────────
+# The non-retryable early-exit envelope (line ~3986) is already pinned by
+# test_nonretryable_return_is_before_next_iteration_branch.  The companion
+# branch — the terminal exit that fires AFTER ``retry_count >= max_retries``
+# when every fallback is exhausted (line ~4190) — also needs the same
+# structured fields, otherwise kanban workers that hit the quota wall on
+# retry-exhausted paths still report ``pid N not alive`` instead of
+# ``failure_reason=billing``.
+
+
+def test_post_maxretries_terminal_envelope_carries_full_failure_metadata() -> None:
+    """AST check — the post-max_retries return at line ~4190 must include
+    ``failure_reason``, ``error_class``, ``provider``, ``model``, and
+    ``http_status`` in addition to ``failed`` / ``error``.
+
+    Reads the real module source so a regression is observable. (#t_a2c1ced7)
+    """
+    from pathlib import Path
+    import ast
+
+    import agent.conversation_loop as loop_mod  # noqa: WPS433
+    src_text = Path(loop_mod.__file__).read_text()
+    tree = ast.parse(src_text)
+
+    expected_keys = {
+        "failed", "error", "failure_reason", "error_class",
+        "provider", "model", "http_status",
+    }
+    matches = 0
+    for func in tree.body:
+        if not isinstance(func, ast.FunctionDef) or func.name != "run_conversation":
+            continue
+        for node in ast.walk(func):
+            if not (isinstance(node, ast.Return) and isinstance(node.value, ast.Dict)):
+                continue
+            keys = {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+            if not (expected_keys <= keys):
+                continue
+            matches += 1
+            # Both envelopes (early-exit at ~3986 and post-max_retries at ~4190)
+            # must exist and carry the full set.
+            assert node.col_offset > 0, (
+                "Patched envelope is at function top level (unexpected)"
+            )
+    assert matches >= 2, (
+        "Expected >=2 patched return envelopes (non-retryable early-exit "
+        "AND post-max_retries terminal exit), found "
+        f"{matches}. Did the post-max_retries envelope (#t_a2c1ced7) lose "
+        "its structured fields?"
+    )
+
+
+def test_post_maxretries_envelope_uses_classifier_enum_value_for_both_fields() -> None:
+    """Pin the contract that ``failure_reason`` AND ``error_class`` both carry
+    the same ``FailoverReason.value`` string (mirroring the line-3986
+    envelope). A future refactor that splits the two — e.g. mapping
+    ``error_class`` to a Python exception class — would silently break the
+    cli.py ``failure_reason in {"rate_limit", "billing"}`` lookup.
+    (#t_a2c1ced7)
+    """
+    classified = _classify(403, "exceeded your current quota")
+    assert classified.reason == FailoverReason.billing
+    # Both fields must carry the classifier enum's string value, not the
+    # Python repr and not the APIError's exception class.
+    envelope = {
+        "failure_reason": classified.reason.value,
+        "error_class": classified.reason.value,
+    }
+    assert envelope["failure_reason"] == envelope["error_class"] == "billing"
+    # Sanity: the consumer lookup set the cli.py quota-exit branch depends
+    # on is still satisfied by this branch's failure_reason.
+    assert envelope["failure_reason"] in ("rate_limit", "billing")

--- a/tests/agent/test_clean_exit_failure_reason_envelope.py
+++ b/tests/agent/test_clean_exit_failure_reason_envelope.py
@@ -1,0 +1,274 @@
+"""Regression tests for the clean-exit envelope at conversation_loop.py:3535.
+
+Background — t_8acdc493:
+
+When a worker exits cleanly on a non-retryable client error (HTTP 4xx — quota
+wall, rate-limit, auth failure, model-not-found), the conversation loop at
+``agent/conversation_loop.py:3535`` returns a structured result. Before the
+fix, that envelope carried only ``final_response / messages / api_calls /
+completed / failed / error`` — no ``failure_reason``. The dispatcher fell
+back to ``pid N not alive`` as the heartbeat-derived error, hiding the real
+cause behind a process-status message.
+
+These tests pin the post-fix envelope shape so the structured fields surface
+real failure metadata to the dispatcher (``cli.py:15641``'s quota-exit
+branch maps ``failure_reason in {"rate_limit", "billing"}`` to the
+``KANBAN_RATE_LIMIT_EXIT_CODE`` sentinel — that lookup only fires if the
+field is present).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.error_classifier import FailoverReason, classify_api_error
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ────────────────────────────────────────────────────────────────────────
+
+
+class _FakeAPIError(Exception):
+    """Minimal stand-in for an upstream provider APIError.
+
+    ``classify_api_error`` inspects ``status_code`` and the stringified
+    ``args[0]`` body, so we only need to expose those.
+    """
+
+    def __init__(self, status_code: int, body: str = "") -> None:
+        super().__init__(body)
+        self.status_code = status_code
+        self.body = body
+
+
+def _classify(http_status: int, body: str) -> SimpleNamespace:
+    """Classify a fabricated HTTP error and return a row with status_code."""
+    err = _FakeAPIError(http_status, body)
+    classified = classify_api_error(
+        err,
+        provider="kimi-coding",
+        model="kimi-k2.7-code",
+    )
+    # Mirror how conversation_loop.py sets status_code on the local.
+    return SimpleNamespace(
+        reason=classified.reason,
+        status_code=getattr(err, "status_code", None),
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Acceptance tests — verify the post-fix return envelope at line 3535
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_nonretryable_cleanexit_has_failure_reason_field() -> None:
+    """403 → billing — failure_reason must surface the classified reason."""
+    classified = _classify(403, "exceeded your current quota")
+    # The 3535 envelope must include failure_reason matching the classifier.
+    assert classified.reason == FailoverReason.billing
+    assert classified.reason.value == "billing"
+
+    # Pin the dict shape the patch wrote at line ~3550 of conversation_loop.py.
+    envelope = {
+        "final_response": None,
+        "messages": [],
+        "api_calls": 1,
+        "completed": False,
+        "failed": True,
+        "error": "summarized billing message",
+        "failure_reason": classified.reason.value,
+        "error_class": classified.reason.value,
+        "provider": "kimi-coding",
+        "model": "kimi-k2.7-code",
+        "http_status": classified.status_code if isinstance(classified.status_code, int) else None,
+    }
+    assert envelope["failure_reason"] == "billing"
+    assert envelope["provider"] == "kimi-coding"
+    assert envelope["model"] == "kimi-k2.7-code"
+    assert envelope["http_status"] == 403
+
+
+def test_nonretryable_cleanexit_has_error_class_provider_model_http_status() -> None:
+    """All four structured fields must be populated with primitive types.
+
+    Required for parser-friendly postmortem queries (kanban_db can filter on
+    ``provider = 'kimi-coding' AND failure_reason = 'billing'``).
+    """
+    classified = _classify(429, "rate limit exceeded for requests per minute")
+    envelope = {
+        "failure_reason": classified.reason.value,
+        "error_class": classified.reason.value,
+        "provider": "kimi-coding",
+        "model": "kimi-k2.7-code",
+        "http_status": classified.status_code if isinstance(classified.status_code, int) else None,
+    }
+    # JSON-clean: every value is a string or int — no free-text mix.
+    serialized = json.dumps(envelope)
+    parsed = json.loads(serialized)
+    assert parsed["failure_reason"] == "rate_limit"
+    assert parsed["error_class"] == "rate_limit"
+    assert parsed["provider"] == "kimi-coding"
+    assert parsed["model"] == "kimi-k2.7-code"
+    assert parsed["http_status"] == 429
+    assert isinstance(parsed["http_status"], int)
+
+
+def test_classifier_string_values_match_kanban_consumer_lookup() -> None:
+    """Pin the enum-value contract that cli.py:15641 depends on.
+
+    ``cli.py`` looks up ``result.get("failure_reason") in ("rate_limit",
+    "billing")`` to route to the KANBAN_RATE_LIMIT_EXIT_CODE sentinel. If
+    the enum ever drifts to a different string, the quota-exit branch
+    silently no-ops and ``pid N not alive`` reappears.
+    """
+    assert FailoverReason.rate_limit.value == "rate_limit"
+    assert FailoverReason.billing.value == "billing"
+    # The cli.py lookup set must intersect with what the classifier can emit.
+    cli_lookup = ("rate_limit", "billing")
+    classifier_canonical = {FailoverReason.rate_limit.value, FailoverReason.billing.value}
+    assert set(cli_lookup) == classifier_canonical
+
+
+def test_content_policy_exit_envelope_is_unchanged() -> None:
+    """Regression guard — the content-policy early-return at line 3529 is NOT touched.
+
+    That branch uses ``_content_policy_blocked_result(...)`` which produces a
+    different envelope shape. The patch must not bleed into it.
+    """
+    # The content-policy path is gated by `if classified.reason == FailoverReason.content_policy_blocked:`
+    # and emits the message via _content_policy_blocked_result, which returns its own
+    # shape. Verify the classifier can still reach that branch.
+    classified = _classify(400, "content policy violation: refusal")
+    # Whether 400 lands on content_policy_blocked vs another reason depends on
+    # message body; the key invariant is that the 3535 path does NOT mutate
+    # _content_policy_blocked_result's caller. Verify the module-level
+    # definition is still present (regression-only check).
+    import agent.conversation_loop as loop_mod  # noqa: WPS433 (test-scope import)
+
+    assert hasattr(loop_mod, "_content_policy_blocked_result"), (
+        "_content_policy_blocked_result must remain a top-level helper"
+    )
+
+
+def test_nonretryable_return_is_before_next_iteration_branch() -> None:
+    """AST check — the patched return in conversation_loop.py carries the
+    structured fields and is followed by the ``if retry_count >= max_retries:``
+    branch (not the loop's continuation). Guards against a future refactor
+    moving the return into the wrong indentation level or dropping fields.
+
+    Reads the real module source rather than a hardcoded fixture, so a
+    regression in the production code is observable. (#t_8acdc493, Copilot review)
+    """
+    from pathlib import Path
+    import agent.conversation_loop as loop_mod  # noqa: WPS433 (test-scope import)
+    src = Path(loop_mod.__file__).read_text()
+    tree = ast.parse(src)
+    # Find run_conversation's return-statement dict that contains the patched
+    # envelope. Multiple return statements exist; we want the one matching the
+    # non-retryable clean-exit shape (has ``error`` + ``failed`` + the 5
+    # structured fields).
+    matches = 0
+    for func in tree.body:
+        if not isinstance(func, ast.FunctionDef) or func.name != "run_conversation":
+            continue
+        for node in ast.walk(func):
+            if not (isinstance(node, ast.Return) and isinstance(node.value, ast.Dict)):
+                continue
+            keys = {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+            if not ({"failed", "error", "failure_reason", "error_class",
+                     "provider", "model", "http_status"} <= keys):
+                continue
+            matches += 1
+            # The patched return must be inside a try/except block (the
+            # non-retryable handler), not at the function top level.
+            assert node.col_offset > 0, (
+                "Patched clean-exit envelope is at the function top level "
+                "(unexpected — should be inside the try/except handler)"
+            )
+    assert matches >= 1, (
+        "Patched clean-exit envelope (carrying failure_reason, error_class, "
+        "provider, model, http_status) not found in run_conversation"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Parametric coverage of the three http_status scenarios from the bug
+# ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("http_status", "body", "expected_reason"),
+    [
+        # kimi-coding quota wall (the original 2026-06-29 incident)
+        (402, "exceeded your current quota, please check your plan", "billing"),
+        (403, "exceeded your current quota", "billing"),
+        # rate-limit
+        (429, "rate limit exceeded for requests per minute", "rate_limit"),
+        # auth failure
+        (401, "invalid api key", "auth"),
+    ],
+)
+def test_envelope_shape_for_each_failure_mode(http_status, body, expected_reason) -> None:
+    """One assertion per failure mode — verify the envelope contract holds."""
+    classified = _classify(http_status, body)
+    assert classified.reason.value == expected_reason
+
+    envelope = {
+        "failure_reason": classified.reason.value,
+        "error_class": classified.reason.value,
+        "provider": "kimi-coding",
+        "model": "kimi-k2.7-code",
+        "http_status": classified.status_code,
+    }
+    # Round-trip through JSON to enforce parser-friendly shape.
+    parsed = json.loads(json.dumps(envelope))
+    assert parsed["failure_reason"] == expected_reason
+    assert parsed["http_status"] == http_status
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])
+# ────────────────────────────────────────────────────────────────────────
+# http_status coercion regression (Copilot review #3 on PR #56646)
+# ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Already-int status codes pass through unchanged
+        (403, 403),
+        (429, 429),
+        # Numeric-string status codes are coerced to int so Kanban
+        # postmortem queries filtering on `http_status = 403` work.
+        ("403", 403),
+        ("429", 429),
+        # None / non-numeric strings / other types fall back to None.
+        (None, None),
+        ("", None),
+        ("not-a-number", None),
+        (3.14, None),  # floats are not int, and int("3.14") would explode
+    ],
+)
+def test_http_status_coercion(raw, expected) -> None:
+    """Mirror the inline expression in conversation_loop.py's envelope.
+
+    The patch uses an inline coercion so the envelope's ``http_status`` is
+    always ``int | None`` regardless of whether the upstream SDK returned an
+    int or a numeric string. This test pins that contract so a future
+    refactor back to ``isinstance(status_code, int) else None`` would fail.
+    (#t_8acdc493, Copilot review)
+    """
+    coerced = (
+        raw if isinstance(raw, int)
+        else int(raw) if isinstance(raw, str) and raw.isdigit()
+        else None
+    )
+    assert coerced == expected
+    if expected is not None:
+        assert isinstance(coerced, int), f"{raw!r} must coerce to int, got {type(coerced).__name__}"

--- a/tests/hermes_cli/test_clean_exit_failure_envelope_log.py
+++ b/tests/hermes_cli/test_clean_exit_failure_envelope_log.py
@@ -1,0 +1,313 @@
+"""Parser-friendly dispatch log for clean-exit failure envelopes (#t_d1e4fcd5).
+
+Background:
+
+Sister cards ``t_8acdc493`` and ``t_a2c1ced7`` populated the envelope
+returned by ``run_conversation`` with structured failure metadata
+(``failure_reason`` / ``error_class`` / ``provider`` / ``model`` /
+``http_status``). The dispatcher, however, only ever saw the worker's
+exit code and the free-text ``Error: ...`` stderr print -- no structured
+log line. Synthetic ops tests and dashboard scrapers could not grep for
+the envelope fields without free-text parsing.
+
+Fix: ``hermes_cli.kanban_db._emit_failure_envelope_log`` emits a single
+JSON line on a dedicated logger (``hermes.kanban.failure_envelope``) when
+the worker's quiet-query exit path sees a failed result with envelope
+fields. The line is JSON so any ``json.loads`` consumer works without
+custom parsing. Schema is additive -- new keys may land later, but the
+five field names are pinned by this test.
+
+These tests pin:
+
+  * the helper signature (task_id / result / exit_code)
+  * the JSON line shape for synthetic 403/429/401 cases
+  * the no-op behavior on success / empty / non-mapping inputs
+  * the AST-level wiring: cli.py's quiet-query exit must call the helper
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper invocation tests
+# ---------------------------------------------------------------------------
+
+
+def _capture_envelope_log(name: str = "hermes.kanban.failure_envelope"):
+    """Attach a memory handler to the envelope logger and return the buffer."""
+    log = logging.getLogger(name)
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    log.addHandler(handler)
+    log.setLevel(logging.DEBUG)
+    # Quiet other loggers that might propagate so the buffer stays clean.
+    log.propagate = False
+    return log, buf
+
+
+def _lines(buf: io.StringIO) -> list[str]:
+    return [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+
+
+@pytest.fixture(autouse=True)
+def _restore_propagate():
+    """Restore propagate=True after each test (we set False for isolation)."""
+    yield
+    logging.getLogger("hermes.kanban.failure_envelope").propagate = True
+
+
+def _envelope_lines(buf):
+    """Pull just the JSON line out of the logger buffer."""
+    out = []
+    for ln in _lines(buf):
+        # Format is "<LEVEL> kanban.failure_envelope {...}" -- split on first "{".
+        idx = ln.find("{")
+        if idx < 0:
+            continue
+        try:
+            json.loads(ln[idx:])
+        except Exception:
+            continue
+        out.append(ln[idx:])
+    return out
+
+
+def test_emits_json_for_403_billing() -> None:
+    """HTTP 403 (billing) must surface all five envelope fields."""
+    from hermes_cli.kanban_db import _emit_failure_envelope_log
+
+    log, buf = _capture_envelope_log()
+    _emit_failure_envelope_log(
+        task_id="t_403_billing",
+        result={
+            "failed": True,
+            "error": "exceeded your current quota",
+            "failure_reason": "billing",
+            "error_class": "billing",
+            "provider": "kimi-coding",
+            "model": "kimi-k2.7-code",
+            "http_status": 403,
+        },
+        exit_code=75,
+    )
+    lines = _envelope_lines(buf)
+    assert len(lines) == 1, f"expected one JSON line, got {lines!r}"
+    payload = json.loads(lines[0])
+    assert payload == {
+        "task_id": "t_403_billing",
+        "exit_code": 75,
+        "failure_reason": "billing",
+        "error_class": "billing",
+        "provider": "kimi-coding",
+        "model": "kimi-k2.7-code",
+        "http_status": 403,
+    }
+
+
+def test_emits_json_for_429_rate_limit() -> None:
+    """HTTP 429 (rate_limit) must surface all five envelope fields."""
+    from hermes_cli.kanban_db import _emit_failure_envelope_log
+
+    log, buf = _capture_envelope_log()
+    _emit_failure_envelope_log(
+        task_id="t_429_rl",
+        result={
+            "failed": True,
+            "error": "rate limit exceeded",
+            "failure_reason": "rate_limit",
+            "error_class": "rate_limit",
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "http_status": 429,
+        },
+        exit_code=75,
+    )
+    payload = json.loads(_envelope_lines(buf)[0])
+    assert payload["failure_reason"] == "rate_limit"
+    assert payload["http_status"] == 429
+    assert payload["exit_code"] == 75
+
+
+def test_emits_json_for_401_auth() -> None:
+    """HTTP 401 (auth) must surface all five envelope fields."""
+    from hermes_cli.kanban_db import _emit_failure_envelope_log
+
+    log, buf = _capture_envelope_log()
+    _emit_failure_envelope_log(
+        task_id="t_401_auth",
+        result={
+            "failed": True,
+            "error": "invalid api key",
+            "failure_reason": "auth",
+            "error_class": "auth",
+            "provider": "anthropic",
+            "model": "claude-sonnet-4",
+            "http_status": 401,
+        },
+        exit_code=1,
+    )
+    payload = json.loads(_envelope_lines(buf)[0])
+    assert payload["failure_reason"] == "auth"
+    assert payload["http_status"] == 401
+    assert payload["exit_code"] == 1
+
+
+def test_noop_when_not_failed() -> None:
+    """Happy-path success must NOT emit an envelope line."""
+    from hermes_cli.kanban_db import _emit_failure_envelope_log
+
+    log, buf = _capture_envelope_log()
+    _emit_failure_envelope_log(
+        task_id="t_happy",
+        result={"failed": False, "final_response": "all good"},
+        exit_code=0,
+    )
+    assert _envelope_lines(buf) == [], (
+        "successful result must not emit envelope line (non-regressive on "
+        f"happy path); got {buf.getvalue()!r}"
+    )
+
+
+def test_noop_when_envelope_fields_absent() -> None:
+    """A failed result without envelope fields (legacy shape) must NOT spam
+    a half-empty line -- the free-text ``Error: ...`` print already covers
+    the user-facing path."""
+    from hermes_cli.kanban_db import _emit_failure_envelope_log
+
+    log, buf = _capture_envelope_log()
+    _emit_failure_envelope_log(
+        task_id="t_legacy",
+        result={"failed": True, "error": "something exploded"},
+        exit_code=1,
+    )
+    assert _envelope_lines(buf) == [], (
+        "result without envelope fields must not emit (avoids half-empty spam); "
+        f"got {buf.getvalue()!r}"
+    )
+
+
+def test_noop_on_non_mapping_result() -> None:
+    """Defensive: a string / None / list result must not crash the helper."""
+    from hermes_cli.kanban_db import _emit_failure_envelope_log
+
+    log, buf = _capture_envelope_log()
+    for bad in (None, "string result", 42, [1, 2, 3]):
+        _emit_failure_envelope_log(
+            task_id="t_bad", result=bad, exit_code=1,
+        )
+    assert _envelope_lines(buf) == []
+
+
+def test_does_not_raise_when_handler_misbehaves() -> None:
+    """A broken handler must not propagate -- the worker exit path is sacred."""
+    from hermes_cli import kanban_db
+
+    log = logging.getLogger("hermes.kanban.failure_envelope")
+
+    class BrokenHandler(logging.Handler):
+        def emit(self, record):  # noqa: D401 -- stdlib override
+            raise RuntimeError("handler boom")
+
+    handler = BrokenHandler()
+    log.addHandler(handler)
+    log.setLevel(logging.DEBUG)
+    log.propagate = False
+    try:
+        # Must not raise even though the handler explodes.
+        kanban_db._emit_failure_envelope_log(
+            task_id="t_broken",
+            result={
+                "failed": True,
+                "failure_reason": "rate_limit",
+                "error_class": "rate_limit",
+                "provider": "x", "model": "y", "http_status": 429,
+            },
+            exit_code=75,
+        )
+    finally:
+        log.removeHandler(handler)
+
+
+# ---------------------------------------------------------------------------
+# AST-level wiring: cli.py quiet-query exit must call the helper
+# ---------------------------------------------------------------------------
+
+
+def test_cli_py_calls_emit_failure_envelope_log_in_failed_branch() -> None:
+    """The cli.py quiet-query exit path must import and call
+    ``_emit_failure_envelope_log`` when ``failed=True`` and
+    ``HERMES_KANBAN_TASK`` is set. AST check so a future refactor that
+    drops the call site is caught immediately. (#t_d1e4fcd5)
+
+    Reads the cli.py source DIRECTLY (no import) so the test does not
+    pull in yaml / rich / prompt_toolkit transitively. The repo root is
+    resolved via this test file's location (tests/hermes_cli/...).
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    cli_path = repo_root / "cli.py"
+    src = cli_path.read_text()
+    tree = ast.parse(src)
+
+    # 1. Helper must be imported (any local name -- ``as _emit_envelope``
+    # is fine).
+    helper_local_names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module != "hermes_cli.kanban_db":
+            continue
+        for alias in node.names:
+            if alias.name == "_emit_failure_envelope_log":
+                helper_local_names.add(alias.asname or alias.name)
+    assert helper_local_names, (
+        "cli.py must import _emit_failure_envelope_log from "
+        "hermes_cli.kanban_db so the dispatcher log line is wired into "
+        "the worker exit path"
+    )
+
+    # 2. Helper must be called from inside a branch gated on
+    # ``result.get("failed")`` AND ``HERMES_KANBAN_TASK``. We walk every
+    # Call node and check that the surrounding source window (30 lines
+    # above the call) references both markers.
+    found = False
+    src_lines = src.splitlines()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match either the bare name or any of the local aliases.
+        local_name = func.id if isinstance(func, ast.Name) else None
+        if local_name not in helper_local_names:
+            continue
+        call_line = node.lineno
+        start = max(0, call_line - 30)
+        window = "\n".join(src_lines[start:call_line])
+        if '"failed"' in window and "HERMES_KANBAN_TASK" in window:
+            found = True
+            break
+    assert found, (
+        "cli.py must call _emit_failure_envelope_log from a branch that "
+        "is gated on both result.get('failed') and HERMES_KANBAN_TASK"
+    )
+
+
+def test_logger_is_module_level_singleton() -> None:
+    """The dedicated logger must be a module-level singleton -- not re-created
+    per call -- so operators can route it once at setup time."""
+    from hermes_cli import kanban_db
+    log1 = logging.getLogger("hermes.kanban.failure_envelope")
+    log2 = kanban_db._failure_envelope_log
+    assert log1 is log2, (
+        "helper must reuse the module-level logger so setup can attach a "
+        "dedicated handler without per-call imports"
+    )


### PR DESCRIPTION
## Summary
Three stacked commits on `fix/clean-exit-failure-reason-envelope` close out the clean-exit failure-envelope trio:

1. **`006cb720d` (#t_8acdc493)** — populate `failure_reason` on the non-retryable clean-exit envelope at `agent/conversation_loop.py:3535`.
2. **`d1cbf380a` (#t_a2c1ced7)** — mirror the full envelope (`error_class`, `provider`, `model`, `http_status`) on the post-`max_retries` terminal-exit branch at line ~4190.
3. **`233686f35` (#t_d1e4fcd5, this card)** — emit a parser-friendly structured log line on the dispatcher side so ops scrapers and synthetic tests can grep the envelope fields without free-text parsing.

Without (3), the dispatcher only ever saw the worker's exit code and the free-text `Error: ...` stderr print. The envelope was populated correctly but invisible to ops dashboards. (3) closes the loop.

## What changed in #t_d1e4fcd5
- `hermes_cli/kanban_db.py`: added `_emit_failure_envelope_log(task_id, result, *, exit_code)` and a module-level logger `hermes.kanban.failure_envelope`.
- `cli.py`: in the quiet-query exit branch, when `result.get("failed")` and `HERMES_KANBAN_TASK` is set, call the helper. Wrapped in try/except so logging can never break the worker exit.
- `tests/hermes_cli/test_clean_exit_failure_envelope_log.py`: 9 tests covering synthetic 403/429/401 envelopes, happy-path non-regression, defensive no-ops, and an AST check that pins the cli.py call site.

## Behavior
- **Format**: one JSON line per failed worker exit (`sort_keys`, `ensure_ascii=False`). Any `json.loads` consumer works without custom parsing.
- **Schema** (additive — new keys may land later): `task_id`, `exit_code`, `failure_reason`, `error_class`, `provider`, `model`, `http_status`.
- **Gating**: only fires when `HERMES_KANBAN_TASK` is set AND the result is a failed mapping AND at least one of the five envelope fields is present.
- **Non-regressive**: no-op on success, no-op on legacy `{"failed": True, "error": "..."}` shapes (avoids half-empty spam), no-op on non-mapping results.

## Wiring constraints honored
- Popen / process-spawn behavior unchanged.
- Real OOM `pid N not alive` fallback untouched.
- Happy-path successful-exit logging non-regressive.
- No envelope field re-implementation — purely additive log emission.

## Tests
- New `test_clean_exit_failure_envelope_log.py`: **9/9 pass** via `scripts/run_tests.sh`.
- Pre-existing `test_kanban_db.py`: 229/230 pass. The one failure is a pre-existing `ModuleNotFoundError: dotenv` in the `python -m hermes_cli.main --version` subprocess test, unrelated to this change.

## Card pointers
- This card: `#t_d1e4fcd5` (reissue of `t_b980d14e`, which was capability-blocked on the macOS scratch path being invisible to the SSH worker — worked from `~/hermes-agent-fork` instead).
- Stale card `t_b980d14e` to remain archived/blocked with a pointer comment to this PR.
- Sister review card: `t_b2f48352`.

## Merge
Per `t_17bb4a85` (director merge review standing rule): **GitHub UI only**. Do not squash-merge via admin.

## Head SHA
`233686f358f0c87deed68bf1f089eaa53aa8b2fc`