### PR TITLE
fix(skills): invalidate config cache after file replacement

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -311,7 +311,21 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 # ── Disabled skills ───────────────────────────────────────────────────────
 
 
-_RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
+_ConfigStatKey = Tuple[str, int, int, int, int, int]
+
+
+def _config_stat_key(config_path: Path, stat: os.stat_result) -> _ConfigStatKey:
+    return (
+        str(config_path),
+        stat.st_dev,
+        stat.st_ino,
+        stat.st_size,
+        stat.st_mtime_ns,
+        stat.st_ctime_ns,
+    )
+
+
+_RAW_CONFIG_CACHE: Dict[_ConfigStatKey, Dict[str, Any]] = {}
 
 
 def _raw_config_cache_clear() -> None:
@@ -320,18 +334,20 @@ def _raw_config_cache_clear() -> None:
 
 
 def _load_raw_config() -> Dict[str, Any]:
-    """Read config.yaml with a shared mtime+size keyed cache.
+    """Read config.yaml with a shared filesystem-metadata keyed cache.
 
     This module intentionally avoids importing ``hermes_cli.config`` on the
     skill prompt/build path. A tiny local cache gives the same repeated-read
-    win without pulling the heavier CLI config stack into startup.
+    win without pulling the heavier CLI config stack into startup. File
+    identity and change time supplement mtime and size so atomic replacements
+    cannot reuse the previous cache entry merely by preserving those values.
     """
     config_path = get_config_path()
     if not config_path.exists():
         return {}
     try:
         stat = config_path.stat()
-        cache_key = (str(config_path), stat.st_mtime_ns, stat.st_size)
+        cache_key = _config_stat_key(config_path, stat)
     except OSError:
         cache_key = None
 
@@ -402,13 +418,14 @@ def _normalize_string_set(values) -> Set[str]:
 
 # ── External skills directories ──────────────────────────────────────────
 
-# (config_path_str, mtime_ns) -> resolved external dirs list.  Keyed by
-# mtime_ns so a config.yaml edit mid-run is picked up automatically;
+# Filesystem metadata key -> resolved external dirs list.  Keyed consistently
+# with the shared raw config cache so a config.yaml edit or replacement is
+# picked up automatically;
 # otherwise every call would re-read + re-YAML-parse the 15KB config,
 # which becomes the dominant cost of ``hermes`` startup when ~120 skills
 # each trigger a category lookup during banner construction (10+ seconds
 # of pure waste).
-_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+_EXTERNAL_DIRS_CACHE: Dict[_ConfigStatKey, List[Path]] = {}
 
 
 def _external_dirs_cache_clear() -> None:
@@ -424,20 +441,20 @@ def get_external_skills_dirs() -> List[Path]:
     path.  Only directories that actually exist are returned.  Duplicates and
     paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    Cached in-process, keyed on ``config.yaml`` filesystem metadata — the
+    function is called once per skill during banner / tool-registry scans, and
+    YAML parsing a non-trivial config dominates ``hermes`` cold-start time when
+    the cache is absent.
     """
     config_path = get_config_path()
     if not config_path.exists():
         return []
 
-    # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
-    # the full YAML parse, so the fast path is nearly free.
+    # stat() is ~2us vs ~85ms for the full YAML parse, so the fast path is
+    # nearly free.
     try:
         stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
+        cache_key: _ConfigStatKey = _config_stat_key(config_path, stat)
     except OSError:
         cache_key = None  # type: ignore[assignment]
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -390,7 +390,21 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 # ── Disabled skills ───────────────────────────────────────────────────────
 
 
-_RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
+_ConfigStatKey = Tuple[str, int, int, int, int, int]
+
+
+def _config_stat_key(config_path: Path, stat: os.stat_result) -> _ConfigStatKey:
+    return (
+        str(config_path),
+        stat.st_dev,
+        stat.st_ino,
+        stat.st_size,
+        stat.st_mtime_ns,
+        stat.st_ctime_ns,
+    )
+
+
+_RAW_CONFIG_CACHE: Dict[_ConfigStatKey, Dict[str, Any]] = {}
 
 
 def _raw_config_cache_clear() -> None:
