### PR TITLE
fix(api-server): count "stopping" runs as active in readiness work counts

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1039,7 +1039,13 @@ class APIServerAdapter(BasePlatformAdapter):
         active_api_runs = sum(
             1
             for status in self._run_statuses.values()
-            if status.get("status") in {"queued", "running", "waiting_for_approval"}
+            # "stopping" (set by _handle_stop_run) is not terminal: the run
+            # stays in this state, doing real executor-thread work, until the
+            # agent actually notices the interrupt and the task settles to
+            # "cancelled" — an unbounded window, not the old ~5s hard-timeout
+            # wait. Excluding it here undercounts active_api_runs for the
+            # whole duration of a cooperative stop.
+            if status.get("status") in {"queued", "running", "waiting_for_approval", "stopping"}
         )
         process_depth = 0
         active_delegations = 0

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -850,6 +850,26 @@ class TestHealthDetailedEndpoint:
              patch("tools.async_delegation.active_count", return_value=2):
             assert adapter._readiness_work_counts() == (3, 4, 2)
 
+    def test_readiness_work_counts_include_stopping_runs(self, adapter):
+        """Regression: _handle_stop_run() sets status="stopping" and holds it
+        there — cooperatively, with no hard timeout — until the agent notices
+        the interrupt and the task actually exits. A run in that window is
+        still doing real executor-thread work and must count as active,
+        the same as "running"; excluding it undercounts active_api_runs for
+        the whole (now-unbounded) cooperative-stop duration."""
+        adapter._run_statuses = {
+            "queued": {"status": "queued"},
+            "running": {"status": "running"},
+            "approval": {"status": "waiting_for_approval"},
+            "stopping": {"status": "stopping"},
+            "done": {"status": "completed"},
+            "cancelled": {"status": "cancelled"},
+        }
+
+        with patch("tools.process_registry.process_registry.completion_queue.qsize", return_value=0), \
+             patch("tools.async_delegation.active_count", return_value=0):
+            assert adapter._readiness_work_counts() == (4, 0, 0)
+
 
 # ---------------------------------------------------------------------------
 # /v1/models endpoint


### PR DESCRIPTION
## What does this PR do?

`_readiness_work_counts()` (`gateway/platforms/api_server.py`) computes `active_api_runs` from `{"queued", "running", "waiting_for_approval"}` — it excludes `"stopping"`, the status `_handle_stop_run()` sets while a run is being interrupted (`POST /v1/runs/{run_id}/stop`).

The stop is fully cooperative: the run stays in `"stopping"` — doing real executor-thread work (whatever tool call or API request was in flight keeps running until the agent notices the interrupt) — until the task actually settles to `"cancelled"`. That's an unbounded window, not a fixed timeout. For the entire duration, `/health/detailed`'s `background_queues.active_api_runs` reports one fewer active run than reality.

## Impact

`background_queues.status` itself is hardcoded `"ok"` (`gateway/readiness.py`), so this doesn't change the overall `/health/detailed` `status` field or any internal gate — nothing in the codebase reads `active_api_runs` for a decision (verified via repo-wide grep). The impact is scoped to external monitoring/observability tooling that trusts this count as "is there live agent work happening right now" — such a tool could see a lower number than reality and act on it (e.g. decide it's safe to scale down) while a stop is still cooperatively draining real work.

## Related Issue

None filed — found via code review while auditing readiness/run-status consistency in this file.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/platforms/api_server.py`: add `"stopping"` to the active-status set in `_readiness_work_counts()` (+1 line, +6 comment lines)
- `tests/gateway/test_api_server.py`: new regression test `test_readiness_work_counts_include_stopping_runs`, mirroring the existing sibling test `test_readiness_work_counts_exclude_retained_completed_runs`

## How to Test
```
python3.11 -m pytest tests/gateway/test_api_server.py tests/gateway/test_readiness.py -v --override-ini="addopts="
```
202 passed. New test mutation-verified: stashing the fix makes it fail with `(3, 0, 0) != (4, 0, 0)` — the exact undercount this PR fixes.

## Note for reviewer: possible mechanical overlap with #52345

Open PR #52345 ("publish API server heartbeat metrics") extracts this same function's inline `sum(...)` into a new `_active_structured_run_count()` helper, but **preserves the same status set** (`{"queued", "running", "waiting_for_approval"}` — still missing `"stopping"`) — it doesn't address this bug, just refactors around it for its own metrics-publishing purpose. If both land, whichever merges second needs a one-line rebase to add `"stopping"` to wherever the set ends up living. No logical conflict — just a textual one on adjacent-purpose PRs.

## Checklist
- [x] Contributing Guide read | Conventional Commits | Duplicate PR checked (`gh pr list --search "readiness active_api_runs stopping"` / `"_readiness_work_counts"` / `"background_queues readiness"` — only #52345 touches this function, see note above, does not fix this bug)
- [x] Only this fix | Tests added | Platform: macOS (pure Python, no OS-specific code)
- [x] Docs — N/A | Cross-platform — N/A