### PR TITLE
feat(hindsight): add v0.8.4 recall parameters behind feature toggle

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -794,6 +794,15 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
 
+        # v0.8.4+ recall parameters — gated behind enable_recall_v084_params toggle.
+        # When enabled, prefer_observations and min_scores are read from config and
+        # passed to the recall API. The toggle exists so users on older Hindsight
+        # servers can safely keep this disabled — older servers ignore unknown
+        # recall-request fields, but the toggle makes the intent explicit.
+        self._enable_recall_v084_params = False
+        self._prefer_observations = False
+        self._min_scores: dict | None = None
+
         # Bank
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
@@ -1092,6 +1101,9 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
+            {"key": "enable_recall_v084_params", "description": "Enable v0.8.4+ recall parameters (prefer_observations, min_scores). Safe to enable with Hindsight >= 0.8.4 — older servers silently ignore unknown recall-request fields, but the toggle makes the intent explicit.", "default": False},
+            {"key": "prefer_observations", "description": "When recalling observation+raw facts together, drop raw facts superseded by consolidated observations. Requires enable_recall_v084_params=true and Hindsight >= 0.8.4.", "default": False},
+            {"key": "min_scores", "description": "Per-stage score floors for recall. JSON object with optional fields: semantic (0-1, minimum vector similarity), keyword (>=0, minimum BM25 score), reranker (0-1, minimum normalized cross-encoder score), final (minimum final ranking score). Requires enable_recall_v084_params=true and Hindsight >= 0.8.4.", "default": ""},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
@@ -1597,6 +1609,12 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        # v0.8.4+ recall parameters — gated behind explicit toggle so older
+        # Hindsight servers silently ignore unknown keys rather than erroring.
+        self._enable_recall_v084_params = self._config.get("enable_recall_v084_params", False)
+        if self._enable_recall_v084_params:
+            self._prefer_observations = self._config.get("prefer_observations", False)
+            self._min_scores = self._config.get("min_scores", None)
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(
@@ -1770,6 +1788,10 @@ class HindsightMemoryProvider(MemoryProvider):
                         recall_kwargs["tags_match"] = self._recall_tags_match
                     if self._recall_types:
                         recall_kwargs["types"] = self._recall_types
+                    if self._enable_recall_v084_params:
+                        recall_kwargs["prefer_observations"] = self._prefer_observations
+                        if self._min_scores is not None:
+                            recall_kwargs["min_scores"] = self._min_scores
                     logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
                                  self._bank_id, len(query), self._budget)
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
@@ -2004,6 +2026,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     recall_kwargs["tags_match"] = self._recall_tags_match
                 if self._recall_types:
                     recall_kwargs["types"] = self._recall_types
+                if self._enable_recall_v084_params:
+                    recall_kwargs["prefer_observations"] = self._prefer_observations
+                    if self._min_scores is not None:
+                        recall_kwargs["min_scores"] = self._min_scores
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -994,6 +994,32 @@ class HindsightMemoryProvider(MemoryProvider):
                             break
                 env_writes["HINDSIGHT_LLM_API_KEY"] = existing_llm_key
 
+        # Step 3.5: v0.8.4+ recall parameters (optional)
+        print("\n  Advanced recall parameters (Hindsight >= 0.8.4 required):")
+        val = input("  Enable v0.8.4+ recall params? [y/N]: ").strip().lower()
+        if val in ("y", "yes"):
+            provider_config["enable_recall_v084_params"] = True
+            existing_prefer = provider_config.get("prefer_observations", False)
+            val = input(
+                f"  Prefer observations over raw facts? [y/N] (current: {existing_prefer}): "
+            ).strip().lower()
+            if val in ("y", "yes", "n", "no", ""):
+                provider_config["prefer_observations"] = val in ("y", "yes")
+
+            existing_min = provider_config.get("min_scores", "")
+            if existing_min and isinstance(existing_min, dict):
+                import json as _json
+                existing_min = _json.dumps(existing_min)
+            prompt = "  min_scores JSON (e.g. {\"semantic\": 0.7}) [blank to skip]"
+            if existing_min:
+                prompt += f" (current: {existing_min})"
+            prompt += ": "
+            val = input(prompt).strip()
+            if val:
+                provider_config["min_scores"] = val
+        else:
+            provider_config["enable_recall_v084_params"] = False
+
         # Step 4: Save everything
         provider_config.setdefault("bank_id", "hermes")
         provider_config.setdefault("recall_budget", "mid")
