### PR TITLE
feat(gateway): plugin platform hints and standalone sender

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -853,6 +853,17 @@ PLATFORM_HINTS = {
     ),
 }
 
+# Merge plugin-registered platform hints (resolved entries only; built-in
+# deferred loaders are skipped because their hints are hardcoded above).
+try:
+    from gateway.platform_registry import platform_registry
+
+    for _entry in platform_registry.values():
+        if _entry.platform_hint and _entry.name not in PLATFORM_HINTS:
+            PLATFORM_HINTS[_entry.name] = _entry.platform_hint
+except Exception:
+    pass
+
 # Telegram rich-messages extension — only injected when the user has opted in
 # to ``platforms.telegram.extra.rich_messages: true``.  The base
 # PLATFORM_HINTS["telegram"] covers MarkdownV2-compatible constructs; this

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -268,6 +268,10 @@ class PlatformRegistry:
         self._resolve_all()
         return [e for e in self._entries.values() if e.source == "plugin"]
 
+    def values(self) -> list[PlatformEntry]:
+        """Return all concretely registered entries (does NOT trigger deferred loaders)."""
+        return list(self._entries.values())
+
     def is_registered(self, name: str) -> bool:
         # A deferred (not-yet-imported) platform still counts as registered --
         # the loader will materialize it on first real use.  This keeps cheap

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1137,6 +1137,37 @@ class TestPromptBuilderConstants:
 
 
 # =========================================================================
+# Plugin platform hints
+# =========================================================================
+
+class TestPluginPlatformHints:
+    def test_dynamically_registered_platform_hint(self, monkeypatch):
+        """A plugin-registered platform_hint is merged into PLATFORM_HINTS."""
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        platform_registry.register(
+            PlatformEntry(
+                name="testpbplat",
+                label="TestPBPlat",
+                adapter_factory=lambda cfg: None,
+                check_fn=lambda: True,
+                source="plugin",
+                platform_hint="You are on TestPBPlat.",
+            )
+        )
+        try:
+            import importlib
+            import sys
+            # Re-import the module so the import-time merge sees the new entry.
+            monkeypatch.delitem(sys.modules, "agent.prompt_builder", raising=False)
+            _pb = importlib.import_module("agent.prompt_builder")
+            assert "testpbplat" in _pb.PLATFORM_HINTS
+            assert "You are on TestPBPlat." in _pb.PLATFORM_HINTS["testpbplat"]
+        finally:
+            platform_registry.unregister("testpbplat")
+
+
+# =========================================================================
 # Environment hints
 # =========================================================================
 

