### PR TITLE
fix(image-gen): bypass macOS system proxy for custom endpoints

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -27,6 +27,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
+from agent.process_bootstrap import build_keepalive_http_client
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
@@ -116,6 +117,17 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
         return candidate, _MODELS[candidate]
 
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _openai_client_kwargs() -> Dict[str, Any]:
+    base_url = os.environ.get("OPENAI_BASE_URL", "").strip()
+    if not base_url:
+        return {}
+    kwargs: Dict[str, Any] = {"base_url": base_url}
+    http_client = build_keepalive_http_client(base_url)
+    if http_client is not None:
+        kwargs["http_client"] = http_client
+    return kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -270,7 +282,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         is_edit = bool(sources)
         modality = "image" if is_edit else "text"
 
-        client = openai.OpenAI()
+        client = openai.OpenAI(**_openai_client_kwargs())
 
         if is_edit:
             # images.edit() expects file-like objects. Download/read each

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -123,6 +123,15 @@ class TestModelResolution:
 
     def test_custom_base_url_ignores_macos_system_proxy(self, monkeypatch):
         monkeypatch.setenv("OPENAI_BASE_URL", "https://proxy.example/v1")
+        # Clear explicit proxy env vars so the test specifically verifies
+        # system-proxy bypass, not env-var-level masking.  Mirrors the
+        # pattern in tests/agent/test_auxiliary_client_proxy_env.py.
+        for key in (
+            "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+            "https_proxy", "http_proxy", "all_proxy",
+            "NO_PROXY", "no_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
         with patch(
             "urllib.request.getproxies",
             return_value={"https": "http://127.0.0.1:7897"},

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 import plugins.image_gen.openai as openai_plugin
@@ -119,6 +120,24 @@ class TestModelResolution:
         model_id, meta = openai_plugin._resolve_model()
         assert model_id == "gpt-image-2-high"
         assert meta["quality"] == "high"
+
+    def test_custom_base_url_ignores_macos_system_proxy(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://proxy.example/v1")
+        with patch(
+            "urllib.request.getproxies",
+            return_value={"https": "http://127.0.0.1:7897"},
+        ):
+            kwargs = openai_plugin._openai_client_kwargs()
+
+        http_client = kwargs["http_client"]
+        assert kwargs["base_url"] == "https://proxy.example/v1"
+        assert isinstance(http_client, httpx.Client)
+        assert not any(
+            type(mount._pool).__name__ == "HTTPProxy"
+            for mount in http_client._mounts.values()
+            if mount is not None and hasattr(mount, "_pool")
+        )
+        http_client.close()
 
 
 # ── Generate ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

The OpenAI image generation provider currently creates its SDK client with the default environment-aware httpx transport. On macOS, that can route a custom `OPENAI_BASE_URL` through the system proxy even when the endpoint is listed in the system proxy exceptions, because those exceptions are not exposed through `urllib.request.getproxies()`.

This change reuses Hermes' existing `build_keepalive_http_client()` policy whenever a custom image endpoint is configured. The default OpenAI client behavior remains unchanged when `OPENAI_BASE_URL` is not set.

## Related Issue

Fixes #64888

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `plugins/image_gen/openai/__init__.py` to inject Hermes' custom httpx client when `OPENAI_BASE_URL` is configured.
- Add a regression test that simulates a macOS system proxy and verifies the custom endpoint client has no `HTTPProxy` transport.
- Preserve the SDK's existing default behavior when no custom base URL is configured.

## How to Test

1. Configure a macOS HTTP/HTTPS system proxy and set `OPENAI_BASE_URL` to a local or custom OpenAI-compatible endpoint.
2. Run `scripts/run_tests.sh tests/plugins/image_gen/test_openai_provider.py -q` and verify all 30 tests pass.
3. Run Ruff for the two changed files and `python3 scripts/check-windows-footguns.py plugins/image_gen/openai/__init__.py tests/plugins/image_gen/test_openai_provider.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: no user-facing configuration or behavior contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the existing default path is unchanged and the footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: no tool schema changed

## Screenshots / Logs

Targeted verification:

- `scripts/run_tests.sh tests/plugins/image_gen/test_openai_provider.py -q`: 30 passed
- Ruff on both changed files: all checks passed
- `git diff --check`: passed
- Windows footgun scan on both changed files: passed
