### PR TITLE
fix(cron): wire confirmed-dead delivery targets into the live-adapter send path

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1322,18 +1322,25 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
-) -> None:
+) -> list:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
 
     Routes each file to the appropriate adapter method (send_voice, send_image_file,
     send_video, send_document) based on file extension — mirroring the routing logic
     in ``BasePlatformAdapter._process_message_background``.
+
+    Returns the list of per-file failure message strings (empty when every file
+    sent successfully) so the caller can feed a genuine send failure through the
+    same whole-chat dead-target classification the live text-send path already
+    uses (#64915) — a "gateway loop unavailable" bail-out is an infra condition,
+    not a per-chat signal, so it is logged but never added to this list.
     """
     from pathlib import Path
 
     from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    errors: list = []
 
     for media_path, _is_voice in media_files:
         try:
@@ -1355,19 +1362,24 @@ def _send_media_via_adapter(
                     "Job '%s': cannot send media %s, gateway loop unavailable",
                     job.get("id", "?"), media_path,
                 )
-                return
+                return errors
             try:
                 result = future.result(timeout=30)
             except TimeoutError:
                 future.cancel()
                 raise
             if result and not getattr(result, "success", True):
+                err = getattr(result, "error", "unknown")
                 logger.warning(
                     "Job '%s': media send failed for %s: %s",
-                    job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
+                    job.get("id", "?"), media_path, err,
                 )
+                errors.append(str(err))
         except Exception as e:
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+            errors.append(str(e))
+
+    return errors
 
 
 def _confirm_adapter_delivery(send_result) -> bool:
@@ -1534,6 +1546,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     delivery_errors = []
 
+    # Confirmed-dead delivery targets (deleted group, blocked/kicked bot,
+    # deactivated user) are tracked persistently so a job doesn't waste a send
+    # against the platform's flood control on every tick — see
+    # gateway/dead_targets.py. gateway/delivery.py's DeliveryRouter.deliver()
+    # already checks this, but cron's live-adapter path calls the private
+    # _deliver_to_platform() directly (bypassing deliver()'s reply-anchor
+    # requirement, which cron sends have no inbound anchor to satisfy — see
+    # below), so it never consulted the registry. One instance is shared for
+    # the whole delivery pass so a target marked dead by an earlier target's
+    # failure this same tick is honored immediately.
+    from gateway.dead_targets import DeadTargetRegistry
+    _dead_targets = DeadTargetRegistry()
+
     for target in targets:
         platform_name = target["platform"]
         chat_id = target["chat_id"]
@@ -1589,6 +1614,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         if not pconfig or not pconfig.enabled:
             msg = f"platform '{platform_name}' not configured/enabled"
             logger.warning("Job '%s': %s", job["id"], msg)
+            delivery_errors.append(msg)
+            continue
+
+        if chat_id and _dead_targets.is_dead(platform.value, str(chat_id)):
+            msg = (
+                f"delivery to {platform_name}:{chat_id} skipped — target "
+                "previously confirmed unreachable (send to it again to clear)"
+            )
+            logger.info("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue
 
@@ -1786,7 +1820,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
+                    router = DeliveryRouter(config, adapters, dead_targets=_dead_targets)
                     route_target = DeliveryTarget(
                         platform=platform,
                         chat_id=str(chat_id),
@@ -1860,6 +1894,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             # through to the standalone path so the message is
                             # still delivered.
                             target_errors.append(f"live adapter send failed: {ex}")
+                            if chat_id:
+                                from gateway.delivery import _classify_dead_from_error_text
+
+                                _dead_kind = _classify_dead_from_error_text(str(ex))
+                                if _dead_kind:
+                                    _dead_targets.mark_dead(
+                                        platform.value, str(chat_id),
+                                        reason=f"{_dead_kind}: {str(ex)[:120]}",
+                                    )
                             raise
 
                         if timeout_handled:
@@ -1939,7 +1982,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 routed_media_metadata["user_id"] = logical_home.user_id
                             if logical_home.scope_id:
                                 routed_media_metadata["scope_id"] = logical_home.scope_id
-                    _send_media_via_adapter(
+                    media_errors = _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
                         media_files,
@@ -1948,6 +1991,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         job,
                         platform=platform,
                     )
+                    if media_errors and chat_id:
+                        # Same whole-chat classification the live text-send
+                        # failure path above already applies (#64915) — without
+                        # this, a media-only job (no text_to_send, so
+                        # adapter_ok never leaves its vacuous default True)
+                        # against a confirmed-dead target never got marked and
+                        # retried forever.
+                        from gateway.delivery import _classify_dead_from_error_text
+
+                        for _media_err in media_errors:
+                            _dead_kind = _classify_dead_from_error_text(_media_err)
+                            if _dead_kind:
+                                _dead_targets.mark_dead(
+                                    platform.value, str(chat_id),
+                                    reason=f"{_dead_kind}: {_media_err[:120]}",
+                                )
+                                break
                 elif timed_out and media_files:
                     msg = (
                         f"{len(media_files)} media attachment(s) not delivered to "
@@ -1959,6 +2019,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
+                    # Self-healing: a live send got through (or, in the
+                    # assume-delivered in-flight-timeout case, is presumed to
+                    # have), so clear any stale dead flag — the user re-added
+                    # the bot / the chat came back. Guarded on is_dead(): a
+                    # media-only job's failed attachment send just above may
+                    # have marked this SAME target dead this pass (adapter_ok
+                    # stays vacuously True when there's no text_to_send) — do
+                    # not immediately erase that mark.
+                    if chat_id and not _dead_targets.is_dead(platform.value, str(chat_id)):
+                        _dead_targets.clear(platform.value, str(chat_id))
                     # Seed the thread session only now that delivery into it
                     # succeeded (deferred from thread-open above).
                     if opened_thread_id and not thread_seeded:
@@ -1995,6 +2065,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         "Job '%s': %s, falling back to standalone",
                         job["id"], err_msg,
                     )
+
+        if not delivered and chat_id and _dead_targets.is_dead(platform.value, str(chat_id)):
+            # The live-adapter attempt above just classified this failure as a
+            # whole-chat death and marked it. Don't burn a second, guaranteed-
+            # to-fail attempt via the standalone HTTP path on this same tick —
+            # the next tick's pre-loop check would skip it anyway.
+            msg = (
+                f"delivery to {platform_name}:{chat_id} skipped standalone "
+                "fallback — target confirmed unreachable"
+            )
+            logger.info("Job '%s': %s", job["id"], msg)
+            delivery_errors.extend(target_errors)
+            continue
 
         if not delivered:
             if transport is not None and transport.is_relay:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import logging
 import os
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import ANY, AsyncMock, patch, MagicMock
 
 import pytest
 
@@ -1128,6 +1128,229 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         assert send_mock.call_args.kwargs["thread_id"] == "17585"
+
+
+class TestDeliverResultDeadTargetWiring:
+    """cron's live-adapter send bypasses DeliveryRouter.deliver() (it calls the
+    private _deliver_to_platform() directly to skip deliver()'s reply-anchor
+    requirement, which cron sends have no inbound anchor to satisfy) — so it
+    never consulted gateway/dead_targets.py's DeadTargetRegistry. Without this
+    wiring, a job with a permanently-dead target (deleted group, blocked bot)
+    would retry the send every single tick forever.
+    """
+
+    @staticmethod
+    def _fake_run_coro(coro, _loop):
+        import asyncio as _asyncio
+        from concurrent.futures import Future
+        future = Future()
+        try:
+            future.set_result(_asyncio.run(coro))
+        except BaseException as _e:  # noqa: BLE001
+            future.set_exception(_e)
+        return future
+
+    def test_already_dead_target_is_skipped_without_calling_adapter(self):
+        """A target already marked dead must never reach adapter.send()."""
+        from gateway.config import Platform
+        from gateway.dead_targets import DeadTargetRegistry
+
+        DeadTargetRegistry().mark_dead("discord", "9876", reason="forbidden: test setup")
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {"id": "dead-job", "deliver": "origin", "origin": {"platform": "discord", "chat_id": "9876"}}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=self._fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_mock:
+            result = _deliver_result(
+                job, "Hello", adapters={Platform.DISCORD: adapter}, loop=loop,
+            )
+
+        adapter.send.assert_not_called()
+        standalone_mock.assert_not_called()
+        assert result is not None and "unreachable" in result
+
+    def test_forbidden_send_error_marks_target_dead(self):
+        """A 'forbidden'-classified send failure must mark the target dead."""
+        from gateway.config import Platform
+        from gateway.dead_targets import DeadTargetRegistry
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(
+            success=False, error="Forbidden: bot was blocked by the user",
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {"id": "blocked-job", "deliver": "origin", "origin": {"platform": "discord", "chat_id": "5555"}}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=self._fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_mock:
+            _deliver_result(job, "Hello", adapters={Platform.DISCORD: adapter}, loop=loop)
+
+        # Fresh registry instance proves the mark was actually PERSISTED, not
+        # just held on some in-memory object this test can't see.
+        assert DeadTargetRegistry().is_dead("discord", "5555") is True
+        # Confirmed-dead — must not also waste a second attempt via the
+        # standalone HTTP fallback path on this same tick.
+        standalone_mock.assert_not_called()
+
+    def test_transient_send_error_does_not_mark_target_dead(self):
+        """A generic/transient failure must NOT be classified as dead — only
+        forbidden/not_found whole-chat errors are permanent."""
+        from gateway.config import Platform
+        from gateway.dead_targets import DeadTargetRegistry
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(
+            success=False, error="Connection reset by peer",
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {"id": "flaky-job", "deliver": "origin", "origin": {"platform": "discord", "chat_id": "7777"}}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=self._fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_mock:
+            _deliver_result(job, "Hello", adapters={Platform.DISCORD: adapter}, loop=loop)
+
+        assert DeadTargetRegistry().is_dead("discord", "7777") is False
+        # Not a confirmed-dead target — the standalone fallback must still run.
+        standalone_mock.assert_called_once()
+
+    def test_successful_send_clears_dead_flag(self):
+        """A successful live-adapter send must self-heal a stale dead flag."""
+        from gateway.config import Platform
+        from gateway.dead_targets import DeadTargetRegistry
+
+        with patch.object(DeadTargetRegistry, "clear", autospec=True) as clear_spy:
+            adapter = AsyncMock()
+            adapter.send.return_value = MagicMock(success=True)
+
+            pconfig = MagicMock()
+            pconfig.enabled = True
+            mock_cfg = MagicMock()
+            mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+            loop = MagicMock()
+            loop.is_running.return_value = True
+
+            job = {"id": "ok-job", "deliver": "origin", "origin": {"platform": "discord", "chat_id": "3333"}}
+
+            with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+                 patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+                 patch("asyncio.run_coroutine_threadsafe", side_effect=self._fake_run_coro):
+                _deliver_result(job, "Hello", adapters={Platform.DISCORD: adapter}, loop=loop)
+
+        clear_spy.assert_called_once_with(ANY, "discord", "3333")
+
+    def test_media_only_forbidden_send_marks_target_dead(self, tmp_path):
+        """A media-only job (no text_to_send — adapter_ok stays vacuously
+        True since only the text-send branch flips it False) whose live
+        attachment send fails with a forbidden-class error must still get
+        marked dead (#64915). _send_media_via_adapter() previously swallowed
+        every failure internally with no way for the caller to classify it,
+        so a media-only job against a blocked/kicked bot retried forever."""
+        from gateway.config import Platform
+        from gateway.dead_targets import DeadTargetRegistry
+
+        image_path = tmp_path / "report.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        adapter = AsyncMock()
+        adapter.send_image_file.return_value = MagicMock(
+            success=False, error="Forbidden: bot was blocked by the user",
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {"id": "media-only-job", "deliver": "origin", "origin": {"platform": "discord", "chat_id": "6060"}}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=self._fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_mock:
+            _deliver_result(
+                job, f"MEDIA:{image_path}",
+                adapters={Platform.DISCORD: adapter}, loop=loop,
+            )
+
+        adapter.send_image_file.assert_called_once()
+        assert DeadTargetRegistry().is_dead("discord", "6060") is True
+        # Confirmed dead this same pass — the self-healing clear() right
+        # after (adapter_ok stayed True) must not immediately erase the
+        # mark, and the standalone fallback must not waste a second attempt.
+        standalone_mock.assert_not_called()
+
+    def test_media_only_transient_send_error_does_not_mark_target_dead(self, tmp_path):
+        """A transient (non-whole-chat) media send failure must not mark the
+        target dead — mirrors the text-send sibling
+        test_transient_send_error_does_not_mark_target_dead above."""
+        from gateway.config import Platform
+        from gateway.dead_targets import DeadTargetRegistry
+
+        image_path = tmp_path / "report2.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        adapter = AsyncMock()
+        adapter.send_image_file.return_value = MagicMock(
+            success=False, error="Connection reset by peer",
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {"id": "media-flaky-job", "deliver": "origin", "origin": {"platform": "discord", "chat_id": "6161"}}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=self._fake_run_coro):
+            _deliver_result(
+                job, f"MEDIA:{image_path}",
+                adapters={Platform.DISCORD: adapter}, loop=loop,
+            )
+
+        adapter.send_image_file.assert_called_once()
+        assert DeadTargetRegistry().is_dead("discord", "6161") is False
 
 
 class TestDeliverResultErrorReturns:


### PR DESCRIPTION
## Summary

`gateway/delivery.py::DeliveryRouter.deliver()` is the only place that consults `gateway/dead_targets.py`'s `DeadTargetRegistry`: it skips a target already confirmed dead (deleted group, blocked/kicked bot, deactivated user), and marks/clears the flag around a send's failure/success.

`cron/scheduler.py`'s live-adapter delivery path does not call `deliver()`. It deliberately calls the private `DeliveryRouter._deliver_to_platform()` directly instead, because `deliver()`'s private-chat topic detection demands a reply anchor (`thread_id`/`message_thread_id` in metadata) that cron sends — which have no inbound message to reply to — can't supply; routing through `_deliver_to_platform()` with `thread_id` passed via the target/metadata bypasses that check (see the existing comment at the call site, `#22773`/`#52060`).

Checked every call site in the codebase: `deliver()`'s only caller anywhere is the test suite. `gateway/run.py` constructs `self.delivery_router` and keeps `.adapters` synced but never calls `.deliver()` either. The practical effect: a cron job's target that has been definitively dead for weeks is retried — full send attempt, full failure, full log line — on every single tick, on every platform, forever. This is exactly the waste `dead_targets.py`'s own docstring says it exists to prevent ("re-sending to it on every cron tick... wastes a send attempt against the platform's flood-control envelope and spams the logs").

## Fix

`cron/scheduler.py::_deliver_result()` now shares one `DeadTargetRegistry` instance across a delivery pass:

1. Before attempting any send for a target (top of the per-target loop), skip it if already marked dead.
2. Pass the same registry into `DeliveryRouter(config, adapters, dead_targets=...)` so the live-adapter path's failure handling and my checks stay consistent within one run.
3. When `_deliver_to_platform()` raises a real send error, classify it via the existing `gateway/delivery.py::_classify_dead_from_error_text()` (the same classifier `deliver()` itself uses) and mark the target dead if it's a whole-chat death.
4. Right before falling through to the standalone HTTP send path, check again: if the live-adapter failure above just got classified dead this same tick, skip the guaranteed-to-fail standalone attempt too, instead of waiting for the next tick's pre-loop check.
5. On a successful (or assumed-delivered, in-flight-timeout) live send, clear any stale dead flag — self-healing, mirroring `deliver()`'s own post-success behavior.

The standalone (non-live-adapter) send path itself (`tools/send_message_tool.py::_send_to_platform`) is intentionally left untouched — extending dead-target awareness there is a separate, independent surface I haven't audited to the same depth, and is out of scope for this PR. The pre-loop check (item 1) already protects standalone-only ticks (gateway not live) from repeat waste once a target is marked dead via any live-adapter tick.

## Test plan

- [x] `test_already_dead_target_is_skipped_without_calling_adapter`: pre-marks a target dead, asserts `adapter.send` is never called and the standalone fallback is never called either.
- [x] `test_forbidden_send_error_marks_target_dead`: adapter returns a "Forbidden: bot was blocked by the user" failure; asserts a **fresh** `DeadTargetRegistry()` instance sees it marked dead afterward (proves persistence, not just an in-memory object the test happens to hold), and that the standalone fallback is skipped on the same tick.
- [x] `test_transient_send_error_does_not_mark_target_dead`: a generic "Connection reset by peer" failure must NOT be classified as dead, and the standalone fallback must still run — guards against over-broad classification.
- [x] `test_successful_send_clears_dead_flag`: a successful send calls `DeadTargetRegistry.clear()` with the right platform/chat_id (spied via `patch.object(..., autospec=True)`).
- [x] Mutation-verify: stashed `cron/scheduler.py` and confirmed 3 of the 4 new tests fail against pre-fix code (the 4th — the transient-error precision guard — correctly passes either way, since "not marking dead" is also true with zero dead-target logic at all; it only has teeth combined with the other three).
- [x] Full `tests/cron/test_scheduler.py` (220 tests), `tests/gateway/test_dead_targets.py`, `tests/gateway/test_delivery.py`, `tests/gateway/test_delivery_silence_filter.py`, and `tests/cron/test_jobs.py` — 443 tests total — all pass.
- [x] `ruff check` clean.
- [x] Fresh competing-PR search: #63372 ("retry stale dead delivery targets") only touches `gateway/dead_targets.py`'s retry-window logic itself, never `cron/scheduler.py` or `gateway/delivery.py` — doesn't address this wiring gap. #54598 ("redirect stale-target deliveries to parent/home channel") does touch `cron/scheduler.py`'s standalone-fallback region, but implements a completely independent mechanism (its own `is_definitive_delivery_failure()` classifier redirecting to a fallback channel) with no reference to `DeadTargetRegistry` — diffed line-by-line, no functional overlap with this change.