### PR TITLE
fix(tui_gateway): route async delegation completions via parent_session_id when session_key unset

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8648,7 +8648,13 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
         return True
     evt_key = str(evt.get("session_key") or "")
     if not evt_key:
-        return False
+        # Fall back to parent_session_id for CLI/Desktop sessions where the
+        # session_key ContextVar may not be bound at dispatch time — the
+        # parent_session_id (the agent's durable state.db session_id) is
+        # always captured and links back to this session's lookup key.
+        evt_key = str(evt.get("parent_session_id") or "")
+        if not evt_key:
+            return False
     current_keys = {
         str(session.get("session_key") or ""),
         _session_lookup_key(session, fallback=sid),


### PR DESCRIPTION
When `delegate_task` is dispatched with `background=true` from a CLI/Desktop session that lacks an explicit `session_key` ContextVar, the completion event arrives with an empty `session_key` — causing `_session_owns_notification_event()` in the TUI gateway to return `False` and the result to be silently dropped as an orphan.

Since `parent_session_id` (the agent's durable state.db `session_id`) is always captured at dispatch time, use it as a routing fallback when `session_key` is empty. The TUI session's lookup key resolves to the same `agent.session_id`, so the event correctly reaches its originating session.

Fixes #64901