### PR TITLE
feat: skill slash-command aliases, dashboard proxy host allowlist, fix secret-name leak

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -26,6 +26,16 @@ _skill_commands_platform: Optional[str] = None
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
+
+def _normalize_skill_command_slug(value: Any) -> str:
+    """Normalize a skill name/alias into the slash-command slug form."""
+    raw = str(value or "").strip().lstrip("/")
+    if not raw:
+        return ""
+    slug = raw.lower().replace(" ", "-").replace("_", "-")
+    slug = _SKILL_INVALID_CHARS.sub("", slug)
+    return _SKILL_MULTI_HYPHEN.sub("-", slug).strip("-")
+
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
 #
@@ -369,17 +379,29 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # Normalize to hyphen-separated slug, stripping
                     # non-alnum chars (e.g. +, /) to avoid invalid
                     # Telegram command names downstream.
-                    cmd_name = name.lower().replace(' ', '-').replace('_', '-')
-                    cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
-                    cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
+                    cmd_name = _normalize_skill_command_slug(name)
                     if not cmd_name:
                         continue
-                    _skill_commands[f"/{cmd_name}"] = {
+                    skill_command_info = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
                     }
+                    _skill_commands[f"/{cmd_name}"] = skill_command_info
+
+                    aliases = frontmatter.get("aliases") or frontmatter.get("slash_aliases") or []
+                    if isinstance(aliases, str):
+                        aliases = [aliases]
+                    if isinstance(aliases, (list, tuple, set)):
+                        for alias in aliases:
+                            alias_name = _normalize_skill_command_slug(alias)
+                            if not alias_name or alias_name == cmd_name:
+                                continue
+                            alias_key = f"/{alias_name}"
+                            # First skill wins on collisions for deterministic
+                            # behavior; canonical names are inserted before aliases.
+                            _skill_commands.setdefault(alias_key, skill_command_info)
                 except Exception:
                     continue
     except Exception:
