### PR TITLE
fix: isolate file tool paths and cron script workdirs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2155,6 +2155,11 @@ def _run_job_script_with_claim_heartbeat(
     storage.  ``heartbeat_run_claim`` compares that stable owner before every
     refresh, so a stale runner cannot extend a replacement owner's claim.
     """
+    def _run_script() -> tuple[bool, str]:
+        if execution_cwd is None:
+            return _run_job_script(script_path)
+        return _run_job_script(script_path, execution_cwd)
+
     schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
@@ -2163,7 +2168,7 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, execution_cwd)
+        return _run_script()
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2194,10 +2199,10 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, execution_cwd)
+        return _run_script()
 
     try:
-        return _run_job_script(script_path, execution_cwd)
+        return _run_script()
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2012,7 +2012,9 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(
+    script_path: str, execution_cwd: Optional[str] = None
+) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -2038,6 +2040,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        execution_cwd: Optional validated child-process CWD. Defaults to the
+            script directory when absent or unusable.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2103,7 +2107,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=execution_cwd or str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
@@ -2137,7 +2141,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str
+    job: dict, script_path: str, execution_cwd: Optional[str] = None
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -2159,7 +2163,7 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path)
+        return _run_job_script(script_path, execution_cwd)
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2190,10 +2194,10 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path)
+        return _run_job_script(script_path, execution_cwd)
 
     try:
-        return _run_job_script(script_path)
+        return _run_job_script(script_path, execution_cwd)
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -2599,22 +2603,11 @@ def run_job(
         # paths. For no_agent jobs this is just the subprocess cwd (not an
         # agent TERMINAL_CWD bridge).
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
-
-        try:
-            ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        if _job_workdir and not Path(_job_workdir).is_dir():
+            _job_workdir = None
+        ok, output = _run_job_script_with_claim_heartbeat(
+            job, script_path, execution_cwd=_job_workdir
+        )
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -2755,7 +2748,12 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
+        _script_workdir = (job.get("workdir") or "").strip() or None
+        if _script_workdir and not Path(_script_workdir).is_dir():
+            _script_workdir = None
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job, script_path, execution_cwd=_script_workdir
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -210,6 +210,34 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_job_no_agent_uses_job_workdir_as_script_cwd(hermes_env, tmp_path):
+    """A configured workdir, not the scripts directory, is the child CWD."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    project = tmp_path / "project"
+    project.mkdir()
+    script_path = hermes_env / "scripts" / "pwd.py"
+    script_path.write_text(
+        "from pathlib import Path\n"
+        "print(Path.cwd().resolve())\n"
+    )
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="pwd.py",
+        no_agent=True,
+        workdir=str(project),
+        deliver="local",
+    )
+    success, _doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final_response == str(project.resolve())
+
+
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     """Empty stdout → SILENT_MARKER, which suppresses delivery downstream."""
     from cron.jobs import create_job

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -390,3 +390,46 @@ class TestRunJobTerminalCwd:
         # And after run_job completes, it's still the sentinel (nothing
         # overwrote or cleared it).
         assert os.environ["TERMINAL_CWD"] == before
