### PR TITLE
fix(agent): prevent empty tool_calls arrays to fix DeepSeek V4 HTTP 400 errors

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2636,7 +2636,10 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()


### PR DESCRIPTION
### PR Description

Some LLMs (such as DeepSeek V4 and other strict OpenAI-compatible APIs) throw an HTTP 400 error: `Invalid 'messages[14].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.`

## What does this PR do?

This PR fixes an issue where empty `tool_calls: []` arrays were either slipping through the pre-API sanitization or being accidentally re-injected by the deduplication logic, causing strict providers (like DeepSeek V4) to reject the entire request.

**Root causes addressed:**
1. **Role-restricted stripping:** The existing sanitization logic (`Drop empty / malformed tool_calls arrays`) only checked messages where `role == "assistant"`. If a `user` or `tool` message accidentally contained `tool_calls: []` (e.g., due to history corruption, context compression, or manual edits), it bypassed the filter and crashed the API call.
2. **Deduplication re-injection:** In the `Deduplicate tool_call_ids` step, if all tool calls in an assistant message were identified as duplicates and removed, the code blindly re-assigned `msg["tool_calls"] = []`. This re-introduced the exact empty array problem the function was designed to prevent.

**Solution:**
- Broadened the initial empty `tool_calls` stripper to clean **all** message roles, not just `assistant`.
- Added a conditional check in the deduplication block: if `kept_tcs` is empty after deduplication, the `tool_calls` key is safely removed entirely instead of being set to `[]`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Screenshots / Logs

**Before this PR:**
```log
2026-07-14 18:40:06,023 WARNING [d5c9d49d-8aae-46bd-a991-a5f6f284e640] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=asyncio_0:127357546153664 provider=deepseek base_url=https://api.deepseek.com/v1 model=deepseek-v4-flash summary=HTTP 400: Invalid 'messages[12].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.
```