@@ -482,7 +504,10 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     """
     if not command:
         return None
-    cmd_key = f"/{command.replace('_', '-')}"
+    normalized = _normalize_skill_command_slug(command)
+    if not normalized:
+        return None
+    cmd_key = f"/{normalized}"
     return cmd_key if cmd_key in get_skill_commands() else None
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -363,8 +363,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         if src.applied:
             print(
                 f"  {src.label}: applied {len(src.applied)} "
-                f"secret{'s' if len(src.applied) != 1 else ''} "
-                f"({', '.join(sorted(src.applied))})",
+                f"secret{'s' if len(src.applied) != 1 else ''}",
                 file=sys.stderr,
             )
         if src.result.error:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -452,10 +452,19 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_host in {"0.0.0.0", "::"}:
         return True
 
-    # Loopback bind: accept the loopback names
+    # Loopback bind: accept loopback names and operator-allowlisted reverse
+    # proxy origins. The allowlist is opt-in; without it, preserve the strict
+    # DNS-rebinding defence above.
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        if host_only in _LOOPBACK_HOST_VALUES:
+            return True
+        allowed_hosts = {
+            entry.strip().lower().rstrip(".")
+            for entry in os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "").split(",")
+            if entry.strip()
+        }
+        return host_only.rstrip(".") in allowed_hosts
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,7 +1903,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1920,7 +1919,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1937,7 +1935,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1954,7 +1951,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1971,7 +1967,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1988,7 +1983,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2005,7 +1999,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2022,7 +2015,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2039,7 +2031,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2056,7 +2047,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2073,7 +2063,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2090,7 +2079,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2107,7 +2095,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2124,7 +2111,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2141,7 +2127,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2158,7 +2143,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2175,7 +2159,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2192,7 +2175,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2209,7 +2191,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2226,7 +2207,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2243,7 +2223,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2260,7 +2239,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2277,7 +2255,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2294,7 +2271,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2311,7 +2287,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2328,7 +2303,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -58,6 +58,18 @@ class TestScanSkillCommands:
         assert "/my-skill" in result
         assert result["/my-skill"]["name"] == "my-skill"
 
+    def test_registers_frontmatter_aliases(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "brainstorming",
+                frontmatter_extra="aliases: [brainstorm]\n",
+            )
+            result = scan_skill_commands()
+        assert "/brainstorming" in result
+        assert "/brainstorm" in result
+        assert result["/brainstorm"] is result["/brainstorming"]
+
     def test_empty_dir(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             result = scan_skill_commands()
@@ -396,6 +408,16 @@ class TestResolveSkillCommandKey:
             _make_skill(tmp_path, "claude-code")
             scan_skill_commands()
             assert resolve_skill_command_key("claude_code") == "/claude-code"
+
+    def test_alias_command_resolves(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "brainstorming",
+                frontmatter_extra="aliases: [brainstorm]\n",
+            )
+            scan_skill_commands()
+            assert resolve_skill_command_key("brainstorm") == "/brainstorm"
 
     def test_single_word_command_resolves(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -83,6 +83,15 @@ class TestHostHeaderValidator:
         assert _is_accepted_host("LOCALHOST", "127.0.0.1")
         assert _is_accepted_host("LocalHost:9119", "127.0.0.1")
 
+    def test_loopback_bind_accepts_explicit_proxy_allowlist(self, monkeypatch):
+        """A trusted reverse-proxy origin is accepted only when explicitly listed."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_HOSTS", "100.76.22.58,hermes.kavyro.com")
+        assert _is_accepted_host("100.76.22.58:9119", "127.0.0.1")
+        assert _is_accepted_host("hermes.kavyro.com", "127.0.0.1")
+        assert not _is_accepted_host("evil.example", "127.0.0.1")
+
 
 class TestHostHeaderMiddleware:
     """End-to-end test via the FastAPI app — verify the middleware

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -71,7 +71,7 @@ def test_format_secret_source_suffix_onepassword_uses_proper_name():
     )
 
 
-def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkeypatch):
+def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkeypatch, capsys):
     """End-to-end: when the Bitwarden source fetches keys, applied vars
     end up in ``_SECRET_SOURCES`` so the UI can label them."""
 
@@ -104,6 +104,9 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
 
     env_loader._apply_external_secret_sources(tmp_path)
 
+    status = capsys.readouterr().err
+    assert "Bitwarden Secrets Manager: applied 1 secret" in status
+    assert "ANTHROPIC_API_KEY" not in status
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "bitwarden"
     assert (
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")


### PR DESCRIPTION
## Summary

Three independent improvements bundled in one branch:

### 1. Skill slash-command aliases from frontmatter
**Files:** `agent/skill_commands.py`, `tests/agent/test_skill_commands.py`

Skills can now declare `aliases` (or `slash_aliases`) in YAML frontmatter. Each alias becomes a callable `/command` pointing at the same skill definition. Canonical names always win on collision (inserted before aliases).

Extracted `_normalize_skill_command_slug()` helper and used it consistently in both `scan_skill_commands` and `resolve_skill_command_key`, fixing edge-case resolution for underscored inputs.

### 2. Opt-in reverse-proxy host allowlist for loopback dashboard binds
**Files:** `hermes_cli/web_server.py`, `tests/hermes_cli/test_web_server_host_header.py`

When the dashboard binds to loopback, a reverse proxy on a different host (e.g. Tailscale IP, domain) was rejected by the DNS-rebinding guard. Added `HERMES_DASHBOARD_ALLOWED_HOSTS` env var so operators can explicitly allowlist trusted proxy origins. Without the env var, strict defence is preserved unchanged.

### 3. Stop leaking resolved secret key names in startup log
**Files:** `hermes_cli/env_loader.py`, `tests/test_env_loader_secret_sources.py`, `package-lock.json`

The external secret-source summary printed the list of applied variable names (e.g. `ANTHROPIC_API_KEY`) to stderr, exposing secret identifiers in logs and terminal output. Removed the inline list; kept only the count.

Also removes stray `peer: true` flags in `package-lock.json` that npm 10 prunes automatically but created noisy diffs.

## Tests

```
pytest tests/agent/test_skill_commands.py tests/hermes_cli/test_web_server_host_header.py tests/test_env_loader_secret_sources.py -x -q
→ 80 passed
```