### PR TITLE
fix(cron): reject durations exceeding timedelta.max in parse_duration

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -458,10 +458,15 @@ def ensure_dirs():
 # Schedule Parsing
 # =============================================================================
 
+# timedelta.max expressed in whole minutes — the largest ``minutes`` value
+# that ``timedelta(minutes=...)`` can accept without OverflowError.
+_MAX_DURATION_MINUTES = int(timedelta.max.total_seconds() // 60)
+
+
 def parse_duration(s: str) -> int:
     """
     Parse duration string into minutes.
-    
+
     Examples:
         "30m" → 30
         "2h" → 120
@@ -471,12 +476,21 @@ def parse_duration(s: str) -> int:
     match = re.match(r'^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
     if not match:
         raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
-    
+
     value = int(match.group(1))
     unit = match.group(2)[0]  # First char: m, h, or d
-    
+
     multipliers = {'m': 1, 'h': 60, 'd': 1440}
-    return value * multipliers[unit]
+    minutes = value * multipliers[unit]
+    # ``timedelta(minutes=...)`` (used by schedule computation) raises
+    # OverflowError once the value exceeds ~1.44e12 (timedelta.max in
+    # minutes). Reject absurdly large values here so the error surfaces at
+    # parse time with a clear message instead of crashing the scheduler.
+    if minutes > _MAX_DURATION_MINUTES:
+        raise ValueError(
+            f"Invalid duration: '{s}'. Value is too large (max {_MAX_DURATION_MINUTES} minutes)."
+        )
+    return minutes
 
 
 def parse_schedule(schedule: str) -> Dict[str, Any]:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -64,6 +64,14 @@ class TestParseDuration:
         with pytest.raises(ValueError):
             parse_duration("m30")
 
+    def test_huge_value_raises_instead_of_overflowing(self):
+        """A duration exceeding timedelta.max must raise ValueError at parse
+        time, not OverflowError later when timedelta(minutes=...) is built."""
+        with pytest.raises(ValueError):
+            # 1e12 days → ~1.44e15 minutes, far beyond timedelta.max
+            parse_duration("999999999999d")
+
+
 
 # =========================================================================
 # parse_schedule


### PR DESCRIPTION
## Problem

`parse_duration` in [`cron/jobs.py`](cron/jobs.py) accepted arbitrarily large integers — the regex only matches `\d+` and Python ints are unbounded. The returned `minutes` value is later fed to `timedelta(minutes=...)` in schedule computation ([`_compute_next_run`](cron/jobs.py)), which raises `OverflowError: Python int too large to convert to C int` for values beyond ~1.44e12 minutes (`timedelta.max`).

Reproduction:
```python
parse_duration("999999999999d")  # → 1,439,999,999,998,560 minutes
# then timedelta(minutes=1_439_999_999_998_560) → OverflowError
```

This crashes the cron scheduler with an uncaught `OverflowError` when a user supplies a huge duration string.

## Fix

Cap the parsed minutes at `timedelta.max` expressed in whole minutes and raise a clear `ValueError` at parse time:

```python
_MAX_DURATION_MINUTES = int(timedelta.max.total_seconds() // 60)

if minutes > _MAX_DURATION_MINUTES:
    raise ValueError(
        f"Invalid duration: '{s}'. Value is too large (max {_MAX_DURATION_MINUTES} minutes)."
    )
```

This surfaces the error at validation time (where it belongs) with an actionable message, consistent with the existing `ValueError` for malformed input.

## Verification

- `ruff check`: clean
- `python -m py_compile`: clean
- Added regression test `test_huge_value_raises_instead_of_overflowing` asserting `parse_duration("999999999999d")` raises `ValueError` (not `OverflowError`).

## Checklist

- [x] Change is minimal and scoped to the bug
- [x] Test added
- [x] Lint passes