### PR TITLE
test(codex): pin codex_backend issuer in xai-scoped salvage test

### DIFF
--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -493,14 +493,21 @@ def test_normalize_codex_response_salvage_strips_closing_tag():
 
 
 def test_normalize_codex_response_salvage_is_xai_scoped():
-    """Non-xAI issuers keep the reasoning-only → incomplete classification;
-    the Codex backend replays encrypted reasoning, so its continuation
-    genuinely progresses and must not be short-circuited."""
+    """Non-xAI special-cased issuers (Codex backend) keep the reasoning-only →
+    incomplete classification; the Codex backend replays encrypted reasoning,
+    so its continuation genuinely progresses and must not be short-circuited.
+
+    Pins ``issuer_kind="codex_backend"`` explicitly: with no issuer at all,
+    the unrecognized-backend rule (#64434) trusts ``status="completed"`` and
+    returns ``stop`` — that path is covered by the #64434 regression tests.
+    """
     response = _xai_reasoning_only_response(
         "Thinking.\n<response>The answer.</response>"
     )
 
-    assistant_message, finish_reason = _normalize_codex_response(response)
+    assistant_message, finish_reason = _normalize_codex_response(
+        response, issuer_kind="codex_backend"
+    )
 
     assert finish_reason == "incomplete"
     assert assistant_message.content == ""


### PR DESCRIPTION
## Summary

Fixes a test broken on current `main` by two same-day merges crossing: `test_normalize_codex_response_salvage_is_xai_scoped` fails on every PR's CI (slice 8/8), including branches that don't touch codex code.

**Root cause:** #64764 (issue #64434) changed `_normalize_codex_response` so an *unrecognized* issuer with `status="completed"` and reasoning-only output now trusts the provider and returns `stop`. #64768 (merged 44 seconds later) added this test calling with **no** `issuer_kind` and expecting `incomplete`. Each PR was green against its own base; combined on main, the test asserts pre-#64434 behavior.

**Fix:** pin `issuer_kind="codex_backend"` in the test — its docstring says it guards the non-xAI *special-cased* backends (Codex replays encrypted reasoning, so continuation genuinely progresses), and that's exactly the path the pin exercises. Same pattern as the sibling `test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete`, which was already pinned for #64434. One test-line change, zero production code.

## Validation

| | Before | After |
|---|---|---|
| `tests/agent/test_codex_responses_adapter.py` on origin/main | 25 pass / 1 fail | 26 pass / 0 fail |

Reproduced on a pristine `origin/main` worktree (569b912d7) before fixing — the failure is pre-existing and unrelated to any open PR's changes.

## Infographic

![CI flake fix infographic](https://v3b.fal.media/files/b/0aa252e2/RVGl1wOOPdBj1RxC9rdKG_4SnYRXsD.png)
