### PR TITLE
fix(agent): prevent session search output leakage

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -621,6 +621,16 @@ def run_conversation(
     final_response = None
     interrupted = False
     failed = False
+    # Once session_search has executed, the next model response may echo its
+    # structured history payload verbatim.  Keep the rest of this turn on the
+    # complete-response path so the finalizer can inspect it before any visible
+    # stream consumer receives text.
+    session_search_used_this_turn = False
+    # Error-shaped tool output is shared across every Hermes tool.  Keep the
+    # actual session_search results keyed by tool_call_id so only a matching
+    # echo is withheld; unrelated {error, success:false} assistant JSON stays
+    # untouched.
+    session_search_output_fingerprints: dict[str, set[str]] = {}
     codex_ack_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
@@ -1318,6 +1328,8 @@ def run_conversation(
                 # attempt — switch to non-streaming for the rest of this
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
+                    _use_streaming = False
+                elif session_search_used_this_turn:
                     _use_streaming = False
                 # CopilotACPClient communicates via subprocess stdio and
                 # returns a plain SimpleNamespace — not an iterable
@@ -4339,6 +4351,26 @@ def run_conversation(
                 else:
                     assistant_message.content = str(raw)
 
+            # Post-session-search calls are forced through the complete-response
+            # path, so this is the earliest shared point after provider
+            # normalization and before post_api_request hooks, message builders,
+            # reasoning callbacks, interim display, or persistence.  Scrub all
+            # structured reasoning fields here; later branch-specific checks are
+            # retained as defense in depth for synthetic/recovery messages.
+            if session_search_used_this_turn:
+                from agent.turn_finalizer import (
+                    _sanitize_session_search_reasoning_fields,
+                )
+
+                if _sanitize_session_search_reasoning_fields(
+                    assistant_message,
+                    session_search_output_fingerprints,
+                ):
+                    logger.warning(
+                        "Withheld raw session_search reasoning before response "
+                        "hooks and message construction"
+                    )
+
             try:
                 from hermes_cli.plugins import (
                     has_hook,
@@ -4738,6 +4770,47 @@ def run_conversation(
                     assistant_message.tool_calls
                 )
 
+                _session_search_call_ids = {
+                    str(tc.id)
+                    for tc in assistant_message.tool_calls
+                    if tc.function.name == "session_search" and tc.id is not None
+                }
+                if _session_search_call_ids:
+                    session_search_used_this_turn = True
+
+                # A model can echo the preceding session_search payload while
+                # also requesting another tool.  This branch is persisted and
+                # surfaced as interim commentary before the turn finalizer runs,
+                # so scrub the content at the earliest shared boundary.  Keep
+                # the tool calls themselves intact and use empty content: the
+                # model is still working and has no user-facing answer yet.
+                if session_search_used_this_turn:
+                    from agent.turn_finalizer import (
+                        _looks_like_session_search_output,
+                        _sanitize_session_search_reasoning_fields,
+                    )
+
+                    _reasoning_sanitized = (
+                        _sanitize_session_search_reasoning_fields(
+                            assistant_message,
+                            session_search_output_fingerprints,
+                        )
+                    )
+                    if _looks_like_session_search_output(
+                        assistant_message.content,
+                        session_search_output_fingerprints,
+                    ):
+                        assistant_message.content = ""
+                        logger.warning(
+                            "Withheld raw session_search output from "
+                            "intermediate assistant tool-call message"
+                        )
+                    elif _reasoning_sanitized:
+                        logger.warning(
+                            "Withheld raw session_search reasoning from "
+                            "intermediate assistant tool-call message"
+                        )
+
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
                 
                 turn_content = assistant_message.content or ""
@@ -4746,7 +4819,7 @@ def run_conversation(
                 # This classification is needed regardless of whether the turn has visible content,
                 # because a substantive tool-only turn must invalidate any older housekeeping fallback.
                 _HOUSEKEEPING_TOOLS = frozenset({
-                    "memory", "todo", "skill_manage", "session_search",
+                    "memory", "todo", "skill_manage",
                 })
                 _all_housekeeping = all(
                     tc.function.name in _HOUSEKEEPING_TOOLS
@@ -4840,7 +4913,28 @@ def run_conversation(
                     except Exception:
                         pass
 
+                _tool_result_start_idx = len(messages)
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                if _session_search_call_ids:
+                    from agent.turn_finalizer import (
+                        _session_search_output_fingerprint,
+                    )
+
+                    for tool_result in messages[_tool_result_start_idx:]:
+                        if not isinstance(tool_result, dict):
+                            continue
+                        call_id = tool_result.get("tool_call_id")
+                        if call_id is None or str(call_id) not in _session_search_call_ids:
+                            continue
+                        fingerprint = _session_search_output_fingerprint(
+                            tool_result.get("content")
+                        )
+                        if fingerprint:
+                            session_search_output_fingerprints.setdefault(
+                                str(call_id),
+                                set(),
+                            ).add(fingerprint)
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
@@ -5268,6 +5362,40 @@ def run_conversation(
                     length_continue_retries = 0
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
+
+                # Post-search responses use the complete-response API so raw
+                # tool JSON can be inspected before it reaches any stream
+                # consumer.  Sanitize now—before building/persisting the final
+                # assistant message—and keep the finalizer as a defense-in-depth
+                # guard for budget and error exits that bypass this branch.
+                if session_search_used_this_turn:
+                    from agent.turn_finalizer import (
+                        _SESSION_SEARCH_OUTPUT_REPLACEMENT,
+                        _looks_like_session_search_output,
+                        _sanitize_session_search_reasoning_fields,
+                    )
+
+                    _reasoning_sanitized = (
+                        _sanitize_session_search_reasoning_fields(
+                            assistant_message,
+                            session_search_output_fingerprints,
+                        )
+                    )
+                    if _looks_like_session_search_output(
+                        final_response,
+                        session_search_output_fingerprints,
+                    ):
+                        final_response = _SESSION_SEARCH_OUTPUT_REPLACEMENT
+                        assistant_message.content = final_response
+                        logger.warning(
+                            "Withheld raw session_search output from final "
+                            "assistant response"
+                        )
+                    elif _reasoning_sanitized:
+                        logger.warning(
+                            "Withheld raw session_search reasoning from final "
+                            "assistant response"
+                        )
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
@@ -5440,6 +5568,21 @@ def run_conversation(
                     final_response = None
                     continue
 
+                # The post-search call was deliberately non-streaming.  Once
+                # every verification/worker stop gate has accepted the answer,
+                # replay the checked text through the normal stream fan-out so
+                # display and TTS receive it and existing delivery tracking can
+                # deduplicate the gateway's final response.  This is normal
+                # stream delivery, not an interim preview, so do not set
+                # _response_was_previewed.
+                if session_search_used_this_turn and agent._has_stream_consumers():
+                    agent._fire_stream_delta(final_response)
+                    # Reuse the normal per-response stream finalization path:
+                    # it flushes a benign partial tag prefix (for example a
+                    # trailing "<") through both display and TTS before the
+                    # gateway consumer receives its independent finish signal.
+                    agent._reset_stream_delivery_tracking()
+
                 messages.append(final_msg)
                 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
@@ -5523,6 +5666,8 @@ def run_conversation(
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
+        session_search_used=session_search_used_this_turn,
+        session_search_output_fingerprints=session_search_output_fingerprints,
     )
 
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -22,9 +22,311 @@ keep the exact logger name (``"agent.conversation_loop"``).
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+
+
+_SESSION_SEARCH_OUTPUT_REPLACEMENT = (
+    "I found relevant conversation history, but the raw session-search data "
+    "was withheld. Ask me to summarize the relevant details instead."
+)
+_SESSION_SEARCH_MODES = frozenset({"browse", "discover", "read", "scroll"})
+_SESSION_SEARCH_STRUCTURAL_MARKERS = (
+    '"bookend_start"',
+    '"bookend_end"',
+    '"match_message_id"',
+    '"messages_before"',
+    '"messages_after"',
+    '"sessions_searched"',
+)
+_SESSION_SEARCH_REASONING_SCALAR_FIELDS = ("reasoning", "reasoning_content")
+_SESSION_SEARCH_REASONING_CONTAINER_FIELDS = (
+    "reasoning_details",
+    "anthropic_content_blocks",
+    "codex_reasoning_items",
+)
+
+
+def _strip_json_fence(text: str) -> str:
+    """Return the body of a single Markdown JSON fence, if present."""
+    lines = text.strip().splitlines()
+    if (
+        len(lines) >= 3
+        and lines[0].strip().lower() in {"```", "```json"}
+        and lines[-1].strip() == "```"
+    ):
+        return "\n".join(lines[1:-1]).strip()
+    return text.strip()
+
+
+def _extract_json_object(value):
+    """Extract the first JSON object from a raw or lightly wrapped string."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    candidate = _strip_json_fence(value)
+    try:
+        payload = json.loads(candidate)
+    except (TypeError, ValueError):
+        payload = None
+    if isinstance(payload, dict):
+        return payload
+
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(candidate):
+        if char != "{":
+            continue
+        try:
+            payload, _end = decoder.raw_decode(candidate[index:])
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def _session_search_output_fingerprint(value):
+    """Return a stable fingerprint for a JSON tool result or echoed wrapper."""
+    payload = value if isinstance(value, dict) else _extract_json_object(value)
+    if not isinstance(payload, dict):
+        return None
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _observed_fingerprint_values(observed_fingerprints) -> set[str]:
+    """Flatten tool-call-id keyed fingerprints into a comparison set."""
+    if not observed_fingerprints:
+        return set()
+    values = (
+        observed_fingerprints.values()
+        if isinstance(observed_fingerprints, dict)
+        else observed_fingerprints
+    )
+    flattened: set[str] = set()
+    for value in values:
+        if isinstance(value, str):
+            flattened.add(value)
+        elif isinstance(value, (set, frozenset, list, tuple)):
+            flattened.update(item for item in value if isinstance(item, str))
+    return flattened
+
+
+def _looks_like_session_search_output(
+    value,
+    observed_fingerprints=None,
+) -> bool:
+    """Recognize a raw session-search result without matching normal prose."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+
+    payload = _extract_json_object(value)
+
+    if isinstance(payload, dict):
+        # session_search uses registry.tool_error(..., success=False) for read,
+        # browse, discover, and scroll failures.  Those payloads intentionally
+        # omit ``mode``.  The shape is shared by every other tool, so only
+        # withhold it when its canonical fingerprint matches a session_search
+        # result actually observed in this turn.
+        if (
+            payload.get("success") is False
+            and isinstance(payload.get("error"), str)
+            and bool(payload["error"].strip())
+        ):
+            fingerprint = _session_search_output_fingerprint(payload)
+            return fingerprint in _observed_fingerprint_values(
+                observed_fingerprints
+            )
+
+        mode = payload.get("mode")
+        if (
+            mode in _SESSION_SEARCH_MODES
+            and payload.get("success") is True
+            and any(key in payload for key in ("messages", "results", "session_id"))
+        ):
+            return True
+
+    compact = "".join(value.lower().split())
+    has_mode = any(f'"mode":"{mode}"' in compact for mode in _SESSION_SEARCH_MODES)
+    has_container = '"messages"' in compact or '"results"' in compact
+    if has_mode and has_container and '"success":true' in compact:
+        return True
+
+    marker_count = sum(marker in value for marker in _SESSION_SEARCH_STRUCTURAL_MARKERS)
+    return marker_count >= 2 and '"role"' in value and '"content"' in value
+
+
+def _value_contains_session_search_output(value, observed_fingerprints=None) -> bool:
+    """Return whether a structured reasoning value contains raw tool output."""
+    if isinstance(value, str):
+        return _looks_like_session_search_output(value, observed_fingerprints)
+    if isinstance(value, dict):
+        return any(
+            _value_contains_session_search_output(item, observed_fingerprints)
+            for item in value.values()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(
+            _value_contains_session_search_output(item, observed_fingerprints)
+            for item in value
+        )
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _value_contains_session_search_output(
+                model_dump(),
+                observed_fingerprints,
+            )
+        except Exception:
+            return False
+    return False
+
+
+def _filter_session_search_reasoning_container(
+    value,
+    observed_fingerprints=None,
+):
+    """Drop only raw-search entries from a provider reasoning container."""
+    if isinstance(value, list):
+        preserved = [
+            item
+            for item in value
+            if not _value_contains_session_search_output(
+                item,
+                observed_fingerprints,
+            )
+        ]
+        return preserved, len(preserved) != len(value)
+    if isinstance(value, tuple):
+        preserved = tuple(
+            item
+            for item in value
+            if not _value_contains_session_search_output(
+                item,
+                observed_fingerprints,
+            )
+        )
+        return preserved, len(preserved) != len(value)
+    if _value_contains_session_search_output(value, observed_fingerprints):
+        return None, True
+    return value, False
+
+
+def _sanitize_session_search_reasoning_fields(
+    message,
+    observed_fingerprints=None,
+) -> bool:
+    """Remove raw session-search output from assistant reasoning fields."""
+    if message is None:
+        return False
+
+    def _has(field):
+        return field in message if isinstance(message, dict) else hasattr(message, field)
+
+    def _get(field):
+        return message.get(field) if isinstance(message, dict) else getattr(message, field, None)
+
+    def _set(field, value):
+        if isinstance(message, dict):
+            message[field] = value
+        else:
+            setattr(message, field, value)
+
+    changed = False
+    for field in _SESSION_SEARCH_REASONING_SCALAR_FIELDS:
+        if _has(field) and _value_contains_session_search_output(
+            _get(field),
+            observed_fingerprints,
+        ):
+            try:
+                _set(field, None)
+                changed = True
+            except Exception:
+                pass
+
+    if _has("reasoning_details"):
+        details, details_changed = _filter_session_search_reasoning_container(
+            _get("reasoning_details"),
+            observed_fingerprints,
+        )
+        if details_changed:
+            try:
+                _set("reasoning_details", details)
+                changed = True
+            except Exception:
+                pass
+
+    for metadata_field in ("provider_data", "model_extra"):
+        metadata = _get(metadata_field) if _has(metadata_field) else None
+        if not isinstance(metadata, dict):
+            continue
+        for field in _SESSION_SEARCH_REASONING_SCALAR_FIELDS:
+            if field in metadata and _value_contains_session_search_output(
+                metadata[field],
+                observed_fingerprints,
+            ):
+                metadata[field] = None
+                changed = True
+        for field in _SESSION_SEARCH_REASONING_CONTAINER_FIELDS:
+            if field not in metadata:
+                continue
+            filtered, field_changed = _filter_session_search_reasoning_container(
+                metadata[field],
+                observed_fingerprints,
+            )
+            if field_changed:
+                metadata[field] = filtered
+                changed = True
+
+    return changed
+
+
+def _sanitize_session_search_output(
+    final_response,
+    messages,
+    observed_fingerprints=None,
+):
+    """Sanitize raw search output in final text and current-turn reasoning."""
+    content_sanitized = _looks_like_session_search_output(
+        final_response,
+        observed_fingerprints,
+    )
+    changed = content_sanitized
+
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "user":
+            break
+        if message.get("role") != "assistant":
+            continue
+        changed = (
+            _sanitize_session_search_reasoning_fields(
+                message,
+                observed_fingerprints,
+            )
+            or changed
+        )
+        if content_sanitized and _looks_like_session_search_output(
+            message.get("content"),
+            observed_fingerprints,
+        ):
+            message["content"] = _SESSION_SEARCH_OUTPUT_REPLACEMENT
+
+    return (
+        _SESSION_SEARCH_OUTPUT_REPLACEMENT
+        if content_sanitized
+        else final_response,
+        changed,
+    )
 
 
 def finalize_turn(
@@ -43,6 +345,8 @@ def finalize_turn(
     _should_review_memory,
     _turn_exit_reason,
     _pending_verification_response=None,
+    session_search_used=False,
+    session_search_output_fingerprints=None,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -95,6 +399,17 @@ def finalize_turn(
             )
         final_response = agent._handle_max_iterations(messages, api_call_count)
         iteration_limit_fallback = True
+
+    if session_search_used:
+        final_response, _session_output_sanitized = _sanitize_session_search_output(
+            final_response,
+            messages,
+            session_search_output_fingerprints,
+        )
+        if _session_output_sanitized:
+            logger.warning(
+                "Withheld raw session_search content/reasoning from final response"
+            )
 
     if iteration_limit_fallback:
         # If running as a kanban worker, signal the dispatcher that the

--- a/tests/run_agent/test_session_search_output_boundary.py
+++ b/tests/run_agent/test_session_search_output_boundary.py
@@ -1,0 +1,695 @@
+"""Behavior regressions for the session-search output boundary.
+
+``session_search`` returns structured conversation history for the model.  That
+tool payload is input to the next model call, not assistant prose for the user.
+These tests keep the boundary intact across empty-response recovery, streaming,
+the returned result, and durable session history.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.turn_finalizer import (
+    _looks_like_session_search_output,
+    _sanitize_session_search_reasoning_fields,
+)
+from agent.transports.types import NormalizedResponse, ToolCall
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from run_agent import AIAgent
+
+
+RAW_SESSION_SEARCH_RESULT = json.dumps(
+    {
+        "success": True,
+        "mode": "discover",
+        "query": "deployment notes",
+        "results": [
+            {
+                "session_id": "prior-session",
+                "match_message_id": 42,
+                "messages": [
+                    {
+                        "id": 42,
+                        "role": "assistant",
+                        "content": "private historical answer",
+                    }
+                ],
+                "messages_before": 3,
+                "messages_after": 2,
+            }
+        ],
+        "count": 1,
+        "sessions_searched": 4,
+    }
+)
+RAW_SESSION_SEARCH_ERROR = json.dumps(
+    {
+        "error": "Session database is temporarily unavailable",
+        "success": False,
+    }
+)
+SAFE_SUMMARY = "The earlier decision was to pin the release commit."
+SAFE_TRAILING_COMPARISON = "Safe comparison: 3 <"
+UNRELATED_ERROR = json.dumps(
+    {
+        "error": "Comparison service is unavailable",
+        "success": False,
+    }
+)
+
+
+def _tool_defs():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "session_search",
+                "description": "search prior sessions",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "search the web",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+
+
+def _tool_call(*, name="session_search", call_id="search-1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(
+            name=name,
+            arguments=(
+                '{"query":"deployment notes"}'
+                if name == "session_search"
+                else '{"query":"current release"}'
+            ),
+        ),
+    )
+
+
+def _response(
+    *,
+    content,
+    finish_reason="stop",
+    tool_calls=None,
+    reasoning=None,
+    reasoning_content=None,
+    reasoning_details=None,
+):
+    message = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=reasoning,
+        reasoning_content=reasoning_content,
+        reasoning_details=reasoning_details,
+    )
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(*, stream_delta_callback=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1/",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=stream_delta_callback,
+        )
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.valid_tool_names = {"session_search", "web_search"}
+    agent._fallback_chain = []
+    return agent
+
+
+def _append_tool_results(
+    assistant_message,
+    messages,
+    *_args,
+    session_search_result=RAW_SESSION_SEARCH_RESULT,
+):
+    for tool_call in assistant_message.tool_calls:
+        name = tool_call.function.name
+        messages.append(
+            {
+                "role": "tool",
+                "name": name,
+                "tool_call_id": tool_call.id,
+                "content": (
+                    session_search_result
+                    if name == "session_search"
+                    else "Current release details"
+                ),
+            }
+        )
+
+
+def _run(
+    agent,
+    *,
+    persist_side_effect=None,
+    flush_side_effect=None,
+    stream_callback=None,
+    session_search_result=RAW_SESSION_SEARCH_RESULT,
+):
+    def _execute_tools(assistant_message, messages, *args):
+        _append_tool_results(
+            assistant_message,
+            messages,
+            *args,
+            session_search_result=session_search_result,
+        )
+
+    with (
+        patch.object(
+            agent,
+            "_execute_tool_calls",
+            side_effect=_execute_tools,
+        ),
+        patch.object(
+            agent,
+            "_flush_messages_to_session_db",
+            side_effect=flush_side_effect,
+        ),
+        patch.object(
+            agent,
+            "_persist_session",
+            side_effect=persist_side_effect,
+        ),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        return agent.run_conversation(
+            "What did we decide about deployment?",
+            stream_callback=stream_callback,
+        )
+
+
+def test_session_search_empty_followup_does_not_reuse_pre_tool_assistant_text():
+    """A search is substantive: an empty follow-up must be retried, not replayed."""
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _response(
+            content="I'll search the earlier conversation.",
+            finish_reason="tool_calls",
+            tool_calls=[_tool_call()],
+        ),
+        _response(content=""),
+        _response(content=SAFE_SUMMARY),
+    ]
+
+    result = _run(agent)
+
+    assert result["final_response"] == SAFE_SUMMARY
+    assert result["api_calls"] == 3
+    assert result["turn_exit_reason"].startswith("text_response")
+
+
+def test_session_search_raw_json_is_absent_from_return_and_persistence():
+    """Raw tool history must not become the final or durable assistant message."""
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _response(content="", finish_reason="tool_calls", tool_calls=[_tool_call()]),
+        _response(content=RAW_SESSION_SEARCH_RESULT),
+    ]
+    persisted = []
+
+    def _capture_persist(messages, _conversation_history):
+        persisted[:] = [dict(message) for message in messages]
+
+    result = _run(agent, persist_side_effect=_capture_persist)
+
+    assert result["final_response"] != RAW_SESSION_SEARCH_RESULT
+    assert "sessions_searched" not in result["final_response"]
+    assert persisted
+    assert persisted[-1]["role"] == "assistant"
+    assert "sessions_searched" not in persisted[-1]["content"]
+    assert "private historical answer" not in persisted[-1]["content"]
+
+
+def test_session_search_followup_bypasses_visible_stream_before_sanitizing():
+    """The post-search model reply must be checked before any visible delta fires."""
+    streamed = []
+    agent = _make_agent(stream_delta_callback=streamed.append)
+    streaming_calls = 0
+
+    def _streaming_response(_api_kwargs, **_kwargs):
+        nonlocal streaming_calls
+        streaming_calls += 1
+        if streaming_calls == 1:
+            return _response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_tool_call()],
+            )
+        agent.stream_delta_callback(RAW_SESSION_SEARCH_RESULT)
+        return _response(content=RAW_SESSION_SEARCH_RESULT)
+
+    with (
+        patch.object(
+            agent,
+            "_interruptible_streaming_api_call",
+            side_effect=_streaming_response,
+        ) as stream_call,
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            return_value=_response(content=RAW_SESSION_SEARCH_RESULT),
+        ) as complete_call,
+    ):
+        result = _run(agent)
+
+    visible_text = "".join(delta for delta in streamed if isinstance(delta, str))
+    assert stream_call.call_count == 1
+    assert complete_call.call_count == 1
+    assert "sessions_searched" not in visible_text
+    assert "private historical answer" not in visible_text
+    assert "sessions_searched" not in result["final_response"]
+
+
+def test_session_search_raw_intermediate_tool_content_never_reaches_boundaries():
+    """Raw history plus a later tool call is scrubbed before every boundary."""
+    interim = []
+    flush_snapshots = []
+    agent = _make_agent()
+    agent.interim_assistant_callback = (
+        lambda content, **_kwargs: interim.append(content)
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _response(content="", finish_reason="tool_calls", tool_calls=[_tool_call()]),
+        _response(
+            content=RAW_SESSION_SEARCH_RESULT,
+            finish_reason="tool_calls",
+            tool_calls=[_tool_call(name="web_search", call_id="web-1")],
+        ),
+        _response(content=SAFE_SUMMARY),
+    ]
+
+    result = _run(
+        agent,
+        flush_side_effect=lambda messages, _history: flush_snapshots.append(
+            copy.deepcopy(messages)
+        ),
+    )
+
+    assert result["final_response"] == SAFE_SUMMARY
+    assert len(flush_snapshots) >= 2
+    assert any(
+        message.get("tool_calls", [{}])[0].get("id") == "web-1"
+        for snapshot in flush_snapshots
+        for message in snapshot
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    assistant_texts = [
+        message.get("content", "")
+        for message in result["messages"]
+        if message.get("role") == "assistant"
+    ]
+    flushed_assistant_texts = [
+        message.get("content", "")
+        for snapshot in flush_snapshots
+        for message in snapshot
+        if message.get("role") == "assistant"
+    ]
+    for boundary_text in interim + assistant_texts + flushed_assistant_texts:
+        assert "sessions_searched" not in boundary_text
+        assert "private historical answer" not in boundary_text
+
+
+def test_session_search_safe_summary_reaches_display_and_tts_callbacks():
+    """A checked full response must preserve normal display and TTS delivery."""
+    display_deltas = []
+    tts_deltas = []
+    agent = _make_agent(stream_delta_callback=display_deltas.append)
+
+    with (
+        patch.object(
+            agent,
+            "_interruptible_streaming_api_call",
+            return_value=_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_tool_call()],
+            ),
+        ) as stream_call,
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            return_value=_response(content=SAFE_SUMMARY),
+        ) as complete_call,
+    ):
+        result = _run(agent, stream_callback=tts_deltas.append)
+
+    display_text = "".join(
+        delta for delta in display_deltas if isinstance(delta, str)
+    )
+    tts_text = "".join(delta for delta in tts_deltas if isinstance(delta, str))
+    assert stream_call.call_count == 1
+    assert complete_call.call_count == 1
+    assert result["final_response"] == SAFE_SUMMARY
+    assert SAFE_SUMMARY in display_text
+    assert SAFE_SUMMARY in tts_text
+    assert result["response_previewed"] is False
+
+
+def test_session_search_raw_reasoning_is_absent_from_all_boundaries():
+    """Raw history in every reasoning field is scrubbed before callbacks/store."""
+    reasoning_deltas = []
+    persisted = []
+    agent = _make_agent()
+
+    def _capture_reasoning(text):
+        reasoning_deltas.append(text)
+
+    agent.reasoning_callback = _capture_reasoning
+    agent.client.chat.completions.create.side_effect = [
+        _response(content="", finish_reason="tool_calls", tool_calls=[_tool_call()]),
+        _response(
+            content=SAFE_SUMMARY,
+            reasoning=RAW_SESSION_SEARCH_RESULT,
+            reasoning_content=RAW_SESSION_SEARCH_RESULT,
+            reasoning_details=[
+                {
+                    "type": "reasoning.text",
+                    "text": RAW_SESSION_SEARCH_RESULT,
+                }
+            ],
+        ),
+    ]
+
+    def _capture_persist(messages, _conversation_history):
+        persisted[:] = copy.deepcopy(messages)
+
+    result = _run(agent, persist_side_effect=_capture_persist)
+
+    def _assistant_reasoning(messages):
+        return [
+            {
+                key: message.get(key)
+                for key in ("reasoning", "reasoning_content", "reasoning_details")
+                if key in message
+            }
+            for message in messages
+            if message.get("role") == "assistant"
+        ]
+
+    boundary_values = {
+        "reasoning_callback": reasoning_deltas,
+        "persisted": _assistant_reasoning(persisted),
+        "result_messages": _assistant_reasoning(result["messages"]),
+        "result_last_reasoning": result["last_reasoning"],
+    }
+    serialized = json.dumps(boundary_values, default=str)
+    assert result["final_response"] == SAFE_SUMMARY
+    assert not reasoning_deltas
+    assert "sessions_searched" not in serialized
+    assert "private historical answer" not in serialized
+
+
+def test_provider_native_reasoning_is_sanitized_before_final_persistence():
+    """Real normalized provider containers cannot persist raw search JSON."""
+    persisted = []
+    agent = _make_agent()
+    transport = agent._get_transport()
+    safe_codex_item = {
+        "id": "reasoning-safe",
+        "type": "reasoning",
+        "encrypted_content": "opaque-safe-reasoning",
+    }
+    safe_anthropic_block = {
+        "type": "tool_use",
+        "id": "tool-safe",
+        "name": "web_search",
+        "input": {"query": "current release"},
+    }
+    unrelated_message_item = {
+        "type": "message",
+        "id": "message-safe",
+        "content": [{"type": "output_text", "text": SAFE_SUMMARY}],
+    }
+    tool_response = NormalizedResponse(
+        content="",
+        tool_calls=[
+            ToolCall(
+                id="search-1",
+                name="session_search",
+                arguments='{"query":"deployment notes"}',
+            )
+        ],
+        finish_reason="tool_calls",
+    )
+    final_response = NormalizedResponse(
+        content=SAFE_SUMMARY,
+        tool_calls=None,
+        finish_reason="stop",
+        provider_data={
+            "codex_reasoning_items": [
+                {
+                    "id": "reasoning-raw",
+                    "type": "reasoning",
+                    "summary": [
+                        {"type": "summary_text", "text": RAW_SESSION_SEARCH_RESULT}
+                    ],
+                },
+                safe_codex_item,
+            ],
+            "anthropic_content_blocks": [
+                {"type": "thinking", "thinking": RAW_SESSION_SEARCH_RESULT},
+                safe_anthropic_block,
+            ],
+            "codex_message_items": [unrelated_message_item],
+            "refusal": "unrelated metadata stays intact",
+        },
+    )
+    # The chat-completions loop normalizes once to inspect finish_reason and
+    # once at the shared response boundary.  Return the same real normalized
+    # object for both reads of each provider response.
+    normalized_responses = [
+        tool_response,
+        tool_response,
+        final_response,
+        final_response,
+    ]
+    agent.client.chat.completions.create.side_effect = [
+        _response(content=""),
+        _response(content=""),
+    ]
+
+    def _capture_persist(messages, _conversation_history):
+        persisted[:] = copy.deepcopy(messages)
+
+    with patch.object(
+        transport,
+        "normalize_response",
+        side_effect=normalized_responses,
+    ):
+        result = _run(agent, persist_side_effect=_capture_persist)
+
+    final_assistant = persisted[-1]
+    serialized = json.dumps(final_assistant, default=str)
+    assert result["final_response"] == SAFE_SUMMARY
+    assert "sessions_searched" not in serialized
+    assert "private historical answer" not in serialized
+    assert final_assistant["codex_reasoning_items"] == [safe_codex_item]
+    assert final_assistant["anthropic_content_blocks"] == [safe_anthropic_block]
+    assert final_assistant["codex_message_items"] == [unrelated_message_item]
+    assert final_response.provider_data["refusal"] == (
+        "unrelated metadata stays intact"
+    )
+
+
+def test_normalized_codex_reasoning_sanitizer_reports_change():
+    """The exact provider_data-only regression returns True and stays narrow."""
+    unrelated_message_items = [{"type": "message", "id": "message-safe"}]
+    response = NormalizedResponse(
+        content=SAFE_SUMMARY,
+        tool_calls=None,
+        finish_reason="stop",
+        provider_data={
+            "codex_reasoning_items": [RAW_SESSION_SEARCH_RESULT],
+            "codex_message_items": unrelated_message_items,
+        },
+    )
+
+    assert _sanitize_session_search_reasoning_fields(response) is True
+    assert response.provider_data["codex_reasoning_items"] == []
+    assert response.provider_data["codex_message_items"] == unrelated_message_items
+
+
+def test_unrelated_error_json_after_session_search_is_preserved():
+    """Only the observed session_search error may be withheld."""
+    persisted = []
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _response(content="", finish_reason="tool_calls", tool_calls=[_tool_call()]),
+        _response(content=UNRELATED_ERROR),
+    ]
+
+    def _capture_persist(messages, _conversation_history):
+        persisted[:] = copy.deepcopy(messages)
+
+    result = _run(agent, persist_side_effect=_capture_persist)
+
+    assert result["final_response"] == UNRELATED_ERROR
+    assert persisted[-1]["content"] == UNRELATED_ERROR
+
+
+@pytest.mark.parametrize(
+    "echo",
+    [
+        f"Tool result: {RAW_SESSION_SEARCH_ERROR}",
+        f"Tool result:\n```json\n{RAW_SESSION_SEARCH_ERROR}\n```",
+    ],
+)
+def test_observed_session_search_error_echo_with_wrapper_is_withheld(echo):
+    """Prefixes and JSON fences do not defeat observed-error correlation."""
+    persisted = []
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _response(content="", finish_reason="tool_calls", tool_calls=[_tool_call()]),
+        _response(content=echo),
+    ]
+
+    def _capture_persist(messages, _conversation_history):
+        persisted[:] = copy.deepcopy(messages)
+
+    result = _run(
+        agent,
+        persist_side_effect=_capture_persist,
+        session_search_result=RAW_SESSION_SEARCH_ERROR,
+    )
+
+    assert "Session database is temporarily unavailable" not in result["final_response"]
+    assert "Session database is temporarily unavailable" not in persisted[-1]["content"]
+
+
+def test_session_search_safe_summary_flushes_trailing_tag_prefix_for_gateway():
+    """The complete checked text reaches display/TTS and is gateway-final."""
+    adapter = MagicMock()
+    adapter.REQUIRES_EDIT_FINALIZE = False
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="message-1")
+    )
+    adapter.edit_message = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="message-1")
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+    )
+    tts_deltas = []
+    agent = _make_agent(stream_delta_callback=consumer.on_delta)
+
+    with (
+        patch.object(
+            agent,
+            "_interruptible_streaming_api_call",
+            return_value=_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_tool_call()],
+            ),
+        ),
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            return_value=_response(content=SAFE_TRAILING_COMPARISON),
+        ),
+    ):
+        result = _run(agent, stream_callback=tts_deltas.append)
+
+    consumer.finish()
+    asyncio.run(consumer.run())
+
+    platform_text = "".join(
+        call.kwargs.get("content", "") for call in adapter.send.call_args_list
+    )
+    platform_text += "".join(
+        call.kwargs.get("content", "") for call in adapter.edit_message.call_args_list
+    )
+    assert result["final_response"] == SAFE_TRAILING_COMPARISON
+    assert SAFE_TRAILING_COMPARISON in platform_text
+    assert SAFE_TRAILING_COMPARISON in "".join(tts_deltas)
+    assert consumer.final_response_sent is True
+    assert adapter.send.call_count == 1
+
+
+def test_session_search_error_json_is_absent_from_return_and_persistence():
+    """The real tool_error shape must not become assistant output or history."""
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = [
+        _response(content="", finish_reason="tool_calls", tool_calls=[_tool_call()]),
+        _response(content=RAW_SESSION_SEARCH_ERROR),
+    ]
+    persisted = []
+
+    def _capture_persist(messages, _conversation_history):
+        persisted[:] = copy.deepcopy(messages)
+
+    result = _run(
+        agent,
+        persist_side_effect=_capture_persist,
+        session_search_result=RAW_SESSION_SEARCH_ERROR,
+    )
+
+    assert result["final_response"] != RAW_SESSION_SEARCH_ERROR
+    assert "Session database is temporarily unavailable" not in result["final_response"]
+    assert persisted[-1]["role"] == "assistant"
+    assert '"success": false' not in persisted[-1]["content"]
+    assert "Session database is temporarily unavailable" not in persisted[-1]["content"]
+
+
+def test_session_search_output_recognizer_covers_all_tool_shapes_and_fences():
+    for mode, container in (
+        ("browse", "results"),
+        ("discover", "results"),
+        ("read", "messages"),
+        ("scroll", "messages"),
+    ):
+        payload = json.dumps({"success": True, "mode": mode, container: []})
+        assert _looks_like_session_search_output(payload)
+        assert _looks_like_session_search_output(f"```json\n{payload}\n```")
+
+    wrapped_compact = (
+        'Tool result: {"success":true,"mode":"discover",'
+        '"results":[{"session_id":"s1"}]}'
+    )
+    assert _looks_like_session_search_output(wrapped_compact)
+
+
+def test_session_search_output_recognizer_keeps_unrelated_json():
+    ordinary_result = json.dumps(
+        {
+            "success": True,
+            "results": [{"name": "release", "status": "ready"}],
+        }
+    )
+    assert not _looks_like_session_search_output(ordinary_result)


### PR DESCRIPTION
## What does this PR do?

Prevents raw `session_search` JSON from becoming a user-visible or persisted assistant response. After a session search, Hermes validates the complete response before stream delivery, correlates error-shaped echoes to the actual tool result, and filters provider-native reasoning containers without deleting unrelated metadata.

## Related Issue

Related context: #57719. This PR addresses the output-boundary leak and does not claim to close that broader issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/conversation_loop.py`: keep post-search responses off visible streaming until checked; correlate actual session-search tool results; replay only sanitized final text.
- `agent/turn_finalizer.py`: sanitize final content and provider-native reasoning containers before persistence.
- `tests/run_agent/test_session_search_output_boundary.py`: cover raw success/error echoes, ordinary JSON preservation, provider reasoning, TTS/display delivery, and trailing partial-tag text.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_session_search_output_boundary.py`
2. Run the related nine-file regression set through `scripts/run_tests.sh`.
3. `.venv/bin/ruff check agent/conversation_loop.py agent/turn_finalizer.py tests/run_agent/test_session_search_output_boundary.py`

Observed: boundary 15/15, related suite 148/148, legacy stream/silence checks 2/2; Ruff and `git diff --check` passed.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] Commit message follows Conventional Commits.
- [x] I searched open and merged issues/PRs for duplicates.
- [x] This PR contains only this bug fix and its tests.
- [x] I ran the focused and related test suites.
- [x] I added regression tests.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior is covered by code comments and tests.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered: no OS-specific path or API added.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

No UI screenshot; tests assert the real gateway stream consumer receives the sanitized final text exactly once.