### PR TITLE
fix(agent): route cross-thread interrupt abort through CopilotACPClient.close()

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5218,6 +5218,36 @@ class AIAgent:
         """
         if client is None:
             return
+        from agent.copilot_acp_client import CopilotACPClient
+
+        if isinstance(client, CopilotACPClient):
+            # Copilot ACP's "client" wraps a subprocess + JSON-RPC loop, not
+            # an httpx transport — _force_close_tcp_sockets() finds no pool
+            # to reach into and is a silent no-op for it, leaving the
+            # subprocess and its two reader threads running (burning the
+            # user's Copilot quota) until the request's own timeout fires,
+            # up to _DEFAULT_TIMEOUT_SECONDS (900s) later. Its close()
+            # (agent/copilot_acp_client.py) is safe to call from a stranger
+            # thread: unlike the httpx SSL BIO FD-aliasing hazard above, it
+            # only takes a lock, sends SIGTERM/SIGKILL via subprocess.Popen,
+            # and is idempotent, so call it directly to kill the subprocess
+            # immediately instead of waiting for the request's own deadline.
+            # Not part of the httpx-pool cache below, so no poisoning needed.
+            try:
+                client.close()
+                logger.info(
+                    "Copilot ACP client aborted (%s, shared=False) %s",
+                    reason,
+                    self._client_log_context(),
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Copilot ACP client abort failed (%s) %s error=%s",
+                    reason,
+                    self._client_log_context(),
+                    exc,
+                )
+            return
         # A pool whose sockets were shut down from a stranger thread must
         # never be reused: poison the cache slot so the owner-thread close
         # discards it and the next create builds a fresh client.

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -232,3 +232,110 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+# ── Cross-thread interrupt abort must kill the ACP subprocess, not no-op
+# (issue: _abort_request_openai_client's socket sweep finds nothing to
+# reach into for this client, so an interrupt during a Copilot ACP call
+# left the subprocess + its two reader threads running for up to the
+# request's own timeout — burning the user's Copilot quota for an
+# abandoned call). ─────────────────────────────────────────────────────
+
+import threading as _threading
+import time as _time
+from unittest.mock import MagicMock as _MagicMock
+
+
+def test_abort_request_openai_client_closes_copilot_acp_client_not_sockets():
+    """``AIAgent._abort_request_openai_client`` must route CopilotACPClient
+    through ``client.close()`` (kills the subprocess) instead of the
+    httpx-only socket sweep, which is a silent no-op for this client type.
+    """
+    from run_agent import AIAgent
+
+    client = CopilotACPClient(acp_cwd="/tmp")
+    fake_proc = _MagicMock()
+    fake_proc.wait.return_value = 0
+    client._active_process = fake_proc
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._client_log_context = lambda: "provider=copilot-acp"
+    agent._force_close_tcp_sockets = _MagicMock(
+        side_effect=AssertionError("must not use the httpx socket sweep for CopilotACPClient")
+    )
+
+    agent._abort_request_openai_client(client, reason="interrupt_abort")
+
+    fake_proc.terminate.assert_called_once()
+    assert client._active_process is None
+    assert client.is_closed is True
+    agent._force_close_tcp_sockets.assert_not_called()
+
+
+def test_abort_request_openai_client_copilot_acp_is_idempotent():
+    """A second abort (e.g. stale-call kill racing the worker's own close)
+    must be a safe no-op, not a double-terminate."""
+    from run_agent import AIAgent
+
+    client = CopilotACPClient(acp_cwd="/tmp")
+    fake_proc = _MagicMock()
+    client._active_process = fake_proc
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._client_log_context = lambda: "provider=copilot-acp"
+
+    agent._abort_request_openai_client(client, reason="interrupt_abort")
+    agent._abort_request_openai_client(client, reason="stale_call_kill")
+
+    fake_proc.terminate.assert_called_once()
+
+
+def test_abort_request_openai_client_kills_real_orphaned_subprocess():
+    """End-to-end proof with a REAL OS subprocess: a cross-thread abort must
+    actually terminate the process promptly, not leave it running until its
+    own multi-minute request timeout.
+
+    Mirrors the reported failure mode: the ACP subprocess is set as the
+    client's active process (as ``_run_prompt`` does right after ``Popen``),
+    an interrupt fires on a different thread mid-call, and — before the
+    fix — nothing killed the subprocess because ``_force_close_tcp_sockets``
+    finds no httpx pool on this client and silently does nothing.
+    """
+    import subprocess
+    import sys
+
+    from run_agent import AIAgent
+
+    client = CopilotACPClient(acp_cwd="/tmp")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    client._active_process = proc
+    try:
+        assert proc.poll() is None, "subprocess must be alive before the abort"
+
+        agent = AIAgent.__new__(AIAgent)
+        agent._client_log_context = lambda: "provider=copilot-acp"
+
+        aborted = _threading.Event()
+
+        def _abort_from_stranger_thread():
+            agent._abort_request_openai_client(client, reason="interrupt_abort")
+            aborted.set()
+
+        t = _threading.Thread(target=_abort_from_stranger_thread, daemon=True)
+        t.start()
+        assert aborted.wait(timeout=5), "abort call did not return"
+
+        deadline = _time.monotonic() + 5
+        while _time.monotonic() < deadline and proc.poll() is None:
+            _time.sleep(0.05)
+        assert proc.poll() is not None, (
+            "subprocess is still running after the abort — it would otherwise "
+            "leak until its own request timeout (up to 15 minutes)"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)


### PR DESCRIPTION
## Summary

`AIAgent._abort_request_openai_client()` (`run_agent.py`) is the cross-thread abort path used by the interrupt-check loop and the stale-call detector in `agent/chat_completion_helpers.py`'s `interruptible_api_call`/`interruptible_streaming_api_call`. It works by reaching into the request client's httpx connection pool (`_force_close_tcp_sockets` → `_iter_pool_sockets`, via `getattr(client, "_client", None)`) and shutting down the raw sockets so the worker thread's blocked `recv`/`send` unwinds.

`CopilotACPClient` (`agent/copilot_acp_client.py`) is a different kind of "client" — it wraps a `subprocess.Popen` running the Copilot ACP CLI and a JSON-RPC request/response loop over stdin/stdout, not an httpx transport. It has no `_client`/`_transport`/`_pool` to reach into, so `_force_close_tcp_sockets` silently finds zero sockets and no-ops.

Consequence: when an interrupt or stale-call kill fires during a Copilot ACP turn, nothing actually stops the subprocess. The worker thread stays blocked polling for a JSON-RPC response inside `_request()`'s loop, and the subprocess + its two daemon reader threads keep running — burning the user's GitHub Copilot subscription quota — until `_request()`'s own deadline expires (`_DEFAULT_TIMEOUT_SECONDS = 900.0`, i.e. up to 15 minutes later), at which point `CopilotACPClient._run_prompt`'s `finally: self.close()` finally cleans it up. If the gateway process itself terminates before that (crash, OOM, restart) the subprocess is never registered anywhere else and is simply abandoned.

## Fix

In `_abort_request_openai_client`, special-case `CopilotACPClient` (`isinstance` check) and call its own `close()` directly instead of the httpx socket sweep. This is safe to call from a stranger thread: `close()` only takes `self._active_process_lock`, then calls `subprocess.Popen.terminate()`/`.wait()`/`.kill()` — unlike the httpx SSL BIO case (#29507), there is no FD-aliasing hazard from calling these from a different thread, and `close()` is idempotent (a second call sees `_active_process` already cleared and returns immediately), so it composes safely with the worker's own `finally: self.close()`.

This covers both the ordinary interrupt case and the gateway-shutdown drain path (`_interrupt_running_agents()` sets the same `agent._interrupt_requested` flag that the same interrupt-check loop observes), since both route through this one method. A true `SIGKILL`/crash of the gateway process remains unfixable at this layer regardless of approach (no Python cleanup code runs at all in that case).

## Test plan

- [x] `test_abort_request_openai_client_closes_copilot_acp_client_not_sockets`: constructs a bare `AIAgent` (mirroring the existing `AIAgent.__new__` pattern from `tests/run_agent/test_tls_fd_recycle_corruption.py`) and asserts the abort routes to `client.close()` (subprocess `terminate()` called, `_active_process` cleared), never to the httpx socket sweep.
- [x] `test_abort_request_openai_client_copilot_acp_is_idempotent`: a second abort call (simulating the stale-call detector racing the worker's own close) does not double-terminate.
- [x] `test_abort_request_openai_client_kills_real_orphaned_subprocess`: end-to-end with a **real** OS subprocess (`sleep 60`-equivalent) — calls the abort from a background thread and asserts the process actually exits within seconds, directly proving the orphan is gone rather than mocking the mechanism.
- [x] Mutation-verify: stashed the `run_agent.py` fix and confirmed all three new tests fail against pre-fix code (the real-subprocess test fails with "subprocess is still running after the abort").
- [x] Full `tests/agent/test_copilot_acp_client.py` (14 tests), `test_copilot_acp_deprecation.py`, `tests/run_agent/test_tls_fd_recycle_corruption.py` (the sibling #29507 abort-mechanism suite), `test_cascading_interrupt_6600.py`, `test_interrupt_propagation.py`, and `test_openai_client_lifecycle.py` — 53 tests total — all pass unaffected.
- [x] `ruff check` clean on both changed files.