### PR TITLE
fix(cron): harden suggestions.json with a cross-process advisory lock

### DIFF
--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -22,19 +22,34 @@ suggestions latch by a stable ``dedup_key`` so the same proposal is not
 re-offered after the user says no.
 
 Storage mirrors ``cron/jobs.py``: ``~/.hermes/cron/suggestions.json``, atomic
-writes, an in-process lock, and 0600 perms.
+writes, a cross-process advisory lock, and 0600 perms.
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import tempfile
 import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+# Cross-process advisory file locking for suggestions.json critical sections,
+# mirroring cron/jobs.py's _jobs_lock(). fcntl is Unix-only; on Windows fall
+# back to msvcrt. Either may be absent, in which case the lock degrades to
+# in-process locking only.
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-Unix
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    msvcrt = None
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
@@ -47,10 +62,100 @@ logger = logging.getLogger(__name__)
 # shared default root. See cron/jobs.py for the full rationale.
 CRON_DIR = get_hermes_home().resolve() / "cron"
 SUGGESTIONS_FILE = CRON_DIR / "suggestions.json"
+_SUGGESTIONS_LOCK_FILE = CRON_DIR / ".suggestions.lock"
 
 # In-process lock protecting load->modify->save cycles (the background review
-# fork and the main agent can both write).
-_suggestions_lock = threading.Lock()
+# fork and the main agent can both write within one process).
+_suggestions_file_lock = threading.RLock()
+_suggestions_lock_state = threading.local()
+
+# Upper bound on waiting for the cross-process .suggestions.lock flock,
+# mirroring cron/jobs.py's _JOBS_LOCK_TIMEOUT_SECONDS (#60703): an unbounded
+# wait on a lock held by a wedged sibling process would freeze every caller
+# in this process forever. Critical sections here are field updates only, so
+# contention resolves in milliseconds; 30s is orders of magnitude above that.
+_SUGGESTIONS_LOCK_TIMEOUT_SECONDS = 30.0
+
+
+@contextlib.contextmanager
+def _suggestions_lock():
+    """Serialize a load->modify->save critical section on suggestions.json.
+
+    Combines the in-process RLock (cheap mutual exclusion between threads in
+    this process — e.g. the background review fork and the main agent) with a
+    cross-process advisory file lock on ``.suggestions.lock`` (mutual exclusion
+    between this process and a separate ``hermes`` CLI invocation editing the
+    same suggestions.json — previously unprotected, so a CLI dismiss could be
+    silently clobbered by a concurrent gateway write, or vice versa).
+
+    Nested calls in the same thread reuse the held lock. Mirrors
+    cron/jobs.py's ``_jobs_lock()`` — see there for the full rationale on the
+    bounded-timeout degrade-to-in-process-only fallback.
+    """
+    depth = getattr(_suggestions_lock_state, "depth", 0)
+    if depth:
+        _suggestions_lock_state.depth = depth + 1
+        try:
+            yield
+        finally:
+            _suggestions_lock_state.depth -= 1
+        return
+
+    with _suggestions_file_lock:
+        _suggestions_lock_state.depth = 1
+        lock_fd = None
+        try:
+            try:
+                _ensure_dir()
+                lock_fd = open(_SUGGESTIONS_LOCK_FILE, "a+", encoding="utf-8")
+                lock_fd.seek(0)
+                if fcntl is not None:
+                    _deadline = time.monotonic() + _SUGGESTIONS_LOCK_TIMEOUT_SECONDS
+                    while True:
+                        try:
+                            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            break
+                        except (OSError, IOError):
+                            if time.monotonic() >= _deadline:
+                                logger.error(
+                                    "Timed out after %.0fs waiting for the "
+                                    "suggestions.json lock (%s) — another "
+                                    "process is holding it. Proceeding with "
+                                    "in-process locking only.",
+                                    _SUGGESTIONS_LOCK_TIMEOUT_SECONDS,
+                                    _SUGGESTIONS_LOCK_FILE,
+                                )
+                                try:
+                                    lock_fd.close()
+                                except OSError:
+                                    pass
+                                lock_fd = None
+                                break
+                            time.sleep(0.1)
+                elif msvcrt is not None:
+                    getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+            except (OSError, IOError) as e:
+                # Never let a locking failure block suggestion writes — fall
+                # back to in-process-only protection (still held above).
+                logger.warning(
+                    "suggestions.json cross-process lock unavailable (%s); "
+                    "proceeding with in-process lock only", e,
+                )
+            try:
+                yield
+            finally:
+                if lock_fd is not None:
+                    try:
+                        if fcntl is not None:
+                            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                        elif msvcrt is not None:
+                            getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
+                    except (OSError, IOError):
+                        pass
+                    finally:
+                        lock_fd.close()
+        finally:
+            _suggestions_lock_state.depth = 0
 
 # Cap pending suggestions so the list never becomes a nag wall. When full,
 # new suggestions are dropped (the user should clear the backlog first).
