### PR TITLE
fix(docker): restore the venv on PATH for login shells on Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -393,6 +393,16 @@ ENV HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages
 # binary by absolute path, so this PATH ordering is transparent to
 # every other consumer.
 ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
+
+# Debian's /etc/profile hardcodes PATH for login shells, discarding the ENV PATH
+# above *before* it sources /etc/profile.d/*.sh. init_session snapshots the
+# environment through a login shell (`bash -l -c ... export -p`), so without a
+# profile.d drop-in the snapshot -- and every later terminal command that sources
+# it -- loses the venv and bare `python3` resolves to the system interpreter
+# (no Pillow, etc.). The drop-in below is sourced after the reset and re-prepends
+# the venv dirs. See issue #56634.
+COPY --chmod=0644 docker/profile.d/99-hermes-venv-path.sh /etc/profile.d/99-hermes-venv-path.sh
+
 RUN mkdir -p /opt/data
 VOLUME [ "/opt/data" ]
 

--- a/docker/profile.d/99-hermes-venv-path.sh
+++ b/docker/profile.d/99-hermes-venv-path.sh
@@ -1,0 +1,22 @@
+# Re-prepend the Hermes venv/bin directories onto PATH for login shells.
+#
+# Debian's /etc/profile hardcodes PATH for login shells, discarding the image's
+# `ENV PATH` *before* it sources /etc/profile.d/*.sh. The terminal tool builds
+# its environment snapshot through a login shell (`bash -l -c ... export -p`,
+# see tools/environments/base.py:init_session), so without this drop-in the
+# snapshot -- and every later terminal command that sources it -- loses the venv
+# and a bare `python3` resolves to the system interpreter, which has none of
+# Hermes' dependencies (not even the Pillow that hermes-agent itself imports).
+#
+# This file is sourced *after* the reset, so re-prepending here repairs it.
+# Prepend only when the venv prefix isn't already leading PATH: that keeps the
+# repair idempotent when a login shell re-sources this file, yet still fixes a
+# PATH where the venv is merely present but not in front (a bare `python3` would
+# otherwise resolve to /usr/bin/python3). Keep the directory list in sync with
+# `ENV PATH` in the Dockerfile (tests/tools/test_dockerfile_login_shell_path.py
+# enforces this). See https://github.com/NousResearch/hermes-agent/issues/56634.
+case "${PATH}" in
+    /opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:*) ;;
+    *) PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}" ;;
+esac
+export PATH

--- a/docker/profile.d/99-hermes-venv-path.sh
+++ b/docker/profile.d/99-hermes-venv-path.sh
@@ -13,8 +13,8 @@
 # repair idempotent when a login shell re-sources this file, yet still fixes a
 # PATH where the venv is merely present but not in front (a bare `python3` would
 # otherwise resolve to /usr/bin/python3). Keep the directory list in sync with
-# `ENV PATH` in the Dockerfile (tests/tools/test_dockerfile_login_shell_path.py
-# enforces this). See https://github.com/NousResearch/hermes-agent/issues/56634.
+# `ENV PATH` in the Dockerfile.
+# See https://github.com/NousResearch/hermes-agent/issues/56634.
 case "${PATH}" in
     /opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:*) ;;
     *) PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}" ;;

--- a/tests/docker/test_login_shell_venv_path.py
+++ b/tests/docker/test_login_shell_venv_path.py
@@ -1,0 +1,54 @@
+"""Integration test for the login-shell venv PATH drop-in (#56634).
+
+Builds the image (or reuses ``HERMES_TEST_IMAGE``) and runs a real login shell
+(``bash -l``, which sources Debian's /etc/profile and only then
+/etc/profile.d/*.sh) as the unprivileged ``hermes`` user -- the same shell
+``init_session`` snapshots via ``bash -l -c ... export -p``. Without the
+/etc/profile.d drop-in the login shell inherits /etc/profile's PATH reset, so a
+bare ``python3`` resolves to /usr/local/bin/python3 (the system interpreter,
+which lacks Pillow). These tests prove the drop-in restores the venv end-to-end
+in the built image.
+
+Auto-skips when Docker is unavailable (see tests/docker/conftest.py).
+"""
+from __future__ import annotations
+
+import subprocess
+
+
+def _login_shell(image: str, script: str) -> subprocess.CompletedProcess[str]:
+    """Run ``script`` in a login shell as the hermes user, entrypoint bypassed."""
+    return subprocess.run(
+        [
+            "docker", "run", "--rm",
+            "--entrypoint", "bash",
+            "--user", "hermes",
+            image,
+            "-lc", script,
+        ],
+        capture_output=True, text=True, timeout=120,
+    )
+
+
+def test_login_shell_resolves_venv_python(built_image: str) -> None:
+    r = _login_shell(built_image, "command -v python3")
+    assert r.returncode == 0, r.stderr
+    python3 = r.stdout.strip()
+    # The venv (and the privilege-drop shim dir ahead of it) live under
+    # /opt/hermes; the system interpreter the /etc/profile reset would leave in
+    # front is /usr/local/bin/python3 or /usr/bin/python3.
+    assert python3.startswith("/opt/hermes/"), (
+        f"login-shell python3 resolved to {python3!r}; expected the Hermes venv "
+        "under /opt/hermes -- the /etc/profile.d drop-in did not restore PATH."
+    )
+
+
+def test_login_shell_python_imports_venv_only_dependency(built_image: str) -> None:
+    # Pillow is installed only in the venv, so a bare ``import PIL`` succeeding
+    # proves the login shell selected the venv interpreter, not the system one.
+    r = _login_shell(built_image, 'python3 -c "import PIL; print(PIL.__name__)"')
+    assert r.returncode == 0, (
+        f"`import PIL` failed in a login shell (rc={r.returncode}): "
+        f"{(r.stderr.strip() or r.stdout.strip())!r}"
+    )
+    assert "PIL" in r.stdout

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -198,7 +198,10 @@ class TestAtomicSnapshotWrite:
         captured = {}
 
         def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
