### PR TITLE
fix(gateway): show context window and reasoning in /status

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -54,6 +54,11 @@ logger = logging.getLogger("gateway.run")
 # its worker thread. (#35994)
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
+# /status is an interactive command. Model metadata resolution may consult a
+# remote registry, so it must degrade gracefully rather than delay or break the
+# whole status response when that lookup is unavailable.
+_STATUS_CONTEXT_METADATA_TIMEOUT_S = 3.0
+
 
 def _model_switch_skew_guard() -> Optional[str]:
     """Refuse a model switch when the gateway is running stale code.
@@ -604,6 +609,44 @@ class GatewaySlashCommandsMixin:
             configured_context = model_cfg.get("context_length") if isinstance(model_cfg, dict) else None
             if isinstance(configured_context, int) and configured_context > 0:
                 context_total = configured_context
+            elif model_name:
+                from agent.model_metadata import get_model_context_length_async
+
+                if not base_url and isinstance(model_cfg, dict):
+                    base_url = _clean_str(model_cfg.get("base_url"))
+                try:
+                    resolved_context = await asyncio.wait_for(
+                        get_model_context_length_async(
+                            model_name,
+                            base_url=base_url,
+                            provider=provider_name,
+                        ),
+                        timeout=_STATUS_CONTEXT_METADATA_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Timed out resolving context length for /status model %s",
+                        model_name,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to resolve context length for /status model %s: %s",
+                        model_name,
+                        exc,
+                    )
+                else:
+                    if (
+                        isinstance(resolved_context, int)
+                        and not isinstance(resolved_context, bool)
+                        and resolved_context > 0
+                    ):
+                        context_total = resolved_context
+                    else:
+                        logger.warning(
+                            "Ignoring invalid context length for /status model %s: %r",
+                            model_name,
+                            resolved_context,
+                        )
 
         model_line = ""
         if model_name:
@@ -611,6 +654,24 @@ class GatewaySlashCommandsMixin:
                 model_line = t("gateway.status.model_provider", model=model_name, provider=provider_name)
             else:
                 model_line = t("gateway.status.model", model=model_name)
+
+        reasoning_config = None
+        if status_agent is not None and status_agent is not _AGENT_PENDING_SENTINEL:
+            candidate = getattr(status_agent, "reasoning_config", None)
+            if isinstance(candidate, dict):
+                reasoning_config = candidate
+        if reasoning_config is None:
+            reasoning_config = self._resolve_session_reasoning_config(
+                source=source,
+                session_key=session_key,
+            )
+        if reasoning_config is None:
+            reasoning_level = t("gateway.reasoning.level_default")
+        elif reasoning_config.get("enabled") is False:
+            reasoning_level = t("gateway.reasoning.level_disabled")
+        else:
+            reasoning_level = reasoning_config.get("effort", "medium")
+        reasoning_line = t("gateway.status.reasoning", level=reasoning_level)
 
         context_line = ""
         if context_total:
@@ -637,6 +698,7 @@ class GatewaySlashCommandsMixin:
         ])
         if model_line:
             lines.append(model_line)
+        lines.append(reasoning_line)
         if context_line:
             lines.append(context_line)
         lines.extend([

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Laaste aktiwiteit:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Redenering:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Kumulatiewe API-tokens (elke oproep weer gestuur):** {tokens}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Letzte Aktivität:** {timestamp}"
     model:                 "**Modell:** `{model}`"
     model_provider:        "**Modell:** `{model}` ({provider})"
+    reasoning:             "**Reasoning:** {level}"
     context:               "**Kontext:** {used} / {total} ({pct}%)"
     context_used:          "**Kontext:** ~{used} Tokens"
     tokens:                "**Kumulierte API-Tokens (bei jedem Aufruf erneut gesendet):** {tokens}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -300,6 +300,7 @@ gateway:
     last_activity:         "**Last Activity:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Reasoning:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Cumulative API tokens (re-sent each call):** {tokens}"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -285,6 +285,7 @@ gateway:
     last_activity:         "**Última actividad:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Razonamiento:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Tokens de API acumulados (reenviados en cada llamada):** {tokens}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Dernière activité :** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Raisonnement:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Jetons :** {tokens}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -292,6 +292,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Gníomhaíocht is déanaí:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Réasúnaíocht:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Comharthaí:** {tokens}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Utolsó tevékenység:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Következtetés:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Tokenek:** {tokens}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Ultima attività:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Ragionamento:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Token:** {tokens}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**最終アクティビティ:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**推論:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**トークン:** {tokens}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**최종 활동:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**추론:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**토큰:** {tokens}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Última atividade:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Raciocínio:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Tokens de API cumulativos (reenviados a cada chamada):** {tokens}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Последняя активность:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Рассуждение:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Токены:** {tokens}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Son etkinlik:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Akıl yürütme:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Token:** {tokens}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**Остання активність:** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**Міркування:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Токени:** {tokens}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**最近活動：** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**推理:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Token 數：** {tokens}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -288,6 +288,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     last_activity:         "**最近活动：** {timestamp}"
     model:                 "**Model:** `{model}`"
     model_provider:        "**Model:** `{model}` ({provider})"
+    reasoning:             "**推理:** {level}"
     context:               "**Context:** {used} / {total} ({pct}%)"
     context_used:          "**Context:** ~{used} tokens"
     tokens:                "**Token 数：** {tokens}"

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -1,6 +1,7 @@
 from hermes_state import AsyncSessionDB
 """Tests for gateway /status behavior and token persistence."""
 
+import asyncio
 from datetime import datetime
 import time
 from types import SimpleNamespace
@@ -65,6 +66,7 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     runner._agent_cache = {}
     runner._agent_cache_lock = MagicMock()
     runner._show_reasoning = False
+    runner._resolve_session_reasoning_config = lambda **_kwargs: None
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
     runner._should_send_voice_reply = lambda *_args, **_kwargs: False
@@ -105,6 +107,28 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
     assert "**Title:**" not in result
     running_agent.interrupt.assert_not_called()
     assert runner._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_effective_reasoning_level():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._resolve_session_reasoning_config = lambda **_kwargs: {
+        "enabled": True,
+        "effort": "high",
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Reasoning:** high" in result
 
 
 @pytest.mark.asyncio
@@ -246,6 +270,157 @@ async def test_status_command_includes_persisted_model_and_context_when_agent_no
     assert "**Model:** `openai/gpt-persisted` (openai-codex)" in result
     assert "**Context:** 24,000 / 272,000 (9%)" in result
     assert "**Cumulative API tokens (re-sent each call):** 2,500" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_resolves_context_total_from_model_metadata_when_unconfigured(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+        last_prompt_tokens=46_737,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "model": "gpt-5.6-sol",
+        "billing_provider": "openai-codex",
+        "billing_base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            }
+        },
+    )
+    resolve_context = AsyncMock(return_value=272_000)
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length_async",
+        resolve_context,
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Context:** 46,737 / 272,000 (17%)" in result
+    resolve_context.assert_awaited_once_with(
+        "gpt-5.6-sol",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_command_survives_context_metadata_error(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+        last_prompt_tokens=46_737,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "model": "gpt-5.6-sol",
+        "billing_provider": "openai-codex",
+    }
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"model": {"default": "gpt-5.6-sol", "provider": "openai-codex"}},
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length_async",
+        AsyncMock(side_effect=RuntimeError("metadata unavailable")),
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Context:** ~46,737 tokens" in result
+    assert "/ 272,000" not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("metadata_value", ["272000", -1])
+async def test_status_command_ignores_invalid_context_metadata(monkeypatch, metadata_value):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+        last_prompt_tokens=46_737,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "model": "gpt-5.6-sol",
+        "billing_provider": "openai-codex",
+    }
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"model": {"default": "gpt-5.6-sol", "provider": "openai-codex"}},
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length_async",
+        AsyncMock(return_value=metadata_value),
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Context:** ~46,737 tokens" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_times_out_context_metadata_lookup(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+        last_prompt_tokens=46_737,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "model": "gpt-5.6-sol",
+        "billing_provider": "openai-codex",
+    }
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"model": {"default": "gpt-5.6-sol", "provider": "openai-codex"}},
+    )
+    monkeypatch.setattr(
+        "gateway.slash_commands._STATUS_CONTEXT_METADATA_TIMEOUT_S",
+        0.01,
+        raising=False,
+    )
+
+    async def never_resolves(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length_async",
+        never_resolves,
+    )
+
+    result = await asyncio.wait_for(
+        runner._handle_message(_make_event("/status")),
+        timeout=0.5,
+    )
+
+    assert "**Context:** ~46,737 tokens" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Improves the gateway `/status` response in two related ways:

- shows the effective reasoning effort for the current session, honoring the live/cached agent configuration and session overrides;
- resolves the model context window from model metadata when neither the resident agent nor `model.context_length` provides it.

The metadata fallback is bounded to 3 seconds, handles lookup failures, validates that the result is a positive non-boolean integer, and gracefully falls back to the existing used-context-only line.

Example:

```text
Model: gpt-5.6-sol (openai-codex)
Reasoning: high
Context: 46,737 / 272,000 (17%)
```

## Why?

For gateway sessions without a resident agent and without an explicit `model.context_length`, `/status` showed only the used token estimate even though Hermes can resolve the model's full context window through its metadata catalog. The command also did not expose the session's effective reasoning level, making session overrides hard to inspect.

## Related work

- #52184 adds a dedicated `/context` command and also touches `gateway/slash_commands.py`; this PR is intentionally limited to improving the existing `/status` fallback and effective reasoning display.
- #8355 proposes a much broader rich-status rewrite across CLI, gateway, persistence, and formatting. This PR is a focused implementation on the current `gateway/slash_commands.py` architecture, with an async metadata lookup bounded by a timeout.
- #64099 concerns the TUI status bar rather than the gateway `/status` command.

## Type of change

- [x] Bug fix / robustness improvement
- [x] Non-breaking gateway status enhancement

## Changes

- `gateway/slash_commands.py`
  - resolve missing context totals with `get_model_context_length_async()`;
  - bound the lookup with `asyncio.wait_for()` and degrade safely;
  - render the effective session reasoning configuration.
- `locales/*.yaml`
  - add `gateway.status.reasoning` for all 16 catalogs.
- `tests/gateway/test_status_command.py`
  - cover reasoning display, successful metadata fallback, exception, timeout, and invalid metadata values.

## Verification

- [x] `tests/gateway/test_status_command.py`: 23 passed
- [x] `tests/agent/test_i18n.py`: 47 passed
- [x] Combined focused suite: 70 passed
- [x] 16 locale catalogs parsed successfully
- [x] `git diff --check`
- [x] Python compile check
- [x] Added-line security scan: clean
- [x] Independent review: no blocking findings

## Checklist

- [x] I read the contributing guide
- [x] I searched open issues and PRs for duplicates/overlap
- [x] The PR contains only related changes
- [x] Tests cover the new behavior and failure modes
- [x] Tested on Linux with a live Telegram gateway
