### PR TITLE
fix(bedrock): honor api_mode=bedrock_converse so bearer-token auth works for Claude

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -992,6 +992,21 @@ def build_converse_kwargs(
     if guardrail_config:
         kwargs["guardrailConfig"] = guardrail_config
 
+    # Unlock the 1M context window for Claude models routed through Converse.
+    # The AnthropicBedrock SDK path attaches this as a client-level
+    # ``anthropic-beta`` header (see build_anthropic_bedrock_client); the
+    # Converse API expects it inside ``additionalModelRequestFields``. Without
+    # it, Bedrock caps these models at 200K even though Anthropic serves 1M.
+    # Bedrock ignores the beta for Claude models that don't support it, so it
+    # is safe to send to any Claude model — but ``anthropic_beta`` is an
+    # Anthropic-only field, so gate on Claude to avoid a ValidationException on
+    # non-Claude Converse models (Nova, Llama, DeepSeek, etc.).
+    if is_anthropic_bedrock_model(model):
+        from agent.anthropic_adapter import _CONTEXT_1M_BETA
+
+        extra_fields = kwargs.setdefault("additionalModelRequestFields", {})
+        extra_fields["anthropic_beta"] = [_CONTEXT_1M_BETA]
+
     return kwargs
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1981,9 +1981,20 @@ def resolve_runtime_provider(
         # a bearer-only setup fails at runtime with "could not resolve
         # credentials from session"). Route these users through the Converse
         # API regardless of model. Ref: #28156.
+        #
+        # An explicit ``model.api_mode: bedrock_converse`` in config forces the
+        # Converse path too — letting users opt Claude into Converse even under
+        # SigV4 (e.g. to exercise the multi-model path). Either signal — a
+        # bearer token or the explicit override — sends Claude to Converse; the
+        # Converse path preserves the 1M context window by injecting the
+        # 1M-context beta (see bedrock_adapter.build_converse_kwargs).
         _current_model = str(target_model or model_cfg.get("default") or "").strip()
         _has_bearer_token = bool(os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip())
-        if is_anthropic_bedrock_model(_current_model) and not _has_bearer_token:
+        _forces_converse = (
+            _has_bearer_token
+            or _parse_api_mode(model_cfg.get("api_mode")) == "bedrock_converse"
+        )
+        if is_anthropic_bedrock_model(_current_model) and not _forces_converse:
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {
                 "provider": "bedrock",

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -700,6 +700,44 @@ class TestBuildConverseKwargs:
         )
         assert "toolConfig" not in kwargs
 
+    def test_injects_1m_context_beta_for_claude(self):
+        """Claude on the Converse path must carry the 1M-context beta so the
+        window matches the AnthropicBedrock SDK path (which sends it as a
+        client-level ``anthropic-beta`` header)."""
+        from agent.anthropic_adapter import _CONTEXT_1M_BETA
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        for model_id in (
+            "anthropic.claude-sonnet-4-6-20250514-v1:0",
+            "us.anthropic.claude-opus-4-8",
+            "global.anthropic.claude-sonnet-5",
+        ):
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+            )
+            assert kwargs["additionalModelRequestFields"]["anthropic_beta"] == [
+                _CONTEXT_1M_BETA
+            ]
+
+    def test_omits_anthropic_beta_for_non_claude(self):
+        """``anthropic_beta`` is Anthropic-only — non-Claude Converse models
+        (Nova, Llama, DeepSeek) must not receive it, or Bedrock raises a
+        ValidationException."""
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        for model_id in (
+            "us.amazon.nova-pro-v1:0",
+            "meta.llama3-1-70b-instruct-v1:0",
+            "deepseek.r1-v1:0",
+        ):
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+            )
+            extra = kwargs.get("additionalModelRequestFields", {})
+            assert "anthropic_beta" not in extra
+
 
 # ---------------------------------------------------------------------------
 # Model discovery
