### PR TITLE
feat(skills): let users mention skills inline

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -534,6 +534,80 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     return sp
 
 
+def _expand_inline_skills_for_turn(
+    agent,
+    user_message: Any,
+    task_id: Optional[str],
+    persist_user_message: Optional[Any],
+) -> tuple[Any, Optional[Any]]:
+    text = None
+    text_index = None
+    mention_text = None
+    if isinstance(user_message, str):
+        text = user_message
+        mention_text = user_message
+    elif isinstance(user_message, list):
+        text_parts = []
+        for index, part in enumerate(user_message):
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ):
+                text_parts.append((index, part["text"]))
+        if text_parts:
+            text_index, text = text_parts[0]
+            mention_text = "\n".join(value for _, value in text_parts)
+
+    if text is None:
+        return user_message, persist_user_message
+
+    if isinstance(persist_user_message, str):
+        mention_text = persist_user_message
+    elif isinstance(persist_user_message, list):
+        persisted_text_parts = []
+        for part in persist_user_message:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ):
+                persisted_text_parts.append(part["text"])
+        mention_text = "\n".join(persisted_text_parts)
+
+    if not mention_text or "$" not in mention_text:
+        return user_message, persist_user_message
+
+    try:
+        from agent.skill_commands import expand_inline_skill_mentions
+
+        expanded = expand_inline_skill_mentions(
+            text,
+            task_id=task_id,
+            platform=getattr(agent, "platform", None),
+            mention_text=mention_text,
+        )
+    except Exception:
+        logger.debug("Inline skill mention expansion failed", exc_info=True)
+        return user_message, persist_user_message
+
+    if expanded is None:
+        return user_message, persist_user_message
+
+    expanded_text, _loaded, _missing = expanded
+    if text_index is None:
+        model_message = expanded_text
+    else:
+        model_message = [
+            dict(part) if isinstance(part, dict) else part for part in user_message
+        ]
+        model_message[text_index]["text"] = expanded_text
+
+    if persist_user_message is None:
+        persist_user_message = user_message
+    return model_message, persist_user_message
+
+
 def run_conversation(
     agent,
     user_message: Any,
@@ -578,6 +652,13 @@ def run_conversation(
                     persist_user_message = _decoded_message
         except Exception:
             pass
+
+    user_message, persist_user_message = _expand_inline_skills_for_turn(
+        agent,
+        user_message,
+        task_id,
+        persist_user_message,
+    )
 
     # ── Per-turn setup (the prologue) ──
     # All once-per-turn setup — stdio guarding, retry-counter resets, user

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -21,10 +21,42 @@ from agent.skill_preprocessing import (
 logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
+_inline_skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_INLINE_SKILL_TOKEN = re.compile(
+    r"(?P<ticks>`+)|(?<![\w\\$])\$(?P<name>[A-Za-z][A-Za-z0-9_-]*)"
+)
+_INLINE_SHELL_NAMES = frozenset({
+    "BASH_SOURCE",
+    "EDITOR",
+    "FUNCNAME",
+    "HOME",
+    "HOSTNAME",
+    "HOSTTYPE",
+    "IFS",
+    "LANG",
+    "LINENO",
+    "MACHTYPE",
+    "OLDPWD",
+    "PAGER",
+    "PATH",
+    "PS1",
+    "PS2",
+    "PWD",
+    "RANDOM",
+    "SHELL",
+    "SHLVL",
+    "TERM",
+    "TMPDIR",
+    "USER",
+    "VISUAL",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+})
 
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
@@ -323,9 +355,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _inline_skill_commands, _skill_commands_platform
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
+    _inline_skill_commands = {}
+    inline_ambiguous: set[str] = set()
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
@@ -375,6 +409,19 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
+                    cmd_key = f"/{cmd_name}"
+                    skill_info = {
+                        "name": name,
+                        "description": description or f"Invoke the {name} skill",
+                        "skill_md_path": str(skill_md),
+                        "skill_dir": str(skill_md.parent),
+                    }
+                    existing_inline = _inline_skill_commands.get(cmd_key)
+                    if existing_inline is None and cmd_key not in inline_ambiguous:
+                        _inline_skill_commands[cmd_key] = skill_info
+                    elif existing_inline and existing_inline.get("name") != name:
+                        _inline_skill_commands.pop(cmd_key, None)
+                        inline_ambiguous.add(cmd_key)
                     # Skip if this skill's auto-generated /command collides
                     # with a core Hermes slash command (name or alias). The
                     # skill remains fully loadable via /skill <name>.
@@ -392,7 +439,6 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # distinct frontmatter names can normalize to the same
                     # slug (e.g. "git_helper" vs "git-helper"). First-wins
                     # preserves local-before-external precedence.
-                    cmd_key = f"/{cmd_name}"
                     if cmd_key in _skill_commands:
                         logger.warning(
                             "Skill %r maps to slash command %s already claimed "
@@ -400,12 +446,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                             name, cmd_key, _skill_commands[cmd_key]["name"],
                         )
                         continue
-                    _skill_commands[cmd_key] = {
-                        "name": name,
-                        "description": description or f"Invoke the {name} skill",
-                        "skill_md_path": str(skill_md),
-                        "skill_dir": str(skill_md.parent),
-                    }
+                    _skill_commands[cmd_key] = skill_info
                 except Exception:
                     continue
     except Exception:
@@ -426,6 +467,15 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     ):
         scan_skill_commands()
     return _skill_commands
+
+
+def get_inline_skill_commands() -> Dict[str, Dict[str, Any]]:
+    if (
+        not _inline_skill_commands
+        or _skill_commands_platform != _resolve_skill_commands_platform()
+    ):
+        scan_skill_commands()
+    return _inline_skill_commands
 
 
 def reload_skills() -> Dict[str, Any]:
@@ -517,6 +567,7 @@ def build_skill_invocation_message(
     user_instruction: str = "",
     task_id: str | None = None,
     runtime_note: str = "",
+    _command_map: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Optional[str]:
     """Build the user message content for a skill slash command invocation.
 
@@ -527,7 +578,7 @@ def build_skill_invocation_message(
     Returns:
         The formatted message string, or None if the skill wasn't found.
     """
-    commands = get_skill_commands()
+    commands = get_skill_commands() if _command_map is None else _command_map
     skill_info = commands.get(cmd_key)
     if not skill_info:
         return None
@@ -612,6 +663,7 @@ def build_stacked_skill_invocation_message(
     cmd_keys: list[str],
     user_instruction: str = "",
     task_id: str | None = None,
+    _command_map: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Optional[tuple[str, list[str], list[str]]]:
     """Build the user message for a stacked multi-skill slash invocation.
 
@@ -623,7 +675,7 @@ def build_stacked_skill_invocation_message(
         ``(message, loaded_skill_names, missing_skill_names)`` or ``None``
         when no skill could be loaded at all.
     """
-    commands = get_skill_commands()
+    commands = get_skill_commands() if _command_map is None else _command_map
 
     loaded_names: list[str] = []
     missing: list[str] = []
@@ -688,6 +740,96 @@ def build_stacked_skill_invocation_message(
 
     header = "\n".join(header_lines)
     return ("\n\n".join([header, *skill_blocks]), loaded_names, missing)
+
+
+def _resolve_inline_skill_command_keys(
+    text: str,
+    platform: str | None = None,
+) -> list[str]:
+    if not text or text.startswith(_SKILL_INVOCATION_PREFIX):
+        return []
+
+    mentions = extract_skill_mentions(text)
+    if not mentions:
+        return []
+
+    commands = get_inline_skill_commands()
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+
+        disabled = get_disabled_skill_names(platform=platform)
+    except Exception:
+        disabled = set()
+
+    keys: list[str] = []
+    for name in mentions:
+        cmd_key = f"/{name.lower().replace('_', '-')}"
+        skill_info = commands.get(cmd_key)
+        if not skill_info or skill_info.get("name") in disabled:
+            continue
+        if cmd_key not in keys:
+            keys.append(cmd_key)
+        if len(keys) == _MAX_STACKED_SKILLS:
+            break
+    return keys
+
+
+def extract_skill_mentions(text: str) -> list[str]:
+    if not text or "$" not in text:
+        return []
+
+    mentions: list[str] = []
+    code_ticks: int | None = None
+    for match in _INLINE_SKILL_TOKEN.finditer(text):
+        ticks = match.group("ticks")
+        if ticks is not None:
+            width = len(ticks)
+            if code_ticks is None:
+                code_ticks = width
+            elif code_ticks == width:
+                code_ticks = None
+            continue
+        if code_ticks is not None:
+            continue
+
+        name = match.group("name")
+        if name in _INLINE_SHELL_NAMES:
+            continue
+        mentions.append(name)
+    return mentions
+
+
+def expand_inline_skill_mentions(
+    text: str,
+    task_id: str | None = None,
+    platform: str | None = None,
+    mention_text: str | None = None,
+) -> Optional[tuple[str, list[str], list[str]]]:
+    cmd_keys = _resolve_inline_skill_command_keys(
+        text if mention_text is None else mention_text,
+        platform=platform,
+    )
+    if not cmd_keys:
+        return None
+
+    if len(cmd_keys) == 1:
+        message = build_skill_invocation_message(
+            cmd_keys[0],
+            text,
+            task_id=task_id,
+            _command_map=get_inline_skill_commands(),
+        )
+        if message is None:
+            return None
+        skill_name = str(get_inline_skill_commands()[cmd_keys[0]].get("name") or "")
+        return message, [skill_name], []
+
+    return build_stacked_skill_invocation_message(
+        cmd_keys,
+        text,
+        task_id=task_id,
+        _command_map=get_inline_skill_commands(),
+    )
 
 
 def build_preloaded_skills_prompt(

--- a/tests/agent/test_inline_skill_mentions.py
+++ b/tests/agent/test_inline_skill_mentions.py
@@ -1,0 +1,258 @@
+from unittest.mock import patch
+
+from agent.conversation_loop import _expand_inline_skills_for_turn
+from agent.skill_commands import (
+    expand_inline_skill_mentions,
+    extract_skill_mentions,
+    extract_user_instruction_from_skill_message,
+    scan_skill_commands,
+)
+
+
+def _make_skill(skills_dir, name, body):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: {name} guidance
+---
+
+# {name}
+
+{body}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_extracts_mentions_without_shell_or_literal_forms():
+    text = (
+        "Use $code-review and $test_driven_development, not $PATH, "
+        "\\$escaped, `$inline-code`, or ```\n$fenced-code\n```."
+    )
+
+    assert extract_skill_mentions(text) == [
+        "code-review",
+        "test_driven_development",
+    ]
+
+
+def test_expands_multiple_mentions_in_first_use_order(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "code-review", "Inspect the patch carefully.")
+        _make_skill(tmp_path, "test-driven-development", "Start with a failing test.")
+        scan_skill_commands()
+        prompt = (
+            "Review this $code-review, use $test_driven_development, "
+            "then confirm with $code-review."
+        )
+        result = expand_inline_skill_mentions(prompt, task_id="turn-1")
+
+    assert result is not None
+    message, loaded, missing = result
+    assert loaded == ["code-review", "test-driven-development"]
+    assert missing == []
+    assert "Inspect the patch carefully." in message
+    assert "Start with a failing test." in message
+    assert extract_user_instruction_from_skill_message(message) == prompt
+
+
+def test_expands_a_single_inline_mention(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "code-review", "Inspect the patch carefully.")
+        scan_skill_commands()
+        prompt = "Please $code-review this change."
+        result = expand_inline_skill_mentions(prompt)
+
+    assert result is not None
+    message, loaded, missing = result
+    assert loaded == ["code-review"]
+    assert missing == []
+    assert "Inspect the patch carefully." in message
+    assert extract_user_instruction_from_skill_message(message) == prompt
+
+
+def test_expands_a_skill_whose_name_collides_with_a_slash_command(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "help", "Apply the help skill.")
+        commands = scan_skill_commands()
+        result = expand_inline_skill_mentions("Use $help for this task.")
+
+    assert "/help" not in commands
+    assert result is not None
+    message, loaded, missing = result
+    assert loaded == ["help"]
+    assert missing == []
+    assert "Apply the help skill." in message
+
+
+def test_skips_ambiguous_normalized_skill_names(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "git-helper", "Hyphenated guidance.")
+        _make_skill(tmp_path, "git_helper", "Underscored guidance.")
+        scan_skill_commands()
+        result = expand_inline_skill_mentions("Use $git-helper for this task.")
+
+    assert result is None
+
+
+def test_leaves_shell_escapes_and_markdown_code_literal(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "home", "Home skill content.")
+        _make_skill(tmp_path, "code-review", "Review skill content.")
+        scan_skill_commands()
+        prompt = (
+            "Keep $HOME and \\$code-review literal, then show `$code-review`.\n"
+            "```sh\n$code-review\n```"
+        )
+        result = expand_inline_skill_mentions(prompt)
+
+    assert result is None
+
+
+def test_lowercase_skill_can_share_a_shell_variable_name(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "home", "Home skill content.")
+        scan_skill_commands()
+        result = expand_inline_skill_mentions("Use $home for this task.")
+
+    assert result is not None
+    message, loaded, missing = result
+    assert loaded == ["home"]
+    assert missing == []
+    assert "Home skill content." in message
+
+
+def test_skips_unknown_and_platform_disabled_skills(tmp_path, monkeypatch):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "code-review", "Review skill content.")
+        scan_skill_commands()
+        monkeypatch.setattr(
+            "agent.skill_utils.get_disabled_skill_names",
+            lambda platform=None: {"code-review"} if platform == "discord" else set(),
+        )
+        result = expand_inline_skill_mentions(
+            "Use $unknown and $code-review.",
+            platform="discord",
+        )
+
+    assert result is None
+
+
+def test_limits_inline_skill_chains_to_five(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        for index in range(6):
+            _make_skill(tmp_path, f"skill-{index}", f"Guidance {index}.")
+        scan_skill_commands()
+        result = expand_inline_skill_mentions(
+            " ".join(f"$skill-{index}" for index in range(6))
+        )
+
+    assert result is not None
+    message, loaded, missing = result
+    assert loaded == [f"skill-{index}" for index in range(5)]
+    assert missing == []
+    assert "Guidance 4." in message
+    assert "Guidance 5." not in message
+
+
+def test_turn_expansion_preserves_the_original_message():
+    class Agent:
+        platform = "telegram"
+
+    with patch(
+        "agent.skill_commands.expand_inline_skill_mentions",
+        return_value=("expanded", ["code-review"], []),
+    ) as expand:
+        model_message, persisted = _expand_inline_skills_for_turn(
+            Agent(),
+            "Please $code-review this.",
+            "turn-2",
+            None,
+        )
+
+    assert model_message == "expanded"
+    assert persisted == "Please $code-review this."
+    expand.assert_called_once_with(
+        "Please $code-review this.",
+        task_id="turn-2",
+        platform="telegram",
+        mention_text="Please $code-review this.",
+    )
+
+
+def test_turn_expansion_keeps_multimodal_parts_and_existing_persistence():
+    class Agent:
+        platform = "discord"
+
+    user_message = [
+        {"type": "text", "text": "Inspect this with $code-review."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+    ]
+    with patch(
+        "agent.skill_commands.expand_inline_skill_mentions",
+        return_value=("expanded", ["code-review"], []),
+    ):
+        model_message, persisted = _expand_inline_skills_for_turn(
+            Agent(),
+            user_message,
+            "turn-3",
+            "Inspect this image with $code-review.",
+        )
+
+    assert model_message[0] == {"type": "text", "text": "expanded"}
+    assert model_message[1] == user_message[1]
+    assert user_message[0]["text"] == "Inspect this with $code-review."
+    assert persisted == "Inspect this image with $code-review."
+
+
+def test_turn_expansion_finds_mentions_in_later_text_parts():
+    class Agent:
+        platform = "tui"
+
+    user_message = [
+        {"type": "text", "text": "Inspect both inputs."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+        {"type": "text", "text": "Apply $code-review."},
+    ]
+    with patch(
+        "agent.skill_commands.expand_inline_skill_mentions",
+        return_value=("expanded", ["code-review"], []),
+    ) as expand:
+        model_message, persisted = _expand_inline_skills_for_turn(
+            Agent(),
+            user_message,
+            "turn-4",
+            None,
+        )
+
+    assert model_message[0] == {"type": "text", "text": "expanded"}
+    assert model_message[1:] == user_message[1:]
+    assert persisted == user_message
+    expand.assert_called_once_with(
+        "Inspect both inputs.",
+        task_id="turn-4",
+        platform="tui",
+        mention_text="Inspect both inputs.\nApply $code-review.",
+    )
+
+
+def test_turn_expansion_ignores_mentions_from_synthetic_context():
+    class Agent:
+        platform = "slack"
+
+    with patch(
+        "agent.skill_commands.expand_inline_skill_mentions",
+        return_value=None,
+    ) as expand:
+        model_message, persisted = _expand_inline_skills_for_turn(
+            Agent(),
+            "[Observed context: $code-review]\nCurrent message: hello",
+            "turn-5",
+            "hello",
+        )
+
+    assert model_message == "[Observed context: $code-review]\nCurrent message: hello"
+    assert persisted == "hello"
+    expand.assert_not_called()

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -354,6 +354,20 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 All four skills appear in your skill index. If you create a new skill called `my-custom-workflow` locally, it shadows the external version.
 
+## Inline Skill Mentions
+
+Mention an installed skill anywhere in a prompt with `$skill-name` to load it for that turn:
+
+```text
+Review this patch with $code-review and use $test-driven-development to fix it.
+```
+
+Hermes loads each mentioned skill once, in the order it appears, and supports up to five skills in one prompt. The original prompt remains the user instruction, so mentions work naturally in the CLI, TUI, dashboard chat, and messaging gateways.
+
+Unknown or disabled skill names remain ordinary text. Shell variables such as `$HOME`, escaped mentions such as `\$code-review`, and mentions inside backtick code spans or fenced code blocks do not activate skills.
+
+Inline mentions only affect the current user turn. Use a slash command when the skill belongs at the start of the prompt, or create a bundle when you repeatedly use the same group of skills.
+
 ## Skill Bundles
 
 Skill bundles are tiny YAML files that group several skills under a single slash command. When you run `/<bundle-name>`, every skill listed in the bundle loads at once — useful when a particular task always benefits from the same set of skills together.


### PR DESCRIPTION
## What does this PR do?

Adds inline skill mentions using `$skill-name`, so users can activate installed skills naturally anywhere in a prompt and chain up to five skills in first-use order.

For example:

```text
Review this patch with $code-review and use $test-driven-development to fix it.
```

The implementation resolves mentions only against active installed skill metadata and reuses the existing secure skill loaders and invocation scaffolding. It keeps slash commands unchanged, preserves the original user message in transcripts and memory, and injects skill content only into the model-facing turn so the byte-stable system prompt remains untouched.

Unknown, ambiguous, and platform-disabled skills remain ordinary text. Common shell variables, escaped mentions, Markdown code spans, and fenced code blocks are deliberately ignored. OpenAI-style multimodal messages are supported without changing image ordering.

## Related Issue

Fixes #64601

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/skill_commands.py`: detect and resolve inline mentions, handle collisions and disabled skills, and reuse single or stacked skill loading.
- `agent/conversation_loop.py`: expand mentions for model-facing turns while preserving clean text and multimodal transcripts.
- `tests/agent/test_inline_skill_mentions.py`: cover extraction, chaining, ambiguity, shell and Markdown literals, platform gates, persistence, and multimodal input.
- `website/docs/user-guide/features/skills.md`: document syntax, limits, literal forms, and turn-local behavior.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_inline_skill_mentions.py tests/agent/test_skill_commands.py tests/agent/test_memory_skill_scaffolding.py`. Expected result: 85 passed.
2. Run `ruff check agent/conversation_loop.py agent/skill_commands.py tests/agent/test_inline_skill_mentions.py`.
3. Run `python scripts/check-windows-footguns.py agent/conversation_loop.py agent/skill_commands.py tests/agent/test_inline_skill_mentions.py website/docs/user-guide/features/skills.md`.

The full canonical `scripts/run_tests.sh` run completed with 38,922 passed and 496 failed. No failure occurred in a changed path. The failures were concentrated in unrelated suites requiring unavailable optional packages or services, restricted network and process behavior, and per-file timeouts.

CI slice 8 currently reports one failure in `tests/agent/test_codex_responses_adapter.py::test_normalize_codex_response_salvage_is_xai_scoped`. The PR does not modify that test or its implementation, and the same command reproduces the identical result on the exact untouched base commit `569b912d7`: 25 passed, 1 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

Not applicable.