### PR TITLE
feat(agent): accept generic tool guardrail halt requests

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -59,6 +59,11 @@ MUTATING_TOOL_NAMES = frozenset(
     }
 )
 
+TOOL_GUARDRAIL_REQUEST_SCHEMA = "hermes.tool_guardrail.request/v1"
+_TOOL_GUARDRAIL_REQUEST_ACTIONS = frozenset({"halt"})
+_TOOL_GUARDRAIL_REQUEST_MAX_CODE_CHARS = 96
+_TOOL_GUARDRAIL_REQUEST_MAX_MESSAGE_CHARS = 512
+
 
 @dataclass(frozen=True)
 class ToolCallGuardrailConfig:
@@ -222,7 +227,7 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
 
 
 class ToolCallGuardrailController:
-    """Per-turn controller for repeated failed/non-progressing tool calls."""
+    """Per-turn controller for tool-requested and loop-detected halts."""
 
     def __init__(self, config: ToolCallGuardrailConfig | None = None):
         self.config = config or ToolCallGuardrailConfig()
@@ -294,6 +299,23 @@ class ToolCallGuardrailController:
         signature = ToolCallSignature.from_call(tool_name, args)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
+
+        requested_halt = _parse_tool_guardrail_halt_request(
+            result,
+            current_tool_name=tool_name,
+            classified_failed=bool(failed),
+        )
+        if requested_halt is not None:
+            decision = ToolGuardrailDecision(
+                action="halt",
+                code=f"requested_{requested_halt['code']}",
+                message=requested_halt["message"],
+                tool_name=tool_name,
+                count=requested_halt["count"],
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
 
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
@@ -421,6 +443,67 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
         "or a different tool that can make progress. If the blocker is external, report "
         "the blocker after one diagnostic attempt instead of repeating the same failing path."
     )
+
+
+def _parse_tool_guardrail_halt_request(
+    result: str | None,
+    *,
+    current_tool_name: str,
+    classified_failed: bool,
+) -> dict[str, Any] | None:
+    """Parse the generic plugin-to-core halt protocol.
+
+    The request is intentionally independent of any plugin name or outer
+    envelope version.  A native failure classification or an explicit failure
+    field in the envelope is required.  The request must also name the tool
+    that actually produced the result so stale or misrouted envelopes are
+    ignored.
+    """
+    payload = safe_json_loads(result or "")
+    if not isinstance(payload, Mapping):
+        return None
+    request = payload.get("guardrail_request")
+    if not isinstance(request, Mapping):
+        return None
+    declared_error = payload.get("error")
+    payload_declares_failure = (
+        payload.get("success") is False
+        or payload.get("failed") is True
+        or declared_error not in (None, "", False, 0, [], {})
+    )
+    if not classified_failed and not payload_declares_failure:
+        return None
+    if request.get("schema") != TOOL_GUARDRAIL_REQUEST_SCHEMA:
+        return None
+    if request.get("action") not in _TOOL_GUARDRAIL_REQUEST_ACTIONS:
+        return None
+
+    code = request.get("code")
+    message = request.get("message")
+    requested_tool_name = request.get("tool_name")
+    count = request.get("count")
+    if not isinstance(code, str) or not code.strip():
+        return None
+    if not isinstance(message, str) or not message.strip():
+        return None
+    if not isinstance(requested_tool_name, str):
+        return None
+    if requested_tool_name.strip() != current_tool_name:
+        return None
+    if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+        return None
+
+    code = code.strip()
+    if len(code) > _TOOL_GUARDRAIL_REQUEST_MAX_CODE_CHARS:
+        return None
+    if not all(character.isalnum() or character in "._-" for character in code):
+        return None
+
+    return {
+        "code": code,
+        "message": message.strip()[:_TOOL_GUARDRAIL_REQUEST_MAX_MESSAGE_CHARS],
+        "count": count,
+    }
 
 
 def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5704,6 +5704,12 @@ class AIAgent:
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
+        if decision.code.startswith("requested_"):
+            return (
+                f"I stopped after {tool} reported a non-retryable blocker "
+                f"({decision.code}) on attempt {decision.count}: {decision.message} "
+                "Resolve that blocker before calling the tool again."
+            )
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -11,6 +11,25 @@ from agent.tool_guardrails import (
 )
 
 
