### PR TITLE
 fix(vision): validate user_prompt and use default when omitted (#53638)

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -1318,3 +1318,149 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# vision_analyze_tool — empty/missing user_prompt validation
+# Issue #53638: empty user_prompt sent to upstream API → HTTP 400
+# ---------------------------------------------------------------------------
+
+
+class TestVisionAnalyzeEmptyPrompt:
+    """Tests for user_prompt validation in vision_analyze_tool.
+
+    Ensures that a missing or blank user_prompt either uses a sensible
+    default or raises a clear ValueError instead of sending an empty
+    message to the upstream API (which returns a confusing HTTP 400).
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_string_prompt_raises_value_error(self):
+        """An explicitly empty user_prompt should raise ValueError, not hit the API."""
+        with pytest.raises(ValueError, match="user_prompt cannot be empty"):
+            await vision_analyze_tool("https://example.com/image.jpg", "")
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_prompt_raises_value_error(self):
+        """A whitespace-only user_prompt should raise ValueError."""
+        with pytest.raises(ValueError, match="user_prompt cannot be empty"):
+            await vision_analyze_tool("https://example.com/image.jpg", "   ")
+
+    @pytest.mark.asyncio
+    async def test_none_prompt_coerced_then_raises_value_error(self):
+        """None user_prompt is coerced to '' which then raises ValueError."""
+        with pytest.raises(ValueError, match="user_prompt cannot be empty"):
+            await vision_analyze_tool("https://example.com/image.jpg", None)
+
+
+class TestHandleVisionAnalyzeEmptyQuestion:
+    """Tests for _handle_vision_analyze when question is missing, empty, or null.
+
+    The handler is the entry point from the agent loop. When the model
+    omits the optional 'question' parameter, the handler should build a
+    sensible default prompt rather than passing an empty string through.
+    Also tests type-safe normalization for "question": null (JSON null),
+    which registry.dispatch() does not validate against the schema.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_question_uses_default_prompt(self):
+        """When 'question' is not in args, full_prompt should be the default."""
+        captured_args = {}
+
+        async def fake_tool(image_url, full_prompt, model, task_id=None):
+            captured_args["full_prompt"] = full_prompt
+
+        with (
+            patch("tools.vision_tools.vision_analyze_tool", side_effect=fake_tool),
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+            patch("tools.vision_tools.os.getenv", return_value=""),
+        ):
+            await _handle_vision_analyze({"image_url": "https://example.com/img.jpg"})
+
+        assert captured_args["full_prompt"] == "Describe this image in detail."
+
+    @pytest.mark.asyncio
+    async def test_empty_question_uses_default_prompt(self):
+        """When 'question' is an empty string, full_prompt should be the default."""
+        captured_args = {}
+
+        async def fake_tool(image_url, full_prompt, model, task_id=None):
+            captured_args["full_prompt"] = full_prompt
+
+        with (
+            patch("tools.vision_tools.vision_analyze_tool", side_effect=fake_tool),
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+            patch("tools.vision_tools.os.getenv", return_value=""),
+        ):
+            await _handle_vision_analyze({"image_url": "https://example.com/img.jpg", "question": ""})
+
+        assert captured_args["full_prompt"] == "Describe this image in detail."
+
+    @pytest.mark.asyncio
+    async def test_whitespace_question_uses_default_prompt(self):
+        """When 'question' is only whitespace, full_prompt should be the default."""
+        captured_args = {}
+
+        async def fake_tool(image_url, full_prompt, model, task_id=None):
+            captured_args["full_prompt"] = full_prompt
+
+        with (
+            patch("tools.vision_tools.vision_analyze_tool", side_effect=fake_tool),
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+            patch("tools.vision_tools.os.getenv", return_value=""),
+        ):
+            await _handle_vision_analyze({"image_url": "https://example.com/img.jpg", "question": "   "})
+
+        assert captured_args["full_prompt"] == "Describe this image in detail."
+
+    @pytest.mark.asyncio
+    async def test_null_question_uses_default_prompt(self):
+        """When 'question' is JSON null, full_prompt should be the default.
+
+        registry.dispatch() forwards parsed tool arguments directly and does
+        not validate against the schema, so a model can emit "question": null.
+        The handler must normalize this type-safely without raising.
+        """
+        captured_args = {}
+
+        async def fake_tool(image_url, full_prompt, model, task_id=None):
+            captured_args["full_prompt"] = full_prompt
+
+        with (
+            patch("tools.vision_tools.vision_analyze_tool", side_effect=fake_tool),
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+            patch("tools.vision_tools.os.getenv", return_value=""),
+        ):
+            await _handle_vision_analyze({"image_url": "https://example.com/img.jpg", "question": None})
+
+        assert captured_args["full_prompt"] == "Describe this image in detail."
+
+    @pytest.mark.asyncio
+    async def test_non_empty_question_uses_question_prompt(self):
+        """When 'question' has content, the full formatted prompt should be used."""
+        captured_args = {}
+
+        async def fake_tool(image_url, full_prompt, model, task_id=None):
+            captured_args["full_prompt"] = full_prompt
+
+        with (
+            patch("tools.vision_tools.vision_analyze_tool", side_effect=fake_tool),
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+            patch("tools.vision_tools.os.getenv", return_value=""),
+        ):
+            await _handle_vision_analyze({"image_url": "https://example.com/img.jpg", "question": "What color is the car?"})
+
+        assert "What color is the car?" in captured_args["full_prompt"]
+        assert "Describe this image in detail." not in captured_args["full_prompt"]
+
+
+class TestVisionAnalyzeSchema:
+    """Tests for the VISION_ANALYZE_SCHEMA — question should be optional."""
+
+    def test_question_not_in_required(self):
+        """The 'question' parameter should not be in the required list."""
+        from tools.vision_tools import VISION_ANALYZE_SCHEMA
+
+        assert "question" not in VISION_ANALYZE_SCHEMA["parameters"]["required"]
+        assert "image_url" in VISION_ANALYZE_SCHEMA["parameters"]["required"]

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1062,7 +1062,7 @@ async def _vision_analyze_native(
 
 async def vision_analyze_tool(
     image_url: str,
-    user_prompt: str,
+    user_prompt: str = "Describe this image in detail.",
     model: str = None,
     task_id: Optional[str] = None,
 ) -> str:
@@ -1100,6 +1100,12 @@ async def vision_analyze_tool(
     """
     if not isinstance(user_prompt, str):
         user_prompt = str(user_prompt) if user_prompt is not None else ""
+    if not user_prompt.strip():
+        raise ValueError(
+            "user_prompt cannot be empty. Provide a question or instruction "
+            "for the vision model, or omit the parameter to use the default "
+            "(\"Describe this image in detail.\")."
+        )
     debug_call_data = {
         "parameters": {
             "image_url": image_url,
@@ -1462,17 +1468,23 @@ VISION_ANALYZE_SCHEMA = {
             },
             "question": {
                 "type": "string",
-                "description": "Your specific question or request about the image. Optional context the model uses on the next turn after seeing the image."
+                "description": "Your specific question or request about the image. If omitted, a default description prompt is used. Optional context the model uses on the next turn after seeing the image."
             }
         },
-        "required": ["image_url", "question"]
+        "required": ["image_url"]
     }
 }
 
 
 async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
     image_url = args.get("image_url", "")
+    # Normalize question type-safely: a model can emit "question": null,
+    # and registry.dispatch() does not validate against the schema before
+    # calling the handler, so we must guard against non-string values.
     question = args.get("question", "")
+    if not isinstance(question, str):
+        question = str(question) if question is not None else ""
+    question = question.strip()
     task_id = kw.get("task_id")
 
     # The fan-out cap lives inside the encode/resize step (offloaded to the
@@ -1491,10 +1503,15 @@ async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
         return await _vision_analyze_native(image_url, question, task_id=task_id)
 
     # Legacy path: aux LLM describes the image and we return its text.
-    full_prompt = (
-        "Fully describe and explain everything about this image, then answer the "
-        f"following question:\n\n{question}"
-    )
+    # When no question is provided, use a sensible default description prompt
+    # instead of sending an empty question to the upstream API.
+    if question:
+        full_prompt = (
+            "Fully describe and explain everything about this image, then answer the "
+            f"following question:\n\n{question}"
+        )
+    else:
+        full_prompt = "Describe this image in detail."
     # Prefer config.yaml auxiliary.vision.model; env var is a legacy override.
     model = None
     try:


### PR DESCRIPTION
    Summary

    Fixes #53638

    Rebased on current main per review feedback from @teknium1. Addresses all points raised in the sweeper review.

    Changes (updated for current main)

    - tools/vision_tools.py:
      - Added default value "Describe this image in detail." to user_prompt parameter in vision_analyze_tool()
      - Added early validation: raises ValueError when user_prompt is empty or whitespace-only after coercion
      - Made question optional in VISION_ANALYZE_SCHEMA (removed from required list, updated description)
      - Type-safe normalization in _handle_vision_analyze: guard against "question": null (JSON null) which registry.dispatch() does not validate against the schema — normalize only after confirming the value is a string, then strip
      - Use default description prompt when question is missing/empty/null instead of building a prompt with an empty question section
      - Preserved task_id and auxiliary-model-resolution paths (config.yaml auxiliary.vision.model + env var fallback)

    - tests/tools/test_vision_tools.py:
      - TestVisionAnalyzeEmptyPrompt: 3 tests for empty/whitespace/None prompt validation
      - TestHandleVisionAnalyzeEmptyQuestion: 5 tests including null-question regression test (per review: model can emit "question": null)
      - TestVisionAnalyzeSchema: 1 test verifying question is not in required list

    Review feedback addressed

    1. ✅ Ported fix to current vision_analyze_tool definition (lines 1063-1102)
    2. ✅ Type-safe question normalization — no unguarded .strip() on non-string values
    3. ✅ Added null-question regression test
    4. ✅ Preserved task_id and auxiliary-model-resolution handling

    Verification

    All 9 new tests pass:

    tests/tools/test_vision_tools.py::TestVisionAnalyzeEmptyPrompt::test_empty_string_prompt_raises_value_error PASSED
    tests/tools/test_vision_tools.py::TestVisionAnalyzeEmptyPrompt::test_whitespace_only_prompt_raises_value_error PASSED
    tests/tools/test_vision_tools.py::TestVisionAnalyzeEmptyPrompt::test_none_prompt_coerced_then_raises_value_error PASSED
    tests/tools/test_vision_tools.py::TestHandleVisionAnalyzeEmptyQuestion::test_missing_question_uses_default_prompt PASSED
    tests/tools/test_vision_tools.py::TestHandleVisionAnalyzeEmptyQuestion::test_empty_question_uses_default_prompt PASSED
    tests/tools/test_vision_tools.py::TestHandleVisionAnalyzeEmptyQuestion::test_whitespace_question_uses_default_prompt PASSED
    tests/tools/test_vision_tools.py::TestHandleVisionAnalyzeEmptyQuestion::test_null_question_uses_default_prompt PASSED
    tests/tools/test_vision_tools.py::TestHandleVisionAnalyzeEmptyQuestion::test_non_empty_question_uses_question_prompt PASSED
    tests/tools/test_vision_tools.py::TestVisionAnalyzeSchema::test_question_not_in_required PASSED