### PR TITLE
fix(tui_gateway): gracefully handle late terminal.read responses after timeout

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -264,7 +264,7 @@ def test_block_and_respond(capture):
     assert result[0] == "my_answer"
 
 
-@pytest.mark.parametrize("event", ["secret.request", "sudo.request"])
+@pytest.mark.parametrize("event", ["secret.request", "sudo.request", "terminal.read.request"])
 def test_sensitive_prompt_timeout_emits_expiry(capture, event):
     server, buf = capture
 
@@ -280,7 +280,7 @@ def test_sensitive_prompt_timeout_emits_expiry(capture, event):
 
 @pytest.mark.parametrize(
     ("method", "value_key"),
-    [("secret.respond", "value"), ("sudo.respond", "password")],
+    [("secret.respond", "value"), ("sudo.respond", "password"), ("terminal.read.respond", "text")],
 )
 def test_late_sensitive_prompt_response_is_idempotent(server, method, value_key):
     response = server.handle_request(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2058,7 +2058,11 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
             answer_present = rid in _answers
             answer = _answers.pop(rid, "")
 
-    if not answered and not answer_present and event in {"secret.request", "sudo.request"}:
+    if not answered and not answer_present and event in {
+        "secret.request",
+        "sudo.request",
+        "terminal.read.request",
+    }:
         _emit(
             f"{event.removesuffix('.request')}.expire",
             sid,
@@ -10253,7 +10257,12 @@ def _(rid, params: dict) -> dict:
 @method("terminal.read.respond")
 def _(rid, params: dict) -> dict:
     # `text` is a JSON string of the serialized terminal buffer + line metadata.
-    return _respond(rid, params, "text")
+    # allow_expired=True: the read_terminal tool's _block() call uses a short
+    # 30s timeout (vs. 300s default), so a slow renderer losing the race is
+    # the common case, not an edge case — same reasoning as sudo/secret below.
+    # Without this, a late response after the tool already gave up on an
+    # empty string hits the generic "no pending text request" 4009 error.
+    return _respond(rid, params, "text", allow_expired=True)
 
 
 @method("sudo.respond")


### PR DESCRIPTION
## What does this PR do?

`_block()` (`tui_gateway/server.py`) is the shared blocking-RPC bridge behind four request types: `secret.request`, `sudo.request`, `clarify.request`, and `terminal.read.request` (the `read_terminal` tool's desktop-GUI bridge — the renderer answers `terminal.read.respond` with the serialized xterm buffer). On timeout, `_block()` emits a `.expire` notification and the corresponding `*.respond` handler tolerates a late reply gracefully — but only for two of the four: `secret.request`/`sudo.request`.

The other two — `clarify.request` and `terminal.read.request` — still hit the generic `_err(rid, 4009, "no pending X request")` on a late response, and never get the `.expire` emit either, because `_block()`'s exempted-event check is hardcoded to `{"secret.request", "sudo.request"}` and neither `clarify.respond` nor `terminal.read.respond` pass `allow_expired=True` to the shared `_respond()` helper.

`terminal.read.request` is the narrower half of this gap that's actually unclaimed: `clarify.request`'s version is the explicit subject of open PR **#56571** ("gracefully handle late clarify responses after timeout"), which is currently under active review (a reviewer flagged a race-guard issue and recommended rebasing it onto the newer `_block()`/`_pending_prompt_payloads` mechanism this repo has since grown). Not touched here, to avoid duplicating that in-flight work.

## Why this matters for terminal.read specifically

`read_terminal_callback`'s `_block()` call uses a **30s timeout** (`timeout=30`), much shorter than the 300s default the other three request types use. A slow desktop renderer losing that race is the *ordinary* case here, not an edge case — the exact same reasoning that already justifies `allow_expired=True` for `sudo`/`secret`.

Unlike `secret`/`sudo`/`clarify`, `terminal.read` has no client-visible overlay to reconcile (the renderer answers synchronously in the background, serializing the local xterm buffer — no UI prompt is shown). So the practical fix that matters is the **respond-side** graceful handling; the `.expire` emit is added alongside it purely for parity/observability with the mechanism the other three already use.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `tui_gateway/server.py`:
  - `_block()`: add `"terminal.read.request"` to the event set that emits `"terminal.read.expire"` on timeout (mirrors `secret`/`sudo` exactly)
  - `terminal.read.respond`: pass `allow_expired=True` to `_respond()`, so a late response after the tool already gave up on an empty string returns `{"status": "expired"}` instead of a 4009 protocol error
- `tests/tui_gateway/test_protocol.py`: extended the two existing parametrized tests that already cover this exact mechanism for `secret`/`sudo` — `test_sensitive_prompt_timeout_emits_expiry` and `test_late_sensitive_prompt_response_is_idempotent` — with a `"terminal.read.request"`/`"terminal.read.respond"` case each, rather than writing new bespoke tests

## How to Test
```
python3.11 -m pytest tests/tui_gateway/test_protocol.py -v --override-ini="addopts="
```
85 passed. Both new parametrized cases mutation-verified: stashing the fix makes them fail with the exact pre-fix symptom (`ValueError: not enough values to unpack` — no `.expire` message emitted — and `KeyError: 'result'` — a 4009 error instead of `{"status": "expired"}`).

## Checklist
- [x] Contributing Guide read | Conventional Commits | Duplicate PR checked (`gh pr list --search "terminal.read expire"` / `"terminal.read.respond"` / `"read_terminal callback timeout"` — #56571 targets `clarify.request` only, not touched here; #49829 mentions `terminal.read.respond` in a comment about alias-meta rehydrate on session reap, doesn't modify its handler, no overlap)
- [x] Only this fix | Tests added | Platform: macOS (pure Python, no OS-specific code)
- [x] Docs — N/A | Cross-platform — N/A