### PR TITLE
fix(feishu): strip auto-generated Markdown links from incoming text

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1166,6 +1166,9 @@ def _normalize_feishu_text(
 
     cleaned = _MENTION_PLACEHOLDER_RE.sub(_sub, text or "")
     cleaned = cleaned.replace("@_all", "@all")
+    # Strip auto-generated Markdown links (e.g. Feishu converts URL-like text
+    # to [label](url) which would otherwise leak into config and commands).
+    cleaned = _MARKDOWN_LINK_RE.sub(r"\1", cleaned)
     cleaned = cleaned.replace("\r\n", "\n").replace("\r", "\n")
     cleaned = "\n".join(_WHITESPACE_RE.sub(" ", line).strip() for line in cleaned.split("\n"))
     cleaned = "\n".join(line for line in cleaned.split("\n") if line)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1278,7 +1278,7 @@ class TestAdapterBehavior(unittest.TestCase):
 
         text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
 
-        self.assertEqual(text, "Title\nhello\n[doc](https://example.com)")
+        self.assertEqual(text, "Title\nhello\ndoc")
         self.assertEqual(msg_type.value, "text")
         self.assertEqual(media_urls, [])
         self.assertEqual(media_types, [])


### PR DESCRIPTION
Fixes #64847

## Problem

Feishu/Lark automatically converts URL-like text in messages to Markdown link format `[label](url)`. When a user runs `/model` with a model name containing a URL-like component, the Markdown-formatted string gets stored in `config.yaml` as `model.default`. Subsequent API calls fail with `503 - model_not_found` because the full Markdown string is sent as the model parameter.

For example, `/model new-api.abrdns.com/DeepSeek-V4-Flash` becomes:
- Raw text in Feishu post: `[new-api.abrdns.com/DeepSeek-V4-Flash](http://new-api.abrdns.com/DeepSeek-V4-Flash)`
- Stored in config: `[new-api.abrdns.com/DeepSeek-V4-Flash](http://new-api.abrdns.com/DeepSeek-V4-Flash)`
- API call fails with: `model_not_found - No available channel for model [DeepSeek-V4-Flash](http://new-api.abrdns.com/DeepSeek-V4-Flash)`

## Fix

Add Markdown link stripping (`[label](url)` → `label`) to `_normalize_feishu_text\`, the shared normalization function applied to all incoming text content. This ensures auto-generated Markdown links never leak into downstream processing (commands, config, etc.).

## Verification

- All 210 existing Feishu adapter tests pass (one test expectation updated to match new behavior).
- Manual verification confirms Markdown links are properly stripped while mention handling, whitespace normalization, and other features remain intact.