@@ -1612,9 +1638,50 @@ class HindsightMemoryProvider(MemoryProvider):
         # v0.8.4+ recall parameters — gated behind explicit toggle so older
         # Hindsight servers silently ignore unknown keys rather than erroring.
         self._enable_recall_v084_params = self._config.get("enable_recall_v084_params", False)
+        self._prefer_observations = False
+        self._min_scores: dict | None = None
+        if self._enable_recall_v084_params:
+            # Guard: these params require hindsight-client >= 0.8.4.
+            try:
+                from importlib.metadata import version as pkg_version
+                from packaging.version import Version
+                installed = pkg_version("hindsight-client")
+                if Version(installed) < Version("0.8.4"):
+                    logger.warning(
+                        "enable_recall_v084_params requires hindsight-client >= 0.8.4 "
+                        "(installed: %s). Feature disabled.", installed,
+                    )
+                    self._enable_recall_v084_params = False
+            except Exception:
+                pass
+
         if self._enable_recall_v084_params:
             self._prefer_observations = self._config.get("prefer_observations", False)
-            self._min_scores = self._config.get("min_scores", None)
+            raw_min_scores = self._config.get("min_scores", None)
+            if raw_min_scores is not None and raw_min_scores != "":
+                if isinstance(raw_min_scores, str):
+                    import json
+                    try:
+                        parsed = json.loads(raw_min_scores)
+                        if isinstance(parsed, dict):
+                            self._min_scores = parsed
+                        else:
+                            logger.warning(
+                                "min_scores must be a JSON object, got %s. Ignored.",
+                                type(parsed).__name__,
+                            )
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "min_scores is not valid JSON: %r. Ignored.",
+                            raw_min_scores[:80],
+                        )
+                elif isinstance(raw_min_scores, dict):
+                    self._min_scores = raw_min_scores
+                else:
+                    logger.warning(
+                        "min_scores must be a JSON object or dict, got %s. Ignored.",
+                        type(raw_min_scores).__name__,
+                    )
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -995,9 +995,12 @@ class HindsightMemoryProvider(MemoryProvider):
         # Step 3.5: v0.8.4+ recall parameters (optional)
         print("\n  Advanced recall parameters (Hindsight >= 0.8.4 required):")
         existing_prefer = provider_config.get("prefer_observations", False)
-        val = input(
-            f"  Prefer observations over raw facts? [y/N] (current: {existing_prefer}): "
-        ).strip().lower()
+        try:
+            val = input(
+                f"  Prefer observations over raw facts? [y/N] (current: {existing_prefer}): "
+            ).strip().lower()
+        except EOFError:
+            val = None  # stdin exhausted (non-interactive) — leave unchanged
         if val in ("y", "yes", "n", "no", ""):
             provider_config["prefer_observations"] = val in ("y", "yes")
 
@@ -1009,14 +1012,18 @@ class HindsightMemoryProvider(MemoryProvider):
         if existing_min:
             prompt += f" (current: {existing_min})"
         prompt += ": "
-        val = input(prompt).strip()
-        if val:
-            provider_config["min_scores"] = val
-        elif "min_scores" in provider_config:
-            # Blank input clears the existing value — consistent with the
-            # prefer_observations prompt above (blank resets to default).
-            del provider_config["min_scores"]
-            print("  min_scores cleared.")
+        try:
+            val = input(prompt).strip()
+        except EOFError:
+            val = None  # stdin exhausted (non-interactive) — leave unchanged
+        if val is not None:
+            if val:
+                provider_config["min_scores"] = val
+            elif "min_scores" in provider_config:
+                # Blank input clears the existing value — consistent with the
+                # prefer_observations prompt above (blank resets to default).
+                del provider_config["min_scores"]
+                print("  min_scores cleared.")
 
         # Step 4: Save everything
         provider_config.setdefault("bank_id", "hermes")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -794,12 +794,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
 
-        # v0.8.4+ recall parameters — gated behind enable_recall_v084_params toggle.
-        # When enabled, prefer_observations and min_scores are read from config and
-        # passed to the recall API. The toggle exists so users on older Hindsight
-        # servers can safely keep this disabled — older servers ignore unknown
-        # recall-request fields, but the toggle makes the intent explicit.
-        self._enable_recall_v084_params = False
+        # v0.8.4+ recall parameters — implicit opt-in: setting prefer_observations
+        # or a non-empty min_scores enables these features. A version guard below
+        # ensures hindsight-client >= 0.8.4 before passing the params.
         self._prefer_observations = False
         self._min_scores: dict | None = None
 
