### PR TITLE
fix(zai): configure strict concurrency gate via config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -892,6 +892,7 @@ def init_agent(
         agent.client = MoAClient(
             agent.model or "default",
             reference_callback=_moa_reference_relay,
+            interrupt_check=lambda: bool(agent._interrupt_requested),
         )
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1931,7 +1931,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.api_key = api_key or "moa-virtual-provider"
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
-            agent.client = MoAClient(agent.model or "default")
+            agent.client = MoAClient(
+                agent.model or "default",
+                interrupt_check=lambda: bool(agent._interrupt_requested),
+            )
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -890,6 +890,7 @@ def run_conversation(
                     temperature=_preset_temperature(moa_config, "reference_temperature"),
                     aggregator_temperature=_preset_temperature(moa_config, "aggregator_temperature"),
                     max_tokens=moa_config.get("reference_max_tokens"),
+                    interrupt_check=lambda: bool(agent._interrupt_requested),
                 )
                 if _moa_context:
                     for _msg in reversed(api_messages):
@@ -1355,11 +1356,20 @@ def run_conversation(
                             allow_stream=False,
                             is_github_responses=agent._is_copilot_url(),
                         )
-                    if _use_streaming:
-                        return agent._interruptible_streaming_api_call(
-                            next_api_kwargs, on_first_delta=_stop_spinner
-                        )
-                    return agent._interruptible_api_call(next_api_kwargs)
+
+                    from agent.zai_concurrency import acquire_zai_slot
+
+                    with acquire_zai_slot(
+                        provider=agent.provider,
+                        model=agent.model,
+                        base_url=agent.base_url,
+                        interrupt_check=lambda: bool(agent._interrupt_requested),
+                    ):
+                        if _use_streaming:
+                            return agent._interruptible_streaming_api_call(
+                                next_api_kwargs, on_first_delta=_stop_spinner
+                            )
+                        return agent._interruptible_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -217,6 +218,51 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _call_moa_model(
+    *,
+    runtime: dict[str, Any],
+    interrupt_check: Callable[[], bool] | None = None,
+    **call_kwargs: Any,
+) -> Any:
+    """Call one resolved MoA model under the shared Z.AI gate when needed.
+
+    Non-Z.AI routes call ``call_llm`` directly. A Z.AI streaming call keeps
+    the slot for the full iterator lifetime, not merely until the SDK returns
+    the stream object.
+    """
+    from agent.zai_concurrency import acquire_zai_slot, is_zai_request
+
+    target = {
+        "provider": runtime.get("provider"),
+        "model": runtime.get("model"),
+        "base_url": runtime.get("base_url"),
+    }
+    if not is_zai_request(**target):
+        return call_llm(**call_kwargs, **runtime)
+
+    def _slot():
+        return acquire_zai_slot(
+            **target,
+            interrupt_check=interrupt_check,
+        )
+
+    if not call_kwargs.get("stream"):
+        with _slot():
+            return call_llm(**call_kwargs, **runtime)
+
+    def _gated_stream():
+        with _slot():
+            stream = call_llm(**call_kwargs, **runtime)
+            try:
+                yield from stream
+            finally:
+                close = getattr(stream, "close", None)
+                if callable(close):
+                    close()
+
+    return _gated_stream()
+
+
 def _maybe_apply_moa_cache_control(
     messages: list[dict[str, Any]],
     runtime: dict[str, Any],
@@ -267,6 +313,7 @@ def _run_reference(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    interrupt_check: Callable[[], bool] | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model and return ``(label, text, usage)``.
 
@@ -314,13 +361,14 @@ def _run_reference(
         # (their caching is automatic; markers are ignored harmlessly, but we
         # only decorate when the policy says the route honors them).
         messages = _maybe_apply_moa_cache_control(messages, runtime)
-        response = call_llm(
+        response = _call_moa_model(
+            runtime=runtime,
+            interrupt_check=interrupt_check,
             task="moa_reference",
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
             reasoning_config=_slot_reasoning_config(slot),
-            **runtime,
         )
         usage = CanonicalUsage()
         raw_usage = getattr(response, "usage", None)
@@ -384,6 +432,7 @@ def _run_references_parallel(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    interrupt_check: Callable[[], bool] | None = None,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -426,6 +475,7 @@ def _run_references_parallel(
                     ref_messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    interrupt_check=interrupt_check,
                 )
             ] = idx
         # Collect every reference before returning — the aggregator needs the
@@ -669,6 +719,7 @@ def aggregate_moa_context(
     temperature: float | None = None,
     aggregator_temperature: float | None = None,
     max_tokens: int | None = None,
+    interrupt_check: Callable[[], bool] | None = None,
 ) -> str:
     """Run configured reference models and synthesize their advice.
 
@@ -693,6 +744,7 @@ def aggregate_moa_context(
         ref_messages,
         temperature=temperature,
         max_tokens=max_tokens,
+        interrupt_check=interrupt_check,
     )
 
     joined = "\n\n".join(
@@ -725,13 +777,14 @@ def aggregate_moa_context(
         agg_messages = _maybe_apply_moa_cache_control(
             [{"role": "user", "content": synth_prompt}], agg_runtime
         )
-        response = call_llm(
+        response = _call_moa_model(
+            runtime=agg_runtime,
+            interrupt_check=interrupt_check,
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=max_tokens,
             reasoning_config=_aggregator_reasoning_config(aggregator),
-            **agg_runtime,
         )
         synthesis = _extract_text(response)
     except Exception as exc:
@@ -791,7 +844,12 @@ def _attach_reference_guidance(agg_messages: list[dict[str, Any]], guidance: str
 class MoAChatCompletions:
     """OpenAI-chat-compatible facade where the aggregator is the acting model."""
 
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(
+        self,
+        preset_name: str,
+        reference_callback: Any = None,
+        interrupt_check: Callable[[], bool] | None = None,
+    ):
         self.preset_name = preset_name or "default"
         # Optional display hook. Called as reference outputs become available so
         # frontends can show each reference model's answer as a labelled block
@@ -802,6 +860,7 @@ class MoAChatCompletions:
         #   "moa.aggregating" kwargs: aggregator (label), ref_count
         # Never raises into the model call — display is best-effort.
         self.reference_callback = reference_callback
+        self.interrupt_check = interrupt_check
         # State-scoped reference cache. The agent loop calls create() once per
         # tool-loop iteration; references should re-run whenever the task STATE
         # advances — i.e. on every new user message AND every new tool result —
@@ -1010,6 +1069,7 @@ class MoAChatCompletions:
                 ref_messages,
                 temperature=temperature,
                 max_tokens=reference_max_tokens,
+                interrupt_check=self.interrupt_check,
             )
             self._ref_cache_key = _cache_key
             self._ref_cache_outputs = list(reference_outputs)
@@ -1118,7 +1178,9 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
-        _agg_response = call_llm(
+        _agg_response = _call_moa_model(
+            runtime=_slot_runtime(aggregator),
+            interrupt_check=self.interrupt_check,
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
@@ -1127,7 +1189,6 @@ class MoAChatCompletions:
             extra_body=agg_kwargs.get("extra_body"),
             reasoning_config=_aggregator_reasoning_config(aggregator),
             **stream_kwargs,
-            **_slot_runtime(aggregator),
         )
         # Non-streaming path (quiet mode / eval / subagents): the aggregator
         # output is available inline, so capture it into the pending trace now.
@@ -1148,9 +1209,18 @@ class MoAChatCompletions:
 
 
 class MoAClient:
-    def __init__(self, preset_name: str, reference_callback: Any = None):
+    def __init__(
+        self,
+        preset_name: str,
+        reference_callback: Any = None,
+        interrupt_check: Callable[[], bool] | None = None,
+    ):
         self.chat = type("_MoAChat", (), {})()
-        self.chat.completions = MoAChatCompletions(preset_name, reference_callback=reference_callback)
+        self.chat.completions = MoAChatCompletions(
+            preset_name,
+            reference_callback=reference_callback,
+            interrupt_check=interrupt_check,
+        )
 
     def consume_reference_usage(self) -> Any:
         """Pop the pending reference-fan-out usage from the completions facade.

--- a/agent/zai_concurrency.py
+++ b/agent/zai_concurrency.py
@@ -1,0 +1,286 @@
+"""Process-local concurrency gate for Z.AI / GLM model calls.
+
+Z.AI Coding Plan can return HTTP 429 / code 1305 under concurrent load.
+Subagent and Mixture-of-Agents fan-out can otherwise keep several long-lived
+requests and their retries in flight at once. This module applies one strict
+process-local bound to calls that resolve to the Z.AI endpoint.
+
+The gate deliberately does not use the model name alone: GLM models can be
+served by local or third-party endpoints that should not be throttled. A call
+is gated only when its resolved provider or base URL identifies Z.AI.
+
+Scope and limitations
+---------------------
+- The semaphore is process-local. Separate Hermes processes that share one API
+  key each have their own limit, so fleet operators may need a lower
+  per-process value.
+- User-facing controls live under ``providers.zai`` in the active profile's
+  ``config.yaml``. No non-secret environment variables are consulted.
+- Non-Z.AI providers and a disabled gate pass through unchanged.
+- Saturated calls queue instead of bypassing the cap. Interactive waits poll
+  for an interrupt. A positive acquire timeout raises locally without sending
+  a request; the default timeout of zero waits until a slot or an interrupt.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from collections.abc import Callable
+from math import isfinite
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+# Field reports show the Coding Plan endpoint remains stable at two concurrent
+# calls while four can still trigger 1305 overload responses.
+_DEFAULT_ZAI_MAX_CONCURRENT = 2
+_DEFAULT_ZAI_ACQUIRE_TIMEOUT = 0.0
+_ZAI_PROVIDER_CONFIG_KEY = "zai"
+
+
+def _non_negative_int(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, float) and not value.is_integer():
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _non_negative_float(value: object, default: float) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if isfinite(parsed) and parsed >= 0 else default
+
+
+def _read_configured_limits() -> tuple[int, float]:
+    """Read the active profile's Z.AI concurrency settings from config.yaml."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+    except Exception:
+        config = {}
+
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(_ZAI_PROVIDER_CONFIG_KEY, {})
+        if isinstance(providers, dict)
+        else {}
+    )
+    if not isinstance(provider_config, dict):
+        provider_config = {}
+
+    max_concurrent = _non_negative_int(
+        provider_config.get("max_concurrent"),
+        _DEFAULT_ZAI_MAX_CONCURRENT,
+    )
+    acquire_timeout = _non_negative_float(
+        provider_config.get("acquire_timeout_seconds"),
+        _DEFAULT_ZAI_ACQUIRE_TIMEOUT,
+    )
+    return max_concurrent, acquire_timeout
+
+
+# Loaded lazily with this module, after profile selection has set HERMES_HOME.
+# 0 disables the gate entirely.
+_ZAI_MAX_CONCURRENT, _ZAI_ACQUIRE_TIMEOUT = _read_configured_limits()
+
+# 0 waits until a slot becomes available. A positive value raises
+# ZaiConcurrencyTimeout after the configured number of seconds.
+_ZAI_ACQUIRE_POLL_INTERVAL = 0.1
+
+# Deliberately asymmetric: Zhipu serves API traffic across bigmodel.cn, so the
+# whole registrable domain is gated, while on z.ai only the api. subtree is —
+# gating chat.z.ai-style non-API properties would throttle traffic that never
+# touches the API concurrency quota.
+_ZAI_HOST_SUFFIXES = ("api.z.ai", "bigmodel.cn")
+
+
+def _resolved_hostname(base_url: Any) -> str:
+    raw = str(base_url or "").strip()
+    if not raw:
+        return ""
+    # An opaque ``https:host/path`` form (no ``//``) hides the host in the
+    # path; peel the scheme so the host still parses. Only web schemes are
+    # peeled — a bare ``host:port`` must not be mistaken for one.
+    raw = re.sub(r"^(?:https?|wss?):(?!//)", "", raw, flags=re.IGNORECASE)
+    # A leading scheme (``https://…``) or protocol-relative prefix (``//…``)
+    # lets urlparse read the netloc directly. Anything else is a bare
+    # ``host[:port]/path`` — even when a later path or query segment contains
+    # ``://`` — and needs a ``//`` prefix so the host is parsed as netloc
+    # rather than path.
+    if raw.startswith("//") or re.match(r"^[a-z][a-z0-9+.-]*://", raw, re.IGNORECASE):
+        parsed = urlparse(raw)
+    else:
+        parsed = urlparse(f"//{raw}")
+    return str(parsed.hostname or "").rstrip(".").lower()
+
+
+class ZaiConcurrencyTimeout(TimeoutError):
+    """Raised when a configured Z.AI slot wait expires."""
+
+
+class _ZaiConcurrencyGate:
+    """Lazy, thread-safe holder for the process-wide Z.AI semaphore."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sem: Optional[threading.BoundedSemaphore] = None
+        self._configured_max = _ZAI_MAX_CONCURRENT
+
+    def _semaphore(self) -> Optional[threading.BoundedSemaphore]:
+        if self._configured_max <= 0:
+            return None
+        if self._sem is None:
+            with self._lock:
+                if self._sem is None:
+                    self._sem = threading.BoundedSemaphore(self._configured_max)
+        return self._sem
+
+    def is_zai(self, *, provider: Any, model: Any, base_url: Any) -> bool:
+        """Return whether the resolved destination is Z.AI / Zhipu.
+
+        Host-first: a resolvable base-URL host is authoritative, so the gate
+        follows the *destination*, not the provider label. This keeps the
+        module's promise that GLM models served by a local or third-party
+        endpoint are not throttled — a ``zai``/``glm`` provider whose
+        ``GLM_BASE_URL`` is overridden to a non-Z.AI host is correctly left
+        ungated. The provider name is consulted only when no host can be parsed
+        (empty or malformed base URL), where the built-in Z.AI provider is the
+        intended target.
+        """
+        host = _resolved_hostname(base_url)
+        if host:
+            return any(
+                host == suffix or host.endswith(f".{suffix}")
+                for suffix in _ZAI_HOST_SUFFIXES
+            )
+        provider_name = str(provider or "").strip().lower()
+        return provider_name in {"zai", "zhipu", "glm", "z-ai", "z.ai"}
+
+
+_gate = _ZaiConcurrencyGate()
+
+
+def is_zai_request(*, provider: Any, model: Any, base_url: Any) -> bool:
+    """Return whether a model call targets Z.AI / Zhipu."""
+    return _gate.is_zai(provider=provider, model=model, base_url=base_url)
+
+
+def acquire_zai_slot(
+    *,
+    provider: Any,
+    model: Any,
+    base_url: Any,
+    interrupt_check: Optional[Callable[[], bool]] = None,
+) -> "_SlotHandle":
+    """Return a context manager that acquires a Z.AI slot on entry.
+
+    Creating a handle without entering it never consumes capacity. Non-Z.AI
+    requests and a disabled gate receive a no-op context manager.
+    """
+    if not is_zai_request(provider=provider, model=model, base_url=base_url):
+        return _NoopHandle()
+    sem = _gate._semaphore()
+    if sem is None:
+        return _NoopHandle()
+    return _SlotHandle(
+        sem,
+        timeout=_ZAI_ACQUIRE_TIMEOUT,
+        interrupt_check=interrupt_check,
+    )
+
+
+class _SlotHandle:
+    """Acquire one semaphore slot on entry and release it on exit."""
+
+    __slots__ = ("_acquired", "_entered", "_interrupt_check", "_sem", "_timeout")
+
+    def __init__(
+        self,
+        sem: threading.BoundedSemaphore,
+        *,
+        timeout: float,
+        interrupt_check: Optional[Callable[[], bool]],
+    ) -> None:
+        self._sem = sem
+        self._timeout = timeout
+        self._interrupt_check = interrupt_check
+        self._entered = False
+        self._acquired = False
+
+    def __enter__(self) -> "_SlotHandle":
+        if self._entered:
+            raise RuntimeError("Z.AI concurrency slot handle cannot be re-entered")
+        self._entered = True
+
+        deadline = time.monotonic() + self._timeout if self._timeout > 0 else None
+        while True:
+            if self._interrupt_check is not None and self._interrupt_check():
+                raise InterruptedError(
+                    "Agent interrupted while waiting for a Z.AI concurrency slot"
+                )
+
+            wait_for = _ZAI_ACQUIRE_POLL_INTERVAL
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ZaiConcurrencyTimeout(
+                        f"Timed out after {self._timeout:g}s waiting for a "
+                        "Z.AI concurrency slot"
+                    )
+                wait_for = min(wait_for, remaining)
+
+            if self._sem.acquire(timeout=wait_for):
+                self._acquired = True
+                if self._interrupt_check is not None and self._interrupt_check():
+                    self._acquired = False
+                    self._sem.release()
+                    raise InterruptedError(
+                        "Agent interrupted while waiting for a Z.AI concurrency slot"
+                    )
+                return self
+
+    def __exit__(self, *exc: Any) -> None:
+        if self._acquired:
+            self._acquired = False
+            self._sem.release()
+
+
+class _NoopHandle:
+    """Pass-through context manager for non-Z.AI or disabled calls."""
+
+    __slots__ = ()
+
+    def __enter__(self) -> "_NoopHandle":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+
+def configured_max_concurrent() -> int:
+    """Return the configured Z.AI in-flight cap; zero means disabled."""
+    return _ZAI_MAX_CONCURRENT
+
+
+def configured_acquire_timeout() -> float:
+    """Return the configured Z.AI slot-acquire timeout in seconds."""
+    return _ZAI_ACQUIRE_TIMEOUT
+
+
+def _reset_for_tests(max_concurrent: int, timeout: float) -> None:
+    """Rebuild the process-local gate with explicit settings."""
+    global _ZAI_MAX_CONCURRENT, _ZAI_ACQUIRE_TIMEOUT, _gate
+    _ZAI_MAX_CONCURRENT = max(0, max_concurrent)
+    _ZAI_ACQUIRE_TIMEOUT = max(0.0, timeout)
+    _gate = _ZaiConcurrencyGate()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -138,6 +138,9 @@ model:
 #     models:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
+#   zai:
+#     max_concurrent: 2                # Strict process-local in-flight cap; 0 disables.
+#     acquire_timeout_seconds: 0       # 0 waits until a slot is free; positive values fail locally.
 
 # =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4777,6 +4777,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
+        "max_concurrent", "acquire_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
     }
@@ -4895,6 +4896,22 @@ def _normalize_custom_provider_entry(
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
 
+    max_concurrent = entry.get("max_concurrent")
+    if (
+        not isinstance(max_concurrent, bool)
+        and isinstance(max_concurrent, int)
+        and max_concurrent >= 0
+    ):
+        normalized["max_concurrent"] = max_concurrent
+
+    acquire_timeout = entry.get("acquire_timeout_seconds")
+    if (
+        not isinstance(acquire_timeout, bool)
+        and isinstance(acquire_timeout, (int, float))
+        and acquire_timeout >= 0
+    ):
+        normalized["acquire_timeout_seconds"] = acquire_timeout
+
     discover_models = entry.get("discover_models")
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
@@ -4945,6 +4962,8 @@ def _custom_provider_entry_to_provider_config(
         "models",
         "context_length",
         "rate_limit_delay",
+        "max_concurrent",
+        "acquire_timeout_seconds",
         "discover_models",
         "extra_body",
         "extra_headers",
@@ -5290,7 +5309,8 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
+    "context_length", "rate_limit_delay", "max_concurrent",
+    "acquire_timeout_seconds", "extra_body",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
@@ -5298,7 +5318,14 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
 }
 
 # Fields that look like they should be inside custom_providers, not at root
-_CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
+_CUSTOM_PROVIDER_LIKE_FIELDS = {
+    "base_url",
+    "api_key",
+    "rate_limit_delay",
+    "max_concurrent",
+    "acquire_timeout_seconds",
+    "api_mode",
+}
 
 
 @dataclass

--- a/tests/agent/test_moa_zai_concurrency.py
+++ b/tests/agent/test_moa_zai_concurrency.py
@@ -1,0 +1,266 @@
+"""Integration tests for Z.AI gating inside Mixture-of-Agents calls."""
+
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent import agent_runtime_helpers, moa_loop, zai_concurrency
+
+
+def _response(content="ok"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="glm-5.2")
+
+
+def _zai_runtime(slot):
+    return {
+        "provider": "zai",
+        "model": slot.get("model") or "glm-5.2",
+        "base_url": "https://api.z.ai/api/coding/paas/v4",
+        "api_key": "test-key",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _stable_gate():
+    zai_concurrency._reset_for_tests(2, 0.0)
+    yield
+    zai_concurrency._reset_for_tests(2, 0.0)
+
+
+def test_parallel_moa_references_share_process_cap(monkeypatch):
+    in_flight = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def fake_call_llm(**kwargs):
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        time.sleep(0.03)
+        with lock:
+            in_flight -= 1
+        return _response(kwargs["model"])
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(moa_loop, "_slot_runtime", _zai_runtime)
+    monkeypatch.setattr(
+        "agent.usage_pricing.estimate_usage_cost",
+        lambda *args, **kwargs: SimpleNamespace(
+            amount_usd=None,
+            status="unknown",
+            source=None,
+        ),
+    )
+
+    refs = [{"provider": "zai", "model": f"glm-{index}"} for index in range(6)]
+    out = moa_loop._run_references_parallel(
+        refs,
+        [{"role": "user", "content": "review"}],
+    )
+
+    assert len(out) == 6
+    assert peak == 2
+
+
+def test_zai_stream_holds_slot_until_iterator_finishes(monkeypatch):
+    zai_concurrency._reset_for_tests(1, 0.0)
+    release_first = threading.Event()
+    first_created = threading.Event()
+    calls = []
+    lock = threading.Lock()
+
+    class _Stream:
+        def __init__(self, index):
+            self.index = index
+            self.done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.done:
+                raise StopIteration
+            self.done = True
+            if self.index == 1:
+                release_first.wait(timeout=2)
+            return self.index
+
+    def fake_call_llm(**kwargs):
+        with lock:
+            calls.append(kwargs)
+            index = len(calls)
+        if index == 1:
+            first_created.set()
+        return _Stream(index)
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    runtime = _zai_runtime({"model": "glm-5.2"})
+    outputs = []
+
+    def consume():
+        outputs.append(
+            list(
+                moa_loop._call_moa_model(
+                    runtime=runtime,
+                    task="moa_aggregator",
+                    messages=[],
+                    stream=True,
+                )
+            )
+        )
+
+    first = threading.Thread(target=consume)
+    second = threading.Thread(target=consume)
+    first.start()
+    assert first_created.wait(timeout=1)
+    second.start()
+    time.sleep(0.05)
+
+    assert len(calls) == 1
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(calls) == 2
+    assert sorted(outputs) == [[1], [2]]
+
+
+def test_moa_client_preserves_interrupt_check():
+    interrupt_check = lambda: True
+    client = moa_loop.MoAClient("review", interrupt_check=interrupt_check)
+    assert client.chat.completions.interrupt_check is interrupt_check
+
+
+def test_switch_to_moa_preserves_interruptible_zai_wait(monkeypatch):
+    zai_concurrency._reset_for_tests(1, 0.0)
+    monkeypatch.setattr(zai_concurrency, "_ZAI_ACQUIRE_POLL_INTERVAL", 0.01)
+    sem = zai_concurrency._gate._semaphore()
+    assert sem.acquire()
+
+    agent = SimpleNamespace(
+        model="minimax-m3",
+        provider="opencode-go",
+        api_mode="anthropic_messages",
+        api_key="old-key",
+        base_url="https://old.example/v1",
+        client=object(),
+        _client_kwargs={"base_url": "https://old.example/v1"},
+        _config_context_length=123456,
+        _transport_cache={},
+        _interrupt_requested=False,
+        quiet_mode=True,
+    )
+
+    # The fake agent intentionally omits post-swap AIAgent helpers. The MoA
+    # client is installed before that machinery runs, which is the live
+    # switch_model path this regression covers.
+    with pytest.raises(AttributeError):
+        agent_runtime_helpers.switch_model(
+            agent,
+            new_model="review",
+            new_provider="moa",
+            api_key="moa-virtual-provider",
+            base_url="moa://local",
+            api_mode="chat_completions",
+        )
+
+    assert type(agent.client).__name__ == "MoAClient"
+    assert agent.client.chat.completions.interrupt_check is not None
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"moa": {}})
+    monkeypatch.setattr(
+        "hermes_cli.moa_config.resolve_moa_preset",
+        lambda *_args, **_kwargs: {
+            "enabled": True,
+            "reference_models": [],
+            "aggregator": {"provider": "zai", "model": "glm-5.2"},
+        },
+    )
+    monkeypatch.setattr(moa_loop, "_slot_runtime", _zai_runtime)
+    provider_calls = []
+
+    def _unexpected_provider_call(**kwargs):
+        provider_calls.append(kwargs)
+        return _response()
+
+    monkeypatch.setattr(moa_loop, "call_llm", _unexpected_provider_call)
+
+    errors = []
+    started = threading.Event()
+
+    def _run_switched_client():
+        started.set()
+        try:
+            agent.client.chat.completions.create(
+                messages=[{"role": "user", "content": "review"}],
+            )
+        except Exception as exc:  # capture the cross-thread interrupt
+            errors.append(exc)
+
+    worker = threading.Thread(target=_run_switched_client)
+    worker.start()
+    try:
+        assert started.wait(timeout=1)
+        time.sleep(0.05)
+        assert worker.is_alive(), "the switched client never queued on the held slot"
+        assert provider_calls == []
+
+        agent._interrupt_requested = True
+        worker.join(timeout=2)
+
+        assert not worker.is_alive()
+        assert len(errors) == 1
+        assert isinstance(errors[0], InterruptedError)
+        assert provider_calls == []
+        assert not sem.acquire(blocking=False)
+    finally:
+        agent._interrupt_requested = True
+        worker.join(timeout=2)
+        sem.release()
+
+
+def test_one_shot_moa_forwards_interrupt_check(monkeypatch):
+    interrupt_check = lambda: True
+    observed = []
+
+    def _fake_references(*args, **kwargs):
+        observed.append(("references", kwargs.get("interrupt_check")))
+        return [("advisor", "advice", None)]
+
+    def _fake_call(*, interrupt_check=None, **kwargs):
+        observed.append(("aggregator", interrupt_check))
+        return _response("synthesis")
+
+    monkeypatch.setattr(moa_loop, "_run_references_parallel", _fake_references)
+    monkeypatch.setattr(moa_loop, "_call_moa_model", _fake_call)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "zai",
+            "model": "glm-5.2",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "test-key",
+        },
+    )
+
+    result = moa_loop.aggregate_moa_context(
+        user_prompt="review",
+        api_messages=[{"role": "user", "content": "review"}],
+        reference_models=[{"provider": "zai", "model": "glm-5.2"}],
+        aggregator={"provider": "zai", "model": "glm-5.2"},
+        interrupt_check=interrupt_check,
+    )
+
+    assert "synthesis" in result
+    assert observed == [
+        ("references", interrupt_check),
+        ("aggregator", interrupt_check),
+    ]

--- a/tests/agent/test_zai_concurrency.py
+++ b/tests/agent/test_zai_concurrency.py
@@ -1,0 +1,412 @@
+"""Tests for the process-local Z.AI concurrency gate."""
+
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from agent import zai_concurrency
+from run_agent import AIAgent
+
+
+def _reset(max_concurrent=2, timeout=0.0):
+    zai_concurrency._reset_for_tests(max_concurrent, timeout)
+
+
+@pytest.fixture(autouse=True)
+def _stable_gate():
+    _reset()
+    yield
+    _reset()
+
+
+class TestDetection:
+    @pytest.mark.parametrize(
+        ("provider", "base_url"),
+        [
+            ("zai", ""),
+            ("ZAI", ""),
+            ("zhipu", ""),
+            ("glm", ""),
+            ("z-ai", ""),
+            ("Z.AI", ""),
+            ("custom", "https://api.z.ai/api/coding/paas/v4"),
+            ("custom", "https://open.bigmodel.cn/api/paas/v4"),
+            ("custom", "api.z.ai/api/coding/paas/v4"),
+            ("custom", "https://edge.api.z.ai/v1"),
+            ("custom", "api.z.ai/v1?next=http://elsewhere.example"),
+            ("custom", "https:api.z.ai/api/coding/paas/v4"),
+            (" zai ", ""),
+        ],
+    )
+    def test_zai_provider_and_host_markers(self, provider, base_url):
+        assert zai_concurrency.is_zai_request(
+            provider=provider,
+            model="glm-5.2",
+            base_url=base_url,
+        )
+
+    @pytest.mark.parametrize(
+        ("provider", "model", "base_url"),
+        [
+            ("openai", "gpt-5", "https://api.openai.com/v1"),
+            ("anthropic", "claude-opus-4", "https://api.anthropic.com"),
+            ("custom", "glm-5.2", "http://localhost:8080/v1"),
+            ("custom", "glm-5.2", "https://api.z.ai.evil.example/v1"),
+            ("custom", "glm-5.2", "https://example.com/proxy/api.z.ai"),
+            ("custom", "glm-5.2", "evil.example/v1?u=http://api.z.ai"),
+            ("custom", "glm-5.2", "https:evil.example/v1"),
+            (None, None, None),
+        ],
+    )
+    def test_non_zai_routes_are_not_gated(self, provider, model, base_url):
+        assert not zai_concurrency.is_zai_request(
+            provider=provider,
+            model=model,
+            base_url=base_url,
+        )
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["zai", "ZAI", "glm", "zhipu", "z-ai", "z.ai"],
+    )
+    def test_zai_provider_with_overridden_non_zai_host_is_not_gated(self, provider):
+        # A ``zai``/``glm`` provider whose GLM_BASE_URL is overridden to a
+        # local or third-party endpoint must not be throttled: the resolved
+        # host is authoritative and does not point at Z.AI.
+        assert not zai_concurrency.is_zai_request(
+            provider=provider,
+            model="glm-5.2",
+            base_url="http://localhost:8080/v1",
+        )
+        assert not zai_concurrency.is_zai_request(
+            provider=provider,
+            model="glm-5.2",
+            base_url="https://glm.internal.corp/v1",
+        )
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["", None, "   "],
+    )
+    def test_zai_provider_without_a_resolvable_host_falls_back_to_name(self, base_url):
+        # No parseable host → the built-in Z.AI provider name is the fallback
+        # signal, so the gate still applies.
+        assert zai_concurrency.is_zai_request(
+            provider="zai",
+            model="glm-5.2",
+            base_url=base_url,
+        )
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "//api.z.ai/api/coding/paas/v4",
+            "//open.bigmodel.cn/api/paas/v4",
+        ],
+    )
+    def test_protocol_relative_zai_host_is_gated(self, base_url):
+        assert zai_concurrency.is_zai_request(
+            provider="custom",
+            model="glm-5.2",
+            base_url=base_url,
+        )
+
+
+class TestLifecycle:
+    def test_non_zai_and_disabled_gate_pass_through(self):
+        with zai_concurrency.acquire_zai_slot(
+            provider="openai",
+            model="gpt-5",
+            base_url="https://api.openai.com/v1",
+        ):
+            pass
+
+        _reset(0)
+        with zai_concurrency.acquire_zai_slot(
+            provider="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        ):
+            pass
+
+    def test_slot_is_acquired_on_enter_not_handle_creation(self):
+        _reset(1)
+        sem = zai_concurrency._gate._semaphore()
+        handle = zai_concurrency.acquire_zai_slot(
+            provider="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+        with handle:
+            assert not sem.acquire(blocking=False)
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+    def test_slot_is_released_after_exception(self):
+        _reset(1)
+        sem = zai_concurrency._gate._semaphore()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            ):
+                raise RuntimeError("boom")
+
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+    def test_handle_cannot_be_reentered(self):
+        handle = zai_concurrency.acquire_zai_slot(
+            provider="zai",
+            model="glm-5.2",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+        with handle:
+            pass
+        with pytest.raises(RuntimeError, match="cannot be re-entered"):
+            with handle:
+                pass
+
+
+class TestStrictBound:
+    def test_parallel_calls_never_exceed_cap(self):
+        _reset(2)
+        observed_peak = 0
+        in_flight = 0
+        lock = threading.Lock()
+
+        def _worker():
+            nonlocal observed_peak, in_flight
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            ):
+                with lock:
+                    in_flight += 1
+                    observed_peak = max(observed_peak, in_flight)
+                time.sleep(0.03)
+                with lock:
+                    in_flight -= 1
+
+        threads = [threading.Thread(target=_worker) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+            assert not thread.is_alive()
+
+        assert observed_peak == 2
+
+    def test_timeout_raises_instead_of_proceeding_uncapped(self):
+        _reset(1, timeout=0.03)
+        sem = zai_concurrency._gate._semaphore()
+        assert sem.acquire()
+
+        with pytest.raises(zai_concurrency.ZaiConcurrencyTimeout):
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            ):
+                pytest.fail("a timed-out caller must never enter uncapped")
+
+        assert not sem.acquire(blocking=False)
+        sem.release()
+
+    def test_interrupt_stops_wait_without_releasing_foreign_slot(self):
+        _reset(1)
+        sem = zai_concurrency._gate._semaphore()
+        assert sem.acquire()
+
+        with pytest.raises(InterruptedError):
+            with zai_concurrency.acquire_zai_slot(
+                provider="zai",
+                model="glm-5.2",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+                interrupt_check=lambda: True,
+            ):
+                pytest.fail("an interrupted caller must not enter")
+
+        assert not sem.acquire(blocking=False)
+        sem.release()
+
+    def test_interrupt_racing_with_acquire_returns_newly_granted_slot(self):
+        interrupted = False
+
+        class _RaceSemaphore:
+            releases = 0
+
+            def acquire(self, timeout):
+                nonlocal interrupted
+                interrupted = True
+                return True
+
+            def release(self):
+                self.releases += 1
+
+        sem = _RaceSemaphore()
+        handle = zai_concurrency._SlotHandle(
+            sem,
+            timeout=0.0,
+            interrupt_check=lambda: interrupted,
+        )
+
+        with pytest.raises(InterruptedError):
+            with handle:
+                pytest.fail("an interrupt that races with acquire must win")
+
+        assert sem.releases == 1
+
+
+def test_direct_agent_request_path_holds_zai_slot(monkeypatch):
+    _reset(1)
+    sem = zai_concurrency._gate._semaphore()
+    observed = []
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5.2",
+        provider="zai",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=[],
+        max_iterations=1,
+    )
+
+    def _fake_api_call(_api_kwargs, **_kwargs):
+        acquired = sem.acquire(blocking=False)
+        if acquired:
+            sem.release()
+        observed.append(acquired)
+        message = type("_Message", (), {"content": "done", "tool_calls": []})()
+        choice = type(
+            "_Choice",
+            (),
+            {"message": message, "finish_reason": "stop"},
+        )()
+        return type(
+            "_Response",
+            (),
+            {"choices": [choice], "usage": None, "model": "glm-5.2"},
+        )()
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+    monkeypatch.setattr(agent, "_interruptible_streaming_api_call", _fake_api_call)
+    monkeypatch.setattr(agent, "_persist_session", lambda *args, **kwargs: None)
+    monkeypatch.setattr(agent, "_save_trajectory", lambda *args, **kwargs: None)
+    monkeypatch.setattr(agent, "_cleanup_task_resources", lambda *args, **kwargs: None)
+
+    result = agent.run_conversation("hello")
+
+    assert result["final_response"] == "done"
+    assert observed == [False]
+
+
+class TestConfiguration:
+    @staticmethod
+    def _subprocess_env(home: Path, **overrides: str) -> dict[str, str]:
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(home)
+        repo_root = str(Path(__file__).resolve().parents[2])
+        existing_path = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            repo_root if not existing_path else repo_root + os.pathsep + existing_path
+        )
+        env.update(overrides)
+        return env
+
+    @classmethod
+    def _set_profile_config(cls, home: Path, max_concurrent: str, timeout: str) -> None:
+        script = (
+            "from hermes_cli.config import set_config_value;"
+            f"set_config_value('providers.zai.max_concurrent', {max_concurrent!r});"
+            "set_config_value("
+            f"'providers.zai.acquire_timeout_seconds', {timeout!r})"
+        )
+        subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path(__file__).resolve().parents[2],
+            env=cls._subprocess_env(home),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @classmethod
+    def _read_profile_limits(cls, home: Path, **env_overrides: str) -> tuple[int, float]:
+        script = (
+            "from agent.zai_concurrency import "
+            "configured_acquire_timeout, configured_max_concurrent;"
+            "print(f'{configured_max_concurrent()}|{configured_acquire_timeout()}')"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path(__file__).resolve().parents[2],
+            env=cls._subprocess_env(home, **env_overrides),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        raw_max, raw_timeout = result.stdout.strip().split("|")
+        return int(raw_max), float(raw_timeout)
+
+    def test_defaults_are_strict_cap_two_with_unbounded_wait(self, tmp_path):
+        assert self._read_profile_limits(tmp_path / "default") == (2, 0.0)
+
+    def test_config_set_is_profile_scoped_and_accepts_fractional_timeout(self, tmp_path):
+        profile_one = tmp_path / "profile-one"
+        profile_two = tmp_path / "profile-two"
+        self._set_profile_config(profile_one, "1", "0.25")
+        self._set_profile_config(profile_two, "4", "1.5")
+
+        assert self._read_profile_limits(profile_one) == (1, 0.25)
+        assert self._read_profile_limits(profile_two) == (4, 1.5)
+
+    def test_zero_disables_and_legacy_environment_controls_are_ignored(self, tmp_path):
+        profile = tmp_path / "disabled"
+        self._set_profile_config(profile, "0", "0")
+
+        assert self._read_profile_limits(
+            profile,
+            HERMES_ZAI_MAX_CONCURRENT="9",
+            HERMES_ZAI_ACQUIRE_TIMEOUT_S="12.5",
+        ) == (0, 0.0)
+
+    def test_invalid_config_values_fall_back_to_safe_defaults(self, tmp_path):
+        profile = tmp_path / "invalid"
+        self._set_profile_config(profile, "-1", "not-a-number")
+
+        assert self._read_profile_limits(profile) == (2, 0.0)
+
+    @pytest.mark.parametrize(
+        ("max_concurrent", "timeout"),
+        [
+            ("1.5", "0"),
+            ("2", "inf"),
+            ("2", "nan"),
+        ],
+    )
+    def test_non_integral_or_non_finite_config_falls_back_safely(
+        self,
+        tmp_path,
+        max_concurrent,
+        timeout,
+    ):
+        profile = tmp_path / f"invalid-{max_concurrent}-{timeout}"
+        self._set_profile_config(profile, max_concurrent, timeout)
+
+        assert self._read_profile_limits(profile) == (2, 0.0)

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -280,6 +280,25 @@ Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_U
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
 :::
 
+:::note Z.AI Concurrency Bound
+Hermes limits direct-agent and MoA calls to Z.AI to two simultaneous in-flight requests per process by default. This prevents a subagent or MoA fan-out from sustaining code 1305 overload retries and repeatedly re-sending a large context.
+
+Configure the active profile in `config.yaml`:
+
+```yaml
+providers:
+  zai:
+    max_concurrent: 2
+    acquire_timeout_seconds: 0
+```
+
+`max_concurrent: 0` disables the gate. A positive `acquire_timeout_seconds` raises locally without contacting the provider when no slot becomes available; the default `0` waits until a slot is free, while interactive waits remain interruptible. You can set the same values with `hermes config set providers.zai.max_concurrent 2` and `hermes config set providers.zai.acquire_timeout_seconds 0`.
+
+The bound is process-local and profile-scoped. If several CLI or gateway processes share one Coding Plan key, their effective combined ceiling is the number of processes multiplied by the per-process value; fleet operators should usually keep the value at `1` or `2`. This gate does not change the separate rolling usage quota or its "Usage limit reached for 5 hour" response.
+
+The gate covers the direct-agent and Mixture-of-Agents request paths. Auxiliary side-model calls (vision, web-extract, approval, compression, and other `auxiliary`-configured tasks) are not routed through it, so a Z.AI-backed auxiliary configuration can add in-flight requests beyond `max_concurrent`. Detection is host-first: a call is gated only when its resolved base-URL host is Z.AI, so a `zai`/`glm` provider pointed at a local or third-party endpoint via `GLM_BASE_URL` is not throttled.
+:::
+
 ### xAI (Grok) — Responses API + Prompt Caching
 
 xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-fast-reasoning`.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -91,6 +91,19 @@ You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming st
 
 Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
+### Z.AI Concurrency
+
+Z.AI Coding Plan can return overload code 1305 when direct-agent, delegated, and Mixture-of-Agents calls fan out concurrently. Hermes applies a strict process-local cap of two Z.AI requests by default. Configure the active profile under `providers.zai`:
+
+```yaml
+providers:
+  zai:
+    max_concurrent: 2
+    acquire_timeout_seconds: 0
+```
+
+Set `max_concurrent` to `0` to disable the gate. `acquire_timeout_seconds: 0` waits until a slot is available; a positive value fails locally after that many seconds without sending another provider request. These are behavioral settings, so they belong in `config.yaml`, not `.env`. Each profile reads its own values through its active `HERMES_HOME`.
+
 ## Update Behavior
 
 `hermes update` settings live under `updates` in `config.yaml`:


### PR DESCRIPTION
## What does this PR do?

Adds one strict process-local concurrency gate for Z.AI requests made by the direct agent path and Mixture-of-Agents reference/aggregator calls.

The gate is profile-configurable, interruptible while queued, and held for the full lifetime of streaming calls. It prevents Z.AI fan-out from bypassing the configured cap or leaking another caller's semaphore permit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Tests

## Changes Made

- Added `agent/zai_concurrency.py`, backed by a process-wide bounded semaphore.
- Added profile settings under `providers.zai`:
  - `max_concurrent` defaults to `2`; `0` disables the gate.
  - `acquire_timeout_seconds` defaults to `0`, meaning wait until a slot or interruption.
- Applied the same gate to:
  - direct agent requests;
  - MoA reference calls;
  - MoA aggregator calls;
  - MoA streaming calls for the iterator's full lifetime.
- Propagated the live agent interruption callback through:
  - initial MoA construction;
  - one-shot MoA context aggregation;
  - runtime model switching to an MoA preset.
- Made slot acquisition ownership-safe across timeout, exception, and interrupt races.
- Detects Z.AI host-first from the parsed base-URL hostname (the provider name is a fallback only when no host parses), without false matches from URL paths, query strings, or lookalike domains, and with protocol-relative, schemeless, and opaque `scheme:host` URL forms all resolving to their real host.
- Rejects non-integral concurrency values and non-finite timeouts by falling back to safe defaults.
- Added configuration and provider documentation.

## How to Test

Focused coverage:

```bash
./scripts/run_tests.sh \
  tests/agent/test_zai_concurrency.py \
  tests/agent/test_moa_zai_concurrency.py \
  -q
```

Static and cross-platform checks:

```bash
uvx ruff check \
  agent/zai_concurrency.py \
  agent/agent_init.py \
  agent/agent_runtime_helpers.py \
  agent/conversation_loop.py \
  agent/moa_loop.py \
  hermes_cli/config.py \
  tests/agent/test_zai_concurrency.py \
  tests/agent/test_moa_zai_concurrency.py

python3 -m py_compile \
  agent/zai_concurrency.py \
  agent/agent_init.py \
  agent/agent_runtime_helpers.py \
  agent/conversation_loop.py \
  agent/moa_loop.py \
  hermes_cli/config.py

python3 scripts/check-windows-footguns.py --diff origin/main
git diff --check
```

## Verification Results

Three independent verification methods passed, with the final branch head at `81c74b3af`:

1. **Repository tests:** 53 focused Z.AI/MoA tests passed on the final head, including adversarial URL-grammar and detection-override regressions. During the final audit, a broader run across 41 Z.AI, MoA, configuration, provider, and model-switch files passed 942 tests. After later upstream movement touched MoA context propagation, the branch was rebased and 52 directly affected Z.AI/MoA/portal-context tests passed before the final focused rerun.
2. **Static and ownership audit:** Ruff, Python compilation, the Windows footgun checker, and whitespace validation passed. Acquire/release, timeout, interrupt-race, stream-close, and model-switch paths were manually traced.
3. **Independent runtime stress:** 200 concurrent threads completed with zero stranded threads and an observed peak of exactly two in-flight Z.AI calls.

The review-specific regression holds the sole Z.AI permit, switches a live agent to MoA, confirms the new client queues without calling the provider, flips `_interrupt_requested`, receives `InterruptedError`, and proves the foreign permit was not released.

## Scope and Limitations

- The cap is process-local. Multiple Hermes processes sharing one Z.AI key each have an independent gate.
- Configuration is read from the active profile's `config.yaml` when the module is loaded.
- Detection is host-first: a call is gated only when its resolved base-URL host is Z.AI, so a `zai`/`glm` provider pointed at a local or third-party endpoint via `GLM_BASE_URL` is not throttled. The provider name is used only when no host can be parsed.
- The gate covers the direct-agent and MoA request paths. Auxiliary side-model calls (vision, web-extract, approval, compression, and other `auxiliary`-configured tasks) are not routed through it, so a Z.AI-backed auxiliary configuration can add in-flight requests beyond `max_concurrent`.
- This PR does not alter provider quota accounting or remote rolling usage limits.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have documented the configuration and operational limitations
- [x] My changes generate no new warnings
- [x] I have added regression and adversarial tests
- [x] Focused and expanded tests pass locally


