### PR TITLE
fix(approval): extend verification-artifact cleanup exemption to Windows del/Remove-Item

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -287,6 +287,62 @@ class TestWindowsShellDestructiveCommands:
         assert desc is None
 
 
+class TestWindowsVerificationArtifactCleanupExemption:
+    """Windows-native sibling of TestDetectDangerousRm's verification-cleanup
+    exemption tests: cmd /c del and powershell Remove-Item, not just POSIX rm -f."""
+
+    _TEMP_DIR = r"C:\Users\test\AppData\Local\Temp"
+
+    def test_cmd_del_verification_cleanup_is_not_dangerous(self):
+        with mock_patch("tempfile.gettempdir", return_value=self._TEMP_DIR):
+            for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
+                target = f"{self._TEMP_DIR}\\{prefix}example.py"
+                assert detect_dangerous_command(f"cmd /c del {target}") == (
+                    False, None, None,
+                )
+                assert detect_dangerous_command(f'cmd.exe /c del "{target}"') == (
+                    False, None, None,
+                )
+
+    def test_powershell_remove_item_verification_cleanup_is_not_dangerous(self):
+        with mock_patch("tempfile.gettempdir", return_value=self._TEMP_DIR):
+            target = f"{self._TEMP_DIR}\\hermes-verify-example.py"
+            assert detect_dangerous_command(f"powershell Remove-Item {target}") == (
+                False, None, None,
+            )
+            assert detect_dangerous_command(
+                f'powershell -Command "Remove-Item \'{target}\'"'
+            ) == (False, None, None)
+            assert detect_dangerous_command(f'pwsh -c Remove-Item "{target}"') == (
+                False, None, None,
+            )
+
+    def test_windows_verification_cleanup_exemption_rejects_broader_deletions(self):
+        target = f"{self._TEMP_DIR}\\hermes-verify-example.py"
+        commands = (
+            f"cmd /c del {target} & echo pwned",
+            f'cmd /c del "{target}" "C:\\Users\\test\\AppData\\Local\\Temp\\other.py"',
+            f"cmd /c del {self._TEMP_DIR}\\nested\\hermes-verify-example.py",
+            f"cmd /c del C:\\Users\\test\\AppData\\Local\\Temp2\\hermes-verify-example.py",
+            f"cmd /c rmdir {target}",
+            # /k (unlike /c) leaves an interactive command interpreter open
+            # after the deletion runs -- the exemption is specifically a
+            # one-shot cleanup, so /k must stay outside it even for an
+            # otherwise-valid artifact path.
+            f"cmd /k del {target}",
+            f"powershell Remove-Item -Recurse {target}",
+            f"powershell Remove-Item {target} -Recurse",
+            f"powershell Remove-Item {target} C:\\Users\\test\\AppData\\Local\\Temp\\other.py",
+            f"powershell Remove-Item {self._TEMP_DIR}\\unrelated.py",
+        )
+        with mock_patch("tempfile.gettempdir", return_value=self._TEMP_DIR):
+            for command in commands:
+                is_dangerous, key, desc = detect_dangerous_command(command)
+                assert is_dangerous is True, command
+                assert key is not None, command
+                assert "delete" in desc.lower(), command
+
+
 class TestDetectDangerousSudo:
     def test_shell_via_c_flag(self):
         is_dangerous, key, desc = detect_dangerous_command("bash -c 'echo pwned'")

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -181,6 +181,62 @@ class TestWindowsShellDestructiveCommands:
         assert desc is None
 
 
