### PR TITLE
fix(tui): pass launch cwd in session.create so Desktop groups TUI sessions

### DIFF
--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -1,7 +1,10 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
 
+import { renderSync } from '@hermes/ink'
+import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { turnController } from '../app/turnController.js'
@@ -12,6 +15,8 @@ import {
   liveSessionInflightMessages,
   scheduleResumeScrollToBottom,
   signalFreshSessionBoundary,
+  useSessionLifecycle,
+  type UseSessionLifecycleOptions,
   writeActiveSessionFile
 } from '../app/useSessionLifecycle.js'
 
@@ -26,6 +31,84 @@ describe('fresh session boundary', () => {
     expect(signalFreshSessionBoundary('old-session', 'new-session')).toBe(false)
     expect(onFreshSessionStarted).toHaveBeenCalledOnce()
     expect(onFreshSessionStarted).toHaveBeenCalledWith('new-session')
+  })
+})
+
+const makeStreams = () => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', () => {})
+
+  return { stderr, stdin, stdout }
+}
+
+function SessionLifecycleHarness({
+  expose,
+  options
+}: {
+  expose: { current: null | ReturnType<typeof useSessionLifecycle> }
+  options: UseSessionLifecycleOptions
+}) {
+  expose.current = useSessionLifecycle(options)
+
+  return null
+}
+
+describe('new session creation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    resetUiState()
+  })
+
+  it('passes the launcher cwd to session.create', async () => {
+    const launchCwd = '/tmp/hermes-tui-launch-workspace'
+    const rpc = vi.fn(async (method: string) => (method === 'setup.status' ? { provider_configured: true } : null))
+    const expose = { current: null as null | ReturnType<typeof useSessionLifecycle> }
+    const streams = makeStreams()
+
+    vi.stubEnv('HERMES_CWD', launchCwd)
+    resetUiState()
+
+    const instance = renderSync(
+      React.createElement(SessionLifecycleHarness, {
+        expose,
+        options: {
+          colsRef: { current: 80 },
+          composerActions: { setPasteSnips: vi.fn() } as unknown as UseSessionLifecycleOptions['composerActions'],
+          gw: {} as UseSessionLifecycleOptions['gw'],
+          panel: vi.fn(),
+          rpc: rpc as unknown as UseSessionLifecycleOptions['rpc'],
+          scrollRef: { current: null },
+          setHistoryItems: vi.fn(),
+          setLastUserMsg: vi.fn(),
+          setSessionStartedAt: vi.fn(),
+          setStickyPrompt: vi.fn(),
+          setVoiceProcessing: vi.fn(),
+          setVoiceRecording: vi.fn(),
+          sys: vi.fn()
+        }
+      }),
+      {
+        patchConsole: false,
+        stderr: streams.stderr as NodeJS.WriteStream,
+        stdin: streams.stdin as NodeJS.ReadStream,
+        stdout: streams.stdout as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await expose.current!.newSession()
+
+      expect(rpc).toHaveBeenCalledWith('session.create', { cols: 80, cwd: launchCwd })
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
   })
 })
 

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -226,7 +226,14 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         await closeSession(previousSid)
       }
 
-      const r = await rpc<SessionCreateResponse>('session.create', { cols: colsRef.current })
+      // Pass the launch cwd so the gateway records it as the session's
+      // workspace (explicit_cwd). Without this, TUI sessions get cwd=NULL and
+      // the Desktop GUI groups them under "No workspace" instead of the
+      // directory the user launched `hermes --tui` from. HERMES_CWD is set by
+      // the Python launcher (main.py:_launch_tui) and falls back to
+      // process.cwd() so embedded- and standalone-TUI both work.
+      const launchCwd = process.env.HERMES_CWD || process.cwd()
+      const r = await rpc<SessionCreateResponse>('session.create', { cols: colsRef.current, cwd: launchCwd })
 
       if (!r) {
         patchUiState({ status: 'ready' })


### PR DESCRIPTION
## Bug: TUI sessions don't record cwd — Desktop groups them under default workspace

Fixes #50438
Supersedes #50440

### Problem

When a user runs `hermes --tui` from a specific directory (e.g. `cd ~/Projects/myapp && hermes --tui`), the resulting session is not grouped under that directory in the Desktop GUI — it lands in "No workspace".

### Root cause

The TUI client (`ui-tui/src/app/useSessionLifecycle.ts`) calls `session.create` **without** a `cwd` parameter:

```typescript
// Before — no cwd sent
const r = await rpc('session.create', { cols: colsRef.current })
```

The gateway (`tui_gateway/server.py:5220-5224`) derives `explicit_cwd` from whether the client sent a valid `cwd`:

```python
raw_cwd = str(params.get("cwd") or "").strip()
explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
```

Without `cwd` in params, `explicit_cwd=False`, so `_ensure_session_db_row` persists `cwd=None` (line 1764):

```python
cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
```

### Why the previous approach (#50440) was wrong

PR #50440 made the cwd write unconditional (`cwd=_session_cwd(session)`), removing the `explicit_cwd` guard. The sweeper correctly flagged this:

- `tui_gateway/server.py:1669-1682` documents that only an *explicitly chosen* workspace should be persisted — otherwise sessions get grouped under whatever directory the gateway happened to launch in.
- `tests/test_tui_gateway_server.py:2358-2376` is a regression test for this contract: a session without `explicit_cwd` must persist `cwd=None`.

The guard is **intentional**: it prevents a desktop gateway launched from `/Applications/Hermes.app/...` from stamping every session with that path. The fix should be on the **client side** (TUI should tell the server "I have an explicit cwd"), not on the server side (remove the guard).

### Fix

The Python launcher (`hermes_cli/main.py:2037`) already sets `HERMES_CWD` to `os.getcwd()` when spawning the TUI:

```python
env.setdefault("HERMES_CWD", os.getcwd())
```

The TUI already reads `HERMES_CWD` for the status bar (`useMainApp.ts:1106`). This PR simply passes it into `session.create`:

```typescript
// After — cwd sent, gateway sets explicit_cwd=True
const launchCwd = process.env.HERMES_CWD || process.cwd()
const r = await rpc('session.create', { cols: colsRef.current, cwd: launchCwd })
```

### Why this is safe

- **Existing test preserved**: `test_ensure_session_db_row_defaults_to_no_workspace` still passes — sessions without `cwd` in params still get `cwd=None`.
- **Remote gateway safe**: If the TUI connects to a remote gateway, `os.path.isdir()` on the server won't find the local path (e.g. `/Users/lestroy/Projects/foo` on a VPS) → `explicit_cwd=False` → `cwd=None` → "No workspace". Correct behavior.
- **Desktop app unaffected**: Desktop already sends `cwd` in its `session.create` (`apps/desktop/.../use-session-actions/index.ts:224`). No change.
- **CLI unaffected**: CLI sessions go through `run_agent.py:_launch_cwd_for_session()` which already records `os.getcwd()` for `source == "cli"`. No change.

### Scope

One file, one line (plus comment). The Desktop app's behavior is unchanged; the server's `explicit_cwd` contract is preserved.