@@ -996,29 +993,24 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Step 3.5: v0.8.4+ recall parameters (optional)
         print("\n  Advanced recall parameters (Hindsight >= 0.8.4 required):")
-        val = input("  Enable v0.8.4+ recall params? [y/N]: ").strip().lower()
-        if val in ("y", "yes"):
-            provider_config["enable_recall_v084_params"] = True
-            existing_prefer = provider_config.get("prefer_observations", False)
-            val = input(
-                f"  Prefer observations over raw facts? [y/N] (current: {existing_prefer}): "
-            ).strip().lower()
-            if val in ("y", "yes", "n", "no", ""):
-                provider_config["prefer_observations"] = val in ("y", "yes")
+        existing_prefer = provider_config.get("prefer_observations", False)
+        val = input(
+            f"  Prefer observations over raw facts? [y/N] (current: {existing_prefer}): "
+        ).strip().lower()
+        if val in ("y", "yes", "n", "no", ""):
+            provider_config["prefer_observations"] = val in ("y", "yes")
 
-            existing_min = provider_config.get("min_scores", "")
-            if existing_min and isinstance(existing_min, dict):
-                import json as _json
-                existing_min = _json.dumps(existing_min)
-            prompt = "  min_scores JSON (e.g. {\"semantic\": 0.7}) [blank to skip]"
-            if existing_min:
-                prompt += f" (current: {existing_min})"
-            prompt += ": "
-            val = input(prompt).strip()
-            if val:
-                provider_config["min_scores"] = val
-        else:
-            provider_config["enable_recall_v084_params"] = False
+        existing_min = provider_config.get("min_scores", "")
+        if existing_min and isinstance(existing_min, dict):
+            import json as _json
+            existing_min = _json.dumps(existing_min)
+        prompt = "  min_scores JSON (e.g. {\"semantic\": 0.7}) [blank to skip]"
+        if existing_min:
+            prompt += f" (current: {existing_min})"
+        prompt += ": "
+        val = input(prompt).strip()
+        if val:
+            provider_config["min_scores"] = val
 
         # Step 4: Save everything
         provider_config.setdefault("bank_id", "hermes")
@@ -1127,9 +1119,8 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
-            {"key": "enable_recall_v084_params", "description": "Enable v0.8.4+ recall parameters (prefer_observations, min_scores). Safe to enable with Hindsight >= 0.8.4 — older servers silently ignore unknown recall-request fields, but the toggle makes the intent explicit.", "default": False},
-            {"key": "prefer_observations", "description": "When recalling observation+raw facts together, drop raw facts superseded by consolidated observations. Requires enable_recall_v084_params=true and Hindsight >= 0.8.4.", "default": False},
-            {"key": "min_scores", "description": "Per-stage score floors for recall. JSON object with optional fields: semantic (0-1, minimum vector similarity), keyword (>=0, minimum BM25 score), reranker (0-1, minimum normalized cross-encoder score), final (minimum final ranking score). Requires enable_recall_v084_params=true and Hindsight >= 0.8.4.", "default": ""},
+            {"key": "prefer_observations", "description": "When recalling observation+raw facts together, drop raw facts superseded by consolidated observations. Requires Hindsight >= 0.8.4.", "default": False},
+            {"key": "min_scores", "description": "Per-stage score floors for recall. JSON object with optional fields: semantic (0-1, minimum vector similarity), keyword (>=0, minimum BM25 score), reranker (0-1, minimum normalized cross-encoder score), final (minimum final ranking score). Requires Hindsight >= 0.8.4.", "default": ""},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
@@ -1635,53 +1626,102 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
-        # v0.8.4+ recall parameters — gated behind explicit toggle so older
-        # Hindsight servers silently ignore unknown keys rather than erroring.
-        self._enable_recall_v084_params = self._config.get("enable_recall_v084_params", False)
-        self._prefer_observations = False
+        # v0.8.4+ recall parameters — implicit opt-in via prefer_observations or
+        # non-empty min_scores. A version guard below ensures hindsight-client
+        # >= 0.8.4 before passing the params.
+
+        # Supported min_scores fields and their valid numeric ranges.
+        # semantic / reranker: [0, 1], keyword: >= 0, final: any numeric.
+        _MIN_SCORE_FIELDS = {
+            "semantic": (0.0, 1.0),
+            "keyword": (0.0, None),
+            "reranker": (0.0, 1.0),
+            "final": (None, None),
+        }
+
+        self._prefer_observations = self._config.get("prefer_observations", False)
         self._min_scores: dict | None = None
