### PR TITLE
fix(model-switch): merge providers.<slug>.models into HERMES_OVERLAYS picker rows

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2556,6 +2556,19 @@ def list_authenticated_providers(
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
                 if hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
+        # A providers.<hermes_slug>.models block extends this overlay
+        # provider's discovered catalog too — same as the Section 1 merge
+        # above. Without this, a model declared under providers.nous.models
+        # (or providers.openai-codex/copilot/opencode-go) is already typeable
+        # via /model <name> (see _configured_provider_matches()) but never
+        # appears in the picker list, unlike the identical config surface for
+        # built-in providers.
+        _configured_models: list[str] = []
+        if isinstance(user_providers, dict):
+            _configured = user_providers.get(hermes_slug)
+            if isinstance(_configured, dict):
+                _configured_models = _declared_model_ids(_configured.get("models"))
+        model_ids = list(dict.fromkeys([*_configured_models, *model_ids]))
         total = len(model_ids)
         if hermes_slug in _UNCAPPED_PICKER_PROVIDERS:
             top = model_ids  # Aggregator: show full catalog regardless of max_models

--- a/tests/hermes_cli/test_configured_builtin_models.py
+++ b/tests/hermes_cli/test_configured_builtin_models.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.providers import HermesOverlay
 
 
 def _provider_row(configured_models, *, max_models=None):
@@ -37,3 +38,90 @@ def test_configured_models_precede_and_deduplicate_discovered_models():
     assert row["total_models"] == 3
 
 
+def _overlay_row(configured_models, *, max_models=None):
+    """Same setup as _provider_row, but for a HERMES_OVERLAYS provider
+    (section 2 — e.g. nous, openai-codex, copilot, opencode-go) instead of
+    a PROVIDER_TO_MODELS_DEV built-in (section 1)."""
+    with (
+        patch("agent.models_dev.fetch_models_dev", return_value={}),
+        patch("agent.models_dev.PROVIDER_TO_MODELS_DEV", {}),
+        patch(
+            "hermes_cli.providers.HERMES_OVERLAYS",
+            {
+                "test-overlay": HermesOverlay(
+                    auth_type="api_key",
+                    extra_env_vars=("TEST_OVERLAY_API_KEY",),
+                ),
+            },
+        ),
+        patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=["live-a", "shared"],
+        ),
+        patch.dict("os.environ", {"TEST_OVERLAY_API_KEY": "test-key"}),
+    ):
+        rows = list_authenticated_providers(
+            current_provider="test-overlay",
+            user_providers={"test-overlay": {"models": configured_models}},
+            max_models=max_models,
+        )
+    return next(row for row in rows if row["slug"] == "test-overlay")
+
+
+def test_configured_models_extend_hermes_overlay_provider_row():
+    """Regression: providers.<slug>.models must extend a HERMES_OVERLAYS
+    row (nous, openai-codex, copilot, opencode-go, ...) the same way it
+    already extends a built-in (section 1) row — otherwise a model the user
+    can already type via /model <name> never appears in the picker list."""
+    row = _overlay_row({"configured-x": {}, "shared": {}})
+
+    assert row["models"] == ["configured-x", "shared", "live-a"]
+    assert row["total_models"] == 3
+
+
+def test_configured_models_are_merged_before_picker_limit_for_overlay():
+    row = _overlay_row(["configured-x", "configured-y"], max_models=2)
+
+    assert row["models"] == ["configured-x", "configured-y"]
+    assert row["total_models"] == 4
+
+
+def test_configured_models_extend_hermes_overlay_provider_row_with_mapped_slug():
+    """Mapped-slug regression: a HERMES_OVERLAYS key can be a models.dev ID
+    (e.g. "github-copilot") that PROVIDER_TO_MODELS_DEV maps back to a
+    different Hermes/config slug ("copilot") — see the
+    "Resolve Hermes slug" comment in list_authenticated_providers(). The
+    providers.<hermes_slug>.models config lookup (and the picker's slug/
+    label) must key off that RESOLVED slug, not the raw overlay/pid key,
+    or a providers.copilot.models block would silently not extend the
+    github-copilot overlay row it's meant for. Also exercises the
+    hermes_slug in {"openai-codex", "copilot", "copilot-acp"} special
+    live-discovery branch specifically (the two other overlay tests above
+    use a synthetic slug that only hits the generic fallback branch)."""
+    with (
+        patch("agent.models_dev.fetch_models_dev", return_value={}),
+        patch("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"copilot": "github-copilot"}),
+        patch(
+            "hermes_cli.providers.HERMES_OVERLAYS",
+            {
+                "github-copilot": HermesOverlay(
+                    auth_type="api_key",
+                    extra_env_vars=("TEST_OVERLAY_API_KEY",),
+                ),
+            },
+        ),
+        patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=["live-a", "shared"],
+        ),
+        patch.dict("os.environ", {"TEST_OVERLAY_API_KEY": "test-key"}),
+    ):
+        rows = list_authenticated_providers(
+            current_provider="copilot",
+            user_providers={"copilot": {"models": {"configured-x": {}, "shared": {}}}},
+            max_models=None,
+        )
+    row = next(row for row in rows if row["slug"] == "copilot")
+
+    assert row["models"] == ["configured-x", "shared", "live-a"]
+    assert row["total_models"] == 3


