### PR TITLE
fix(acp): pass fallback_model chain to ACP sessions

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -596,6 +596,7 @@ class SessionManager:
 
         from run_agent import AIAgent
         from hermes_cli.config import load_config
+        from hermes_cli.fallback_config import get_fallback_chain
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
         config = load_config()
@@ -624,6 +625,7 @@ class SessionManager:
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
+            "fallback_model": get_fallback_chain(config) or None,
         }
 
         try:

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -114,6 +114,61 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     assert captured["session_id"] == "acp-session"
 
 
+def test_acp_real_agent_gets_fallback_chain_from_config(monkeypatch):
+    """ACP sessions must inherit the configured fallback chain (issue #64441).
+
+    The CLI and cron paths both pass ``fallback_model`` to ``AIAgent``; the ACP
+    session manager used to omit it, so ACP sessions could never fall back when
+    the primary provider hit a rate-limit or connection failure.
+    """
+    captured = {}
+    fallback_chain = [{"provider": "p2", "model": "m2"}]
+
+    class CapturingAgent(FakeAgent):
+        def __init__(self, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+
+    def mod(name, **attrs):
+        module = ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=CapturingAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m", "provider": "p"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.fallback_config",
+        mod("hermes_cli.fallback_config", get_fallback_chain=lambda _cfg: fallback_chain),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "base_url": "u",
+                "api_key": "k",
+                "command": None,
+                "args": [],
+            },
+        ),
+    )
+
+    manager = SessionManager(db=NoopDb())
+    agent = manager._make_agent(session_id="acp-session", cwd=".")
+
+    assert isinstance(agent, CapturingAgent)
+    assert captured["fallback_model"] == fallback_chain
+
+
 @pytest.mark.asyncio
 async def test_acp_steer_slash_command_injects_into_running_agent():
     acp_agent, state, fake, _conn = make_agent_and_state()


### PR DESCRIPTION
## Problem

ACP (editor) sessions built via `_make_agent` constructed `AIAgent` without the `fallback_model` kwarg, unlike the CLI ([cli.py](https://github.com/NousResearch/hermes-agent/blob/main/cli.py)) and cron ([scheduler.py](https://github.com/NousResearch/hermes-agent/blob/main/cron/scheduler.py)) paths, which both wire `get_fallback_chain(config)`.

As a result, ACP sessions silently ignored the configured `fallback_providers` / `fallback_model` chain — when the primary provider hit a rate-limit, overload, or connection failure, the session could never fall back to a backup provider.

Closes #64441

## Fix

Pass `fallback_model=get_fallback_chain(config) or None` in [`acp_adapter/session.py`](acp_adapter/session.py) `_make_agent`, matching the other agent-construction paths.

## Verification

- `ruff check` on touched files: clean
- `python -m py_compile`: clean
- Added a regression test (`test_acp_real_agent_gets_fallback_chain_from_config`) mirroring the existing `test_acp_real_agent_gets_session_db_for_recall` pattern, asserting the fallback chain reaches `AIAgent`.

## Checklist

- [x] Change is minimal and scoped to the bug
- [x] Tests added
- [x] Lint passes