+class TestWindowsVerificationArtifactCleanupExemption:
+    """Windows-native sibling of TestDetectDangerousRm's verification-cleanup
+    exemption tests: cmd /c del and powershell Remove-Item, not just POSIX rm -f."""
+
+    _TEMP_DIR = r"C:\Users\test\AppData\Local\Temp"
+
+    def test_cmd_del_verification_cleanup_is_not_dangerous(self):
+        with mock_patch("tempfile.gettempdir", return_value=self._TEMP_DIR):
+            for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
+                target = f"{self._TEMP_DIR}\\{prefix}example.py"
+                assert detect_dangerous_command(f"cmd /c del {target}") == (
+                    False, None, None,
+                )
+                assert detect_dangerous_command(f'cmd.exe /c del "{target}"') == (
+                    False, None, None,
+                )
+
+    def test_powershell_remove_item_verification_cleanup_is_not_dangerous(self):
+        with mock_patch("tempfile.gettempdir", return_value=self._TEMP_DIR):
+            target = f"{self._TEMP_DIR}\\hermes-verify-example.py"
+            assert detect_dangerous_command(f"powershell Remove-Item {target}") == (
+                False, None, None,
+            )
+            assert detect_dangerous_command(
+                f'powershell -Command "Remove-Item \'{target}\'"'
+            ) == (False, None, None)
+            assert detect_dangerous_command(f'pwsh -c Remove-Item "{target}"') == (
+                False, None, None,
+            )
+
+    def test_windows_verification_cleanup_exemption_rejects_broader_deletions(self):
+        target = f"{self._TEMP_DIR}\\hermes-verify-example.py"
+        commands = (
+            f"cmd /c del {target} & echo pwned",
+            f'cmd /c del "{target}" "C:\\Users\\test\\AppData\\Local\\Temp\\other.py"',
+            f"cmd /c del {self._TEMP_DIR}\\nested\\hermes-verify-example.py",
+            f"cmd /c del C:\\Users\\test\\AppData\\Local\\Temp2\\hermes-verify-example.py",
+            f"cmd /c rmdir {target}",
+            # /k (unlike /c) leaves an interactive command interpreter open
+            # after the deletion runs -- the exemption is specifically a
+            # one-shot cleanup, so /k must stay outside it even for an
+            # otherwise-valid artifact path.
+            f"cmd /k del {target}",
+            f"powershell Remove-Item -Recurse {target}",
+            f"powershell Remove-Item {target} -Recurse",
+            f"powershell Remove-Item {target} C:\\Users\\test\\AppData\\Local\\Temp\\other.py",
+            f"powershell Remove-Item {self._TEMP_DIR}\\unrelated.py",
+        )
+        with mock_patch("tempfile.gettempdir", return_value=self._TEMP_DIR):
+            for command in commands:
+                is_dangerous, key, desc = detect_dangerous_command(command)
+                assert is_dangerous is True, command
+                assert key is not None, command
+                assert "delete" in desc.lower(), command
+
+
 class TestDetectDangerousSudo:
     def test_shell_via_c_flag(self):
         is_dangerous, key, desc = detect_dangerous_command("bash -c 'echo pwned'")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2035,6 +2035,77 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
     return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
 
 
