### PR TITLE
fix(qqbot): authorize approval clicks for DM (private) sessions

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,7 +1100,10 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # DM (private) sessions are 1:1 like c2c: chat_id holds the peer's
+        # openid, so the operator must match it. Previously "dm" fell through
+        # to the default `return False`, rejecting every DM approval click.
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2254,3 +2254,44 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+
+# ---------------------------------------------------------------------------
+# _is_authorized_interaction_for_session — DM approval authorization
+# ---------------------------------------------------------------------------
+
+class TestIsAuthorizedInteractionForSession:
+    """Regression tests for issue #64840 — DM approvals were always rejected."""
+
+    def _adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    def _event(self, operator_openid=""):
+        from gateway.platforms.qqbot.keyboards import InteractionEvent
+        # operator_openid is a property: for c2c/dm it resolves from user_openid.
+        return InteractionEvent(user_openid=operator_openid)
+
+    def test_dm_session_authorizes_matching_operator(self):
+        adapter = self._adapter()
+        # DM session key: agent:main:qqbot:dm:<user_openid>
+        session_key = "agent:main:qqbot:dm:USER_OPENID"
+        assert adapter._is_authorized_interaction_for_session(
+            self._event(operator_openid="USER_OPENID"), session_key
+        ) is True
+
+    def test_dm_session_rejects_non_matching_operator(self):
+        adapter = self._adapter()
+        session_key = "agent:main:qqbot:dm:USER_OPENID"
+        assert adapter._is_authorized_interaction_for_session(
+            self._event(operator_openid="OTHER"), session_key
+        ) is False
+
+    def test_c2c_session_still_authorizes(self):
+        """Existing c2c behavior must be preserved."""
+        adapter = self._adapter()
+        session_key = "agent:main:qqbot:c2c:USER_OPENID"
+        assert adapter._is_authorized_interaction_for_session(
+            self._event(operator_openid="USER_OPENID"), session_key
+        ) is True
+


### PR DESCRIPTION
## Problem

`_is_authorized_interaction_for_session` only handled `chat_type` values `c2c`, `group`, and `guild`. DM (private) sessions use `chat_type="dm"` (see [`_handle_c2c_message`](gateway/platforms/qqbot/adapter.py) → `build_source(chat_type="dm")`), so every DM approval button click fell through to the default `return False` and was logged as:

```
Rejected unauthorized approval click for session agent:main:qqbot:dm:...
```

This made tool approvals impossible in QQ Bot private chats.

Closes #64840

## Fix

DM sessions are 1:1 like c2c: the session key's `chat_id` holds the peer's `user_openid`, so the operator must match it. Treat `"dm"` identically to `"c2c"`:

```python
if chat_type in {"c2c", "dm"}:
    return bool(chat_id) and operator == chat_id
```

This matches the fix proposed by the issue reporter.

## Verification

- `ruff check`: clean
- `python -m py_compile`: clean
- Added 3 regression tests in `TestIsAuthorizedInteractionForSession`: DM authorizes matching operator, DM rejects non-matching operator, c2c behavior preserved.

## Checklist

- [x] Change is minimal and scoped to the bug
- [x] Tests added
- [x] Lint passes