+def _generic_halt_result(**request_overrides):
+    request = {
+        "schema": "hermes.tool_guardrail.request/v1",
+        "action": "halt",
+        "code": "missing_credentials",
+        "message": "OpenAI API key is missing",
+        "tool_name": "terminal",
+        "count": 1,
+    }
+    request.update(request_overrides)
+    return json.dumps(
+        {
+            "vendor_envelope": "independent-plugin/v9",
+            "error": "MISSING_CREDENTIALS: OpenAI API key is missing",
+            "guardrail_request": request,
+        }
+    )
+
+
 def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposing_raw_args():
     args_a = {
         "z": [{"β": "☤", "a": 1}],
@@ -256,3 +275,66 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+def test_failed_result_can_request_generic_halt_without_hard_stop_config():
+    controller = ToolCallGuardrailController()
+
+    decision = controller.after_call(
+        "terminal",
+        {"command": "deploy"},
+        _generic_halt_result(),
+        failed=True,
+    )
+
+    assert decision.action == "halt"
+    assert decision.code == "requested_missing_credentials"
+    assert decision.message == "OpenAI API key is missing"
+    assert decision.tool_name == "terminal"
+    assert decision.count == 1
+    assert controller.halt_decision == decision
+
+
+def test_generic_halt_request_is_independent_of_outer_plugin_identity():
+    controller = ToolCallGuardrailController()
+    payload = json.loads(_generic_halt_result())
+    payload.pop("vendor_envelope")
+    payload["another_outer_protocol"] = "different-plugin/v2"
+
+    decision = controller.after_call(
+        "terminal", {}, json.dumps(payload), failed=True
+    )
+
+    assert decision.action == "halt"
+    assert decision.code == "requested_missing_credentials"
+
+
+def test_generic_halt_request_requires_failed_result_and_exact_protocol():
+    no_failure_signal = json.loads(_generic_halt_result())
+    no_failure_signal.pop("error")
+    invalid_requests = (
+        (json.dumps(no_failure_signal), False),
+        (_generic_halt_result(schema="third-party.private/v1"), True),
+        (_generic_halt_result(action="warn"), True),
+        (_generic_halt_result(tool_name="execute_code"), True),
+        (_generic_halt_result(count=0), True),
+        (_generic_halt_result(count=True), True),
+        (_generic_halt_result(message=""), True),
+    )
+
+    for result, failed in invalid_requests:
+        controller = ToolCallGuardrailController()
+        decision = controller.after_call("terminal", {}, result, failed=failed)
+        assert decision.action != "halt"
+        assert controller.halt_decision is None
+
+
+def test_generic_halt_request_uses_explicit_envelope_error_when_native_classifier_misses_it():
+    controller = ToolCallGuardrailController()
+
+    decision = controller.after_call(
+        "terminal", {}, _generic_halt_result(), failed=False
+    )
+
+    assert decision.action == "halt"
+    assert decision.code == "requested_missing_credentials"

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -86,6 +86,23 @@ def _hard_stop_config(**overrides) -> dict:
     return cfg
 
 
+def _generic_halt_result() -> str:
+    return json.dumps(
+        {
+            "version": "unrelated-plugin-envelope/v3",
+            "error": "MISSING_CREDENTIALS: OpenAI API key is missing",
+            "guardrail_request": {
+                "schema": "hermes.tool_guardrail.request/v1",
+                "action": "halt",
+                "code": "missing_credentials",
+                "message": "OpenAI API key is missing",
+                "tool_name": "terminal",
+                "count": 1,
+            },
+        }
+    )
+
+
 def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_execution():
     agent = _make_agent("web_search")
     args = {"query": "same"}
@@ -266,6 +283,50 @@ def test_default_run_conversation_warns_without_guardrail_halt():
     assert result["final_response"] == "done"
     tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
     assert any("repeated_exact_failure_warning" in content for content in tool_contents)
+
+
+def test_generic_plugin_request_halts_after_first_failed_tool_result():
+    agent = _make_agent("terminal", max_iterations=10)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "terminal",
+                    json.dumps({"command": "deploy"}),
+                    "c-auth",
+                )
+            ],
+        ),
+        _mock_response(content="SHOULD_NOT_BE_REQUESTED", finish_reason="stop"),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value=_generic_halt_result()) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("deploy the service")
+
+    mock_hfc.assert_called_once()
+    assert result["api_calls"] == 1
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["guardrail"]["action"] == "halt"
+    assert result["guardrail"]["code"] == "requested_missing_credentials"
+    assert result["guardrail"]["tool_name"] == "terminal"
+    assert result["guardrail"]["count"] == 1
+    assert "non-retryable blocker" in result["final_response"]
+    assert "OpenAI API key is missing" in result["final_response"]
+    assert "repeated non-progressing" not in result["final_response"]
+    tool_result = next(
+        message["content"]
+        for message in result["messages"]
+        if message.get("role") == "tool"
+    )
+    assert "hermes.tool_guardrail.request/v1" in tool_result
+    assert "Tool loop hard stop" in tool_result
 
 
 def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_halt_without_top_level_error():


### PR DESCRIPTION
## What does this PR do?

Adds a small, generic protocol seam that lets any transformed tool result request the existing per-turn guardrail halt. The controller accepts only an exact `hermes.tool_guardrail.request/v1` payload tied to the tool that produced the result and backed by a failure signal. It does not depend on a plugin name or private outer envelope.

The controlled final response also distinguishes a tool-requested non-retryable blocker from Hermes native repeated-call detection, so a first-attempt halt is not described as a repeated attempt.

## Related Issue

No exact duplicate issue or PR was found for a generic `transform_tool_result` halt request.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/tool_guardrails.py`: validate and consume the generic halt request in `ToolCallGuardrailController.after_call`.
- `run_agent.py`: render an accurate final message for `requested_*` decisions while preserving native repeated-call wording.
- Unit and runtime tests cover valid requests, malformed/forged payloads, tool-name mismatch, failure gating, and stopping before a second model call.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py`
2. `.venv/bin/ruff check agent/tool_guardrails.py run_agent.py tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py`

Observed: 27/27 tests passed; Ruff and `git diff --check` passed. An independent integration check confirmed one failed tool call yields `api_calls=1`, `tool_calls=1`, and `turn_exit_reason=guardrail_halt`.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] Commit message follows Conventional Commits.
- [x] I searched open and merged issues/PRs for duplicates.
- [x] This PR contains only the generic protocol seam and tests.
- [x] I ran the focused test suites.
- [x] I added tests for the new behavior.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; the protocol is documented in code and tests.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered: standard JSON and Python only.
- [x] Tool descriptions/schemas: N/A; no tool schema changed.

## Screenshots / Logs

No UI screenshot; the runtime test asserts the second model call is never made and the user-facing response describes the first non-retryable blocker accurately.