-            captured.setdefault("cmd", cmd_string)  # only the bootstrap; ignore the failure-path probe
+            # Capture only the login bootstrap; the non-login ambient-PATH probe
+            # and the failure-path probe (both login=False) are ignored.
+            if login:
+                captured["cmd"] = cmd_string
             raise RuntimeError("stop after capture")
 
         env._run_bash = fake_run_bash  # type: ignore[assignment]
@@ -225,7 +228,10 @@ class TestAtomicSnapshotWrite:
         captured = {}
 
         def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
-            captured.setdefault("cmd", cmd_string)  # only the bootstrap; ignore the failure-path probe
+            # Capture only the login bootstrap; the non-login ambient-PATH probe
+            # and the failure-path probe (both login=False) are ignored.
+            if login:
+                captured["cmd"] = cmd_string
             raise RuntimeError("stop after capture")
 
         env._run_bash = fake_run_bash  # type: ignore[assignment]

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -221,9 +221,11 @@ class TestCleanup:
 class TestExecute:
     def test_basic_command(self, make_env):
         sb = _make_sandbox()
-        # Calls: (1) $HOME detection, (2) init_session bootstrap, (3) actual command
+        # Calls: (1) $HOME, (2) ambient PATH probe, (3) init_session bootstrap,
+        # (4) actual command
         sb.process.exec.side_effect = [
             _make_exec_response(result="/root"),       # $HOME
+            _make_exec_response(result="", exit_code=0),  # ambient PATH probe
             _make_exec_response(result="", exit_code=0),  # init_session
             _make_exec_response(result="hello", exit_code=0),  # actual cmd
         ]
@@ -239,6 +241,7 @@ class TestExecute:
         sb = _make_sandbox()
         sb.process.exec.side_effect = [
             _make_exec_response(result="/root"),
+            _make_exec_response(result="", exit_code=0),  # ambient PATH probe
             _make_exec_response(result="", exit_code=0),  # init_session
             _make_exec_response(result="ok", exit_code=0),
         ]
@@ -258,6 +261,7 @@ class TestExecute:
         sb = _make_sandbox()
         sb.process.exec.side_effect = [
             _make_exec_response(result="/root"),
+            _make_exec_response(result="", exit_code=0),  # ambient PATH probe
             _make_exec_response(result="", exit_code=0),  # init_session
             _make_exec_response(result="", exit_code=124),  # actual cmd
         ]
@@ -271,6 +275,7 @@ class TestExecute:
         sb = _make_sandbox()
         sb.process.exec.side_effect = [
             _make_exec_response(result="/root"),
+            _make_exec_response(result="", exit_code=0),  # ambient PATH probe
             _make_exec_response(result="", exit_code=0),  # init_session
             _make_exec_response(result="not found", exit_code=127),
         ]
@@ -284,6 +289,7 @@ class TestExecute:
         sb = _make_sandbox()
         sb.process.exec.side_effect = [
             _make_exec_response(result="/root"),
+            _make_exec_response(result="", exit_code=0),  # ambient PATH probe
             _make_exec_response(result="", exit_code=0),  # init_session
             _make_exec_response(result="ok", exit_code=0),
         ]