### PR DESCRIPTION
## What does this PR do?

`list_authenticated_providers()` (`hermes_cli/model_switch.py`) merges a `providers.<slug>.models` config block into a built-in provider's (section 1, `PROVIDER_TO_MODELS_DEV`) discovered catalog (#63055), so a model declared there shows up in the `/model` picker. Section 2 (`HERMES_OVERLAYS` — `nous`, `openai-codex`, `copilot`, `opencode-go`, etc.) builds its `model_ids` through the same shape of code but never applies this merge.

Root cause: a model declared under `providers.nous.models` (or `providers.opencode-go.models`, `providers.openai-codex.models`, `providers.copilot.models`) is already **typeable** via `/model <name>` today — `_configured_provider_matches()` (line 728) scans `user_providers` generically by slug, with no built-in/overlay distinction, specifically to route a typed model name to the right provider (#45006). But it never **appears in the picker list** for that provider, because section 2's `model_ids` construction has no equivalent merge. This is inconsistent with the identical config surface already working correctly for built-in providers.

Fix: apply the same merge (configured models first, deduplicated against the discovered list) right before `model_ids` is capped to `max_models`, keyed by `hermes_slug` — the same slug the row itself reports as `"slug"` in the picker, and the same namespace `providers.nous`/`providers.openai-codex` are documented as (`hermes_cli/auth.py`'s own comments reference these exact keys).

## Scope note

Section 2b (`CANONICAL_PROVIDERS`) has the same "`providers.<slug>.models` is invisible to the picker" symptom for a different subset of providers. I found and fixed it too, but **two other open PRs already actively rework that exact code region** with a different approach:
- #21983 (`skip canonical providers when user has config-defined models`) — a slug present in `user_providers` at all makes section 2b skip the row entirely and defer to section 3, discarding the discovered catalog.
- #60656 (`make picker discovery config-aware`) — adds a new `_is_configured_builtin_provider()` gate at the top of both section 2 and section 2b.

Both touch the same few lines my section-2b fix would have touched, with a philosophy that conflicts with a pure merge (skip-and-defer vs. merge-and-keep-both). Rather than add a third competing change to contested territory, I scoped this PR to section 2 only, where there's no existing open PR.

## Related Issue

None filed — found via code review while auditing today's (2026-07-12) `#63055`/`#63052`/`#63046` model-picker series for consistency across all four sections of `list_authenticated_providers()`.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `hermes_cli/model_switch.py`: section 2 (`HERMES_OVERLAYS` loop) now merges `providers.<hermes_slug>.models` into `model_ids` before capping to `max_models`, mirroring section 1's existing merge (+13 lines)
- `tests/hermes_cli/test_configured_builtin_models.py`: two new regression tests — `test_configured_models_extend_hermes_overlay_provider_row` and `test_configured_models_are_merged_before_picker_limit_for_overlay`, mirroring the existing section-1 tests in the same file but against a synthetic `HermesOverlay` entry

## How to Test
```
python3.11 -m pytest tests/hermes_cli/test_configured_builtin_models.py tests/hermes_cli/test_overlay_slug_resolution.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_opencode_zen_model_limit.py tests/hermes_cli/test_ollama_cloud_provider.py tests/hermes_cli/test_model_switch_filter_unresolved.py tests/hermes_cli/test_openai_picker_curated.py tests/hermes_cli/test_list_picker_providers.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_codex_cli_model_picker.py tests/hermes_cli/test_bedrock_model_picker.py tests/hermes_cli/test_picker_prewarm.py tests/hermes_cli/test_copilot_in_model_list.py tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_opencode_go_in_model_list.py tests/hermes_cli/test_authenticated_providers_exhausted_pool.py -v --override-ini="addopts="
```
199 passed. New tests mutation-verified: stashing the fix reproduces the exact bug — both new tests fail with `row["models"] == ["live-a", "shared"]` (configured models missing), confirming they genuinely catch the regression.

## Checklist
- [x] Contributing Guide read | Conventional Commits | Duplicate PR checked (`gh pr list --search "HERMES_OVERLAYS configured models picker"` / `"opencode-go providers models picker"` / `"list_authenticated_providers configured models"` — found #21983/#60656/#57399, all confirmed scoped to section 2b only, not section 2; see scope note above)
- [x] Only this fix | Tests added | Platform: macOS (pure Python control-flow, no OS-specific code)
- [x] Docs — N/A (no new config key, `providers.<slug>.models` is already documented) | Cross-platform — N/A