-        if self._enable_recall_v084_params:
-            # Guard: these params require hindsight-client >= 0.8.4.
+
+        raw_min_scores = self._config.get("min_scores", None)
+        if raw_min_scores is not None and raw_min_scores != "":
+            parsed = None
+            if isinstance(raw_min_scores, str):
+                import json
+                try:
+                    parsed = json.loads(raw_min_scores)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "min_scores is not valid JSON: %r. Rejected.",
+                        raw_min_scores[:80],
+                    )
+            elif isinstance(raw_min_scores, dict):
+                parsed = raw_min_scores
+            else:
+                logger.warning(
+                    "min_scores must be a JSON object or dict, got %s. Rejected.",
+                    type(raw_min_scores).__name__,
+                )
+
+            if parsed is not None:
+                if not isinstance(parsed, dict):
+                    logger.warning(
+                        "min_scores must be a JSON object, got %s. Rejected.",
+                        type(parsed).__name__,
+                    )
+                else:
+                    # Validate each key and value — fail closed.
+                    valid = True
+                    for key, val in parsed.items():
+                        if key not in _MIN_SCORE_FIELDS:
+                            logger.warning(
+                                "min_scores: unsupported field %r. "
+                                "Supported fields: %s. Rejected.",
+                                key, ", ".join(sorted(_MIN_SCORE_FIELDS)),
+                            )
+                            valid = False
+                            break
+                        if not isinstance(val, (int, float)):
+                            logger.warning(
+                                "min_scores: value for %r must be numeric, got %s. Rejected.",
+                                key, type(val).__name__,
+                            )
+                            valid = False
+                            break
+                        lo, hi = _MIN_SCORE_FIELDS[key]
+                        if lo is not None and val < lo:
+                            logger.warning(
+                                "min_scores: %s must be >= %s, got %s. Rejected.",
+                                key, lo, val,
+                            )
+                            valid = False
+                            break
+                        if hi is not None and val > hi:
+                            logger.warning(
+                                "min_scores: %s must be <= %s, got %s. Rejected.",
+                                key, hi, val,
+                            )
+                            valid = False
+                            break
+
+                    if valid:
+                        self._min_scores = parsed
+
+        # Version guard: if any v0.8.4 param is active, require hindsight-client >= 0.8.4.
+        _v084_active = self._prefer_observations or self._min_scores is not None
+        if _v084_active:
             try:
                 from importlib.metadata import version as pkg_version
                 from packaging.version import Version
                 installed = pkg_version("hindsight-client")
                 if Version(installed) < Version("0.8.4"):
                     logger.warning(
-                        "enable_recall_v084_params requires hindsight-client >= 0.8.4 "
-                        "(installed: %s). Feature disabled.", installed,
+                        "v0.8.4 recall params require hindsight-client >= 0.8.4 "
+                        "(installed: %s). Params disabled.", installed,
                     )
-                    self._enable_recall_v084_params = False
+                    self._prefer_observations = False
+                    self._min_scores = None
             except Exception:
                 pass