@@ -305,6 +311,7 @@ class TestExecute:
         sb.state = "started"
         sb.process.exec.side_effect = [
             _make_exec_response(result="/root"),  # $HOME
+            _make_exec_response(result="", exit_code=0),  # ambient PATH probe
             _make_exec_response(result="", exit_code=0),  # init_session
             daytona_sdk.DaytonaError("transient"),  # first attempt fails
             _make_exec_response(result="ok", exit_code=0),  # retry succeeds
@@ -355,8 +362,9 @@ class TestInterrupt:
             calls["n"] += 1
             if calls["n"] == 1:
                 return _make_exec_response(result="/root")  # $HOME detection
-            if calls["n"] == 2:
-                return _make_exec_response(result="", exit_code=0)  # init_session
+            if calls["n"] in (2, 3):
+                # ambient PATH probe, then the init_session bootstrap
+                return _make_exec_response(result="", exit_code=0)
             event.wait(timeout=5)  # simulate long-running command
             return _make_exec_response(result="done", exit_code=0)
 
@@ -387,6 +395,7 @@ class TestRetryExhausted:
         sb.state = "started"
         sb.process.exec.side_effect = [
             _make_exec_response(result="/root"),       # $HOME
+            _make_exec_response(result="", exit_code=0),  # ambient PATH probe
             _make_exec_response(result="", exit_code=0),  # init_session
             daytona_sdk.DaytonaError("fail1"),         # actual command fails
         ]

--- a/tests/tools/test_docker_probe_env.py
+++ b/tests/tools/test_docker_probe_env.py
@@ -1,0 +1,38 @@
+"""Docker _run_bash env-forwarding regression for #56634.
+
+The ambient-PATH probe and the login bootstrap both run before the snapshot
+exists, so both must receive the same ``-e`` init env -- otherwise the probe
+captures the image-default PATH instead of a configured one. Injection keys on
+``not _snapshot_ready`` rather than ``login``.
+"""
+from __future__ import annotations
+
+import pytest
+
+docker = pytest.importorskip("tools.environments.docker")
+
+
+def _stub_env(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(
+        docker, "_popen_bash", lambda cmd, stdin_data=None: captured.setdefault("cmd", cmd)
+    )
+    env = docker.DockerEnvironment.__new__(docker.DockerEnvironment)
+    env._docker_exe = "docker"
+    env._container_id = "cid"
+    env._init_env_args = ["-e", "FOO=bar"]
+    return env, captured
+
+
+def test_probe_gets_init_env_before_snapshot_ready(monkeypatch):
+    env, captured = _stub_env(monkeypatch)
+    env._snapshot_ready = False
+    env._run_bash("builtin printf x", login=False)  # the ambient probe
+    assert "-e" in captured["cmd"] and "FOO=bar" in captured["cmd"]
+
+
+def test_commands_omit_init_env_after_snapshot_ready(monkeypatch):
+    env, captured = _stub_env(monkeypatch)
+    env._snapshot_ready = True
+    env._run_bash("echo hi", login=False)
+    assert "FOO=bar" not in captured["cmd"]

--- a/tests/tools/test_dockerfile_login_shell_path.py
+++ b/tests/tools/test_dockerfile_login_shell_path.py
@@ -1,0 +1,119 @@
+"""Contract + behavior tests for the login-shell PATH drop-in (#56634).
+
+Debian's /etc/profile hardcodes PATH for login shells, discarding the image's
+``ENV PATH`` *before* it sources /etc/profile.d/*.sh. init_session snapshots the
+environment through a login shell (``bash -l -c ... export -p``), so without a
+profile.d drop-in the snapshot loses the venv and a bare ``python3`` resolves to
+the system interpreter (which lacks Hermes' deps, including Pillow). These tests
+pin the drop-in into the image and prove -- with a real login-style shell, no
+Docker build required -- that it survives the /etc/profile PATH reset.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+DROPIN = REPO_ROOT / "docker" / "profile.d" / "99-hermes-venv-path.sh"
+
+# Debian's /etc/profile PATH for a non-root shell, set before profile.d is
+# sourced. Reproduced verbatim so the test exercises the exact reset the drop-in
+# has to survive.
+DEBIAN_NONROOT_PATH = "/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games"
+
+
+def _dockerfile_env_path_prepend() -> str:
+    """The venv/bin prefix the Dockerfile's ``ENV PATH`` puts ahead of $PATH."""
+    text = DOCKERFILE.read_text()
+    match = re.search(r'ENV PATH="([^"]*):\$\{PATH\}"', text)
+    assert match, "Dockerfile must set ENV PATH with a ${PATH} suffix"
+    return match.group(1)
+
+
+def _dropin_path_prepend() -> str:
+    """The venv/bin prefix the drop-in prepends onto $PATH."""
+    text = DROPIN.read_text()
+    match = re.search(r'PATH="([^"]*):\$\{PATH\}"', text)
+    assert match, "drop-in must prepend the venv dirs onto ${PATH}"
+    return match.group(1)
+
+
+def test_dockerfile_installs_login_shell_path_dropin() -> None:
+    text = DOCKERFILE.read_text()
+    assert DROPIN.exists(), "the login-shell PATH drop-in file must exist"
+    # The drop-in must be copied into the directory /etc/profile is sourced from.
+    assert re.search(
+        r"COPY[^\n]*docker/profile\.d/99-hermes-venv-path\.sh\s+"
+        r"/etc/profile\.d/99-hermes-venv-path\.sh",
+        text,
+    ), "Dockerfile must COPY the drop-in into /etc/profile.d/"
+
+
+def test_dropin_matches_env_path_prepend() -> None:
+    """Drift guard: the drop-in and ``ENV PATH`` must prepend the same dirs, so a
+    future edit to one cannot silently diverge from the other."""
+    assert _dropin_path_prepend() == _dockerfile_env_path_prepend()
+    # And it must actually include the venv the whole bug is about.
+    assert "/opt/hermes/.venv/bin" in _dropin_path_prepend()
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_dropin_restores_venv_after_debian_profile_reset() -> None:
+    """Reproduce /etc/profile's reset, then source the real drop-in as
+    /etc/profile.d sourcing would, and confirm the venv dirs lead PATH."""
+    script = (
+        f'PATH="{DEBIAN_NONROOT_PATH}"\n'
+        f'. "{DROPIN}"\n'
+        'printf "%s" "$PATH"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    entries = result.stdout.split(":")
+    # The privilege-drop shim dir leads, the venv is present, and both sit ahead
+    # of the system interpreter dir that the reset left in front.
+    assert entries[0] == "/opt/hermes/bin"
+    assert "/opt/hermes/.venv/bin" in entries
+    assert entries.index("/opt/hermes/.venv/bin") < entries.index("/usr/bin")
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_dropin_is_idempotent_when_resourced() -> None:
+    """Re-sourcing the drop-in (the profile chain can run more than once in a
+    session) must not duplicate the venv entries or unboundedly grow PATH."""
+    script = (
+        f'PATH="{DEBIAN_NONROOT_PATH}"\n'
+        f'. "{DROPIN}"\n'
+        f'. "{DROPIN}"\n'
+        'printf "%s" "$PATH"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split(":").count("/opt/hermes/.venv/bin") == 1
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_dropin_repairs_venv_present_but_not_leading() -> None:
+    """If the venv is on PATH but NOT in front (so a bare ``python3`` still
+    resolves to the system interpreter), the drop-in must still prepend the full
+    prefix — the guard keys on the prefix leading PATH, not on mere presence."""
+    script = (
+        'PATH="/usr/bin:/opt/hermes/.venv/bin"\n'
+        f'. "{DROPIN}"\n'
+        'printf "%s" "$PATH"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    entries = result.stdout.split(":")
+    assert entries[0] == "/opt/hermes/bin"
+    assert entries.index("/opt/hermes/.venv/bin") < entries.index("/usr/bin")

--- a/tests/tools/test_login_path_restore.py
+++ b/tests/tools/test_login_path_restore.py
@@ -1,0 +1,277 @@
+"""Tests for the shared login-shell PATH restore (#56634).
+
+A Debian-family ``/etc/profile`` hardcode-resets PATH before sourcing
+``/etc/profile.d/*.sh``, so ``init_session``'s login-shell ``export -p`` would
+snapshot a PATH without the image/host venv. ``BaseEnvironment`` repairs it: it
+probes the ambient *non-login* PATH (which never sourced ``/etc/profile``) and,
+before ``export -p``, prepends the entries the login shell dropped. These tests
+drive the merge shell and probe directly (no Docker), plus the full
+``init_session`` snapshot chain against a simulated Debian login shell.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+
+import pytest
+
+from tools.environments.base import BaseEnvironment
+
+BASH = shutil.which("bash")
+requires_bash = pytest.mark.skipif(BASH is None, reason="bash not available")
+
+# Debian's non-root login PATH, set before profile.d is sourced.
+DEBIAN_RESET_PATH = "/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games"
+VENV_PREFIX = "/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin"
+
+
+def _run_restore(ambient: str, login_path: str, prelude: str = "") -> str:
+    """Render the restore snippet, run it atop *login_path*, echo the result."""
+    snippet = BaseEnvironment._render_login_path_restore(ambient)
+    script = f"{prelude}PATH={shlex.quote(login_path)}\n{snippet}printf '%s' \"${{PATH-}}\"\n"
+    r = subprocess.run([BASH, "-c", script], capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, r.stderr
+    return r.stdout
+
+
+# ----- merge shell behavior -----
+
+
+def test_render_is_noop_without_ambient() -> None:
+    assert BaseEnvironment._render_login_path_restore(None) == ""
+    assert BaseEnvironment._render_login_path_restore("") == ""
+
+
+@requires_bash
+def test_restores_venv_dropped_by_debian_reset() -> None:
+    out = _run_restore(f"{VENV_PREFIX}:/usr/bin:/bin", DEBIAN_RESET_PATH)
+    assert out == f"{VENV_PREFIX}:{DEBIAN_RESET_PATH}"
+    entries = out.split(":")
+    assert entries[0] == "/opt/hermes/bin"
+    assert entries.index("/opt/hermes/.venv/bin") < entries.index("/usr/bin")
+
+
+@requires_bash
+def test_noop_when_nothing_missing() -> None:
+    login = "/usr/local/bin:/usr/bin:/bin"
+    assert _run_restore("/usr/bin:/bin", login) == login
+
+
+@requires_bash
+def test_empty_login_path_introduces_no_current_dir_entry() -> None:
+    out = _run_restore("/opt/hermes/.venv/bin:/usr/bin", "")
+    assert out == "/opt/hermes/.venv/bin:/usr/bin"
+    assert not out.startswith(":") and not out.endswith(":") and "::" not in out
+
+
+@requires_bash
+def test_unset_login_path_is_handled() -> None:
+    # Genuinely unset (not just empty) -- ${PATH-} must not trip nounset.
+    snippet = BaseEnvironment._render_login_path_restore("/opt/hermes/.venv/bin:/usr/bin")
+    script = f"unset PATH\n{snippet}/usr/bin/printf '%s' \"${{PATH-}}\"\n"
+    r = subprocess.run([BASH, "-c", script], capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout == "/opt/hermes/.venv/bin:/usr/bin"
+
+
+@requires_bash
+def test_dedupes_repeated_ambient_entries() -> None:
+    assert _run_restore("/x:/x:/y", "/z") == "/x:/y:/z"
+
+
+@requires_bash
+def test_dedup_treats_glob_chars_literally() -> None:
+    # The dedup `case` pattern quotes the entry, so glob chars (* ? [ ]) match
+    # literally: "/opt/x*z" must NOT be treated as already-present just because
+    # it globs onto "/opt/xyz". (A real duplicate still dedupes.)
+    assert _run_restore("/opt/xyz:/opt/x*z", "") == "/opt/xyz:/opt/x*z"
+    assert _run_restore("/opt/a?c:/opt/[ab]", "/usr/bin") == "/opt/a?c:/opt/[ab]:/usr/bin"
+    assert _run_restore("/o*t:/o*t", "/z") == "/o*t:/z"
+
+
+@requires_bash
+def test_skips_empty_ambient_entries() -> None:
+    assert _run_restore(":/opt/v::/usr/bin:", "/bin") == "/opt/v:/usr/bin:/bin"
+
+
+@requires_bash
+def test_preserves_path_entry_with_spaces() -> None:
+    assert _run_restore("/opt/my venv/bin:/usr/bin", "/bin") == "/opt/my venv/bin:/usr/bin:/bin"
+
+
+@requires_bash
+def test_survives_set_eu_and_leaves_flags_enabled() -> None:
+    # A login profile may leave set -e/-u active: the merge must not abort the
+    # bootstrap and, since it no longer toggles options, must leave both on.
+    snippet = BaseEnvironment._render_login_path_restore(f"{VENV_PREFIX}:/usr/bin")
+    script = (
+        "set -e\nset -u\n"
+        f"PATH={shlex.quote(DEBIAN_RESET_PATH)}\n"
+        f"{snippet}"
+        'printf "%s|" "${PATH-}"; case $- in *e*) printf E;; esac; case $- in *u*) printf U;; esac\n'
+    )
+    r = subprocess.run([BASH, "-c", script], capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, r.stderr
+    path, flags = r.stdout.split("|")
+    assert path.split(":")[0] == "/opt/hermes/bin"
+    assert flags == "EU"
+
+
+# ----- ambient-PATH probe -----
+
+
+class _ProbeEnv(BaseEnvironment):
+    """Concrete env with canned _run_bash/_wait_for_process for probe tests."""
+
+    def __init__(self, output: str = "", returncode: int = 0, raise_exc=None):
+        self._canned = {"output": output, "returncode": returncode}
+        self._raise = raise_exc
+        self.ran = False
+        super().__init__(cwd="/tmp", timeout=10)
+
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        self.ran = True
+        self._last_login = login
+        self._last_cmd = cmd_string
+        if self._raise is not None:
+            raise self._raise
+        return object()
+
+    def _wait_for_process(self, proc, timeout=120):
+        return self._canned
+
+    def cleanup(self):
+        pass
+
+
+def _marker(env: _ProbeEnv) -> str:
+    return f"__HERMES_PATH_{env._session_id}__"
+
+
+def test_probe_disabled_does_not_even_spawn() -> None:
+    env = _ProbeEnv()
+    env._restore_ambient_login_path = False
+    assert env._capture_ambient_login_path() is None
+    assert env.ran is False
+
+
+def test_probe_parses_marker_framed_value_ignoring_noise() -> None:
+    env = _ProbeEnv()
+    m = _marker(env)
+    path = "/opt/hermes/.venv/bin:/usr/bin"
+    env._canned = {"output": f"BASH_ENV noise\n{m}{path}{m}", "returncode": 0}
+    assert env._capture_ambient_login_path() == path
+    assert env._last_login is False
+    assert "builtin printf" in env._last_cmd and "${PATH-}" in env._last_cmd
+
+
+def test_probe_returns_value_verbatim_without_stripping() -> None:
+    env = _ProbeEnv()
+    m = _marker(env)
+    path = "  /leading:/trailing/dir  "  # surrounding spaces are legal, must survive
+    env._canned = {"output": f"{m}{path}{m}", "returncode": 0}
+    assert env._capture_ambient_login_path() == path
+
+
+def test_probe_uses_output_key_not_stdout() -> None:
+    env = _ProbeEnv()
+    m = _marker(env)
+    env._canned = {"output": f"{m}/usr/bin{m}", "returncode": 0, "stdout": "WRONG"}
+    assert env._capture_ambient_login_path() == "/usr/bin"
+
+
+def test_probe_nonzero_returncode_returns_none() -> None:
+    env = _ProbeEnv()
+    m = _marker(env)
+    env._canned = {"output": f"{m}/usr/bin{m}", "returncode": 1}
+    assert env._capture_ambient_login_path() is None
+
+
+def test_probe_missing_marker_returns_none() -> None:
+    assert _ProbeEnv(output="no markers", returncode=0)._capture_ambient_login_path() is None
+
+
+def test_probe_empty_path_returns_none() -> None:
+    env = _ProbeEnv()
+    m = _marker(env)
+    env._canned = {"output": f"{m}{m}", "returncode": 0}
+    assert env._capture_ambient_login_path() is None
+
+
+def test_probe_exception_returns_none() -> None:
+    assert _ProbeEnv(raise_exc=RuntimeError("boom"))._capture_ambient_login_path() is None
+
+
+@requires_bash
+def test_builtin_printf_defeats_shadowed_printf() -> None:
+    # The probe uses `builtin printf` so a printf shadowed by a function (which a
+    # non-login shell can inherit via an exported function/BASH_ENV) cannot make
+    # it capture the format string instead of $PATH.
+    marker, path = "__M__", "/opt/hermes/.venv/bin:/usr/bin"
+    shadow = 'printf() { builtin printf "%s" "$1"; }\n'
+    fmt = f'"{marker}%s{marker}" {shlex.quote(path)}'
+    naive = subprocess.run([BASH, "-c", shadow + f"printf {fmt}"], capture_output=True, text=True)
+    safe = subprocess.run([BASH, "-c", shadow + f"builtin printf {fmt}"], capture_output=True, text=True)
+    assert naive.stdout != f"{marker}{path}{marker}"  # shadowed printf corrupts it
+    assert safe.stdout == f"{marker}{path}{marker}"  # builtin is immune
+
+
+# ----- full init_session snapshot chain -----
+
+
+class _FakeDebianEnv(BaseEnvironment):
+    """A login shell whose /etc/profile resets PATH; non-login keeps the venv."""
+
+    def __init__(self, ambient: str, reset: str):
+        self._ambient = ambient
+        self._reset = reset
+        super().__init__(cwd="/tmp", timeout=10)
+
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        env = dict(os.environ, PATH=self._ambient)
+        script = f"export PATH={shlex.quote(self._reset)}\n{cmd_string}" if login else cmd_string
+        return subprocess.run(
+            [BASH, "-c", script], capture_output=True, text=True, env=env, timeout=timeout
+        )
+
+    def _wait_for_process(self, proc, timeout=120):
+        return {"output": proc.stdout, "returncode": proc.returncode}
+
+    def cleanup(self):
+        pass
+
+
+@requires_bash
+def test_init_session_snapshot_restores_venv_end_to_end() -> None:
+    env = _FakeDebianEnv(ambient=f"{VENV_PREFIX}:/usr/bin:/bin", reset=DEBIAN_RESET_PATH)
+    try:
+        env.init_session()
+        assert env._snapshot_ready
+        r = subprocess.run(
+            [BASH, "-c", f"source {shlex.quote(env._snapshot_path)} >/dev/null 2>&1; printf '%s' \"$PATH\""],
+            capture_output=True, text=True, timeout=30,
+        )
+        entries = r.stdout.split(":")
+        assert entries[0] == "/opt/hermes/bin"
+        assert entries.index("/opt/hermes/.venv/bin") < entries.index("/usr/bin")
+    finally:
+        for p in (env._snapshot_path, env._cwd_file):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+def test_local_env_gates_restore_on_windows(monkeypatch) -> None:
+    """Gate follows _IS_WINDOWS per call, so a POSIX CI run can still exercise
+    the Git-Bash path (a class-body binding would freeze it at import).
+    """
+    from tools.environments import local as local_mod
+
+    env = local_mod.LocalEnvironment.__new__(local_mod.LocalEnvironment)
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    assert env._restore_ambient_login_path is False
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+    assert env._restore_ambient_login_path is True

--- a/tests/tools/test_login_shell_path_dropin.py
+++ b/tests/tools/test_login_shell_path_dropin.py
@@ -1,16 +1,16 @@
-"""Contract + behavior tests for the login-shell PATH drop-in (#56634).
+"""Behavior tests for the login-shell PATH drop-in (#56634).
 
 Debian's /etc/profile hardcodes PATH for login shells, discarding the image's
 ``ENV PATH`` *before* it sources /etc/profile.d/*.sh. init_session snapshots the
 environment through a login shell (``bash -l -c ... export -p``), so without a
 profile.d drop-in the snapshot loses the venv and a bare ``python3`` resolves to
 the system interpreter (which lacks Hermes' deps, including Pillow). These tests
-pin the drop-in into the image and prove -- with a real login-style shell, no
-Docker build required -- that it survives the /etc/profile PATH reset.
+reproduce that PATH reset in bash and source the real drop-in the way
+/etc/profile.d sourcing would -- no Docker build required. The built-image
+login-shell behavior is covered by tests/docker/test_login_shell_venv_path.py.
 """
 from __future__ import annotations
 
-import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -18,7 +18,6 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DOCKERFILE = REPO_ROOT / "Dockerfile"
 DROPIN = REPO_ROOT / "docker" / "profile.d" / "99-hermes-venv-path.sh"
 
 # Debian's /etc/profile PATH for a non-root shell, set before profile.d is
@@ -26,46 +25,16 @@ DROPIN = REPO_ROOT / "docker" / "profile.d" / "99-hermes-venv-path.sh"
 # has to survive.
 DEBIAN_NONROOT_PATH = "/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games"
 
-
-def _dockerfile_env_path_prepend() -> str:
-    """The venv/bin prefix the Dockerfile's ``ENV PATH`` puts ahead of $PATH."""
-    text = DOCKERFILE.read_text()
-    match = re.search(r'ENV PATH="([^"]*):\$\{PATH\}"', text)
-    assert match, "Dockerfile must set ENV PATH with a ${PATH} suffix"
-    return match.group(1)
-
-
-def _dropin_path_prepend() -> str:
-    """The venv/bin prefix the drop-in prepends onto $PATH."""
-    text = DROPIN.read_text()
-    match = re.search(r'PATH="([^"]*):\$\{PATH\}"', text)
-    assert match, "drop-in must prepend the venv dirs onto ${PATH}"
-    return match.group(1)
-
-
-def test_dockerfile_installs_login_shell_path_dropin() -> None:
-    text = DOCKERFILE.read_text()
-    assert DROPIN.exists(), "the login-shell PATH drop-in file must exist"
-    # The drop-in must be copied into the directory /etc/profile is sourced from.
-    assert re.search(
-        r"COPY[^\n]*docker/profile\.d/99-hermes-venv-path\.sh\s+"
-        r"/etc/profile\.d/99-hermes-venv-path\.sh",
-        text,
-    ), "Dockerfile must COPY the drop-in into /etc/profile.d/"
-
-
-def test_dropin_matches_env_path_prepend() -> None:
-    """Drift guard: the drop-in and ``ENV PATH`` must prepend the same dirs, so a
-    future edit to one cannot silently diverge from the other."""
-    assert _dropin_path_prepend() == _dockerfile_env_path_prepend()
-    # And it must actually include the venv the whole bug is about.
-    assert "/opt/hermes/.venv/bin" in _dropin_path_prepend()
+# The exact prefix the drop-in prepends: the privilege-drop shim dir, the venv,
+# and the data user's local bin -- mirrors the Dockerfile's ``ENV PATH``.
+VENV_PREFIX = "/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin"
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
 def test_dropin_restores_venv_after_debian_profile_reset() -> None:
     """Reproduce /etc/profile's reset, then source the real drop-in as
-    /etc/profile.d sourcing would, and confirm the venv dirs lead PATH."""
+    /etc/profile.d sourcing would: the full prefix must lead PATH, with the
+    reset PATH intact behind it."""
     script = (
         f'PATH="{DEBIAN_NONROOT_PATH}"\n'
         f'. "{DROPIN}"\n'
@@ -75,12 +44,7 @@ def test_dropin_restores_venv_after_debian_profile_reset() -> None:
         ["bash", "-c", script], capture_output=True, text=True, timeout=30
     )
     assert result.returncode == 0, result.stderr
-    entries = result.stdout.split(":")
-    # The privilege-drop shim dir leads, the venv is present, and both sit ahead
-    # of the system interpreter dir that the reset left in front.
-    assert entries[0] == "/opt/hermes/bin"
-    assert "/opt/hermes/.venv/bin" in entries
-    assert entries.index("/opt/hermes/.venv/bin") < entries.index("/usr/bin")
+    assert result.stdout == f"{VENV_PREFIX}:{DEBIAN_NONROOT_PATH}"
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
@@ -97,7 +61,7 @@ def test_dropin_is_idempotent_when_resourced() -> None:
         ["bash", "-c", script], capture_output=True, text=True, timeout=30
     )
     assert result.returncode == 0, result.stderr
-    assert result.stdout.split(":").count("/opt/hermes/.venv/bin") == 1
+    assert result.stdout == f"{VENV_PREFIX}:{DEBIAN_NONROOT_PATH}"
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
@@ -114,6 +78,4 @@ def test_dropin_repairs_venv_present_but_not_leading() -> None:
         ["bash", "-c", script], capture_output=True, text=True, timeout=30
     )
     assert result.returncode == 0, result.stderr
-    entries = result.stdout.split(":")
-    assert entries[0] == "/opt/hermes/bin"
-    assert entries.index("/opt/hermes/.venv/bin") < entries.index("/usr/bin")
+    assert result.stdout == f"{VENV_PREFIX}:/usr/bin:/opt/hermes/.venv/bin"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -457,6 +457,10 @@ class BaseEnvironment(ABC):
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
 
+    # Restore PATH entries a login shell's /etc/profile dropped before export -p
+    # snapshots them (#56634). Off for Windows Git Bash (see LocalEnvironment).
+    _restore_ambient_login_path: bool = True
+
     def get_temp_dir(self) -> str:
         """Return the backend temp directory used for session artifacts.
 
@@ -510,6 +514,74 @@ class BaseEnvironment(ABC):
     # Session snapshot (init_session)
     # ------------------------------------------------------------------
 
+    def _capture_ambient_login_path(self) -> str | None:
+        """PATH from a non-login shell (never sources /etc/profile), or None.
+
+        Best-effort. A per-session marker frames the value so BASH_ENV output
+        can't pollute it; the bytes between markers are returned as-is (PATH
+        entries may contain spaces, so never stripped).
+        """
+        if not self._restore_ambient_login_path:
+            return None
+        probe_timeout = min(15, self._snapshot_timeout)
+        marker = f"__HERMES_PATH_{self._session_id}__"
+        try:
+            proc = self._run_bash(
+                # `builtin` bypasses a printf shadowed by a function/BASH_ENV.
+                f"builtin printf '{marker}%s{marker}' \"${{PATH-}}\"",
+                login=False,
+                timeout=probe_timeout,
+            )
+            result = self._wait_for_process(proc, timeout=probe_timeout)
+        except Exception:
+            return None
+        if int(result.get("returncode") or 0) != 0:
+            return None
+        output = result.get("output") or ""
+        first = output.find(marker)
+        if first == -1:
+            return None
+        second = output.find(marker, first + len(marker))
+        if second == -1:
+            return None
+        ambient = output[first + len(marker) : second]
+        return ambient or None
+
+    @staticmethod
+    def _render_login_path_restore(ambient_path: str | None) -> str:
+        """Bootstrap shell (before export -p) that prepends ambient PATH entries
+        missing from the login PATH, restoring a venv /etc/profile dropped
+        (#56634). Order-stable, deduped, no-op if nothing is missing. Safe under
+        the login shell's set -e/-u (uses ${PATH-} and guarded constructs, never
+        toggles options); an empty login PATH is assigned directly so no
+        current-dir ``:`` is introduced.
+        """
+        if not ambient_path:
+            return ""
+        quoted = shlex.quote(ambient_path)
+        return (
+            f"__hermes_amb={quoted}\n"
+            "__hermes_login=${PATH-}\n"
+            "__hermes_add=\n"
+            "__hermes_rest=$__hermes_amb\n"
+            'while [ -n "$__hermes_rest" ]; do\n'
+            "  __hermes_e=${__hermes_rest%%:*}\n"
+            '  if [ "$__hermes_rest" = "$__hermes_e" ]; then __hermes_rest=; '
+            "else __hermes_rest=${__hermes_rest#*:}; fi\n"
+            '  [ -n "$__hermes_e" ] || continue\n'
+            '  case ":$__hermes_login:$__hermes_add:" in\n'
+            '    *":$__hermes_e:"*) ;;\n'
+            "    *) __hermes_add=${__hermes_add:+$__hermes_add:}$__hermes_e ;;\n"
+            "  esac\n"
+            "done\n"
+            'if [ -n "$__hermes_add" ]; then\n'
+            '  if [ -n "$__hermes_login" ]; then PATH=$__hermes_add:$__hermes_login; '
+            "else PATH=$__hermes_add; fi\n"
+            "  export PATH\n"
+            "fi\n"
+            "unset __hermes_amb __hermes_login __hermes_add __hermes_rest __hermes_e\n"
+        )
+
     def init_session(self):
         """Capture login shell environment into a snapshot file.
 
@@ -552,8 +624,13 @@ class BaseEnvironment(ABC):
         # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
         # with ``$BASHPID`` left outside the quotes so it still expands.
         _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Repair a login /etc/profile PATH reset before export -p captures it (#56634).
+        _path_restore = self._render_login_path_restore(
+            self._capture_ambient_login_path()
+        )
         bootstrap = (
             f"umask 077\n"
+            f"{_path_restore}"
             f"{_export_dump_excluding_session_vars(_snap_tmp)}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
@@ -607,7 +684,8 @@ class BaseEnvironment(ABC):
                 probe_result = self._wait_for_process(probe, timeout=min(15, self._snapshot_timeout))
                 prefer_nonlogin = int(probe_result.get("returncode") or 0) == 0
                 if not prefer_nonlogin:
-                    detail = (probe_result.get("stdout") or detail).strip() or detail
+                    # _wait_for_process returns captured text under "output".
+                    detail = (probe_result.get("output") or detail).strip() or detail
             except Exception as probe_exc:
                 detail = f"{detail}; non-login probe: {probe_exc}"
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1512,9 +1512,11 @@ class DockerEnvironment(BaseEnvironment):
         if stdin_data is not None:
             cmd.append("-i")
 
-        # Only inject -e env args during init_session (login=True).
-        # Subsequent commands get env vars from the snapshot.
-        if login:
+        # Inject -e env args until the snapshot exists: the ambient-PATH probe
+        # and login bootstrap must see the same env, else the probe captures the
+        # image-default PATH instead of a configured one. Later commands get env
+        # from the snapshot.
+        if not self._snapshot_ready:
             cmd.extend(self._init_env_args)
 
         cmd.extend([self._container_id])

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1293,6 +1293,16 @@ class LocalEnvironment(BaseEnvironment):
     CWD persists via file-based read after each command.
     """
 
+    @property
+    def _restore_ambient_login_path(self) -> bool:
+        """Git Bash's /etc/profile is additive (nothing to repair) and its PATH
+        order must not be disturbed, so keep the #56634 repair POSIX-only.
+
+        Read per call, not bound in the class body: ``_IS_WINDOWS`` is patched
+        by the Git-Bash tests, which run on POSIX CI.
+        """
+        return not _IS_WINDOWS
+
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)


### PR DESCRIPTION
## What does this PR do?

On Debian-family targets, `/etc/profile` hardcode-resets `PATH` for login shells
and only *then* sources `/etc/profile.d/*.sh`, discarding the image/host `ENV`
venv dirs (`/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin`). This
PR closes that gap on **two independent contracts**:

1. **Shared terminal-snapshot correctness (the root cause).** `init_session`
   captures the environment snapshot through a *login* shell
   (`bash -l -c … export -p`, `tools/environments/base.py`), so `export -p`
   records the reset `PATH`. Every later terminal command sources that snapshot,
   so a bare `python3` resolves to the system interpreter — which lacks the
   venv's packages (not even the Pillow hermes-agent imports). This `init_session`
   is **shared by every backend** (`docker`, `ssh`, `daytona`, `singularity`,
   `modal`, `local`), so the bug is *not* Docker-image-specific — it fires on any
   Debian-family target, including the local backend and remote hosts.
   To place the impact: `tools/environments/docker.py::_run_bash()` runs
   `docker exec … bash -l -c` whenever `login=True`, and `init_session` is the
   caller that passes it — so this is the normal terminal-tool path, not just
   interactive debugging.

   The fix repairs it at that shared layer: before `export -p`, `init_session`
   probes the ambient PATH from a **non-login** shell (which never sources
   `/etc/profile`, so it still sees the venv) and prepends any entries the login
   shell dropped back into the snapshot. This is backend- and image-agnostic —
   it needs no knowledge of where the venv lives, only what the environment
   itself already put on `PATH`.

2. **Official-image login-shell correctness.** A `docker/profile.d`
   drop-in re-prepends the venv dirs for *any* login shell inside the shipped
   image — including an interactive `docker exec -it <container> bash -l`, which
   the snapshot repair (Hermes-managed commands only) does not cover. The
   Dockerfile already intends the venv to be on `PATH` for `docker exec`; this
   makes that hold for login shells too.

The two are complementary defense-in-depth, not redundant: the snapshot repair
fixes Hermes' terminal across all backends/images; the drop-in fixes the
image's own login-shell contract.

## Related Issue

Fixes #56634

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Root fix (shared, all backends):**
- `tools/environments/base.py` —
  - `_capture_ambient_login_path()`: a best-effort non-login `printf` probe,
    framed in a per-session marker (a non-interactive bash may emit `BASH_ENV`
    output that a bare probe would capture as noise). Returns the PATH verbatim
    (entries may contain spaces) or `None` on any failure/empty result.
  - `_render_login_path_restore()`: the shell, run in the bootstrap immediately
    before `export -p`, that prepends only the ambient entries **missing** from
    the login `PATH` (order-stable, deduped) — restoring a dropped venv without
    reordering dirs the login profile placed deliberately. `set +e`/`set +u` and
    `${PATH-}` match the snapshot's own contract; an empty login `PATH` is
    assigned directly so no trailing `:` (current-directory) entry is created.
  - Gated by `_restore_ambient_login_path` (default on).
  - Drive-by: the failure-branch diagnostic probe now reads the process result
    under `"output"` (it read a never-present `"stdout"` key before).
- `tools/environments/local.py` — `LocalEnvironment` disables the repair on
  Windows Git Bash (`_IS_WINDOWS`), whose `/etc/profile` is additive (nothing to
  reset) and whose coreutils-before-System32 precedence must not be disturbed.
  Read per call (a property), since the Git-Bash tests patch `_IS_WINDOWS` and
  run on POSIX CI.

**Image login-shell fix (shipped image):**
- `docker/profile.d/99-hermes-venv-path.sh` (new) + `Dockerfile` `COPY` into
  `/etc/profile.d/`, sourced after the reset, re-prepending the venv dirs
  (guard keys on the prefix *leading* `PATH`, so it is idempotent and also
  repairs a `PATH` where the venv is present but not in front).

**Tests:**
- `tests/tools/test_login_path_restore.py` (new) — merge-shell behavior
  (reset→restore, no-op, empty/unset PATH, dedup, empty entries, spaces,
  `set -u`/`set -e` survival) and probe parsing/gating (marker parse over noise,
  `"output"` key, nonzero-rc/exception/missing-marker/empty → `None`, real-bash
  end-to-end, Windows gating). No Docker build required.
- `tests/tools/test_login_shell_path_dropin.py` (new) — sources the real drop-in
  in bash and asserts the exact resulting `PATH` (reset-and-restore, not-leading
  repair, idempotency). No source-text assertions.
- `tests/docker/test_login_shell_venv_path.py` (new) — integration test: builds
  the image and runs a real `bash -l` as the `hermes` user, asserting `python3`
  resolves under `/opt/hermes` and `import PIL` succeeds. Auto-skips without Docker.
- `tests/tools/test_base_environment.py` — two bootstrap tests now capture the
  `login=True` bootstrap (a `login=False` ambient-PATH probe now precedes it).
- `tests/tools/test_daytona_environment.py` — the mocked `process.exec`
  sequences hardcode the init call order, so they gain the probe's response
  between `$HOME` detection and the bootstrap.

## How to Test

1. `pytest tests/tools/test_login_path_restore.py -q` → exercises the root fix
   (merge shell + probe) with no Docker.
2. `pytest tests/tools/test_login_shell_path_dropin.py -q` → drop-in contract.
3. `pytest tests/docker/test_login_shell_venv_path.py -q` → builds the image and
   verifies a real login shell resolves the venv `python3` + `import PIL`
   (skips without a Docker daemon).
4. Reproduce end-to-end: in a Debian environment whose venv is on `ENV PATH`,
   compare a bare login-shell `python3` before/after — before, it resolves to the
   system interpreter; after, to the venv.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — the only prior attempt (#56642) restores
      `PATH` in `local.py` *after* `export -p` (too late — the snapshot is
      already written) and only for the local backend; this repairs the shared
      `init_session` snapshot before `export -p`, so it sticks and covers every
      backend.
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the new + touched
      files (all pass; one pre-existing macOS concurrency race,
      `test_concurrent_writes_never_tear_the_snapshot`, is flaky independent of
      this change); full-suite run left to CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (host `bash` behavior + probe tests) and
      the `debian:13.4` image via Docker (login shell → venv `python3` + `import PIL`)

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (no user-facing docs; the code, drop-in, and
      Dockerfile carry explanatory comments)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — the snapshot repair is disabled on Windows Git Bash;
      the drop-in only affects the Linux image; no macOS/Windows host regression
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
# login shell in a Debian image WITH the fix:
python3 -> /opt/hermes/bin/python3
import PIL OK: PIL

# negative control (fix removed):
python3 -> /usr/local/bin/python3
ModuleNotFoundError: No module named 'PIL'
```