+_WINDOWS_VERIFY_CLEANUP_CMD_RE = re.compile(r"cmd(?:\.exe)?\s+/c\s+(.+)", re.IGNORECASE)
+_WINDOWS_VERIFY_CLEANUP_DEL_RE = re.compile(r"del\s+(.+)", re.IGNORECASE)
+_WINDOWS_VERIFY_CLEANUP_PS_RE = re.compile(
+    r"(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:command|c)\s+)?(.+)", re.IGNORECASE
+)
+_WINDOWS_VERIFY_CLEANUP_REMOVE_ITEM_RE = re.compile(r"remove-item\s+(.+)", re.IGNORECASE)
+
+
+def _is_windows_verification_artifact_cleanup(command: str) -> bool:
+    """Windows-native sibling of :func:`_is_verification_artifact_cleanup`.
+
+    Verify-on-stop's cleanup instruction (``agent/verification_stop.py``,
+    ``tempfile.gettempdir()`` + a ``hermes-verify-``/``hermes-ad-hoc-``
+    filename) is platform-agnostic, but the POSIX exemption above only
+    recognizes ``rm -f <path>`` — a Windows-native agent cleaning up the
+    same self-prescribed artifact via ``cmd /c del <path>`` or
+    ``powershell Remove-Item <path>`` still trips the Windows destructive-
+    delete patterns below, reproducing the exact "two safety policies
+    compose into mandatory approval friction" bug for Windows sessions.
+
+    Uses ``ntpath`` explicitly (not ``os.path``) so the path lexical checks
+    are deterministic regardless of the OS actually running Hermes — the
+    same reasoning ``tools/file_tools.py`` already applies to Windows path
+    handling elsewhere in this codebase.
+    """
+    normalized = command.strip()
+
+    match = _WINDOWS_VERIFY_CLEANUP_CMD_RE.fullmatch(normalized)
+    if match:
+        inner = _strip_optional_shell_quotes(match.group(1).strip())
+        del_match = _WINDOWS_VERIFY_CLEANUP_DEL_RE.fullmatch(inner)
+        if not del_match:
+            return False
+        operand_raw = del_match.group(1)
+    else:
+        match = _WINDOWS_VERIFY_CLEANUP_PS_RE.fullmatch(normalized)
+        if not match:
+            return False
+        inner = _strip_optional_shell_quotes(match.group(1).strip())
+        ri_match = _WINDOWS_VERIFY_CLEANUP_REMOVE_ITEM_RE.fullmatch(inner)
+        if not ri_match:
+            return False
+        operand_raw = ri_match.group(1)
+
+    operand_raw = operand_raw.strip()
+    was_quoted = (
+        len(operand_raw) >= 2
+        and operand_raw[0] == operand_raw[-1]
+        and operand_raw[0] in ("'", '"')
+    )
+    operand = _strip_optional_shell_quotes(operand_raw)
+    if not operand:
+        return False
+    # An unquoted operand must be a single bare token — remaining whitespace
+    # means a second path/flag was appended (e.g. "del a.py & echo pwned"),
+    # which the basename/dirname checks below cannot always catch on their
+    # own. A quoted operand's boundaries are unambiguous, so real temp-dir
+    # usernames containing spaces (e.g. "C:\Users\John Doe\...\Temp") still
+    # work as long as the agent quoted the path.
+    if not was_quoted and re.search(r"\s", operand):
+        return False
+
+    import ntpath
+
+    temp_dir = ntpath.normpath(tempfile.gettempdir())
+    basename = ntpath.basename(operand)
+    if ntpath.normpath(ntpath.dirname(operand)) != temp_dir:
+        return False
+    return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
@@ -2043,7 +2114,7 @@ def detect_dangerous_command(command: str) -> tuple:
     """
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION, _PARSER_LIMIT_DESCRIPTION)
-    if _is_verification_artifact_cleanup(command):
+    if _is_verification_artifact_cleanup(command) or _is_windows_verification_artifact_cleanup(command):
         return (False, None, None)
 
     for command_variant in _command_detection_variants(command):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2260,6 +2260,77 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
     return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
 
 
+_WINDOWS_VERIFY_CLEANUP_CMD_RE = re.compile(r"cmd(?:\.exe)?\s+/c\s+(.+)", re.IGNORECASE)
+_WINDOWS_VERIFY_CLEANUP_DEL_RE = re.compile(r"del\s+(.+)", re.IGNORECASE)
+_WINDOWS_VERIFY_CLEANUP_PS_RE = re.compile(
+    r"(?:powershell|pwsh)(?:\.exe)?\s+(?:-(?:command|c)\s+)?(.+)", re.IGNORECASE
+)
+_WINDOWS_VERIFY_CLEANUP_REMOVE_ITEM_RE = re.compile(r"remove-item\s+(.+)", re.IGNORECASE)
+
+
+def _is_windows_verification_artifact_cleanup(command: str) -> bool:
+    """Windows-native sibling of :func:`_is_verification_artifact_cleanup`.
+
+    Verify-on-stop's cleanup instruction (``agent/verification_stop.py``,
+    ``tempfile.gettempdir()`` + a ``hermes-verify-``/``hermes-ad-hoc-``
+    filename) is platform-agnostic, but the POSIX exemption above only
+    recognizes ``rm -f <path>`` — a Windows-native agent cleaning up the
+    same self-prescribed artifact via ``cmd /c del <path>`` or
+    ``powershell Remove-Item <path>`` still trips the Windows destructive-
+    delete patterns below, reproducing the exact "two safety policies
+    compose into mandatory approval friction" bug for Windows sessions.
+
+    Uses ``ntpath`` explicitly (not ``os.path``) so the path lexical checks
+    are deterministic regardless of the OS actually running Hermes — the
+    same reasoning ``tools/file_tools.py`` already applies to Windows path
+    handling elsewhere in this codebase.
+    """
+    normalized = command.strip()
+
+    match = _WINDOWS_VERIFY_CLEANUP_CMD_RE.fullmatch(normalized)
+    if match:
+        inner = _strip_optional_shell_quotes(match.group(1).strip())
+        del_match = _WINDOWS_VERIFY_CLEANUP_DEL_RE.fullmatch(inner)
+        if not del_match:
+            return False
+        operand_raw = del_match.group(1)
+    else:
+        match = _WINDOWS_VERIFY_CLEANUP_PS_RE.fullmatch(normalized)
+        if not match:
+            return False
+        inner = _strip_optional_shell_quotes(match.group(1).strip())
+        ri_match = _WINDOWS_VERIFY_CLEANUP_REMOVE_ITEM_RE.fullmatch(inner)
+        if not ri_match:
+            return False
+        operand_raw = ri_match.group(1)
+
+    operand_raw = operand_raw.strip()
+    was_quoted = (
+        len(operand_raw) >= 2
+        and operand_raw[0] == operand_raw[-1]
+        and operand_raw[0] in ("'", '"')
+    )
+    operand = _strip_optional_shell_quotes(operand_raw)
+    if not operand:
+        return False
+    # An unquoted operand must be a single bare token — remaining whitespace
+    # means a second path/flag was appended (e.g. "del a.py & echo pwned"),
+    # which the basename/dirname checks below cannot always catch on their
+    # own. A quoted operand's boundaries are unambiguous, so real temp-dir
+    # usernames containing spaces (e.g. "C:\Users\John Doe\...\Temp") still
+    # work as long as the agent quoted the path.
+    if not was_quoted and re.search(r"\s", operand):
+        return False
+
+    import ntpath
+
+    temp_dir = ntpath.normpath(tempfile.gettempdir())
+    basename = ntpath.basename(operand)
+    if ntpath.normpath(ntpath.dirname(operand)) != temp_dir:
+        return False
+    return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
@@ -2268,7 +2339,7 @@ def detect_dangerous_command(command: str) -> tuple:
     """
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION, _PARSER_LIMIT_DESCRIPTION)
-    if _is_verification_artifact_cleanup(command):
+    if _is_verification_artifact_cleanup(command) or _is_windows_verification_artifact_cleanup(command):
         return (False, None, None)
 
     for command_variant in _command_detection_variants(command):