@@ -399,18 +413,20 @@ def _raw_config_cache_clear() -> None:
 
 
 def _load_raw_config() -> Dict[str, Any]:
-    """Read config.yaml with a shared mtime+size keyed cache.
+    """Read config.yaml with a shared filesystem-metadata keyed cache.
 
     This module intentionally avoids importing ``hermes_cli.config`` on the
     skill prompt/build path. A tiny local cache gives the same repeated-read
-    win without pulling the heavier CLI config stack into startup.
+    win without pulling the heavier CLI config stack into startup. File
+    identity and change time supplement mtime and size so atomic replacements
+    cannot reuse the previous cache entry merely by preserving those values.
     """
     config_path = get_config_path()
     if not config_path.exists():
         return {}
     try:
         stat = config_path.stat()
-        cache_key = (str(config_path), stat.st_mtime_ns, stat.st_size)
+        cache_key = _config_stat_key(config_path, stat)
     except OSError:
         cache_key = None
 
@@ -481,13 +497,14 @@ def _normalize_string_set(values) -> Set[str]:
 
 # ── External skills directories ──────────────────────────────────────────
 
-# (config_path_str, mtime_ns) -> resolved external dirs list.  Keyed by
-# mtime_ns so a config.yaml edit mid-run is picked up automatically;
+# Filesystem metadata key -> resolved external dirs list.  Keyed consistently
+# with the shared raw config cache so a config.yaml edit or replacement is
+# picked up automatically;
 # otherwise every call would re-read + re-YAML-parse the 15KB config,
 # which becomes the dominant cost of ``hermes`` startup when ~120 skills
 # each trigger a category lookup during banner construction (10+ seconds
 # of pure waste).
-_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+_EXTERNAL_DIRS_CACHE: Dict[_ConfigStatKey, List[Path]] = {}
 
 
 def _external_dirs_cache_clear() -> None:
@@ -503,20 +520,20 @@ def get_external_skills_dirs() -> List[Path]:
     path.  Only directories that actually exist are returned.  Duplicates and
     paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    Cached in-process, keyed on ``config.yaml`` filesystem metadata — the
+    function is called once per skill during banner / tool-registry scans, and
+    YAML parsing a non-trivial config dominates ``hermes`` cold-start time when
+    the cache is absent.
     """
     config_path = get_config_path()
     if not config_path.exists():
         return []
 
-    # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
-    # the full YAML parse, so the fast path is nearly free.
+    # stat() is ~2us vs ~85ms for the full YAML parse, so the fast path is
+    # nearly free.
     try:
         stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