-
-        if self._enable_recall_v084_params:
-            self._prefer_observations = self._config.get("prefer_observations", False)
-            raw_min_scores = self._config.get("min_scores", None)
-            if raw_min_scores is not None and raw_min_scores != "":
-                if isinstance(raw_min_scores, str):
-                    import json
-                    try:
-                        parsed = json.loads(raw_min_scores)
-                        if isinstance(parsed, dict):
-                            self._min_scores = parsed
-                        else:
-                            logger.warning(
-                                "min_scores must be a JSON object, got %s. Ignored.",
-                                type(parsed).__name__,
-                            )
-                    except json.JSONDecodeError:
-                        logger.warning(
-                            "min_scores is not valid JSON: %r. Ignored.",
-                            raw_min_scores[:80],
-                        )
-                elif isinstance(raw_min_scores, dict):
-                    self._min_scores = raw_min_scores
-                else:
-                    logger.warning(
-                        "min_scores must be a JSON object or dict, got %s. Ignored.",
-                        type(raw_min_scores).__name__,
-                    )
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(
@@ -1855,10 +1895,10 @@ class HindsightMemoryProvider(MemoryProvider):
                         recall_kwargs["tags_match"] = self._recall_tags_match
                     if self._recall_types:
                         recall_kwargs["types"] = self._recall_types
-                    if self._enable_recall_v084_params:
+                    if self._prefer_observations:
                         recall_kwargs["prefer_observations"] = self._prefer_observations
-                        if self._min_scores is not None:
-                            recall_kwargs["min_scores"] = self._min_scores
+                    if self._min_scores is not None:
+                        recall_kwargs["min_scores"] = self._min_scores
                     logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
                                  self._bank_id, len(query), self._budget)
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
@@ -2093,10 +2133,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     recall_kwargs["tags_match"] = self._recall_tags_match
                 if self._recall_types:
                     recall_kwargs["types"] = self._recall_types
-                if self._enable_recall_v084_params:
+                if self._prefer_observations:
                     recall_kwargs["prefer_observations"] = self._prefer_observations
-                    if self._min_scores is not None:
-                        recall_kwargs["min_scores"] = self._min_scores
+                if self._min_scores is not None:
+                    recall_kwargs["min_scores"] = self._min_scores
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,6 +35,7 @@ import atexit
 import importlib
 import json
 import logging
+import math
 import os
 import queue
 import sys
@@ -1011,6 +1012,11 @@ class HindsightMemoryProvider(MemoryProvider):
         val = input(prompt).strip()
         if val:
             provider_config["min_scores"] = val
+        elif "min_scores" in provider_config:
+            # Blank input clears the existing value — consistent with the
+            # prefer_observations prompt above (blank resets to default).
+            del provider_config["min_scores"]
+            print("  min_scores cleared.")
 
         # Step 4: Save everything
         provider_config.setdefault("bank_id", "hermes")
@@ -1631,12 +1637,13 @@ class HindsightMemoryProvider(MemoryProvider):
         # >= 0.8.4 before passing the params.
 
         # Supported min_scores fields and their valid numeric ranges.
-        # semantic / reranker: [0, 1], keyword: >= 0, final: any numeric.
+        # Per the Hindsight recall API: semantic / reranker / final are
+        # normalized scores in [0, 1], keyword is a BM25 score >= 0.
         _MIN_SCORE_FIELDS = {
             "semantic": (0.0, 1.0),
             "keyword": (0.0, None),
             "reranker": (0.0, 1.0),
-            "final": (None, None),
+            "final": (0.0, 1.0),
         }
 
         self._prefer_observations = self._config.get("prefer_observations", False)
@@ -1687,6 +1694,17 @@ class HindsightMemoryProvider(MemoryProvider):
                             )
                             valid = False
                             break
+                        # NaN and ±Infinity must be rejected explicitly: NaN
+                        # comparisons are always False, so range checks alone
+                        # cannot catch it, and json.dumps would serialize NaN
+                        # into invalid JSON on the wire.
+                        if isinstance(val, float) and not math.isfinite(val):
+                            logger.warning(
+                                "min_scores: value for %r must be finite, got %r. Rejected.",
+                                key, val,
+                            )
+                            valid = False
+                            break
                         lo, hi = _MIN_SCORE_FIELDS[key]
                         if lo is not None and val < lo:
                             logger.warning(
@@ -1720,8 +1738,16 @@ class HindsightMemoryProvider(MemoryProvider):
                     )
                     self._prefer_observations = False
                     self._min_scores = None