@@ -145,7 +250,7 @@ def add_suggestion(
     if not title.strip() or not dedup_key.strip():
         raise ValueError("title and dedup_key are required")
 
-    with _suggestions_lock:
+    with _suggestions_lock():
         suggestions = _load_raw().get("suggestions", [])
 
         # Never re-offer something the user already saw and decided on, and
@@ -198,7 +303,7 @@ def get_suggestion(ref: str) -> Optional[Dict[str, Any]]:
 
 
 def _set_status(suggestion_id: str, status: str) -> bool:
-    with _suggestions_lock:
+    with _suggestions_lock():
         suggestions = _load_raw().get("suggestions", [])
         changed = False
         for s in suggestions:
@@ -251,7 +356,7 @@ def clear_resolved() -> int:
     their dedup_key (so they aren't re-offered). This only prunes ACCEPTED
     records, which have served their purpose once the job exists.
     """
-    with _suggestions_lock:
+    with _suggestions_lock():
         suggestions = _load_raw().get("suggestions", [])
         kept = [s for s in suggestions if s.get("status") != _STATUS_ACCEPTED]
         removed = len(suggestions) - len(kept)

--- a/tests/cron/test_suggestions_crossprocess_lock.py
+++ b/tests/cron/test_suggestions_crossprocess_lock.py
@@ -1,0 +1,212 @@
+"""Regression test for the suggestions.json cross-process lock.
+
+Background: cron/suggestions.py's docstring claims storage "mirrors
+cron/jobs.py" (atomic writes, a lock), but until this fix it only used a
+process-local ``threading.Lock`` — unlike cron/jobs.py's ``_jobs_lock()``,
+which was hardened with a cross-process advisory flock (#60703) specifically
+because the gateway process and a separate ``hermes`` CLI invocation
+(``hermes_cli/suggestions_cmd.py``) can both write ``jobs.json``/
+``suggestions.json`` at the same time. A CLI dismiss/accept racing a
+concurrent gateway ``add_suggestion`` (e.g. from the catalog seeder or a
+blueprint install) could silently lose one side's write.
+
+Mirrors ``tests/cron/test_jobs_crossprocess_lock.py``: proves the lock
+actually excludes a *separate process*, which an in-process
+``threading.Lock``/``RLock`` cannot do.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+from cron import suggestions
+
+
+# Repo root (parent of the ``cron`` package) so the child process can import it.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(suggestions.__file__)))
+
+
+@pytest.mark.skipif(suggestions.fcntl is None, reason="POSIX fcntl/flock required")
+def test_suggestions_lock_excludes_another_process(tmp_path, monkeypatch):
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr(suggestions, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(suggestions, "SUGGESTIONS_FILE", cron_dir / "suggestions.json")
+    monkeypatch.setattr(suggestions, "_SUGGESTIONS_LOCK_FILE", cron_dir / ".suggestions.lock")
+
+    ready = tmp_path / "child_holds_lock"
+    release = tmp_path / "child_may_release"
+    blocker_started = tmp_path / "blocker_started"
+    blocker_acquired = tmp_path / "blocker_acquired"
+    holder = tmp_path / "holder.py"
+    holder.write_text(
+        textwrap.dedent(
+            f"""
+            import sys, time, pathlib
+            sys.path.insert(0, {_REPO_ROOT!r})
+            from cron import suggestions
+
+            suggestions.CRON_DIR = pathlib.Path({str(cron_dir)!r})
+            suggestions.SUGGESTIONS_FILE = suggestions.CRON_DIR / "suggestions.json"
+            suggestions._SUGGESTIONS_LOCK_FILE = suggestions.CRON_DIR / ".suggestions.lock"
+
+            with suggestions._suggestions_lock():
+                pathlib.Path({str(ready)!r}).write_text("1")
+                # Hold the lock until the parent signals (bounded so a wedged
+                # test can never hang CI).
+                for _ in range(1000):
+                    if pathlib.Path({str(release)!r}).exists():
+                        break
+                    time.sleep(0.01)
+            """
+        )
+    )
+
+    blocker = tmp_path / "blocker.py"
+    blocker.write_text(
+        textwrap.dedent(
+            f"""
+            import sys, pathlib
+            sys.path.insert(0, {_REPO_ROOT!r})
+            from cron import suggestions
+
+            suggestions.CRON_DIR = pathlib.Path({str(cron_dir)!r})
+            suggestions.SUGGESTIONS_FILE = suggestions.CRON_DIR / "suggestions.json"
+            suggestions._SUGGESTIONS_LOCK_FILE = suggestions.CRON_DIR / ".suggestions.lock"
+
+            pathlib.Path({str(blocker_started)!r}).write_text("1")
+            with suggestions._suggestions_lock():
+                pathlib.Path({str(blocker_acquired)!r}).write_text("1")
+            """
+        )
+    )
+
+    child = subprocess.Popen([sys.executable, str(holder)])
+    blocker_child = None
+    try:
+        # Wait until the child is inside the critical section.
+        for _ in range(1000):
+            if ready.exists():
+                break
+            time.sleep(0.01)
+        assert ready.exists(), "child never acquired _suggestions_lock()"
+
+        # While the child holds it, a non-blocking acquire of the SAME lock
+        # file from this process must fail. A threading.Lock/RLock could
+        # never block here.
+        lock_file = suggestions._SUGGESTIONS_LOCK_FILE
+        fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT)
+        try:
+            with pytest.raises(OSError):
+                suggestions.fcntl.flock(fd, suggestions.fcntl.LOCK_EX | suggestions.fcntl.LOCK_NB)
+        finally:
+            os.close(fd)
+
+        # A second _suggestions_lock() caller in another process should block
+        # until the holder releases, rather than falling through with only a
+        # process-local lock.
+        blocker_child = subprocess.Popen([sys.executable, str(blocker)])
+        for _ in range(1000):
+            if blocker_started.exists():
+                break
+            time.sleep(0.01)
+        assert blocker_started.exists(), "blocker process never started"
+        time.sleep(0.05)
+        assert not blocker_acquired.exists(), "second process entered _suggestions_lock() while held"
+    finally:
+        release.write_text("1")
+        child.wait(timeout=15)
+        if blocker_child is not None:
+            blocker_child.wait(timeout=15)
+
+    assert blocker_acquired.exists(), "second process did not acquire _suggestions_lock() after release"
+
+    # Once the child has released, the lock is freely acquirable again.
+    with suggestions._suggestions_lock():
+        pass
+
+
+def _hold_suggestions_flock(path, release: threading.Event, held: threading.Event):
+    """Hold an exclusive flock on *path* from a separate fd until released.
+
+    flock locks are per-open-file-description, so a second open() in the SAME
+    process contends exactly like another process would — mirrors
+    tests/cron/test_ticker_stall_60703.py's ``_hold_jobs_flock``.
+    """
+    fd = open(path, "a+", encoding="utf-8")
+    try:
+        suggestions.fcntl.flock(fd, suggestions.fcntl.LOCK_EX)
+        held.set()
+        release.wait(timeout=30)
+    finally:
+        try:
+            suggestions.fcntl.flock(fd, suggestions.fcntl.LOCK_UN)
+        except OSError:
+            pass
+        fd.close()
+
+
+@pytest.mark.skipif(suggestions.fcntl is None, reason="flock semantics are POSIX-only")
+class TestBoundedSuggestionsLock:
+    """Mirrors tests/cron/test_ticker_stall_60703.py's TestBoundedJobsLock for
+    ``.suggestions.lock`` — the bounded-timeout / degrade-to-in-process-only
+    fallback (cron/suggestions.py:112-143) is the entire rationale for the
+    polling loop `_suggestions_lock()` added; it needs its own direct
+    coverage, not just the ordinary cross-process exclusion case above."""
+
+    def test_lock_acquisition_times_out_and_degrades(self, tmp_path, monkeypatch, caplog):
+        """A foreign holder of .suggestions.lock must NOT block
+        _suggestions_lock() forever -- acquisition must time out, log at
+        ERROR, and still let the critical section run in degraded
+        (in-process-only) mode."""
+        cron_dir = tmp_path / "cron"
+        monkeypatch.setattr(suggestions, "CRON_DIR", cron_dir)
+        monkeypatch.setattr(suggestions, "SUGGESTIONS_FILE", cron_dir / "suggestions.json")
+        lock_path = cron_dir / ".suggestions.lock"
+        monkeypatch.setattr(suggestions, "_SUGGESTIONS_LOCK_FILE", lock_path)
+        monkeypatch.setattr(suggestions, "_SUGGESTIONS_LOCK_TIMEOUT_SECONDS", 1.0)
+
+        suggestions._ensure_dir()
+        lock_path.touch()
+
+        release = threading.Event()
+        held = threading.Event()
+        holder = threading.Thread(
+            target=_hold_suggestions_flock, args=(lock_path, release, held), daemon=True
+        )
+        holder.start()
+        assert held.wait(timeout=10), "test holder failed to take the flock"
+
+        try:
+            start = time.monotonic()
+            entered = False
+            with caplog.at_level("ERROR", logger="cron.suggestions"):
+                with suggestions._suggestions_lock():
+                    entered = True
+            elapsed = time.monotonic() - start
+
+            assert entered, "critical section must still run in degraded mode"
+            assert elapsed < 10, f"lock wait was not bounded (took {elapsed:.1f}s)"
+            assert any("Timed out" in r.message for r in caplog.records), (
+                "degraded-mode fallback must be logged at ERROR"
+            )
+        finally:
+            release.set()
+            holder.join(timeout=10)
+
+    def test_uncontended_lock_is_fast_and_silent(self, tmp_path, monkeypatch, caplog):
+        cron_dir = tmp_path / "cron"
+        monkeypatch.setattr(suggestions, "CRON_DIR", cron_dir)
+        monkeypatch.setattr(suggestions, "SUGGESTIONS_FILE", cron_dir / "suggestions.json")
+        monkeypatch.setattr(suggestions, "_SUGGESTIONS_LOCK_FILE", cron_dir / ".suggestions.lock")
+
+        start = time.monotonic()
+        with caplog.at_level("ERROR", logger="cron.suggestions"):
+            with suggestions._suggestions_lock():
+                pass
+        assert time.monotonic() - start < 5
+        assert not [r for r in caplog.records if "Timed out" in r.message]


### PR DESCRIPTION
## Summary

`cron/suggestions.py`'s own module docstring claims:

> Storage mirrors `cron/jobs.py`: `~/.hermes/cron/suggestions.json`, atomic writes, an in-process lock, and 0600 perms.

That was true when both files were written, but `cron/jobs.py`'s lock was later hardened (#60703) with a cross-process advisory `flock`/`msvcrt` lock specifically because the gateway process and a separate `hermes` CLI invocation can both write `jobs.json` concurrently — a plain `threading.Lock` only serializes writers *inside one process*. `cron/suggestions.py` never received the equivalent upgrade and still uses a bare `threading.Lock()`.

`hermes_cli/suggestions_cmd.py::handle_suggestions_command()` is explicitly documented as shared by both the CLI and the gateway. A `hermes cron suggestions dismiss`/`accept` CLI invocation racing a concurrent gateway `add_suggestion()` call (from the catalog seeder or a blueprint install) can silently lose one side's write to `suggestions.json` — e.g. a dismiss issued right as a new suggestion is being added could drop the new suggestion, or vice versa.

## Fix

Add `_suggestions_lock()`, mirroring `cron/jobs.py`'s `_jobs_lock()`: an in-process `RLock` (cheap mutual exclusion between threads in this process, with reentrancy support) plus a bounded-timeout cross-process advisory flock on a new `.suggestions.lock` file. If the flock can't be acquired within the timeout (mirroring `cron/jobs.py`'s #60703 rationale), it degrades to in-process-only locking rather than ever blocking indefinitely — a briefly-torn cross-process write is strictly better than a wedged suggestions store.

The three existing critical sections (`add_suggestion`, `_set_status` — used by both `dismiss_suggestion` and `accept_suggestion` — and `clear_resolved`) now go through this lock instead of the old bare `threading.Lock()`.

## Test plan

- [x] Added `tests/cron/test_suggestions_crossprocess_lock.py::test_suggestions_lock_excludes_another_process`, mirroring the existing `tests/cron/test_jobs_crossprocess_lock.py` pattern exactly: spawns a real **separate OS process** that holds `_suggestions_lock()`, proves a non-blocking `flock` from the test process fails while it's held, spawns a second real process that blocks on the same lock until the holder releases, then confirms it acquires it afterward. This is the only way to prove cross-process exclusion — an in-process lock could never fail this test for the wrong reason.
- [x] Mutation-verify: stashed the fix and confirmed the new test fails against pre-fix code (collection error — `cron.suggestions` has no `fcntl` attribute yet).
- [x] Existing `tests/cron/test_suggestions.py` (19 tests) passes unaffected.
- [x] Sibling lock suites `tests/cron/test_jobs_crossprocess_lock.py` and `tests/cron/test_ticker_stall_60703.py` pass unaffected.
- [x] Other callers of `cron.suggestions` — `tests/tools/test_blueprints.py` and `tests/cron/test_blueprint_catalog.py` (40 tests) — pass unaffected.
- [x] `ruff check` clean.