### PR TITLE
feat(gateway): add /mcp slash command to inspect MCP server status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9970,6 +9970,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
+        if canonical == "mcp":
+            return await self._handle_mcp_command(event)
+
         if canonical == "reload-mcp":
             return await self._handle_reload_mcp_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4139,6 +4139,63 @@ class GatewaySlashCommandsMixin:
             logger.error("Insights command error: %s", e, exc_info=True)
             return t("gateway.insights.error", error=e)
 
+    async def _handle_mcp_command(self, event: MessageEvent) -> str:
+        """Handle /mcp — show configured MCP servers and connection status.
+
+        Read-only companion to ``/reload-mcp``: renders the same information
+        surfaced by ``hermes mcp list`` plus the runtime connection state
+        tracked in ``tools.mcp_tool`` (connected / connecting / failed /
+        disabled / configured). No side effects, no prompt-cache impact.
+        """
+        try:
+            from tools.mcp_tool import get_mcp_status
+        except Exception as exc:
+            logger.warning("MCP status unavailable: %s", exc)
+            return f"MCP subsystem unavailable: {exc}"
+
+        try:
+            statuses = get_mcp_status()
+        except Exception as exc:
+            logger.warning("get_mcp_status failed: %s", exc, exc_info=True)
+            return f"Failed to read MCP status: {exc}"
+
+        if not statuses:
+            return (
+                "No MCP servers configured.\n"
+                "Add one on the host with:\n"
+                "  `hermes mcp add <name> --url <endpoint>`\n"
+                "  `hermes mcp add <name> --command <cmd> --args <args...>`\n"
+                "Then run `/reload-mcp` to connect."
+            )
+
+        # Status glyphs mirror `hermes mcp list` conventions.
+        glyph = {
+            "connected":  "✓ connected",
+            "connecting": "… connecting",
+            "configured": "· configured",
+            "disabled":   "✗ disabled",
+            "failed":     "⚠ failed",
+        }
+
+        lines = [f"**MCP Servers** ({len(statuses)} configured):", ""]
+        for entry in statuses:
+            name = entry.get("name", "?")
+            transport = entry.get("transport", "?")
+            status = entry.get("status", "?")
+            label = glyph.get(status, status)
+            tools = entry.get("tools", 0)
+            row = f"• `{name}` — {label} · {transport} · {tools} tool(s)"
+            err = entry.get("error")
+            if err and status == "failed":
+                # Keep error compact — one line, first sentence.
+                err_str = str(err).splitlines()[0][:120]
+                row += f"\n    error: {err_str}"
+            lines.append(row)
+
+        lines.append("")
+        lines.append("Reload after config changes with `/reload-mcp`.")
+        return "\n".join(lines)
+
     async def _handle_reload_mcp_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /reload-mcp — reconnect MCP servers and rebuild the cached agent.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -212,6 +212,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                             "heartbeat", "assignees", "context", "specify", "gc")),
     CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills",
                cli_only=True),
