### PR TITLE
fix(browser_supervisor): store asyncio.create_task refs to prevent GC warnings

### DIFF
--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -666,3 +666,33 @@ def test_evaluate_runtime_unserializable_value(chrome_cdp, supervisor_registry):
     out = supervisor.evaluate_runtime("Infinity")
     assert out["ok"] is True
     assert out["result"] == "Infinity"
+
+
+def test_dialog_tasks_ref_stored_and_retained(chrome_cdp, supervisor_registry):
+    """Verify that fire-and-forget dialog tasks are stored in _dialog_tasks
+    to prevent GC warnings ('Task was destroyed but it is pending!')."""
+    cdp_url, _port = chrome_cdp
+    supervisor = supervisor_registry.get_or_start(task_id="pytest-eval-6", cdp_url=cdp_url)
+
+    _fire_on_page(cdp_url, "void 0")
+    time.sleep(0.5)
+
+    # Trigger a dialog by evaluating alert() - with AUTO_DISMISS policy,
+    # this creates a fire-and-forget task that should be stored.
+    import asyncio
+
+    async def _check():
+        # Fire an alert on the page
+        await supervisor._cdp_session.send(
+            "Runtime.evaluate", expression="alert('test')", awaitPromise=False
+        )
+        await asyncio.sleep(0.3)
+        # Verify the task was stored
+        assert len(supervisor._dialog_tasks) >= 1, "Dialog task should be stored"
+        # Wait for tasks to complete and auto-dismiss
+        await asyncio.sleep(2)
+        # Tasks should be cleaned up by done callback
+        # (or still present if still running - both are valid)
+        assert hasattr(supervisor, "_dialog_tasks")
+
+    asyncio.get_event_loop().run_until_complete(_check())

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -341,6 +341,9 @@ class CDPSupervisor:
 
         # Dialog auto-dismiss watchdog handles (per dialog id).
         self._dialog_watchdogs: Dict[str, asyncio.TimerHandle] = {}
+        # Track fire-and-forget dialog tasks so the GC doesn't destroy them
+        # mid-flight (produces "Task was destroyed but it is pending!" warnings).
+        self._dialog_tasks: set[asyncio.Task] = set()
         # Monotonic id generator for dialogs (human-readable in snapshots).
         self._dialog_seq = 0
 
@@ -918,17 +921,21 @@ class CDPSupervisor:
             # re-archive it as "remote".
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            task = asyncio.create_task(
                 self._auto_handle_dialog(dialog, accept=False, prompt_text="")
             )
+            self._dialog_tasks.add(task)
+            task.add_done_callback(self._dialog_tasks.discard)
         elif self.dialog_policy == DIALOG_POLICY_AUTO_ACCEPT:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            task = asyncio.create_task(
                 self._auto_handle_dialog(
                     dialog, accept=True, prompt_text=dialog.default_prompt
                 )
             )
+            self._dialog_tasks.add(task)
+            task.add_done_callback(self._dialog_tasks.discard)
         else:
             # must_respond → add to pending and arm watchdog.
             with self._state_lock:
@@ -1138,17 +1145,21 @@ class CDPSupervisor:
         if self.dialog_policy == DIALOG_POLICY_AUTO_DISMISS:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            task = asyncio.create_task(
                 self._fulfill_bridge_request(dialog, accept=False, prompt_text="")
             )
+            self._dialog_tasks.add(task)
+            task.add_done_callback(self._dialog_tasks.discard)
         elif self.dialog_policy == DIALOG_POLICY_AUTO_ACCEPT:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            task = asyncio.create_task(
                 self._fulfill_bridge_request(
                     dialog, accept=True, prompt_text=default_prompt
                 )
             )
+            self._dialog_tasks.add(task)
+            task.add_done_callback(self._dialog_tasks.discard)
         else:
             # must_respond — add to pending + arm watchdog.
             with self._state_lock:


### PR DESCRIPTION
## Summary

Store references to fire-and-forget `asyncio.create_task()` calls in `CDPSupervisor._dialog_tasks` so the GC doesn't destroy them mid-flight.

## Problem

Four `asyncio.create_task()` calls in `tools/browser_supervisor.py` (lines 921, 927, 1141, 1147) fire off auto-dismiss/auto-accept dialog coroutines without storing the returned task reference.  When the GC collects an unawaited task before it completes, Python logs *"Task was destroyed but it is pending!"* warnings and the dialog CDP call may be silently dropped — leaving the browser page permanently blocked on a dialog.

## Fix

Added `self._dialog_tasks: set[asyncio.Task]` to `CDPSupervisor.__init__` and wrapped each `create_task` with:
- `self._dialog_tasks.add(task)`
- `task.add_done_callback(self._dialog_tasks.discard)`

This is the same pattern already used in `agent/lsp/manager.py` (PR #64833) and other modules.

## Testing
- Syntax check passed (py_compile)
- Behavior verified