### PR DESCRIPTION
## What does this PR do?

`_is_verification_artifact_cleanup()` (added by #63120, closing issue #62377) lets a verify-on-stop / kanban worker clean up its own self-prescribed `hermes-verify-*`/`hermes-ad-hoc-*` temp script without tripping the dangerous-command approval gate — but only recognizes POSIX `rm -f <path>`.

`agent/verification_stop.py`'s cleanup instruction is platform-agnostic: it uses `tempfile.gettempdir()` and says "clean it up when possible" with no OS-specific phrasing. A Windows-native session cleaning up the same artifact via `cmd /c del <path>` or `powershell Remove-Item <path>` still trips the existing `"Windows cmd destructive delete"` / `"Windows PowerShell destructive delete"` patterns — reproducing the exact bug #62377 reported ("two safety policies compose into mandatory approval friction for the normal workflow one of them prescribes"), just via the Windows shell forms instead of `rm`. #62377's own repro and "Suggested narrow fix" were written from a Linux environment (`rm -f`/`rm --force` specifically), so the fix as merged inherited that scope without excluding Windows on purpose.

Fix: add `_is_windows_verification_artifact_cleanup()`, a Windows-native sibling recognizing only `cmd /c del <path>` and `powershell [-Command] Remove-Item <path>` (bare or `-Command`-wrapped, matching the same verb-position anchoring the existing Windows dangerous-patterns already use) removing a single `hermes-verify-`/`hermes-ad-hoc-` artifact whose resolved parent is the OS temp directory.

## Design notes

- Uses `ntpath` explicitly (not `os.path`) for the lexical path checks, so the exemption is deterministic regardless of the OS actually running Hermes — mirrors the existing pattern `tools/file_tools.py` already uses for Windows path handling elsewhere in this codebase.
- An unquoted operand must be a single bare token (no embedded whitespace) — a quoted operand's boundaries are trusted instead, so a real temp-dir path with a spaced username (`C:\Users\John Doe\...\Temp`) still works as long as the agent quoted it.
- Every broader deletion stays dangerous: recursive/extra flags, extra operands (even quote-adjacent ones), wrong directory, non-hermes-prefixed filename, and shell chaining (`&`, wrapped in an outer script) — see the rejection tests, mirroring the coverage the POSIX sibling already has.

## Related Issue

None filed — extends the fix for #62377 to a platform it didn't cover.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `tools/approval.py`: new `_is_windows_verification_artifact_cleanup()` + 4 module-level regexes, wired into `detect_dangerous_command()` alongside the existing POSIX check (+92 lines)
- `tests/tools/test_approval.py`: new `TestWindowsVerificationArtifactCleanupExemption` class — 3 tests mirroring `TestDetectDangerousRm`'s existing POSIX exemption tests (`cmd /c del`/`cmd.exe /c del "..."`, `powershell Remove-Item`/`powershell -Command "Remove-Item '...'"`/`pwsh -c Remove-Item "..."`, and a broader-deletion rejection sweep covering chaining, extra operands, wrong directory, and non-exempt verbs)

## How to Test
```
python3.11 -m pytest tests/tools/test_approval.py -v --override-ini="addopts="
```
314/315 passed. The 1 failure (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`) is **pre-existing on unmodified `main`** in this sandbox (verified via `git stash` — fails identically with zero changes applied, unrelated to this PR; looks like a `/tmp` → `/private/tmp` symlink interaction with the mocked `tempfile.gettempdir()` specific to this environment). All 3 new tests mutation-verified: stashing the fix makes the two "is not dangerous" tests fail with the exact pre-fix symptom (`Windows cmd/PowerShell destructive delete` fires); the rejection-sweep test is unaffected by the fix by design (it asserts broader deletions were *already* dangerous) and correctly stays green in both states.

## Checklist
- [x] Contributing Guide read | Conventional Commits | Duplicate PR checked (`gh pr list --search "verification cleanup windows del"` / `"hermes-verify windows approval"` / `"Remove-Item verification artifact"` — no PR targets this specific exemption; #38979 touches unrelated `tools/approval.py` line ranges, no overlap)
- [x] Only this fix | Tests added | Platform: macOS (logic is host-OS-independent by design, see Design notes)
- [x] Docs — N/A | Cross-platform — this PR's entire purpose is a Windows-specific fix; POSIX behavior unchanged