### PR TITLE
fix(kanban): raise ValueError instead of OverflowError for huge durations

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1210,6 +1210,11 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+# SQLite INTEGER ceiling (2**63 - 1) — the largest whole-second value that
+# can be persisted without overflow in the kanban database.
+_MAX_DURATION_SECONDS = (1 << 63) - 1
+
+
 def _parse_duration(val) -> Optional[int]:
     """Parse ``30s`` / ``5m`` / ``2h`` / ``1d`` or a raw integer → seconds.
 
@@ -1231,11 +1236,16 @@ def _parse_duration(val) -> Optional[int]:
             n = float(s[:-1])
         except ValueError as exc:
             raise ValueError(f"malformed duration {val!r}") from exc
-        # float() accepts huge strings as +inf; int(inf * k) raises
-        # OverflowError which the CLI caller only catches ValueError for.
-        if not math.isfinite(n):
+        # Validate the *converted* seconds, not just the parsed float.
+        # A finite float like 1e308 becomes inf after multiplying by
+        # the unit scale (e.g. 86400 for days), and int(inf) raises
+        # OverflowError — which the CLI caller only catches ValueError
+        # for.  Also enforce the SQLite INTEGER ceiling (2**63-1) so
+        # that persisted values remain representable.
+        seconds = n * units[s[-1]]
+        if not math.isfinite(seconds) or seconds > _MAX_DURATION_SECONDS:
             raise ValueError(f"malformed duration {val!r}: value too large")
-        return int(n * units[s[-1]])
+        return int(seconds)
     raise ValueError(f"malformed duration {val!r} (expected 30s, 5m, 2h, 1d, or a number)")
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import math
 import os
 import shlex
 import sys
@@ -1230,6 +1231,10 @@ def _parse_duration(val) -> Optional[int]:
             n = float(s[:-1])
         except ValueError as exc:
             raise ValueError(f"malformed duration {val!r}") from exc
+        # float() accepts huge strings as +inf; int(inf * k) raises
+        # OverflowError which the CLI caller only catches ValueError for.
+        if not math.isfinite(n):
+            raise ValueError(f"malformed duration {val!r}: value too large")
         return int(n * units[s[-1]])
     raise ValueError(f"malformed duration {val!r} (expected 30s, 5m, 2h, 1d, or a number)")
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1375,6 +1375,16 @@ def test_parse_duration_rejects_garbage():
         _parse_duration("fish")
 
 
+def test_parse_duration_rejects_huge_value_as_value_error():
+    """A value that float() turns into +inf must raise ValueError, not
+    OverflowError — the CLI caller only catches ValueError (#_parse_duration)."""
+    from hermes_cli.kanban import _parse_duration
+    import pytest as _p
+    with _p.raises(ValueError):
+        _parse_duration("9" * 310 + "d")
+
+
+
 def test_cli_create_max_runtime_via_duration(kanban_home):
     """`hermes kanban create --max-runtime 2h` should persist 7200 seconds."""
     out = run_slash("create 'long task' --max-runtime 2h --json")

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1377,11 +1377,14 @@ def test_parse_duration_rejects_garbage():
 
 def test_parse_duration_rejects_huge_value_as_value_error():
     """A value that float() turns into +inf must raise ValueError, not
-    OverflowError — the CLI caller only catches ValueError (#_parse_duration)."""
+    OverflowError — the CLI caller only catches ValueError."""
     from hermes_cli.kanban import _parse_duration
     import pytest as _p
     with _p.raises(ValueError):
         _parse_duration("9" * 310 + "d")
+    # Finite float that overflows after unit scaling (1e308 * 86400 → inf).
+    with _p.raises(ValueError):
+        _parse_duration("1e308d")
 
 
 


### PR DESCRIPTION
## Problem

`_parse_duration` in [`hermes_cli/kanban.py`](hermes_cli/kanban.py) parsed the numeric part with `float(s[:-1])`, which silently returns `+inf` for very large strings (e.g. `"9"*310 + "d"`). The subsequent `int(inf * units[unit])` then raised:

```
OverflowError: cannot convert float infinity to integer
```

The CLI caller ([`_cmd_create`](hermes_cli/kanban.py)) only catches `ValueError`:

```python
try:
    max_runtime = _parse_duration(getattr(args, "max_runtime", None))
except ValueError as exc:
    print(f"kanban: --max-runtime: {exc}", file=sys.stderr)
    return 2
```

So the `OverflowError` escaped and crashed the `kanban create` command.

Reproduction:
```python
_parse_duration("9" * 310 + "d")
# float("9"*310) → inf
# int(inf * 86400) → OverflowError
```

## Fix

Guard with `math.isfinite(n)` after the `float()` parse and raise `ValueError` for non-finite values, consistent with the existing malformed-input handling:

```python
if not math.isfinite(n):
```

## Verification

- `ruff check`: clean
- `python -m py_compile`: clean
- Added regression test `test_parse_duration_rejects_huge_value_as_value_error` asserting `_parse_duration("9"*310 + "d")` raises `ValueError`.

## Checklist

- [x] Change is minimal and scoped to the bug
- [x] Test added
- [x] Lint passes