### PR TITLE
fix(qqbot): authorize DM sessions in approval interaction guard

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,7 +1100,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
Fixes #64840

## Problem

QQ Bot approval button clicks fail for DM (direct message) sessions because `_is_authorized_interaction_for_session()` only checks for `chat_type="c2c"`, but QQ Bot DM sessions use `chat_type="dm"`.

## Fix

Add `"dm"` to the set of authorized chat types in the `_is_authorized_interaction_for_session` check, alongside the existing `"c2c"` check.

## Verification

- All 166 existing QQ Bot adapter tests pass.
- Minimal change: 1 insertion, 1 deletion.