+
+    def test_workdir_uses_job_workdir_for_prerun_script(self, tmp_path, monkeypatch):
+        """The agent pre-run script receives the configured child-process CWD."""
+        import importlib
+        import hermes_constants
+
+        home = tmp_path / ".hermes"
+        scripts_dir = home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        project = tmp_path / "project"
+        project.mkdir()
+        (scripts_dir / "pwd.py").write_text(
+            "from pathlib import Path\n"
+            "print(Path.cwd().resolve())\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        importlib.reload(hermes_constants)
+
+        import cron.scheduler as sched
+        importlib.reload(sched)
+
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        def capture_prerun_script(_job, prerun_script=None):
+            observed["prerun_script"] = prerun_script
+            return "hi"
+
+        monkeypatch.setattr(sched, "_build_job_prompt", capture_prerun_script)
+        job = {
+            "id": "pre-run-cwd",
+            "name": "pre-run cwd",
+            "prompt": "use collected data",
+            "model": "test-model",
+            "script": "pwd.py",
+            "workdir": str(project),
+            "schedule_display": "manual",
+        }
+
+        success, _output, _response, error = sched.run_job(job)
+
+        assert success is True, error
+        assert observed["prerun_script"] == (True, str(project.resolve()))

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -27,7 +28,7 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert result["content"] == "line1\nline2"
         assert result["total_lines"] == 2
-        mock_ops.read_file.assert_called_once_with("/tmp/test.txt", 1, 500)
+        mock_ops.read_file.assert_called_once_with(str(Path("/tmp/test.txt").resolve()), 1, 500)
 
     @patch("tools.file_tools._get_file_ops")
     def test_custom_offset_and_limit(self, mock_get):
@@ -40,7 +41,7 @@ class TestReadFileHandler:
 
         from tools.file_tools import read_file_tool
         read_file_tool("/tmp/big.txt", offset=10, limit=20)
-        mock_ops.read_file.assert_called_once_with("/tmp/big.txt", 10, 20)
+        mock_ops.read_file.assert_called_once_with(str(Path("/tmp/big.txt").resolve()), 10, 20)
 
     @patch("tools.file_tools._get_file_ops")
     def test_invalid_offset_and_limit_are_normalized_before_dispatch(self, mock_get):
@@ -53,7 +54,7 @@ class TestReadFileHandler:
 
         from tools.file_tools import read_file_tool
         read_file_tool("/tmp/big.txt", offset=0, limit=0)
-        mock_ops.read_file.assert_called_once_with("/tmp/big.txt", 1, 1)
+        mock_ops.read_file.assert_called_once_with(str(Path("/tmp/big.txt").resolve()), 1, 1)
 
     @patch("tools.file_tools._get_file_ops")
     def test_exception_returns_error_json(self, mock_get):
@@ -425,6 +426,57 @@ class TestSearchHandler:
         from tools.file_tools import search_tool
         result = json.loads(search_tool(pattern="x"))
         assert "error" in result
+
+
+class TestTaskRootReadDispatch:
+    """Public reads must not dispatch a validated relative path in another cwd."""
+
+    @staticmethod
+    def _shared_backend_cwd(tmp_path, monkeypatch):
+        import tools.file_tools as file_tools
+        import tools.terminal_tool as terminal_tool
+        from tools.environments.local import LocalEnvironment
+        from tools.file_operations import ShellFileOperations
+
+        task_id = "task-a"
+        task_a_workspace = tmp_path / "task-a-workspace"
+        task_b_hermes_home = tmp_path / "task-b-hermes-home"
+        task_a_workspace.mkdir()
+        task_b_hermes_home.mkdir()
+        marker = "FIXTURE-LEAK"
+        (task_b_hermes_home / "auth.json").write_text(marker + "\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(task_b_hermes_home))
+        monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+        monkeypatch.setattr(terminal_tool, "_active_environments", {})
+        monkeypatch.setattr(file_tools, "_file_ops_cache", {})
+        terminal_tool.register_task_env_overrides(task_id, {"cwd": str(task_a_workspace)})
+
+        file_ops = ShellFileOperations(
+            LocalEnvironment(cwd=str(task_b_hermes_home), timeout=15),
+            cwd=str(task_b_hermes_home),
+        )
+        monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: file_ops)
+
+        resolved = task_a_workspace / "auth.json"
+        assert file_tools._resolve_path_for_task("auth.json", task_id) == resolved
+        assert file_tools.get_read_block_error(str(resolved)) is None
+        assert file_tools.get_read_block_error(str(task_b_hermes_home / "auth.json")) is not None
+        return file_tools, task_id, marker
+
+    def test_read_file_does_not_return_marker_from_shared_backend_cwd(self, tmp_path, monkeypatch):
+        file_tools, task_id, marker = self._shared_backend_cwd(tmp_path, monkeypatch)
+
+        result = json.loads(file_tools.read_file_tool("auth.json", task_id=task_id))
+
+        assert marker not in result.get("content", ""), result
+
+    def test_search_does_not_return_marker_from_shared_backend_cwd(self, tmp_path, monkeypatch):
+        file_tools, task_id, marker = self._shared_backend_cwd(tmp_path, monkeypatch)
+
+        result = json.loads(file_tools.search_tool(marker, path="auth.json", task_id=task_id))
+
+        assert marker not in json.dumps(result), result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -17,6 +17,7 @@ Run with:  python -m pytest tests/tools/test_read_loop_detection.py -v
 
 import json
 import unittest
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from tools.file_tools import (
@@ -144,12 +145,13 @@ class TestReadLoopDetection(unittest.TestCase):
     @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
     def test_warning_still_returns_content(self, _mock_ops):
         """Even with a warning (3rd read), the file content is still returned."""
+        test_path = str(Path.cwd().resolve() / "test.py")
         for _ in range(2):
-            read_file_tool("/tmp/test.py", task_id="t1")
-        result = json.loads(read_file_tool("/tmp/test.py", task_id="t1"))
+            read_file_tool(test_path, task_id="t1")
+        result = json.loads(read_file_tool(test_path, task_id="t1"))
         self.assertIn("_warning", result)
         self.assertIn("content", result)
-        self.assertIn("content of /tmp/test.py", result["content"])
+        self.assertIn(f"content of {test_path}", result["content"])
 
 
 class TestNotifyOtherToolCall(unittest.TestCase):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1363,7 +1363,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        result = file_ops.read_file(str(_resolved), offset, limit)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -1993,8 +1993,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
 
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
+            pattern=pattern, path=str(resolved_path) if resolved_path else path,
+            target=target, file_glob=file_glob, limit=limit, offset=offset,
+            output_mode=output_mode, context=context
         )
         omitted = _filter_read_blocked_search_results(result, task_id)
         if hasattr(result, 'matches'):


### PR DESCRIPTION
## Summary

- Resolve local `read_file` and `search_files` backend paths against the task's own validated root before dispatch, preventing a cross-task backend-CWD escape.
- Run cron scripts in the configured `workdir`, falling back to the script directory when unset or invalid; child CWD selection does not use process-global `os.chdir`.
- Preserve the legacy one-argument script-runner seam when no execution CWD is selected.
- Keep the read-loop regression expectation portable across POSIX/macOS and native Windows path contracts.

## Validation

Focused suites passed:

- `tests/tools/test_file_tools.py -k 'TaskRootReadDispatch or WindowsMsysPathResolution'`: 6 passed
- `tests/tools/test_read_loop_detection.py`: 25 passed
- `tests/cron/test_cron_no_agent.py tests/cron/test_cron_workdir.py tests/cron/test_cron_script.py`: 79 passed
- `tests/cron/test_script_claim_heartbeat.py`: 3 passed
- `tests/cron/test_scheduler.py::TestRunJobWakeGate::test_script_runs_only_once_on_wake`: 1 passed
- heartbeat-related suites: 8 passed
- `git diff --check`: passed

Full suite was run before and after the integration fixes. It is not clean on this macOS environment due to pre-existing platform/config/timing failures and 11 collection/import failures.

- Base audit SHA `46e87b14fd6c943ef0d6671fb0d74c5dde5d4c6b`: 36 failures across 17 files + 11 collection/import failures.
- Final integration run: 39 failures across 20 files + the same 11 collection/import failures. The original SEC read-loop and CRON heartbeat/scheduler regressions no longer appear.
- The remaining apparent delta is environmental/flaky: the Honcho client and web-memory nodes reproduce identically against base and integration with fresh `HERMES_HOME`; the approved-command interrupt node passed 3/3 direct runs in both worktrees; the atomic snapshot node flakes on base (1/3 failure).

## Scope

No configuration, lockfile, credentials, or global-CWD behavior changed.
