### PR TITLE
fix(desktop): clear $newChatProfile on /new, matching top-nav and keybind

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -10,6 +10,7 @@ import { $composerAttachments, $composerDraft, type ComposerAttachment, setCompo
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
+import { $newChatProfile } from '@/store/profile'
 import {
   $busy,
   $connection,
@@ -1574,6 +1575,37 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     await handle!.submitText('/ pasted context that must not vanish')
 
     expect($composerDraft.get()).toBe('/ pasted context that must not vanish')
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+})
+
+describe('usePromptActions /new', () => {
+  afterEach(() => {
+    cleanup()
+    $newChatProfile.set(null)
+    vi.restoreAllMocks()
+  })
+
+  it('clears a sticky per-profile "+" selection so the next new chat follows the live context', async () => {
+    // A plain "new session" trigger (top nav, keybind, /new) is documented to
+    // leave $newChatProfile null so createBackendSessionForSend() falls back
+    // to the active gateway profile (see use-session-actions/index.ts's own
+    // comment) — only the per-profile "+" (newSessionInProfile) and /profile
+    // <name> are supposed to set it explicitly. /new must clear it just like
+    // the top-nav "New Session" row and the Cmd+N keybind already do, or a
+    // stale per-profile selection silently keeps targeting the old profile.
+    $newChatProfile.set('analyst')
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/new')
+
+    expect($newChatProfile.get()).toBeNull()
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -474,7 +474,15 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // registry row in desktop-slash-commands.ts plus an entry here — never a
       // new branch in a dispatch ladder.
       const actionHandlers: Record<DesktopActionId, (ctx: SlashActionCtx) => Promise<void>> = {
+        // A plain new session (top nav "New Session", /new, the Cmd+N keybind)
+        // leaves $newChatProfile null so createBackendSessionForSend() falls
+        // back to the active gateway profile — only an explicit per-profile
+        // "+" (newSessionInProfile) or /profile <name> is meant to set it.
+        // The top-nav row and the keybind already clear it; /new must too, or
+        // a stale per-profile selection from an earlier "+" silently keeps
+        // targeting the old profile.
         new: async () => {
+          $newChatProfile.set(null)
           startFreshSessionDraft()
         },
         branch: async () => {


### PR DESCRIPTION
## What does this PR do?

`createBackendSessionForSend()` (`use-session-actions/index.ts`) has its own comment documenting the intended contract:

> A plain new session (top "New Session", /new, keybind) leaves `$newChatProfile` null to mean "use the live context"; the per-profile "+" sets it explicitly.

The top-nav "New Session" row (`chat/sidebar/index.tsx`) and the Cmd+N keybind (`use-keybinds.ts`) both implement this correctly — each calls `$newChatProfile.set(null)` before starting the fresh draft. The `/new` slash command's action handler never did: it only called `startFreshSessionDraft()`, despite being explicitly named in the same comment as one of the three triggers that should leave `$newChatProfile` null.

## Impact

After using the per-profile "+" (`newSessionInProfile`) or `/profile <name>`, `$newChatProfile` stays set to that profile — by design, since both are meant to "point the next new chat" at it. A later `/new`, though, falls through to `createBackendSessionForSend()`'s `$newChatProfile.get() ?? $activeGatewayProfile.get()` fallback and picks up the stale profile instead of the live gateway context — contradicting the "leaves it null" contract the code documents for this exact trigger. Concretely: switch into profile B via the "+", then type `/new` expecting a plain new chat on whatever profile is currently live — it silently opens in B again instead.

## Related Issue

None filed — found via code review while auditing the three call sites the code's own comment lists against what they actually do.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`: the `/new` action handler now calls `$newChatProfile.set(null)` before `startFreshSessionDraft()`, mirroring the two existing call sites exactly (+8 lines, mostly comment)
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx`: new test `clears a sticky per-profile "+" selection so the next new chat follows the live context` in a new `describe('usePromptActions /new', ...)` block, using the existing `Harness`/`submitText` pattern already established for other slash commands in this file

## How to Test
```
npx vitest run --project ui src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-session-actions.test.tsx
```
64 passed. New test mutation-verified: stashing the fix makes it fail with `expected 'analyst' to be null` — `$newChatProfile` stays stuck on the stale per-profile selection exactly as described above.

`npx tsc --noEmit` and `npx eslint` on the changed files show only pre-existing, unrelated warnings/errors (verified identical on unmodified `main` via `git stash` — none touch these two files).

## Checklist
- [x] Contributing Guide read | Conventional Commits | Duplicate PR checked (`gh pr list --search "newChatProfile"` / `"new chat profile reset slash"` / `"desktop /new profile sticky"` — #61205 also touches `slash.ts` but only the `profile:` handler, no overlap with `new:`)
- [x] Only this fix | Tests added | Platform: macOS (pure TS/React state logic, no OS-specific code)
- [x] Docs — N/A | Cross-platform — N/A