### PR TITLE
fix(openai-codex): strip colon provider prefix in normalize_model_for_provider (#64787)

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -224,23 +224,25 @@ def _normalize_provider_alias(provider_name: str) -> str:
 
 
 def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> str:
-    """Strip ``provider/`` only when the prefix matches the target provider.
+    """Strip ``provider/`` or ``provider:`` only when the prefix matches.
 
-    This prevents arbitrary slash-bearing model IDs from being mangled on
-    native providers while still repairing manual config values like
-    ``zai/glm-5.1`` for the ``zai`` provider.
+    ``parse_model_input`` splits on ``:`` (``openai-codex:gpt-5.6-sol``),
+    but some callers supply a ``/``-delineated name.  Handle both so the
+    colon prefix used by CLI ``-m provider:model`` gets stripped too.
+
+    This prevents arbitrary slash/colon-bearing model IDs from being
+    mangled on native providers while still repairing manual config
+    values like ``zai/glm-5.1`` for the ``zai`` provider.
     """
-    if "/" not in model_name:
-        return model_name
-
-    prefix, remainder = model_name.split("/", 1)
-    if not prefix.strip() or not remainder.strip():
-        return model_name
-
-    normalized_prefix = _normalize_provider_alias(prefix)
-    normalized_target = _normalize_provider_alias(target_provider)
-    if normalized_prefix and normalized_prefix == normalized_target:
-        return remainder.strip()
+    for sep in ("/", ":"):
+        if sep in model_name:
+            prefix, remainder = model_name.split(sep, 1)
+            if not prefix.strip() or not remainder.strip():
+                continue
+            normalized_prefix = _normalize_provider_alias(prefix)
+            normalized_target = _normalize_provider_alias(target_provider)
+            if normalized_prefix and normalized_prefix == normalized_target:
+                return remainder.strip()
     return model_name
 
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -145,6 +145,26 @@ class TestCopilotModelNormalization:
         """Regression: openai-codex must still strip the openai/ prefix."""
         assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"
 
+    def test_openai_codex_strips_colon_prefix(self):
+        """``openai-codex:gpt-5.6-sol`` must strip the colon prefix (#64787).
+
+        ``parse_model_input`` splits on ``:`` (``openai-codex:gpt-5.6-sol``),
+        but ``_strip_matching_provider_prefix`` only handled ``/`` so the
+        colon-delineated prefix survived all the way to the API, causing
+        HTTP 400 (``model not supported``).
+        """
+        assert normalize_model_for_provider("openai-codex:gpt-5.6-sol", "openai-codex") == "gpt-5.6-sol"
+        # Non-matching colon prefix should be preserved unchanged.
+        result = normalize_model_for_provider("other:model", "openai-codex")
+        assert result == "other:model"
+        # Copilot colon prefix should also work.
+        result = normalize_model_for_provider("copilot:claude-sonnet-4.6", "copilot")
+        assert result == "claude-sonnet-4.6"
+        # Bare model name still passes through.
+        assert normalize_model_for_provider("gpt-5.6-sol", "openai-codex") == "gpt-5.6-sol"
+        # Slash syntax still works alongside colon.
+        assert normalize_model_for_provider("openai-codex/gpt-5.6-sol", "openai-codex") == "gpt-5.6-sol"
+
 
 # ── Aggregator providers (regression) ──────────────────────────────────
 


### PR DESCRIPTION
## Problem

When selecting the Codex provider with Hermes `provider:model` syntax:

    hermes chat -m openai-codex:gpt-5.6-sol

the request fails with HTTP 400 — the model name is sent with the `openai-codex:` prefix still attached.

## Root cause

`_strip_matching_provider_prefix` only handled `/` separator, but `parse_model_input` (used by `-m`/`/model`) splits on `:`. So `openai-codex:gpt-5.6-sol` survived normalization unchanged, while `openai/gpt-5.4` worked fine.

## Fix

Changed `_strip_matching_provider_prefix` to iterate over both `/` and `:` separators, matching whichever splits into `prefix + remainder` and stripping only when the normalized prefix matches the target provider.

## Verification

| Input | Provider | Before | After |
|-------|----------|--------|-------|
| `openai-codex:gpt-5.6-sol` | openai-codex | `openai-codex:gpt-5.6-sol` ❌ | `gpt-5.6-sol` ✅ |
| `openai-codex/gpt-5.6-sol` | openai-codex | `gpt-5.6-sol` ✅ | `gpt-5.6-sol` ✅ |
| `copilot:claude-sonnet-4.6` | copilot | `copilot:claude-sonnet-4.6` ❌ | `claude-sonnet-4.6` ✅ |
| `other:model` | openai-codex | `other:model` ✅ | `other:model` ✅ |
| `gpt-5.6-sol` | openai-codex | `gpt-5.6-sol` ✅ | `gpt-5.6-sol` ✅ |

Fixes #64787