+        cache_key: _ConfigStatKey = _config_stat_key(config_path, stat)
     except OSError:
         cache_key = None  # type: ignore[assignment]
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,5 +1,7 @@
 """Tests for agent/skill_utils.py."""
 
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 from agent.skill_utils import (
@@ -166,10 +168,130 @@ def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch
     assert get_disabled_skill_names() == {"old-skill"}
 
     config_path.write_text("skills:\n  disabled: [new-skill]\n", encoding="utf-8")
-    import os
-    os.utime(config_path, None)
+    updated_stat = config_path.stat()
+    os.utime(
+        config_path,
+        ns=(updated_stat.st_atime_ns, updated_stat.st_mtime_ns + 1_000_000_000),
+    )
 
     assert get_disabled_skill_names() == {"new-skill"}
+
+
+def _replace_preserving_size_and_mtime(path: Path, content: str) -> None:
+    """Atomically replace *path* while preserving its weak cache metadata."""
+    original_stat = path.stat()
+    assert len(content.encode()) == original_stat.st_size
+    replacement = path.with_suffix(".tmp")
+    replacement.write_text(content, encoding="utf-8")
+    replacement.replace(path)
+    os.utime(path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+    replaced_stat = path.stat()
+    assert (replaced_stat.st_size, replaced_stat.st_mtime_ns) == (
+        original_stat.st_size,
+        original_stat.st_mtime_ns,
+    )
+    assert (replaced_stat.st_dev, replaced_stat.st_ino) != (
+        original_stat.st_dev,
+        original_stat.st_ino,
+    )
+
+
+def test_skill_config_cache_invalidates_after_same_stat_replacement(
+    tmp_path, monkeypatch
+):
+    """Replacing config content must invalidate every skill config consumer."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    external_a = tmp_path / "skills-a"
+    external_b = tmp_path / "skills-b"
+    external_a.mkdir()
+    external_b.mkdir()
+    config_path = hermes_home / "config.yaml"
+    before = (
+        "skills:\n"
+        "  disabled: [skill-a]\n"
+        f"  external_dirs: [{external_a}]\n"
+        "  config:\n"
+        "    demo:\n"
+        "      value: value-a\n"
+    )
+    after = (
+        "skills:\n"
+        "  disabled: [skill-b]\n"
+        f"  external_dirs: [{external_b}]\n"
+        "  config:\n"
+        "    demo:\n"
+        "      value: value-b\n"
+    )
+    assert len(before.encode()) == len(after.encode())
+    config_path.write_text(before, encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+    assert get_disabled_skill_names() == {"skill-a"}
+    assert get_external_skills_dirs() == [external_a.resolve()]
+    assert resolve_skill_config_values([{"key": "demo.value"}]) == {
+        "demo.value": "value-a"
+    }
+    _replace_preserving_size_and_mtime(config_path, after)
+
+    assert get_disabled_skill_names() == {"skill-b"}
+    assert get_external_skills_dirs() == [external_b.resolve()]
+    assert resolve_skill_config_values([{"key": "demo.value"}]) == {
+        "demo.value": "value-b"
+    }
+
+
+def test_skill_config_cache_invalidates_with_future_coarse_mtime(
+    tmp_path, monkeypatch
+):
+    """Invalidation must not depend on comparing mtime with wall-clock time."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    before = "skills:\n  disabled: [skill-a]\n"
+    after = "skills:\n  disabled: [skill-b]\n"
+    assert len(before) == len(after)
+    config_path.write_text(before, encoding="utf-8")
+    initial_stat = config_path.stat()
+    two_seconds_ns = 2_000_000_000
+    future_mtime_ns = (
+        (initial_stat.st_mtime_ns + 86_400_000_000_000) // two_seconds_ns
+    ) * two_seconds_ns
+    os.utime(config_path, ns=(initial_stat.st_atime_ns, future_mtime_ns))
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._raw_config_cache_clear()
+    assert get_disabled_skill_names() == {"skill-a"}
+    _replace_preserving_size_and_mtime(config_path, after)
+
+    assert get_disabled_skill_names() == {"skill-b"}
+
+
+def test_skill_config_cache_stable_file_avoids_repeated_reads(tmp_path, monkeypatch):
+    """An unchanged config keeps the stat-only fast path after the first read."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text("skills:\n  disabled: [skill-a]\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._raw_config_cache_clear()
+    assert get_disabled_skill_names() == {"skill-a"}
+
+    with patch.object(
+        Path,
+        "read_text",
+        side_effect=AssertionError("stable config should not be read again"),
+    ):
+        assert get_disabled_skill_names() == {"skill-a"}
+        assert resolve_skill_config_values([]) == {}
 
 
 def test_is_external_skill_path_matches_configured_external_dir(tmp_path, monkeypatch):

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,5 +1,7 @@
 """Tests for agent/skill_utils.py."""
 
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -75,6 +77,123 @@ skills:
 
 
 
+
+
+def _replace_preserving_size_and_mtime(path: Path, content: str) -> None:
+    """Atomically replace *path* while preserving its weak cache metadata."""
+    original_stat = path.stat()
+    assert len(content.encode()) == original_stat.st_size
+    replacement = path.with_suffix(".tmp")
+    replacement.write_text(content, encoding="utf-8")
+    replacement.replace(path)
+    os.utime(path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+    replaced_stat = path.stat()
+    assert (replaced_stat.st_size, replaced_stat.st_mtime_ns) == (
+        original_stat.st_size,
+        original_stat.st_mtime_ns,
+    )
+    assert (replaced_stat.st_dev, replaced_stat.st_ino) != (
+        original_stat.st_dev,
+        original_stat.st_ino,
+    )
+
+
+def test_skill_config_cache_invalidates_after_same_stat_replacement(
+    tmp_path, monkeypatch
+):
+    """Replacing config content must invalidate every skill config consumer."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    external_a = tmp_path / "skills-a"
+    external_b = tmp_path / "skills-b"
+    external_a.mkdir()
+    external_b.mkdir()
+    config_path = hermes_home / "config.yaml"
+    before = (
+        "skills:\n"
+        "  disabled: [skill-a]\n"
+        f"  external_dirs: [{external_a}]\n"
+        "  config:\n"
+        "    demo:\n"
+        "      value: value-a\n"
+    )
+    after = (
+        "skills:\n"
+        "  disabled: [skill-b]\n"
+        f"  external_dirs: [{external_b}]\n"
+        "  config:\n"
+        "    demo:\n"
+        "      value: value-b\n"
+    )
+    assert len(before.encode()) == len(after.encode())
+    config_path.write_text(before, encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+    assert get_disabled_skill_names() == {"skill-a"}
+    assert get_external_skills_dirs() == [external_a.resolve()]
+    assert resolve_skill_config_values([{"key": "demo.value"}]) == {
+        "demo.value": "value-a"
+    }
+    _replace_preserving_size_and_mtime(config_path, after)
+
+    assert get_disabled_skill_names() == {"skill-b"}
+    assert get_external_skills_dirs() == [external_b.resolve()]
+    assert resolve_skill_config_values([{"key": "demo.value"}]) == {
+        "demo.value": "value-b"
+    }
+
+
+def test_skill_config_cache_invalidates_with_future_coarse_mtime(
+    tmp_path, monkeypatch
+):
+    """Invalidation must not depend on comparing mtime with wall-clock time."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    before = "skills:\n  disabled: [skill-a]\n"
+    after = "skills:\n  disabled: [skill-b]\n"
+    assert len(before) == len(after)
+    config_path.write_text(before, encoding="utf-8")
+    initial_stat = config_path.stat()
+    two_seconds_ns = 2_000_000_000
+    future_mtime_ns = (
+        (initial_stat.st_mtime_ns + 86_400_000_000_000) // two_seconds_ns
+    ) * two_seconds_ns
+    os.utime(config_path, ns=(initial_stat.st_atime_ns, future_mtime_ns))
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._raw_config_cache_clear()
+    assert get_disabled_skill_names() == {"skill-a"}
+    _replace_preserving_size_and_mtime(config_path, after)
+
+    assert get_disabled_skill_names() == {"skill-b"}
+
+
+def test_skill_config_cache_stable_file_avoids_repeated_reads(tmp_path, monkeypatch):
+    """An unchanged config keeps the stat-only fast path after the first read."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text("skills:\n  disabled: [skill-a]\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._raw_config_cache_clear()
+    assert get_disabled_skill_names() == {"skill-a"}
+
+    with patch.object(
+        Path,
+        "read_text",
+        side_effect=AssertionError("stable config should not be read again"),
+    ):
+        assert get_disabled_skill_names() == {"skill-a"}
+        assert resolve_skill_config_values([]) == {}
 
 
 def test_iter_skill_index_files_prunes_skill_support_dirs(tmp_path):


### PR DESCRIPTION
## Summary
- invalidate skill configuration caches when `config.yaml` is replaced without changing its size or mtime
- keep the unchanged-file fast path free of content reads and repeated YAML parsing

## Problem
The raw skill configuration cache used `(path, mtime, size)`, while the external-directory cache used `(path, mtime)`. An atomic replacement that preserved those values could leave disabled skills, external directories, and skill settings stale in a long-lived process.

## Fix
Both caches now key on path, device, inode, size, mtime, and ctime. A replaced file gets a new cache entry even when its size and mtime are restored; an unchanged file still uses the stat-only fast path.

This covers replacement writes. An in-place writer that deliberately preserves every reported stat value remains outside the stat-only cache contract.

## Tests
- `scripts/run_tests.sh tests/agent/test_skill_utils.py tests/agent/test_external_skills_dirs_cache.py tests/agent/test_prompt_builder.py -q` — 80 passed
- `python -m py_compile agent/skill_utils.py tests/agent/test_skill_utils.py`
- `ruff check agent/skill_utils.py tests/agent/test_skill_utils.py`
- `ty check agent/skill_utils.py`
- `git diff --check origin/main...HEAD`
