### PR TITLE
fix(model_metadata): read llama.cpp context from meta.n_ctx + accept sole model

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1176,11 +1176,36 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
             if resp.status_code == 200:
                 data = resp.json()
                 models_list = data.get("data", [])
+                # Match by id; on single-model servers (e.g. llama.cpp) the
+                # configured name rarely equals the reported id (a GGUF path),
+                # so fall back to the sole model when nothing matches.
+                matched = None
                 for m in models_list:
                     if _model_id_matches(m.get("id", ""), model):
-                        ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
-                        if ctx and isinstance(ctx, (int, float)):
-                            return int(ctx)
+                        matched = m
+                        break
+                if matched is None and len(models_list) == 1:
+                    matched = models_list[0]
+                if matched is not None:
+                    # llama.cpp nests the runtime context under meta.n_ctx; the
+                    # vLLM/OpenAI keys are also checked. Runtime n_ctx is
+                    # preferred over n_ctx_train (the training maximum, which
+                    # can be larger than what the server actually allocates).
+                    for source in (matched, matched.get("meta") or {}):
+                        if not isinstance(source, dict):
+                            continue
+                        for key in (
+                            "n_ctx",
+                            "context_length",
+                            "context_window",
+                            "max_model_len",
+                            "max_context_length",
+                            "max_tokens",
+                            "n_ctx_train",
+                        ):
+                            val = source.get(key)
+                            if isinstance(val, (int, float)) and val:
+                                return int(val)
     except Exception:
         pass
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -216,12 +216,17 @@ class TestQueryLocalContextLengthModelsList:
         assert result == 131072
 
     def test_models_list_model_not_found_returns_none(self):
-        """Returns None when model is not in the /v1/models list."""
+        """Returns None when the model is absent from a multi-model /v1/models
+        list. (Single-model servers are accepted even when the configured name
+        doesn't match the reported id — see the llama.cpp tests below.)"""
         from agent.model_metadata import _query_local_context_length
 
         detail_resp = self._make_resp(404, {})
         list_resp = self._make_resp(200, {
-            "data": [{"id": "other-model", "max_model_len": 4096}]
+            "data": [
+                {"id": "other-model", "max_model_len": 4096},
+                {"id": "yet-another-model", "max_model_len": 8192},
+            ]
         })
 
         call_count = [0]
@@ -242,6 +247,73 @@ class TestQueryLocalContextLengthModelsList:
             result = _query_local_context_length("omnicoder-9b", "http://localhost:1234")
 
         assert result is None
+
+    def test_models_list_llamacpp_meta_n_ctx_sole_model(self):
+        """llama.cpp nests the runtime context under meta.n_ctx and serves a
+        single model whose id (a GGUF path) doesn't match the configured name.
+
+        The sole model should be accepted and meta.n_ctx read, instead of
+        returning None and falling back to a family default (e.g. qwen=131072).
+        """
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "id": "/app/models/qwen3.6-35b.gguf",
+                    "meta": {"n_ctx": 256000, "n_ctx_train": 262144},
+                }
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp  # /v1/models/{model}
+            return list_resp  # /v1/models
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("qwen3.6-35b", "http://localhost:8080")
+
+        assert result == 256000
+
+    def test_models_list_llamacpp_prefers_runtime_n_ctx_over_train(self):
+        """Runtime n_ctx (256000) is preferred over n_ctx_train (262144),
+        since the server can only actually serve the runtime value."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {"id": "/app/models/m.gguf", "meta": {"n_ctx": 256000, "n_ctx_train": 262144}}
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            return detail_resp if call_count[0] == 1 else list_resp
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("m", "http://localhost:8080")
+
+        assert result == 256000
 
 
 class TestQueryLocalContextLengthLmStudio:


### PR DESCRIPTION
Fixes #64897

## Problem

When Hermes targets a local `llama.cpp` server via a custom OpenAI-compatible endpoint, the model's context length resolves to the family fallback (e.g. `131072` for any `qwen*` name) instead of the server's actual context. The server exposes the value, but `_query_local_context_length` doesn't read it.

`GET /v1/models` from llama.cpp:

```json
{"data":[{"id":"/app/.../<model>.gguf","meta":{"n_ctx":256000,"n_ctx_train":262144}}]}
```

## Root cause

In `agent/model_metadata.py`, `_query_local_context_length`, the `/v1/models` list branch:

1. only checks top-level `max_model_len` / `context_length` / `max_tokens` — llama.cpp nests the value under `meta.n_ctx`, so all three miss;
2. matches by `_model_id_matches(id, model)`, but the configured name (e.g. `qwen3.6-35b-a3b`) never matches the server's id (a GGUF path), so on a single-model server the branch is skipped entirely.

The function returns `None` and the caller falls back to `DEFAULT_CONTEXT_LENGTHS` (e.g. `"qwen": 131072`).

## Fix

In the `/v1/models` list branch:

- accept the **sole model** when the server lists only one (single-model servers like llama.cpp serve exactly one model regardless of the configured name);
- search both the top-level keys and the nested `meta` object, preferring the runtime `n_ctx` over `n_ctx_train` (the training max can be larger than what the server actually allocates).

## Behavior change

Single-model servers now resolve even when the configured name doesn't match the reported id. Multi-model servers with no matching model still return `None` — the existing `test_models_list_model_not_found_returns_none` test was updated to cover that multi-model case explicitly.

## Verification

- New unit tests cover the `meta.n_ctx` path and the `n_ctx`-over-`n_ctx_train` preference; the existing suite stays green (`tests/agent/test_model_metadata_local_ctx.py`: 24 passed, `tests/agent/test_model_metadata.py`: 100 passed).
- Live against a local llama.cpp server started with `-c 256000`: `_query_local_context_length` now returns `256000` (previously `None` → `131072` family default).

## Related

#24891, #2051, #29802