-            except Exception:
-                pass
+            except Exception as exc:
+                # Fail closed: if the installed version cannot be determined
+                # (client missing, packaging unavailable), never pass the
+                # v0.8.4 kwargs to an unknown client.
+                logger.warning(
+                    "Could not verify hindsight-client version (%s); "
+                    "v0.8.4 recall params disabled.", exc,
+                )
+                self._prefer_observations = False
+                self._min_scores = None
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1373,3 +1373,158 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+# ---------------------------------------------------------------------------
+# v0.8.4+ recall parameters
+# ---------------------------------------------------------------------------
+
+
+class TestV084RecallParams:
+    """Tests for enable_recall_v084_params: prefer_observations, min_scores."""
+
+    def test_queue_prefetch_passes_v084_params(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Auto-recall (prefetch) path passes v0.8.4 params when enabled."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            enable_recall_v084_params=True,
+            prefer_observations=True,
+            min_scores={"semantic": 0.7, "keyword": 2},
+            recall_tags=["t1"],
+        )
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["prefer_observations"] is True
+        assert call_kwargs["min_scores"] == {"semantic": 0.7, "keyword": 2}
+
+    def test_tool_recall_passes_v084_params(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Tool recall path passes v0.8.4 params when enabled."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            enable_recall_v084_params=True,
+            prefer_observations=True,
+            min_scores={"reranker": 0.5},
+        )
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["prefer_observations"] is True
+        assert call_kwargs["min_scores"] == {"reranker": 0.5}
+
+    def test_no_v084_params_when_disabled(
+        self, provider_with_config,
+    ) -> None:
+        """When toggle is off, v0.8.4 params are absent from both paths."""
+        p = provider_with_config(
+            enable_recall_v084_params=False,
+            prefer_observations=True,
+            min_scores={"semantic": 0.9},
+        )
+
+        # Tool recall
+        p.handle_tool_call("hindsight_recall", {"query": "t1"})
+        kwargs = p._client.arecall.call_args.kwargs
+        assert "prefer_observations" not in kwargs
+        assert "min_scores" not in kwargs
+
+        # Recreate for prefetch test
+        p2 = provider_with_config(
+            enable_recall_v084_params=False,
+            prefer_observations=True,
+            min_scores={"semantic": 0.9},
+        )
+        p2.queue_prefetch("t2")
+        if p2._prefetch_thread:
+            p2._prefetch_thread.join(timeout=5.0)
+        kwargs2 = p2._client.arecall.call_args.kwargs
+        assert "prefer_observations" not in kwargs2
+        assert "min_scores" not in kwargs2
+
+    def test_version_guard_disables_on_old_client(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Toggle is force-disabled when hindsight-client < 0.8.4."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.6.1",
+        )
+        p = provider_with_config(
+            enable_recall_v084_params=True,
+            prefer_observations=True,
+            min_scores={"semantic": 0.7},
+        )
+        # Feature should be disabled despite config saying True
+        assert p._enable_recall_v084_params is False
+        assert p._prefer_observations is False
+        assert p._min_scores is None
+
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        kwargs = p._client.arecall.call_args.kwargs
+        assert "prefer_observations" not in kwargs
+
+    def test_min_scores_parsed_from_json_string(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """min_scores passed as a JSON string is parsed into a dict."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            enable_recall_v084_params=True,
+            min_scores='{"semantic": 0.6, "final": 0.3}',
+        )
+        assert p._min_scores == {"semantic": 0.6, "final": 0.3}
+
+    def test_min_scores_invalid_json_ignored(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Invalid JSON in min_scores is silently ignored."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            enable_recall_v084_params=True,
+            min_scores="not json",
+        )
+        assert p._min_scores is None
+
+    def test_min_scores_non_dict_json_ignored(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """JSON that isn't an object (e.g. array) is ignored."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            enable_recall_v084_params=True,
+            min_scores='[1, 2, 3]',
+        )
+        assert p._min_scores is None
+
+    def test_empty_min_scores_string_ignored(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Empty string for min_scores is treated as not set."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            enable_recall_v084_params=True,
+            min_scores="",
+        )
+        assert p._min_scores is None

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1557,3 +1557,59 @@ class TestV084RecallParams:
             min_scores={"semantic": "high"},
         )
         assert p._min_scores is None
