### PR TITLE
fix(mcp): cap keepalive reconnect loop + empty exception handling (supersedes #62515)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -494,7 +494,19 @@ def _is_method_not_found_error(exc: BaseException) -> bool:
         return True
     msg = str(exc).lower()
     if not msg:
-        return False
+        # Empty exception message — ambiguous for generic Exception, but
+        # known transport/real-failure types (TimeoutError, ConnectionError,
+        # OSError, etc.) are always real failures even with no message (#62212).
+        _TRANSPORT_FAILURES = (
+            TimeoutError, ConnectionError, BrokenPipeError, OSError, EOFError,
+        )
+        if isinstance(exc, _TRANSPORT_FAILURES):
+            return False
+        # For other exception types (e.g. CancelledError, bare Exception,
+        # McpError without code), treat as "method not found" so the caller
+        # latches ``_ping_unsupported`` and falls back to ``list_tools``
+        # instead of triggering an immediate reconnect.
+        return True
     return (
         str(_JSONRPC_METHOD_NOT_FOUND) in msg
         or "method not found" in msg
@@ -1485,6 +1497,7 @@ class MCPServerTask:
         "_pending_call_context",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries",
+        "_keepalive_reconnect_count",
     )
 
     def __init__(self, name: str):
@@ -1507,6 +1520,7 @@ class MCPServerTask:
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
         self._reconnect_retries: int = 0
+        self._keepalive_reconnect_count: int = 0
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -1826,12 +1840,28 @@ class MCPServerTask:
                 if self.session:
                     try:
                         await self._keepalive_probe()
+                        self._keepalive_reconnect_count = 0
                     except Exception as exc:
+                        self._keepalive_reconnect_count += 1
                         logger.warning(
-                            "MCP server '%s' keepalive failed, "
-                            "triggering reconnect: %s",
-                            self.name, exc,
+                            "MCP server '%s' keepalive failed "
+                            "(%d consecutive), triggering reconnect: %s",
+                            self.name,
+                            self._keepalive_reconnect_count,
+                            exc,
                         )
+                        if self._keepalive_reconnect_count >= 3:
+                            logger.error(
+                                "MCP server '%s': %d consecutive keepalive "
+                                "failures — parking to prevent infinite "
+                                "reconnect loop. Use /mcp to revive.",
+                                self.name,
+                                self._keepalive_reconnect_count,
+                            )
+                            # Park instead of shutdown: the task stays alive
+                            # so _reconnect_event always has a listener.
+                            # Shutdown would permanently wedge the server.
+                            break
                         self._reconnect_event.set()
                         break
         finally:


### PR DESCRIPTION
## Supersedes #62515

Addresses all issues raised by @teknium1 in the #62515 review:

### 1. Off-by-one fix: `>= 3` not `> 3`

The original PR used `> 3` which permits a 4th consecutive failure before triggering. Changed to `>= 3` for a true cap of three.

### 2. Parking instead of shutdown

The original PR called `_shutdown_event.set()` + `break`, which exits the task. As teknium1 noted, current main intentionally parks after reconnect exhaustion because returning would permanently wedge the server (see `tools/mcp_tool.py:2825-2862`).

Fix: after 3 consecutive keepalive failures, log an error and break without setting `_shutdown_event` or `_reconnect_event`. The normal post-loop flow reaches `_wait_for_reconnect_or_shutdown()` which parks the task — it stays alive so `_reconnect_event` always has a listener and can be revived via `/mcp`.

### 3. Empty exception message handling

`_is_method_not_found_error()` currently returns `False` for empty messages, which triggers immediate reconnect. But known transport failure types (TimeoutError, ConnectionError, OSError) are real failures even with no message. Generic exceptions with empty messages should latch `_ping_unsupported` instead.

Fix: empty-message transport failures → `False` (real failure). Empty-message generic exceptions → `True` (latch ping_unsupported, fall back to list_tools).

### 4. Counter reset

Reset `_keepalive_reconnect_count` to 0 on successful keepalive so transient blips don't accumulate.