@@ -1760,7 +1798,7 @@ class TestBearerTokenRoutesToConverse:
     AWS_BEARER_TOKEN_BEDROCK. Ref: #28156.
     """
 
-    def _resolve(self, monkeypatch, *, bearer: bool):
+    def _resolve(self, monkeypatch, *, bearer: bool, api_mode=None):
         import os
 
         from hermes_cli import runtime_provider as rp
@@ -1772,14 +1810,14 @@ class TestBearerTokenRoutesToConverse:
         monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
         assert "AWS_BEARER_TOKEN_BEDROCK" in os.environ or not bearer
 
-        monkeypatch.setattr(
-            rp,
-            "_get_model_config",
-            lambda: {
-                "default": "us.anthropic.claude-sonnet-4-6",
-                "provider": "bedrock",
-            },
-        )
+        model_cfg = {
+            "default": "us.anthropic.claude-sonnet-4-6",
+            "provider": "bedrock",
+        }
+        if api_mode is not None:
+            model_cfg["api_mode"] = api_mode
+
+        monkeypatch.setattr(rp, "_get_model_config", lambda: model_cfg)
         monkeypatch.setattr(rp, "load_config", lambda: {"bedrock": {}})
         return rp.resolve_runtime_provider(requested="bedrock")
 
@@ -1792,5 +1830,29 @@ class TestBearerTokenRoutesToConverse:
     def test_sigv4_claude_still_uses_anthropic_bedrock_sdk(self, monkeypatch):
         """Without a bearer token, Claude keeps the AnthropicBedrock SDK path."""
         runtime = self._resolve(monkeypatch, bearer=False)
+        assert runtime["api_mode"] == "anthropic_messages"
+        assert runtime.get("bedrock_anthropic") is True
+
+    def test_explicit_api_mode_forces_converse_under_sigv4(self, monkeypatch):
+        """An explicit ``api_mode: bedrock_converse`` routes Claude through
+        Converse even without a bearer token (SigV4)."""
+        runtime = self._resolve(
+            monkeypatch, bearer=False, api_mode="bedrock_converse"
+        )
+        assert runtime["api_mode"] == "bedrock_converse"
+        assert "bedrock_anthropic" not in runtime
+
+    def test_explicit_api_mode_does_not_break_bearer_route(self, monkeypatch):
+        """The explicit override coexists with bearer-token auto-routing."""
+        runtime = self._resolve(
+            monkeypatch, bearer=True, api_mode="bedrock_converse"
+        )
+        assert runtime["api_mode"] == "bedrock_converse"
+        assert "bedrock_anthropic" not in runtime
+
+    def test_unset_api_mode_keeps_anthropic_sdk_under_sigv4(self, monkeypatch):
+        """Without the override or a bearer token, Claude keeps the SDK path —
+        the explicit override must not change the default."""
+        runtime = self._resolve(monkeypatch, bearer=False, api_mode=None)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True


### PR DESCRIPTION
## Problem

Claude models on Bedrock are hardcoded to `api_mode=anthropic_messages` in `resolve_runtime_provider()` (`hermes_cli/runtime_provider.py`), which routes them through the **AnthropicBedrock SDK**. That SDK signs requests with **SigV4** and resolves credentials via boto3's `session.get_credentials()` — it never reads `AWS_BEARER_TOKEN_BEDROCK`.

For users authenticated with a **Bedrock bearer token only** (no IAM access key, no `~/.aws`), every Claude call fails:

```
RuntimeError: could not resolve credentials from session
API call failed after 3 retries: could not resolve credentials from session
```

The retries can't recover a missing credential, so it always exhausts them. Non-Claude Bedrock models already use the Converse API, which **does** honor the bearer token.

## Fix

- `resolve_runtime_provider()`: honor an explicit `model.api_mode: bedrock_converse` in config so Claude-on-Bedrock can route through the Converse API too. **Default behavior is unchanged** — without that config, Claude still uses the AnthropicBedrock path.
- `build_converse_kwargs()`: inject the 1M-context beta via `additionalModelRequestFields` so the Converse path keeps the 1M context window (the AnthropicBedrock client attaches it as a client-level `anthropic-beta` header). Bedrock ignores the beta for models that don't support it, so it's safe to send unconditionally — matching `build_anthropic_bedrock_client()`.

## Testing

Verified on `us-east-1` with a bearer-token-only setup (no IAM):
- `resolve_runtime_provider()` returns `bedrock_converse` when configured.
- Real Converse calls to `claude-sonnet-5` and `claude-opus-4-8` succeed (`end_turn`, real content) using only `AWS_BEARER_TOKEN_BEDROCK`.
- The 1M beta is accepted by Bedrock (HTTP 200) and is a harmless no-op on models that don't support it.