### PR TITLE
fix(installer): verify SSH/HTTPS clone has valid .git and HEAD (supersedes #62436)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1273,12 +1273,16 @@ clone_repo() {
         # so SSH fails fast instead of hanging when no key is configured.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+           git clone --depth 1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null \
+           && [ -d "$INSTALL_DIR/.git" ] \
+           && git -C "$INSTALL_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
             log_info "SSH failed, trying HTTPS..."
-            if git clone --depth 1 --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+            if git clone --depth 1 --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR" \
+               && [ -d "$INSTALL_DIR/.git" ] \
+               && git -C "$INSTALL_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
                 log_success "Cloned via HTTPS"
             else
                 log_error "Failed to clone repository"


### PR DESCRIPTION
## Supersedes #62436

Addresses all issues raised by @teknium1 in the #62436 review:

### Problem

The SSH clone check only verified `git clone` exit code. A zero-exit clone that produces a broken checkout (`.git` exists but no initial commit) would be accepted.

### Fix

Add two validation gates after both SSH and HTTPS clone:
1. `[ -d "$INSTALL_DIR/.git" ]` — .git directory exists
2. `git -C "$INSTALL_DIR" rev-parse --verify HEAD` — resolvable HEAD (initial commit exists)

### What this does NOT include

- **MCP OAuth refresh_token fix** (commit `e86a51822887` in #62436): per reviewer guidance, this unrelated change should be submitted as a separate PR.
- **PowerShell changes**: `install.ps1` already has comprehensive post-clone validation at lines 1258-1287 (.git + rev-parse + HEAD check), so no changes needed.