+    CommandDef("mcp", "Show configured MCP servers and connection status", "Tools & Skills"),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
                aliases=("reload_mcp",)),
     CommandDef("reload-skills", "Re-scan ~/.hermes/skills/ for newly installed or removed skills",
@@ -1163,7 +1164,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - mcp: rarely-needed MCP server inspector; /hermes mcp keeps a native
+#     slot free for a hotter command (the Slack cap is 50).
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug", "mcp"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/tests/gateway/test_mcp_command.py
+++ b/tests/gateway/test_mcp_command.py
@@ -1,0 +1,130 @@
+"""Tests for the ``/mcp`` gateway slash command handler.
+
+``/mcp`` is a read-only companion to ``/reload-mcp``: it lists configured
+MCP servers and their live connection status by delegating to
+``tools.mcp_tool.get_mcp_status``. This file exercises just the gateway
+handler wiring — the underlying status collection is covered by
+``tests/tools/test_mcp_tool.py``.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str = "/mcp") -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    return runner
+
+
+class TestHandleMcpCommand:
+    def test_no_servers_configured(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(mcp_tool, "get_mcp_status", lambda: [])
+        runner = _make_runner()
+        result = asyncio.run(runner._handle_mcp_command(_make_event()))
+        assert "No MCP servers configured" in result
+        assert "hermes mcp add" in result
+
+    def test_lists_connected_server(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(
+            mcp_tool,
+            "get_mcp_status",
+            lambda: [
+                {
+                    "name": "codegraph",
+                    "transport": "stdio",
+                    "tools": 12,
+                    "connected": True,
+                    "disabled": False,
+                    "status": "connected",
+                }
+            ],
+        )
+        runner = _make_runner()
+        result = asyncio.run(runner._handle_mcp_command(_make_event()))
+        assert "codegraph" in result
+        assert "connected" in result
+        assert "stdio" in result
+        assert "12 tool" in result
+
+    def test_shows_disabled_and_failed(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(
+            mcp_tool,
+            "get_mcp_status",
+            lambda: [
+                {"name": "off-server", "transport": "http", "tools": 0,
+                 "connected": False, "disabled": True, "status": "disabled"},
+                {"name": "broken", "transport": "stdio", "tools": 0,
+                 "connected": False, "disabled": False, "status": "failed",
+                 "error": "connection refused"},
+            ],
+        )
+        runner = _make_runner()
+        result = asyncio.run(runner._handle_mcp_command(_make_event()))
+        assert "off-server" in result
+        assert "disabled" in result
+        assert "broken" in result
+        assert "failed" in result
+        assert "connection refused" in result
+
+    def test_survives_status_exception(self, monkeypatch):
+        """A crash in get_mcp_status must not take down the gateway thread."""
+        import tools.mcp_tool as mcp_tool
+
+        def _boom():
+            raise RuntimeError("mcp subsystem exploded")
+
+        monkeypatch.setattr(mcp_tool, "get_mcp_status", _boom)
+        runner = _make_runner()
+        result = asyncio.run(runner._handle_mcp_command(_make_event()))
+        assert "Failed to read MCP status" in result
+        assert "exploded" in result
+
+
+class TestCommandRegistration:
+    def test_mcp_is_gateway_known(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+        assert "mcp" in GATEWAY_KNOWN_COMMANDS
+
+    def test_mcp_resolves_to_a_command_def(self):
+        from hermes_cli.commands import resolve_command
+        cmd = resolve_command("mcp")
+        assert cmd is not None
+        assert cmd.name == "mcp"
+        assert not cmd.gateway_only  # available in both CLI and gateway


### PR DESCRIPTION
## What

Add a read-only `/mcp` slash command that lists configured MCP servers and their live connection state (connected / connecting / configured / disabled / failed). Read-only companion to the existing `/reload-mcp`.

## Why

The TUI already has `/reload-mcp` to hot-reload MCP config, but there's no way to *see* what's connected without dropping to another terminal and running `hermes mcp list`. That's an obvious UX gap for anyone iterating on their MCP setup — after editing `mcp_servers.json` a user naturally wants to (a) reload and (b) verify what's now live, and the gateway only offered (a).

## How

- **New `CommandDef("mcp", …)`** in `hermes_cli/commands.py`.
- **Dispatcher branch** in `gateway/run.py` alongside `/reload-mcp`.
- **`_handle_mcp_command`** in `gateway/slash_commands.py` — delegates to `tools.mcp_tool.get_mcp_status()` (the same source the startup banner uses) and renders it as markdown. Graceful fallback if the subsystem is unavailable or raises.
- **Slack**: added to `_SLACK_VIA_HERMES_ONLY` so it reaches Slack via `/hermes mcp` instead of burning a native slot on the 50-command cap — same pattern as `/debug` and `/billing`.

## Design notes

- Zero core-tool footprint: it's a slash command, not a model tool, so it doesn't ship on every API call.
- Cache-safe: pure read, no prompt-cache invalidation.

## Example output

```
**MCP Servers** (2 configured):

• `codegraph` — ✓ connected · stdio · 12 tool(s)
• `broken` — ⚠ failed · stdio · 0 tool(s)
    error: connection refused

Reload after config changes with `/reload-mcp`.
```

## Tests

New `tests/gateway/test_mcp_command.py` — 6 cases: empty list, connected server rendering, disabled + failed rows (with error text), a defensive fallback when `get_mcp_status` raises, and `CommandDef` registration checks.

Full suite covering the affected areas: `pytest tests/gateway/test_mcp_command.py tests/hermes_cli/test_commands.py tests/gateway/test_unknown_command.py tests/gateway/test_bundles_command.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py` → **197 passed**.