+
+    def test_min_scores_nan_rejected(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """NaN in min_scores is rejected — range checks alone can't catch it
+        (NaN comparisons are always False), and json.dumps would serialize it
+        into invalid JSON on the wire."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            min_scores={"semantic": float("nan")},
+        )
+        assert p._min_scores is None
+
+    def test_min_scores_infinity_rejected(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """±Infinity in min_scores is rejected for every field."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        for field in ("semantic", "keyword", "reranker", "final"):
+            for bad in (float("inf"), float("-inf")):
+                p = provider_with_config(
+                    min_scores={field: bad},
+                )
+                assert p._min_scores is None, (
+                    f"{field}={bad} should be rejected"
+                )
+
+    def test_version_guard_fail_closed_on_error(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """v0.8.4 params are disabled when the client version cannot be
+        verified (fail closed, never pass kwargs to an unknown client)."""
+        def _boom(_pkg: str):
+            raise RuntimeError("distribution not found")
+
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            _boom,
+        )
+        p = provider_with_config(
+            prefer_observations=True,
+            min_scores={"semantic": 0.7},
+        )
+        assert p._prefer_observations is False
+        assert p._min_scores is None
+
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        kwargs = p._client.arecall.call_args.kwargs
+        assert "prefer_observations" not in kwargs
+        assert "min_scores" not in kwargs

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1379,18 +1379,17 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
 
 
 class TestV084RecallParams:
-    """Tests for enable_recall_v084_params: prefer_observations, min_scores."""
+    """Tests for v0.8.4+ recall parameters: prefer_observations, min_scores (implicit opt-in)."""
 
     def test_queue_prefetch_passes_v084_params(
         self, provider_with_config, monkeypatch,
     ) -> None:
-        """Auto-recall (prefetch) path passes v0.8.4 params when enabled."""
+        """Auto-recall (prefetch) path passes v0.8.4 params when configured."""
         monkeypatch.setattr(
             "importlib.metadata.version",
             lambda _: "0.8.4",
         )
         p = provider_with_config(
-            enable_recall_v084_params=True,
             prefer_observations=True,
             min_scores={"semantic": 0.7, "keyword": 2},
             recall_tags=["t1"],
@@ -1406,13 +1405,12 @@ class TestV084RecallParams:
     def test_tool_recall_passes_v084_params(
         self, provider_with_config, monkeypatch,
     ) -> None:
-        """Tool recall path passes v0.8.4 params when enabled."""
+        """Tool recall path passes v0.8.4 params when configured."""
         monkeypatch.setattr(
             "importlib.metadata.version",
             lambda _: "0.8.4",
         )
         p = provider_with_config(
-            enable_recall_v084_params=True,
             prefer_observations=True,
             min_scores={"reranker": 0.5},
         )
@@ -1422,14 +1420,13 @@ class TestV084RecallParams:
         assert call_kwargs["prefer_observations"] is True
         assert call_kwargs["min_scores"] == {"reranker": 0.5}
 
-    def test_no_v084_params_when_disabled(
+    def test_no_v084_params_when_not_set(
         self, provider_with_config,
     ) -> None:
-        """When toggle is off, v0.8.4 params are absent from both paths."""
+        """When prefer_observations is False and min_scores is empty, no v0.8.4 params are passed."""
         p = provider_with_config(
-            enable_recall_v084_params=False,
-            prefer_observations=True,
-            min_scores={"semantic": 0.9},
+            prefer_observations=False,
+            min_scores="",
         )
 
         # Tool recall
@@ -1440,9 +1437,8 @@ class TestV084RecallParams:
 
         # Recreate for prefetch test
         p2 = provider_with_config(
-            enable_recall_v084_params=False,
-            prefer_observations=True,
-            min_scores={"semantic": 0.9},
+            prefer_observations=False,
+            min_scores="",
         )
         p2.queue_prefetch("t2")
         if p2._prefetch_thread:
@@ -1454,18 +1450,16 @@ class TestV084RecallParams:
     def test_version_guard_disables_on_old_client(
         self, provider_with_config, monkeypatch,
     ) -> None:
-        """Toggle is force-disabled when hindsight-client < 0.8.4."""
+        """v0.8.4 params are disabled when hindsight-client < 0.8.4."""
         monkeypatch.setattr(
             "importlib.metadata.version",
             lambda _: "0.6.1",
         )
         p = provider_with_config(
-            enable_recall_v084_params=True,
             prefer_observations=True,
             min_scores={"semantic": 0.7},
         )
-        # Feature should be disabled despite config saying True
-        assert p._enable_recall_v084_params is False
+        # Feature should be disabled despite config being set
         assert p._prefer_observations is False
         assert p._min_scores is None
 
@@ -1482,35 +1476,32 @@ class TestV084RecallParams:
             lambda _: "0.8.4",
         )
         p = provider_with_config(
-            enable_recall_v084_params=True,
             min_scores='{"semantic": 0.6, "final": 0.3}',
         )
         assert p._min_scores == {"semantic": 0.6, "final": 0.3}
 
-    def test_min_scores_invalid_json_ignored(
+    def test_min_scores_invalid_json_rejected(
         self, provider_with_config, monkeypatch,
     ) -> None:
-        """Invalid JSON in min_scores is silently ignored."""
+        """Invalid JSON in min_scores is rejected (fail closed)."""
         monkeypatch.setattr(
             "importlib.metadata.version",
             lambda _: "0.8.4",
         )
         p = provider_with_config(
-            enable_recall_v084_params=True,
             min_scores="not json",
         )
         assert p._min_scores is None
 
-    def test_min_scores_non_dict_json_ignored(
+    def test_min_scores_non_dict_json_rejected(
         self, provider_with_config, monkeypatch,
     ) -> None:
-        """JSON that isn't an object (e.g. array) is ignored."""
+        """JSON that isn't an object (e.g. array) is rejected."""
         monkeypatch.setattr(
             "importlib.metadata.version",
             lambda _: "0.8.4",
         )
         p = provider_with_config(
-            enable_recall_v084_params=True,
             min_scores='[1, 2, 3]',
         )
         assert p._min_scores is None
@@ -1524,7 +1515,45 @@ class TestV084RecallParams:
             lambda _: "0.8.4",
         )
         p = provider_with_config(
-            enable_recall_v084_params=True,
             min_scores="",
+        )
+        assert p._min_scores is None
+
+    def test_min_scores_unsupported_key_rejected(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Unsupported field name in min_scores is rejected (fail closed)."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            min_scores={"semantic": 0.7, "invalid_field": 0.5},
+        )
+        assert p._min_scores is None
+
+    def test_min_scores_out_of_range_rejected(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Out-of-range value in min_scores is rejected."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            min_scores={"semantic": 1.5},
+        )
+        assert p._min_scores is None
+
+    def test_min_scores_non_numeric_value_rejected(
+        self, provider_with_config, monkeypatch,
+    ) -> None:
+        """Non-numeric value in min_scores is rejected."""
+        monkeypatch.setattr(
+            "importlib.metadata.version",
+            lambda _: "0.8.4",
+        )
+        p = provider_with_config(
+            min_scores={"semantic": "high"},
         )
         assert p._min_scores is None


### PR DESCRIPTION
## Summary

Adds support for Hindsight v0.8.4's new recall parameters (`prefer_observations`, `min_scores`) behind an explicit feature toggle.

## Background

Hindsight v0.8.4 introduced two new optional parameters on the recall API:

- **`prefer_observations`** (boolean) — when recalling `observation` alongside raw `world`/`experience` facts, drop raw facts that an observation was consolidated from, so the observation supersedes duplicate content. Freed slots are backfilled.
- **`min_scores`** (object) — per-stage score floors for recall. Supports `semantic` (0-1, vector similarity), `keyword` (>=0, BM25), `reranker` (0-1, cross-encoder), `final` (final ranking). Retrieval-level cutoffs (`semantic`, `keyword`) are pushed into SQL; post-query filters (`reranker`, `final`) are applied after scoring.

Both are already available in `hindsight-client>=0.8.4` as optional `arecall()` kwargs, but the Hermes plugin doesn't currently pass them — meaning config like `prefer_observations: true` in `hindsight/config.json` is silently ignored.

## Changes

Single file: `plugins/memory/hindsight/__init__.py` (+26 lines)

1. **Constructor** (line ~711): new instance vars `_enable_recall_v084_params`, `_prefer_observations`, `_min_scores`, all defaulting to safe (off/False/None) values.

2. **Config schema** (line ~1015): three new entries visible via `hermes memory setup`:
   - `enable_recall_v084_params` — feature toggle (default: false)
   - `prefer_observations` (default: false)
   - `min_scores` (default: "")

3. **initialize()** (line ~1366): reads config when toggle is enabled.

4. **queue_prefetch()** (auto-recall, line ~1529) and **hindsight_recall tool handler** (line ~1762): both pass the params to `client.arecall()` when toggle is active.

## Design Decisions

- **Feature toggle**: `enable_recall_v084_params = false` by default. Users must explicitly opt in. This protects users still on older Hindsight servers — unknown request fields are silently ignored, but the toggle makes the intent explicit and prevents surprises.
- **Minimal footprint**: only the recall-call paths are touched. No changes to core, tests, or other files.