--- a/tests/gateway/test_plugin_platform_parity.py
+++ b/tests/gateway/test_plugin_platform_parity.py
@@ -1,0 +1,149 @@
+"""Tests for plugin platform parity: system-prompt hints and standalone sending."""
+
+import importlib
+
+import pytest
+
+from gateway.platform_registry import PlatformEntry, platform_registry
+from gateway.config import Platform
+
+
+# ── Platform hints ───────────────────────────────────────────────────────
+
+
+class TestPluginPlatformHints:
+    """Plugin-registered platform_hint is merged into PLATFORM_HINTS."""
+
+    def test_registered_hint_appears_in_platform_hints(self):
+        """A plugin platform's platform_hint is merged into PLATFORM_HINTS at import time."""
+        entry = PlatformEntry(
+            name="testplatform",
+            label="TestPlatform",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            source="plugin",
+            platform_hint="You are on TestPlatform. No markdown.",
+        )
+        platform_registry.register(entry)
+        try:
+            # Reload prompt_builder so the import-time merge picks up the new entry.
+            import agent.prompt_builder as _pb
+            importlib.reload(_pb)
+            assert "testplatform" in _pb.PLATFORM_HINTS
+            assert "No markdown." in _pb.PLATFORM_HINTS["testplatform"]
+        finally:
+            platform_registry.unregister("testplatform")
+
+    def test_builtin_hint_not_overwritten_by_registry(self):
+        """Hardcoded PLATFORM_HINTS win over registry hints for built-in names."""
+        entry = PlatformEntry(
+            name="telegram",
+            label="FakeTelegram",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            source="plugin",
+            platform_hint="Fake telegram hint.",
+        )
+        platform_registry.register(entry)
+        try:
+            import agent.prompt_builder as _pb
+            importlib.reload(_pb)
+            assert _pb.PLATFORM_HINTS["telegram"] != "Fake telegram hint."
+            assert "Telegram" in _pb.PLATFORM_HINTS["telegram"]
+        finally:
+            platform_registry.unregister("telegram")
+
+
+# ── Standalone sender ──────────────────────────────────────────────────────
+
+
+class TestPluginPlatformStandaloneSend:
+    """Plugin-registered standalone_sender_fn is invoked by _send_to_platform."""
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_fn_routed_by_send_to_platform(self):
+        """_send_to_platform invokes a plugin's standalone_sender_fn directly."""
+        recorded = {}
+
+        async def _stub_sender(
+            pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False
+        ):
+            recorded["args"] = {
+                "pconfig": pconfig,
+                "chat_id": chat_id,
+                "message": message,
+                "thread_id": thread_id,
+                "media_files": media_files,
+                "force_document": force_document,
+            }
+            return {"success": True, "message_id": "msg-123"}
+
+        entry = PlatformEntry(
+            name="testsendplat",
+            label="TestSendPlat",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            source="plugin",
+            standalone_sender_fn=_stub_sender,
+        )
+        platform_registry.register(entry)
+        try:
+            from tools.send_message_tool import _send_to_platform
+            from gateway.config import PlatformConfig
+
+            pconfig = PlatformConfig(enabled=True, token="tok")
+            plat = Platform("testsendplat")
+            result = await _send_to_platform(
+                plat,
+                pconfig,
+                "chat-1",
+                "hello world",
+                thread_id="th-1",
+                media_files=[("/tmp/f.png", False)],
+                force_document=True,
+            )
+            assert isinstance(result, dict)
+            assert result.get("success") is True
+            assert result.get("message_id") == "msg-123"
+            assert recorded["args"]["chat_id"] == "chat-1"
+            assert recorded["args"]["message"] == "hello world"
+            assert recorded["args"]["thread_id"] == "th-1"
+            assert recorded["args"]["media_files"] == [("/tmp/f.png", False)]
+            assert recorded["args"]["force_document"] is True
+        finally:
+            platform_registry.unregister("testsendplat")
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_fn_exception_graceful(self):
+        """If standalone_sender_fn raises, the error is caught and returned."""
+
+        async def _bad_sender(
+            pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False
+        ):
+            raise RuntimeError("network down")
+
+        entry = PlatformEntry(
+            name="testbadplat",
+            label="TestBadPlat",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            source="plugin",
+            standalone_sender_fn=_bad_sender,
+        )
+        platform_registry.register(entry)
+        try:
+            from tools.send_message_tool import _send_to_platform
+            from gateway.config import PlatformConfig
+
+            pconfig = PlatformConfig(enabled=True, token="tok")
+            plat = Platform("testbadplat")
+            result = await _send_to_platform(
+                plat,
+                pconfig,
+                "chat-1",
+                "hello world",
+            )
+            assert isinstance(result, dict)
+            assert result.get("error") == "Plugin standalone send failed: network down"
+        finally:
+            platform_registry.unregister("testbadplat")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -785,6 +785,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     """
     from gateway.config import Platform
 
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
+
     media_files = media_files or []
 
     # Weixin handles text/media delivery inside its native helper and does not
@@ -1081,17 +1083,32 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.YUANBAO:
             result = await _send_yuanbao(chat_id, chunk)
         else:
-            # Plugin platform: route through the gateway's live adapter if
-            # available, otherwise the plugin's standalone_sender_fn.
-            result = await _send_via_adapter(
-                platform,
-                pconfig,
-                chat_id,
-                chunk,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document,
-            )
+            # Plugin platform: check registry for a standalone_sender_fn before
+            # falling back to the generic _send_via_adapter path.
+            from gateway.platform_registry import platform_registry
+            entry = platform_registry.get(platform_name)
+            if entry and entry.standalone_sender_fn:
+                try:
+                    result = await entry.standalone_sender_fn(
+                        pconfig, chat_id, chunk,
+                        thread_id=thread_id,
+                        media_files=media_files,
+                        force_document=force_document,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    result = {"error": f"Plugin standalone send failed: {e}"}
+            else:
+                result = await _send_via_adapter(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    chunk,
+                    thread_id=thread_id,
+                    media_files=media_files,
+                    force_document=force_document,
+                )
 
         if isinstance(result, dict) and result.get("error"):
             return result


### PR DESCRIPTION
## What does this PR do?

Adds two hooks to PlatformEntry so plugin platforms can inject system-prompt hints and send messages from cron/CLI without a live gateway adapter.

- platform_hint — merged into PLATFORM_HINTS at import time so the agent knows how to format responses for the platform.
- standalone_sender_fn — invoked by send_message when no live gateway adapter is present (e.g. cron in a separate process).

## Related Issue

Fixes #64899

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)

## Changes Made

- gateway/platform_registry.py: add values() method to PlatformRegistry; standalone_sender_fn already exists on PlatformEntry.
- agent/prompt_builder.py: merge plugin platform_hint entries into PLATFORM_HINTS after the hardcoded dict is built.
- tools/send_message_tool.py: in _send_to_platform, check the registry for standalone_sender_fn before falling back to _send_via_adapter.
- tests/gateway/test_plugin_platform_parity.py: new tests for hint injection and standalone send routing.
- tests/agent/test_prompt_builder.py: add test for dynamically registered platform hints.

## How to Test

scripts/run_tests.sh tests/gateway/test_plugin_platform_parity.py -v
scripts/run_tests.sh tests/agent/test_prompt_builder.py::TestPluginPlatformHints -v

## Checklist

- [x] Read Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] No duplicate PRs
- [x] Only related changes
- [x] Tests added
- [x] Tested on Ubuntu 24.04
- [x] No docs/config updates needed (N/A)