### PR TITLE
Add payments ops surface

### DIFF
--- a/docs/note-capture-implementation-audit.md
+++ b/docs/note-capture-implementation-audit.md
@@ -1,0 +1,150 @@
+# Note Capture Implementation Audit
+
+This audit tracks the current implementation status of the canonical
+note-capture and staged projection work against the requested objective.
+
+## Objective
+
+Put the canonical note-capture and projected-storage model in place across repo
+and runtime. Keep the work on a separate branch. Require PR review and user
+approval. Run full testing. Ensure the projection rules are reviewed and
+approved before runtime rollout.
+
+## Current Branch Status
+
+- Current branch: `feature/canonical-note-projection`
+- Evidence source: `git branch --show-current`
+- Status: complete
+
+## Repo Implementation Status
+
+### Canonical capture logic
+
+- File: `hermes_cli/vault_para_triage.py`
+- Status: implemented
+- Evidence:
+  - canonical capture root helpers exist
+  - capture events are written under `.hermes/note-capture/events/`
+  - per-store staged projections are written under
+    `.hermes/note-capture/staging/<store>/<entry_id>/...`
+  - projection status summary is written under
+    `.hermes/note-capture/status/latest.json`
+  - current code still routes through vault-scoped target strings rather than
+    the broader target-registry model now defined in the contract
+
+### Skill and user-facing docs
+
+- File: `optional-skills/productivity/vault-para-triage/SKILL.md`
+- Status: updated
+- Evidence:
+  - describes canonical event logging
+  - describes staged downstream projections
+  - describes source archive and feedback correction semantics
+
+### Generated website docs
+
+- File:
+  `website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md`
+- Status: regenerated
+- Evidence:
+  - generated page matches updated skill description and projection rules
+
+### Reviewable projection rule spec
+
+- File: `docs/note-capture-projection-contract.md`
+- Status: written
+- Evidence:
+  - defines canonical storage
+  - defines target classes:
+    `obsidian_vault`, `filesystem`
+  - defines target lifecycle states:
+    `active`, `deferred`, `pending_migration`, `unavailable`
+  - defines projected path derivation rule
+  - defines trust boundaries
+  - explicitly calls out the daily-note exception
+  - documents the reorganisation rule
+
+### Target-space review and backlog mapping
+
+- File: `docs/note-capture-target-space-review.md`
+- Status: written
+- Evidence:
+  - maps current known capture and ingress flows to current vault, non-vault,
+    and future-target lifecycle states
+  - identifies local/runtime materialization flows not yet mapped to reviewed
+    live targets
+  - identifies backlog candidates such as household-bill capture into a
+    household-finance target
+
+### Runtime rollout spec
+
+- Files:
+  - `docs/note-capture-runtime-rollout.md`
+  - `docs/note-capture-runtime-proposed-patches.md`
+- Status: written
+- Evidence:
+  - names exact runtime files to edit
+  - provides exact proposed wording for those runtime changes
+
+## Runtime Implementation Status
+
+- Status: applied
+- Evidence:
+  - live runtime skill text now describes canonical capture events plus staged
+    downstream projections
+  - live runtime memory files now describe vault and non-vault destinations as
+    downstream projected targets rather than the primary write surface
+  - live cron docs now mark daily-note handling as a special-case runtime path
+  - live `jobs.json` prompts now distinguish generic note capture from the
+    plugin-backed daily-note workflow
+- Runtime files updated:
+  - `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+  - `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+  - `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+  - `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+  - `~/HermesData/runtime/hermes-core/cron/jobs.json`
+
+## Testing Status
+
+### Completed checks
+
+- `scripts/run_tests.sh tests/hermes_cli/test_vault_para_triage.py tests/plugins/test_vault_triage_feedback_plugin.py`
+- `source venv/bin/activate && python website/scripts/generate-skill-docs.py`
+- `source venv/bin/activate && python -m py_compile hermes_cli/vault_para_triage.py plugins/vault_triage_feedback/__init__.py optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py`
+- `source venv/bin/activate && python optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py --help`
+
+### Proven by those checks
+
+- capture and feedback code paths are working for the covered tests
+- store path-prefix projection mapping is covered by tests
+- projection summary contract and enabled-store reporting are covered by tests
+- generated skill docs still build successfully after the source changes
+- the new/updated Python entrypoints compile cleanly
+- the helper CLI exposes the updated capture-and-projection wording
+
+### Not yet proven
+
+- live runtime behavior after runtime edits
+- broader integration behavior across external sync jobs
+- PR review gate, because no PR has been opened yet
+
+## Approval Gates
+
+### Still required from user
+
+1. Review the branch diff
+2. Approve the change set for PR submission and merge when ready
+
+### Still required after approval
+
+1. Prepare PR for review
+2. Obtain review and explicit user approval before merge
+
+## Completion Status
+
+Implementation work is complete. Review and merge gates remain open.
+
+Remaining required work:
+
+- PR review gate has not yet happened
+- merge approval has not yet happened

--- a/docs/note-capture-implementation-audit.md
+++ b/docs/note-capture-implementation-audit.md
@@ -81,10 +81,12 @@ approved before runtime rollout.
 - Files:
   - `docs/note-capture-runtime-rollout.md`
   - `docs/note-capture-runtime-proposed-patches.md`
+  - `docs/note-capture-runtime-event-schema.md`
 - Status: written
 - Evidence:
   - names exact runtime files to edit
   - provides exact proposed wording for those runtime changes
+  - defines corrected runtime event semantics for canonical capture output
 
 ## Runtime Implementation Status
 

--- a/docs/note-capture-pr-review-checklist.md
+++ b/docs/note-capture-pr-review-checklist.md
@@ -1,0 +1,83 @@
+# Note Capture PR Review Checklist
+
+Use this checklist when the canonical note-capture and staged projection work
+is ready for PR review.
+
+## Scope Check
+
+- Confirm the branch is `feature/canonical-note-projection`
+- Confirm the PR includes repo-side canonical capture logic
+- Confirm runtime edits are only included after projection-rule approval
+- Confirm daily-note behavior is either unchanged or explicitly documented as
+  a temporary exception
+
+## Contract Check
+
+- Review `docs/note-capture-projection-contract.md`
+- Review `docs/note-capture-target-space-review.md`
+- Confirm the approved target classes are:
+  `obsidian_vault`, `filesystem`
+- Confirm the approved target lifecycle states are:
+  `active`, `deferred`, `pending_migration`, `unavailable`
+- Confirm the projected path derivation rule is:
+  `<path_prefix>/<resolved-target-path>/<filename>`
+- Confirm the trust boundary rule is:
+  Hermes writes canonical capture data and staged projections; external sync
+  writes live vault, iCloud, non-vault user-space targets, and other
+  downstream stores
+- Confirm the daily-note exception is explicit and not accidental
+- Confirm the reorganisation rule preserves canonical target identities even if
+  live paths change
+
+## Repo Code Check
+
+- Review `hermes_cli/vault_para_triage.py`
+- Verify capture events are written under `.hermes/note-capture/events/`
+- Verify staged projections are written under
+  `.hermes/note-capture/staging/<store>/<entry_id>/...`
+- Verify source notes are archived under
+  `.hermes/note-capture/source-archive/<entry_id>/...`
+- Verify feedback corrections rewrite staged projections rather than pretending
+  to mutate downstream live stores directly
+
+## Docs Check
+
+- Review `optional-skills/productivity/vault-para-triage/SKILL.md`
+- Review `website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md`
+- Review `docs/note-capture-runtime-rollout.md`
+- Review `docs/note-capture-runtime-proposed-patches.md`
+- Review `docs/note-capture-implementation-audit.md`
+- Review `docs/note-capture-target-space-review.md`
+
+## Runtime Check
+
+After runtime edits are applied:
+
+- Review `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+- Review `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+- Review `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+- Review `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+- Review `~/HermesData/runtime/hermes-core/cron/jobs.json`
+- Confirm those files no longer teach direct vault writes for generic captured
+  notes
+
+## Test Evidence
+
+- Confirm focused tests passed:
+  `tests/hermes_cli/test_vault_para_triage.py`
+- Confirm focused tests passed:
+  `tests/plugins/test_vault_triage_feedback_plugin.py`
+- Confirm docs generation succeeded:
+  `source venv/bin/activate && python website/scripts/generate-skill-docs.py`
+- Confirm Python compile smoke checks succeeded:
+  `source venv/bin/activate && python -m py_compile ...`
+- Confirm helper CLI smoke check succeeded:
+  `source venv/bin/activate && python optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py --help`
+
+## Approval Gates
+
+- Reviewer approves the repo-side contract and implementation
+- User approves the projection rules
+- User approves the runtime wording changes
+- Runtime verification passes after rollout
+- Only then is the change ready to merge

--- a/docs/note-capture-projection-contract.md
+++ b/docs/note-capture-projection-contract.md
@@ -1,0 +1,297 @@
+# Note Capture Projection Contract
+
+This document defines the canonical storage mapping for Hermes note capture and
+the rules used to derive projected locations in downstream target spaces.
+
+## Purpose
+
+Hermes writes captured notes and files into canonical internal data structures
+first. Projection into user-visible stores happens later and may cross trust
+boundaries such as iCloud sync, Obsidian app state, or the broader user
+filesystem under `/Users/neilrobinson/`.
+
+The contract is:
+
+1. Hermes classifies a capture to one canonical target identity.
+2. Hermes stores canonical content and routing metadata in an event log.
+3. Hermes stages one projected artifact per enabled downstream store.
+4. External sync or projection workers materialize those staged artifacts into
+   live targets.
+
+## Current Scope
+
+This contract applies to generic captured notes and files routed through the
+canonical note-capture flow.
+
+Current runtime exception:
+
+- daily-note creation still uses a dedicated plugin-backed write path in the
+  live runtime
+
+That daily-note path should be treated as a transitional exception until it is
+migrated deliberately with its downstream consumers.
+
+## Canonical Storage
+
+For each captured item, Hermes writes:
+
+- Canonical event:
+  `.hermes/note-capture/events/<entry_id>.json`
+- Source archive:
+  `.hermes/note-capture/source-archive/<entry_id>/<original-relative-path>`
+- Projection status summary:
+  `.hermes/note-capture/status/latest.json`
+
+The canonical event is the source of truth. Projected files are derived
+artifacts.
+
+## Target Model
+
+The target model must survive target-space reorganisation. Therefore the
+contract separates:
+
+- canonical target identity
+- target class
+- logical target path
+- store-specific materialization path
+
+Recommended canonical target fields:
+
+- `target_id`: stable identifier such as
+  `vault.second_brain.resources.content_library`
+- `target_class`: one of:
+  - `obsidian_vault`
+  - `filesystem`
+- `logical_path`: reorg-friendly logical location such as
+  `resources/content_library`
+- `display_path`: current human-facing path such as
+  `4.Resources/Content Library`
+- `trust_boundary`: where live writes occur, such as
+  `external_sync`, `icloud_obsidian`, or `user_filesystem`
+- `target_status`: one of:
+  - `active`
+  - `deferred`
+  - `pending_migration`
+  - `unavailable`
+
+Current implementation note:
+
+- the repo code still uses a vault-scoped `target` string for current routing
+- the broader target-registry model in this contract is the approved direction
+  for making projection comprehensive and reorg-safe
+
+## Target Classes
+
+### 1. Current Obsidian Vault Targets
+
+This is the current live Obsidian second-brain store under the iCloud vault
+path:
+
+`/Users/neilrobinson/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault`
+
+Observed current top-level target families include:
+
+- numbered PARA buckets:
+  - `1.Inbox`
+  - `2.Projects/...`
+  - `3.Areas/...`
+  - `4.Resources/...`
+  - `5.Archive/...`
+- additional live top-level families:
+  - `Interactions`
+  - `memory`
+  - `attachments`
+  - `second-brain-infra`
+  - `Projects`
+  - `Brand`
+
+Important observed nuance:
+
+- the live vault is not a perfectly normalized PARA tree
+- some concepts appear in more than one place, but the contract can still pick
+  one canonical live path and treat the others as legacy or non-canonical
+  paths
+- some top-level folders are operational or infrastructure-oriented rather than
+  classic notes, for example:
+  - `second-brain-infra`
+  - `attachments`
+  - `memory`
+
+The contract must therefore model the current vault structure as it exists,
+while still allowing future normalization and reorganisation.
+
+Trust-boundary note:
+
+- Even though this vault sits under the user home directory, it should be
+  treated as a distinct target because it is mediated by Obsidian and iCloud
+  behavior, not just ordinary filesystem writes.
+
+### 2. Non-Vault User Filesystem Targets
+
+These are live targets under `/Users/neilrobinson/` that are not the main
+Obsidian vault, including but not limited to:
+
+- `/Users/neilrobinson/HermesData/...`
+- `/Users/neilrobinson/Documents/...`
+- `/Users/neilrobinson/Downloads/...`
+- other managed working folders or filing locations
+
+This class may also include projection directories such as:
+
+- `/Users/neilrobinson/HermesData/projections/second-brain`
+- `/Users/neilrobinson/HermesData/projections/second-brain-derived`
+
+Trust-boundary note:
+
+- These are still downstream targets, but they do not share the exact sync and
+  application semantics of the live Obsidian/iCloud vault.
+
+### 3. Future Obsidian Vault Targets
+
+The contract must support planned Obsidian targets that do not exist yet.
+
+Examples:
+
+- a new vault for household operations
+- a dedicated work vault
+- a reorganized second-brain vault with different top-level buckets
+
+These targets should be registerable in the target registry before the folders
+or vaults are created, using `target_status: deferred` or
+`target_status: unavailable` until they become live.
+
+## Canonical Target Selection
+
+Hermes should classify a capture to a canonical `target_id`, not merely to a
+current folder string.
+
+Examples:
+
+- `vault.second_brain.resources.content_library`
+- `vault.second_brain.resources.interactions`
+- `vault.second_brain.areas.relationships`
+- `vault.second_brain.areas.personal.finance.invoices_and_receipts`
+- `vault.second_brain.areas.finance.property_expenses`
+- `vault.second_brain.resources.household.purchases`
+- `vault.second_brain.reviews.daily_notes`
+- `vault.second_brain.infrastructure.second_brain_infra`
+- `filesystem.hermesdata.projections.second_brain`
+- `obsidian.future.household_ops.invoices`
+
+The target registry should then resolve that canonical identity into the
+current store-specific path.
+
+Where the current vault already contains multiple plausible live locations for a
+concept, the target registry should pick one approved canonical target id and
+record any legacy or alternate live paths as aliases during migration.
+
+Current approved canonical examples from the live vault:
+
+- interaction notes:
+  - approved canonical target path: `3.Areas/Relationships`
+  - current target status: `pending_migration`
+  - current live alternatives include:
+    - top-level `Interactions`
+    - `4.Resources/Interactions`
+- invoice and receipt filing:
+  - approved canonical target path:
+    `3.Areas/Personal/Finance/Invoices and Receipts`
+  - current target status: `pending_migration`
+  - current live predecessor path:
+    `3.Areas/Personal/Invoices and receipts`
+
+## Projected Path Derivation
+
+For each enabled projection store:
+
+```text
+projected_relative_path = <store.path_prefix>/<resolved-target-path>/<filename>
+```
+
+Rules:
+
+- `store.path_prefix` may be empty.
+- `resolved-target-path` is derived from the canonical target identity through
+  the active target registry.
+- `filename` is the captured artifact filename.
+- Path separators are normalized to `/`.
+
+Current compatibility rule:
+
+- For vault-scoped targets already implemented in the repo, `resolved-target-path`
+  is currently the routed vault-relative folder string.
+
+## Staging Layout
+
+Projected artifacts are staged under:
+
+```text
+.hermes/note-capture/staging/<store>/<entry_id>/<projected-relative-path>
+```
+
+This guarantees:
+
+- one canonical event can fan out to multiple stores
+- each staged output is tied to a stable `entry_id`
+- sync jobs can reconcile by store and event id
+- Hermes never needs direct write access to the live target spaces
+
+## Status Semantics
+
+Per-store projections start in `pending` state inside the event log. Hermes
+summarizes aggregate store state in `.hermes/note-capture/status/latest.json`.
+
+Current state meanings:
+
+- `pending`: staged and waiting for external projection
+
+Future projection workers may extend this with states such as `projected`,
+`failed`, `superseded`, or store-local materialization states, but the
+canonical event remains authoritative. Canonical target lifecycle is tracked by
+`target_status`, not by per-store projection state.
+
+## Feedback and Corrections
+
+Reviewer feedback changes routing metadata and staged projections, not the live
+target space directly.
+
+- `approve`: keep the canonical target and clear feedback-needed state
+- `correct`: update the canonical target, rewrite staged projections, and
+  remove obsolete staged files
+- `ignore`: record reviewer action without changing staging
+
+Corrections preserve the same `entry_id`. The event is updated in place because
+it is the canonical record for that captured item.
+
+## Trust Boundaries
+
+Hermes is responsible for:
+
+- routing
+- canonical content rendering
+- event logging
+- staging
+- audit/status updates
+
+External sync or projection workers are responsible for:
+
+- copying staged artifacts into the live Obsidian vault
+- copying staged artifacts into non-vault user folders
+- projecting into future vaults when they exist
+- target-space migration and cleanup during reorganisation
+- projection health notifications and reconciliation
+
+## Reorganisation Rule
+
+The target space can be reorganised. Reorganisation must not require changing
+historical capture events by hand.
+
+Best-practice rule:
+
+- historical events keep their canonical `target_id`
+- the target registry is updated to map that `target_id` to a new live path
+- projection workers re-materialize from canonical staging or canonical content
+  as needed
+
+This is why the contract prefers canonical target identities over hard-coded
+folder strings.

--- a/docs/note-capture-projection-contract.md
+++ b/docs/note-capture-projection-contract.md
@@ -10,6 +10,11 @@ first. Projection into user-visible stores happens later and may cross trust
 boundaries such as iCloud sync, Obsidian app state, or the broader user
 filesystem under `/Users/neilrobinson/`.
 
+Recommended capability name:
+
+- `canonical note-capture projection flow`
+- short form: `canonical note-capture projection`
+
 The contract is:
 
 1. Hermes classifies a capture to one canonical target identity.
@@ -44,6 +49,9 @@ For each captured item, Hermes writes:
 
 The canonical event is the source of truth. Projected files are derived
 artifacts.
+
+For the corrected runtime event shape that matches this contract, see
+[`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md).
 
 ## Target Model
 
@@ -199,6 +207,60 @@ Current approved canonical examples from the live vault:
   - current target status: `pending_migration`
   - current live predecessor path:
     `3.Areas/Personal/Invoices and receipts`
+- raw capture fallback:
+  - `1.Inbox` is a valid canonical target when explicitly selected
+  - `Resources/_Inbox Review` remains the low-confidence fallback destination
+
+## Runtime Agent Prompt
+
+Use the following prompt text when you need the runtime agent to apply this
+capability consistently:
+
+```md
+Use the canonical note-capture projection flow for generic captured notes and
+files.
+
+Rules:
+1. Resolve the capture to one canonical target identity before choosing a live
+   path.
+2. Treat `1.Inbox` as a valid explicit canonical target when the routing
+   decision says the note should remain in inbox form.
+3. Use `Resources/_Inbox Review` as the low-confidence fallback when the route
+   is uncertain.
+4. Write a canonical capture event first, including routing metadata.
+5. Stage one projected artifact per enabled downstream store.
+6. Do not treat the live Obsidian vault or other user-space folders as the
+   primary write surface for generic note capture.
+7. Treat external sync or projection workers as responsible for materializing
+   staged artifacts into live vault or filesystem targets.
+8. Treat daily-note creation as a special-case workflow, not the generic note
+   capture model.
+
+If routing metadata is available, preserve and propagate:
+- `target_id`
+- `target_class`
+- `logical_path`
+- `display_path`
+- `resolved_target_path`
+- `target_status`
+- `trust_boundary`
+
+Capability name: canonical note-capture projection flow.
+```
+
+## Runtime Schema
+
+When implementing or reviewing runtime capture output, use the corrected event
+shape and field semantics in
+[`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md).
+
+In particular:
+
+- `target_id` is a stable canonical identity, not a folder path
+- `resolved_target_path` is the resolved live target-relative path, not a
+  staging path
+- `target_status` tracks target lifecycle, not projection state
+- projection state lives under the per-store projection block
 
 ## Projected Path Derivation
 

--- a/docs/note-capture-runtime-event-schema.md
+++ b/docs/note-capture-runtime-event-schema.md
@@ -1,0 +1,328 @@
+# Note Capture Runtime Event Schema
+
+This document defines the corrected runtime event shape for the canonical
+note-capture projection flow.
+
+Use it when aligning Hermes runtime capture code, runtime memories, and
+vault-routing instructions with the repo-side projection contract.
+
+## Design Rules
+
+Keep these meanings separate:
+
+- `target_id`: stable canonical identity
+- `resolved_target_path`: resolved live target-relative path
+- `staged_relative_path`: staged artifact location under trusted runtime storage
+- `target_status`: target lifecycle state
+- `projection.*.state`: per-store projection/materialization state
+
+Do not:
+
+- use a folder path as `target_id`
+- use a staging file path as `resolved_target_path`
+- use `staged` as `target_status`
+- collapse target lifecycle and projection state into one field
+
+## Corrected Example Event
+
+```json
+{
+  "event_id": "ce_20260713_rosmcp_001",
+  "capture_model": "canonical_event_log",
+  "event_type": "note_capture",
+  "captured_at": "2026-07-13T12:00:00Z",
+  "capture_source": "hermes-agent:slack",
+  "content_type": "knowledge_reference",
+  "content_class": "report",
+  "title": "Return on Security MCP - Cyber VC Integration Report",
+  "source": {
+    "origin": "slack",
+    "author": "NeilRobinson",
+    "original_filename": "2026-07-13 ROS MCP Cyber VC Integration Report.md"
+  },
+  "routing": {
+    "target": "3.Areas/cyber futures frontier",
+    "target_id": "vault.second_brain.areas.cyber_futures_frontier",
+    "target_class": "obsidian_vault",
+    "logical_path": "areas/cyber_futures_frontier",
+    "display_path": "3.Areas/cyber futures frontier",
+    "resolved_target_path": "3.Areas/cyber futures frontier",
+    "target_status": "active",
+    "trust_boundary": "icloud_obsidian",
+    "confidence": 0.93,
+    "reason": "Cyber VC workflow report belongs with the existing cyber futures frontier operating area."
+  },
+  "routing_review": {
+    "uncertainty": "low",
+    "alternative_targets": [
+      "4.Resources/knowledge",
+      "4.Resources/Content Library",
+      "1.Inbox"
+    ],
+    "rejected_alternatives": {
+      "4.Resources/knowledge": "Too general; this is specific to Cyber Future Frontier operating context.",
+      "4.Resources/Content Library": "Not consumable external content.",
+      "1.Inbox": "Routing confidence is high enough not to defer."
+    }
+  },
+  "canonical_content": {
+    "format": "markdown",
+    "filename": "2026-07-13 ROS MCP Cyber VC Integration Report.md"
+  },
+  "projection": {
+    "stores": {
+      "vault": {
+        "state": "pending",
+        "target_relative_path": "3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md",
+        "staged_relative_path": "staging/vault/ce_20260713_rosmcp_001/3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md"
+      },
+      "second_brain": {
+        "state": "pending",
+        "target_relative_path": "runtime-source/3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md",
+        "staged_relative_path": "staging/second_brain/ce_20260713_rosmcp_001/runtime-source/3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md"
+      }
+    }
+  },
+  "sync_contract": {
+    "capture_model": "canonical_event_log",
+    "write_policy": "trusted_staging_only",
+    "projection_status_source": "structured_status",
+    "stores": [
+      "vault",
+      "second_brain"
+    ]
+  }
+}
+```
+
+## JSON Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CanonicalNoteCaptureEvent",
+  "type": "object",
+  "required": [
+    "event_id",
+    "capture_model",
+    "event_type",
+    "captured_at",
+    "title",
+    "routing",
+    "projection",
+    "sync_contract"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 1 },
+    "capture_model": { "const": "canonical_event_log" },
+    "event_type": { "const": "note_capture" },
+    "captured_at": { "type": "string", "format": "date-time" },
+    "capture_source": { "type": "string" },
+    "content_type": { "type": "string" },
+    "content_class": { "type": "string" },
+    "title": { "type": "string", "minLength": 1 },
+    "source": {
+      "type": "object",
+      "properties": {
+        "origin": { "type": "string" },
+        "author": { "type": "string" },
+        "original_filename": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "routing": {
+      "type": "object",
+      "required": [
+        "target",
+        "target_id",
+        "target_class",
+        "logical_path",
+        "display_path",
+        "resolved_target_path",
+        "target_status",
+        "trust_boundary"
+      ],
+      "properties": {
+        "target": { "type": "string", "minLength": 1 },
+        "target_id": { "type": "string", "minLength": 1 },
+        "target_class": {
+          "type": "string",
+          "enum": ["obsidian_vault", "filesystem"]
+        },
+        "logical_path": { "type": "string", "minLength": 1 },
+        "display_path": { "type": "string", "minLength": 1 },
+        "resolved_target_path": { "type": "string", "minLength": 1 },
+        "target_status": {
+          "type": "string",
+          "enum": ["active", "deferred", "pending_migration", "unavailable"]
+        },
+        "trust_boundary": { "type": "string", "minLength": 1 },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "reason": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "routing_review": {
+      "type": "object",
+      "properties": {
+        "uncertainty": { "type": "string" },
+        "alternative_targets": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "rejected_alternatives": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "canonical_content": {
+      "type": "object",
+      "properties": {
+        "format": { "type": "string" },
+        "filename": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "projection": {
+      "type": "object",
+      "required": ["stores"],
+      "properties": {
+        "stores": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "object",
+            "required": ["state", "target_relative_path", "staged_relative_path"],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["pending", "projected", "failed", "superseded"]
+              },
+              "target_relative_path": { "type": "string", "minLength": 1 },
+              "staged_relative_path": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "sync_contract": {
+      "type": "object",
+      "required": ["capture_model", "write_policy", "projection_status_source", "stores"],
+      "properties": {
+        "capture_model": { "const": "canonical_event_log" },
+        "write_policy": { "const": "trusted_staging_only" },
+        "projection_status_source": { "type": "string" },
+        "stores": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}
+```
+
+## Pydantic Model
+
+```python
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+TargetClass = Literal["obsidian_vault", "filesystem"]
+TargetStatus = Literal["active", "deferred", "pending_migration", "unavailable"]
+ProjectionState = Literal["pending", "projected", "failed", "superseded"]
+
+
+class SourceRef(BaseModel):
+    origin: Optional[str] = None
+    author: Optional[str] = None
+    original_filename: Optional[str] = None
+
+
+class RoutingMetadata(BaseModel):
+    target: str
+    target_id: str
+    target_class: TargetClass
+    logical_path: str
+    display_path: str
+    resolved_target_path: str
+    target_status: TargetStatus
+    trust_boundary: str
+    confidence: Optional[float] = Field(default=None, ge=0, le=1)
+    reason: Optional[str] = None
+
+
+class RoutingReview(BaseModel):
+    uncertainty: Optional[str] = None
+    alternative_targets: List[str] = Field(default_factory=list)
+    rejected_alternatives: Dict[str, str] = Field(default_factory=dict)
+
+
+class CanonicalContent(BaseModel):
+    format: Optional[str] = None
+    filename: Optional[str] = None
+
+
+class ProjectionStoreEntry(BaseModel):
+    state: ProjectionState
+    target_relative_path: str
+    staged_relative_path: str
+
+
+class ProjectionStateBlock(BaseModel):
+    stores: Dict[str, ProjectionStoreEntry]
+
+
+class SyncContract(BaseModel):
+    capture_model: Literal["canonical_event_log"]
+    write_policy: Literal["trusted_staging_only"]
+    projection_status_source: str
+    stores: List[str]
+
+
+class CanonicalNoteCaptureEvent(BaseModel):
+    event_id: str
+    capture_model: Literal["canonical_event_log"]
+    event_type: Literal["note_capture"]
+    captured_at: str
+    capture_source: Optional[str] = None
+    content_type: Optional[str] = None
+    content_class: Optional[str] = None
+    title: str
+    source: Optional[SourceRef] = None
+    routing: RoutingMetadata
+    routing_review: Optional[RoutingReview] = None
+    canonical_content: Optional[CanonicalContent] = None
+    projection: ProjectionStateBlock
+    sync_contract: SyncContract
+```
+
+## Runtime Prompt Addendum
+
+Use this short rule block in runtime prompts or memories when the full schema
+is too heavy:
+
+```md
+For generic note capture, preserve four separate concepts:
+- canonical identity (`target_id`)
+- resolved live target path (`resolved_target_path`)
+- staged artifact path (`staged_relative_path`)
+- projection state (`pending` / `projected` / `failed`)
+
+Do not use a folder path as `target_id`.
+Do not use a staging path as `resolved_target_path`.
+Do not use `staged` as `target_status`.
+Use `target_status` only for target lifecycle:
+`active`, `deferred`, `pending_migration`, `unavailable`.
+```

--- a/docs/note-capture-runtime-proposed-patches.md
+++ b/docs/note-capture-runtime-proposed-patches.md
@@ -5,6 +5,59 @@ after approval of the projection contract.
 
 It is intentionally concrete so approval can be based on exact wording.
 
+For the corrected runtime event shape and field semantics, see
+[`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md).
+
+## Runtime Agent Prompt
+
+Use this prompt block when you want Hermes-core runtime surfaces to understand
+and consistently apply the capability:
+
+```md
+Use the canonical note-capture projection flow for generic captured notes and
+files.
+
+Resolve each capture to one canonical target identity before choosing a live
+path. `1.Inbox` is a valid explicit canonical target when the routing decision
+is to keep the note as raw inbox material. `Resources/_Inbox Review` remains
+the low-confidence fallback when the route is uncertain.
+
+Write a canonical capture event first, preserve routing metadata, and stage
+one projected artifact per enabled downstream store. Do not treat the live
+Obsidian vault, `/opt/second_brain/`, or other user-space folders as the
+primary write surface for generic note capture. External sync or projection
+workers are responsible for materializing staged artifacts into live targets.
+
+Preserve and propagate routing metadata when available:
+- `target_id`
+- `target_class`
+- `logical_path`
+- `display_path`
+- `resolved_target_path`
+- `target_status`
+- `trust_boundary`
+
+Treat daily-note creation as a special-case workflow, not the generic note
+capture model.
+```
+
+Add this schema rule block where runtime prompts need a compact implementation
+guardrail:
+
+```md
+For generic note capture, preserve four separate concepts:
+- canonical identity (`target_id`)
+- resolved live target path (`resolved_target_path`)
+- staged artifact path (`staged_relative_path`)
+- projection state (`pending` / `projected` / `failed`)
+
+Do not use a folder path as `target_id`.
+Do not use a staging path as `resolved_target_path`.
+Do not use `staged` as `target_status`.
+Use `target_status` only for target lifecycle:
+`active`, `deferred`, `pending_migration`, `unavailable`.
+```
+
 ## 1. `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
 
 ### Proposed replacement header
@@ -66,7 +119,8 @@ maps content to one canonical target identity, writes canonical capture events,
 and stages downstream projections per store. Vault, projection trees, and
 non-vault user-space targets are downstream materializations, not the primary
 write surface. Check structured projection status rather than assuming a direct
-live-path write.
+live-path write. `1.Inbox` is a valid explicit target; `Resources/_Inbox Review`
+is the low-confidence fallback.
 ```
 
 ## 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`

--- a/docs/note-capture-runtime-proposed-patches.md
+++ b/docs/note-capture-runtime-proposed-patches.md
@@ -1,0 +1,144 @@
+# Note Capture Runtime Proposed Patches
+
+This document contains the proposed runtime text changes that should be applied
+after approval of the projection contract.
+
+It is intentionally concrete so approval can be based on exact wording.
+
+## 1. `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+
+### Proposed replacement header
+
+```md
+---
+name: vault-routing
+description: Vault routing table for the Obsidian second brain — maps content types to canonical destinations and downstream projected paths. Load this skill before saving captured content.
+platforms: [linux]
+---
+
+# Vault Routing — Content Destination Rules
+
+Load this skill whenever you need to save content related to Neil's Obsidian
+second brain.
+
+Hermes does not treat `/opt/second_brain/` as the primary write surface for
+generic captured content. The vault is one downstream projected target class.
+
+**CRITICAL:** `/opt/second_brain/` is mounted read-only from this container
+over VirtioFS. For generic note capture, Hermes should:
+
+1. decide one canonical routing target
+2. render canonical markdown content
+3. write a canonical capture event
+4. stage one projected artifact per enabled downstream store and target class
+
+External sync outside the Hermes trust boundary then projects those staged
+artifacts into the live vault, iCloud-backed Obsidian targets, broader
+user-space folders, or targets that are currently deferred in the registry.
+
+Current daily-note workflows remain a special runtime exception and may still
+use the dedicated daily-note plugin path until they are migrated explicitly.
+```
+
+### Proposed replacement for the final mistake rule
+
+```md
+4. ❌ **Don't treat the mounted vault as the generic write surface** — it is
+   read-only and downstream of canonical capture. For generic captured notes,
+   write canonical capture data and staged projections first.
+```
+
+## 2. `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+
+### Proposed replacement for the vault-routing memory line
+
+Replace:
+
+```md
+Vault routing: load vault-routing skill before saving content. YouTube→Content Library, meetings→Interactions, raw→Inbox. Stage at /opt/data/staging/.
+```
+
+With:
+
+```md
+Vault routing: load vault-routing skill before saving captured content. Hermes
+maps content to one canonical target identity, writes canonical capture events,
+and stages downstream projections per store. Vault, projection trees, and
+non-vault user-space targets are downstream materializations, not the primary
+write surface. Check structured projection status rather than assuming a direct
+live-path write.
+```
+
+## 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+
+### Proposed replacement for the write-boundary memory line
+
+Replace:
+
+```md
+HERMES_WRITE_SAFE_ROOT=/opt/data blocks Hermes write_file/patch from /opt/second_brain/. Plugin bypasses via Python I/O — workaround: write to /opt/data/ and report.
+```
+
+With:
+
+```md
+HERMES_WRITE_SAFE_ROOT=/opt/data blocks Hermes write_file/patch from
+/opt/second_brain/. Treat `/opt/second_brain/` as one downstream projected
+target class for generic note capture. Hermes should write canonical capture
+data and staged projections under trusted runtime storage, with external sync
+responsible for projecting into the live vault and other approved user-space
+targets. The daily-note plugin remains a special-case runtime path.
+```
+
+## 4. `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+
+### Proposed addition near the top
+
+```md
+## Note on Trust Boundary
+
+These cron jobs include a daily-note workflow that still uses a dedicated
+plugin-backed runtime write path. That is a special case.
+
+For generic note capture and vault routing, Hermes should use the canonical
+note-capture flow: canonical event log first, staged projections second, live
+vault, iCloud-backed Obsidian targets, and non-vault user-space targets outside
+the Hermes trust boundary.
+```
+
+## 5. `~/HermesData/runtime/hermes-core/cron/jobs.json`
+
+### Proposed wording change for `Daily Morning Briefing`
+
+Add after the vault path introduction:
+
+```text
+The live vault is one projected surface for most captured notes. Do not treat
+generic captured content as direct live-path writes. Daily-note creation
+remains a special plugin-backed workflow.
+```
+
+### Proposed wording change for `Daily Memo Preparer`
+
+Add after the task description:
+
+```text
+This job is a special-case daily-note workflow. It should not be generalized
+into the generic note-capture routing path, which uses canonical capture events
+plus staged downstream projections into approved target classes.
+```
+
+## Approval Questions
+
+Applying the runtime edits above means approving these points:
+
+1. Generic captured notes use canonical event logging plus staged projections.
+2. Projected relative paths are derived as
+   `<path_prefix>/<resolved-target-path>/<filename>`.
+3. The mounted vault, projection trees, and non-vault user-space targets are
+   described to Hermes as downstream target classes with distinct trust
+   boundaries.
+4. Daily-note creation remains an explicit runtime exception for now.
+5. Future targets are represented through target registry status values
+   (`deferred`, `unavailable`, `pending_migration`) rather than a separate
+   target class.

--- a/docs/note-capture-runtime-rollout.md
+++ b/docs/note-capture-runtime-rollout.md
@@ -1,0 +1,146 @@
+# Note Capture Runtime Rollout
+
+This document records the runtime-side changes required to align Hermes-core
+with the canonical note-capture and staged projection contract defined in
+[`docs/note-capture-projection-contract.md`](./note-capture-projection-contract.md)
+and the target-space review in
+[`docs/note-capture-target-space-review.md`](./note-capture-target-space-review.md).
+
+These runtime changes should be applied only after the projection contract is
+explicitly approved.
+
+## Scope
+
+The runtime rollout is limited to communication, memory, and orchestration
+surfaces that currently describe note writes as direct writes to the projected
+vault or to a single staging mirror.
+
+It does not change the already-running external sync layer. Instead, it changes
+what Hermes-core says and expects about the trust boundaries across:
+
+- the current Obsidian vault
+- non-vault user filesystem targets
+- future targets represented through target registry status within those same
+  target classes
+
+## Runtime Files To Update
+
+### 1. `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+
+Current issue:
+
+- Describes content routing as staging directly to `/opt/data/staging/<vault-path>`
+- Frames the vault projection as a single downstream path
+
+Required update:
+
+- Explain that Hermes captures canonical content first and stages one projected
+  artifact per enabled store and target class
+- Keep the existing routing table
+- Replace direct-write wording with canonical event plus staged projection
+- Clarify that downstream sync projects staged files into the live vault and
+  other stores outside the trust boundary
+
+### 2. `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+
+Current issue:
+
+- The memory pointer says `Vault routing: ... Stage at /opt/data/staging/.`
+
+Required update:
+
+- Replace that line with a pointer to the canonical note-capture model
+- State that vault, projection trees, and non-vault user-space targets are
+  downstream projections with different trust boundaries
+- Reflect that future targets are represented by `target_status` rather than a
+  separate `target_class`
+- Point the agent toward structured projection status rather than assuming a
+  direct vault write
+
+### 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+
+Current issue:
+
+- Still teaches the old write workaround model for `/opt/second_brain/`
+
+Required update:
+
+- Mirror the same canonical capture and downstream sync guidance used in the
+  main runtime memory
+
+### 4. `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+
+Current issue:
+
+- Documents direct daily-note creation in the mounted vault as the primary
+  write model
+
+Required update:
+
+- Clarify that daily-note creation is a special runtime path distinct from the
+  generic note-capture projection contract
+- Note that general note routing should use canonical capture and staged
+  projection into approved target classes, not direct vault writes
+
+### 5. `~/HermesData/runtime/hermes-core/cron/jobs.json`
+
+Current issue:
+
+- Morning briefing and daily memo preparer prompts still read as if the vault
+  is the primary writable source of truth
+
+Required update:
+
+- Leave the objective and daily-note workflow intact if it truly must write via
+  the daily-note plugin
+- Add wording that the live vault is one projected surface and that generic
+  note capture should prefer canonical capture plus staged projections across
+  approved target classes
+- Avoid conflating the daily-note plugin’s special-case write path with the
+  general note-routing contract
+
+## Special Case: Daily Notes
+
+Daily notes are the one runtime path that currently behaves differently from
+generic note capture.
+
+Observed current state:
+
+- `daily_memo_preparer_v2.py` writes to
+  `/opt/second_brain/4.Resources/Reviews/Daily Notes`
+- It uses the `daily_note_capture` plugin’s internal write path
+
+Rollout guidance:
+
+- Do not casually force daily notes through the new generic note-capture flow
+  unless the projection worker and downstream consumers are updated together
+- Treat daily notes as an explicit exception until there is a verified end-to-end
+  replacement for the current plugin-backed workflow
+
+## Verification After Runtime Rollout
+
+After approval and runtime edits, verify:
+
+1. Runtime skill text no longer instructs direct vault writes for generic note
+   capture.
+2. Runtime memory files describe vault, projection trees, and non-vault
+   user-space targets as downstream target classes with distinct trust
+   boundaries.
+3. Cron prompts do not teach a contradictory generic note-routing model.
+4. Existing daily-note jobs still run successfully.
+5. Projection-status files remain readable and semantically consistent with the
+   approved contract.
+
+## Approval Gate
+
+Before applying runtime edits, confirm:
+
+- The target classes are approved:
+  `obsidian_vault`, `filesystem`
+- The target lifecycle states are approved:
+  `active`, `deferred`, `pending_migration`, `unavailable`
+- The projected path derivation rule
+  `<path_prefix>/<resolved-target-path>/<filename>` is approved
+- The trust-boundary rule is approved:
+  Hermes writes canonical capture data and staging; external sync writes live
+  vault, iCloud, and non-vault user-space destinations

--- a/docs/note-capture-runtime-rollout.md
+++ b/docs/note-capture-runtime-rollout.md
@@ -5,6 +5,8 @@ with the canonical note-capture and staged projection contract defined in
 [`docs/note-capture-projection-contract.md`](./note-capture-projection-contract.md)
 and the target-space review in
 [`docs/note-capture-target-space-review.md`](./note-capture-target-space-review.md).
+Use [`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md)
+as the runtime output shape for canonical capture events.
 
 These runtime changes should be applied only after the projection contract is
 explicitly approved.
@@ -22,6 +24,10 @@ what Hermes-core says and expects about the trust boundaries across:
 - non-vault user filesystem targets
 - future targets represented through target registry status within those same
   target classes
+
+Use the capability name `canonical note-capture projection flow` when updating
+runtime skills, memories, and orchestration prompts so the model has one stable
+term for this behavior.
 
 ## Runtime Files To Update
 
@@ -56,6 +62,8 @@ Required update:
   separate `target_class`
 - Point the agent toward structured projection status rather than assuming a
   direct vault write
+- Clarify that `1.Inbox` is a valid explicit target while
+  `Resources/_Inbox Review` remains the low-confidence fallback
 
 ### 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
 
@@ -130,6 +138,9 @@ After approval and runtime edits, verify:
 4. Existing daily-note jobs still run successfully.
 5. Projection-status files remain readable and semantically consistent with the
    approved contract.
+6. Runtime capture events use the corrected field semantics:
+   stable `target_id`, live-relative `resolved_target_path`, lifecycle-only
+   `target_status`, and per-store projection state.
 
 ## Approval Gate
 

--- a/docs/note-capture-target-space-review.md
+++ b/docs/note-capture-target-space-review.md
@@ -1,0 +1,291 @@
+# Note Capture Target Space Review
+
+This review maps current known capture and ingress flows onto the revised target
+space model and identifies gaps for backlog work.
+
+## Target Classes In Scope
+
+### Current Obsidian Vault
+
+Observed live store:
+
+- `/Users/neilrobinson/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault`
+
+Observed current top-level structures include:
+
+- `1.Inbox`
+- `2.Projects`
+- `3.Areas`
+- `4.Resources`
+- `5.Archive`
+- `Interactions`
+- `memory`
+- `attachments`
+- `second-brain-infra`
+- `Projects`
+- `Brand`
+
+Observed structural realities that should inform the contract:
+
+- the vault is not a pure PARA tree
+- some domains exist both inside and outside the numbered PARA structure
+- there are operational and code-bearing folders inside the vault
+- there are duplicate or near-duplicate concepts across current paths
+
+Examples:
+
+- interaction material currently exists in multiple live places, including:
+  - top-level `Interactions`
+  - `4.Resources/Interactions`
+  - approved canonical target: `3.Areas/Relationships`
+- household and finance concepts already exist in multiple live places:
+  - `3.Areas/household`
+  - `3.Areas/finance`
+  - `3.Areas/Personal/Finance/Invoices and Receipts`
+  - `4.Resources/Household`
+- review material already has concrete live structure:
+  - `4.Resources/Reviews/Daily Notes`
+  - `4.Resources/Reviews/Weekly Notes`
+  - `4.Resources/Reviews/Annual Notes`
+- content and knowledge targets already exist:
+  - `4.Resources/Content Library`
+  - `4.Resources/Content Queue`
+  - `4.Resources/knowledge`
+- infrastructure and attachment-like targets already exist:
+  - `second-brain-infra`
+  - `attachments`
+  - `4.Resources/attachments`
+
+### Non-Vault User Filesystem
+
+Observed live stores include:
+
+- `/Users/neilrobinson/HermesData/projections/second-brain`
+- `/Users/neilrobinson/HermesData/projections/second-brain-derived`
+- `/Users/neilrobinson/HermesData/daily-notes`
+- other user-space folders under `/Users/neilrobinson/`
+
+### Future Obsidian Targets
+
+Not yet created, but explicitly requested as part of the target model.
+
+Examples to plan for:
+
+- additional thematic vaults
+- reorganized vault structures
+- domain-specific note spaces such as household operations
+
+Modeling note:
+
+- these are still represented with `target_class: obsidian_vault`
+- their lifecycle is expressed via `target_status`, such as `deferred` or
+  `unavailable`
+
+## Current Known Capture / Ingress Flows
+
+### 1. Vault PARA triage
+
+Source:
+
+- `hermes_cli/vault_para_triage.py`
+- optional skill `vault-para-triage`
+
+Current state:
+
+- captures markdown inbox notes
+- routes to vault-scoped PARA targets
+- stages outputs per enabled store
+
+Mapped target class:
+
+- current Obsidian vault
+
+Gap:
+
+- target identity is still a vault-relative folder string, not a registry-backed
+  canonical target id
+- approved canonical choice:
+  - approved canonical target path: `3.Areas/Relationships`
+  - current target status: `pending_migration`
+  - current live alternatives:
+    - top-level `Interactions`
+    - `4.Resources/Interactions`
+
+### 2. Daily note capture
+
+Source:
+
+- runtime plugin `daily_note_capture`
+- runtime script `daily_memo_preparer_v2.py`
+
+Current state:
+
+- special-case direct daily-note workflow
+- writes to daily notes in the live second-brain vault
+
+Mapped target class:
+
+- current Obsidian vault
+
+Gap:
+
+- still bypasses the generic note-capture projection contract
+
+### 3. Meeting classification
+
+Source:
+
+- runtime plugin `google_workspace_cli`
+- tool `run_meeting_classification`
+
+Current state:
+
+- classifies calendar meetings
+- writes meeting-classification artifacts associated with the vault review area
+
+Mapped target class:
+
+- current Obsidian vault
+
+Gap:
+
+- artifacts are not yet expressed through the broader target registry model
+
+### 4. Research capture
+
+Source:
+
+- runtime plugin `research_capture`
+- Gmail-backed ingest methods
+
+Current state:
+
+- approved runtime plugin
+- newsletter ingest and local materialization
+
+Mapped target class:
+
+- currently local/runtime materialization first
+
+Gap:
+
+- no reviewed canonical mapping yet into the broader target registry across
+  vault and non-vault destinations
+
+### 5. Payments review
+
+Source:
+
+- runtime plugin `payments_review`
+- Gmail-backed invoice/payment-request ingest
+
+Current state:
+
+- captures likely invoices and payment instructions into deterministic local
+  state and materialized review artifacts
+- explicitly avoids initiating any transfer
+
+Mapped target class:
+
+- currently local/runtime materialization first
+
+Gap:
+
+- not yet mapped to a canonical household-finance or finance-review target in
+  the approved target registry
+- current live candidates already exist and should be reviewed explicitly, for
+  example:
+  - `3.Areas/Personal/Finance/Invoices and Receipts`
+  - `3.Areas/finance/Property Expenses`
+  - `4.Resources/Household/Purchases`
+
+Current approved path correction:
+
+- point-two approved canonical target path:
+  `3.Areas/Personal/Finance/Invoices and Receipts`
+- current target status: `pending_migration`
+- current live predecessor path:
+  `3.Areas/Personal/Invoices and receipts`
+
+### 6. Expense submission
+
+Source:
+
+- runtime memory points to `expense_submit.py`
+
+Current state:
+
+- operational workflow with ledger and email send
+
+Mapped target class:
+
+- non-vault operational state today
+
+Gap:
+
+- no reviewed projection target for durable note/file capture output
+
+## Backlog Candidates
+
+### High-value target registry work
+
+1. Introduce a target registry that maps stable `target_id` values to current
+   live target paths and target classes.
+2. Add reorganisation support so existing target ids survive path changes.
+3. Support planned future targets through `target_status` values such as
+   `deferred` and `unavailable` before folders exist.
+
+### Capture coverage gaps
+
+1. Household bills automated capture from email into a household-finance target.
+   Current live candidates to review:
+   - `3.Areas/Personal/Finance/Invoices and Receipts`
+     (approved canonical target path, current status `pending_migration`)
+   - `3.Areas/Personal/Invoices and receipts`
+     (current live predecessor path)
+   - `3.Areas/finance/Property Expenses`
+   - `4.Resources/Household/Purchases`
+   Recommended outcome:
+   use `3.Areas/Personal/Finance/Invoices and Receipts` as the approved
+   canonical target path and treat the current live predecessor path as a
+   migration source unless a later reorganisation promotes a different
+   approved target id.
+2. Payment-request and invoice capture from Gmail into a reviewed finance
+   workflow target rather than only local materialized review state.
+3. Research/newsletter capture into approved knowledge/library targets across
+   vault and non-vault stores.
+4. Attachment capture policy for invoices, statements, bills, and research
+   documents.
+5. Non-markdown file projection rules for PDFs, receipts, and other binary
+   assets.
+
+### Runtime/ops gaps
+
+1. Runtime wording still teaches vault-centric paths instead of the broader
+   target-space model.
+2. Daily-note capture remains a special-case direct write path.
+3. `research_capture` exists in runtime but requires reviewed enablement and
+   target mapping decisions.
+
+## Review Guidance
+
+Before runtime rollout, review and approve:
+
+1. target classes:
+   `obsidian_vault`, `filesystem`
+2. trust boundaries for each target class
+3. the move from hard-coded folder strings toward canonical `target_id`
+4. which current live vault paths become canonical when duplicates or competing
+   locations exist
+5. the initial backlog additions for household finance, payments, research, and
+   attachments
+6. target lifecycle states:
+   `active`, `deferred`, `pending_migration`, `unavailable`
+
+Current decisions already incorporated:
+
+- `3.Areas/Relationships` is the approved canonical target path for
+  interactions with `target_status: pending_migration`
+- `3.Areas/Personal/Finance/Invoices and Receipts` is the approved canonical
+  target path for the invoice-and-receipts point with
+  `target_status: pending_migration`

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6840,6 +6840,14 @@ def _default_spawn(
     from hermes_cli.profiles import resolve_profile_env
     try:
         env["HERMES_HOME"] = resolve_profile_env(profile_arg)
+        # Some nested worker helper processes consult HOME directly even when
+        # HERMES_HOME is pinned. Keep them off any stale launch-profile HOME
+        # (for example an old admin wrapper home) while preserving the prior
+        # real home under HERMES_REAL_HOME for external tools that need it.
+        prior_home = str(env.get("HOME") or "").strip()
+        if prior_home and prior_home != env["HERMES_HOME"] and not env.get("HERMES_REAL_HOME"):
+            env["HERMES_REAL_HOME"] = prior_home
+        env["HOME"] = env["HERMES_HOME"]
     except FileNotFoundError:
         # Profile dir doesn't exist — defer resolution to the CLI's
         # _apply_profile_override() via HERMES_PROFILE (set below).

--- a/hermes_cli/payments.py
+++ b/hermes_cli/payments.py
@@ -1,30 +1,20 @@
-"""Profile-scoped payment-request storage for the dashboard Payments page.
-
-The first slice is intentionally narrow:
-  * keep a durable, profile-local review queue of extracted payment requests
-  * expose source status (Gmail / Email / Uploads / Slack) for the dashboard
-  * support manual status transitions only; no payment initiation
-
-Actual ingestion/extraction can be layered on top of this store later without
-changing the dashboard contract.
-"""
+"""Canonical payments-review adapter for dashboard + Slack operator surfaces."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from email.utils import parseaddr, parsedate_to_datetime
+import importlib.util
 import json
+import types
+import os
 from pathlib import Path
 import re
-import subprocess
+import sqlite3
 import sys
 from typing import Any, Dict, List
 
 from hermes_constants import get_hermes_home
 from hermes_cli.config import load_env
-
-PAYMENTS_DIR = "payments"
-REQUESTS_FILE = "requests.json"
 
 PAYMENT_STATUSES = {
     "new",
@@ -34,6 +24,15 @@ PAYMENT_STATUSES = {
     "ignored",
 }
 
+OPERATOR_STATUSES = (
+    "needs_review",
+    "ready_to_pay",
+    "paid",
+    "ignored",
+)
+
+INBOX_ITEM_STATUSES = PAYMENT_STATUSES
+
 PAYMENT_SOURCES = (
     ("gmail", "Gmail"),
     ("email", "Email"),
@@ -41,315 +40,570 @@ PAYMENT_SOURCES = (
     ("slack", "Slack"),
 )
 
-DEFAULT_GMAIL_QUERY = (
-    'newer_than:120d (invoice OR "payment due" OR "request for payment" OR '
-    '"bank transfer" OR remittance OR billing OR statement)'
-)
-DEFAULT_GMAIL_MAX_RESULTS = 25
+PAYMENTS_GMAIL_SYNC_CRON_SCRIPT = "payments_sync_gmail.py"
+PAYMENTS_GMAIL_SYNC_CRON_JOB_NAME = "Payments Gmail sync"
+DEFAULT_GMAIL_SYNC_SCHEDULE = "every 1h"
+PAYMENTS_GMAIL_SHADOW_SYNC_CRON_SCRIPT = "payments_shadow_sync_gmail.py"
+PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME = "Payments Gmail shadow sync"
+DEFAULT_GMAIL_SHADOW_SYNC_SCHEDULE = "every 6h"
 
-_AMOUNT_PATTERNS = [
-    re.compile(r"\b(GBP|USD|EUR|AUD|CAD|NZD|CHF|SEK|NOK|DKK)\s?([0-9][0-9,]*(?:\.[0-9]{2})?)\b", re.I),
-    re.compile(r"([£$€])\s?([0-9][0-9,]*(?:\.[0-9]{2})?)"),
-]
-_SORT_CODE_RE = re.compile(r"\b\d{2}-\d{2}-\d{2}\b")
-_ACCOUNT_NUMBER_RE = re.compile(r"\b\d{8}\b")
-_IBAN_RE = re.compile(r"\b[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}\b")
-_SWIFT_RE = re.compile(r"\b[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b")
-_ROUTING_RE = re.compile(r"\brouting number\b[:\s]*([0-9]{9})", re.I)
-_REFERENCE_RE = re.compile(
-    r"\b(?:reference|payment reference|remittance reference)\b[:\s#-]*([A-Z0-9-]{4,})",
-    re.I,
+DEFAULT_GMAIL_QUERY = (
+    '((subject:invoice OR subject:receipt OR subject:"payment due" OR '
+    'subject:remittance OR subject:"remittance advice" OR '
+    'subject:"booking confirmation" OR "amount due" OR "view invoice" OR '
+    '"payment reference" OR "invoice #") -category:promotions '
+    '-category:social -label:spam) newer_than:90d'
 )
-_INVOICE_RE = re.compile(r"\b(?:invoice|inv(?:oice)? number|invoice #)\b[:\s#-]*([A-Z0-9-]{3,})", re.I)
-_DUE_RE = re.compile(
-    r"\b(?:due date|payment due|due)\b[:\s-]*("
-    r"[A-Z][a-z]{2,8}\s+\d{1,2},?\s+\d{4}"
-    r"|\d{4}-\d{2}-\d{2}"
-    r"|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}"
-    r")",
-    re.I,
+DEFAULT_GMAIL_MAX_RESULTS = 20
+
+_PAID_TITLES_RE = re.compile(
+    r"\b(receipt|booking confirmation|thanks for riding|amount paid|paid)\b",
+    re.IGNORECASE,
 )
+_PAID_WARNING_RE = re.compile(r"already been made", re.IGNORECASE)
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_PAYMENTS_QUEUE = "payments"
 
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _payments_dir() -> Path:
-    return get_hermes_home() / PAYMENTS_DIR
-
-
-def _requests_path() -> Path:
-    return _payments_dir() / REQUESTS_FILE
-
-
-def _google_api_script() -> Path:
-    return (
-        Path(__file__).resolve().parents[1]
-        / "skills"
-        / "productivity"
-        / "google-workspace"
-        / "scripts"
-        / "google_api.py"
-    )
-
-
-def _empty_record(payment_id: str) -> Dict[str, Any]:
-    return {
-        "id": payment_id,
-        "source": "uploads",
-        "source_label": "Uploads",
-        "status": "new",
-        "confidence": "low",
-        "received_at": None,
-        "updated_at": None,
-        "vendor": "",
-        "title": "",
-        "amount": {"value": None, "currency": "", "display": ""},
-        "due_date": None,
-        "payee_name": "",
-        "account_holder": "",
-        "account_number": "",
-        "sort_code": "",
-        "iban": "",
-        "swift": "",
-        "routing_number": "",
-        "payment_reference": "",
-        "invoice_number": "",
-        "billing_address": "",
-        "tax_details": "",
-        "preview_text": "",
-        "warnings": [],
-        "attachments": [],
-        "original": {"label": "", "url": "", "message_id": "", "thread_id": ""},
-    }
-
-
-def _normalize_record(raw: Dict[str, Any], *, index: int) -> Dict[str, Any]:
-    record = _empty_record(str(raw.get("id") or f"payment-{index + 1}"))
-    record.update({k: v for k, v in raw.items() if k in record})
-
-    amount = raw.get("amount")
-    if isinstance(amount, dict):
-        record["amount"] = {
-            "value": amount.get("value"),
-            "currency": str(amount.get("currency") or ""),
-            "display": str(amount.get("display") or ""),
-        }
-
-    original = raw.get("original")
-    if isinstance(original, dict):
-        record["original"] = {
-            "label": str(original.get("label") or ""),
-            "url": str(original.get("url") or ""),
-            "message_id": str(original.get("message_id") or ""),
-            "thread_id": str(original.get("thread_id") or ""),
-        }
-
-    status = str(record.get("status") or "new").strip()
-    record["status"] = status if status in PAYMENT_STATUSES else "needs_review"
-
-    source = str(record.get("source") or "uploads").strip()
-    record["source"] = source or "uploads"
-    record["source_label"] = str(record.get("source_label") or source.title())
-    record["confidence"] = str(record.get("confidence") or "low")
-    record["warnings"] = [
-        str(item).strip()
-        for item in (record.get("warnings") or [])
-        if str(item).strip()
-    ]
-    record["attachments"] = [
-        str(item).strip()
-        for item in (record.get("attachments") or [])
-        if str(item).strip()
-    ]
-    return record
-
-
-def _run_google_api(args: List[str]) -> Any:
-    script = _google_api_script()
-    result = subprocess.run(
-        [sys.executable, str(script), *args],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        err = (result.stderr or result.stdout or "").strip() or "google_api.py failed"
-        raise RuntimeError(err)
-    stdout = result.stdout.strip()
-    if not stdout:
-        return []
+def _load_runtime_env() -> dict[str, Any]:
     try:
-        return json.loads(stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"Unexpected google_api.py output: {stdout[:200]}") from exc
+        return load_env()
+    except Exception:
+        return {}
 
 
-def _clean_text(text: str) -> str:
-    return re.sub(r"\s+", " ", text or "").strip()
+def _require_env_value(name: str) -> str:
+    env = _load_runtime_env()
+    value = str(os.environ.get(name) or env.get(name) or "").strip()
+    return value
 
 
-def _format_vendor(sender: str) -> str:
-    name, addr = parseaddr(sender or "")
-    if name.strip():
-        return name.strip().strip('"')
-    if addr:
-        return addr.split("@", 1)[0]
-    return sender.strip()
+def _canonical_db_path() -> Path | None:
+    value = _require_env_value("PAYMENTS_REVIEW_DB_PATH")
+    return Path(value) if value else None
 
 
-def _parse_amount(text: str) -> Dict[str, Any]:
-    for pattern in _AMOUNT_PATTERNS:
-        match = pattern.search(text)
-        if not match:
-            continue
-        if len(match.groups()) == 2:
-            g1, g2 = match.groups()
-            symbol_currency = {"£": "GBP", "$": "USD", "€": "EUR"}
-            currency = symbol_currency.get(g1, g1.upper())
-            display = f"{currency} {g2}"
-            try:
-                value = float(g2.replace(",", ""))
-            except ValueError:
-                value = None
-            return {"value": value, "currency": currency, "display": display}
-    return {"value": None, "currency": "", "display": ""}
+def _canonical_asset_root() -> Path | None:
+    value = _require_env_value("PAYMENTS_REVIEW_ASSET_ROOT")
+    return Path(value) if value else None
 
 
-def _extract_match(pattern: re.Pattern[str], text: str) -> str:
-    match = pattern.search(text)
-    if not match:
-        return ""
-    if match.lastindex:
-        return str(match.group(1) or "").strip()
-    return str(match.group(0) or "").strip()
+def _canonical_materialized_root() -> Path | None:
+    value = _require_env_value("PAYMENTS_REVIEW_MATERIALIZED_ROOT")
+    return Path(value) if value else None
 
 
-def _parse_received_at(value: str) -> str | None:
+def _google_token_path() -> Path:
+    env = _load_runtime_env()
+    raw = str(
+        os.environ.get("GOOGLE_WORKSPACE_TOKEN_PATH")
+        or env.get("GOOGLE_WORKSPACE_TOKEN_PATH")
+        or get_hermes_home() / "google_token.json"
+    ).strip()
+    return Path(raw)
+
+
+def _slack_token_present() -> bool:
+    env = _load_runtime_env()
+    return bool(
+        str(os.environ.get("SLACK_BOT_TOKEN") or env.get("SLACK_BOT_TOKEN") or "").strip()
+    )
+
+
+def _storage_display_path() -> str:
+    db_path = _canonical_db_path()
+    if db_path is not None:
+        return str(db_path)
+    return str(get_hermes_home() / "payments" / "requests.json")
+
+
+def _canonical_enabled() -> bool:
+    return _canonical_db_path() is not None
+
+
+def _row_value(row: sqlite3.Row, key: str, default: Any = None) -> Any:
+    return row[key] if key in row.keys() else default
+
+
+def _json_loads(value: Any, default: Any) -> Any:
+    if value in (None, ""):
+        return default
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+def _load_runtime_from_path(module_name: str, runtime_path: Path):
+    plugin_parents = {str(runtime_path.parent.parent)}
+    for env_name in ("PAYMENTS_REVIEW_PLUGIN_ROOT", "GOOGLE_WORKSPACE_PLUGIN_ROOT"):
+        value = _require_env_value(env_name)
+        if value:
+            plugin_parents.add(str(Path(value).expanduser().resolve().parent))
+    for plugin_parent in sorted(parent for parent in plugin_parents if parent):
+        if plugin_parent not in sys.path:
+            sys.path.insert(0, plugin_parent)
+    if "." in module_name:
+        package_name = module_name.rsplit(".", 1)[0]
+        package = sys.modules.get(package_name)
+        if package is None:
+            package = types.ModuleType(package_name)
+            package.__path__ = [str(runtime_path.parent)]  # type: ignore[attr-defined]
+            sys.modules[package_name] = package
+    spec = importlib.util.spec_from_file_location(module_name, runtime_path)
+    if not spec or not spec.loader:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _candidate_runtime_paths() -> list[Path]:
+    candidates = [
+        Path("/opt/data/plugins/payments_review/runtime.py"),
+        get_hermes_home() / "plugins" / "payments_review" / "runtime.py",
+        Path.cwd() / "plugins" / "payments_review" / "runtime.py",
+    ]
+    value = _require_env_value("PAYMENTS_REVIEW_PLUGIN_ROOT")
+    if value:
+        candidates.insert(0, Path(value) / "runtime.py")
+    seen: set[str] = set()
+    deduped: list[Path] = []
+    for path in candidates:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(path)
+    return deduped
+
+
+def _payments_review_runtime():
+    try:
+        from plugins.payments_review import runtime as payments_runtime
+
+        return payments_runtime
+    except Exception:
+        try:
+            import payments_review.runtime as payments_runtime
+
+            return payments_runtime
+        except Exception:
+            for runtime_path in _candidate_runtime_paths():
+                if runtime_path.is_file():
+                    module = _load_runtime_from_path("payments_review.runtime", runtime_path)
+                    if module is not None:
+                        return module
+    raise RuntimeError("payments_review runtime is unavailable")
+
+
+def _connect() -> sqlite3.Connection:
+    db_path = _canonical_db_path()
+    if db_path is None:
+        raise RuntimeError("PAYMENTS_REVIEW_DB_PATH is not configured")
+    attempts: list[tuple[Any, dict[str, Any]]] = [
+        (str(db_path), {}),
+        (f"file:{db_path}?mode=ro&immutable=1", {"uri": True}),
+    ]
+    last_error: sqlite3.OperationalError | None = None
+    for target, kwargs in attempts:
+        try:
+            conn = sqlite3.connect(target, **kwargs)
+            # Force SQLite to open the schema now so read-only mounts fail over
+            # before later queries reach the dashboard surface.
+            conn.execute("SELECT COUNT(*) FROM sqlite_master").fetchone()
+            conn.row_factory = sqlite3.Row
+            return conn
+        except sqlite3.OperationalError as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Failed to connect to canonical payments storage")
+
+
+def _canonical_storage_tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('inbox_items', 'payment_requests')"
+    ).fetchall()
+    return {str(row["name"]) for row in rows}
+
+
+def _canonical_storage_kind(conn: sqlite3.Connection, *, prefer: str = "payment_requests") -> str:
+    names = _canonical_storage_tables(conn)
+    if prefer == "payment_requests":
+        if "payment_requests" in names:
+            return "payment_requests"
+        if "inbox_items" in names:
+            return "inbox_items"
+    else:
+        if "inbox_items" in names:
+            return "inbox_items"
+        if "payment_requests" in names:
+            return "payment_requests"
+    raise RuntimeError("Canonical payments storage is not initialized")
+
+
+def _ensure_inbox_items_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS inbox_items (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            source_account TEXT,
+            source_thread_id TEXT,
+            source_message_id TEXT,
+            source_url TEXT,
+            captured_at TEXT,
+            updated_at TEXT,
+            last_classified_at TEXT,
+            workflow_type TEXT NOT NULL,
+            queue TEXT NOT NULL,
+            status TEXT NOT NULL,
+            title TEXT,
+            summary TEXT,
+            counterparty TEXT,
+            action_required INTEGER,
+            confidence REAL,
+            amount_value REAL,
+            amount_currency TEXT,
+            amount_display TEXT,
+            due_date TEXT,
+            meeting_dates_json TEXT,
+            meeting_timezone TEXT,
+            reference_id TEXT,
+            receipt_like INTEGER,
+            invoice_like INTEGER,
+            calendar_like INTEGER,
+            warning_flags_json TEXT,
+            operator_notes TEXT,
+            raw_payload_path TEXT,
+            materialized_path TEXT,
+            manual_status INTEGER,
+            manual_notes INTEGER,
+            reviewed_at TEXT,
+            reviewed_by TEXT,
+            entities_json TEXT,
+            artifacts_json TEXT
+        )
+        """
+    )
+
+
+def _format_due_date(value: str | None) -> str:
     text = (value or "").strip()
     if not text:
-        return None
+        return ""
+    if _DATE_ONLY_RE.match(text):
+        return text
     try:
-        return parsedate_to_datetime(text).astimezone(timezone.utc).isoformat()
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
     except Exception:
         return text
 
 
-def _confidence_for(record: Dict[str, Any]) -> str:
-    score = 0
-    if record["amount"]["display"]:
-        score += 1
-    if record.get("invoice_number"):
-        score += 1
-    if record.get("payment_reference"):
-        score += 1
-    if any(
-        record.get(key)
-        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
-    ):
-        score += 2
-    if record.get("due_date"):
-        score += 1
-    if score >= 4:
-        return "high"
-    if score >= 2:
-        return "medium"
-    return "low"
+def _looks_paid(row: dict[str, Any]) -> bool:
+    if str(row.get("status") or "") == "paid":
+        return True
+    title = str(row.get("title") or "")
+    if _PAID_TITLES_RE.search(title):
+        return True
+    warnings = row.get("warnings") or []
+    return any(_PAID_WARNING_RE.search(str(item)) for item in warnings)
 
 
-def _warnings_for(record: Dict[str, Any]) -> List[str]:
-    warnings = []
-    if not record["amount"]["display"]:
-        warnings.append("No amount detected.")
-    if not any(
-        record.get(key)
-        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
-    ):
-        warnings.append("No bank account details detected.")
-    if not record.get("payment_reference") and not record.get("invoice_number"):
-        warnings.append("No invoice or payment reference detected.")
-    return warnings
+def _operator_status(status: str) -> str:
+    return "needs_review" if status == "new" else status
 
 
-def _build_gmail_payment_record(summary: Dict[str, Any], detail: Dict[str, Any], existing: Dict[str, Any] | None) -> Dict[str, Any]:
-    subject = str(detail.get("subject") or summary.get("subject") or "").strip()
-    body = str(detail.get("body") or "").strip()
-    snippet = str(summary.get("snippet") or "").strip()
-    combined = "\n".join(part for part in (subject, snippet, body) if part).strip()
-    vendor = _format_vendor(str(detail.get("from") or summary.get("from") or ""))
-    amount = _parse_amount(combined)
-    record = _empty_record(f"gmail:{detail['id']}")
-    record.update(
-        {
-            "source": "gmail",
-            "source_label": "Gmail",
-            "status": existing.get("status") if existing else "needs_review",
-            "received_at": _parse_received_at(str(detail.get("date") or summary.get("date") or "")),
-            "updated_at": _now_iso(),
-            "vendor": vendor,
-            "title": subject,
-            "amount": amount,
-            "due_date": _extract_match(_DUE_RE, combined) or None,
-            "payee_name": vendor,
-            "account_holder": vendor,
-            "account_number": _extract_match(_ACCOUNT_NUMBER_RE, combined),
-            "sort_code": _extract_match(_SORT_CODE_RE, combined),
-            "iban": _extract_match(_IBAN_RE, combined),
-            "swift": _extract_match(_SWIFT_RE, combined),
-            "routing_number": _extract_match(_ROUTING_RE, combined),
-            "payment_reference": _extract_match(_REFERENCE_RE, combined),
-            "invoice_number": _extract_match(_INVOICE_RE, combined),
-            "preview_text": _clean_text(body or snippet)[:1500],
-            "attachments": existing.get("attachments", []) if existing else [],
-            "original": {
-                "label": str(detail.get("from") or summary.get("from") or ""),
-                "url": f"https://mail.google.com/mail/u/0/#all/{detail['id']}",
-                "message_id": str(detail.get("id") or ""),
-                "thread_id": str(detail.get("threadId") or summary.get("threadId") or ""),
-            },
-        }
-    )
-    record["confidence"] = _confidence_for(record)
-    record["warnings"] = _warnings_for(record)
-    return record
+def _status_label(status: str) -> str:
+    return {
+        "new": "New",
+        "needs_review": "Needs review",
+        "ready_to_pay": "Ready to pay",
+        "paid": "Paid",
+        "ignored": "Ignored",
+    }.get(status, status.replace("_", " ").title())
 
 
-def _load_requests() -> List[Dict[str, Any]]:
-    path = _requests_path()
-    if not path.exists():
-        return []
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return []
-    items = data.get("requests") if isinstance(data, dict) else data
-    if not isinstance(items, list):
-        return []
-    return [_normalize_record(item, index=i) for i, item in enumerate(items) if isinstance(item, dict)]
+def _source_label(source: str) -> str:
+    for source_id, label in PAYMENT_SOURCES:
+        if source_id == source:
+            return label
+    return source.title() or "Unknown"
 
 
-def _save_requests(requests: List[Dict[str, Any]]) -> None:
-    path = _requests_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "requests": requests,
-        "updated_at": _now_iso(),
+def _row_to_request(row: sqlite3.Row) -> Dict[str, Any]:
+    request = {
+        "id": row["payment_id"],
+        "payment_id": row["payment_id"],
+        "source": row["source"],
+        "source_label": _source_label(row["source"]),
+        "status": row["status"],
+        "operator_status": _operator_status(row["status"]),
+        "confidence": row["confidence"],
+        "received_at": row["captured_at"],
+        "updated_at": row["updated_at"],
+        "vendor": row["vendor"] or "",
+        "title": row["title"] or "",
+        "amount": {
+            "value": row["amount_value"],
+            "currency": row["amount_currency"] or "",
+            "display": row["amount_display"] or "",
+        },
+        "due_date": _format_due_date(row["due_date"]),
+        "payee_name": row["payee_name"] or "",
+        "account_holder": row["account_holder"] or "",
+        "account_number": row["account_number"] or "",
+        "sort_code": row["sort_code"] or "",
+        "iban": row["iban"] or "",
+        "swift": row["swift"] or "",
+        "routing_number": row["routing_number"] or "",
+        "payment_reference": row["payment_reference"] or "",
+        "invoice_number": row["invoice_number"] or "",
+        "billing_address": row["billing_address"] or "",
+        "tax_details": row["tax_details"] or "",
+        "preview_text": row["preview_text"] or "",
+        "warnings": json.loads(row["warnings_json"] or "[]"),
+        "attachments": json.loads(row["attachments_json"] or "[]"),
+        "original": json.loads(row["original_json"] or "{}"),
+        "raw_text_path": row["raw_text_path"],
+        "materialized_path": row["materialized_path"],
+        "review_note": row["review_note"] or "",
+        "looks_paid": False,
     }
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    request["looks_paid"] = _looks_paid(request)
+    return request
+
+
+def _payment_workflow_type(request: Dict[str, Any]) -> str:
+    return "payment_receipt" if request.get("looks_paid") or request.get("status") == "paid" else "payment_request"
+
+
+def _request_to_inbox_item(request: Dict[str, Any]) -> Dict[str, Any]:
+    from plugins.inbox_ops_payments import PaymentCandidateClassifier, PaymentCandidateExtractor
+
+    classification = PaymentCandidateClassifier().classify(request)
+    return PaymentCandidateExtractor().extract(request, classification)
+
+
+def _inbox_item_to_request(row: sqlite3.Row) -> Dict[str, Any]:
+    entities = _json_loads(_row_value(row, "entities_json", "{}"), {})
+    artifacts = _json_loads(_row_value(row, "artifacts_json", "{}"), {})
+    warnings = [str(item) for item in _json_loads(_row_value(row, "warning_flags_json", "[]"), [])]
+    attachments = [str(item) for item in artifacts.get("attachments", []) if str(item).strip()]
+    original = {
+        "label": str(artifacts.get("label") or entities.get("sender") or ""),
+        "url": str(_row_value(row, "source_url", "") or artifacts.get("original_thread_url") or ""),
+        "message_id": str(_row_value(row, "source_message_id", "") or artifacts.get("message_id") or ""),
+        "thread_id": str(_row_value(row, "source_thread_id", "") or artifacts.get("thread_id") or ""),
+    }
+    request = {
+        "id": str(_row_value(row, "id", "")),
+        "payment_id": str(_row_value(row, "id", "")),
+        "source": str(_row_value(row, "source", "gmail") or "gmail"),
+        "source_label": _source_label(str(_row_value(row, "source", "gmail") or "gmail")),
+        "status": str(_row_value(row, "status", "needs_review") or "needs_review"),
+        "operator_status": _operator_status(str(_row_value(row, "status", "needs_review") or "needs_review")),
+        "confidence": _row_value(row, "confidence", ""),
+        "received_at": _row_value(row, "captured_at"),
+        "updated_at": _row_value(row, "updated_at", _row_value(row, "last_classified_at")),
+        "vendor": str(_row_value(row, "counterparty", "") or entities.get("organization") or ""),
+        "title": str(_row_value(row, "title", "") or ""),
+        "amount": {
+            "value": _row_value(row, "amount_value"),
+            "currency": str(_row_value(row, "amount_currency", "") or ""),
+            "display": str(_row_value(row, "amount_display", "") or ""),
+        },
+        "due_date": _format_due_date(_row_value(row, "due_date")),
+        "payee_name": str(entities.get("payee_name") or ""),
+        "account_holder": str(entities.get("account_holder") or ""),
+        "account_number": str(entities.get("account_number") or ""),
+        "sort_code": str(entities.get("sort_code") or ""),
+        "iban": str(entities.get("iban") or ""),
+        "swift": str(entities.get("swift") or ""),
+        "routing_number": str(entities.get("routing_number") or ""),
+        "payment_reference": str(entities.get("payment_reference") or _row_value(row, "reference_id", "") or ""),
+        "invoice_number": str(entities.get("invoice_number") or ""),
+        "billing_address": str(entities.get("billing_address") or ""),
+        "tax_details": str(entities.get("tax_details") or ""),
+        "preview_text": str(_row_value(row, "summary", "") or ""),
+        "warnings": warnings,
+        "attachments": attachments,
+        "original": original,
+        "raw_text_path": _row_value(row, "raw_payload_path"),
+        "materialized_path": _row_value(row, "materialized_path"),
+        "review_note": str(_row_value(row, "operator_notes", "") or ""),
+        "looks_paid": bool(_row_value(row, "receipt_like", 0)),
+    }
+    request["looks_paid"] = request["looks_paid"] or _looks_paid(request)
+    return request
+
+
+def _upsert_inbox_item(conn: sqlite3.Connection, item: Dict[str, Any]) -> None:
+    _ensure_inbox_items_schema(conn)
+    amount = item.get("amount") or {}
+    entities = item.get("entities") if isinstance(item.get("entities"), dict) else {}
+    artifacts = item.get("artifacts") if isinstance(item.get("artifacts"), dict) else {}
+    payload = {
+        "id": str(item.get("id") or ""),
+        "source": str(item.get("source") or "gmail"),
+        "source_account": str(item.get("source_account") or ""),
+        "source_thread_id": str(item.get("source_thread_id") or ""),
+        "source_message_id": str(item.get("source_message_id") or ""),
+        "source_url": str(item.get("source_url") or ""),
+        "captured_at": item.get("captured_at"),
+        "updated_at": item.get("updated_at"),
+        "last_classified_at": item.get("last_classified_at") or item.get("updated_at"),
+        "workflow_type": str(item.get("workflow_type") or "payment_request"),
+        "queue": str(item.get("queue") or _PAYMENTS_QUEUE),
+        "status": str(item.get("status") or "needs_review"),
+        "title": str(item.get("title") or ""),
+        "summary": str(item.get("summary") or ""),
+        "counterparty": str(item.get("counterparty") or ""),
+        "action_required": 1 if bool(item.get("action_required")) else 0,
+        "confidence": item.get("confidence"),
+        "amount_value": amount.get("value"),
+        "amount_currency": str(amount.get("currency") or ""),
+        "amount_display": str(amount.get("display") or ""),
+        "due_date": item.get("due_date"),
+        "meeting_dates_json": json.dumps(item.get("meeting_dates") or []),
+        "meeting_timezone": str(item.get("meeting_timezone") or ""),
+        "reference_id": str(item.get("reference_id") or ""),
+        "receipt_like": 1 if bool(item.get("receipt_like")) else 0,
+        "invoice_like": 1 if bool(item.get("invoice_like")) else 0,
+        "calendar_like": 1 if bool(item.get("calendar_like")) else 0,
+        "warning_flags_json": json.dumps(item.get("warning_flags") or []),
+        "operator_notes": str(item.get("operator_notes") or ""),
+        "raw_payload_path": item.get("raw_payload_path"),
+        "materialized_path": item.get("materialized_path"),
+        "manual_status": 1 if bool(item.get("manual_status")) else 0,
+        "manual_notes": 1 if bool(item.get("manual_notes")) else 0,
+        "reviewed_at": item.get("reviewed_at"),
+        "reviewed_by": item.get("reviewed_by"),
+        "entities_json": json.dumps(entities, sort_keys=True),
+        "artifacts_json": json.dumps(artifacts, sort_keys=True),
+    }
+    columns = list(payload.keys())
+    placeholders = ", ".join("?" for _ in columns)
+    updates = ", ".join(f"{column}=excluded.{column}" for column in columns if column != "id")
+    conn.execute(
+        f"""
+        INSERT INTO inbox_items ({", ".join(columns)}) VALUES ({placeholders})
+        ON CONFLICT(id) DO UPDATE SET {updates}
+        """,
+        tuple(payload[column] for column in columns),
+    )
+
+
+def _row_to_inbox_item(row: sqlite3.Row) -> Dict[str, Any]:
+    entities = _json_loads(_row_value(row, "entities_json", "{}"), {})
+    artifacts = _json_loads(_row_value(row, "artifacts_json", "{}"), {})
+    warning_flags = [str(item) for item in _json_loads(_row_value(row, "warning_flags_json", "[]"), [])]
+    return {
+        "id": str(_row_value(row, "id", "")),
+        "source": str(_row_value(row, "source", "gmail") or "gmail"),
+        "source_account": str(_row_value(row, "source_account", "") or ""),
+        "source_thread_id": str(_row_value(row, "source_thread_id", "") or ""),
+        "source_message_id": str(_row_value(row, "source_message_id", "") or ""),
+        "source_url": str(_row_value(row, "source_url", "") or ""),
+        "captured_at": _row_value(row, "captured_at"),
+        "updated_at": _row_value(row, "updated_at"),
+        "last_classified_at": _row_value(row, "last_classified_at"),
+        "workflow_type": str(_row_value(row, "workflow_type", "") or ""),
+        "queue": str(_row_value(row, "queue", "") or ""),
+        "status": str(_row_value(row, "status", "needs_review") or "needs_review"),
+        "title": str(_row_value(row, "title", "") or ""),
+        "summary": str(_row_value(row, "summary", "") or ""),
+        "counterparty": str(_row_value(row, "counterparty", "") or ""),
+        "action_required": bool(_row_value(row, "action_required", 0)),
+        "confidence": _row_value(row, "confidence"),
+        "amount": {
+            "value": _row_value(row, "amount_value"),
+            "currency": str(_row_value(row, "amount_currency", "") or ""),
+            "display": str(_row_value(row, "amount_display", "") or ""),
+        },
+        "due_date": _format_due_date(_row_value(row, "due_date")),
+        "meeting_dates": _json_loads(_row_value(row, "meeting_dates_json", "[]"), []),
+        "meeting_timezone": str(_row_value(row, "meeting_timezone", "") or ""),
+        "reference_id": str(_row_value(row, "reference_id", "") or ""),
+        "receipt_like": bool(_row_value(row, "receipt_like", 0)),
+        "invoice_like": bool(_row_value(row, "invoice_like", 0)),
+        "calendar_like": bool(_row_value(row, "calendar_like", 0)),
+        "warning_flags": warning_flags,
+        "operator_notes": str(_row_value(row, "operator_notes", "") or ""),
+        "raw_payload_path": _row_value(row, "raw_payload_path"),
+        "materialized_path": _row_value(row, "materialized_path"),
+        "manual_status": bool(_row_value(row, "manual_status", 0)),
+        "manual_notes": bool(_row_value(row, "manual_notes", 0)),
+        "reviewed_at": _row_value(row, "reviewed_at"),
+        "reviewed_by": _row_value(row, "reviewed_by"),
+        "entities": entities,
+        "artifacts": artifacts,
+    }
+
+
+def _fetch_canonical_request(payment_id: str) -> Dict[str, Any]:
+    with _connect() as conn:
+        storage_kind = _canonical_storage_kind(conn)
+        if storage_kind == "inbox_items":
+            row = conn.execute(
+                "SELECT * FROM inbox_items WHERE id = ? AND queue = ?",
+                (payment_id, _PAYMENTS_QUEUE),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT * FROM payment_requests WHERE payment_id = ?",
+                (payment_id,),
+            ).fetchone()
+    if row is None:
+        raise KeyError(payment_id)
+    return _inbox_item_to_request(row) if storage_kind == "inbox_items" else _row_to_request(row)
+
+
+def _update_canonical_status(payment_id: str, status: str) -> Dict[str, Any]:
+    with _connect() as conn:
+        storage_kind = _canonical_storage_kind(conn)
+        if storage_kind == "inbox_items":
+            existing = conn.execute(
+                "SELECT id FROM inbox_items WHERE id = ? AND queue = ?",
+                (payment_id, _PAYMENTS_QUEUE),
+            ).fetchone()
+            if existing is None:
+                raise KeyError(payment_id)
+            conn.execute(
+                """
+                UPDATE inbox_items
+                SET status = ?, updated_at = ?, manual_status = 1, reviewed_at = COALESCE(reviewed_at, ?)
+                WHERE id = ? AND queue = ?
+                """,
+                (status, _now_iso(), _now_iso(), payment_id, _PAYMENTS_QUEUE),
+            )
+        else:
+            existing = conn.execute(
+                "SELECT payment_id FROM payment_requests WHERE payment_id = ?",
+                (payment_id,),
+            ).fetchone()
+            if existing is None:
+                raise KeyError(payment_id)
+            conn.execute(
+                "UPDATE payment_requests SET status = ?, updated_at = ? WHERE payment_id = ?",
+                (status, _now_iso(), payment_id),
+            )
+        conn.commit()
+    return _fetch_canonical_request(payment_id)
 
 
 def _source_statuses() -> List[Dict[str, Any]]:
-    env = load_env()
-    home = get_hermes_home()
-
-    gmail_token = home / "google_token.json"
+    env = _load_runtime_env()
     email_address = str(env.get("EMAIL_ADDRESS") or "").strip()
-    slack_token = str(env.get("SLACK_BOT_TOKEN") or "").strip()
-
     statuses = []
     for source_id, label in PAYMENT_SOURCES:
         if source_id == "gmail":
-            connected = gmail_token.exists()
+            connected = _google_token_path().exists()
             statuses.append(
                 {
                     "id": source_id,
@@ -382,7 +636,7 @@ def _source_statuses() -> List[Dict[str, Any]]:
                 }
             )
         elif source_id == "slack":
-            connected = bool(slack_token)
+            connected = _slack_token_present()
             statuses.append(
                 {
                     "id": source_id,
@@ -391,27 +645,162 @@ def _source_statuses() -> List[Dict[str, Any]]:
                     "detail": (
                         "Slack bot token is configured."
                         if connected
-                        else "Slack capture can be added once the Slack channel is configured."
+                        else "Slack mobile inbox requires the Slack gateway bot token."
                     ),
                 }
             )
     return statuses
 
 
+def _legacy_requests_path() -> Path:
+    return get_hermes_home() / "payments" / "requests.json"
+
+
+def _shadow_report_path() -> Path:
+    return get_hermes_home() / "payments" / "shadow-report.json"
+
+
+def _normalize_legacy_request(raw: Dict[str, Any], *, index: int) -> Dict[str, Any]:
+    source = str(raw.get("source") or "uploads").strip() or "uploads"
+    amount = raw.get("amount") if isinstance(raw.get("amount"), dict) else {}
+    request = {
+        "id": str(raw.get("id") or f"payment-{index + 1}"),
+        "payment_id": str(raw.get("id") or f"payment-{index + 1}"),
+        "source": source,
+        "source_label": _source_label(source),
+        "status": str(raw.get("status") or "needs_review"),
+        "operator_status": _operator_status(str(raw.get("status") or "needs_review")),
+        "confidence": str(raw.get("confidence") or "low"),
+        "received_at": raw.get("received_at"),
+        "updated_at": raw.get("updated_at"),
+        "vendor": str(raw.get("vendor") or ""),
+        "title": str(raw.get("title") or ""),
+        "amount": {
+            "value": amount.get("value"),
+            "currency": str(amount.get("currency") or ""),
+            "display": str(amount.get("display") or ""),
+        },
+        "due_date": _format_due_date(raw.get("due_date")),
+        "payee_name": str(raw.get("payee_name") or ""),
+        "account_holder": str(raw.get("account_holder") or ""),
+        "account_number": str(raw.get("account_number") or ""),
+        "sort_code": str(raw.get("sort_code") or ""),
+        "iban": str(raw.get("iban") or ""),
+        "swift": str(raw.get("swift") or ""),
+        "routing_number": str(raw.get("routing_number") or ""),
+        "payment_reference": str(raw.get("payment_reference") or ""),
+        "invoice_number": str(raw.get("invoice_number") or ""),
+        "billing_address": str(raw.get("billing_address") or ""),
+        "tax_details": str(raw.get("tax_details") or ""),
+        "preview_text": str(raw.get("preview_text") or ""),
+        "warnings": [str(item) for item in (raw.get("warnings") or [])],
+        "attachments": [str(item) for item in (raw.get("attachments") or [])],
+        "original": raw.get("original") if isinstance(raw.get("original"), dict) else {},
+        "raw_text_path": str(raw.get("raw_text_path") or ""),
+        "materialized_path": str(raw.get("materialized_path") or ""),
+        "review_note": str(raw.get("review_note") or ""),
+        "looks_paid": False,
+    }
+    request["looks_paid"] = _looks_paid(request)
+    return request
+
+
+def _load_legacy_requests() -> list[Dict[str, Any]]:
+    path = _legacy_requests_path()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    items = data.get("requests") if isinstance(data, dict) else data
+    if not isinstance(items, list):
+        return []
+    return [
+        _normalize_legacy_request(item, index=i)
+        for i, item in enumerate(items)
+        if isinstance(item, dict)
+    ]
+
+
+def _save_legacy_requests(requests: list[Dict[str, Any]]) -> None:
+    path = _legacy_requests_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"requests": requests, "updated_at": _now_iso()}
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
 def list_payment_requests() -> Dict[str, Any]:
-    requests = _load_requests()
-    requests.sort(
-        key=lambda item: (
-            str(item.get("received_at") or ""),
-            str(item.get("updated_at") or ""),
-            str(item.get("id") or ""),
-        ),
-        reverse=True,
-    )
+    if _canonical_enabled():
+        with _connect() as conn:
+            storage_kind = _canonical_storage_kind(conn, prefer="payment_requests")
+            if storage_kind == "inbox_items":
+                rows = conn.execute(
+                    """
+                    SELECT * FROM inbox_items
+                    WHERE queue = ?
+                    ORDER BY captured_at DESC, updated_at DESC, id DESC
+                    """,
+                    (_PAYMENTS_QUEUE,),
+                ).fetchall()
+                requests = [_inbox_item_to_request(row) for row in rows]
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM payment_requests ORDER BY captured_at DESC, updated_at DESC, payment_id DESC"
+                ).fetchall()
+                requests = [_row_to_request(row) for row in rows]
+    else:
+        requests = _load_legacy_requests()
     return {
         "sources": _source_statuses(),
         "requests": requests,
-        "storage_path": str(_requests_path()),
+        "storage_path": _storage_display_path(),
+    }
+
+
+def list_inbox_items(
+    *,
+    queue: str | None = None,
+    workflow_type: str | None = None,
+) -> Dict[str, Any]:
+    normalized_queue = str(queue or "").strip().lower()
+    normalized_workflow = str(workflow_type or "").strip().lower()
+    if _canonical_enabled():
+        with _connect() as conn:
+            storage_kind = _canonical_storage_kind(conn, prefer="inbox_items")
+            if storage_kind == "inbox_items":
+                clauses: list[str] = []
+                params: list[Any] = []
+                if normalized_queue:
+                    clauses.append("queue = ?")
+                    params.append(normalized_queue)
+                if normalized_workflow:
+                    clauses.append("workflow_type = ?")
+                    params.append(normalized_workflow)
+                where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+                rows = conn.execute(
+                    f"SELECT * FROM inbox_items {where} ORDER BY captured_at DESC, updated_at DESC, id DESC",
+                    tuple(params),
+                ).fetchall()
+                items = [_row_to_inbox_item(row) for row in rows]
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM payment_requests ORDER BY captured_at DESC, updated_at DESC, payment_id DESC"
+                ).fetchall()
+                items = [_request_to_inbox_item(_row_to_request(row)) for row in rows]
+        if normalized_queue:
+            items = [item for item in items if item["queue"] == normalized_queue]
+        if normalized_workflow:
+            items = [item for item in items if item["workflow_type"] == normalized_workflow]
+    else:
+        items = [_request_to_inbox_item(request) for request in _load_legacy_requests()]
+        if normalized_queue:
+            items = [item for item in items if item["queue"] == normalized_queue]
+        if normalized_workflow:
+            items = [item for item in items if item["workflow_type"] == normalized_workflow]
+    return {
+        "items": items,
+        "storage_path": _storage_display_path(),
     }
 
 
@@ -419,41 +808,397 @@ def sync_gmail_payment_requests(
     query: str = DEFAULT_GMAIL_QUERY,
     max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
 ) -> Dict[str, Any]:
-    summaries = _run_google_api(["gmail", "search", query, "--max", str(max_results)])
-    if not isinstance(summaries, list):
-        raise RuntimeError("Gmail search returned an unexpected payload")
+    if _canonical_enabled():
+        runtime = _payments_review_runtime()
+        payload = json.loads(
+            runtime.ingest_payments_from_gmail(
+                {"query_override": query, "max_threads": int(max_results)}
+            )
+        )
+        if not payload.get("ok"):
+            raise RuntimeError(str(payload.get("error") or "payments ingest failed"))
+        requests = []
+        imported = 0
+        updated = 0
+        for item in payload.get("payments", []):
+            request = dict(item)
+            request["id"] = request.get("payment_id")
+            request["source_label"] = _source_label(str(request.get("source") or "gmail"))
+            request["operator_status"] = _operator_status(str(request.get("status") or "needs_review"))
+            request["looks_paid"] = _looks_paid(request)
+            requests.append(request)
+            if request.get("duplicate"):
+                updated += 1
+            else:
+                imported += 1
+        return {
+            "source": "gmail",
+            "query": str(payload.get("query") or query),
+            "fetched": int(payload.get("thread_count") or 0),
+            "imported": imported,
+            "updated": updated,
+            "requests": requests,
+        }
 
-    requests = _load_requests()
-    existing_by_id = {str(record.get("id")): record for record in requests}
-    imported = 0
-    updated = 0
+    raise RuntimeError("Canonical payments_review storage is not configured")
 
-    for summary in summaries:
-        if not isinstance(summary, dict) or not summary.get("id"):
-            continue
-        detail = _run_google_api(["gmail", "get", str(summary["id"])])
-        if not isinstance(detail, dict) or not detail.get("id"):
-            continue
-        record_id = f"gmail:{detail['id']}"
-        existing = existing_by_id.get(record_id)
-        record = _build_gmail_payment_record(summary, detail, existing)
-        if existing is None:
-            requests.append(record)
-            existing_by_id[record_id] = record
-            imported += 1
-        else:
-            existing.update(record)
-            updated += 1
 
-    _save_requests(requests)
-    return {
-        "source": "gmail",
-        "query": query,
-        "fetched": len(summaries),
-        "imported": imported,
-        "updated": updated,
-        "requests": requests,
+def sync_gmail_payment_requests_shadow(
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> Dict[str, Any]:
+    result = sync_gmail_payment_requests(query=query, max_results=max_results)
+    if not _canonical_enabled():
+        raise RuntimeError("Canonical payments_review storage is not configured")
+
+    mirrored = 0
+    with _connect() as conn:
+        _ensure_inbox_items_schema(conn)
+        for request in list_payment_requests()["requests"]:
+            item = _request_to_inbox_item(request)
+            _upsert_inbox_item(conn, item)
+            mirrored += 1
+        conn.commit()
+
+    report = generate_payments_shadow_report()
+    response = {
+        **result,
+        "shadow": {
+            "mirrored": mirrored,
+            "storage_path": _storage_display_path(),
+            "parity": report,
+        },
     }
+    _save_shadow_report_snapshot(response)
+    return response
+
+
+def generate_payments_shadow_report() -> Dict[str, Any]:
+    payments = {item["id"]: item for item in list_payment_requests()["requests"]}
+    inbox_items = {
+        item["id"]: item for item in list_inbox_items(queue=_PAYMENTS_QUEUE)["items"]
+    }
+    all_ids = sorted(set(payments) | set(inbox_items))
+    status_mismatches: list[str] = []
+    amount_mismatches: list[str] = []
+    due_date_mismatches: list[str] = []
+    reference_mismatches: list[str] = []
+    missing_in_shadow: list[str] = []
+    shadow_only: list[str] = []
+    for item_id in all_ids:
+        payment = payments.get(item_id)
+        shadow = inbox_items.get(item_id)
+        if payment is None:
+            shadow_only.append(item_id)
+            continue
+        if shadow is None:
+            missing_in_shadow.append(item_id)
+            continue
+        if str(payment.get("status") or "") != str(shadow.get("status") or ""):
+            status_mismatches.append(item_id)
+        if str((payment.get("amount") or {}).get("display") or "") != str((shadow.get("amount") or {}).get("display") or ""):
+            amount_mismatches.append(item_id)
+        if str(payment.get("due_date") or "") != str(shadow.get("due_date") or ""):
+            due_date_mismatches.append(item_id)
+        if str(payment.get("payment_reference") or "") != str(shadow.get("reference_id") or ""):
+            reference_mismatches.append(item_id)
+
+    compared = len([item_id for item_id in all_ids if item_id in payments and item_id in inbox_items])
+    parity_ok = not any(
+        [
+            status_mismatches,
+            amount_mismatches,
+            due_date_mismatches,
+            reference_mismatches,
+            missing_in_shadow,
+        ]
+    )
+    return {
+        "generated_at": _now_iso(),
+        "payments_count": len(payments),
+        "shadow_count": len(inbox_items),
+        "compared_count": compared,
+        "parity_ok": parity_ok,
+        "status_mismatches": status_mismatches,
+        "amount_mismatches": amount_mismatches,
+        "due_date_mismatches": due_date_mismatches,
+        "reference_mismatches": reference_mismatches,
+        "missing_in_shadow": missing_in_shadow,
+        "shadow_only": shadow_only,
+    }
+
+
+def _save_shadow_report_snapshot(result: Dict[str, Any]) -> None:
+    path = _shadow_report_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "updated_at": _now_iso(),
+        "result": result,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def load_shadow_report_snapshot() -> Dict[str, Any]:
+    path = _shadow_report_path()
+    if not path.exists():
+        return {
+            "updated_at": None,
+            "result": None,
+            "path": str(path),
+        }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        payload = {}
+    return {
+        "updated_at": payload.get("updated_at"),
+        "result": payload.get("result"),
+        "path": str(path),
+    }
+
+
+def format_sync_summary(result: Dict[str, Any]) -> str:
+    return (
+        "synced gmail payments"
+        f" fetched={int(result.get('fetched') or 0)}"
+        f" imported={int(result.get('imported') or 0)}"
+        f" updated={int(result.get('updated') or 0)}"
+    )
+
+
+def format_shadow_summary(result: Dict[str, Any]) -> str:
+    shadow = result.get("shadow") or {}
+    parity = shadow.get("parity") or {}
+    return (
+        f"{format_sync_summary(result)}"
+        f" shadow_mirrored={int(shadow.get('mirrored') or 0)}"
+        f" parity_ok={bool(parity.get('parity_ok'))}"
+        f" compared={int(parity.get('compared_count') or 0)}"
+        f" payments={int(parity.get('payments_count') or 0)}"
+        f" shadow={int(parity.get('shadow_count') or 0)}"
+    )
+
+
+def render_gmail_sync_cron_script(
+    *,
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> str:
+    return (
+        "#!/usr/bin/env python3\n"
+        "\"\"\"Managed Hermes cron script: sync Gmail payments into the canonical store.\"\"\"\n"
+        "\n"
+        "from hermes_cli.payments import format_sync_summary, sync_gmail_payment_requests\n"
+        "\n"
+        "\n"
+        "def main() -> int:\n"
+        f"    result = sync_gmail_payment_requests(query={query!r}, max_results={int(max_results)})\n"
+        "    print(format_sync_summary(result))\n"
+        "    return 0\n"
+        "\n"
+        "\n"
+        "if __name__ == \"__main__\":\n"
+        "    raise SystemExit(main())\n"
+    )
+
+
+def render_gmail_shadow_sync_cron_script(
+    *,
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> str:
+    return (
+        "#!/usr/bin/env python3\n"
+        "\"\"\"Managed Hermes cron script: shadow-sync Gmail payments into inbox_items.\"\"\"\n"
+        "\n"
+        "from hermes_cli.payments import format_shadow_summary, sync_gmail_payment_requests_shadow\n"
+        "\n"
+        "\n"
+        "def main() -> int:\n"
+        f"    result = sync_gmail_payment_requests_shadow(query={query!r}, max_results={int(max_results)})\n"
+        "    print(format_shadow_summary(result))\n"
+        "    return 0\n"
+        "\n"
+        "\n"
+        "if __name__ == \"__main__\":\n"
+        "    raise SystemExit(main())\n"
+    )
+
+
+def install_gmail_sync_cron_script(
+    *,
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> Path:
+    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    script_path = scripts_dir / PAYMENTS_GMAIL_SYNC_CRON_SCRIPT
+    content = render_gmail_sync_cron_script(query=query, max_results=max_results)
+    script_path.write_text(content, encoding="utf-8")
+    try:
+        script_path.chmod(0o700)
+    except OSError:
+        pass
+    return script_path
+
+
+def install_gmail_shadow_sync_cron_script(
+    *,
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> Path:
+    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    script_path = scripts_dir / PAYMENTS_GMAIL_SHADOW_SYNC_CRON_SCRIPT
+    content = render_gmail_shadow_sync_cron_script(query=query, max_results=max_results)
+    script_path.write_text(content, encoding="utf-8")
+    try:
+        script_path.chmod(0o700)
+    except OSError:
+        pass
+    return script_path
+
+
+def ensure_gmail_sync_cron_job(
+    *,
+    schedule: str = DEFAULT_GMAIL_SYNC_SCHEDULE,
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+    name: str = PAYMENTS_GMAIL_SYNC_CRON_JOB_NAME,
+) -> Dict[str, Any]:
+    from cron.jobs import create_job, resolve_job_ref, update_job
+
+    install_gmail_sync_cron_script(query=query, max_results=max_results)
+    spec = {
+        "prompt": "Sync Gmail payment requests into the canonical payments review store.",
+        "schedule": schedule,
+        "name": str(name or PAYMENTS_GMAIL_SYNC_CRON_JOB_NAME).strip() or PAYMENTS_GMAIL_SYNC_CRON_JOB_NAME,
+        "deliver": "local",
+        "script": PAYMENTS_GMAIL_SYNC_CRON_SCRIPT,
+        "no_agent": True,
+    }
+    existing = resolve_job_ref(spec["name"])
+    if existing is not None:
+        updated = update_job(existing["id"], spec)
+        if updated is None:
+            raise RuntimeError(f"Failed to update cron job: {existing['id']}")
+        return updated
+    return create_job(**spec)
+
+
+def ensure_gmail_shadow_sync_cron_job(
+    *,
+    schedule: str = DEFAULT_GMAIL_SHADOW_SYNC_SCHEDULE,
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+    name: str = PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME,
+) -> Dict[str, Any]:
+    from cron.jobs import create_job, resolve_job_ref, update_job
+
+    install_gmail_shadow_sync_cron_script(query=query, max_results=max_results)
+    spec = {
+        "prompt": "Shadow-sync Gmail payment requests into inbox_items and capture parity metrics.",
+        "schedule": schedule,
+        "name": str(name or PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME).strip()
+        or PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME,
+        "deliver": "local",
+        "script": PAYMENTS_GMAIL_SHADOW_SYNC_CRON_SCRIPT,
+        "no_agent": True,
+    }
+    existing = resolve_job_ref(spec["name"])
+    if existing is not None:
+        updated = update_job(existing["id"], spec)
+        if updated is None:
+            raise RuntimeError(f"Failed to update cron job: {existing['id']}")
+        return updated
+    return create_job(**spec)
+
+
+def payments_command(args: Any) -> int:
+    subcommand = str(getattr(args, "payments_command", "") or "").strip()
+    if not subcommand:
+        print(
+            "usage: hermes payments <subcommand>\n"
+            "\n"
+            "subcommands:\n"
+            "  sync-gmail             Run the Gmail -> canonical payments sync now\n"
+            "  schedule-gmail-sync    Install/update a recurring Hermes cron job\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    if subcommand == "sync-gmail":
+        result = sync_gmail_payment_requests(
+            query=str(getattr(args, "query", DEFAULT_GMAIL_QUERY) or DEFAULT_GMAIL_QUERY),
+            max_results=int(getattr(args, "max_results", DEFAULT_GMAIL_MAX_RESULTS) or DEFAULT_GMAIL_MAX_RESULTS),
+        )
+        print(format_sync_summary(result))
+        return 0
+
+    if subcommand == "shadow-sync-gmail":
+        result = sync_gmail_payment_requests_shadow(
+            query=str(getattr(args, "query", DEFAULT_GMAIL_QUERY) or DEFAULT_GMAIL_QUERY),
+            max_results=int(getattr(args, "max_results", DEFAULT_GMAIL_MAX_RESULTS) or DEFAULT_GMAIL_MAX_RESULTS),
+        )
+        print(format_shadow_summary(result))
+        return 0
+
+    if subcommand == "shadow-report":
+        print(json.dumps(generate_payments_shadow_report(), indent=2, sort_keys=True))
+        return 0
+
+    if subcommand == "schedule-shadow-sync":
+        job = ensure_gmail_shadow_sync_cron_job(
+            schedule=str(
+                getattr(args, "schedule", DEFAULT_GMAIL_SHADOW_SYNC_SCHEDULE)
+                or DEFAULT_GMAIL_SHADOW_SYNC_SCHEDULE
+            ),
+            query=str(getattr(args, "query", DEFAULT_GMAIL_QUERY) or DEFAULT_GMAIL_QUERY),
+            max_results=int(
+                getattr(args, "max_results", DEFAULT_GMAIL_MAX_RESULTS)
+                or DEFAULT_GMAIL_MAX_RESULTS
+            ),
+            name=str(
+                getattr(args, "name", PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME)
+                or PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME
+            ),
+        )
+        print(
+            f"scheduled payments gmail shadow sync job id={job['id']} "
+            f"schedule={job.get('schedule_display') or job.get('schedule')}"
+        )
+        if bool(getattr(args, "run_now", False)):
+            result = sync_gmail_payment_requests_shadow(
+                query=str(getattr(args, "query", DEFAULT_GMAIL_QUERY) or DEFAULT_GMAIL_QUERY),
+                max_results=int(
+                    getattr(args, "max_results", DEFAULT_GMAIL_MAX_RESULTS)
+                    or DEFAULT_GMAIL_MAX_RESULTS
+                ),
+            )
+            print(format_shadow_summary(result))
+        return 0
+
+    if subcommand == "schedule-gmail-sync":
+        job = ensure_gmail_sync_cron_job(
+            schedule=str(getattr(args, "schedule", DEFAULT_GMAIL_SYNC_SCHEDULE) or DEFAULT_GMAIL_SYNC_SCHEDULE),
+            query=str(getattr(args, "query", DEFAULT_GMAIL_QUERY) or DEFAULT_GMAIL_QUERY),
+            max_results=int(getattr(args, "max_results", DEFAULT_GMAIL_MAX_RESULTS) or DEFAULT_GMAIL_MAX_RESULTS),
+            name=str(getattr(args, "name", PAYMENTS_GMAIL_SYNC_CRON_JOB_NAME) or PAYMENTS_GMAIL_SYNC_CRON_JOB_NAME),
+        )
+        print(
+            f"scheduled payments gmail sync job id={job['id']} "
+            f"schedule={job.get('schedule_display') or job.get('schedule')}"
+        )
+        if bool(getattr(args, "run_now", False)):
+            result = sync_gmail_payment_requests(
+                query=str(getattr(args, "query", DEFAULT_GMAIL_QUERY) or DEFAULT_GMAIL_QUERY),
+                max_results=int(getattr(args, "max_results", DEFAULT_GMAIL_MAX_RESULTS) or DEFAULT_GMAIL_MAX_RESULTS),
+            )
+            print(format_sync_summary(result))
+        return 0
+
+    print(f"Unknown payments subcommand: {subcommand}", file=sys.stderr)
+    return 1
 
 
 def update_payment_status(payment_id: str, status: str) -> Dict[str, Any]:
@@ -461,11 +1206,256 @@ def update_payment_status(payment_id: str, status: str) -> Dict[str, Any]:
     if normalized_status not in PAYMENT_STATUSES:
         raise ValueError(f"Unknown payment status: {status}")
 
-    requests = _load_requests()
+    if _canonical_enabled():
+        return _update_canonical_status(payment_id, normalized_status)
+
+    requests = _load_legacy_requests()
     for record in requests:
         if str(record.get("id")) == payment_id:
             record["status"] = normalized_status
+            record["operator_status"] = _operator_status(normalized_status)
             record["updated_at"] = _now_iso()
-            _save_requests(requests)
+            _save_legacy_requests(requests)
             return record
     raise KeyError(payment_id)
+
+
+def update_inbox_item_status(item_id: str, status: str) -> Dict[str, Any]:
+    normalized_status = str(status or "").strip()
+    if normalized_status not in INBOX_ITEM_STATUSES:
+        raise ValueError(f"Unknown inbox item status: {status}")
+
+    if _canonical_enabled():
+        with _connect() as conn:
+            storage_kind = _canonical_storage_kind(conn, prefer="inbox_items")
+            if storage_kind == "inbox_items":
+                existing = conn.execute(
+                    "SELECT id FROM inbox_items WHERE id = ?",
+                    (item_id,),
+                ).fetchone()
+                if existing is None:
+                    raise KeyError(item_id)
+                now = _now_iso()
+                conn.execute(
+                    """
+                    UPDATE inbox_items
+                    SET status = ?, updated_at = ?, manual_status = 1, reviewed_at = COALESCE(reviewed_at, ?)
+                    WHERE id = ?
+                    """,
+                    (normalized_status, now, now, item_id),
+                )
+                conn.commit()
+                row = conn.execute("SELECT * FROM inbox_items WHERE id = ?", (item_id,)).fetchone()
+                if row is None:
+                    raise KeyError(item_id)
+                return _row_to_inbox_item(row)
+
+    updated = update_payment_status(item_id, normalized_status)
+    return _request_to_inbox_item(updated)
+
+
+def _summarize_payment_line(payment: Dict[str, Any]) -> str:
+    amount = payment["amount"]["display"] or "Amount missing"
+    due = payment.get("due_date") or "No due date"
+    warning = " receipt-like" if payment.get("looks_paid") else ""
+    status = _status_label(str(payment.get("operator_status") or payment.get("status") or "needs_review"))
+    return (
+        f"- **{payment.get('vendor') or payment.get('title') or payment.get('id')}**"
+        f" · {amount} · due {due} · {status}{warning}"
+    )
+
+
+def render_slack_canvas_markdown(
+    *,
+    dashboard_url: str = "",
+    per_status_limit: int = 8,
+) -> str:
+    payload = list_payment_requests()
+    requests = payload["requests"]
+    sections = [
+        ("Needs review", [item for item in requests if item["operator_status"] == "needs_review"]),
+        ("Ready to pay", [item for item in requests if item["operator_status"] == "ready_to_pay"]),
+        ("Recently paid", [item for item in requests if item["status"] == "paid"]),
+    ]
+    lines = [
+        "# Payments Ops",
+        "",
+        f"_Refreshed: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}_",
+        "",
+        "This canvas is a compact summary. Use the dashboard or Slack action inbox to make updates.",
+    ]
+    if dashboard_url.strip():
+        lines.extend(["", f"[Open dashboard payments board]({dashboard_url.strip()})"])
+    for title, items in sections:
+        lines.extend(["", f"## {title}", ""])
+        if not items:
+            lines.append("- None")
+            continue
+        for payment in items[:per_status_limit]:
+            lines.append(_summarize_payment_line(payment))
+    return "\n".join(lines).strip() + "\n"
+
+
+def render_slack_canvas_spec(
+    *,
+    channel_key: str,
+    channel_name: str,
+    dashboard_url: str = "",
+    canvas_title: str = "Payments Ops",
+    per_status_limit: int = 8,
+) -> str:
+    markdown = render_slack_canvas_markdown(
+        dashboard_url=dashboard_url,
+        per_status_limit=per_status_limit,
+    ).rstrip("\n")
+    indented_markdown = "\n".join(f"          {line}" if line else "" for line in markdown.splitlines())
+    return (
+        "channels:\n"
+        f"  - key: {channel_key}\n"
+        f"    name: {json.dumps(channel_name)}\n"
+        "    canvases:\n"
+        f"      - key: payments-ops\n"
+        f"        title: {json.dumps(canvas_title)}\n"
+        "        channel_canvas: true\n"
+        "        markdown: |\n"
+        f"{indented_markdown}\n"
+    )
+
+
+def _slack_payment_summary(payment: Dict[str, Any]) -> str:
+    title = payment.get("vendor") or payment.get("title") or payment.get("id")
+    amount = payment["amount"]["display"] or "Amount missing"
+    due = payment.get("due_date") or "No due date"
+    status = _status_label(str(payment.get("operator_status") or payment.get("status") or "needs_review"))
+    suffix = " · receipt-like" if payment.get("looks_paid") else ""
+    return f"*{title}*\n{amount} · due {due} · {status}{suffix}"
+
+
+def build_slack_status_modal_view(
+    payment: Dict[str, Any],
+    *,
+    private_metadata: str = "",
+) -> Dict[str, Any]:
+    payment_id = str(payment["id"])
+    return {
+        "type": "modal",
+        "callback_id": "payments_status_modal",
+        "title": {"type": "plain_text", "text": "Update payment", "emoji": True},
+        "close": {"type": "plain_text", "text": "Close", "emoji": True},
+        "private_metadata": private_metadata,
+        "blocks": [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": _slack_payment_summary(payment)},
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "This updates the canonical payments review store. No payment is executed automatically.",
+                    }
+                ],
+            },
+            {
+                "type": "actions",
+                "block_id": f"payment-status:{payment_id}",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "payments_mark_review",
+                        "text": {"type": "plain_text", "text": "Needs review"},
+                        "value": payment_id,
+                    },
+                    {
+                        "type": "button",
+                        "action_id": "payments_mark_ready",
+                        "text": {"type": "plain_text", "text": "Ready to pay"},
+                        "value": payment_id,
+                    },
+                    {
+                        "type": "button",
+                        "action_id": "payments_mark_paid",
+                        "text": {"type": "plain_text", "text": "Paid"},
+                        "style": "primary",
+                        "value": payment_id,
+                    },
+                    {
+                        "type": "button",
+                        "action_id": "payments_mark_ignored",
+                        "text": {"type": "plain_text", "text": "Ignored"},
+                        "style": "danger",
+                        "value": payment_id,
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def build_slack_mobile_blocks(
+    *,
+    statuses: tuple[str, ...] = ("needs_review", "ready_to_pay"),
+    per_status_limit: int = 5,
+) -> list[dict[str, Any]]:
+    payload = list_payment_requests()
+    requests = payload["requests"]
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "Payments mobile inbox", "emoji": True},
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"Refreshed {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} · status updates are local only",
+                }
+            ],
+        },
+    ]
+    for status in statuses:
+        label = {
+            "needs_review": "Needs review",
+            "ready_to_pay": "Ready to pay",
+            "paid": "Recently paid",
+            "ignored": "Ignored",
+        }.get(status, _status_label(status))
+        items = [item for item in requests if item["operator_status"] == status or item["status"] == status]
+        blocks.append({"type": "divider"})
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*{label}*"},
+            }
+        )
+        if not items:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": "_None_"}],
+                }
+            )
+            continue
+        for payment in items[:per_status_limit]:
+            title = payment.get("vendor") or payment.get("title") or payment.get("id")
+            amount = payment["amount"]["display"] or "Amount missing"
+            due = payment.get("due_date") or "No due date"
+            blocks.append(
+                {
+                    "type": "section",
+                    "block_id": f"payment:{payment['id']}",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": _slack_payment_summary(payment),
+                    },
+                    "accessory": {
+                        "type": "button",
+                        "action_id": "payments_open_status_modal",
+                        "text": {"type": "plain_text", "text": "Update status"},
+                        "value": payment["id"],
+                    },
+                }
+            )
+    return blocks

--- a/hermes_cli/payments.py
+++ b/hermes_cli/payments.py
@@ -1,0 +1,471 @@
+"""Profile-scoped payment-request storage for the dashboard Payments page.
+
+The first slice is intentionally narrow:
+  * keep a durable, profile-local review queue of extracted payment requests
+  * expose source status (Gmail / Email / Uploads / Slack) for the dashboard
+  * support manual status transitions only; no payment initiation
+
+Actual ingestion/extraction can be layered on top of this store later without
+changing the dashboard contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from email.utils import parseaddr, parsedate_to_datetime
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any, Dict, List
+
+from hermes_constants import get_hermes_home
+from hermes_cli.config import load_env
+
+PAYMENTS_DIR = "payments"
+REQUESTS_FILE = "requests.json"
+
+PAYMENT_STATUSES = {
+    "new",
+    "needs_review",
+    "ready_to_pay",
+    "paid",
+    "ignored",
+}
+
+PAYMENT_SOURCES = (
+    ("gmail", "Gmail"),
+    ("email", "Email"),
+    ("uploads", "Uploads"),
+    ("slack", "Slack"),
+)
+
+DEFAULT_GMAIL_QUERY = (
+    'newer_than:120d (invoice OR "payment due" OR "request for payment" OR '
+    '"bank transfer" OR remittance OR billing OR statement)'
+)
+DEFAULT_GMAIL_MAX_RESULTS = 25
+
+_AMOUNT_PATTERNS = [
+    re.compile(r"\b(GBP|USD|EUR|AUD|CAD|NZD|CHF|SEK|NOK|DKK)\s?([0-9][0-9,]*(?:\.[0-9]{2})?)\b", re.I),
+    re.compile(r"([£$€])\s?([0-9][0-9,]*(?:\.[0-9]{2})?)"),
+]
+_SORT_CODE_RE = re.compile(r"\b\d{2}-\d{2}-\d{2}\b")
+_ACCOUNT_NUMBER_RE = re.compile(r"\b\d{8}\b")
+_IBAN_RE = re.compile(r"\b[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}\b")
+_SWIFT_RE = re.compile(r"\b[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b")
+_ROUTING_RE = re.compile(r"\brouting number\b[:\s]*([0-9]{9})", re.I)
+_REFERENCE_RE = re.compile(
+    r"\b(?:reference|payment reference|remittance reference)\b[:\s#-]*([A-Z0-9-]{4,})",
+    re.I,
+)
+_INVOICE_RE = re.compile(r"\b(?:invoice|inv(?:oice)? number|invoice #)\b[:\s#-]*([A-Z0-9-]{3,})", re.I)
+_DUE_RE = re.compile(
+    r"\b(?:due date|payment due|due)\b[:\s-]*("
+    r"[A-Z][a-z]{2,8}\s+\d{1,2},?\s+\d{4}"
+    r"|\d{4}-\d{2}-\d{2}"
+    r"|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}"
+    r")",
+    re.I,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _payments_dir() -> Path:
+    return get_hermes_home() / PAYMENTS_DIR
+
+
+def _requests_path() -> Path:
+    return _payments_dir() / REQUESTS_FILE
+
+
+def _google_api_script() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "skills"
+        / "productivity"
+        / "google-workspace"
+        / "scripts"
+        / "google_api.py"
+    )
+
+
+def _empty_record(payment_id: str) -> Dict[str, Any]:
+    return {
+        "id": payment_id,
+        "source": "uploads",
+        "source_label": "Uploads",
+        "status": "new",
+        "confidence": "low",
+        "received_at": None,
+        "updated_at": None,
+        "vendor": "",
+        "title": "",
+        "amount": {"value": None, "currency": "", "display": ""},
+        "due_date": None,
+        "payee_name": "",
+        "account_holder": "",
+        "account_number": "",
+        "sort_code": "",
+        "iban": "",
+        "swift": "",
+        "routing_number": "",
+        "payment_reference": "",
+        "invoice_number": "",
+        "billing_address": "",
+        "tax_details": "",
+        "preview_text": "",
+        "warnings": [],
+        "attachments": [],
+        "original": {"label": "", "url": "", "message_id": "", "thread_id": ""},
+    }
+
+
+def _normalize_record(raw: Dict[str, Any], *, index: int) -> Dict[str, Any]:
+    record = _empty_record(str(raw.get("id") or f"payment-{index + 1}"))
+    record.update({k: v for k, v in raw.items() if k in record})
+
+    amount = raw.get("amount")
+    if isinstance(amount, dict):
+        record["amount"] = {
+            "value": amount.get("value"),
+            "currency": str(amount.get("currency") or ""),
+            "display": str(amount.get("display") or ""),
+        }
+
+    original = raw.get("original")
+    if isinstance(original, dict):
+        record["original"] = {
+            "label": str(original.get("label") or ""),
+            "url": str(original.get("url") or ""),
+            "message_id": str(original.get("message_id") or ""),
+            "thread_id": str(original.get("thread_id") or ""),
+        }
+
+    status = str(record.get("status") or "new").strip()
+    record["status"] = status if status in PAYMENT_STATUSES else "needs_review"
+
+    source = str(record.get("source") or "uploads").strip()
+    record["source"] = source or "uploads"
+    record["source_label"] = str(record.get("source_label") or source.title())
+    record["confidence"] = str(record.get("confidence") or "low")
+    record["warnings"] = [
+        str(item).strip()
+        for item in (record.get("warnings") or [])
+        if str(item).strip()
+    ]
+    record["attachments"] = [
+        str(item).strip()
+        for item in (record.get("attachments") or [])
+        if str(item).strip()
+    ]
+    return record
+
+
+def _run_google_api(args: List[str]) -> Any:
+    script = _google_api_script()
+    result = subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip() or "google_api.py failed"
+        raise RuntimeError(err)
+    stdout = result.stdout.strip()
+    if not stdout:
+        return []
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Unexpected google_api.py output: {stdout[:200]}") from exc
+
+
+def _clean_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _format_vendor(sender: str) -> str:
+    name, addr = parseaddr(sender or "")
+    if name.strip():
+        return name.strip().strip('"')
+    if addr:
+        return addr.split("@", 1)[0]
+    return sender.strip()
+
+
+def _parse_amount(text: str) -> Dict[str, Any]:
+    for pattern in _AMOUNT_PATTERNS:
+        match = pattern.search(text)
+        if not match:
+            continue
+        if len(match.groups()) == 2:
+            g1, g2 = match.groups()
+            symbol_currency = {"£": "GBP", "$": "USD", "€": "EUR"}
+            currency = symbol_currency.get(g1, g1.upper())
+            display = f"{currency} {g2}"
+            try:
+                value = float(g2.replace(",", ""))
+            except ValueError:
+                value = None
+            return {"value": value, "currency": currency, "display": display}
+    return {"value": None, "currency": "", "display": ""}
+
+
+def _extract_match(pattern: re.Pattern[str], text: str) -> str:
+    match = pattern.search(text)
+    if not match:
+        return ""
+    if match.lastindex:
+        return str(match.group(1) or "").strip()
+    return str(match.group(0) or "").strip()
+
+
+def _parse_received_at(value: str) -> str | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    try:
+        return parsedate_to_datetime(text).astimezone(timezone.utc).isoformat()
+    except Exception:
+        return text
+
+
+def _confidence_for(record: Dict[str, Any]) -> str:
+    score = 0
+    if record["amount"]["display"]:
+        score += 1
+    if record.get("invoice_number"):
+        score += 1
+    if record.get("payment_reference"):
+        score += 1
+    if any(
+        record.get(key)
+        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
+    ):
+        score += 2
+    if record.get("due_date"):
+        score += 1
+    if score >= 4:
+        return "high"
+    if score >= 2:
+        return "medium"
+    return "low"
+
+
+def _warnings_for(record: Dict[str, Any]) -> List[str]:
+    warnings = []
+    if not record["amount"]["display"]:
+        warnings.append("No amount detected.")
+    if not any(
+        record.get(key)
+        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
+    ):
+        warnings.append("No bank account details detected.")
+    if not record.get("payment_reference") and not record.get("invoice_number"):
+        warnings.append("No invoice or payment reference detected.")
+    return warnings
+
+
+def _build_gmail_payment_record(summary: Dict[str, Any], detail: Dict[str, Any], existing: Dict[str, Any] | None) -> Dict[str, Any]:
+    subject = str(detail.get("subject") or summary.get("subject") or "").strip()
+    body = str(detail.get("body") or "").strip()
+    snippet = str(summary.get("snippet") or "").strip()
+    combined = "\n".join(part for part in (subject, snippet, body) if part).strip()
+    vendor = _format_vendor(str(detail.get("from") or summary.get("from") or ""))
+    amount = _parse_amount(combined)
+    record = _empty_record(f"gmail:{detail['id']}")
+    record.update(
+        {
+            "source": "gmail",
+            "source_label": "Gmail",
+            "status": existing.get("status") if existing else "needs_review",
+            "received_at": _parse_received_at(str(detail.get("date") or summary.get("date") or "")),
+            "updated_at": _now_iso(),
+            "vendor": vendor,
+            "title": subject,
+            "amount": amount,
+            "due_date": _extract_match(_DUE_RE, combined) or None,
+            "payee_name": vendor,
+            "account_holder": vendor,
+            "account_number": _extract_match(_ACCOUNT_NUMBER_RE, combined),
+            "sort_code": _extract_match(_SORT_CODE_RE, combined),
+            "iban": _extract_match(_IBAN_RE, combined),
+            "swift": _extract_match(_SWIFT_RE, combined),
+            "routing_number": _extract_match(_ROUTING_RE, combined),
+            "payment_reference": _extract_match(_REFERENCE_RE, combined),
+            "invoice_number": _extract_match(_INVOICE_RE, combined),
+            "preview_text": _clean_text(body or snippet)[:1500],
+            "attachments": existing.get("attachments", []) if existing else [],
+            "original": {
+                "label": str(detail.get("from") or summary.get("from") or ""),
+                "url": f"https://mail.google.com/mail/u/0/#all/{detail['id']}",
+                "message_id": str(detail.get("id") or ""),
+                "thread_id": str(detail.get("threadId") or summary.get("threadId") or ""),
+            },
+        }
+    )
+    record["confidence"] = _confidence_for(record)
+    record["warnings"] = _warnings_for(record)
+    return record
+
+
+def _load_requests() -> List[Dict[str, Any]]:
+    path = _requests_path()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    items = data.get("requests") if isinstance(data, dict) else data
+    if not isinstance(items, list):
+        return []
+    return [_normalize_record(item, index=i) for i, item in enumerate(items) if isinstance(item, dict)]
+
+
+def _save_requests(requests: List[Dict[str, Any]]) -> None:
+    path = _requests_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "requests": requests,
+        "updated_at": _now_iso(),
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _source_statuses() -> List[Dict[str, Any]]:
+    env = load_env()
+    home = get_hermes_home()
+
+    gmail_token = home / "google_token.json"
+    email_address = str(env.get("EMAIL_ADDRESS") or "").strip()
+    slack_token = str(env.get("SLACK_BOT_TOKEN") or "").strip()
+
+    statuses = []
+    for source_id, label in PAYMENT_SOURCES:
+        if source_id == "gmail":
+            connected = gmail_token.exists()
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": (
+                        "Google Workspace token is present."
+                        if connected
+                        else "Connect Google Workspace to scan Gmail invoices."
+                    ),
+                }
+            )
+        elif source_id == "email":
+            connected = bool(email_address)
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": email_address if connected else "Configure the Email channel to ingest invoices.",
+                }
+            )
+        elif source_id == "uploads":
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": True,
+                    "detail": "Use the Files page to stage invoice PDFs and screenshots.",
+                }
+            )
+        elif source_id == "slack":
+            connected = bool(slack_token)
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": (
+                        "Slack bot token is configured."
+                        if connected
+                        else "Slack capture can be added once the Slack channel is configured."
+                    ),
+                }
+            )
+    return statuses
+
+
+def list_payment_requests() -> Dict[str, Any]:
+    requests = _load_requests()
+    requests.sort(
+        key=lambda item: (
+            str(item.get("received_at") or ""),
+            str(item.get("updated_at") or ""),
+            str(item.get("id") or ""),
+        ),
+        reverse=True,
+    )
+    return {
+        "sources": _source_statuses(),
+        "requests": requests,
+        "storage_path": str(_requests_path()),
+    }
+
+
+def sync_gmail_payment_requests(
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> Dict[str, Any]:
+    summaries = _run_google_api(["gmail", "search", query, "--max", str(max_results)])
+    if not isinstance(summaries, list):
+        raise RuntimeError("Gmail search returned an unexpected payload")
+
+    requests = _load_requests()
+    existing_by_id = {str(record.get("id")): record for record in requests}
+    imported = 0
+    updated = 0
+
+    for summary in summaries:
+        if not isinstance(summary, dict) or not summary.get("id"):
+            continue
+        detail = _run_google_api(["gmail", "get", str(summary["id"])])
+        if not isinstance(detail, dict) or not detail.get("id"):
+            continue
+        record_id = f"gmail:{detail['id']}"
+        existing = existing_by_id.get(record_id)
+        record = _build_gmail_payment_record(summary, detail, existing)
+        if existing is None:
+            requests.append(record)
+            existing_by_id[record_id] = record
+            imported += 1
+        else:
+            existing.update(record)
+            updated += 1
+
+    _save_requests(requests)
+    return {
+        "source": "gmail",
+        "query": query,
+        "fetched": len(summaries),
+        "imported": imported,
+        "updated": updated,
+        "requests": requests,
+    }
+
+
+def update_payment_status(payment_id: str, status: str) -> Dict[str, Any]:
+    normalized_status = str(status or "").strip()
+    if normalized_status not in PAYMENT_STATUSES:
+        raise ValueError(f"Unknown payment status: {status}")
+
+    requests = _load_requests()
+    for record in requests:
+        if str(record.get("id")) == payment_id:
+            record["status"] = normalized_status
+            record["updated_at"] = _now_iso()
+            _save_requests(requests)
+            return record
+    raise KeyError(payment_id)

--- a/hermes_cli/subcommands/payments.py
+++ b/hermes_cli/subcommands/payments.py
@@ -1,0 +1,77 @@
+"""``hermes payments`` subcommand parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_payments_parser(subparsers, *, cmd_payments: Callable) -> None:
+    """Attach the ``payments`` subcommand family to ``subparsers``."""
+    payments_parser = subparsers.add_parser(
+        "payments",
+        help="Payments review sync helpers",
+        description=(
+            "Run the Gmail payments sync immediately or install a recurring "
+            "Hermes cron job that keeps the canonical payments review store fresh."
+        ),
+    )
+    payments_subparsers = payments_parser.add_subparsers(dest="payments_command")
+
+    sync = payments_subparsers.add_parser(
+        "sync-gmail",
+        help="Sync Gmail payment candidates into the canonical payments review store",
+    )
+    sync.add_argument("--query", default=None, help="Override the default Gmail search query")
+    sync.add_argument("--max-results", type=int, default=None, help="Maximum Gmail threads to inspect")
+
+    shadow_sync = payments_subparsers.add_parser(
+        "shadow-sync-gmail",
+        help="Run Gmail sync using the existing pipeline, then mirror results into inbox_items shadow storage",
+    )
+    shadow_sync.add_argument("--query", default=None, help="Override the default Gmail search query")
+    shadow_sync.add_argument("--max-results", type=int, default=None, help="Maximum Gmail threads to inspect")
+
+    payments_subparsers.add_parser(
+        "shadow-report",
+        help="Compare the legacy payments queue against the inbox_items shadow store",
+    )
+
+    shadow_schedule = payments_subparsers.add_parser(
+        "schedule-shadow-sync",
+        help="Install or update a recurring Hermes cron job for Gmail shadow sync",
+    )
+    shadow_schedule.add_argument(
+        "schedule",
+        nargs="?",
+        default=None,
+        help="Cron schedule like 'every 6h', '30m', or '0 */6 * * *'",
+    )
+    shadow_schedule.add_argument("--query", default=None, help="Override the default Gmail search query")
+    shadow_schedule.add_argument("--max-results", type=int, default=None, help="Maximum Gmail threads to inspect")
+    shadow_schedule.add_argument("--name", default=None, help="Friendly cron job name")
+    shadow_schedule.add_argument(
+        "--run-now",
+        action="store_true",
+        help="Run one shadow sync immediately after installing or updating the cron job",
+    )
+
+    schedule = payments_subparsers.add_parser(
+        "schedule-gmail-sync",
+        help="Install or update a recurring Hermes cron job for Gmail payments sync",
+    )
+    schedule.add_argument(
+        "schedule",
+        nargs="?",
+        default=None,
+        help="Cron schedule like 'every 1h', '30m', or '0 * * * *'",
+    )
+    schedule.add_argument("--query", default=None, help="Override the default Gmail search query")
+    schedule.add_argument("--max-results", type=int, default=None, help="Maximum Gmail threads to inspect")
+    schedule.add_argument("--name", default=None, help="Friendly cron job name")
+    schedule.add_argument(
+        "--run-now",
+        action="store_true",
+        help="Run one sync immediately after installing or updating the cron job",
+    )
+
+    payments_parser.set_defaults(func=cmd_payments)

--- a/hermes_cli/vault_para_triage.py
+++ b/hermes_cli/vault_para_triage.py
@@ -17,6 +17,8 @@ import logging
 import os
 import re
 import shlex
+import urllib.error
+import urllib.request
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,6 +35,16 @@ DEFAULT_REVIEW_DIR = "Resources/_Inbox Review"
 DEFAULT_AUDIT_ROOT = ".hermes/para-triage"
 DEFAULT_CAPTURE_ROOT = ".hermes/note-capture"
 DEFAULT_CONFIG_REL_PATH = ".hermes/para-triage.yaml"
+
+_CANONICAL_ROUTING_FIELDS = (
+    "target_id",
+    "target_class",
+    "logical_path",
+    "display_path",
+    "resolved_target_path",
+    "target_status",
+    "trust_boundary",
+)
 
 
 def _utc_now() -> datetime:
@@ -86,6 +98,11 @@ def _default_config() -> dict[str, Any]:
             "low_confidence_action": "review",
             "example_limit": 8,
             "rules": [],
+            "target_resolver": {
+                "enabled": False,
+                "api_url": "",
+                "timeout_seconds": 5.0,
+            },
         },
         "projection": {
             "stores": {
@@ -429,14 +446,53 @@ def _rule_decision(
             continue
         if _rules_match(rule, title=title, body=body, tags=tags):
             reason = str(rule.get("reason") or f"matched routing rule {idx}").strip()
-            return {
+            decision = {
                 "target": target,
                 "confidence": float(rule.get("confidence", 0.95)),
                 "reason": reason,
                 "source": "rule",
                 "needs_feedback": bool(rule.get("needs_feedback", False)),
             }
+            for key in _CANONICAL_ROUTING_FIELDS:
+                value = rule.get(key)
+                if value not in (None, ""):
+                    decision[key] = value
+            return decision
     return None
+
+
+def _target_resolver_config(config: dict[str, Any]) -> dict[str, Any]:
+    routing = config.get("routing") or {}
+    resolver = routing.get("target_resolver") or {}
+    return resolver if isinstance(resolver, dict) else {}
+
+
+def _resolver_api_url(config: dict[str, Any]) -> str:
+    resolver = _target_resolver_config(config)
+    configured = str(resolver.get("api_url") or "").strip()
+    if configured:
+        return configured
+    for env_name in ("HERMES_NOTE_TARGET_RESOLVER_URL", "NOTE_CAPTURE_TARGET_RESOLVER_URL"):
+        value = os.getenv(env_name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _resolver_enabled(config: dict[str, Any]) -> bool:
+    resolver = _target_resolver_config(config)
+    if bool(resolver.get("enabled", False)):
+        return True
+    return bool(_resolver_api_url(config))
+
+
+def _resolver_timeout_seconds(config: dict[str, Any]) -> float:
+    resolver = _target_resolver_config(config)
+    try:
+        timeout = float(resolver.get("timeout_seconds", 5.0) or 5.0)
+    except (TypeError, ValueError):
+        timeout = 5.0
+    return max(timeout, 0.1)
 
 
 def _normalize_target(target: str, *, vault_path: Path, config: dict[str, Any]) -> str:
@@ -445,6 +501,7 @@ def _normalize_target(target: str, *, vault_path: Path, config: dict[str, Any]) 
         return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
     first = target.split("/", 1)[0].lower()
     allowed_roots = {str(v).split("/", 1)[0].lower() for v in (config.get("para_roots") or {}).values()}
+    allowed_roots.add(str(config.get("inbox_dir") or "Inbox").split("/", 1)[0].lower())
     allowed_roots.add(str(config.get("review_dir") or DEFAULT_REVIEW_DIR).split("/", 1)[0].lower())
     if first not in allowed_roots:
         return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
@@ -474,6 +531,123 @@ def _parse_json_object(text: str) -> dict[str, Any]:
             except json.JSONDecodeError:
                 return {}
     return {}
+
+
+def _copy_canonical_routing_fields(source: dict[str, Any], dest: dict[str, Any]) -> dict[str, Any]:
+    for key in _CANONICAL_ROUTING_FIELDS:
+        value = source.get(key)
+        if value not in (None, ""):
+            dest[key] = str(value).strip()
+    return dest
+
+
+def _normalize_resolver_decision(
+    decision: dict[str, Any],
+    *,
+    vault_path: Path,
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    canonical_target = decision.get("canonical_target") or {}
+    if not isinstance(canonical_target, dict):
+        canonical_target = {}
+    merged = dict(canonical_target)
+    for key in (
+        "target",
+        "target_id",
+        "target_class",
+        "logical_path",
+        "display_path",
+        "resolved_target_path",
+        "target_status",
+        "trust_boundary",
+    ):
+        value = decision.get(key)
+        if value not in (None, "") and key not in merged:
+            merged[key] = value
+
+    raw_target = ""
+    for key in ("resolved_target_path", "target", "display_path"):
+        candidate = str(merged.get(key) or "").strip()
+        if candidate:
+            raw_target = candidate
+            break
+
+    normalized = {
+        "target": _normalize_target(raw_target, vault_path=vault_path, config=config),
+        "confidence": float(decision.get("confidence", 0.0) or 0.0),
+        "reason": str(decision.get("reason") or "resolved by target resolver").strip() or "resolved by target resolver",
+        "source": str(decision.get("source") or "target_resolver"),
+        "needs_feedback": bool(decision.get("needs_feedback", False)),
+    }
+    return _copy_canonical_routing_fields(merged, normalized)
+
+
+def _resolver_decision(
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    targets: list[str],
+    examples: list[dict[str, Any]],
+    config: dict[str, Any],
+    vault_path: Path,
+    state_root: Path,
+    structure: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not _resolver_enabled(config):
+        return None
+
+    api_url = _resolver_api_url(config)
+    if not api_url:
+        return None
+
+    payload = {
+        "note": {
+            "title": title,
+            "tags": tags,
+            "body": body,
+            "excerpt": _excerpt(body, 1600),
+        },
+        "allowed_targets": targets,
+        "review_target": str(config.get("review_dir") or DEFAULT_REVIEW_DIR),
+        "examples": examples,
+        "vault_path": str(vault_path),
+        "state_root": str(state_root),
+        "structure": structure,
+    }
+    body_bytes = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        api_url,
+        method="POST",
+        data=body_bytes,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    timeout = _resolver_timeout_seconds(config)
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        raw = response.read().decode("utf-8")
+
+    parsed: Any
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        parsed = _parse_json_object(raw)
+
+    if not isinstance(parsed, dict):
+        raise ValueError("target resolver returned a non-object")
+
+    decision = parsed
+    for wrapper_key in ("decision", "result", "data"):
+        wrapped = decision.get(wrapper_key)
+        if isinstance(wrapped, dict):
+            decision = wrapped
+            break
+
+    if not isinstance(decision, dict):
+        raise ValueError("target resolver returned a non-object decision")
+    return _normalize_resolver_decision(decision, vault_path=vault_path, config=config)
 
 
 def _llm_decision(
@@ -552,6 +726,7 @@ def _classify_note(
     state_root: Path,
     structure: dict[str, Any],
     classifier: Callable[..., dict[str, Any]] | None = None,
+    target_resolver: Callable[..., dict[str, Any] | None] | None = None,
 ) -> dict[str, Any]:
     rule_hit = _rule_decision(config, title=title, body=body, tags=tags)
     if rule_hit:
@@ -564,6 +739,35 @@ def _classify_note(
         tags=tags,
         limit=int(((config.get("routing") or {}).get("example_limit")) or 8),
     )
+
+    try:
+        resolver_decision = target_resolver(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+            vault_path=vault_path,
+            state_root=state_root,
+            structure=structure,
+        ) if target_resolver else _resolver_decision(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+            vault_path=vault_path,
+            state_root=state_root,
+            structure=structure,
+        )
+    except Exception as exc:
+        logger.warning("Vault target resolver failed: %s", exc)
+        resolver_decision = None
+
+    if isinstance(resolver_decision, dict):
+        return _normalize_resolver_decision(resolver_decision, vault_path=vault_path, config=config)
 
     try:
         decision = classifier(
@@ -598,7 +802,7 @@ def _classify_note(
         "source": str(decision.get("source") or "llm"),
         "needs_feedback": bool(decision.get("needs_feedback", False)),
     }
-    return normalized
+    return _copy_canonical_routing_fields(decision, normalized)
 
 
 def _move_note(
@@ -774,6 +978,7 @@ def run_triage(
     config_path: str | Path | None = None,
     config_override: dict[str, Any] | None = None,
     classifier: Callable[..., dict[str, Any]] | None = None,
+    target_resolver: Callable[..., dict[str, Any] | None] | None = None,
     dry_run: bool = False,
     limit: int | None = None,
 ) -> dict[str, Any]:
@@ -813,6 +1018,7 @@ def run_triage(
             state_root=state_root,
             structure=structure,
             classifier=classifier,
+            target_resolver=target_resolver,
         )
 
         target = str(decision.get("target") or config.get("review_dir") or DEFAULT_REVIEW_DIR)
@@ -903,6 +1109,10 @@ def run_triage(
             "canonical_content": rendered,
             "sync_contract": _sync_contract(config),
         }
+        for key in _CANONICAL_ROUTING_FIELDS:
+            value = decision.get(key)
+            if value not in (None, ""):
+                capture_event["routing"][key] = value
         if not dry_run:
             _json_dump(_capture_event_path(capture_root, entry_id), capture_event)
 
@@ -925,6 +1135,10 @@ def run_triage(
             "archived_path": archived_rel,
             "stores": sorted(staged_projection_paths),
         }
+        for key in _CANONICAL_ROUTING_FIELDS:
+            value = decision.get(key)
+            if value not in (None, ""):
+                event[key] = value
         processed.append(event)
         if not dry_run:
             _jsonl_append(_audit_events_path(state_root), event)

--- a/hermes_cli/vault_para_triage.py
+++ b/hermes_cli/vault_para_triage.py
@@ -1,0 +1,1443 @@
+"""PARA vault inbox triage helpers shared by the skill script and Slack plugin.
+
+The workflow is intentionally edge-scoped:
+
+* notes are read from an Obsidian-style vault inbox
+* missing YAML frontmatter is added deterministically
+* routing decisions are logged to an immutable audit trail
+* user corrections are stored as examples for future runs
+* Slack-facing commands call these helpers rather than touching core tools
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import shlex
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+import yaml
+
+from agent.skill_utils import parse_frontmatter
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REVIEW_DIR = "Resources/_Inbox Review"
+DEFAULT_AUDIT_ROOT = ".hermes/para-triage"
+DEFAULT_CAPTURE_ROOT = ".hermes/note-capture"
+DEFAULT_CONFIG_REL_PATH = ".hermes/para-triage.yaml"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _iso_now() -> str:
+    return _utc_now().isoformat().replace("+00:00", "Z")
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in (override or {}).items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _default_config() -> dict[str, Any]:
+    return {
+        "inbox_dir": "Inbox",
+        "para_roots": {
+            "projects": "Projects",
+            "areas": "Areas",
+            "resources": "Resources",
+            "archives": "Archives",
+        },
+        "review_dir": DEFAULT_REVIEW_DIR,
+        "audit": {
+            "root": DEFAULT_AUDIT_ROOT,
+        },
+        "capture": {
+            "root": DEFAULT_CAPTURE_ROOT,
+            "source_archive_dir": "source-archive",
+        },
+        "frontmatter": {
+            "title_field": "title",
+            "created_field": "created",
+            "updated_field": "updated",
+            "tags_field": "tags",
+            "triage_status_field": "para_triage_status",
+            "triage_target_field": "para_target",
+            "triage_confidence_field": "para_confidence",
+            "triage_reason_field": "para_reason",
+            "triaged_at_field": "para_triaged_at",
+        },
+        "routing": {
+            "min_confidence": 0.7,
+            "low_confidence_action": "review",
+            "example_limit": 8,
+            "rules": [],
+        },
+        "projection": {
+            "stores": {
+                "vault": {
+                    "enabled": True,
+                    "path_prefix": "",
+                },
+                "second_brain": {
+                    "enabled": True,
+                    "path_prefix": "",
+                },
+            }
+        },
+    }
+
+
+def resolve_vault_path(explicit: str | Path | None = None) -> Path:
+    """Resolve the Obsidian vault path from an explicit arg, env, or fallback."""
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+
+    env_path = os.getenv("OBSIDIAN_VAULT_PATH", "").strip()
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    candidates.append(Path("~/Documents/Obsidian Vault").expanduser())
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+
+    first = candidates[0]
+    raise FileNotFoundError(
+        f"Could not resolve Obsidian vault path. Checked: {', '.join(str(p) for p in candidates)}. "
+        f"Set OBSIDIAN_VAULT_PATH or pass --vault. First missing candidate: {first}"
+    )
+
+
+def _resolve_config_path(vault_path: Path, explicit: str | Path | None = None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    return (vault_path / DEFAULT_CONFIG_REL_PATH).resolve()
+
+
+def load_config(
+    vault_path: Path,
+    *,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], Path]:
+    """Load triage config from YAML and merge it with defaults."""
+    resolved_config_path = _resolve_config_path(vault_path, config_path)
+    loaded: dict[str, Any] = {}
+    if resolved_config_path.exists():
+        data = yaml.safe_load(resolved_config_path.read_text(encoding="utf-8")) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"{resolved_config_path} must contain a YAML mapping")
+        loaded = data
+    merged = _deep_merge(_default_config(), loaded)
+    if config_override:
+        merged = _deep_merge(merged, config_override)
+    return merged, resolved_config_path
+
+
+def _state_root(vault_path: Path, config: dict[str, Any]) -> Path:
+    configured = str(((config.get("audit") or {}).get("root")) or DEFAULT_AUDIT_ROOT).strip()
+    root = Path(configured).expanduser()
+    if not root.is_absolute():
+        root = vault_path / root
+    return root.resolve()
+
+
+def _capture_root(vault_path: Path, config: dict[str, Any]) -> Path:
+    configured = str(((config.get("capture") or {}).get("root")) or DEFAULT_CAPTURE_ROOT).strip()
+    root = Path(configured).expanduser()
+    if not root.is_absolute():
+        root = vault_path / root
+    return root.resolve()
+
+
+def _source_archive_root(vault_path: Path, config: dict[str, Any]) -> Path:
+    configured = str(((config.get("capture") or {}).get("source_archive_dir")) or "source-archive").strip()
+    root = Path(configured).expanduser()
+    if root.is_absolute():
+        return root.resolve()
+    return (_capture_root(vault_path, config) / configured).resolve()
+
+
+def _ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _json_load(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Could not parse %s; returning default", path)
+        return default
+
+
+def _json_dump(path: Path, payload: Any) -> None:
+    _ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _jsonl_append(path: Path, payload: dict[str, Any]) -> None:
+    _ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed JSONL row in %s", path)
+                continue
+            if isinstance(item, dict):
+                rows.append(item)
+    return rows
+
+
+def _slugify(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-") or "note"
+
+
+def _extract_tags(frontmatter: dict[str, Any], field_name: str) -> list[str]:
+    raw = frontmatter.get(field_name, [])
+    if isinstance(raw, str):
+        pieces = [raw]
+    elif isinstance(raw, list):
+        pieces = raw
+    else:
+        pieces = []
+    out: list[str] = []
+    for piece in pieces:
+        text = str(piece or "").strip().lstrip("#")
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _extract_title(frontmatter: dict[str, Any], body: str, path: Path, *, title_field: str) -> str:
+    title = str(frontmatter.get(title_field) or "").strip()
+    if title:
+        return title
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip()
+    return path.stem.replace("-", " ").replace("_", " ").strip() or path.stem
+
+
+def _excerpt(text: str, limit: int = 280) -> str:
+    compact = re.sub(r"\s+", " ", text or "").strip()
+    return compact[:limit]
+
+
+def _render_note(frontmatter: dict[str, Any], body: str) -> str:
+    yaml_text = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+    rendered_body = body.lstrip("\n")
+    if rendered_body:
+        return f"---\n{yaml_text}\n---\n\n{rendered_body}\n"
+    return f"---\n{yaml_text}\n---\n"
+
+
+def _unique_destination(path: Path) -> Path:
+    if not path.exists():
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    for idx in range(2, 1000):
+        candidate = path.with_name(f"{stem} {idx}{suffix}")
+        if not candidate.exists():
+            return candidate
+    raise FileExistsError(f"Could not find a free destination for {path}")
+
+
+def _normalize_relative(path: Path, vault_path: Path) -> str:
+    return str(path.resolve().relative_to(vault_path.resolve())).replace("\\", "/")
+
+
+def _normalize_low_confidence_action(config: dict[str, Any]) -> str:
+    action = str(((config.get("routing") or {}).get("low_confidence_action")) or "review").strip().lower()
+    if action in {"review", "inbox", "auto-file"}:
+        return action
+    return "review"
+
+
+def _enabled_projection_stores(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    stores = (config.get("projection") or {}).get("stores") or {}
+    enabled: dict[str, dict[str, Any]] = {}
+    for store_name, store_cfg in stores.items():
+        if not isinstance(store_cfg, dict):
+            continue
+        if not store_cfg.get("enabled", True):
+            continue
+        enabled[str(store_name)] = dict(store_cfg)
+    if enabled:
+        return enabled
+    return {"vault": {"enabled": True, "path_prefix": ""}}
+
+
+def _projection_relative_path(target: str, filename: str, store_cfg: dict[str, Any]) -> str:
+    prefix = str(store_cfg.get("path_prefix") or "").strip().strip("/\\")
+    rel = "/".join(part for part in (target.strip("/\\"), filename) if part)
+    if prefix:
+        rel = f"{prefix}/{rel}"
+    return rel.replace("\\", "/")
+
+
+def _inbox_path(vault_path: Path, config: dict[str, Any]) -> Path:
+    inbox_dir = str(config.get("inbox_dir") or "Inbox").strip().strip("/\\")
+    return (vault_path / inbox_dir).resolve()
+
+
+def _available_targets(vault_path: Path, config: dict[str, Any]) -> list[str]:
+    targets: list[str] = []
+    para_roots = config.get("para_roots") or {}
+    for rel_root in para_roots.values():
+        root = (vault_path / str(rel_root)).resolve()
+        if not root.exists():
+            continue
+        targets.append(_normalize_relative(root, vault_path))
+        for candidate in sorted(p for p in root.rglob("*") if p.is_dir()):
+            targets.append(_normalize_relative(candidate, vault_path))
+
+    review_dir = str(config.get("review_dir") or DEFAULT_REVIEW_DIR).strip()
+    if review_dir and review_dir not in targets:
+        targets.append(review_dir)
+    # Preserve order but dedupe.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in targets:
+        if item not in seen:
+            ordered.append(item)
+            seen.add(item)
+    return ordered
+
+
+def capture_structure_memory(vault_path: Path, config: dict[str, Any], *, state_root: Path | None = None) -> dict[str, Any]:
+    """Snapshot PARA folder structure so later runs have stable context."""
+    targets = _available_targets(vault_path, config)
+    snapshot = {
+        "captured_at": _iso_now(),
+        "vault_path": str(vault_path),
+        "inbox_dir": str(config.get("inbox_dir") or "Inbox"),
+        "targets": targets,
+        "para_roots": dict(config.get("para_roots") or {}),
+    }
+    if state_root is not None:
+        _json_dump(state_root / "structure.json", snapshot)
+    return snapshot
+
+
+def _load_examples(state_root: Path) -> list[dict[str, Any]]:
+    data = _json_load(state_root / "routing_examples.json", {"examples": []})
+    examples = data.get("examples", []) if isinstance(data, dict) else []
+    return [x for x in examples if isinstance(x, dict)]
+
+
+def _save_examples(state_root: Path, examples: list[dict[str, Any]]) -> None:
+    _json_dump(state_root / "routing_examples.json", {"examples": examples})
+
+
+def _keyword_overlap(needles: Iterable[str], haystack: str) -> int:
+    lowered = haystack.lower()
+    total = 0
+    for needle in needles:
+        token = str(needle or "").strip().lower()
+        if token and token in lowered:
+            total += 1
+    return total
+
+
+def _best_examples(
+    state_root: Path,
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    limit: int,
+) -> list[dict[str, Any]]:
+    haystack = " ".join([title, body, " ".join(tags)]).lower()
+    scored: list[tuple[int, dict[str, Any]]] = []
+    for example in _load_examples(state_root):
+        signals = example.get("signals") or []
+        if isinstance(signals, str):
+            signals = [signals]
+        score = _keyword_overlap(signals, haystack)
+        if score > 0:
+            scored.append((score, example))
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [example for _score, example in scored[:limit]]
+
+
+def _rules_match(
+    rule: dict[str, Any],
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+) -> bool:
+    haystack = " ".join([title, body]).lower()
+    match_any = [str(x).strip().lower() for x in rule.get("match_any", []) if str(x).strip()]
+    match_all = [str(x).strip().lower() for x in rule.get("match_all", []) if str(x).strip()]
+    tags_any = [str(x).strip().lower().lstrip("#") for x in rule.get("tags_any", []) if str(x).strip()]
+    if match_any and not any(token in haystack for token in match_any):
+        return False
+    if match_all and not all(token in haystack for token in match_all):
+        return False
+    if tags_any and not any(tag in {t.lower() for t in tags} for tag in tags_any):
+        return False
+    return bool(match_any or match_all or tags_any)
+
+
+def _rule_decision(
+    config: dict[str, Any],
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+) -> dict[str, Any] | None:
+    for idx, rule in enumerate((config.get("routing") or {}).get("rules", []), start=1):
+        if not isinstance(rule, dict):
+            continue
+        target = str(rule.get("target") or "").strip()
+        if not target:
+            continue
+        if _rules_match(rule, title=title, body=body, tags=tags):
+            reason = str(rule.get("reason") or f"matched routing rule {idx}").strip()
+            return {
+                "target": target,
+                "confidence": float(rule.get("confidence", 0.95)),
+                "reason": reason,
+                "source": "rule",
+                "needs_feedback": bool(rule.get("needs_feedback", False)),
+            }
+    return None
+
+
+def _normalize_target(target: str, *, vault_path: Path, config: dict[str, Any]) -> str:
+    target = (target or "").strip().strip("/\\")
+    if not target:
+        return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
+    first = target.split("/", 1)[0].lower()
+    allowed_roots = {str(v).split("/", 1)[0].lower() for v in (config.get("para_roots") or {}).values()}
+    allowed_roots.add(str(config.get("review_dir") or DEFAULT_REVIEW_DIR).split("/", 1)[0].lower())
+    if first not in allowed_roots:
+        return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
+    resolved = (vault_path / target).resolve()
+    vault_resolved = vault_path.resolve()
+    if not str(resolved).startswith(str(vault_resolved) + os.sep) and resolved != vault_resolved:
+        raise ValueError(f"Target escapes the vault: {target}")
+    return target.replace("\\", "/")
+
+
+def _parse_json_object(text: str) -> dict[str, Any]:
+    raw = (text or "").strip()
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+        if "\n" in raw:
+            raw = raw.split("\n", 1)[1]
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except json.JSONDecodeError:
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                parsed = json.loads(raw[start : end + 1])
+                return parsed if isinstance(parsed, dict) else {}
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def _llm_decision(
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    targets: list[str],
+    examples: list[dict[str, Any]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    from agent.auxiliary_client import call_llm
+
+    prompt = {
+        "task": "Route this note into the user's PARA vault.",
+        "allowed_targets": targets,
+        "review_target": str(config.get("review_dir") or DEFAULT_REVIEW_DIR),
+        "examples": examples,
+        "note": {
+            "title": title,
+            "tags": tags,
+            "excerpt": _excerpt(body, 1600),
+        },
+        "rules": [
+            "Choose exactly one target from allowed_targets.",
+            "Prefer the narrowest existing folder that fits the note.",
+            "Use the review_target when uncertain.",
+            "Return JSON only.",
+        ],
+        "response_schema": {
+            "target": "string",
+            "confidence": "number 0..1",
+            "reason": "short string",
+            "needs_feedback": "boolean",
+        },
+    }
+    response = call_llm(
+        task="monitor",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You classify personal notes into an existing PARA vault. "
+                    "Return ONLY one JSON object with keys target, confidence, reason, needs_feedback."
+                ),
+            },
+            {"role": "user", "content": json.dumps(prompt, ensure_ascii=False)},
+        ],
+        max_tokens=500,
+        temperature=0,
+    )
+    content = getattr(response.choices[0].message, "content", "") or ""
+    parsed = _parse_json_object(str(content))
+    if not parsed:
+        raise ValueError("classifier returned no JSON object")
+    return parsed
+
+
+def _fallback_decision(config: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "target": str(config.get("review_dir") or DEFAULT_REVIEW_DIR),
+        "confidence": 0.0,
+        "reason": reason,
+        "source": "fallback",
+        "needs_feedback": True,
+    }
+
+
+def _classify_note(
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    vault_path: Path,
+    config: dict[str, Any],
+    state_root: Path,
+    structure: dict[str, Any],
+    classifier: Callable[..., dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    rule_hit = _rule_decision(config, title=title, body=body, tags=tags)
+    if rule_hit:
+        return rule_hit
+
+    examples = _best_examples(
+        state_root,
+        title=title,
+        body=body,
+        tags=tags,
+        limit=int(((config.get("routing") or {}).get("example_limit")) or 8),
+    )
+
+    try:
+        decision = classifier(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+            vault_path=vault_path,
+            state_root=state_root,
+            structure=structure,
+        ) if classifier else _llm_decision(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+        )
+    except Exception as exc:
+        logger.warning("Vault note classification failed: %s", exc)
+        return _fallback_decision(config, f"classifier failed: {exc}")
+
+    if not isinstance(decision, dict):
+        return _fallback_decision(config, "classifier returned a non-object")
+
+    normalized = {
+        "target": _normalize_target(str(decision.get("target") or ""), vault_path=vault_path, config=config),
+        "confidence": float(decision.get("confidence", 0.0) or 0.0),
+        "reason": str(decision.get("reason") or "classified").strip() or "classified",
+        "source": str(decision.get("source") or "llm"),
+        "needs_feedback": bool(decision.get("needs_feedback", False)),
+    }
+    return normalized
+
+
+def _move_note(
+    source_path: Path,
+    dest_rel: str,
+    *,
+    vault_path: Path,
+    content: str,
+) -> Path:
+    dest_dir = (vault_path / dest_rel).resolve()
+    _ensure_dir(dest_dir)
+    proposed = dest_dir / source_path.name
+    if proposed.resolve() == source_path.resolve():
+        dest_path = proposed
+    else:
+        dest_path = _unique_destination(proposed)
+    dest_path.write_text(content, encoding="utf-8")
+    if source_path.resolve() != dest_path.resolve() and source_path.exists():
+        source_path.unlink()
+    return dest_path
+
+
+def _capture_event_path(capture_root: Path, entry_id: str) -> Path:
+    return capture_root / "events" / f"{entry_id}.json"
+
+
+def _projection_status_path(capture_root: Path) -> Path:
+    return capture_root / "status" / "latest.json"
+
+
+def _stage_projection_file(
+    *,
+    capture_root: Path,
+    entry_id: str,
+    store_name: str,
+    relative_path: str,
+    content: str,
+    dry_run: bool,
+) -> tuple[str, Path]:
+    staged_rel = f"staging/{store_name}/{entry_id}/{relative_path}".replace("\\", "/")
+    staged_path = capture_root / staged_rel
+    if not dry_run:
+        _ensure_dir(staged_path.parent)
+        staged_path.write_text(content, encoding="utf-8")
+    return staged_rel, staged_path
+
+
+def _archive_source_note(
+    *,
+    source_path: Path,
+    vault_path: Path,
+    capture_root: Path,
+    source_archive_root: Path,
+    entry_id: str,
+    dry_run: bool,
+) -> tuple[str, Path]:
+    archived_rel = f"source-archive/{entry_id}/{_normalize_relative(source_path, vault_path)}".replace("\\", "/")
+    archived_path = capture_root / archived_rel
+    if dry_run:
+        return archived_rel, archived_path
+    _ensure_dir(source_archive_root / entry_id / Path(_normalize_relative(source_path, vault_path)).parent)
+    _ensure_dir(archived_path.parent)
+    archived_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    source_path.unlink()
+    return archived_rel, archived_path
+
+
+def _sync_contract(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "capture_model": "canonical_event_log",
+        "write_policy": "trusted_staging_only",
+        "projection_status_source": "structured_status",
+        "stores": sorted(_enabled_projection_stores(config)),
+    }
+
+
+def _summarize_projection_status(capture_root: Path, config: dict[str, Any]) -> dict[str, Any]:
+    events_dir = capture_root / "events"
+    stores: dict[str, dict[str, int]] = {}
+    total_events = 0
+    pending_events = 0
+    needs_feedback = 0
+    if events_dir.exists():
+        for event_path in sorted(events_dir.glob("*.json")):
+            event = _json_load(event_path, {})
+            if not isinstance(event, dict):
+                continue
+            total_events += 1
+            if event.get("needs_feedback"):
+                needs_feedback += 1
+            has_pending = False
+            projection = ((event.get("projection") or {}).get("stores")) or {}
+            for store_name, store_state in projection.items():
+                state = str((store_state or {}).get("state") or "unknown")
+                bucket = stores.setdefault(store_name, {})
+                bucket[state] = bucket.get(state, 0) + 1
+                if state == "pending":
+                    has_pending = True
+            if has_pending:
+                pending_events += 1
+    summary = {
+        "captured_at": _iso_now(),
+        "sync_contract": _sync_contract(config),
+        "total_events": total_events,
+        "pending_events": pending_events,
+        "needs_feedback": needs_feedback,
+        "stores": stores,
+        "memory_hint": (
+            "Hermes captures notes into a canonical internal event log first. "
+            "Vault and second-brain outputs are downstream staged projections; "
+            "check structured status for live sync health."
+        ),
+    }
+    _json_dump(_projection_status_path(capture_root), summary)
+    return summary
+
+
+def _make_feedback_example(event: dict[str, Any], target: str, action: str) -> dict[str, Any]:
+    tokens: list[str] = []
+    for field in ("title", "excerpt"):
+        for piece in re.findall(r"[A-Za-z0-9][A-Za-z0-9/_-]+", str(event.get(field) or "")):
+            lowered = piece.lower()
+            if lowered not in tokens:
+                tokens.append(lowered)
+    for tag in event.get("tags") or []:
+        lowered = str(tag or "").strip().lower()
+        if lowered and lowered not in tokens:
+            tokens.append(lowered)
+    return {
+        "entry_id": event["entry_id"],
+        "target": target,
+        "action": action,
+        "title": event.get("title", ""),
+        "signals": tokens[:16],
+        "excerpt": event.get("excerpt", ""),
+        "tags": event.get("tags") or [],
+        "learned_at": _iso_now(),
+    }
+
+
+def _feedback_files(state_root: Path) -> tuple[Path, Path]:
+    return state_root / "feedback.jsonl", state_root / "feedback_index.json"
+
+
+def _load_feedback_index(state_root: Path) -> dict[str, Any]:
+    data = _json_load(state_root / "feedback_index.json", {})
+    return data if isinstance(data, dict) else {}
+
+
+def _save_feedback_index(state_root: Path, payload: dict[str, Any]) -> None:
+    _json_dump(state_root / "feedback_index.json", payload)
+
+
+def _audit_events_path(state_root: Path) -> Path:
+    return state_root / "audit.jsonl"
+
+
+def load_audit_events(
+    *,
+    vault_path: Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], Path, dict[str, Any], Path]:
+    vault = resolve_vault_path(vault_path)
+    config, _resolved_config_path = load_config(vault, config_path=config_path, config_override=config_override)
+    state_root = _ensure_dir(_state_root(vault, config))
+    return _read_jsonl(_audit_events_path(state_root)), vault, config, state_root
+
+
+def run_triage(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+    classifier: Callable[..., dict[str, Any]] | None = None,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Capture inbox notes into a canonical event log and stage projections."""
+    vault = resolve_vault_path(vault_path)
+    config, resolved_config_path = load_config(vault, config_path=config_path, config_override=config_override)
+    state_root = _ensure_dir(_state_root(vault, config))
+    capture_root = _ensure_dir(_capture_root(vault, config))
+    source_archive_root = _ensure_dir(_source_archive_root(vault, config))
+    structure = capture_structure_memory(vault, config, state_root=state_root)
+    inbox = _inbox_path(vault, config)
+    _ensure_dir(inbox)
+    projection_stores = _enabled_projection_stores(config)
+
+    run_id = _utc_now().strftime("%Y%m%dT%H%M%SZ")
+    min_conf = float(((config.get("routing") or {}).get("min_confidence")) or 0.7)
+    low_conf_action = _normalize_low_confidence_action(config)
+
+    processed: list[dict[str, Any]] = []
+    note_paths = sorted(inbox.rglob("*.md"))
+    if limit is not None:
+        note_paths = note_paths[: max(limit, 0)]
+
+    for note_path in note_paths:
+        raw = note_path.read_text(encoding="utf-8")
+        frontmatter, body = parse_frontmatter(raw)
+        title_field = str(((config.get("frontmatter") or {}).get("title_field")) or "title")
+        tags_field = str(((config.get("frontmatter") or {}).get("tags_field")) or "tags")
+        title = _extract_title(frontmatter, body, note_path, title_field=title_field)
+        tags = _extract_tags(frontmatter, tags_field)
+        decision = _classify_note(
+            title=title,
+            body=body,
+            tags=tags,
+            vault_path=vault,
+            config=config,
+            state_root=state_root,
+            structure=structure,
+            classifier=classifier,
+        )
+
+        target = str(decision.get("target") or config.get("review_dir") or DEFAULT_REVIEW_DIR)
+        confidence = float(decision.get("confidence", 0.0) or 0.0)
+        needs_feedback = bool(decision.get("needs_feedback", False))
+        if confidence < min_conf:
+            needs_feedback = True
+            if low_conf_action == "review":
+                target = str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
+            elif low_conf_action == "inbox":
+                target = _normalize_relative(note_path.parent, vault)
+
+        frontmatter = dict(frontmatter or {})
+        fields = config.get("frontmatter") or {}
+        created_field = str(fields.get("created_field") or "created")
+        updated_field = str(fields.get("updated_field") or "updated")
+        status_field = str(fields.get("triage_status_field") or "para_triage_status")
+        target_field = str(fields.get("triage_target_field") or "para_target")
+        conf_field = str(fields.get("triage_confidence_field") or "para_confidence")
+        reason_field = str(fields.get("triage_reason_field") or "para_reason")
+        triaged_at_field = str(fields.get("triaged_at_field") or "para_triaged_at")
+
+        frontmatter.setdefault(title_field, title)
+        frontmatter.setdefault(created_field, _iso_now())
+        frontmatter[updated_field] = _iso_now()
+        frontmatter[status_field] = "needs-feedback" if needs_feedback else "captured"
+        frontmatter[target_field] = target
+        frontmatter[conf_field] = round(confidence, 3)
+        frontmatter[reason_field] = str(decision.get("reason") or "").strip()
+        frontmatter[triaged_at_field] = _iso_now()
+
+        rendered = _render_note(frontmatter, body)
+        entry_id = f"{run_id}-{uuid.uuid4().hex[:8]}"
+        path_before = _normalize_relative(note_path, vault)
+        default_store = next(iter(projection_stores))
+        staged_projection_paths: dict[str, dict[str, Any]] = {}
+        default_projected_rel = _projection_relative_path(target, note_path.name, projection_stores[default_store])
+        for store_name, store_cfg in projection_stores.items():
+            projected_rel = _projection_relative_path(target, note_path.name, store_cfg)
+            staged_rel, _staged_path = _stage_projection_file(
+                capture_root=capture_root,
+                entry_id=entry_id,
+                store_name=store_name,
+                relative_path=projected_rel,
+                content=rendered,
+                dry_run=dry_run,
+            )
+            staged_projection_paths[store_name] = {
+                "state": "pending",
+                "target_relative_path": projected_rel,
+                "staged_relative_path": staged_rel,
+            }
+        archived_rel, _archived_path = _archive_source_note(
+            source_path=note_path,
+            vault_path=vault,
+            capture_root=capture_root,
+            source_archive_root=source_archive_root,
+            entry_id=entry_id,
+            dry_run=dry_run,
+        )
+
+        capture_event = {
+            "event_id": entry_id,
+            "run_id": run_id,
+            "captured_at": _iso_now(),
+            "capture_model": "canonical_event_log",
+            "status": "needs_feedback" if needs_feedback else "projection_pending",
+            "needs_feedback": needs_feedback,
+            "content_class": "vault_note",
+            "vault_path": str(vault),
+            "config_path": str(resolved_config_path),
+            "title": title,
+            "tags": tags,
+            "source": {
+                "original_relative_path": path_before,
+                "archived_relative_path": archived_rel,
+                "filename": note_path.name,
+            },
+            "routing": {
+                "target": target,
+                "confidence": confidence,
+                "reason": str(decision.get("reason") or "").strip(),
+                "source": str(decision.get("source") or "llm"),
+            },
+            "projection": {
+                "stores": staged_projection_paths,
+            },
+            "canonical_content": rendered,
+            "sync_contract": _sync_contract(config),
+        }
+        if not dry_run:
+            _json_dump(_capture_event_path(capture_root, entry_id), capture_event)
+
+        event = {
+            "entry_id": entry_id,
+            "run_id": run_id,
+            "timestamp": _iso_now(),
+            "title": title,
+            "tags": tags,
+            "source": str(decision.get("source") or "llm"),
+            "reason": str(decision.get("reason") or "").strip(),
+            "confidence": confidence,
+            "needs_feedback": needs_feedback,
+            "path_before": path_before,
+            "path_after": default_projected_rel,
+            "target": target,
+            "status": "dry-run" if dry_run else "captured",
+            "excerpt": _excerpt(body, 300),
+            "config_path": str(resolved_config_path),
+            "archived_path": archived_rel,
+            "stores": sorted(staged_projection_paths),
+        }
+        processed.append(event)
+        if not dry_run:
+            _jsonl_append(_audit_events_path(state_root), event)
+
+    latest = {
+        "run_id": run_id,
+        "timestamp": _iso_now(),
+        "processed": len(processed),
+        "needs_feedback": sum(1 for item in processed if item["needs_feedback"]),
+        "config_path": str(resolved_config_path),
+        "vault_path": str(vault),
+    }
+    if not dry_run:
+        _json_dump(state_root / "latest_run.json", latest)
+        projection_summary = _summarize_projection_status(capture_root, config)
+    else:
+        projection_summary = {
+            "sync_contract": _sync_contract(config),
+            "total_events": len(processed),
+            "pending_events": len(processed),
+            "needs_feedback": sum(1 for item in processed if item["needs_feedback"]),
+            "stores": {store_name: {"pending": len(processed)} for store_name in projection_stores},
+        }
+
+    return {
+        "run_id": run_id,
+        "vault_path": str(vault),
+        "config_path": str(resolved_config_path),
+        "state_root": str(state_root),
+        "capture_root": str(capture_root),
+        "processed": processed,
+        "projection_status": projection_summary,
+        "counts": {
+            "processed": len(processed),
+            "needs_feedback": sum(1 for item in processed if item["needs_feedback"]),
+            "captured": sum(1 for item in processed if item["status"] == "captured"),
+        },
+        "dry_run": dry_run,
+    }
+
+
+def list_pending_feedback(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    events, _vault, _config, state_root = load_audit_events(
+        vault_path=vault_path,
+        config_path=config_path,
+        config_override=config_override,
+    )
+    feedback_index = _load_feedback_index(state_root)
+    pending: list[dict[str, Any]] = []
+    for event in reversed(events):
+        if not event.get("needs_feedback"):
+            continue
+        status = (feedback_index.get(event["entry_id"]) or {}).get("action")
+        if status in {"approve", "correct", "ignore"}:
+            continue
+        pending.append(event)
+        if len(pending) >= max(limit, 0):
+            break
+    return pending
+
+
+def feedback_status(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    events, vault, config, state_root = load_audit_events(
+        vault_path=vault_path,
+        config_path=config_path,
+        config_override=config_override,
+    )
+    latest = _json_load(state_root / "latest_run.json", {})
+    feedback_log = _read_jsonl(state_root / "feedback.jsonl")
+    capture_root = _capture_root(vault, config)
+    projection_status = _json_load(_projection_status_path(capture_root), {})
+    return {
+        "vault_path": str(vault),
+        "pending": len(list_pending_feedback(vault_path=vault, config_path=config_path, config_override=config_override, limit=999999)),
+        "audited": len(events),
+        "feedback_events": len(feedback_log),
+        "latest_run": latest or None,
+        "projection_status": projection_status or None,
+    }
+
+
+def _find_event(events: list[dict[str, Any]], entry_id: str) -> dict[str, Any]:
+    for event in events:
+        if event.get("entry_id") == entry_id:
+            return event
+    raise KeyError(f"Audit entry not found: {entry_id}")
+
+
+def _load_capture_event(capture_root: Path, entry_id: str) -> dict[str, Any]:
+    payload = _json_load(_capture_event_path(capture_root, entry_id), {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _rewrite_projection_staging(
+    *,
+    vault: Path,
+    config: dict[str, Any],
+    capture_root: Path,
+    capture_event: dict[str, Any],
+    target: str,
+) -> str:
+    fields = config.get("frontmatter") or {}
+    raw = str(capture_event.get("canonical_content") or "")
+    frontmatter, body = parse_frontmatter(raw)
+    frontmatter[str(fields.get("triage_status_field") or "para_triage_status")] = "corrected"
+    frontmatter[str(fields.get("triage_target_field") or "para_target")] = target
+    frontmatter[str(fields.get("updated_field") or "updated")] = _iso_now()
+    rendered = _render_note(frontmatter, body)
+
+    projection = ((capture_event.get("projection") or {}).get("stores")) or {}
+    filename = str(((capture_event.get("source") or {}).get("filename")) or Path(str(capture_event.get("path_after") or "note.md")).name)
+    stores = _enabled_projection_stores(config)
+    relocated_path = ""
+    for store_name, store_cfg in stores.items():
+        projected_rel = _projection_relative_path(target, filename, store_cfg)
+        staged_rel, staged_path = _stage_projection_file(
+            capture_root=capture_root,
+            entry_id=str(capture_event.get("event_id") or ""),
+            store_name=store_name,
+            relative_path=projected_rel,
+            content=rendered,
+            dry_run=False,
+        )
+        old_rel = str((projection.get(store_name) or {}).get("staged_relative_path") or "")
+        if old_rel and old_rel != staged_rel:
+            old_path = capture_root / old_rel
+            if old_path.exists():
+                old_path.unlink()
+        projection[store_name] = {
+            "state": "pending",
+            "target_relative_path": projected_rel,
+            "staged_relative_path": staged_rel,
+        }
+        if not relocated_path:
+            relocated_path = projected_rel
+    capture_event["canonical_content"] = rendered
+    capture_event["status"] = "projection_pending"
+    capture_event["needs_feedback"] = False
+    capture_event["routing"] = dict(capture_event.get("routing") or {})
+    capture_event["routing"]["target"] = target
+    capture_event["projection"] = {"stores": projection}
+    _json_dump(_capture_event_path(capture_root, str(capture_event.get("event_id") or "")), capture_event)
+    _summarize_projection_status(capture_root, config)
+    return relocated_path
+
+
+def apply_feedback(
+    *,
+    action: str,
+    entry_id: str,
+    target: str | None = None,
+    reviewer: str = "user",
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Persist reviewer feedback and update staged projection targets."""
+    normalized_action = str(action or "").strip().lower()
+    if normalized_action not in {"approve", "correct", "ignore"}:
+        raise ValueError("action must be one of: approve, correct, ignore")
+
+    events, vault, config, state_root = load_audit_events(
+        vault_path=vault_path,
+        config_path=config_path,
+        config_override=config_override,
+    )
+    event = _find_event(events, entry_id)
+    capture_root = _capture_root(vault, config)
+    capture_event = _load_capture_event(capture_root, entry_id)
+    resolved_target = None
+    relocated_path = None
+    if normalized_action == "correct":
+        if not target:
+            raise ValueError("correct requires a target path")
+        resolved_target = _normalize_target(target, vault_path=vault, config=config)
+        if not capture_event:
+            raise KeyError(f"Capture event not found: {entry_id}")
+        relocated_path = _rewrite_projection_staging(
+            vault=vault,
+            config=config,
+            capture_root=capture_root,
+            capture_event=capture_event,
+            target=resolved_target,
+        )
+    elif normalized_action == "approve":
+        resolved_target = str(event.get("target") or "")
+        if capture_event:
+            capture_event["needs_feedback"] = False
+            capture_event["status"] = "projection_pending"
+            _json_dump(_capture_event_path(capture_root, entry_id), capture_event)
+            _summarize_projection_status(capture_root, config)
+
+    feedback_record = {
+        "entry_id": entry_id,
+        "action": normalized_action,
+        "reviewer": reviewer,
+        "timestamp": _iso_now(),
+        "target": resolved_target,
+        "relocated_path": relocated_path,
+    }
+    _jsonl_append(state_root / "feedback.jsonl", feedback_record)
+    feedback_index = _load_feedback_index(state_root)
+    feedback_index[entry_id] = feedback_record
+    _save_feedback_index(state_root, feedback_index)
+
+    if normalized_action in {"approve", "correct"} and resolved_target:
+        examples = _load_examples(state_root)
+        new_example = _make_feedback_example(event, resolved_target, normalized_action)
+        examples = [item for item in examples if item.get("entry_id") != entry_id]
+        examples.append(new_example)
+        _save_examples(state_root, examples[-200:])
+
+    return feedback_record
+
+
+def format_pending_feedback(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "No pending PARA feedback items."
+    lines = ["Pending PARA feedback:"]
+    for item in items:
+        lines.append(
+            f"- {item['entry_id']} | {item['path_after']} | conf={item['confidence']:.2f} | {item['reason']}"
+        )
+    return "\n".join(lines)
+
+
+def format_run_report(summary: dict[str, Any]) -> str:
+    counts = summary.get("counts") or {}
+    processed = summary.get("processed") or []
+    if not processed:
+        return "[SILENT]"
+
+    lines = [
+        (
+            f"Vault PARA triage run `{summary['run_id']}`: "
+            f"{counts.get('captured', 0)} captured, {counts.get('needs_feedback', 0)} need feedback."
+        ),
+        f"Vault: {summary['vault_path']}",
+    ]
+    for item in processed[:12]:
+        lines.append(
+            f"- {item['entry_id']} | {item['path_before']} -> staged:{item['path_after']} "
+            f"(conf={item['confidence']:.2f})"
+        )
+        if item.get("needs_feedback"):
+            lines.append(
+                f"  /para-feedback approve {item['entry_id']}  |  "
+                f"/para-feedback correct {item['entry_id']} {item['target']}"
+            )
+    remaining = len(processed) - 12
+    if remaining > 0:
+        lines.append(f"...and {remaining} more item(s).")
+    lines.append("On-demand audit: /para-feedback status | /para-feedback list")
+    return "\n".join(lines)
+
+
+def _format_status(status: dict[str, Any]) -> str:
+    lines = [
+        f"Vault: {status['vault_path']}",
+        f"Audited entries: {status['audited']}",
+        f"Pending feedback: {status['pending']}",
+        f"Feedback events: {status['feedback_events']}",
+    ]
+    latest = status.get("latest_run")
+    if latest:
+        lines.append(
+            f"Latest run: {latest.get('run_id')} at {latest.get('timestamp')} "
+            f"({latest.get('processed', 0)} processed)"
+        )
+    projection = status.get("projection_status") or {}
+    if projection:
+        lines.append(
+            f"Projection status: {projection.get('pending_events', 0)} pending event(s) "
+            f"across {len(projection.get('stores') or {})} store(s)"
+        )
+    return "\n".join(lines)
+
+
+def handle_feedback_command(raw_args: str) -> str:
+    """Slash-command entrypoint used by the Slack/plugin feedback surface."""
+    argv = shlex.split(raw_args or "")
+    if not argv or argv[0] in {"help", "-h", "--help"}:
+        return (
+            "/para-feedback list [limit]\n"
+            "/para-feedback approve <entry_id>\n"
+            "/para-feedback correct <entry_id> <target>\n"
+            "/para-feedback ignore <entry_id>\n"
+            "/para-feedback status"
+        )
+
+    action = argv[0].lower()
+    try:
+        if action == "list":
+            limit = int(argv[1]) if len(argv) > 1 else 20
+            return format_pending_feedback(list_pending_feedback(limit=limit))
+        if action == "status":
+            return _format_status(feedback_status())
+        if action == "approve":
+            if len(argv) < 2:
+                return "Usage: /para-feedback approve <entry_id>"
+            record = apply_feedback(action="approve", entry_id=argv[1], reviewer="slack")
+            return f"Approved {record['entry_id']}."
+        if action == "correct":
+            if len(argv) < 3:
+                return "Usage: /para-feedback correct <entry_id> <target>"
+            record = apply_feedback(
+                action="correct",
+                entry_id=argv[1],
+                target=" ".join(argv[2:]),
+                reviewer="slack",
+            )
+            return (
+                f"Corrected {record['entry_id']} to {record.get('target')}."
+                + (f" Relocated to {record['relocated_path']}." if record.get("relocated_path") else "")
+            )
+        if action == "ignore":
+            if len(argv) < 2:
+                return "Usage: /para-feedback ignore <entry_id>"
+            record = apply_feedback(action="ignore", entry_id=argv[1], reviewer="slack")
+            return f"Ignored {record['entry_id']}."
+    except Exception as exc:
+        return f"para-feedback error: {exc}"
+
+    return "Unknown para-feedback subcommand. Use: list, approve, correct, ignore, status."
+
+
+def install_cron_wrapper(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    script_name: str = "vault-para-triage-nightly.py",
+    output_format: str = "slack",
+) -> Path:
+    """Write a cron-safe launcher under ``HERMES_HOME/scripts``.
+
+    Cron script jobs are constrained to that directory, so this helper bridges
+    the optional-skill install location and the scheduler's trusted script root.
+    """
+    vault = resolve_vault_path(vault_path)
+    resolved_config = _resolve_config_path(vault, config_path)
+    scripts_dir = get_hermes_home() / "scripts"
+    _ensure_dir(scripts_dir)
+
+    clean_name = Path(script_name).name
+    if not clean_name.endswith(".py"):
+        clean_name = f"{clean_name}.py"
+    target = (scripts_dir / clean_name).resolve()
+    try:
+        target.relative_to(scripts_dir.resolve())
+    except ValueError as exc:
+        raise ValueError(f"Wrapper path escapes scripts dir: {script_name}") from exc
+
+    content = (
+        "#!/usr/bin/env python3\n"
+        "\"\"\"Cron-safe PARA vault triage launcher.\"\"\"\n\n"
+        "import sys\n\n"
+        "from hermes_cli.vault_para_triage import main\n\n\n"
+        "if __name__ == \"__main__\":\n"
+        "    raise SystemExit(main([\n"
+        f"        \"--vault\", {str(vault)!r},\n"
+        f"        \"--config\", {str(resolved_config)!r},\n"
+        "        \"run\",\n"
+        f"        \"--format\", {output_format!r},\n"
+        "    ]))\n"
+    )
+    target.write_text(content, encoding="utf-8")
+    try:
+        target.chmod(0o755)
+    except OSError:
+        pass
+    return target
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="PARA vault inbox triage helper")
+    parser.add_argument("--vault", default=None, help="Absolute path to the Obsidian vault")
+    parser.add_argument("--config", default=None, help="Path to para-triage.yaml")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = sub.add_parser(
+        "run",
+        help="Process inbox notes into canonical capture events and staged PARA projections",
+    )
+    run_parser.add_argument("--dry-run", action="store_true", help="Do not write capture or staging files")
+    run_parser.add_argument("--limit", type=int, default=None, help="Maximum inbox notes to process")
+    run_parser.add_argument(
+        "--format",
+        choices=("text", "json", "slack"),
+        default="text",
+        help="Output format",
+    )
+
+    feedback_parser = sub.add_parser("feedback", help="Review or apply feedback to prior audit entries")
+    feedback_sub = feedback_parser.add_subparsers(dest="feedback_action", required=True)
+
+    feedback_list = feedback_sub.add_parser("list", help="List pending feedback items")
+    feedback_list.add_argument("--limit", type=int, default=20)
+
+    feedback_approve = feedback_sub.add_parser("approve", help="Approve an audit entry")
+    feedback_approve.add_argument("entry_id")
+
+    feedback_correct = feedback_sub.add_parser("correct", help="Correct an audit entry target")
+    feedback_correct.add_argument("entry_id")
+    feedback_correct.add_argument("target")
+
+    feedback_ignore = feedback_sub.add_parser("ignore", help="Ignore an audit entry")
+    feedback_ignore.add_argument("entry_id")
+
+    sub.add_parser("status", help="Summarize audit and feedback state")
+
+    install_wrapper = sub.add_parser(
+        "install-wrapper",
+        help="Write a cron-safe launcher into HERMES_HOME/scripts",
+    )
+    install_wrapper.add_argument(
+        "--name",
+        default="vault-para-triage-nightly.py",
+        help="Filename to create under HERMES_HOME/scripts",
+    )
+    install_wrapper.add_argument(
+        "--format",
+        choices=("text", "json", "slack"),
+        default="slack",
+        help="Output format used by the generated nightly wrapper",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        summary = run_triage(
+            vault_path=args.vault,
+            config_path=args.config,
+            dry_run=args.dry_run,
+            limit=args.limit,
+        )
+        if args.format == "json":
+            print(json.dumps(summary, ensure_ascii=False, indent=2))
+        else:
+            print(format_run_report(summary))
+        return 0
+
+    if args.command == "status":
+        print(_format_status(feedback_status(vault_path=args.vault, config_path=args.config)))
+        return 0
+
+    if args.command == "install-wrapper":
+        target = install_cron_wrapper(
+            vault_path=args.vault,
+            config_path=args.config,
+            script_name=args.name,
+            output_format=args.format,
+        )
+        print(str(target))
+        return 0
+
+    if args.command == "feedback":
+        if args.feedback_action == "list":
+            print(
+                format_pending_feedback(
+                    list_pending_feedback(
+                        vault_path=args.vault,
+                        config_path=args.config,
+                        limit=args.limit,
+                    )
+                )
+            )
+            return 0
+        if args.feedback_action == "approve":
+            result = apply_feedback(
+                action="approve",
+                entry_id=args.entry_id,
+                reviewer="cli",
+                vault_path=args.vault,
+                config_path=args.config,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+        if args.feedback_action == "correct":
+            result = apply_feedback(
+                action="correct",
+                entry_id=args.entry_id,
+                target=args.target,
+                reviewer="cli",
+                vault_path=args.vault,
+                config_path=args.config,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+        if args.feedback_action == "ignore":
+            result = apply_feedback(
+                action="ignore",
+                entry_id=args.entry_id,
+                reviewer="cli",
+                vault_path=args.vault,
+                config_path=args.config,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7962,6 +7962,65 @@ async def instantiate_blueprint(body: AutomationBlueprintInstantiate, profile: s
 
 
 # ---------------------------------------------------------------------------
+# Payments dashboard endpoints — profile-scoped manual-payment review queue.
+# ---------------------------------------------------------------------------
+
+
+class PaymentStatusUpdate(BaseModel):
+    status: str
+
+
+class PaymentSyncRequest(BaseModel):
+    source: str = "gmail"
+    query: Optional[str] = None
+    max_results: Optional[int] = None
+
+
+@app.get("/api/payments")
+async def list_payments(profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        return payments_store.list_payment_requests()
+
+
+@app.post("/api/payments/{payment_id}/status")
+async def update_payment_status(
+    payment_id: str,
+    body: PaymentStatusUpdate,
+    profile: Optional[str] = None,
+):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        try:
+            return payments_store.update_payment_status(payment_id, body.status)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail="Payment request not found") from exc
+
+
+@app.post("/api/payments/sync")
+async def sync_payments(body: PaymentSyncRequest, profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    source = (body.source or "gmail").strip().lower()
+    with _profile_scope(profile):
+        try:
+            if source != "gmail":
+                raise HTTPException(status_code=400, detail=f"Unsupported payment source: {source}")
+            return payments_store.sync_gmail_payment_requests(
+                query=body.query or payments_store.DEFAULT_GMAIL_QUERY,
+                max_results=int(body.max_results or payments_store.DEFAULT_GMAIL_MAX_RESULTS),
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
 # MCP server endpoints — list / add / remove / test.
 #
 # Wraps the same config data layer the CLI uses (hermes_cli.mcp_config), so

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7976,6 +7976,171 @@ class PaymentSyncRequest(BaseModel):
     max_results: Optional[int] = None
 
 
+class InboxItemStatusUpdate(BaseModel):
+    status: str
+
+
+class PaymentShadowScheduleRequest(BaseModel):
+    schedule: Optional[str] = None
+    query: Optional[str] = None
+    max_results: Optional[int] = None
+    name: Optional[str] = None
+    run_now: bool = False
+
+
+def _ops_service_summary(
+    *,
+    service_id: str,
+    title: str,
+    url: str,
+    description: str = "",
+    group: str = "Operations",
+    tags: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    return {
+        "id": service_id,
+        "title": title,
+        "url": url,
+        "description": description,
+        "group": group,
+        "tags": list(tags or []),
+    }
+
+
+def _default_ops_services(request: Request) -> list[dict[str, Any]]:
+    host = request.url.hostname or "127.0.0.1"
+    scheme = request.url.scheme or "http"
+    dashboard_base = f"{scheme}://{host}:9121"
+    grafana_url = f"{scheme}://{host}:3000"
+    prometheus_url = f"{dashboard_base}/api/ops/webhub/prometheus"
+    return [
+        _ops_service_summary(
+            service_id="payments",
+            title="Payments",
+            url=f"{dashboard_base}/payments",
+            description="Review and update the live payments queue.",
+            group="Hermes",
+            tags=["payments", "ops"],
+        ),
+        _ops_service_summary(
+            service_id="chat",
+            title="Hermes Chat",
+            url=f"{dashboard_base}/chat",
+            description="Open the embedded Hermes terminal chat surface.",
+            group="Hermes",
+            tags=["chat", "agent"],
+        ),
+        _ops_service_summary(
+            service_id="sessions",
+            title="Sessions",
+            url=f"{dashboard_base}/sessions",
+            description="Browse recent Hermes work and resume threads.",
+            group="Hermes",
+            tags=["history"],
+        ),
+        _ops_service_summary(
+            service_id="logs",
+            title="Logs",
+            url=f"{dashboard_base}/logs",
+            description="Inspect gateway and agent logs from the dashboard.",
+            group="Hermes",
+            tags=["logs", "debug"],
+        ),
+        _ops_service_summary(
+            service_id="system",
+            title="System",
+            url=f"{dashboard_base}/system",
+            description="Check gateway health, runtime status, and admin actions.",
+            group="Hermes",
+            tags=["status", "admin"],
+        ),
+        _ops_service_summary(
+            service_id="grafana",
+            title="Grafana",
+            url=grafana_url,
+            description="Metrics and dashboards running on the Mac mini.",
+            group="Observability",
+            tags=["grafana", "metrics"],
+        ),
+        _ops_service_summary(
+            service_id="prometheus",
+            title="Prometheus Export",
+            url=prometheus_url,
+            description="OpenRouter observability metrics in Prometheus text format.",
+            group="Observability",
+            tags=["prometheus", "metrics", "openrouter"],
+        ),
+    ]
+
+
+def _configured_ops_services(config: dict[str, Any]) -> list[dict[str, Any]]:
+    dashboard = config.get("dashboard") if isinstance(config, dict) else {}
+    raw_links = dashboard.get("ops_links") if isinstance(dashboard, dict) else []
+    services: list[dict[str, Any]] = []
+    if not isinstance(raw_links, list):
+        return services
+    for index, item in enumerate(raw_links):
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title") or item.get("label") or "").strip()
+        url = str(item.get("url") or "").strip()
+        if not title or not url:
+            continue
+        service_id = str(item.get("id") or f"custom-{index + 1}").strip() or f"custom-{index + 1}"
+        description = str(item.get("description") or "").strip()
+        group = str(item.get("group") or "Custom").strip() or "Custom"
+        tags = item.get("tags") if isinstance(item.get("tags"), list) else []
+        services.append(
+            _ops_service_summary(
+                service_id=service_id,
+                title=title,
+                url=url,
+                description=description,
+                group=group,
+                tags=[str(tag).strip() for tag in tags if str(tag).strip()],
+            )
+        )
+    return services
+
+
+@app.get("/api/ops/services")
+async def list_ops_services(request: Request):
+    config = load_config() or {}
+    services = {item["id"]: item for item in _default_ops_services(request)}
+    for item in _configured_ops_services(config):
+        services[item["id"]] = item
+    return {"services": list(services.values())}
+
+
+@app.get("/api/ops/webhub")
+async def get_webhub_ops_summary(request: Request):
+    from plugins.observability.webhub import get_dashboard_summary, get_runtime_status
+
+    host = request.url.hostname or "127.0.0.1"
+    scheme = request.url.scheme or "http"
+    dashboard_base = f"{scheme}://{host}:9121"
+    return {
+        "status": get_runtime_status(),
+        "summary": get_dashboard_summary(window_hours=24),
+        "links": {
+            "grafana_url": f"{scheme}://{host}:3000",
+            "prometheus_url": f"{dashboard_base}/api/ops/webhub/prometheus",
+            "channels_url": f"{dashboard_base}/channels",
+            "ops_url": f"{dashboard_base}/ops",
+        },
+    }
+
+
+@app.get("/api/ops/webhub/prometheus")
+async def get_webhub_prometheus_metrics():
+    from plugins.observability.webhub import render_prometheus_metrics
+
+    return Response(
+        content=render_prometheus_metrics(),
+        media_type="text/plain; version=0.0.4; charset=utf-8",
+    )
+
+
 @app.get("/api/payments")
 async def list_payments(profile: Optional[str] = None):
     from hermes_cli import payments as payments_store
@@ -8018,6 +8183,92 @@ async def sync_payments(body: PaymentSyncRequest, profile: Optional[str] = None)
             raise
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/payments/shadow-sync")
+async def shadow_sync_payments(body: PaymentSyncRequest, profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    source = (body.source or "gmail").strip().lower()
+    with _profile_scope(profile):
+        try:
+            if source != "gmail":
+                raise HTTPException(status_code=400, detail=f"Unsupported payment source: {source}")
+            return payments_store.sync_gmail_payment_requests_shadow(
+                query=body.query or payments_store.DEFAULT_GMAIL_QUERY,
+                max_results=int(body.max_results or payments_store.DEFAULT_GMAIL_MAX_RESULTS),
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/payments/shadow-report")
+async def payments_shadow_report(profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        return {
+            "storage_path": payments_store._storage_display_path(),
+            "snapshot": payments_store.load_shadow_report_snapshot(),
+            "parity": payments_store.generate_payments_shadow_report(),
+        }
+
+
+@app.post("/api/payments/shadow-schedule")
+async def payments_shadow_schedule(
+    body: PaymentShadowScheduleRequest,
+    profile: Optional[str] = None,
+):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        try:
+            job = payments_store.ensure_gmail_shadow_sync_cron_job(
+                schedule=body.schedule or payments_store.DEFAULT_GMAIL_SHADOW_SYNC_SCHEDULE,
+                query=body.query or payments_store.DEFAULT_GMAIL_QUERY,
+                max_results=int(body.max_results or payments_store.DEFAULT_GMAIL_MAX_RESULTS),
+                name=body.name or payments_store.PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME,
+            )
+            result: dict[str, Any] = {"job": job}
+            if body.run_now:
+                result["run_now"] = payments_store.sync_gmail_payment_requests_shadow(
+                    query=body.query or payments_store.DEFAULT_GMAIL_QUERY,
+                    max_results=int(body.max_results or payments_store.DEFAULT_GMAIL_MAX_RESULTS),
+                )
+            return result
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/inbox-items")
+async def list_inbox_items(
+    queue: Optional[str] = None,
+    workflow_type: Optional[str] = None,
+    profile: Optional[str] = None,
+):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        return payments_store.list_inbox_items(queue=queue, workflow_type=workflow_type)
+
+
+@app.post("/api/inbox-items/{item_id}/status")
+async def update_inbox_item_status(
+    item_id: str,
+    body: InboxItemStatusUpdate,
+    profile: Optional[str] = None,
+):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        try:
+            return payments_store.update_inbox_item_status(item_id, body.status)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail="Inbox item not found") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/optional-skills/productivity/vault-para-triage/SKILL.md
+++ b/optional-skills/productivity/vault-para-triage/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: vault-para-triage
+description: Capture an Obsidian inbox into a canonical capture event log, stage PARA projections for downstream stores, and learn from Slack feedback.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [obsidian, para, vault, notes, cron, slack, routing, frontmatter]
+    category: productivity
+    related_skills: [obsidian, slack-surfaces]
+---
+
+# Vault PARA Triage
+
+Use this optional skill when the user wants Hermes to clean up an Obsidian inbox
+into a PARA-organized note system on a schedule, while keeping a canonical
+capture event log, downstream staged projections, an audit trail, and a review
+loop.
+
+This skill ships a helper script, `scripts/vault_para_triage.py`, backed by the
+shared `hermes_cli.vault_para_triage` module.
+
+## What it does
+
+For each markdown note in the configured inbox folder:
+
+1. ensures YAML frontmatter exists
+2. classifies the note into a canonical PARA target folder
+3. writes canonical markdown content into a capture event log
+4. stages one projected file per enabled downstream store
+5. archives the original inbox note into the capture root
+6. writes immutable audit and status records
+7. marks uncertain routes for review and learns from later feedback
+
+The review loop is designed to pair with the bundled `vault-triage-feedback`
+plugin, which exposes `/para-feedback` inside Slack and other chat surfaces.
+
+## Default paths
+
+- Vault path: `OBSIDIAN_VAULT_PATH`, otherwise `~/Documents/Obsidian Vault`
+- Config file: `<vault>/.hermes/para-triage.yaml`
+- Audit/state root: `<vault>/.hermes/para-triage/`
+- Capture root: `<vault>/.hermes/note-capture/`
+
+The capture root is the canonical handoff point for external sync jobs. Hermes
+does not write directly into the projected vault or second-brain destinations.
+
+## Locate the helper script
+
+```bash
+SCRIPT="$(find ~/.hermes/skills -path '*/vault-para-triage/scripts/vault_para_triage.py' -print -quit)"
+```
+
+If `SCRIPT` is empty, install the skill first.
+
+## Install
+
+```bash
+hermes skills search vault-para-triage
+hermes skills install official/productivity/vault-para-triage
+```
+
+Enable the feedback plugin so `/para-feedback` is available:
+
+```bash
+hermes plugins enable vault-triage-feedback
+```
+
+## Minimal config
+
+Create `<vault>/.hermes/para-triage.yaml`:
+
+```yaml
+inbox_dir: Inbox
+para_roots:
+  projects: Projects
+  areas: Areas
+  resources: Resources
+  archives: Archives
+review_dir: Resources/_Inbox Review
+capture:
+  root: .hermes/note-capture
+  source_archive_dir: source-archive
+projection:
+  stores:
+    vault:
+      enabled: true
+      path_prefix: ""
+    second_brain:
+      enabled: true
+      path_prefix: ""
+routing:
+  min_confidence: 0.72
+  low_confidence_action: review   # one of: review, inbox, auto-file
+  rules:
+    - name: health-notes
+      match_any: ["health", "doctor", "medication"]
+      target: Areas/Health
+      confidence: 0.95
+      reason: Health-related notes belong in Areas/Health.
+    - name: taxes
+      match_any: ["tax", "hmrc", "invoice"]
+      target: Areas/Finance
+      confidence: 0.95
+```
+
+Add more explicit rules as the vault evolves. The helper also stores learned
+examples from reviewer corrections under `.hermes/para-triage/routing_examples.json`.
+
+Projection rules:
+
+- Hermes first decides one canonical logical `target`, such as `Projects/Acme`
+  or `Resources/Content Library`.
+- For each enabled store, Hermes derives the projected relative path as
+  `<path_prefix>/<target>/<filename>`.
+- Hermes stages files under
+  `.hermes/note-capture/staging/<store>/<entry_id>/<projected-relative-path>`.
+- Hermes archives the original note under
+  `.hermes/note-capture/source-archive/<entry_id>/<original-relative-path>`.
+- Hermes records the canonical event under
+  `.hermes/note-capture/events/<entry_id>.json`.
+- External sync outside the Hermes trust boundary is responsible for projecting
+  staged files into the live vault, iCloud, second brain, or other stores.
+
+Low-confidence behavior:
+
+- `review` — stage uncertain notes to `review_dir`
+- `inbox` — keep uncertain notes mapped to their inbox-relative location
+- `auto-file` — still stage uncertain notes to the predicted target, then rely on Slack corrections
+
+## Dry-run and status
+
+Preview the next triage pass:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" run --dry-run
+```
+
+Inspect audit and review state:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" feedback list --limit 20
+```
+
+Inspect canonical capture status:
+
+```bash
+cat "$OBSIDIAN_VAULT_PATH/.hermes/note-capture/status/latest.json"
+```
+
+## Overnight cron job
+
+Use a script-only cron job so the canonical capture logic runs the same way
+every night and the output can be delivered directly to Slack.
+
+First install a cron-safe launcher into `~/.hermes/scripts/`:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper
+```
+
+This prints the generated path, usually:
+
+```text
+~/.hermes/scripts/vault-para-triage-nightly.py
+```
+
+Then schedule that generated wrapper:
+
+```bash
+hermes cron create "0 2 * * *" \
+  --name "Vault PARA triage" \
+  --deliver slack:C0B6MV5RA06 \
+  --script ~/.hermes/scripts/vault-para-triage-nightly.py \
+  --no-agent
+```
+
+For this rollout, `slack:C0B6MV5RA06` is the explicit `#hermes-ops` channel
+target. Using the raw Slack channel ID is safer than relying on name
+resolution.
+
+If the scheduler environment on your machine does not preserve
+`OBSIDIAN_VAULT_PATH`, the generated wrapper already bakes in the absolute vault
+and config path you passed to `install-wrapper`, so cron does not need that env
+var later.
+
+If you want a different filename or output mode:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper \
+  --name para-nightly-review.py \
+  --format slack
+```
+
+## Slack feedback loop
+
+After the nightly run posts to Slack, review uncertain entries with:
+
+```text
+/para-feedback list
+/para-feedback approve <entry_id>
+/para-feedback correct <entry_id> Areas/Health
+/para-feedback ignore <entry_id>
+/para-feedback status
+```
+
+For an on-demand audit summary, use:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+```
+
+`approve` and `correct` both teach future runs. `correct` rewrites the staged
+projection targets for the current capture event to the supplied canonical
+target path.
+
+## Notes
+
+- The helper remembers the vault structure by snapshotting available PARA
+  folders on every run into `.hermes/para-triage/structure.json`.
+- Canonical captures are logged under `.hermes/note-capture/events/`.
+- Projected store health is summarized in `.hermes/note-capture/status/latest.json`.
+- All capture audit rows are logged to `.hermes/para-triage/audit.jsonl`.
+- Reviewer actions are logged separately to `.hermes/para-triage/feedback.jsonl`.
+- This keeps the capability outside Hermes core tools while still making it
+  schedulable and auditable.

--- a/optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py
+++ b/optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Thin wrapper for the bundled PARA triage helper.
+
+When cron runs this file directly it passes no arguments, so default to the
+nightly Slack-friendly triage run. Manual invocations still accept the full CLI.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from hermes_cli.vault_para_triage import main
+
+
+if __name__ == "__main__":
+    argv = sys.argv[1:] or ["run", "--format", "slack"]
+    raise SystemExit(main(argv))

--- a/plugins/inbox_ops_payments/__init__.py
+++ b/plugins/inbox_ops_payments/__init__.py
@@ -1,0 +1,100 @@
+"""Plugin-shaped payment candidate classifier/extractor wrappers.
+
+These wrappers preserve the current payments adapter semantics while exposing
+explicit classifier/extractor steps that a generalized inbox-ops runtime can
+compose during shadow mode and cutover.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PaymentCandidateClassification:
+    workflow_type: str
+    status: str
+    confidence: Any
+    action_required: bool
+    receipt_like: bool
+    invoice_like: bool
+
+
+class PaymentCandidateClassifier:
+    """Classify an existing payment-shaped record without changing thresholds."""
+
+    def classify(self, request: dict[str, Any]) -> PaymentCandidateClassification:
+        status = str(request.get("status") or "needs_review")
+        receipt_like = bool(request.get("looks_paid")) or status == "paid"
+        return PaymentCandidateClassification(
+            workflow_type="payment_receipt" if receipt_like else "payment_request",
+            status=status,
+            confidence=request.get("confidence"),
+            action_required=status != "paid",
+            receipt_like=receipt_like,
+            invoice_like=bool(request.get("invoice_number")),
+        )
+
+
+class PaymentCandidateExtractor:
+    """Extract canonical inbox-ops fields from an existing payment-shaped record."""
+
+    def extract(self, request: dict[str, Any], classification: PaymentCandidateClassification) -> dict[str, Any]:
+        original = request.get("original") or {}
+        return {
+            "id": str(request.get("id") or request.get("payment_id") or ""),
+            "source": str(request.get("source") or "gmail"),
+            "source_account": "",
+            "source_thread_id": str(original.get("thread_id") or ""),
+            "source_message_id": str(original.get("message_id") or ""),
+            "source_url": str(original.get("url") or ""),
+            "captured_at": request.get("received_at"),
+            "updated_at": request.get("updated_at"),
+            "last_classified_at": request.get("updated_at"),
+            "workflow_type": classification.workflow_type,
+            "queue": "payments",
+            "status": classification.status,
+            "title": str(request.get("title") or ""),
+            "summary": str(request.get("preview_text") or ""),
+            "counterparty": str(request.get("vendor") or ""),
+            "action_required": classification.action_required,
+            "confidence": classification.confidence,
+            "amount": dict(request.get("amount") or {}),
+            "due_date": request.get("due_date"),
+            "meeting_dates": [],
+            "meeting_timezone": "",
+            "reference_id": str(request.get("payment_reference") or ""),
+            "receipt_like": classification.receipt_like,
+            "invoice_like": classification.invoice_like,
+            "calendar_like": False,
+            "warning_flags": [str(item) for item in (request.get("warnings") or [])],
+            "operator_notes": str(request.get("review_note") or ""),
+            "raw_payload_path": request.get("raw_text_path"),
+            "materialized_path": request.get("materialized_path"),
+            "manual_status": False,
+            "manual_notes": bool(request.get("review_note")),
+            "reviewed_at": None,
+            "reviewed_by": None,
+            "entities": {
+                "sender": str(original.get("label") or ""),
+                "organization": str(request.get("vendor") or ""),
+                "payee_name": str(request.get("payee_name") or ""),
+                "account_holder": str(request.get("account_holder") or ""),
+                "account_number": str(request.get("account_number") or ""),
+                "sort_code": str(request.get("sort_code") or ""),
+                "iban": str(request.get("iban") or ""),
+                "swift": str(request.get("swift") or ""),
+                "routing_number": str(request.get("routing_number") or ""),
+                "payment_reference": str(request.get("payment_reference") or ""),
+                "invoice_number": str(request.get("invoice_number") or ""),
+                "billing_address": str(request.get("billing_address") or ""),
+                "tax_details": str(request.get("tax_details") or ""),
+            },
+            "artifacts": {
+                "label": str(original.get("label") or ""),
+                "attachments": [str(item) for item in (request.get("attachments") or [])],
+                "original_thread_url": str(original.get("url") or ""),
+            },
+        }
+

--- a/plugins/inbox_ops_payments/plugin.yaml
+++ b/plugins/inbox_ops_payments/plugin.yaml
@@ -1,0 +1,4 @@
+name: inbox-ops-payments
+version: 1.0.0
+description: "Plugin-shaped payment candidate classifier and extractor wrappers for inbox-ops shadow ingestion."
+author: Hermes Agent

--- a/plugins/payments_ops/README.md
+++ b/plugins/payments_ops/README.md
@@ -1,0 +1,26 @@
+# Payments Ops Slack Surface
+
+This plugin adds the small-screen companion workflow for the dashboard payments board.
+
+What it does:
+
+- Registers Slack Block Kit action handlers for `needs_review`, `ready_to_pay`, `paid`, and `ignored`
+- Opens a compact Slack modal from the mobile inbox message so status changes are one tap away
+- Adds `/payments-due` and `/payments-ready` slash commands for quick queue summaries
+- Best-effort refreshes the paired Slack canvas after a status change when canvas channel env vars are configured
+
+Operator scripts:
+
+- Render a canvas spec:
+  - `python3 scripts/payments-slack-surface.py canvas-spec`
+- Publish the canvas:
+  - `python3 scripts/payments-slack-surface.py publish-canvas`
+- Post the compact mobile inbox:
+  - `python3 scripts/payments-slack-surface.py post-mobile-inbox --channel <channel-or-dm-id>`
+
+Relevant env vars:
+
+- `SLACK_BOT_TOKEN`
+- `HERMES_PAYMENTS_DASHBOARD_URL`
+- `PAYMENTS_SLACK_CANVAS_CHANNEL_KEY`
+- `PAYMENTS_SLACK_CANVAS_CHANNEL_NAME`

--- a/plugins/payments_ops/__init__.py
+++ b/plugins/payments_ops/__init__.py
@@ -1,0 +1,247 @@
+"""Slack companion surface for payments operations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+from hermes_cli import payments as payments_store
+from hermes_cli.config import load_env
+
+logger = logging.getLogger(__name__)
+
+
+def _env_value(name: str) -> str:
+    try:
+        env = load_env()
+    except Exception:
+        env = {}
+    return str(os.environ.get(name) or env.get(name) or "").strip()
+
+
+def _slack_client():
+    try:
+        from slack_sdk.web.async_client import AsyncWebClient
+    except Exception as exc:  # pragma: no cover - dependency is optional in tests
+        raise RuntimeError("slack_sdk is not installed") from exc
+    token = _env_value("SLACK_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("SLACK_BOT_TOKEN is not configured")
+    return AsyncWebClient(token=token)
+
+
+def _dashboard_url() -> str:
+    return _env_value("HERMES_PAYMENTS_DASHBOARD_URL")
+
+
+def _canvas_channel_key() -> str:
+    return _env_value("PAYMENTS_SLACK_CANVAS_CHANNEL_KEY")
+
+
+def _canvas_channel_name() -> str:
+    return _env_value("PAYMENTS_SLACK_CANVAS_CHANNEL_NAME")
+
+
+def _find_payment(payment_id: str) -> dict[str, Any]:
+    for payment in payments_store.list_payment_requests()["requests"]:
+        if str(payment.get("id")) == payment_id:
+            return payment
+    raise KeyError(payment_id)
+
+
+def _mobile_blocks() -> list[dict[str, Any]]:
+    return payments_store.build_slack_mobile_blocks(
+        statuses=("needs_review", "ready_to_pay", "paid"),
+        per_status_limit=5,
+    )
+
+
+def _status_text(status: str) -> str:
+    return status.replace("_", " ")
+
+
+def _parse_message_context(body: dict[str, Any]) -> tuple[str, str]:
+    channel_id = str(
+        body.get("channel", {}).get("id")
+        or body.get("container", {}).get("channel_id")
+        or ""
+    ).strip()
+    message_ts = str(
+        body.get("message", {}).get("ts")
+        or body.get("container", {}).get("message_ts")
+        or ""
+    ).strip()
+    if not channel_id and isinstance(body.get("view"), dict):
+        raw = str(body["view"].get("private_metadata") or "").strip()
+        if raw:
+            try:
+                parsed = json.loads(raw)
+            except Exception:
+                parsed = {}
+            channel_id = channel_id or str(parsed.get("channel_id") or "").strip()
+            message_ts = message_ts or str(parsed.get("message_ts") or "").strip()
+    return channel_id, message_ts
+
+
+async def _refresh_mobile_message(client, body: dict[str, Any]) -> None:
+    channel_id, message_ts = _parse_message_context(body)
+    if not channel_id or not message_ts:
+        return
+    try:
+        await client.chat_update(
+            channel=channel_id,
+            ts=message_ts,
+            text="Payments mobile inbox",
+            blocks=_mobile_blocks(),
+        )
+    except Exception:
+        logger.debug("payments_ops: mobile inbox refresh failed", exc_info=True)
+
+
+async def _refresh_canvas_surface() -> None:
+    channel_key = _canvas_channel_key()
+    channel_name = _canvas_channel_name()
+    if not channel_key or not channel_name:
+        return
+    script = Path(__file__).resolve().parents[2] / "scripts" / "payments-slack-surface.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "publish-canvas",
+        "--channel-key",
+        channel_key,
+        "--channel-name",
+        channel_name,
+    ]
+    dashboard_url = _dashboard_url()
+    if dashboard_url:
+        cmd.extend(["--dashboard-url", dashboard_url])
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=30)
+    except Exception:
+        logger.debug("payments_ops: canvas refresh failed", exc_info=True)
+
+
+async def _notify_result(client, body: dict[str, Any], text: str) -> None:
+    channel_id = str(
+        body.get("channel", {}).get("id")
+        or body.get("container", {}).get("channel_id")
+        or ""
+    ).strip()
+    user_id = str(body.get("user", {}).get("id") or "").strip()
+    if not channel_id or not user_id:
+        return
+    try:
+        await client.chat_postEphemeral(channel=channel_id, user=user_id, text=text)
+    except Exception:
+        logger.debug("payments_ops: ephemeral confirmation failed", exc_info=True)
+
+
+async def _open_status_modal(ack, body, action) -> None:
+    await ack()
+    payment_id = str(action.get("value") or "").strip()
+    if not payment_id:
+        return
+    payment = _find_payment(payment_id)
+    channel_id, message_ts = _parse_message_context(body)
+    private_metadata = json.dumps(
+        {"channel_id": channel_id, "message_ts": message_ts},
+        separators=(",", ":"),
+    )
+    client = _slack_client()
+    await client.views_open(
+        trigger_id=body.get("trigger_id"),
+        view=payments_store.build_slack_status_modal_view(
+            payment,
+            private_metadata=private_metadata,
+        ),
+    )
+
+
+async def _handle_status_change(target_status: str, ack, body, action) -> None:
+    if body.get("container", {}).get("type") == "view":
+        await ack({"response_action": "clear"})
+    else:
+        await ack()
+
+    payment_id = str(action.get("value") or "").strip()
+    if not payment_id:
+        return
+
+    client = _slack_client()
+    try:
+        updated = payments_store.update_payment_status(payment_id, target_status)
+    except KeyError:
+        await _notify_result(client, body, "That payment no longer exists in the review queue.")
+        return
+    except Exception as exc:
+        await _notify_result(client, body, f"Payments update failed: {exc}")
+        return
+
+    await _refresh_mobile_message(client, body)
+    await _refresh_canvas_surface()
+    title = updated.get("vendor") or updated.get("title") or updated.get("id") or payment_id
+    await _notify_result(client, body, f"{title} marked {_status_text(target_status)}.")
+
+
+def _status_handler(target_status: str):
+    async def _handler(ack, body, action) -> None:
+        await _handle_status_change(target_status, ack, body, action)
+
+    return _handler
+
+
+def _command_summary(status: str, limit: int = 5) -> str:
+    requests = payments_store.list_payment_requests()["requests"]
+    items = [
+        item
+        for item in requests
+        if item.get("operator_status") == status or item.get("status") == status
+    ][:limit]
+    heading = {
+        "needs_review": "Payments due",
+        "ready_to_pay": "Payments ready",
+        "paid": "Payments paid",
+    }.get(status, f"Payments {_status_text(status)}")
+    lines = [f"{heading}:"]
+    if not items:
+        lines.append("- none")
+    else:
+        for item in items:
+            title = item.get("vendor") or item.get("title") or item.get("id")
+            amount = item.get("amount", {}).get("display") or "Amount missing"
+            due = item.get("due_date") or "No due date"
+            lines.append(f"- {title} · {amount} · due {due}")
+    dashboard_url = _dashboard_url()
+    if dashboard_url:
+        lines.append("")
+        lines.append(f"Dashboard: {dashboard_url}")
+    return "\n".join(lines)
+
+
+def register(ctx) -> None:
+    ctx.register_slack_action_handler("payments_open_status_modal", _open_status_modal)
+    ctx.register_slack_action_handler("payments_mark_review", _status_handler("needs_review"))
+    ctx.register_slack_action_handler("payments_mark_ready", _status_handler("ready_to_pay"))
+    ctx.register_slack_action_handler("payments_mark_paid", _status_handler("paid"))
+    ctx.register_slack_action_handler("payments_mark_ignored", _status_handler("ignored"))
+    ctx.register_command(
+        "payments-due",
+        lambda _args: _command_summary("needs_review"),
+        description="Show the top payment requests still needing review",
+    )
+    ctx.register_command(
+        "payments-ready",
+        lambda _args: _command_summary("ready_to_pay"),
+        description="Show the top payment requests ready to pay",
+    )

--- a/plugins/payments_ops/plugin.yaml
+++ b/plugins/payments_ops/plugin.yaml
@@ -1,0 +1,4 @@
+name: payments-ops
+version: 1.0.0
+description: "Slack companion surface for the payments review board: compact canvas summaries plus mobile status actions."
+author: Hermes Agent

--- a/plugins/vault_triage_feedback/__init__.py
+++ b/plugins/vault_triage_feedback/__init__.py
@@ -1,0 +1,14 @@
+"""Plugin slash command for reviewing PARA vault triage audit items."""
+
+from __future__ import annotations
+
+from hermes_cli.vault_para_triage import handle_feedback_command
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        "para-feedback",
+        handle_feedback_command,
+        description="Review or correct PARA vault triage audit items",
+        args_hint="list|status|approve <entry_id>|correct <entry_id> <target>|ignore <entry_id>",
+    )

--- a/plugins/vault_triage_feedback/plugin.yaml
+++ b/plugins/vault_triage_feedback/plugin.yaml
@@ -1,0 +1,4 @@
+name: vault-triage-feedback
+version: 1.0.0
+description: "Expose /para-feedback so vault triage audit items can be reviewed and corrected from Slack and other chat surfaces."
+author: Hermes Agent

--- a/scripts/payments-slack-surface.py
+++ b/scripts/payments-slack-surface.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Render and publish the Slack companion surface for payments ops."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+VENV_PYTHON = REPO_ROOT / "venv" / "bin" / "python"
+if (
+    not os.environ.get("VIRTUAL_ENV")
+    and VENV_PYTHON.exists()
+    and Path(sys.executable) != VENV_PYTHON
+):
+    os.execv(str(VENV_PYTHON), [str(VENV_PYTHON), __file__, *sys.argv[1:]])
+
+from hermes_cli import payments as payments_store
+from hermes_cli.config import load_env
+
+MOBILE_INBOX_TEXT = "Payments mobile inbox"
+
+
+def _env_value(name: str) -> str:
+    try:
+        env = load_env()
+    except Exception:
+        env = {}
+    return str(os.environ.get(name) or env.get(name) or "").strip()
+
+
+def _default_dashboard_url() -> str:
+    return _env_value("HERMES_PAYMENTS_DASHBOARD_URL")
+
+
+def _slack_token() -> str:
+    token = _env_value("SLACK_BOT_TOKEN")
+    if not token:
+        raise SystemExit("SLACK_BOT_TOKEN is not configured")
+    return token
+
+
+def _optional_slack_token() -> str:
+    return _env_value("SLACK_BOT_TOKEN")
+
+
+def render_canvas_spec(args: argparse.Namespace) -> int:
+    print(
+        payments_store.render_slack_canvas_spec(
+            channel_key=args.channel_key,
+            channel_name=args.channel_name,
+            canvas_title=args.canvas_title,
+            dashboard_url=args.dashboard_url,
+            per_status_limit=args.per_status_limit,
+        ),
+        end="",
+    )
+    return 0
+
+
+def publish_canvas(args: argparse.Namespace) -> int:
+    spec = payments_store.render_slack_canvas_spec(
+        channel_key=args.channel_key,
+        channel_name=args.channel_name,
+        canvas_title=args.canvas_title,
+        dashboard_url=args.dashboard_url,
+        per_status_limit=args.per_status_limit,
+    )
+    wrapper = Path(__file__).resolve().parent / "slack-surfaces-run.sh"
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False, encoding="utf-8") as handle:
+        handle.write(spec)
+        temp_path = Path(handle.name)
+    try:
+        cmd = [str(wrapper), "sync", "--spec", str(temp_path), "--apply"]
+        subprocess.run(cmd, check=True)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+    return 0
+
+
+def _mobile_blocks(args: argparse.Namespace) -> list[dict[str, Any]]:
+    return payments_store.build_slack_mobile_blocks(
+        statuses=tuple(args.statuses),
+        per_status_limit=args.per_status_limit,
+    )
+
+
+def _find_existing_mobile_inbox_ts(messages: list[dict[str, Any]]) -> str:
+    for message in messages:
+        if str(message.get("text") or "").strip() == MOBILE_INBOX_TEXT:
+            ts = str(message.get("ts") or "").strip()
+            if ts:
+                return ts
+    return ""
+
+
+async def _post_mobile_inbox_async(args: argparse.Namespace) -> int:
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    client = AsyncWebClient(token=_slack_token())
+    blocks = _mobile_blocks(args)
+    result = await client.chat_postMessage(
+        channel=args.channel,
+        text=MOBILE_INBOX_TEXT,
+        blocks=blocks,
+    )
+    ts = result.get("ts") if isinstance(result, dict) else None
+    print(f"posted payments mobile inbox to {args.channel} ts={ts or 'unknown'}")
+    return 0
+
+
+def post_mobile_inbox(args: argparse.Namespace) -> int:
+    return asyncio.run(_post_mobile_inbox_async(args))
+
+
+async def _upsert_mobile_inbox_async(args: argparse.Namespace) -> int:
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    client = AsyncWebClient(token=_slack_token())
+    blocks = _mobile_blocks(args)
+    history = await client.conversations_history(channel=args.channel, limit=20)
+    messages = history.get("messages", []) if isinstance(history, dict) else []
+    existing_ts = _find_existing_mobile_inbox_ts(messages)
+    if existing_ts:
+        result = await client.chat_update(
+            channel=args.channel,
+            ts=existing_ts,
+            text=MOBILE_INBOX_TEXT,
+            blocks=blocks,
+        )
+        ts = result.get("ts") if isinstance(result, dict) else existing_ts
+        print(f"updated payments mobile inbox in {args.channel} ts={ts or existing_ts}")
+        return 0
+
+    return await _post_mobile_inbox_async(args)
+
+
+def upsert_mobile_inbox(args: argparse.Namespace) -> int:
+    return asyncio.run(_upsert_mobile_inbox_async(args))
+
+
+def _sync_gmail(args: argparse.Namespace) -> dict[str, Any]:
+    return payments_store.sync_gmail_payment_requests(
+        query=args.query,
+        max_results=args.max_results,
+    )
+
+
+def _print_sync_summary(result: dict[str, Any]) -> None:
+    print(payments_store.format_sync_summary(result))
+
+
+async def _sync_and_upsert_async(args: argparse.Namespace) -> int:
+    result = _sync_gmail(args)
+    _print_sync_summary(result)
+
+    if not args.channel.strip():
+        print("skipped slack inbox refresh: no channel configured")
+        return 0
+    if not _optional_slack_token():
+        print("skipped slack inbox refresh: SLACK_BOT_TOKEN is not configured")
+        return 0
+
+    return await _upsert_mobile_inbox_async(args)
+
+
+def sync_gmail(args: argparse.Namespace) -> int:
+    _print_sync_summary(_sync_gmail(args))
+    return 0
+
+
+def sync_and_upsert(args: argparse.Namespace) -> int:
+    return asyncio.run(_sync_and_upsert_async(args))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    canvas = sub.add_parser("canvas-spec", help="Render a slack-surfaces YAML spec")
+    canvas.add_argument("--channel-key", default="payments-ops")
+    canvas.add_argument("--channel-name", default="payments-ops")
+    canvas.add_argument("--canvas-title", default="Payments Ops")
+    canvas.add_argument("--dashboard-url", default=_default_dashboard_url())
+    canvas.add_argument("--per-status-limit", type=int, default=8)
+    canvas.set_defaults(func=render_canvas_spec)
+
+    publish = sub.add_parser("publish-canvas", help="Publish the canvas via slack-surfaces")
+    publish.add_argument("--channel-key", default="payments-ops")
+    publish.add_argument("--channel-name", default="payments-ops")
+    publish.add_argument("--canvas-title", default="Payments Ops")
+    publish.add_argument("--dashboard-url", default=_default_dashboard_url())
+    publish.add_argument("--per-status-limit", type=int, default=8)
+    publish.set_defaults(func=publish_canvas)
+
+    inbox = sub.add_parser("post-mobile-inbox", help="Post the compact mobile action inbox")
+    inbox.add_argument("--channel", required=True, help="Slack channel or DM ID")
+    inbox.add_argument(
+        "--statuses",
+        nargs="+",
+        default=["needs_review", "ready_to_pay", "paid"],
+        choices=["needs_review", "ready_to_pay", "paid", "ignored"],
+    )
+    inbox.add_argument("--per-status-limit", type=int, default=5)
+    inbox.set_defaults(func=post_mobile_inbox)
+
+    upsert = sub.add_parser(
+        "upsert-mobile-inbox",
+        help="Update the latest compact mobile action inbox in-place, or post it if missing",
+    )
+    upsert.add_argument("--channel", required=True, help="Slack channel or DM ID")
+    upsert.add_argument(
+        "--statuses",
+        nargs="+",
+        default=["needs_review", "ready_to_pay", "paid"],
+        choices=["needs_review", "ready_to_pay", "paid", "ignored"],
+    )
+    upsert.add_argument("--per-status-limit", type=int, default=5)
+    upsert.set_defaults(func=upsert_mobile_inbox)
+
+    sync = sub.add_parser(
+        "sync-gmail",
+        help="Sync Gmail payment candidates into the canonical payments review store",
+    )
+    sync.add_argument("--query", default=payments_store.DEFAULT_GMAIL_QUERY)
+    sync.add_argument("--max-results", type=int, default=payments_store.DEFAULT_GMAIL_MAX_RESULTS)
+    sync.set_defaults(func=sync_gmail)
+
+    sync_upsert = sub.add_parser(
+        "sync-and-upsert",
+        help="Sync Gmail into the canonical store and refresh the Slack mobile inbox when credentials are available",
+    )
+    sync_upsert.add_argument("--channel", default="", help="Slack channel or DM ID")
+    sync_upsert.add_argument("--query", default=payments_store.DEFAULT_GMAIL_QUERY)
+    sync_upsert.add_argument("--max-results", type=int, default=payments_store.DEFAULT_GMAIL_MAX_RESULTS)
+    sync_upsert.add_argument(
+        "--statuses",
+        nargs="+",
+        default=["needs_review", "ready_to_pay", "paid"],
+        choices=["needs_review", "ready_to_pay", "paid", "ignored"],
+    )
+    sync_upsert.add_argument("--per-status-limit", type=int, default=5)
+    sync_upsert.set_defaults(func=sync_and_upsert)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -10,6 +10,7 @@ exit codes.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from unittest.mock import patch, MagicMock
 
@@ -77,6 +78,15 @@ class TestDashboardStop:
         assert exc.value.code == 0
         out = capsys.readouterr().out
         assert "No hermes dashboard processes running" in out
+
+    def test_stop_marks_saved_state_stopped_even_when_no_process_running(self, tmp_path):
+        with patch("hermes_cli.main.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.main._find_stale_dashboard_pids", return_value=[]), \
+             pytest.raises(SystemExit):
+            cmd_dashboard(_ns(stop=True))
+
+        state = json.loads((tmp_path / "dashboard_state.json").read_text(encoding="utf-8"))
+        assert state["desired_state"] == "stopped"
 
     def test_stop_kills_and_exits_zero_when_all_killed(self, capsys):
         """After the kill, if the second scan returns empty we exit 0."""

--- a/tests/hermes_cli/test_payments.py
+++ b/tests/hermes_cli/test_payments.py
@@ -1,12 +1,94 @@
-"""Tests for the dashboard Payments storage and API surface."""
+"""Tests for the dashboard Payments adapter, API surface, and Slack helpers."""
 
 from __future__ import annotations
 
 import importlib
 import json
+import sqlite3
+import io
 from pathlib import Path
+import runpy
+from contextlib import redirect_stdout
 
 import pytest
+
+
+SCHEMA_SQL = """
+CREATE TABLE payment_requests (
+    payment_id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    status TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    captured_at TEXT,
+    updated_at TEXT,
+    vendor TEXT,
+    title TEXT,
+    amount_value REAL,
+    amount_currency TEXT,
+    amount_display TEXT,
+    due_date TEXT,
+    payee_name TEXT,
+    account_holder TEXT,
+    account_number TEXT,
+    sort_code TEXT,
+    iban TEXT,
+    swift TEXT,
+    routing_number TEXT,
+    payment_reference TEXT,
+    invoice_number TEXT,
+    billing_address TEXT,
+    tax_details TEXT,
+    preview_text TEXT,
+    warnings_json TEXT,
+    attachments_json TEXT,
+    original_json TEXT,
+    raw_text_path TEXT,
+    materialized_path TEXT,
+    review_note TEXT
+)
+"""
+
+INBOX_ITEMS_SCHEMA_SQL = """
+CREATE TABLE inbox_items (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    source_account TEXT,
+    source_thread_id TEXT,
+    source_message_id TEXT,
+    source_url TEXT,
+    captured_at TEXT,
+    updated_at TEXT,
+    last_classified_at TEXT,
+    workflow_type TEXT NOT NULL,
+    queue TEXT NOT NULL,
+    status TEXT NOT NULL,
+    title TEXT,
+    summary TEXT,
+    counterparty TEXT,
+    action_required INTEGER,
+    confidence REAL,
+    amount_value REAL,
+    amount_currency TEXT,
+    amount_display TEXT,
+    due_date TEXT,
+    meeting_dates_json TEXT,
+    meeting_timezone TEXT,
+    reference_id TEXT,
+    receipt_like INTEGER,
+    invoice_like INTEGER,
+    calendar_like INTEGER,
+    warning_flags_json TEXT,
+    operator_notes TEXT,
+    raw_payload_path TEXT,
+    materialized_path TEXT,
+    manual_status INTEGER,
+    manual_notes INTEGER,
+    reviewed_at TEXT,
+    reviewed_by TEXT,
+    entities_json TEXT,
+    artifacts_json TEXT
+)
+"""
 
 
 @pytest.fixture
@@ -18,49 +100,220 @@ def isolated_home(tmp_path, monkeypatch):
     monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: home)
     monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: home / "config.yaml")
     monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: home / ".env")
-    try:
-        import hermes_cli.payments as payments
-
-        monkeypatch.setattr(payments, "get_hermes_home", lambda: home)
-        monkeypatch.setattr(
-            payments,
-            "load_env",
-            lambda: {},
-        )
-    except Exception:
-        pass
     return home
 
 
-def _write_requests(home: Path, requests: list[dict]) -> None:
-    payments_dir = home / "payments"
-    payments_dir.mkdir(parents=True, exist_ok=True)
-    (payments_dir / "requests.json").write_text(
-        json.dumps({"requests": requests}, ensure_ascii=False, indent=2),
-        encoding="utf-8",
+@pytest.fixture
+def canonical_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "payments-review.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(SCHEMA_SQL)
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+    monkeypatch.delenv("PAYMENTS_REVIEW_PLUGIN_ROOT", raising=False)
+    return db_path
+
+
+def _insert_payment(db_path: Path, **overrides) -> None:
+    row = {
+        "payment_id": "pay-1",
+        "source": "gmail",
+        "status": "new",
+        "confidence": "high",
+        "captured_at": "2026-07-01T10:00:00+00:00",
+        "updated_at": "2026-07-01T10:00:00+00:00",
+        "vendor": "Example Vendor",
+        "title": "Invoice INV-1001",
+        "amount_value": 42.0,
+        "amount_currency": "GBP",
+        "amount_display": "GBP 42.00",
+        "due_date": "2026-07-05",
+        "payee_name": "Example Vendor Ltd",
+        "account_holder": "Example Vendor Ltd",
+        "account_number": "12345678",
+        "sort_code": "12-34-56",
+        "iban": "GB11TEST00000012345678",
+        "swift": "TESTGB2L",
+        "routing_number": "",
+        "payment_reference": "ACME-1001",
+        "invoice_number": "INV-1001",
+        "billing_address": "1 Example Street",
+        "tax_details": "VAT GB123",
+        "preview_text": "Amount due GBP 42.00 by 2026-07-05",
+        "warnings_json": json.dumps([]),
+        "attachments_json": json.dumps(["invoice.pdf"]),
+        "original_json": json.dumps(
+            {
+                "label": "Acme Billing <billing@example.test>",
+                "url": "https://mail.google.com/mail/u/0/#inbox/pay-1",
+                "message_id": "msg-1",
+                "thread_id": "thread-1",
+            }
+        ),
+        "raw_text_path": "/tmp/pay-1.txt",
+        "materialized_path": "/tmp/pay-1.md",
+        "review_note": "",
+    }
+    row.update(overrides)
+    columns = ", ".join(row)
+    placeholders = ", ".join("?" for _ in row)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        f"INSERT OR REPLACE INTO payment_requests ({columns}) VALUES ({placeholders})",
+        tuple(row.values()),
     )
+    conn.commit()
+    conn.close()
+
+
+def _create_inbox_items_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(INBOX_ITEMS_SCHEMA_SQL)
+    conn.commit()
+    conn.close()
+
+
+def _insert_inbox_item(db_path: Path, **overrides) -> None:
+    row = {
+        "id": "pay-1",
+        "source": "gmail",
+        "source_account": "default",
+        "source_thread_id": "thread-1",
+        "source_message_id": "msg-1",
+        "source_url": "https://mail.google.com/mail/u/0/#inbox/thread-1",
+        "captured_at": "2026-07-01T10:00:00+00:00",
+        "updated_at": "2026-07-01T10:00:00+00:00",
+        "last_classified_at": "2026-07-01T10:00:00+00:00",
+        "workflow_type": "payment_request",
+        "queue": "payments",
+        "status": "new",
+        "title": "Invoice INV-1001",
+        "summary": "Amount due GBP 42.00 by 2026-07-05",
+        "counterparty": "Example Vendor",
+        "action_required": 1,
+        "confidence": 0.95,
+        "amount_value": 42.0,
+        "amount_currency": "GBP",
+        "amount_display": "GBP 42.00",
+        "due_date": "2026-07-05",
+        "meeting_dates_json": json.dumps([]),
+        "meeting_timezone": "",
+        "reference_id": "ACME-1001",
+        "receipt_like": 0,
+        "invoice_like": 1,
+        "calendar_like": 0,
+        "warning_flags_json": json.dumps([]),
+        "operator_notes": "Keep manual note",
+        "raw_payload_path": "/tmp/pay-1.txt",
+        "materialized_path": "/tmp/pay-1.md",
+        "manual_status": 0,
+        "manual_notes": 1,
+        "reviewed_at": None,
+        "reviewed_by": None,
+        "entities_json": json.dumps(
+            {
+                "sender": "Acme Billing <billing@example.test>",
+                "organization": "Example Vendor",
+                "payee_name": "Example Vendor Ltd",
+                "account_holder": "Example Vendor Ltd",
+                "account_number": "12345678",
+                "sort_code": "12-34-56",
+                "iban": "GB11TEST00000012345678",
+                "swift": "TESTGB2L",
+                "payment_reference": "ACME-1001",
+                "invoice_number": "INV-1001",
+                "billing_address": "1 Example Street",
+                "tax_details": "VAT GB123",
+            }
+        ),
+        "artifacts_json": json.dumps(
+            {
+                "label": "Acme Billing <billing@example.test>",
+                "attachments": ["invoice.pdf"],
+                "original_thread_url": "https://mail.google.com/mail/u/0/#inbox/pay-1",
+            }
+        ),
+    }
+    row.update(overrides)
+    columns = ", ".join(row)
+    placeholders = ", ".join("?" for _ in row)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        f"INSERT OR REPLACE INTO inbox_items ({columns}) VALUES ({placeholders})",
+        tuple(row.values()),
+    )
+    conn.commit()
+    conn.close()
+
+
+class _RuntimeStub:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+
+    def update_payment_request_status(self, payload: dict[str, str]) -> str:
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "UPDATE payment_requests SET status = ?, updated_at = ? WHERE payment_id = ?",
+            (payload["status"], "2026-07-04T12:00:00+00:00", payload["payment_id"]),
+        )
+        changed = conn.total_changes
+        conn.commit()
+        conn.close()
+        if not changed:
+            return json.dumps({"ok": False, "error": f"Unknown payment_id: {payload['payment_id']}"})
+        return json.dumps({"ok": True, "payment": {"payment_id": payload["payment_id"]}})
+
+    def ingest_payments_from_gmail(self, payload: dict[str, object]) -> str:
+        _insert_payment(
+            self.db_path,
+            payment_id="pay-2",
+            status="needs_review",
+            vendor="Trainline",
+            title="Trainline booking confirmation",
+            amount_value=55.0,
+            amount_currency="GBP",
+            amount_display="GBP 55.00",
+            due_date="2026-07-07",
+            warnings_json=json.dumps(["This looks like a receipt"]),
+            preview_text="Your booking receipt is attached",
+        )
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "UPDATE payment_requests SET status = ?, updated_at = ? WHERE payment_id = ?",
+            ("paid", "2026-07-04T12:05:00+00:00", "pay-1"),
+        )
+        conn.commit()
+        conn.close()
+        return json.dumps(
+            {
+                "ok": True,
+                "query": payload["query_override"],
+                "thread_count": 2,
+                "payments": [
+                    {
+                        "payment_id": "pay-2",
+                        "source": "gmail",
+                        "status": "needs_review",
+                        "amount": {"display": "GBP 55.00"},
+                    },
+                    {
+                        "payment_id": "pay-1",
+                        "source": "gmail",
+                        "status": "paid",
+                        "duplicate": True,
+                        "amount": {"display": "GBP 42.00"},
+                    },
+                ],
+            }
+        )
 
 
 class TestPaymentsStore:
-    def test_list_requests_reports_sources_and_normalizes_records(self, isolated_home):
+    def test_list_requests_reads_canonical_store(self, isolated_home, canonical_db, monkeypatch):
         (isolated_home / "google_token.json").write_text('{"token": "x"}', encoding="utf-8")
-        (isolated_home / ".env").write_text("EMAIL_ADDRESS=bills@example.test\n", encoding="utf-8")
-        _write_requests(
-            isolated_home,
-            [
-                {
-                    "id": "pay-1",
-                    "source": "gmail",
-                    "source_label": "Gmail",
-                    "status": "new",
-                    "confidence": "high",
-                    "received_at": "2026-07-01T10:00:00+00:00",
-                    "vendor": "Example Vendor",
-                    "title": "July invoice",
-                    "amount": {"value": 42, "currency": "GBP", "display": "GBP 42.00"},
-                }
-            ],
-        )
+        monkeypatch.setattr("hermes_cli.config.load_env", lambda: {"EMAIL_ADDRESS": "bills@example.test"})
+        _insert_payment(canonical_db, review_note="Keep manual note")
 
         import hermes_cli.payments as payments
 
@@ -69,87 +322,451 @@ class TestPaymentsStore:
 
         gmail = next(source for source in result["sources"] if source["id"] == "gmail")
         email = next(source for source in result["sources"] if source["id"] == "email")
-        uploads = next(source for source in result["sources"] if source["id"] == "uploads")
+        request = result["requests"][0]
 
         assert gmail["connected"] is True
         assert email["connected"] is True
-        assert uploads["connected"] is True
-        assert result["requests"][0]["vendor"] == "Example Vendor"
-        assert result["requests"][0]["amount"]["display"] == "GBP 42.00"
+        assert request["id"] == "pay-1"
+        assert request["operator_status"] == "needs_review"
+        assert request["source_label"] == "Gmail"
+        assert request["amount"]["display"] == "GBP 42.00"
+        assert request["review_note"] == "Keep manual note"
+        assert request["raw_text_path"] == "/tmp/pay-1.txt"
 
-    def test_update_status_persists_change(self, isolated_home):
-        _write_requests(
-            isolated_home,
-            [
-                {
-                    "id": "pay-1",
-                    "status": "new",
-                    "vendor": "Example Vendor",
-                }
-            ],
-        )
+    def test_list_requests_falls_back_to_immutable_read_only_store(
+        self, isolated_home, canonical_db, monkeypatch
+    ):
+        (isolated_home / "google_token.json").write_text('{"token": "x"}', encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.load_env", lambda: {"EMAIL_ADDRESS": "bills@example.test"})
+        _insert_payment(canonical_db)
 
         import hermes_cli.payments as payments
 
         importlib.reload(payments)
+
+        real_connect = payments.sqlite3.connect
+        attempts: list[tuple[str, bool]] = []
+
+        class _SchemaProbeFailure:
+            row_factory = None
+
+            def execute(self, query, *args, **kwargs):
+                if "sqlite_master" in query:
+                    raise sqlite3.OperationalError("unable to open database file")
+                raise AssertionError("unexpected query before immutable fallback")
+
+        def fake_connect(database, *args, **kwargs):
+            attempts.append((str(database), bool(kwargs.get("uri"))))
+            if str(database) == str(canonical_db):
+                return _SchemaProbeFailure()
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(payments.sqlite3, "connect", fake_connect)
+        result = payments.list_payment_requests()
+
+        assert result["requests"][0]["id"] == "pay-1"
+        assert attempts[0] == (str(canonical_db), False)
+        assert attempts[1] == (f"file:{canonical_db}?mode=ro&immutable=1", True)
+
+    def test_list_requests_reads_inbox_items_compatibility_store(self, isolated_home, tmp_path, monkeypatch):
+        db_path = tmp_path / "inbox-items.db"
+        _create_inbox_items_db(db_path)
+        _insert_inbox_item(db_path)
+        monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+        (isolated_home / "google_token.json").write_text('{"token": "x"}', encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.load_env", lambda: {"EMAIL_ADDRESS": "bills@example.test"})
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        result = payments.list_payment_requests()
+
+        request = result["requests"][0]
+        assert request["id"] == "pay-1"
+        assert request["payment_id"] == "pay-1"
+        assert request["operator_status"] == "needs_review"
+        assert request["vendor"] == "Example Vendor"
+        assert request["amount"]["display"] == "GBP 42.00"
+        assert request["review_note"] == "Keep manual note"
+        assert request["attachments"] == ["invoice.pdf"]
+        assert request["original"]["thread_id"] == "thread-1"
+
+    def test_update_status_round_trips_through_canonical_store(self, canonical_db, monkeypatch):
+        _insert_payment(canonical_db)
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+
         updated = payments.update_payment_status("pay-1", "paid")
 
         assert updated["status"] == "paid"
+        assert updated["operator_status"] == "paid"
 
-        saved = json.loads((isolated_home / "payments" / "requests.json").read_text(encoding="utf-8"))
-        assert saved["requests"][0]["status"] == "paid"
-        assert saved["requests"][0]["updated_at"]
+        listed = payments.list_payment_requests()["requests"][0]
+        assert listed["status"] == "paid"
+        assert listed["updated_at"] != "2026-07-01T10:00:00+00:00"
 
-    def test_sync_gmail_payment_requests_extracts_fields(self, isolated_home, monkeypatch):
+    def test_update_status_round_trips_through_inbox_items_store(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "inbox-items.db"
+        _create_inbox_items_db(db_path)
+        _insert_inbox_item(db_path)
+        monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+
         import hermes_cli.payments as payments
 
         importlib.reload(payments)
 
-        def fake_run_google_api(args):
-            if args[:2] == ["gmail", "search"]:
-                return [
-                    {
-                        "id": "msg-1",
-                        "threadId": "thread-1",
-                        "from": "Acme Billing <billing@acme.test>",
-                        "subject": "Invoice INV-1001",
-                        "date": "Fri, 01 Jul 2026 12:00:00 +0000",
-                        "snippet": "Amount due GBP 42.00 by 2026-07-05",
-                        "labels": ["INBOX"],
-                    }
-                ]
-            if args[:2] == ["gmail", "get"]:
-                return {
-                    "id": "msg-1",
-                    "threadId": "thread-1",
-                    "from": "Acme Billing <billing@acme.test>",
-                    "subject": "Invoice INV-1001",
-                    "date": "Fri, 01 Jul 2026 12:00:00 +0000",
-                    "body": (
-                        "Invoice number: INV-1001\n"
-                        "Amount due: GBP 42.00\n"
-                        "Due date: 2026-07-05\n"
-                        "Sort code: 12-34-56\n"
-                        "Account number: 12345678\n"
-                        "Payment reference: ACME-1001\n"
-                    ),
-                }
-            raise AssertionError(args)
+        updated = payments.update_payment_status("pay-1", "paid")
 
-        monkeypatch.setattr(payments, "_run_google_api", fake_run_google_api)
+        assert updated["status"] == "paid"
+        assert updated["operator_status"] == "paid"
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT status, manual_status, reviewed_at FROM inbox_items WHERE id = ?",
+            ("pay-1",),
+        ).fetchone()
+        conn.close()
+        assert row[0] == "paid"
+        assert row[1] == 1
+        assert row[2]
+
+    def test_list_inbox_items_filters_queue_and_workflow(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "inbox-items.db"
+        _create_inbox_items_db(db_path)
+        _insert_inbox_item(db_path, id="pay-1", workflow_type="payment_request", queue="payments")
+        _insert_inbox_item(
+            db_path,
+            id="meet-1",
+            workflow_type="meeting_request",
+            queue="calendar",
+            title="Can we meet next week?",
+            summary="Meeting request",
+            counterparty="Alice",
+            amount_value=None,
+            amount_currency="",
+            amount_display="",
+            due_date=None,
+            receipt_like=0,
+            invoice_like=0,
+            calendar_like=1,
+            warning_flags_json=json.dumps([]),
+            operator_notes="",
+            entities_json=json.dumps({"sender": "Alice <alice@example.test>"}),
+            artifacts_json=json.dumps({"original_thread_url": "https://mail.google.com/mail/u/0/#inbox/meet-1"}),
+        )
+        monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+
+        only_payments = payments.list_inbox_items(queue="payments")
+        only_meetings = payments.list_inbox_items(workflow_type="meeting_request")
+
+        assert [item["id"] for item in only_payments["items"]] == ["pay-1"]
+        assert [item["id"] for item in only_meetings["items"]] == ["meet-1"]
+
+    def test_payments_prefer_legacy_table_when_shadow_table_also_exists(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "both.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute(SCHEMA_SQL)
+        conn.execute(INBOX_ITEMS_SCHEMA_SQL)
+        conn.commit()
+        conn.close()
+        _insert_payment(db_path, payment_id="pay-legacy", vendor="Legacy Vendor")
+        _insert_inbox_item(db_path, id="pay-shadow", counterparty="Shadow Vendor")
+        monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+
+        listed = payments.list_payment_requests()["requests"]
+        assert [item["id"] for item in listed] == ["pay-legacy"]
+
+        inbox = payments.list_inbox_items(queue="payments")["items"]
+        assert [item["id"] for item in inbox] == ["pay-shadow"]
+
+    def test_update_inbox_item_status_updates_canonical_row(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "inbox-items.db"
+        _create_inbox_items_db(db_path)
+        _insert_inbox_item(db_path, id="meet-1", workflow_type="meeting_request", queue="calendar")
+        monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+
+        updated = payments.update_inbox_item_status("meet-1", "ignored")
+
+        assert updated["id"] == "meet-1"
+        assert updated["status"] == "ignored"
+        assert updated["manual_status"] is True
+
+    def test_shadow_sync_mirrors_legacy_payments_into_inbox_items(self, canonical_db, monkeypatch):
+        _insert_payment(canonical_db)
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        monkeypatch.setattr(payments, "_payments_review_runtime", lambda: _RuntimeStub(canonical_db))
+
+        result = payments.sync_gmail_payment_requests_shadow(query="invoice", max_results=5)
+
+        shadow = result["shadow"]
+        assert shadow["mirrored"] == 2
+        assert shadow["parity"]["payments_count"] == 2
+        assert shadow["parity"]["shadow_count"] == 2
+        assert shadow["parity"]["parity_ok"] is True
+
+        conn = sqlite3.connect(canonical_db)
+        rows = conn.execute(
+            "SELECT id, workflow_type, queue, status FROM inbox_items ORDER BY id"
+        ).fetchall()
+        conn.close()
+        assert rows == [
+            ("pay-1", "payment_receipt", "payments", "paid"),
+            ("pay-2", "payment_receipt", "payments", "needs_review"),
+        ]
+        snapshot = payments.load_shadow_report_snapshot()
+        assert snapshot["updated_at"]
+        assert snapshot["result"]["shadow"]["parity"]["parity_ok"] is True
+
+    def test_sync_gmail_payment_requests_uses_canonical_runtime(self, canonical_db, monkeypatch):
+        _insert_payment(canonical_db)
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        monkeypatch.setattr(payments, "_payments_review_runtime", lambda: _RuntimeStub(canonical_db))
 
         result = payments.sync_gmail_payment_requests(query="invoice", max_results=5)
 
+        assert result["query"] == "invoice"
+        assert result["fetched"] == 2
         assert result["imported"] == 1
-        saved = payments.list_payment_requests()["requests"][0]
-        assert saved["id"] == "gmail:msg-1"
-        assert saved["vendor"] == "Acme Billing"
-        assert saved["amount"]["display"] == "GBP 42.00"
-        assert saved["sort_code"] == "12-34-56"
-        assert saved["account_number"] == "12345678"
-        assert saved["payment_reference"] == "ACME-1001"
-        assert saved["invoice_number"] == "INV-1001"
-        assert saved["confidence"] in {"medium", "high"}
+        assert result["updated"] == 1
+        listed = payments.list_payment_requests()["requests"]
+        assert {item["id"] for item in listed} == {"pay-1", "pay-2"}
+        assert next(item for item in listed if item["id"] == "pay-1")["status"] == "paid"
+
+    def test_install_gmail_sync_cron_script_and_job(self, isolated_home, canonical_db, monkeypatch):
+        import cron.jobs as cron_jobs
+        import hermes_cli.payments as payments
+
+        cron_dir = isolated_home / "cron"
+        scripts_dir = isolated_home / "scripts"
+        cron_dir.mkdir(exist_ok=True)
+        (cron_dir / "output").mkdir(exist_ok=True)
+        scripts_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(cron_jobs, "HERMES_DIR", isolated_home)
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir)
+        monkeypatch.setattr(cron_jobs, "JOBS_FILE", cron_dir / "jobs.json")
+        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output")
+
+        importlib.reload(payments)
+
+        script_path = payments.install_gmail_sync_cron_script(query="invoice newer_than:7d", max_results=7)
+        assert script_path == scripts_dir / payments.PAYMENTS_GMAIL_SYNC_CRON_SCRIPT
+        script_text = script_path.read_text(encoding="utf-8")
+        assert "invoice newer_than:7d" in script_text
+        assert "max_results=7" in script_text
+
+        created = payments.ensure_gmail_sync_cron_job(
+            schedule="every 2h",
+            query="invoice newer_than:7d",
+            max_results=7,
+        )
+        assert created["name"] == payments.PAYMENTS_GMAIL_SYNC_CRON_JOB_NAME
+        assert created["script"] == payments.PAYMENTS_GMAIL_SYNC_CRON_SCRIPT
+        assert created["no_agent"] is True
+        assert created["deliver"] == "local"
+
+        updated = payments.ensure_gmail_sync_cron_job(
+            schedule="every 3h",
+            query="receipt newer_than:30d",
+            max_results=9,
+        )
+        assert updated["id"] == created["id"]
+        jobs = cron_jobs.list_jobs(include_disabled=True)
+        assert len(jobs) == 1
+        assert jobs[0]["script"] == payments.PAYMENTS_GMAIL_SYNC_CRON_SCRIPT
+        assert jobs[0]["schedule_display"] == "every 180m"
+        assert "receipt newer_than:30d" in script_path.read_text(encoding="utf-8")
+        assert "max_results=9" in script_path.read_text(encoding="utf-8")
+
+    def test_install_gmail_shadow_sync_cron_script_and_job(self, isolated_home, canonical_db, monkeypatch):
+        import cron.jobs as cron_jobs
+        import hermes_cli.payments as payments
+
+        cron_dir = isolated_home / "cron"
+        scripts_dir = isolated_home / "scripts"
+        cron_dir.mkdir(exist_ok=True)
+        (cron_dir / "output").mkdir(exist_ok=True)
+        scripts_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(cron_jobs, "HERMES_DIR", isolated_home)
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir)
+        monkeypatch.setattr(cron_jobs, "JOBS_FILE", cron_dir / "jobs.json")
+        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output")
+
+        importlib.reload(payments)
+
+        script_path = payments.install_gmail_shadow_sync_cron_script(
+            query="invoice newer_than:7d", max_results=7
+        )
+        assert script_path == scripts_dir / payments.PAYMENTS_GMAIL_SHADOW_SYNC_CRON_SCRIPT
+        script_text = script_path.read_text(encoding="utf-8")
+        assert "sync_gmail_payment_requests_shadow" in script_text
+        assert "invoice newer_than:7d" in script_text
+        assert "max_results=7" in script_text
+
+        created = payments.ensure_gmail_shadow_sync_cron_job(
+            schedule="every 6h",
+            query="invoice newer_than:7d",
+            max_results=7,
+        )
+        assert created["name"] == payments.PAYMENTS_GMAIL_SHADOW_SYNC_CRON_JOB_NAME
+        assert created["script"] == payments.PAYMENTS_GMAIL_SHADOW_SYNC_CRON_SCRIPT
+        assert created["no_agent"] is True
+
+    def test_runtime_loader_supports_relative_imports(self, tmp_path, monkeypatch):
+        plugins_root = tmp_path / "plugins"
+        plugin_root = plugins_root / "payments_review"
+        plugin_root.mkdir(parents=True)
+        (plugin_root / "validate.py").write_text(
+            "def marker():\n    return 'ok'\n",
+            encoding="utf-8",
+        )
+        sibling_root = plugins_root / "google_workspace_cli"
+        sibling_root.mkdir()
+        (sibling_root / "__init__.py").write_text("", encoding="utf-8")
+        (sibling_root / "runtime.py").write_text(
+            "def sibling_marker():\n    return 'sibling-ok'\n",
+            encoding="utf-8",
+        )
+        (plugin_root / "runtime.py").write_text(
+            "from .validate import marker\n"
+            "from google_workspace_cli.runtime import sibling_marker\n\n"
+            "VALUE = marker()\n"
+            "SIBLING = sibling_marker()\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PAYMENTS_REVIEW_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.delenv("PAYMENTS_REVIEW_DB_PATH", raising=False)
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        runtime = payments._payments_review_runtime()
+
+        assert runtime.VALUE == "ok"
+        assert runtime.SIBLING == "sibling-ok"
+
+    def test_slack_helpers_render_summary_and_modal(self, monkeypatch):
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        monkeypatch.setattr(
+            payments,
+            "list_payment_requests",
+            lambda: {
+                "sources": [],
+                "storage_path": "/tmp/payments-review.db",
+                "requests": [
+                    {
+                        "id": "pay-1",
+                        "payment_id": "pay-1",
+                        "source": "gmail",
+                        "source_label": "Gmail",
+                        "status": "needs_review",
+                        "operator_status": "needs_review",
+                        "confidence": "high",
+                        "received_at": "2026-07-01T10:00:00+00:00",
+                        "updated_at": "2026-07-01T10:00:00+00:00",
+                        "vendor": "Acme",
+                        "title": "Invoice INV-1001",
+                        "amount": {"value": 42.0, "currency": "GBP", "display": "GBP 42.00"},
+                        "due_date": "2026-07-05",
+                        "payee_name": "",
+                        "account_holder": "",
+                        "account_number": "",
+                        "sort_code": "",
+                        "iban": "",
+                        "swift": "",
+                        "routing_number": "",
+                        "payment_reference": "",
+                        "invoice_number": "INV-1001",
+                        "billing_address": "",
+                        "tax_details": "",
+                        "preview_text": "Invoice attached",
+                        "warnings": [],
+                        "attachments": [],
+                        "original": {"label": "Acme", "url": "", "message_id": "", "thread_id": ""},
+                        "looks_paid": False,
+                    },
+                    {
+                        "id": "pay-2",
+                        "payment_id": "pay-2",
+                        "source": "gmail",
+                        "source_label": "Gmail",
+                        "status": "paid",
+                        "operator_status": "paid",
+                        "confidence": "medium",
+                        "received_at": "2026-07-01T10:00:00+00:00",
+                        "updated_at": "2026-07-01T10:00:00+00:00",
+                        "vendor": "Uber",
+                        "title": "Trip receipt",
+                        "amount": {"value": 18.0, "currency": "GBP", "display": "GBP 18.00"},
+                        "due_date": None,
+                        "payee_name": "",
+                        "account_holder": "",
+                        "account_number": "",
+                        "sort_code": "",
+                        "iban": "",
+                        "swift": "",
+                        "routing_number": "",
+                        "payment_reference": "",
+                        "invoice_number": "",
+                        "billing_address": "",
+                        "tax_details": "",
+                        "preview_text": "Thanks for riding",
+                        "warnings": ["Payment already been made"],
+                        "attachments": [],
+                        "original": {"label": "Uber", "url": "", "message_id": "", "thread_id": ""},
+                        "looks_paid": True,
+                    },
+                ],
+            },
+        )
+
+        markdown = payments.render_slack_canvas_markdown(dashboard_url="https://example.test/payments")
+        blocks = payments.build_slack_mobile_blocks()
+        modal = payments.build_slack_status_modal_view(
+            {
+                "id": "pay-1",
+                "vendor": "Acme",
+                "title": "Invoice INV-1001",
+                "amount": {"display": "GBP 42.00"},
+                "due_date": "2026-07-05",
+                "status": "needs_review",
+                "operator_status": "needs_review",
+                "looks_paid": False,
+            },
+            private_metadata='{"channel_id":"C1","message_ts":"123.45"}',
+        )
+
+        assert "Needs review" in markdown
+        assert "Recently paid" in markdown
+        assert "receipt-like" in markdown
+        assert any(
+            block.get("accessory", {}).get("action_id") == "payments_open_status_modal"
+            for block in blocks
+            if block.get("type") == "section"
+        )
+        assert modal["private_metadata"] == '{"channel_id":"C1","message_ts":"123.45"}'
+        assert modal["blocks"][2]["elements"][2]["action_id"] == "payments_mark_paid"
 
 
 class TestPaymentsApi:
@@ -161,32 +778,26 @@ class TestPaymentsApi:
             pytest.skip("fastapi/starlette not installed")
 
         import hermes_state
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN, app
 
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", isolated_home / "state.db")
 
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
-    def test_list_and_update_payments(self, isolated_home):
-        _write_requests(
-            isolated_home,
-            [
-                {
-                    "id": "pay-1",
-                    "source": "gmail",
-                    "source_label": "Gmail",
-                    "status": "needs_review",
-                    "vendor": "Example Vendor",
-                    "title": "July invoice",
-                }
-            ],
-        )
+    def test_list_and_update_payments(self, canonical_db, monkeypatch):
+        _insert_payment(canonical_db)
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        monkeypatch.setattr(payments, "_payments_review_runtime", lambda: _RuntimeStub(canonical_db))
 
         listed = self.client.get("/api/payments")
         assert listed.status_code == 200
         payload = listed.json()
         assert payload["requests"][0]["id"] == "pay-1"
+        assert payload["requests"][0]["operator_status"] == "needs_review"
 
         updated = self.client.post("/api/payments/pay-1/status", json={"status": "ready_to_pay"})
         assert updated.status_code == 200
@@ -196,8 +807,10 @@ class TestPaymentsApi:
         updated = self.client.post("/api/payments/missing/status", json={"status": "bogus"})
         assert updated.status_code == 400
 
-    def test_sync_payments_endpoint(self, monkeypatch):
+    def test_sync_payments_endpoint(self, canonical_db, monkeypatch):
         import hermes_cli.payments as payments
+
+        importlib.reload(payments)
 
         def fake_sync(query, max_results):
             assert query == payments.DEFAULT_GMAIL_QUERY
@@ -205,13 +818,191 @@ class TestPaymentsApi:
             return {
                 "source": "gmail",
                 "query": query,
-                "fetched": 1,
+                "fetched": 2,
                 "imported": 1,
-                "updated": 0,
+                "updated": 1,
                 "requests": [],
             }
 
         monkeypatch.setattr(payments, "sync_gmail_payment_requests", fake_sync)
         resp = self.client.post("/api/payments/sync", json={"source": "gmail"})
         assert resp.status_code == 200
-        assert resp.json()["imported"] == 1
+        assert resp.json()["updated"] == 1
+
+    def test_shadow_sync_and_report_endpoints(self, canonical_db, monkeypatch):
+        _insert_payment(canonical_db)
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        monkeypatch.setattr(payments, "_payments_review_runtime", lambda: _RuntimeStub(canonical_db))
+
+        sync_response = self.client.post("/api/payments/shadow-sync", json={"source": "gmail"})
+        assert sync_response.status_code == 200
+        assert sync_response.json()["shadow"]["parity"]["parity_ok"] is True
+
+        report_response = self.client.get("/api/payments/shadow-report")
+        assert report_response.status_code == 200
+        payload = report_response.json()
+        assert payload["parity"]["parity_ok"] is True
+        assert payload["snapshot"]["result"]["shadow"]["mirrored"] == 2
+
+    def test_shadow_schedule_endpoint(self, isolated_home, canonical_db, monkeypatch):
+        import cron.jobs as cron_jobs
+        import hermes_cli.payments as payments
+
+        cron_dir = isolated_home / "cron"
+        scripts_dir = isolated_home / "scripts"
+        cron_dir.mkdir(exist_ok=True)
+        (cron_dir / "output").mkdir(exist_ok=True)
+        scripts_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(cron_jobs, "HERMES_DIR", isolated_home)
+        monkeypatch.setattr(cron_jobs, "CRON_DIR", cron_dir)
+        monkeypatch.setattr(cron_jobs, "JOBS_FILE", cron_dir / "jobs.json")
+        monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", cron_dir / "output")
+
+        importlib.reload(payments)
+
+        response = self.client.post(
+            "/api/payments/shadow-schedule",
+            json={"schedule": "every 6h", "run_now": False},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["job"]["script"] == payments.PAYMENTS_GMAIL_SHADOW_SYNC_CRON_SCRIPT
+
+    def test_list_inbox_items_endpoint(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "inbox-items.db"
+        _create_inbox_items_db(db_path)
+        _insert_inbox_item(db_path, id="pay-1", workflow_type="payment_request", queue="payments")
+        _insert_inbox_item(db_path, id="meet-1", workflow_type="meeting_request", queue="calendar")
+        monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+
+        response = self.client.get("/api/inbox-items?queue=payments")
+        assert response.status_code == 200
+        payload = response.json()
+        assert [item["id"] for item in payload["items"]] == ["pay-1"]
+
+    def test_update_inbox_item_status_endpoint(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "inbox-items.db"
+        _create_inbox_items_db(db_path)
+        _insert_inbox_item(db_path, id="meet-1", workflow_type="meeting_request", queue="calendar")
+        monkeypatch.setenv("PAYMENTS_REVIEW_DB_PATH", str(db_path))
+
+        response = self.client.post("/api/inbox-items/meet-1/status", json={"status": "ignored"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "ignored"
+
+    def test_ops_services_endpoint_includes_defaults_and_config_overrides(self, isolated_home):
+        (isolated_home / "config.yaml").write_text(
+            """
+dashboard:
+  ops_links:
+    - id: grafana
+      title: Grafana Cloud
+      url: https://grafana.example.test
+      description: Shared Grafana endpoint
+      group: Observability
+      tags: [grafana, cloud]
+    - id: n8n
+      title: n8n
+      url: http://automation.example.test
+      description: Workflow automation
+      group: Automation
+      tags: [automation]
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        response = self.client.get("/api/ops/services")
+        assert response.status_code == 200
+        payload = response.json()
+        services = {item["id"]: item for item in payload["services"]}
+
+        assert services["payments"]["url"].endswith(":9121/payments")
+        assert services["grafana"]["title"] == "Grafana Cloud"
+        assert services["grafana"]["url"] == "https://grafana.example.test"
+        assert services["n8n"]["group"] == "Automation"
+
+    def test_webhub_ops_summary_endpoint(self, isolated_home, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+        import plugins.observability.webhub as webhub
+
+        importlib.reload(webhub)
+        webhub.on_post_api_request(
+            session_id="s1",
+            turn_id="t1",
+            api_request_id="r1",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            model="anthropic/claude-sonnet-4.5",
+            api_mode="chat_completions",
+            api_duration=0.75,
+            usage={
+                "input_tokens": 40,
+                "output_tokens": 10,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "request_count": 1,
+                "total_tokens": 50,
+            },
+        )
+
+        response = self.client.get("/api/ops/webhub")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"]["openrouter_configured"] is True
+        assert payload["status"]["slack_configured"] is True
+        assert payload["summary"]["requests"]["total"] == 1
+        assert payload["links"]["channels_url"].endswith(":9121/channels")
+
+    def test_webhub_prometheus_endpoint(self, isolated_home):
+        response = self.client.get("/api/ops/webhub/prometheus")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/plain")
+        assert "hermes_webhub_requests_total" in response.text
+
+
+class TestPaymentsSlackSurfaceScript:
+    def test_find_existing_mobile_inbox_ts_prefers_latest_matching_text(self):
+        module = runpy.run_path(
+            str(Path(__file__).resolve().parents[2] / "scripts" / "payments-slack-surface.py")
+        )
+
+        find_ts = module["_find_existing_mobile_inbox_ts"]
+        mobile_text = module["MOBILE_INBOX_TEXT"]
+
+        messages = [
+            {"ts": "300.0", "text": "something else"},
+            {"ts": "200.0", "text": mobile_text},
+            {"ts": "100.0", "text": mobile_text},
+        ]
+
+        assert find_ts(messages) == "200.0"
+
+    def test_find_existing_mobile_inbox_ts_returns_empty_when_missing(self):
+        module = runpy.run_path(
+            str(Path(__file__).resolve().parents[2] / "scripts" / "payments-slack-surface.py")
+        )
+
+        find_ts = module["_find_existing_mobile_inbox_ts"]
+
+        assert find_ts([{"ts": "100.0", "text": "no match"}]) == ""
+
+    def test_print_sync_summary_formats_counts(self):
+        module = runpy.run_path(
+            str(Path(__file__).resolve().parents[2] / "scripts" / "payments-slack-surface.py")
+        )
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            module["_print_sync_summary"]({"fetched": 12, "imported": 3, "updated": 9})
+
+        assert (
+            buffer.getvalue().strip()
+            == "synced gmail payments fetched=12 imported=3 updated=9"
+        )

--- a/tests/hermes_cli/test_payments.py
+++ b/tests/hermes_cli/test_payments.py
@@ -1,0 +1,217 @@
+"""Tests for the dashboard Payments storage and API surface."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: home)
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: home / "config.yaml")
+    monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: home / ".env")
+    try:
+        import hermes_cli.payments as payments
+
+        monkeypatch.setattr(payments, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(
+            payments,
+            "load_env",
+            lambda: {},
+        )
+    except Exception:
+        pass
+    return home
+
+
+def _write_requests(home: Path, requests: list[dict]) -> None:
+    payments_dir = home / "payments"
+    payments_dir.mkdir(parents=True, exist_ok=True)
+    (payments_dir / "requests.json").write_text(
+        json.dumps({"requests": requests}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+class TestPaymentsStore:
+    def test_list_requests_reports_sources_and_normalizes_records(self, isolated_home):
+        (isolated_home / "google_token.json").write_text('{"token": "x"}', encoding="utf-8")
+        (isolated_home / ".env").write_text("EMAIL_ADDRESS=bills@example.test\n", encoding="utf-8")
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "source": "gmail",
+                    "source_label": "Gmail",
+                    "status": "new",
+                    "confidence": "high",
+                    "received_at": "2026-07-01T10:00:00+00:00",
+                    "vendor": "Example Vendor",
+                    "title": "July invoice",
+                    "amount": {"value": 42, "currency": "GBP", "display": "GBP 42.00"},
+                }
+            ],
+        )
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        result = payments.list_payment_requests()
+
+        gmail = next(source for source in result["sources"] if source["id"] == "gmail")
+        email = next(source for source in result["sources"] if source["id"] == "email")
+        uploads = next(source for source in result["sources"] if source["id"] == "uploads")
+
+        assert gmail["connected"] is True
+        assert email["connected"] is True
+        assert uploads["connected"] is True
+        assert result["requests"][0]["vendor"] == "Example Vendor"
+        assert result["requests"][0]["amount"]["display"] == "GBP 42.00"
+
+    def test_update_status_persists_change(self, isolated_home):
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "status": "new",
+                    "vendor": "Example Vendor",
+                }
+            ],
+        )
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        updated = payments.update_payment_status("pay-1", "paid")
+
+        assert updated["status"] == "paid"
+
+        saved = json.loads((isolated_home / "payments" / "requests.json").read_text(encoding="utf-8"))
+        assert saved["requests"][0]["status"] == "paid"
+        assert saved["requests"][0]["updated_at"]
+
+    def test_sync_gmail_payment_requests_extracts_fields(self, isolated_home, monkeypatch):
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+
+        def fake_run_google_api(args):
+            if args[:2] == ["gmail", "search"]:
+                return [
+                    {
+                        "id": "msg-1",
+                        "threadId": "thread-1",
+                        "from": "Acme Billing <billing@acme.test>",
+                        "subject": "Invoice INV-1001",
+                        "date": "Fri, 01 Jul 2026 12:00:00 +0000",
+                        "snippet": "Amount due GBP 42.00 by 2026-07-05",
+                        "labels": ["INBOX"],
+                    }
+                ]
+            if args[:2] == ["gmail", "get"]:
+                return {
+                    "id": "msg-1",
+                    "threadId": "thread-1",
+                    "from": "Acme Billing <billing@acme.test>",
+                    "subject": "Invoice INV-1001",
+                    "date": "Fri, 01 Jul 2026 12:00:00 +0000",
+                    "body": (
+                        "Invoice number: INV-1001\n"
+                        "Amount due: GBP 42.00\n"
+                        "Due date: 2026-07-05\n"
+                        "Sort code: 12-34-56\n"
+                        "Account number: 12345678\n"
+                        "Payment reference: ACME-1001\n"
+                    ),
+                }
+            raise AssertionError(args)
+
+        monkeypatch.setattr(payments, "_run_google_api", fake_run_google_api)
+
+        result = payments.sync_gmail_payment_requests(query="invoice", max_results=5)
+
+        assert result["imported"] == 1
+        saved = payments.list_payment_requests()["requests"][0]
+        assert saved["id"] == "gmail:msg-1"
+        assert saved["vendor"] == "Acme Billing"
+        assert saved["amount"]["display"] == "GBP 42.00"
+        assert saved["sort_code"] == "12-34-56"
+        assert saved["account_number"] == "12345678"
+        assert saved["payment_reference"] == "ACME-1001"
+        assert saved["invoice_number"] == "INV-1001"
+        assert saved["confidence"] in {"medium", "high"}
+
+
+class TestPaymentsApi:
+    @pytest.fixture(autouse=True)
+    def _setup_client(self, isolated_home, monkeypatch):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", isolated_home / "state.db")
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_list_and_update_payments(self, isolated_home):
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "source": "gmail",
+                    "source_label": "Gmail",
+                    "status": "needs_review",
+                    "vendor": "Example Vendor",
+                    "title": "July invoice",
+                }
+            ],
+        )
+
+        listed = self.client.get("/api/payments")
+        assert listed.status_code == 200
+        payload = listed.json()
+        assert payload["requests"][0]["id"] == "pay-1"
+
+        updated = self.client.post("/api/payments/pay-1/status", json={"status": "ready_to_pay"})
+        assert updated.status_code == 200
+        assert updated.json()["status"] == "ready_to_pay"
+
+    def test_update_rejects_unknown_status(self):
+        updated = self.client.post("/api/payments/missing/status", json={"status": "bogus"})
+        assert updated.status_code == 400
+
+    def test_sync_payments_endpoint(self, monkeypatch):
+        import hermes_cli.payments as payments
+
+        def fake_sync(query, max_results):
+            assert query == payments.DEFAULT_GMAIL_QUERY
+            assert max_results == payments.DEFAULT_GMAIL_MAX_RESULTS
+            return {
+                "source": "gmail",
+                "query": query,
+                "fetched": 1,
+                "imported": 1,
+                "updated": 0,
+                "requests": [],
+            }
+
+        monkeypatch.setattr(payments, "sync_gmail_payment_requests", fake_sync)
+        resp = self.client.post("/api/payments/sync", json={"source": "gmail"})
+        assert resp.status_code == 200
+        assert resp.json()["imported"] == 1

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -23,6 +23,9 @@ import pytest
 from hermes_cli.main import (
     _find_stale_dashboard_pids,
     _kill_stale_dashboard_processes,
+    _read_dashboard_state,
+    _restart_dashboard_from_saved_state,
+    _save_dashboard_launch_state,
     _warn_stale_dashboard_processes,  # back-compat alias
 )
 
@@ -47,6 +50,9 @@ def _refresh_bindings_against_live_module():
     """
     global _find_stale_dashboard_pids
     global _kill_stale_dashboard_processes
+    global _read_dashboard_state
+    global _restart_dashboard_from_saved_state
+    global _save_dashboard_launch_state
     global _warn_stale_dashboard_processes
 
     live = sys.modules.get("hermes_cli.main")
@@ -55,6 +61,9 @@ def _refresh_bindings_against_live_module():
 
     _find_stale_dashboard_pids = live._find_stale_dashboard_pids
     _kill_stale_dashboard_processes = live._kill_stale_dashboard_processes
+    _read_dashboard_state = live._read_dashboard_state
+    _restart_dashboard_from_saved_state = live._restart_dashboard_from_saved_state
+    _save_dashboard_launch_state = live._save_dashboard_launch_state
     _warn_stale_dashboard_processes = live._warn_stale_dashboard_processes
     yield
 
@@ -384,6 +393,76 @@ class TestBackCompatAlias:
 
     def test_alias_is_the_kill_function(self):
         assert _warn_stale_dashboard_processes is _kill_stale_dashboard_processes
+
+
+class TestDashboardRestartState:
+    def test_save_dashboard_launch_state_persists_args(self, tmp_path, monkeypatch):
+        import argparse
+
+        monkeypatch.setattr("hermes_cli.main.get_hermes_home", lambda: tmp_path)
+        args = argparse.Namespace(
+            host="0.0.0.0",
+            port=9119,
+            no_open=True,
+            insecure=True,
+            skip_build=True,
+        )
+
+        _save_dashboard_launch_state(args)
+        state = _read_dashboard_state()
+
+        assert state["desired_state"] == "running"
+        assert state["hermes_home"] == str(tmp_path)
+        assert state["argv"] == [
+            "dashboard",
+            "--host", "0.0.0.0",
+            "--port", "9119",
+            "--no-open",
+            "--insecure",
+            "--skip-build",
+        ]
+
+    def test_restart_dashboard_from_saved_state_uses_saved_home(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr("hermes_cli.main.get_hermes_home", lambda: tmp_path)
+        (tmp_path / "dashboard_state.json").write_text(
+            '{"desired_state":"running","argv":["dashboard","--host","127.0.0.1","--port","9119","--no-open"],"hermes_home":"/tmp/hermes-home"}\n',
+            encoding="utf-8",
+        )
+
+        captured: dict[str, object] = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return MagicMock()
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+        restarted = _restart_dashboard_from_saved_state(reason="update")
+
+        assert restarted is True
+        assert captured["cmd"] == [
+            sys.executable, "-m", "hermes_cli.main",
+            "dashboard", "--host", "127.0.0.1", "--port", "9119", "--no-open",
+        ]
+        kwargs = captured["kwargs"]
+        assert kwargs["env"]["HERMES_HOME"] == "/tmp/hermes-home"
+        if sys.platform != "win32":
+            assert kwargs["start_new_session"] is True
+        out = capsys.readouterr().out
+        assert "Restarted dashboard after update" in out
+
+    def test_restart_dashboard_from_saved_state_skips_when_stopped(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("hermes_cli.main.get_hermes_home", lambda: tmp_path)
+        (tmp_path / "dashboard_state.json").write_text(
+            '{"desired_state":"stopped","argv":["dashboard","--host","127.0.0.1","--port","9119"]}\n',
+            encoding="utf-8",
+        )
+
+        with patch("subprocess.Popen") as popen:
+            restarted = _restart_dashboard_from_saved_state(reason="update")
+
+        assert restarted is False
+        popen.assert_not_called()
 
 
 class TestWindowsWmicEncoding:

--- a/tests/hermes_cli/test_vault_para_triage.py
+++ b/tests/hermes_cli/test_vault_para_triage.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_cli import vault_para_triage as triage
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "Inbox").mkdir(parents=True)
+    (vault / "Projects").mkdir()
+    (vault / "Areas" / "Health").mkdir(parents=True)
+    (vault / "Resources" / "Reference").mkdir(parents=True)
+    (vault / "Resources" / "_Inbox Review").mkdir(parents=True)
+    (vault / "Archives").mkdir()
+    return vault
+
+
+def test_run_triage_adds_frontmatter_moves_note_and_writes_audit(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "doctor-follow-up.md"
+    note.write_text("Need to call the doctor tomorrow about blood tests.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "routing": {
+                "rules": [
+                    {
+                        "name": "health",
+                        "match_any": ["doctor", "blood test"],
+                        "target": "Areas/Health",
+                        "confidence": 0.96,
+                        "reason": "health note",
+                    }
+                ]
+            }
+        },
+    )
+
+    staged = vault / ".hermes" / "note-capture" / "staging" / "vault" / summary["processed"][0]["entry_id"] / "Areas" / "Health" / "doctor-follow-up.md"
+    assert staged.exists()
+    content = staged.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "title: doctor follow up" in content.lower()
+    assert "para_target: Areas/Health" in content
+    assert "para_triage_status: captured" in content
+
+    audit_path = vault / ".hermes" / "para-triage" / "audit.jsonl"
+    audit_rows = triage._read_jsonl(audit_path)
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["path_before"] == "Inbox/doctor-follow-up.md"
+    assert audit_rows[0]["path_after"] == "Areas/Health/doctor-follow-up.md"
+    assert summary["counts"]["captured"] == 1
+    assert not note.exists()
+
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{summary['processed'][0]['entry_id']}.json").read_text(encoding="utf-8")
+    )
+    assert capture_event["capture_model"] == "canonical_event_log"
+    assert sorted(capture_event["projection"]["stores"]) == ["second_brain", "vault"]
+
+    structure = json.loads((vault / ".hermes" / "para-triage" / "structure.json").read_text(encoding="utf-8"))
+    assert "Areas/Health" in structure["targets"]
+
+
+def test_apply_feedback_correct_relocates_note_and_learns_example(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "clinic-plan.md"
+    note.write_text("Follow up with the clinic and update my records.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.31,
+            "reason": "not sure",
+            "needs_feedback": True,
+        },
+    )
+
+    event = summary["processed"][0]
+    initial = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / event["entry_id"]
+        / "Resources"
+        / "_Inbox Review"
+        / "clinic-plan.md"
+    )
+    assert initial.exists()
+
+    feedback = triage.apply_feedback(
+        action="correct",
+        entry_id=event["entry_id"],
+        target="Areas/Health",
+        vault_path=vault,
+    )
+
+    corrected = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / event["entry_id"]
+        / "Areas"
+        / "Health"
+        / "clinic-plan.md"
+    )
+    assert corrected.exists()
+    assert feedback["target"] == "Areas/Health"
+    assert feedback["relocated_path"] == "Areas/Health/clinic-plan.md"
+
+    pending = triage.list_pending_feedback(vault_path=vault)
+    assert pending == []
+
+    examples_path = vault / ".hermes" / "para-triage" / "routing_examples.json"
+    examples = json.loads(examples_path.read_text(encoding="utf-8"))["examples"]
+    assert examples[0]["entry_id"] == event["entry_id"]
+    assert examples[0]["target"] == "Areas/Health"
+
+
+def test_handle_feedback_command_lists_pending_items(tmp_path, monkeypatch):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "mystery-note.md"
+    note.write_text("A note that should probably be reviewed later.\n", encoding="utf-8")
+
+    triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.2,
+            "reason": "uncertain",
+            "needs_feedback": True,
+        },
+    )
+
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    output = triage.handle_feedback_command("list")
+    assert "Pending PARA feedback" in output
+    assert "Resources/_Inbox Review/mystery-note.md" in output
+
+
+def test_low_confidence_action_inbox_keeps_note_in_inbox(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "unsure-note.md"
+    note.write_text("Something ambiguous that should stay for review.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "routing": {
+                "min_confidence": 0.8,
+                "low_confidence_action": "inbox",
+            }
+        },
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.22,
+            "reason": "too ambiguous",
+            "needs_feedback": True,
+        },
+    )
+
+    kept = vault / "Inbox" / "unsure-note.md"
+    assert not kept.exists()
+    content = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / summary["processed"][0]["entry_id"]
+        / "Inbox"
+        / "unsure-note.md"
+    ).read_text(encoding="utf-8")
+    assert "para_triage_status: needs-feedback" in content
+    assert "para_target: Inbox" in content
+    assert summary["processed"][0]["path_after"] == "Inbox/unsure-note.md"
+
+
+def test_feedback_status_includes_projection_summary(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "ops.md"
+    note.write_text("Review the system and route this later.\n", encoding="utf-8")
+
+    triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.9,
+            "reason": "reference",
+            "needs_feedback": False,
+        },
+    )
+
+    status = triage.feedback_status(vault_path=vault)
+    assert status["projection_status"]["sync_contract"]["capture_model"] == "canonical_event_log"
+    assert status["projection_status"]["pending_events"] == 1
+
+
+def test_format_run_report_includes_on_demand_audit_hint():
+    report = triage.format_run_report(
+        {
+            "run_id": "20260712T020000Z",
+            "vault_path": "/tmp/vault",
+            "counts": {"captured": 1, "needs_feedback": 0},
+            "processed": [
+                {
+                    "entry_id": "entry-1",
+                    "path_before": "Inbox/example.md",
+                    "path_after": "Projects/Example/example.md",
+                    "confidence": 0.95,
+                    "needs_feedback": False,
+                }
+            ],
+        }
+    )
+
+    assert "On-demand audit: /para-feedback status | /para-feedback list" in report
+
+
+def test_projection_store_path_prefix_is_applied_to_staged_relative_path(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "launch-summary.md"
+    note.write_text("OpenAI launch notes and takeaways.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "projection": {
+                "stores": {
+                    "vault": {"enabled": True, "path_prefix": ""},
+                    "second_brain": {"enabled": True, "path_prefix": "runtime-source"},
+                }
+            },
+            "routing": {
+                "rules": [
+                    {
+                        "name": "launch",
+                        "match_any": ["launch", "takeaways"],
+                        "target": "Resources/Reference",
+                        "confidence": 0.99,
+                        "reason": "reference note",
+                    }
+                ]
+            },
+        },
+    )
+
+    event_id = summary["processed"][0]["entry_id"]
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{event_id}.json").read_text(encoding="utf-8")
+    )
+    second_brain = capture_event["projection"]["stores"]["second_brain"]
+    assert second_brain["target_relative_path"] == "runtime-source/Resources/Reference/launch-summary.md"
+    assert second_brain["staged_relative_path"] == (
+        f"staging/second_brain/{event_id}/runtime-source/Resources/Reference/launch-summary.md"
+    )
+
+
+def test_projection_summary_includes_memory_hint_and_enabled_stores(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "capture.md"
+    note.write_text("Something to route.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "projection": {
+                "stores": {
+                    "vault": {"enabled": True, "path_prefix": ""},
+                    "second_brain": {"enabled": False, "path_prefix": "runtime-source"},
+                }
+            },
+            "routing": {
+                "rules": [
+                    {
+                        "name": "capture",
+                        "match_any": ["route"],
+                        "target": "Resources/Reference",
+                        "confidence": 0.95,
+                        "reason": "reference note",
+                    }
+                ]
+            },
+        },
+    )
+
+    projection_status = summary["projection_status"]
+    assert projection_status["sync_contract"]["stores"] == ["vault"]
+    assert "downstream staged projections" in projection_status["memory_hint"]

--- a/tests/hermes_cli/test_vault_para_triage.py
+++ b/tests/hermes_cli/test_vault_para_triage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from hermes_cli import vault_para_triage as triage
 
@@ -184,6 +185,46 @@ def test_low_confidence_action_inbox_keeps_note_in_inbox(tmp_path):
     assert summary["processed"][0]["path_after"] == "Inbox/unsure-note.md"
 
 
+def test_explicit_inbox_target_is_allowed(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "scratch-capture.md"
+    note.write_text("Keep this as a raw inbox capture for later sorting.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Inbox",
+            "confidence": 0.93,
+            "reason": "raw capture should remain in inbox",
+            "needs_feedback": False,
+        },
+    )
+
+    staged = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / summary["processed"][0]["entry_id"]
+        / "Inbox"
+        / "scratch-capture.md"
+    )
+    assert staged.exists()
+    assert summary["processed"][0]["path_after"] == "Inbox/scratch-capture.md"
+
+    capture_event = json.loads(
+        (
+            vault
+            / ".hermes"
+            / "note-capture"
+            / "events"
+            / f"{summary['processed'][0]['entry_id']}.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert capture_event["routing"]["target"] == "Inbox"
+
+
 def test_feedback_status_includes_projection_summary(tmp_path):
     vault = _make_vault(tmp_path)
     note = vault / "Inbox" / "ops.md"
@@ -295,3 +336,134 @@ def test_projection_summary_includes_memory_hint_and_enabled_stores(tmp_path):
     projection_status = summary["projection_status"]
     assert projection_status["sync_contract"]["stores"] == ["vault"]
     assert "downstream staged projections" in projection_status["memory_hint"]
+
+
+def test_target_resolver_decision_is_used_and_preserved_in_capture_event(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "lab-results.md"
+    note.write_text("Need to file these blood test notes.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        target_resolver=lambda **_: {
+            "target": "Areas/Health",
+            "confidence": 0.87,
+            "reason": "resolved by runtime target registry",
+            "source": "target_resolver",
+            "needs_feedback": False,
+            "target_id": "vault.second_brain.areas.health",
+            "logical_path": "areas/health",
+            "display_path": "4.Resources/Health and Wellbeing",
+            "resolved_target_path": "Areas/Health",
+            "target_status": "active",
+        },
+        classifier=lambda **_: (_ for _ in ()).throw(AssertionError("classifier should not run")),
+    )
+
+    event_id = summary["processed"][0]["entry_id"]
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{event_id}.json").read_text(encoding="utf-8")
+    )
+    routing = capture_event["routing"]
+    assert routing["target"] == "Areas/Health"
+    assert routing["target_id"] == "vault.second_brain.areas.health"
+    assert routing["logical_path"] == "areas/health"
+    assert routing["display_path"] == "4.Resources/Health and Wellbeing"
+    assert routing["resolved_target_path"] == "Areas/Health"
+    assert routing["target_status"] == "active"
+    assert summary["processed"][0]["path_after"] == "Areas/Health/lab-results.md"
+
+
+def test_http_target_resolver_uses_configured_api_before_classifier(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "launch-plan.md"
+    note.write_text("Capture these launch notes for later reference.\n", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    class _FakeResponse:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    def _fake_urlopen(request, timeout=0):
+        seen["url"] = request.full_url
+        seen["timeout"] = timeout
+        seen["payload"] = json.loads(request.data.decode("utf-8"))
+        return _FakeResponse(
+            {
+                "decision": {
+                    "resolved_target_path": "Resources/Reference",
+                    "confidence": 0.94,
+                    "reason": "api routed note",
+                    "needs_feedback": False,
+                    "target_id": "vault.second_brain.resources.reference",
+                }
+            }
+        )
+
+    with patch.object(triage.urllib.request, "urlopen", side_effect=_fake_urlopen):
+        summary = triage.run_triage(
+            vault_path=vault,
+            config_override={
+                "routing": {
+                    "target_resolver": {
+                        "enabled": True,
+                        "api_url": "http://resolver.test/v1/resolve-note-target",
+                        "timeout_seconds": 2.5,
+                    }
+                }
+            },
+            classifier=lambda **_: (_ for _ in ()).throw(AssertionError("classifier should not run")),
+        )
+
+    assert seen["url"] == "http://resolver.test/v1/resolve-note-target"
+    assert seen["timeout"] == 2.5
+    payload = seen["payload"]
+    assert payload["note"]["title"] == "launch plan"
+    assert payload["review_target"] == "Resources/_Inbox Review"
+    assert "Resources/Reference" in payload["allowed_targets"]
+    assert summary["processed"][0]["path_after"] == "Resources/Reference/launch-plan.md"
+
+
+def test_classifier_canonical_fields_are_preserved_in_capture_event(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "receipt.md"
+    note.write_text("HMRC invoice and payment confirmation.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Areas/Health",
+            "confidence": 0.91,
+            "reason": "test classifier",
+            "needs_feedback": False,
+            "target_id": "vault.second_brain.areas.personal.finance.invoices_and_receipts",
+            "target_class": "obsidian_vault",
+            "logical_path": "areas/personal/finance/invoices_and_receipts",
+            "display_path": "3.Areas/Personal/Finance/Invoices and Receipts",
+            "resolved_target_path": "Areas/Health",
+            "target_status": "pending_migration",
+            "trust_boundary": "icloud_obsidian",
+        },
+    )
+
+    event_id = summary["processed"][0]["entry_id"]
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{event_id}.json").read_text(encoding="utf-8")
+    )
+    routing = capture_event["routing"]
+    assert routing["target_id"] == "vault.second_brain.areas.personal.finance.invoices_and_receipts"
+    assert routing["target_class"] == "obsidian_vault"
+    assert routing["logical_path"] == "areas/personal/finance/invoices_and_receipts"
+    assert routing["display_path"] == "3.Areas/Personal/Finance/Invoices and Receipts"
+    assert routing["resolved_target_path"] == "Areas/Health"
+    assert routing["target_status"] == "pending_migration"
+    assert routing["trust_boundary"] == "icloud_obsidian"

--- a/tests/plugins/test_vault_triage_feedback_plugin.py
+++ b/tests/plugins/test_vault_triage_feedback_plugin.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from plugins.vault_triage_feedback import register
+
+
+class _DummyContext:
+    def __init__(self):
+        self.calls = []
+
+    def register_command(self, name, handler, description="", args_hint=""):
+        self.calls.append(
+            {
+                "name": name,
+                "handler": handler,
+                "description": description,
+                "args_hint": args_hint,
+            }
+        )
+
+
+def test_register_exposes_para_feedback_command():
+    ctx = _DummyContext()
+    register(ctx)
+
+    assert len(ctx.calls) == 1
+    call = ctx.calls[0]
+    assert call["name"] == "para-feedback"
+    assert "correct <entry_id> <target>" in call["args_hint"]
+    assert callable(call["handler"])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,7 @@ import {
   Star,
   Terminal,
   Users,
+  Wallet,
   Webhook,
   Wrench,
   X,
@@ -81,6 +82,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
+import PaymentsPage from "@/pages/PaymentsPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
 import SkillsPage from "@/pages/SkillsPage";
@@ -138,6 +140,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/models": ModelsPage,
   "/logs": LogsPage,
   "/cron": CronPage,
+  "/payments": PaymentsPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
   "/mcp": McpPage,
@@ -182,6 +185,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
+  { path: "/payments", label: "Payments", icon: Wallet },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/mcp", label: "MCP", icon: Plug },
@@ -218,6 +222,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Database,
   Shield,
   Users,
+  Wallet,
   Wrench,
   Zap,
   Heart,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -82,6 +82,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
+import OpsPage from "@/pages/OpsPage";
 import PaymentsPage from "@/pages/PaymentsPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
@@ -140,6 +141,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/models": ModelsPage,
   "/logs": LogsPage,
   "/cron": CronPage,
+  "/ops": OpsPage,
   "/payments": PaymentsPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
@@ -185,6 +187,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
+  { path: "/ops", label: "Ops", icon: Globe },
   { path: "/payments", label: "Payments", icon: Wallet },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -66,6 +66,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/status",
   "/api/gateway",
   "/api/analytics",
+  "/api/payments",
   "/api/skills",
   "/api/tools/toolsets",
   "/api/config",
@@ -556,6 +557,22 @@ export const api = {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
+    }),
+
+  // Payments
+  getPayments: () =>
+    fetchJSON<PaymentsResponse>("/api/payments"),
+  syncPayments: (body?: { source?: string; query?: string; max_results?: number }) =>
+    fetchJSON<PaymentSyncResponse>("/api/payments/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    }),
+  updatePaymentStatus: (id: string, status: PaymentRequest["status"]) =>
+    fetchJSON<PaymentRequest>(`/api/payments/${encodeURIComponent(id)}/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
     }),
 
   // Profiles
@@ -1756,6 +1773,66 @@ export interface ManagedFileWriteResponse {
   root: string | null;
   locked_root: string | null;
   can_change_path: boolean;
+}
+
+export interface PaymentSourceStatus {
+  id: string;
+  label: string;
+  connected: boolean;
+  detail: string;
+}
+
+export interface PaymentRequest {
+  id: string;
+  source: string;
+  source_label: string;
+  status: "new" | "needs_review" | "ready_to_pay" | "paid" | "ignored";
+  confidence: string;
+  received_at: string | null;
+  updated_at: string | null;
+  vendor: string;
+  title: string;
+  amount: {
+    value: number | null;
+    currency: string;
+    display: string;
+  };
+  due_date: string | null;
+  payee_name: string;
+  account_holder: string;
+  account_number: string;
+  sort_code: string;
+  iban: string;
+  swift: string;
+  routing_number: string;
+  payment_reference: string;
+  invoice_number: string;
+  billing_address: string;
+  tax_details: string;
+  preview_text: string;
+  warnings: string[];
+  attachments: string[];
+  original: {
+    label: string;
+    url: string;
+    message_id: string;
+    thread_id: string;
+  };
+}
+
+export interface PaymentsResponse {
+  sources: PaymentSourceStatus[];
+  requests: PaymentRequest[];
+  storage_path: string;
+}
+
+export interface PaymentSyncResponse {
+  source: string;
+  query: string;
+  fetched: number;
+  imported: number;
+  updated: number;
+  requests: PaymentRequest[];
 }
 
 export interface AnalyticsDailyEntry {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -67,6 +67,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/gateway",
   "/api/analytics",
   "/api/payments",
+  "/api/inbox-items",
   "/api/skills",
   "/api/tools/toolsets",
   "/api/config",
@@ -560,16 +561,53 @@ export const api = {
     }),
 
   // Payments
+  getOpsServices: () =>
+    fetchJSON<OpsServicesResponse>("/api/ops/services"),
+  getWebhubOpsSummary: () =>
+    fetchJSON<WebhubOpsSummaryResponse>("/api/ops/webhub"),
   getPayments: () =>
     fetchJSON<PaymentsResponse>("/api/payments"),
+  getInboxItems: (params?: { queue?: string; workflow_type?: string }) => {
+    const search = new URLSearchParams();
+    if (params?.queue) search.set("queue", params.queue);
+    if (params?.workflow_type) search.set("workflow_type", params.workflow_type);
+    const suffix = search.size ? `?${search.toString()}` : "";
+    return fetchJSON<InboxItemsResponse>(`/api/inbox-items${suffix}`);
+  },
   syncPayments: (body?: { source?: string; query?: string; max_results?: number }) =>
     fetchJSON<PaymentSyncResponse>("/api/payments/sync", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body || {}),
     }),
+  shadowSyncPayments: (body?: { source?: string; query?: string; max_results?: number }) =>
+    fetchJSON<PaymentShadowSyncResponse>("/api/payments/shadow-sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    }),
+  getPaymentsShadowReport: () =>
+    fetchJSON<PaymentShadowReportResponse>("/api/payments/shadow-report"),
+  schedulePaymentsShadowSync: (body?: {
+    schedule?: string;
+    query?: string;
+    max_results?: number;
+    name?: string;
+    run_now?: boolean;
+  }) =>
+    fetchJSON<PaymentShadowScheduleResponse>("/api/payments/shadow-schedule", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    }),
   updatePaymentStatus: (id: string, status: PaymentRequest["status"]) =>
     fetchJSON<PaymentRequest>(`/api/payments/${encodeURIComponent(id)}/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    }),
+  updateInboxItemStatus: (id: string, status: InboxItem["status"]) =>
+    fetchJSON<InboxItem>(`/api/inbox-items/${encodeURIComponent(id)}/status`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status }),
@@ -1784,9 +1822,11 @@ export interface PaymentSourceStatus {
 
 export interface PaymentRequest {
   id: string;
+  payment_id?: string;
   source: string;
   source_label: string;
   status: "new" | "needs_review" | "ready_to_pay" | "paid" | "ignored";
+  operator_status?: "needs_review" | "ready_to_pay" | "paid" | "ignored";
   confidence: string;
   received_at: string | null;
   updated_at: string | null;
@@ -1818,11 +1858,62 @@ export interface PaymentRequest {
     message_id: string;
     thread_id: string;
   };
+  raw_text_path?: string;
+  materialized_path?: string;
+  review_note?: string;
+  looks_paid?: boolean;
 }
 
 export interface PaymentsResponse {
   sources: PaymentSourceStatus[];
   requests: PaymentRequest[];
+  storage_path: string;
+}
+
+export interface InboxItem {
+  id: string;
+  source: string;
+  source_account: string;
+  source_thread_id: string;
+  source_message_id: string;
+  source_url: string;
+  captured_at: string | null;
+  updated_at: string | null;
+  last_classified_at: string | null;
+  workflow_type: string;
+  queue: string;
+  status: "new" | "needs_review" | "ready_to_pay" | "paid" | "ignored";
+  title: string;
+  summary: string;
+  counterparty: string;
+  action_required: boolean;
+  confidence: string | number | null;
+  amount: {
+    value: number | null;
+    currency: string;
+    display: string;
+  };
+  due_date: string | null;
+  meeting_dates: string[];
+  meeting_timezone: string;
+  reference_id: string;
+  receipt_like: boolean;
+  invoice_like: boolean;
+  calendar_like: boolean;
+  warning_flags: string[];
+  operator_notes: string;
+  raw_payload_path?: string | null;
+  materialized_path?: string | null;
+  manual_status: boolean;
+  manual_notes: boolean;
+  reviewed_at: string | null;
+  reviewed_by: string | null;
+  entities: Record<string, unknown>;
+  artifacts: Record<string, unknown>;
+}
+
+export interface InboxItemsResponse {
+  items: InboxItem[];
   storage_path: string;
 }
 
@@ -1833,6 +1924,131 @@ export interface PaymentSyncResponse {
   imported: number;
   updated: number;
   requests: PaymentRequest[];
+}
+
+export interface PaymentShadowParityReport {
+  generated_at: string | null;
+  payments_count: number;
+  shadow_count: number;
+  compared_count: number;
+  parity_ok: boolean;
+  status_mismatches: string[];
+  amount_mismatches: string[];
+  due_date_mismatches: string[];
+  reference_mismatches: string[];
+  missing_in_shadow: string[];
+  shadow_only: string[];
+}
+
+export interface PaymentShadowSyncResponse extends PaymentSyncResponse {
+  shadow: {
+    mirrored: number;
+    storage_path: string;
+    parity: PaymentShadowParityReport;
+  };
+}
+
+export interface PaymentShadowReportSnapshot {
+  updated_at: string | null;
+  result: PaymentShadowSyncResponse | null;
+  path: string;
+}
+
+export interface PaymentShadowReportResponse {
+  storage_path: string;
+  snapshot: PaymentShadowReportSnapshot;
+  parity: PaymentShadowParityReport;
+}
+
+export interface PaymentShadowScheduleResponse {
+  job: {
+    id: string;
+    name?: string;
+    schedule?: string;
+    schedule_display?: string;
+    script?: string;
+    no_agent?: boolean;
+  };
+  run_now?: PaymentShadowSyncResponse;
+}
+
+export interface OpsService {
+  id: string;
+  title: string;
+  url: string;
+  description: string;
+  group: string;
+  tags: string[];
+}
+
+export interface OpsServicesResponse {
+  services: OpsService[];
+}
+
+export interface WebhubTopModel {
+  model: string;
+  requests: number;
+  estimated_cost_usd: number;
+  avg_latency_ms: number;
+  total_tokens: number;
+}
+
+export interface WebhubHourlyPoint {
+  bucket_start: string;
+  requests: number;
+  estimated_cost_usd: number;
+  avg_latency_ms: number;
+}
+
+export interface WebhubRecentError {
+  observed_at: string;
+  model: string;
+  error_type: string;
+  error_message: string;
+}
+
+export interface WebhubOpsSummaryResponse {
+  status: {
+    plugin_enabled: boolean;
+    openrouter_configured: boolean;
+    slack_configured: boolean;
+    briefing_file: string;
+  };
+  summary: {
+    window_hours: number;
+    requests: {
+      total: number;
+      ok: number;
+      error: number;
+      success_rate: number;
+      throughput_per_hour: number;
+    };
+    tokens: {
+      input: number;
+      output: number;
+      cache_read: number;
+      cache_write: number;
+      reasoning: number;
+      total: number;
+    };
+    cost: {
+      estimated_usd: number;
+    };
+    latency: {
+      avg_ms: number;
+    };
+    last_request_at: string;
+    top_models: WebhubTopModel[];
+    hourly: WebhubHourlyPoint[];
+    recent_errors: WebhubRecentError[];
+    briefing_markdown: string;
+  };
+  links: {
+    grafana_url: string;
+    prometheus_url: string;
+    channels_url: string;
+    ops_url: string;
+  };
 }
 
 export interface AnalyticsDailyEntry {

--- a/web/src/pages/OpsPage.tsx
+++ b/web/src/pages/OpsPage.tsx
@@ -1,0 +1,408 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowUpRight, Copy, ExternalLink, RefreshCw, Server, Wallet } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent } from "@nous-research/ui/ui/components/card";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Toast } from "@nous-research/ui/ui/components/toast";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api, type OpsService, type WebhubOpsSummaryResponse } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+function groupServices(services: OpsService[]): Array<[string, OpsService[]]> {
+  const grouped = new Map<string, OpsService[]>();
+  for (const service of services) {
+    const bucket = grouped.get(service.group) ?? [];
+    bucket.push(service);
+    grouped.set(service.group, bucket);
+  }
+  return [...grouped.entries()];
+}
+
+function serviceAccent(service: OpsService): string {
+  const key = `${service.id} ${service.title}`.toLowerCase();
+  if (key.includes("payment")) return "from-[#f2d2a2]/30 via-[#8f5f2c]/15 to-transparent";
+  if (key.includes("grafana") || key.includes("metric")) return "from-[#d86f45]/30 via-[#58332d]/10 to-transparent";
+  if (key.includes("chat")) return "from-[#9bc9c2]/30 via-[#2e5e5b]/10 to-transparent";
+  return "from-[#c1d8d0]/20 via-[#34453f]/10 to-transparent";
+}
+
+function serviceIcon(service: OpsService) {
+  const key = `${service.id} ${service.title}`.toLowerCase();
+  if (key.includes("payment")) return Wallet;
+  return Server;
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(value >= 10 ? 2 : 4)}`;
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export default function OpsPage() {
+  const { toast, showToast } = useToast();
+  const { setEnd } = usePageHeader();
+  const [services, setServices] = useState<OpsService[]>([]);
+  const [webhub, setWebhub] = useState<WebhubOpsSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = async (mode: "initial" | "refresh" = "initial") => {
+    if (mode === "refresh") setRefreshing(true);
+    try {
+      const [servicesResponse, webhubResponse] = await Promise.all([
+        api.getOpsServices(),
+        api.getWebhubOpsSummary(),
+      ]);
+      setServices(servicesResponse.services);
+      setWebhub(webhubResponse);
+    } catch (error) {
+      showToast(`Could not load ops data: ${error}`, "error");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  useEffect(() => {
+    setEnd(
+      <Button ghost type="button" onClick={() => void load("refresh")} disabled={refreshing}>
+        {refreshing ? <Spinner /> : <RefreshCw className="h-4 w-4" />}
+        Refresh
+      </Button>,
+    );
+    return () => setEnd(null);
+  }, [refreshing, setEnd]);
+
+  const grouped = useMemo(() => groupServices(services), [services]);
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+
+  const copyUrl = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      showToast("Copied link", "success");
+    } catch (error) {
+      showToast(`Could not copy link: ${error}`, "error");
+    }
+  };
+
+  const openUrl = (value: string) => {
+    window.open(value, "_blank", "noopener,noreferrer");
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 pb-8">
+      <Toast toast={toast} />
+      <section className="relative overflow-hidden rounded-[28px] border border-border/70 bg-background/95 p-6 shadow-[0_24px_90px_rgba(0,0,0,0.18)]">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(211,190,149,0.16),transparent_38%),radial-gradient(circle_at_bottom_right,rgba(112,163,154,0.12),transparent_42%)]" />
+        <div className="relative flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-2xl space-y-3">
+            <p className="font-mondwest text-[0.72rem] uppercase tracking-[0.24em] text-muted-foreground">
+              Tailnet Ops
+            </p>
+            <h1 className="font-mondwest text-3xl uppercase tracking-[0.08em] text-foreground">
+              Mac Mini Service Directory
+            </h1>
+            <p className="max-w-xl text-sm text-muted-foreground">
+              One jump page for the Hermes surfaces and nearby services you use from your
+              Mac mini, MacBook, phone, and iPad over Tailscale.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-sm text-muted-foreground sm:grid-cols-3">
+            <div className="rounded-2xl border border-border/70 bg-background/80 px-4 py-3">
+              <p className="font-mondwest text-[0.65rem] uppercase tracking-[0.18em]">Services</p>
+              <p className="mt-2 text-xl text-foreground">{services.length}</p>
+            </div>
+            <div className="rounded-2xl border border-border/70 bg-background/80 px-4 py-3">
+              <p className="font-mondwest text-[0.65rem] uppercase tracking-[0.18em]">Host</p>
+              <p className="mt-2 truncate text-foreground">{origin.replace(/^https?:\/\//, "") || "Unknown"}</p>
+            </div>
+            <div className="rounded-2xl border border-border/70 bg-background/80 px-4 py-3">
+              <p className="font-mondwest text-[0.65rem] uppercase tracking-[0.18em]">Mode</p>
+              <p className="mt-2 text-foreground">Tailscale only</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {webhub && (
+        <section className="space-y-3">
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="font-mondwest text-sm uppercase tracking-[0.18em] text-foreground">
+                Webhub Observability
+              </p>
+              <p className="text-sm text-muted-foreground">
+                OpenRouter cost, throughput, and latency feeding the dashboard, Prometheus,
+                and the rolling morning-briefing snippet.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge tone={webhub.status.plugin_enabled ? "secondary" : "outline"}>
+                Plugin {webhub.status.plugin_enabled ? "enabled" : "disabled"}
+              </Badge>
+              <Badge tone={webhub.status.openrouter_configured ? "secondary" : "outline"}>
+                OpenRouter {webhub.status.openrouter_configured ? "ready" : "missing key"}
+              </Badge>
+              <Badge tone={webhub.status.slack_configured ? "secondary" : "outline"}>
+                Slack {webhub.status.slack_configured ? "ready" : "configure in Channels"}
+              </Badge>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <Card className="border-border/70 bg-background/90">
+              <CardContent className="p-5">
+                <p className="font-mondwest text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                  Estimated Cost
+                </p>
+                <p className="mt-2 text-2xl text-foreground">
+                  {formatUsd(webhub.summary.cost.estimated_usd)}
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Last {webhub.summary.window_hours}h
+                </p>
+              </CardContent>
+            </Card>
+            <Card className="border-border/70 bg-background/90">
+              <CardContent className="p-5">
+                <p className="font-mondwest text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                  Throughput
+                </p>
+                <p className="mt-2 text-2xl text-foreground">
+                  {webhub.summary.requests.throughput_per_hour.toFixed(2)}
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  requests/hour
+                </p>
+              </CardContent>
+            </Card>
+            <Card className="border-border/70 bg-background/90">
+              <CardContent className="p-5">
+                <p className="font-mondwest text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                  Success Rate
+                </p>
+                <p className="mt-2 text-2xl text-foreground">
+                  {formatPercent(webhub.summary.requests.success_rate)}
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {webhub.summary.requests.ok} ok / {webhub.summary.requests.error} errors
+                </p>
+              </CardContent>
+            </Card>
+            <Card className="border-border/70 bg-background/90">
+              <CardContent className="p-5">
+                <p className="font-mondwest text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                  Avg Latency
+                </p>
+                <p className="mt-2 text-2xl text-foreground">
+                  {webhub.summary.latency.avg_ms.toFixed(1)} ms
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {webhub.summary.requests.total} requests observed
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+            <Card className="border-border/70 bg-background/90">
+              <CardContent className="space-y-4 p-5">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 className="font-mondwest text-lg uppercase tracking-[0.08em] text-foreground">
+                      Dashboard Feed
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                      Rolling summary written to <span className="font-mono">{webhub.status.briefing_file}</span>
+                    </p>
+                  </div>
+                  <Button ghost type="button" onClick={() => openUrl(webhub.links.prometheus_url)}>
+                    Prometheus
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                </div>
+                <pre className="overflow-x-auto rounded-2xl border border-border/70 bg-background/85 p-4 text-xs text-muted-foreground">
+                  {webhub.summary.briefing_markdown}
+                </pre>
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/70 bg-background/90">
+              <CardContent className="space-y-4 p-5">
+                <div>
+                  <h2 className="font-mondwest text-lg uppercase tracking-[0.08em] text-foreground">
+                    Top Models
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    Highest request volume across the rolling window.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  {webhub.summary.top_models.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No OpenRouter traffic captured yet.
+                    </p>
+                  ) : (
+                    webhub.summary.top_models.map((item) => (
+                      <div
+                        key={item.model}
+                        className="rounded-2xl border border-border/70 bg-background/85 px-4 py-3"
+                      >
+                        <p className="truncate font-mono text-sm text-foreground">{item.model}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {item.requests} requests • {formatUsd(item.estimated_cost_usd)} •{" "}
+                          {item.avg_latency_ms.toFixed(1)} ms
+                        </p>
+                      </div>
+                    ))
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" onClick={() => openUrl(webhub.links.grafana_url)}>
+                    Open Grafana
+                    <ArrowUpRight className="h-4 w-4" />
+                  </Button>
+                  <Button ghost type="button" onClick={() => openUrl(webhub.links.channels_url)}>
+                    Slack / Channels
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {webhub.summary.recent_errors.length > 0 && (
+            <Card className="border-border/70 bg-background/90">
+              <CardContent className="space-y-3 p-5">
+                <div>
+                  <h2 className="font-mondwest text-lg uppercase tracking-[0.08em] text-foreground">
+                    Recent Errors
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    Latest OpenRouter failures captured by the webhub sink.
+                  </p>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  {webhub.summary.recent_errors.map((item, index) => (
+                    <div
+                      key={`${item.observed_at}-${item.model}-${index}`}
+                      className="rounded-2xl border border-border/70 bg-background/85 px-4 py-3"
+                    >
+                      <p className="truncate font-mono text-xs text-foreground">{item.model || "unknown model"}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">{item.error_type || "request_error"}</p>
+                      <p className="mt-2 line-clamp-3 text-sm text-muted-foreground">
+                        {item.error_message || "No error message captured."}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </section>
+      )}
+
+      {grouped.map(([group, items]) => (
+        <section key={group} className="space-y-3">
+          <div>
+            <p className="font-mondwest text-sm uppercase tracking-[0.18em] text-foreground">
+              {group}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {group === "Hermes"
+                ? "Primary Hermes surfaces on the Mac mini."
+                : "Adjacent infrastructure and observability endpoints."}
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {items.map((service) => {
+              const Icon = serviceIcon(service);
+              return (
+                <Card
+                  key={service.id}
+                  className={cn(
+                    "overflow-hidden border-border/70 bg-background/90",
+                    "shadow-[0_12px_40px_rgba(0,0,0,0.12)]",
+                  )}
+                >
+                  <CardContent className="relative p-0">
+                    <div className={cn("absolute inset-0 bg-gradient-to-br", serviceAccent(service))} />
+                    <div className="relative flex h-full flex-col gap-4 p-5">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-2 text-foreground">
+                            <Icon className="h-4 w-4" />
+                            <h2 className="font-mondwest text-lg uppercase tracking-[0.08em]">
+                              {service.title}
+                            </h2>
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            {service.description || "No description configured."}
+                          </p>
+                        </div>
+                        <Badge tone="outline">{service.group}</Badge>
+                      </div>
+
+                      <div className="rounded-2xl border border-border/70 bg-background/85 px-3 py-3">
+                        <p className="line-clamp-2 break-all font-mono text-xs text-muted-foreground">
+                          {service.url}
+                        </p>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        {service.tags.map((tag) => (
+                          <Badge key={tag} tone="secondary">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+
+                      <div className="mt-auto flex items-center gap-2">
+                        <Button type="button" className="flex-1" onClick={() => openUrl(service.url)}>
+                          Open
+                          <ArrowUpRight className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          ghost
+                          type="button"
+                          onClick={() => void copyUrl(service.url)}
+                          aria-label={`Copy ${service.title} URL`}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          ghost
+                          type="button"
+                          aria-label={`Open ${service.title} in a new tab`}
+                          onClick={() => openUrl(service.url)}
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/web/src/pages/PaymentsPage.tsx
+++ b/web/src/pages/PaymentsPage.tsx
@@ -15,7 +15,12 @@ import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { usePageHeader } from "@/contexts/usePageHeader";
-import { api, type PaymentRequest, type PaymentsResponse } from "@/lib/api";
+import {
+  api,
+  type PaymentRequest,
+  type PaymentsResponse,
+  type PaymentShadowReportResponse,
+} from "@/lib/api";
 import { PluginSlot } from "@/plugins";
 import { cn } from "@/lib/utils";
 
@@ -28,9 +33,19 @@ const DATETIME_FORMAT = new Intl.DateTimeFormat(undefined, {
   timeStyle: "short",
 });
 
+const BOARD_COLUMNS: Array<{
+  id: "needs_review" | "ready_to_pay" | "paid" | "ignored";
+  label: string;
+  empty: string;
+}> = [
+  { id: "needs_review", label: "Needs review", empty: "Nothing waiting for review." },
+  { id: "ready_to_pay", label: "Ready to pay", empty: "Nothing queued for payment." },
+  { id: "paid", label: "Paid", empty: "No recently settled items." },
+  { id: "ignored", label: "Ignored", empty: "No parked false positives." },
+];
+
 const STATUS_OPTIONS: Array<{ id: PaymentRequest["status"] | "all"; label: string }> = [
   { id: "all", label: "All" },
-  { id: "new", label: "New" },
   { id: "needs_review", label: "Needs review" },
   { id: "ready_to_pay", label: "Ready to pay" },
   { id: "paid", label: "Paid" },
@@ -85,6 +100,36 @@ function searchText(payment: PaymentRequest): string {
     .toLowerCase();
 }
 
+function operatorStatus(
+  payment: PaymentRequest,
+): "needs_review" | "ready_to_pay" | "paid" | "ignored" {
+  return payment.operator_status || (payment.status === "new" ? "needs_review" : payment.status);
+}
+
+function fileDownloadUrl(path: string | undefined): string {
+  return path ? `/api/files/download?path=${encodeURIComponent(path)}` : "";
+}
+
+function dueSoon(payment: PaymentRequest): boolean {
+  if (!payment.due_date) return false;
+  const due = new Date(payment.due_date);
+  if (Number.isNaN(due.getTime())) return false;
+  const now = new Date();
+  const diffDays = (due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+  return diffDays <= 7;
+}
+
+function sortPayments(payments: PaymentRequest[]): PaymentRequest[] {
+  return [...payments].sort((a, b) => {
+    const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.POSITIVE_INFINITY;
+    const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.POSITIVE_INFINITY;
+    if (aDue !== bDue) return aDue - bDue;
+    const aReceived = a.received_at ? new Date(a.received_at).getTime() : 0;
+    const bReceived = b.received_at ? new Date(b.received_at).getTime() : 0;
+    return bReceived - aReceived;
+  });
+}
+
 function PaymentField({
   label,
   value,
@@ -121,6 +166,92 @@ function PaymentField({
   );
 }
 
+function PaymentCard({
+  payment,
+  selected,
+  onSelect,
+  onStatusChange,
+  savingStatus,
+}: {
+  payment: PaymentRequest;
+  selected: boolean;
+  onSelect: () => void;
+  onStatusChange: (status: PaymentRequest["status"]) => void;
+  savingStatus: string | null;
+}) {
+  const activeStatus = operatorStatus(payment);
+  const busy = savingStatus !== null;
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border p-4 transition-colors",
+        selected ? "border-foreground/20 bg-foreground/5" : "border-border/70 bg-background/90",
+      )}
+    >
+      <button type="button" onClick={onSelect} className="w-full text-left">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate font-medium text-foreground">{paymentTitle(payment)}</p>
+            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+              {payment.title || payment.preview_text || "No captured summary"}
+            </p>
+          </div>
+          <Badge tone={statusBadgeTone(activeStatus)}>
+            {activeStatus.replaceAll("_", " ")}
+          </Badge>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <Badge tone={confidenceBadgeTone(payment.confidence)}>
+            {payment.confidence} confidence
+          </Badge>
+          {payment.looks_paid ? <Badge tone="secondary">Receipt-like</Badge> : null}
+          {dueSoon(payment) ? <Badge tone="warning">Due soon</Badge> : null}
+          <span>{amountLabel(payment)}</span>
+          <span>Due {formatDate(payment.due_date)}</span>
+        </div>
+      </button>
+      <div className="mt-4 grid grid-cols-2 gap-2">
+        <Button
+          type="button"
+          size="sm"
+          outlined={activeStatus !== "ready_to_pay"}
+          disabled={busy || activeStatus === "ready_to_pay"}
+          onClick={() => void onStatusChange("ready_to_pay")}
+        >
+          {savingStatus === "ready_to_pay" ? <Spinner /> : "Ready"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          outlined={activeStatus !== "paid"}
+          disabled={busy || activeStatus === "paid"}
+          onClick={() => void onStatusChange("paid")}
+        >
+          {savingStatus === "paid" ? <Spinner /> : "Paid"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          outlined={activeStatus !== "needs_review"}
+          disabled={busy || activeStatus === "needs_review"}
+          onClick={() => void onStatusChange("needs_review")}
+        >
+          {savingStatus === "needs_review" ? <Spinner /> : "Review"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          outlined={activeStatus !== "ignored"}
+          disabled={busy || activeStatus === "ignored"}
+          onClick={() => void onStatusChange("ignored")}
+        >
+          {savingStatus === "ignored" ? <Spinner /> : "Ignore"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export default function PaymentsPage() {
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
@@ -132,12 +263,21 @@ export default function PaymentsPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [savingStatus, setSavingStatus] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
+  const [shadowReport, setShadowReport] = useState<PaymentShadowReportResponse | null>(null);
+  const [shadowSyncing, setShadowSyncing] = useState(false);
+  const [shadowScheduling, setShadowScheduling] = useState(false);
+  const [dueSoonOnly, setDueSoonOnly] = useState(false);
+  const [likelyPaidOnly, setLikelyPaidOnly] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const result = await api.getPayments();
-      setData(result);
+      const [paymentsResult, shadowResult] = await Promise.all([
+        api.getPayments(),
+        api.getPaymentsShadowReport().catch(() => null),
+      ]);
+      setData(paymentsResult);
+      setShadowReport(shadowResult);
     } catch (error) {
       showToast(`Failed to load payments: ${error}`, "error");
     } finally {
@@ -169,11 +309,13 @@ export default function PaymentsPage() {
     const needle = query.trim().toLowerCase();
     return (data?.requests || []).filter((payment) => {
       if (sourceFilter !== "all" && payment.source !== sourceFilter) return false;
-      if (statusFilter !== "all" && payment.status !== statusFilter) return false;
+      if (statusFilter !== "all" && operatorStatus(payment) !== statusFilter) return false;
+      if (dueSoonOnly && !dueSoon(payment)) return false;
+      if (likelyPaidOnly && !payment.looks_paid) return false;
       if (needle && !searchText(payment).includes(needle)) return false;
       return true;
     });
-  }, [data?.requests, query, sourceFilter, statusFilter]);
+  }, [data?.requests, dueSoonOnly, likelyPaidOnly, query, sourceFilter, statusFilter]);
 
   useEffect(() => {
     if (!filteredRequests.length) {
@@ -187,6 +329,18 @@ export default function PaymentsPage() {
 
   const selectedPayment =
     filteredRequests.find((payment) => payment.id === selectedId) || filteredRequests[0] || null;
+
+  const grouped = useMemo(() => {
+    const buckets = new Map(BOARD_COLUMNS.map((column) => [column.id, [] as PaymentRequest[]]));
+    for (const payment of filteredRequests) {
+      const lane = operatorStatus(payment);
+      if (buckets.has(lane)) buckets.get(lane)!.push(payment);
+    }
+    for (const [key, items] of buckets) {
+      buckets.set(key, sortPayments(items));
+    }
+    return buckets;
+  }, [filteredRequests]);
 
   const copyValue = useCallback(
     async (label: string, value: string) => {
@@ -202,11 +356,10 @@ export default function PaymentsPage() {
   );
 
   const updateStatus = useCallback(
-    async (status: PaymentRequest["status"]) => {
-      if (!selectedPayment) return;
-      setSavingStatus(status);
+    async (paymentId: string, status: PaymentRequest["status"]) => {
+      setSavingStatus(`${paymentId}:${status}`);
       try {
-        const updated = await api.updatePaymentStatus(selectedPayment.id, status);
+        const updated = await api.updatePaymentStatus(paymentId, status);
         setData((prev) =>
           prev
             ? {
@@ -224,7 +377,7 @@ export default function PaymentsPage() {
         setSavingStatus(null);
       }
     },
-    [selectedPayment, showToast],
+    [showToast],
   );
 
   const sourceFilters = data?.sources || [];
@@ -245,6 +398,52 @@ export default function PaymentsPage() {
       setSyncing(false);
     }
   }, [load, showToast]);
+
+  const shadowSyncGmail = useCallback(async () => {
+    setShadowSyncing(true);
+    try {
+      const result = await api.shadowSyncPayments({ source: "gmail" });
+      showToast(
+        `Shadow sync complete: ${result.shadow.mirrored} mirrored, parity ${result.shadow.parity.parity_ok ? "ok" : "needs review"}`,
+        "success",
+      );
+      await load();
+    } catch (error) {
+      showToast(`Failed to run shadow sync: ${error}`, "error");
+    } finally {
+      setShadowSyncing(false);
+    }
+  }, [load, showToast]);
+
+  const scheduleShadowSync = useCallback(async () => {
+    setShadowScheduling(true);
+    try {
+      const result = await api.schedulePaymentsShadowSync({
+        schedule: "every 6h",
+        run_now: false,
+      });
+      showToast(
+        `Shadow sync schedule updated: ${result.job.schedule_display || result.job.schedule || "configured"}`,
+        "success",
+      );
+      await load();
+    } catch (error) {
+      showToast(`Failed to schedule shadow sync: ${error}`, "error");
+    } finally {
+      setShadowScheduling(false);
+    }
+  }, [load, showToast]);
+
+  const shadowParity = shadowReport?.parity || null;
+  const shadowSnapshot = shadowReport?.snapshot || null;
+  const shadowIssueCount = shadowParity
+    ? shadowParity.status_mismatches.length +
+      shadowParity.amount_mismatches.length +
+      shadowParity.due_date_mismatches.length +
+      shadowParity.reference_mismatches.length +
+      shadowParity.missing_in_shadow.length +
+      shadowParity.shadow_only.length
+    : 0;
 
   return (
     <>
@@ -268,139 +467,243 @@ export default function PaymentsPage() {
           ))}
         </section>
 
-        <section className="grid gap-6 xl:grid-cols-[21rem_minmax(0,1fr)_22rem]">
-          <Card className="min-h-[36rem] border-border/70 bg-background/80">
-            <CardHeader className="space-y-4 pb-4">
-              <div className="flex items-center justify-between gap-3">
-                <CardTitle>Queue</CardTitle>
-                <div className="flex items-center gap-2">
-                  <Badge tone="outline">{filteredRequests.length}</Badge>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => void syncGmail()}
-                    disabled={syncing || gmailSource?.connected === false}
-                  >
-                    {syncing ? <Spinner /> : "Sync Gmail"}
-                  </Button>
-                </div>
+        <Card className="border-border/70 bg-background/80">
+          <CardHeader className="space-y-4 pb-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <CardTitle>Shadow parity</CardTitle>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Mirror the legacy payments queue into <code>inbox_items</code> and compare parity before cutover.
+                </p>
               </div>
-              <Input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search vendor, invoice, reference..."
-              />
-              <div className="flex flex-wrap gap-2">
+              <div className="flex items-center gap-2">
+                <Badge tone={shadowParity?.parity_ok ? "success" : shadowParity ? "warning" : "outline"}>
+                  {shadowParity ? (shadowParity.parity_ok ? "Parity ok" : "Mismatches detected") : "Unavailable"}
+                </Badge>
                 <Button
                   type="button"
                   size="sm"
-                  variant={sourceFilter === "all" ? "default" : "secondary"}
-                  onClick={() => setSourceFilter("all")}
+                  outlined
+                  onClick={() => void shadowSyncGmail()}
+                  disabled={shadowSyncing || gmailSource?.connected === false}
                 >
-                  All sources
+                  {shadowSyncing ? <Spinner /> : "Shadow sync"}
                 </Button>
-                {sourceFilters.map((source) => (
-                  <Button
-                    key={source.id}
-                    type="button"
-                    size="sm"
-                    variant={sourceFilter === source.id ? "default" : "secondary"}
-                    onClick={() => setSourceFilter(source.id)}
-                  >
-                    {source.label}
-                  </Button>
-                ))}
+                <Button
+                  type="button"
+                  size="sm"
+                  outlined
+                  onClick={() => void scheduleShadowSync()}
+                  disabled={shadowScheduling}
+                >
+                  {shadowScheduling ? <Spinner /> : "Schedule"}
+                </Button>
               </div>
-              <div className="flex flex-wrap gap-2">
-                {STATUS_OPTIONS.map((status) => (
-                  <Button
-                    key={status.id}
-                    type="button"
-                    size="sm"
-                    variant={statusFilter === status.id ? "default" : "secondary"}
-                    onClick={() => setStatusFilter(status.id)}
-                  >
-                    {status.label}
-                  </Button>
-                ))}
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {loading ? (
-                <div className="grid min-h-48 place-items-center">
-                  <Spinner />
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-xl border border-border/70 bg-background p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Counts</p>
+              <p className="mt-3 text-sm text-foreground">
+                {shadowParity
+                  ? `${shadowParity.payments_count} payments · ${shadowParity.shadow_count} shadow · ${shadowParity.compared_count} compared`
+                  : "No parity data available"}
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-background p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Mismatch count</p>
+              <p className="mt-3 text-sm text-foreground">{shadowParity ? shadowIssueCount : "Unavailable"}</p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-background p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Last snapshot</p>
+              <p className="mt-3 text-sm text-foreground">
+                {shadowSnapshot?.updated_at ? formatDateTime(shadowSnapshot.updated_at) : "No snapshot yet"}
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-background p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Storage</p>
+              <p className="mt-3 break-all font-mono-ui text-xs text-muted-foreground">
+                {shadowSnapshot?.path || shadowReport?.storage_path || "Unavailable"}
+              </p>
+            </div>
+            {shadowParity && !shadowParity.parity_ok ? (
+              <div className="md:col-span-2 xl:col-span-4 rounded-xl border border-warning/40 bg-warning/5 p-4 text-sm text-foreground">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+                  <div>
+                    <p className="font-medium">Parity issues need review before cutover.</p>
+                    <p className="mt-2 text-muted-foreground">
+                      Status mismatches: {shadowParity.status_mismatches.length} · Amount mismatches: {shadowParity.amount_mismatches.length} · Due date mismatches: {shadowParity.due_date_mismatches.length} · Reference mismatches: {shadowParity.reference_mismatches.length} · Missing in shadow: {shadowParity.missing_in_shadow.length}
+                    </p>
+                  </div>
                 </div>
-              ) : filteredRequests.length === 0 ? (
-                <div className="space-y-3 rounded-xl border border-dashed border-border/80 bg-muted/20 p-5 text-sm text-muted-foreground">
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <section className="grid gap-6 2xl:grid-cols-[minmax(0,1fr)_25rem]">
+          <div className="space-y-6">
+            <Card className="border-border/70 bg-background/80">
+              <CardHeader className="space-y-4 pb-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <CardTitle>Payments board</CardTitle>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Manual review queue backed by the canonical payments review store.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge tone="outline">{filteredRequests.length}</Badge>
+                    <Button
+                      type="button"
+                      size="sm"
+                      outlined
+                      onClick={() => void syncGmail()}
+                      disabled={syncing || gmailSource?.connected === false}
+                    >
+                      {syncing ? <Spinner /> : "Sync Gmail"}
+                    </Button>
+                  </div>
+                </div>
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search vendor, invoice, reference..."
+                />
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    outlined={sourceFilter !== "all"}
+                    onClick={() => setSourceFilter("all")}
+                  >
+                    All sources
+                  </Button>
+                  {sourceFilters.map((source) => (
+                    <Button
+                      key={source.id}
+                      type="button"
+                      size="sm"
+                      outlined={sourceFilter !== source.id}
+                      onClick={() => setSourceFilter(source.id)}
+                    >
+                      {source.label}
+                    </Button>
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {STATUS_OPTIONS.map((status) => (
+                    <Button
+                      key={status.id}
+                      type="button"
+                      size="sm"
+                      outlined={statusFilter !== status.id}
+                      onClick={() => setStatusFilter(status.id)}
+                    >
+                      {status.label}
+                    </Button>
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    outlined={!dueSoonOnly}
+                    onClick={() => setDueSoonOnly((value) => !value)}
+                  >
+                    Due soon
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    outlined={!likelyPaidOnly}
+                    onClick={() => setLikelyPaidOnly((value) => !value)}
+                  >
+                    Receipt-like
+                  </Button>
+                </div>
+              </CardHeader>
+            </Card>
+
+            {loading ? (
+              <Card className="grid min-h-72 place-items-center border-border/70 bg-background/80">
+                <Spinner />
+              </Card>
+            ) : filteredRequests.length === 0 ? (
+              <Card className="border-border/70 bg-background/80">
+                <CardContent className="space-y-3 p-5 text-sm text-muted-foreground">
                   <div className="flex items-center gap-2 text-foreground">
                     <Wallet className="h-4 w-4" />
-                    <span className="font-medium">No captured payment requests yet</span>
+                    <span className="font-medium">No captured payment requests match this view</span>
                   </div>
                   <p>
-                    Connect Gmail or Email, or stage invoice files for extraction. This queue
-                    will keep the manual-payment details once capture is wired in.
+                    Adjust filters or sync Gmail to refresh the review queue.
                   </p>
                   {data?.storage_path ? (
                     <p className="font-mono-ui text-xs text-muted-foreground/80">
                       Storage: {data.storage_path}
                     </p>
                   ) : null}
-                </div>
-              ) : (
-                filteredRequests.map((payment) => (
-                  <button
-                    key={payment.id}
-                    type="button"
-                    onClick={() => setSelectedId(payment.id)}
-                    className={cn(
-                      "w-full rounded-xl border px-4 py-3 text-left transition-colors",
-                      selectedPayment?.id === payment.id
-                        ? "border-foreground/20 bg-foreground/5"
-                        : "border-border/70 bg-background hover:bg-muted/25",
-                    )}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate font-medium text-foreground">
-                          {paymentTitle(payment)}
-                        </p>
-                        <p className="truncate text-sm text-muted-foreground">
-                          {payment.title || payment.preview_text || "No source summary"}
-                        </p>
-                      </div>
-                      <Badge tone={statusBadgeTone(payment.status)}>
-                        {payment.status.replaceAll("_", " ")}
-                      </Badge>
-                    </div>
-                    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                      <Badge tone="outline">{payment.source_label}</Badge>
-                      <Badge tone={confidenceBadgeTone(payment.confidence)}>
-                        {payment.confidence} confidence
-                      </Badge>
-                      <span>{amountLabel(payment)}</span>
-                      <span>Due {formatDate(payment.due_date)}</span>
-                    </div>
-                  </button>
-                ))
-              )}
-            </CardContent>
-          </Card>
+                </CardContent>
+              </Card>
+            ) : (
+              <section className="grid gap-4 lg:grid-cols-2 2xl:grid-cols-4">
+                {BOARD_COLUMNS.map((column) => {
+                  const items = grouped.get(column.id) || [];
+                  return (
+                    <Card key={column.id} className="border-border/70 bg-background/80">
+                      <CardHeader className="pb-4">
+                        <div className="flex items-center justify-between gap-3">
+                          <CardTitle className="text-base">{column.label}</CardTitle>
+                          <Badge tone="outline">{items.length}</Badge>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="space-y-3">
+                        {items.length === 0 ? (
+                          <p className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-4 text-sm text-muted-foreground">
+                            {column.empty}
+                          </p>
+                        ) : (
+                          items.map((payment) => (
+                            <PaymentCard
+                              key={payment.id}
+                              payment={payment}
+                              selected={selectedPayment?.id === payment.id}
+                              onSelect={() => setSelectedId(payment.id)}
+                              onStatusChange={(status) => updateStatus(payment.id, status)}
+                              savingStatus={
+                                savingStatus?.startsWith(`${payment.id}:`)
+                                  ? savingStatus.split(":", 2)[1]
+                                  : null
+                              }
+                            />
+                          ))
+                        )}
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </section>
+            )}
+          </div>
 
-          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+          <Card className="h-fit border-border/70 bg-background/80 2xl:sticky 2xl:top-6">
             <CardHeader className="space-y-3 pb-4">
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <CardTitle>{selectedPayment ? paymentTitle(selectedPayment) : "Invoice / Request"}</CardTitle>
+                  <CardTitle>
+                    {selectedPayment ? paymentTitle(selectedPayment) : "Payment details"}
+                  </CardTitle>
                   <p className="mt-2 text-sm text-muted-foreground">
                     {selectedPayment
                       ? selectedPayment.title || "No subject captured yet."
-                      : "Select a captured item to inspect the source and extracted fields."}
+                      : "Select a payment card to inspect the source and extracted fields."}
                   </p>
                 </div>
                 {selectedPayment ? (
-                  <Badge tone={statusBadgeTone(selectedPayment.status)}>
-                    {selectedPayment.status.replaceAll("_", " ")}
+                  <Badge tone={statusBadgeTone(operatorStatus(selectedPayment))}>
+                    {operatorStatus(selectedPayment).replaceAll("_", " ")}
                   </Badge>
                 ) : null}
               </div>
@@ -408,7 +711,11 @@ export default function PaymentsPage() {
             <CardContent className="space-y-5">
               {selectedPayment ? (
                 <>
-                  <div className="grid gap-4 md:grid-cols-2">
+                  <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-1">
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Source</p>
+                      <p className="text-sm text-foreground">{selectedPayment.source_label}</p>
+                    </div>
                     <div className="space-y-1">
                       <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">From</p>
                       <p className="text-sm text-foreground">
@@ -439,7 +746,7 @@ export default function PaymentsPage() {
                     </p>
                   </div>
 
-                  <div className="grid gap-4 md:grid-cols-2">
+                  <div className="grid gap-4">
                     <div className="rounded-xl border border-border/70 bg-background p-4">
                       <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
                         Attachments
@@ -453,6 +760,14 @@ export default function PaymentsPage() {
                       ) : (
                         <p className="mt-3 text-sm italic text-muted-foreground">No attachments recorded</p>
                       )}
+                    </div>
+                    <div className="rounded-xl border border-border/70 bg-background p-4">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        Review note
+                      </p>
+                      <p className="mt-3 text-sm text-foreground">
+                        {selectedPayment.review_note || "No manual note recorded"}
+                      </p>
                     </div>
                     <div className="rounded-xl border border-border/70 bg-background p-4">
                       <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
@@ -475,135 +790,152 @@ export default function PaymentsPage() {
                     </div>
                   </div>
 
-                  <div className="flex flex-wrap gap-3">
+                  <div className="grid gap-3">
                     <Button
                       type="button"
-                      variant="secondary"
+                      outlined
                       onClick={() => window.open(selectedPayment.original.url, "_blank", "noopener,noreferrer")}
                       disabled={!selectedPayment.original.url}
                     >
                       <ExternalLink className="mr-2 h-4 w-4" />
                       Open original
                     </Button>
+                    <Button
+                      type="button"
+                      outlined
+                      onClick={() =>
+                        window.open(fileDownloadUrl(selectedPayment.raw_text_path), "_blank", "noopener,noreferrer")
+                      }
+                      disabled={!selectedPayment.raw_text_path}
+                    >
+                      Download raw artifact
+                    </Button>
+                    <Button
+                      type="button"
+                      outlined
+                      onClick={() =>
+                        window.open(
+                          fileDownloadUrl(selectedPayment.materialized_path),
+                          "_blank",
+                          "noopener,noreferrer",
+                        )
+                      }
+                      disabled={!selectedPayment.materialized_path}
+                    >
+                      Download materialized artifact
+                    </Button>
+                    <Button
+                      type="button"
+                      outlined
+                      onClick={() => void updateStatus(selectedPayment.id, "ready_to_pay")}
+                      disabled={savingStatus !== null || operatorStatus(selectedPayment) === "ready_to_pay"}
+                    >
+                      {savingStatus === `${selectedPayment.id}:ready_to_pay` ? <Spinner /> : "Mark ready to pay"}
+                    </Button>
+                    <Button
+                      type="button"
+                      className="w-full"
+                      onClick={() => void updateStatus(selectedPayment.id, "paid")}
+                      disabled={savingStatus !== null || operatorStatus(selectedPayment) === "paid"}
+                    >
+                      {savingStatus === `${selectedPayment.id}:paid` ? <Spinner /> : "Mark paid"}
+                    </Button>
+                    <Button
+                      type="button"
+                      outlined
+                      onClick={() => void updateStatus(selectedPayment.id, "needs_review")}
+                      disabled={savingStatus !== null || operatorStatus(selectedPayment) === "needs_review"}
+                    >
+                      {savingStatus === `${selectedPayment.id}:needs_review` ? <Spinner /> : "Needs review"}
+                    </Button>
+                    <Button
+                      type="button"
+                      outlined
+                      onClick={() => void updateStatus(selectedPayment.id, "ignored")}
+                      disabled={savingStatus !== null || operatorStatus(selectedPayment) === "ignored"}
+                    >
+                      {savingStatus === `${selectedPayment.id}:ignored` ? <Spinner /> : "Ignore / not a payment"}
+                    </Button>
+                  </div>
+
+                  <div className="space-y-4 rounded-xl border border-border/70 bg-background p-4">
+                    <p className="text-sm text-muted-foreground">
+                      Copy these fields into your banking app. No payments are sent automatically.
+                    </p>
+                    <PaymentField
+                      label="Payee"
+                      value={selectedPayment.payee_name}
+                      onCopy={() => copyValue("payee", selectedPayment.payee_name)}
+                    />
+                    <PaymentField
+                      label="Account holder"
+                      value={selectedPayment.account_holder}
+                      onCopy={() => copyValue("account holder", selectedPayment.account_holder)}
+                    />
+                    <PaymentField
+                      label="Account number"
+                      value={selectedPayment.account_number}
+                      onCopy={() => copyValue("account number", selectedPayment.account_number)}
+                    />
+                    <PaymentField
+                      label="Sort code"
+                      value={selectedPayment.sort_code}
+                      onCopy={() => copyValue("sort code", selectedPayment.sort_code)}
+                    />
+                    <PaymentField
+                      label="IBAN"
+                      value={selectedPayment.iban}
+                      onCopy={() => copyValue("IBAN", selectedPayment.iban)}
+                    />
+                    <PaymentField
+                      label="SWIFT"
+                      value={selectedPayment.swift}
+                      onCopy={() => copyValue("SWIFT", selectedPayment.swift)}
+                    />
+                    <PaymentField
+                      label="Routing number"
+                      value={selectedPayment.routing_number}
+                      onCopy={() => copyValue("routing number", selectedPayment.routing_number)}
+                    />
+                    <PaymentField
+                      label="Amount"
+                      value={amountLabel(selectedPayment)}
+                      onCopy={() => copyValue("amount", amountLabel(selectedPayment))}
+                    />
+                    <PaymentField
+                      label="Reference"
+                      value={selectedPayment.payment_reference}
+                      onCopy={() => copyValue("reference", selectedPayment.payment_reference)}
+                    />
+                    <PaymentField
+                      label="Invoice number"
+                      value={selectedPayment.invoice_number}
+                      onCopy={() => copyValue("invoice number", selectedPayment.invoice_number)}
+                    />
+                    <PaymentField
+                      label="Raw artifact path"
+                      value={selectedPayment.raw_text_path || ""}
+                      onCopy={() => copyValue("raw artifact path", selectedPayment.raw_text_path || "")}
+                    />
+                    <PaymentField
+                      label="Materialized artifact path"
+                      value={selectedPayment.materialized_path || ""}
+                      onCopy={() =>
+                        copyValue("materialized artifact path", selectedPayment.materialized_path || "")
+                      }
+                    />
+                    <PaymentField
+                      label="Due date"
+                      value={formatDate(selectedPayment.due_date)}
+                      onCopy={() => copyValue("due date", formatDate(selectedPayment.due_date))}
+                    />
+                    <PaymentField label="Billing address" value={selectedPayment.billing_address} />
+                    <PaymentField label="Tax details" value={selectedPayment.tax_details} />
                   </div>
                 </>
               ) : (
                 <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
-                  Select a payment request from the queue.
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          <Card className="min-h-[36rem] border-border/70 bg-background/80">
-            <CardHeader className="space-y-3 pb-4">
-              <CardTitle>Payment Details</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Copy these fields into your banking app. No payments are sent automatically.
-              </p>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {selectedPayment ? (
-                <>
-                  <PaymentField
-                    label="Payee"
-                    value={selectedPayment.payee_name}
-                    onCopy={() => copyValue("payee", selectedPayment.payee_name)}
-                  />
-                  <PaymentField
-                    label="Account holder"
-                    value={selectedPayment.account_holder}
-                    onCopy={() => copyValue("account holder", selectedPayment.account_holder)}
-                  />
-                  <PaymentField
-                    label="Account number"
-                    value={selectedPayment.account_number}
-                    onCopy={() => copyValue("account number", selectedPayment.account_number)}
-                  />
-                  <PaymentField
-                    label="Sort code"
-                    value={selectedPayment.sort_code}
-                    onCopy={() => copyValue("sort code", selectedPayment.sort_code)}
-                  />
-                  <PaymentField
-                    label="IBAN"
-                    value={selectedPayment.iban}
-                    onCopy={() => copyValue("IBAN", selectedPayment.iban)}
-                  />
-                  <PaymentField
-                    label="SWIFT"
-                    value={selectedPayment.swift}
-                    onCopy={() => copyValue("SWIFT", selectedPayment.swift)}
-                  />
-                  <PaymentField
-                    label="Routing number"
-                    value={selectedPayment.routing_number}
-                    onCopy={() => copyValue("routing number", selectedPayment.routing_number)}
-                  />
-                  <PaymentField
-                    label="Amount"
-                    value={amountLabel(selectedPayment)}
-                    onCopy={() => copyValue("amount", amountLabel(selectedPayment))}
-                  />
-                  <PaymentField
-                    label="Reference"
-                    value={selectedPayment.payment_reference}
-                    onCopy={() => copyValue("reference", selectedPayment.payment_reference)}
-                  />
-                  <PaymentField
-                    label="Invoice number"
-                    value={selectedPayment.invoice_number}
-                    onCopy={() => copyValue("invoice number", selectedPayment.invoice_number)}
-                  />
-                  <PaymentField
-                    label="Due date"
-                    value={formatDate(selectedPayment.due_date)}
-                    onCopy={() => copyValue("due date", formatDate(selectedPayment.due_date))}
-                  />
-                  <PaymentField label="Billing address" value={selectedPayment.billing_address} />
-                  <PaymentField label="Tax details" value={selectedPayment.tax_details} />
-
-                  <div className="space-y-2 pt-2">
-                    <Button
-                      type="button"
-                      className="w-full"
-                      onClick={() => void updateStatus("ready_to_pay")}
-                      disabled={savingStatus !== null || selectedPayment.status === "ready_to_pay"}
-                    >
-                      {savingStatus === "ready_to_pay" ? <Spinner /> : "Mark ready to pay"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      className="w-full"
-                      onClick={() => void updateStatus("paid")}
-                      disabled={savingStatus !== null || selectedPayment.status === "paid"}
-                    >
-                      {savingStatus === "paid" ? <Spinner /> : "Mark paid"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      className="w-full"
-                      onClick={() => void updateStatus("needs_review")}
-                      disabled={savingStatus !== null || selectedPayment.status === "needs_review"}
-                    >
-                      {savingStatus === "needs_review" ? <Spinner /> : "Needs review"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      className="w-full"
-                      onClick={() => void updateStatus("ignored")}
-                      disabled={savingStatus !== null || selectedPayment.status === "ignored"}
-                    >
-                      {savingStatus === "ignored" ? <Spinner /> : "Not a payment"}
-                    </Button>
-                  </div>
-                </>
-              ) : (
-                <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
-                  Payment details will appear here.
+                  Select a payment card from the board.
                 </div>
               )}
             </CardContent>
@@ -613,7 +945,7 @@ export default function PaymentsPage() {
 
       <PluginSlot name="dashboard.payments.below" />
 
-      {toast && <Toast message={toast.message} type={toast.type} onClose={toast.hide} />}
+      <Toast toast={toast} />
     </>
   );
 }

--- a/web/src/pages/PaymentsPage.tsx
+++ b/web/src/pages/PaymentsPage.tsx
@@ -1,0 +1,619 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Copy,
+  ExternalLink,
+  Mail,
+  RefreshCw,
+  Wallet,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Toast } from "@nous-research/ui/ui/components/toast";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api, type PaymentRequest, type PaymentsResponse } from "@/lib/api";
+import { PluginSlot } from "@/plugins";
+import { cn } from "@/lib/utils";
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+});
+
+const DATETIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const STATUS_OPTIONS: Array<{ id: PaymentRequest["status"] | "all"; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "new", label: "New" },
+  { id: "needs_review", label: "Needs review" },
+  { id: "ready_to_pay", label: "Ready to pay" },
+  { id: "paid", label: "Paid" },
+  { id: "ignored", label: "Ignored" },
+];
+
+function statusBadgeTone(status: PaymentRequest["status"]) {
+  if (status === "paid") return "success";
+  if (status === "ready_to_pay") return "warning";
+  if (status === "ignored") return "secondary";
+  return "outline";
+}
+
+function confidenceBadgeTone(confidence: string) {
+  if (confidence === "high") return "success";
+  if (confidence === "medium") return "warning";
+  return "outline";
+}
+
+function amountLabel(payment: PaymentRequest): string {
+  return payment.amount.display || "Amount missing";
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Missing";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATE_FORMAT.format(date);
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "Missing";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATETIME_FORMAT.format(date);
+}
+
+function paymentTitle(payment: PaymentRequest): string {
+  return payment.vendor || payment.title || "Untitled payment request";
+}
+
+function searchText(payment: PaymentRequest): string {
+  return [
+    payment.vendor,
+    payment.title,
+    payment.preview_text,
+    payment.invoice_number,
+    payment.payment_reference,
+    payment.original.label,
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+function PaymentField({
+  label,
+  value,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  onCopy?: () => void;
+}) {
+  const isMissing = !value.trim() || value === "Missing";
+  return (
+    <div className="space-y-1 border-b border-border/60 pb-3 last:border-b-0 last:pb-0">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </span>
+        {onCopy ? (
+          <Button
+            ghost
+            size="icon"
+            type="button"
+            onClick={() => void onCopy()}
+            aria-label={`Copy ${label}`}
+            disabled={isMissing}
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </Button>
+        ) : null}
+      </div>
+      <p className={cn("text-sm text-foreground", isMissing && "italic text-muted-foreground")}>
+        {isMissing ? "Missing" : value}
+      </p>
+    </div>
+  );
+}
+
+export default function PaymentsPage() {
+  const { toast, showToast } = useToast();
+  const { setEnd } = usePageHeader();
+  const [data, setData] = useState<PaymentsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sourceFilter, setSourceFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState<PaymentRequest["status"] | "all">("all");
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [savingStatus, setSavingStatus] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await api.getPayments();
+      setData(result);
+    } catch (error) {
+      showToast(`Failed to load payments: ${error}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    setEnd(
+      <Button
+        ghost
+        size="icon"
+        type="button"
+        onClick={() => void load()}
+        disabled={loading}
+        aria-label="Refresh payments"
+      >
+        {loading ? <Spinner /> : <RefreshCw />}
+      </Button>,
+    );
+    return () => setEnd(null);
+  }, [load, loading, setEnd]);
+
+  const filteredRequests = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return (data?.requests || []).filter((payment) => {
+      if (sourceFilter !== "all" && payment.source !== sourceFilter) return false;
+      if (statusFilter !== "all" && payment.status !== statusFilter) return false;
+      if (needle && !searchText(payment).includes(needle)) return false;
+      return true;
+    });
+  }, [data?.requests, query, sourceFilter, statusFilter]);
+
+  useEffect(() => {
+    if (!filteredRequests.length) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !filteredRequests.some((payment) => payment.id === selectedId)) {
+      setSelectedId(filteredRequests[0].id);
+    }
+  }, [filteredRequests, selectedId]);
+
+  const selectedPayment =
+    filteredRequests.find((payment) => payment.id === selectedId) || filteredRequests[0] || null;
+
+  const copyValue = useCallback(
+    async (label: string, value: string) => {
+      if (!value.trim()) return;
+      try {
+        await navigator.clipboard.writeText(value);
+        showToast(`${label} copied`, "success");
+      } catch (error) {
+        showToast(`Failed to copy ${label}: ${error}`, "error");
+      }
+    },
+    [showToast],
+  );
+
+  const updateStatus = useCallback(
+    async (status: PaymentRequest["status"]) => {
+      if (!selectedPayment) return;
+      setSavingStatus(status);
+      try {
+        const updated = await api.updatePaymentStatus(selectedPayment.id, status);
+        setData((prev) =>
+          prev
+            ? {
+                ...prev,
+                requests: prev.requests.map((item) =>
+                  item.id === updated.id ? updated : item,
+                ),
+              }
+            : prev,
+        );
+        showToast(`Payment marked ${status.replaceAll("_", " ")}`, "success");
+      } catch (error) {
+        showToast(`Failed to update payment: ${error}`, "error");
+      } finally {
+        setSavingStatus(null);
+      }
+    },
+    [selectedPayment, showToast],
+  );
+
+  const sourceFilters = data?.sources || [];
+  const gmailSource = sourceFilters.find((source) => source.id === "gmail");
+
+  const syncGmail = useCallback(async () => {
+    setSyncing(true);
+    try {
+      const result = await api.syncPayments({ source: "gmail" });
+      showToast(
+        `Gmail sync complete: ${result.imported} imported, ${result.updated} updated`,
+        "success",
+      );
+      await load();
+    } catch (error) {
+      showToast(`Failed to sync Gmail: ${error}`, "error");
+    } finally {
+      setSyncing(false);
+    }
+  }, [load, showToast]);
+
+  return (
+    <>
+      <div className="space-y-6">
+        <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {sourceFilters.map((source) => (
+            <Card key={source.id} className="border-border/70 bg-background/70">
+              <CardContent className="flex items-start justify-between gap-4 p-4">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-foreground">{source.label}</span>
+                    <Badge tone={source.connected ? "success" : "outline"}>
+                      {source.connected ? "Connected" : "Not connected"}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{source.detail}</p>
+                </div>
+                <Mail className="mt-0.5 h-4 w-4 text-muted-foreground" />
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-[21rem_minmax(0,1fr)_22rem]">
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-4 pb-4">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle>Queue</CardTitle>
+                <div className="flex items-center gap-2">
+                  <Badge tone="outline">{filteredRequests.length}</Badge>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => void syncGmail()}
+                    disabled={syncing || gmailSource?.connected === false}
+                  >
+                    {syncing ? <Spinner /> : "Sync Gmail"}
+                  </Button>
+                </div>
+              </div>
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search vendor, invoice, reference..."
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={sourceFilter === "all" ? "default" : "secondary"}
+                  onClick={() => setSourceFilter("all")}
+                >
+                  All sources
+                </Button>
+                {sourceFilters.map((source) => (
+                  <Button
+                    key={source.id}
+                    type="button"
+                    size="sm"
+                    variant={sourceFilter === source.id ? "default" : "secondary"}
+                    onClick={() => setSourceFilter(source.id)}
+                  >
+                    {source.label}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {STATUS_OPTIONS.map((status) => (
+                  <Button
+                    key={status.id}
+                    type="button"
+                    size="sm"
+                    variant={statusFilter === status.id ? "default" : "secondary"}
+                    onClick={() => setStatusFilter(status.id)}
+                  >
+                    {status.label}
+                  </Button>
+                ))}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {loading ? (
+                <div className="grid min-h-48 place-items-center">
+                  <Spinner />
+                </div>
+              ) : filteredRequests.length === 0 ? (
+                <div className="space-y-3 rounded-xl border border-dashed border-border/80 bg-muted/20 p-5 text-sm text-muted-foreground">
+                  <div className="flex items-center gap-2 text-foreground">
+                    <Wallet className="h-4 w-4" />
+                    <span className="font-medium">No captured payment requests yet</span>
+                  </div>
+                  <p>
+                    Connect Gmail or Email, or stage invoice files for extraction. This queue
+                    will keep the manual-payment details once capture is wired in.
+                  </p>
+                  {data?.storage_path ? (
+                    <p className="font-mono-ui text-xs text-muted-foreground/80">
+                      Storage: {data.storage_path}
+                    </p>
+                  ) : null}
+                </div>
+              ) : (
+                filteredRequests.map((payment) => (
+                  <button
+                    key={payment.id}
+                    type="button"
+                    onClick={() => setSelectedId(payment.id)}
+                    className={cn(
+                      "w-full rounded-xl border px-4 py-3 text-left transition-colors",
+                      selectedPayment?.id === payment.id
+                        ? "border-foreground/20 bg-foreground/5"
+                        : "border-border/70 bg-background hover:bg-muted/25",
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-foreground">
+                          {paymentTitle(payment)}
+                        </p>
+                        <p className="truncate text-sm text-muted-foreground">
+                          {payment.title || payment.preview_text || "No source summary"}
+                        </p>
+                      </div>
+                      <Badge tone={statusBadgeTone(payment.status)}>
+                        {payment.status.replaceAll("_", " ")}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <Badge tone="outline">{payment.source_label}</Badge>
+                      <Badge tone={confidenceBadgeTone(payment.confidence)}>
+                        {payment.confidence} confidence
+                      </Badge>
+                      <span>{amountLabel(payment)}</span>
+                      <span>Due {formatDate(payment.due_date)}</span>
+                    </div>
+                  </button>
+                ))
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-3 pb-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle>{selectedPayment ? paymentTitle(selectedPayment) : "Invoice / Request"}</CardTitle>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {selectedPayment
+                      ? selectedPayment.title || "No subject captured yet."
+                      : "Select a captured item to inspect the source and extracted fields."}
+                  </p>
+                </div>
+                {selectedPayment ? (
+                  <Badge tone={statusBadgeTone(selectedPayment.status)}>
+                    {selectedPayment.status.replaceAll("_", " ")}
+                  </Badge>
+                ) : null}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              {selectedPayment ? (
+                <>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">From</p>
+                      <p className="text-sm text-foreground">
+                        {selectedPayment.original.label || selectedPayment.vendor || "Missing"}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Received</p>
+                      <p className="text-sm text-foreground">{formatDateTime(selectedPayment.received_at)}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Amount</p>
+                      <p className="text-sm text-foreground">{amountLabel(selectedPayment)}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Due date</p>
+                      <p className="text-sm text-foreground">{formatDate(selectedPayment.due_date)}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-border/70 bg-muted/20 p-4">
+                    <div className="flex items-center gap-2">
+                      <AlertTriangle className="h-4 w-4 text-warning" />
+                      <p className="font-medium text-foreground">Review summary</p>
+                    </div>
+                    <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">
+                      {selectedPayment.preview_text || "No preview text has been captured yet."}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="rounded-xl border border-border/70 bg-background p-4">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        Attachments
+                      </p>
+                      {selectedPayment.attachments.length ? (
+                        <ul className="mt-3 space-y-2 text-sm text-foreground">
+                          {selectedPayment.attachments.map((attachment) => (
+                            <li key={attachment}>{attachment}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-3 text-sm italic text-muted-foreground">No attachments recorded</p>
+                      )}
+                    </div>
+                    <div className="rounded-xl border border-border/70 bg-background p-4">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        Warnings
+                      </p>
+                      {selectedPayment.warnings.length ? (
+                        <ul className="mt-3 space-y-2 text-sm text-foreground">
+                          {selectedPayment.warnings.map((warning) => (
+                            <li key={warning} className="flex gap-2">
+                              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+                              <span>{warning}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-3 text-sm italic text-muted-foreground">
+                          No extraction warnings
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-3">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => window.open(selectedPayment.original.url, "_blank", "noopener,noreferrer")}
+                      disabled={!selectedPayment.original.url}
+                    >
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      Open original
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
+                  Select a payment request from the queue.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-3 pb-4">
+              <CardTitle>Payment Details</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Copy these fields into your banking app. No payments are sent automatically.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {selectedPayment ? (
+                <>
+                  <PaymentField
+                    label="Payee"
+                    value={selectedPayment.payee_name}
+                    onCopy={() => copyValue("payee", selectedPayment.payee_name)}
+                  />
+                  <PaymentField
+                    label="Account holder"
+                    value={selectedPayment.account_holder}
+                    onCopy={() => copyValue("account holder", selectedPayment.account_holder)}
+                  />
+                  <PaymentField
+                    label="Account number"
+                    value={selectedPayment.account_number}
+                    onCopy={() => copyValue("account number", selectedPayment.account_number)}
+                  />
+                  <PaymentField
+                    label="Sort code"
+                    value={selectedPayment.sort_code}
+                    onCopy={() => copyValue("sort code", selectedPayment.sort_code)}
+                  />
+                  <PaymentField
+                    label="IBAN"
+                    value={selectedPayment.iban}
+                    onCopy={() => copyValue("IBAN", selectedPayment.iban)}
+                  />
+                  <PaymentField
+                    label="SWIFT"
+                    value={selectedPayment.swift}
+                    onCopy={() => copyValue("SWIFT", selectedPayment.swift)}
+                  />
+                  <PaymentField
+                    label="Routing number"
+                    value={selectedPayment.routing_number}
+                    onCopy={() => copyValue("routing number", selectedPayment.routing_number)}
+                  />
+                  <PaymentField
+                    label="Amount"
+                    value={amountLabel(selectedPayment)}
+                    onCopy={() => copyValue("amount", amountLabel(selectedPayment))}
+                  />
+                  <PaymentField
+                    label="Reference"
+                    value={selectedPayment.payment_reference}
+                    onCopy={() => copyValue("reference", selectedPayment.payment_reference)}
+                  />
+                  <PaymentField
+                    label="Invoice number"
+                    value={selectedPayment.invoice_number}
+                    onCopy={() => copyValue("invoice number", selectedPayment.invoice_number)}
+                  />
+                  <PaymentField
+                    label="Due date"
+                    value={formatDate(selectedPayment.due_date)}
+                    onCopy={() => copyValue("due date", formatDate(selectedPayment.due_date))}
+                  />
+                  <PaymentField label="Billing address" value={selectedPayment.billing_address} />
+                  <PaymentField label="Tax details" value={selectedPayment.tax_details} />
+
+                  <div className="space-y-2 pt-2">
+                    <Button
+                      type="button"
+                      className="w-full"
+                      onClick={() => void updateStatus("ready_to_pay")}
+                      disabled={savingStatus !== null || selectedPayment.status === "ready_to_pay"}
+                    >
+                      {savingStatus === "ready_to_pay" ? <Spinner /> : "Mark ready to pay"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("paid")}
+                      disabled={savingStatus !== null || selectedPayment.status === "paid"}
+                    >
+                      {savingStatus === "paid" ? <Spinner /> : "Mark paid"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("needs_review")}
+                      disabled={savingStatus !== null || selectedPayment.status === "needs_review"}
+                    >
+                      {savingStatus === "needs_review" ? <Spinner /> : "Needs review"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("ignored")}
+                      disabled={savingStatus !== null || selectedPayment.status === "ignored"}
+                    >
+                      {savingStatus === "ignored" ? <Spinner /> : "Not a payment"}
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
+                  Payment details will appear here.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+
+      <PluginSlot name="dashboard.payments.below" />
+
+      {toast && <Toast message={toast.message} type={toast.type} onClose={toast.hide} />}
+    </>
+  );
+}

--- a/website/docs/user-guide/features/payments.md
+++ b/website/docs/user-guide/features/payments.md
@@ -1,0 +1,153 @@
+---
+sidebar_position: 16
+title: "Payments Review"
+description: "Capture invoice and payment-request details from Gmail and other sources for manual payment in your banking app."
+---
+
+# Payments Review
+
+The **Payments** page in the web dashboard is a review queue for invoices and payment requests. Hermes does **not** send money or trigger bank transfers. Instead, it captures payment details, highlights missing fields, and gives you structured values to copy into your banking app manually.
+
+## What it does
+
+- **Captures payment requests** into a profile-scoped queue
+- **Syncs Gmail** for likely invoice / payment-due messages
+- **Stores extracted fields** such as amount, due date, invoice number, payment reference, and bank details
+- **Flags uncertainty** when important details are missing or low-confidence
+- **Tracks manual review state** so you can move items from new → ready to pay → paid
+
+## Where it lives
+
+Open the [Web Dashboard](./web-dashboard.md) and select **Payments** in the sidebar.
+
+The queue is profile-scoped, like the rest of the management dashboard. If you switch profiles, you are looking at that profile's payment-request store.
+
+## Current sources
+
+### Gmail
+
+The first real ingestion path is **Gmail**.
+
+When Google Workspace is configured, the page can run **Sync Gmail**, which:
+
+1. Searches for likely invoices and payment requests
+2. Reads candidate messages through the existing Google Workspace bridge
+3. Extracts fields such as:
+   - payee
+   - amount and currency
+   - due date
+   - invoice number
+   - payment reference
+   - sort code / account number
+   - IBAN / SWIFT / routing number when present
+4. Adds or updates queue entries in the Payments store
+
+Set up Gmail/Google Workspace first:
+
+- [Google Workspace skill](../skills/bundled/productivity/productivity-google-workspace.md)
+
+### Email
+
+The page also detects whether the built-in [Email channel](../messaging/email.md) is configured. That source is currently surfaced as a connection status and review target; the real extraction path is still Gmail-first.
+
+### Uploads
+
+Uploads are supported as a staging concept today. The page points you to the [Files](./web-dashboard.md#files) workflow so invoice PDFs or screenshots can be placed under your Hermes home for later extraction/review flows.
+
+### Slack
+
+Slack appears as a source-status card so the eventual cross-channel review model is visible in one place, but Gmail is the only fully wired sync source right now.
+
+## Page layout
+
+The Payments page is split into three areas:
+
+### Queue
+
+The left column shows captured payment requests with:
+
+- vendor / sender
+- title or subject
+- amount
+- due date
+- source
+- confidence
+- review status
+
+Filters let you narrow by source, status, or free-text search.
+
+### Invoice / Request detail
+
+The middle panel shows:
+
+- sender / source metadata
+- received time
+- amount and due date
+- extracted preview text
+- attachment list
+- warnings about missing or uncertain fields
+- a link back to the original Gmail message when available
+
+### Payment details
+
+The right panel gives you copy-ready fields for your banking app:
+
+- payee
+- account holder
+- account number
+- sort code
+- IBAN
+- SWIFT
+- routing number
+- amount
+- payment reference
+- invoice number
+- due date
+- billing address
+- tax details
+
+## Manual review states
+
+Each payment request can be moved between these states:
+
+- `new`
+- `needs_review`
+- `ready_to_pay`
+- `paid`
+- `ignored`
+
+These are review-only states. Marking an item `paid` does not send anything externally.
+
+## Storage
+
+The queue is stored under your profile's Hermes home:
+
+```text
+~/.hermes/payments/requests.json
+```
+
+If you're using multiple profiles, each profile has its own `payments/requests.json`.
+
+## Safety model
+
+The Payments workflow is intentionally conservative:
+
+- Hermes does **not** initiate transfers
+- Missing details remain visible as missing
+- Low-confidence extraction is surfaced as warnings instead of hidden
+- Gmail sync updates existing entries rather than silently duplicating every read
+
+## Current limitations
+
+As of July 4, 2026:
+
+- **Gmail sync is the only fully wired ingestion path**
+- extraction is heuristic, not OCR- or attachment-parser-driven yet
+- uploads and other channels are surfaced in the UI, but not fully ingested into the queue
+- validation against a user's real invoice examples still depends on the connected mailbox and real message content
+
+## Related
+
+- [Web Dashboard](./web-dashboard.md)
+- [Google Workspace](../skills/bundled/productivity/productivity-google-workspace.md)
+- [Files](./web-dashboard.md#files)

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 15
 title: "Web Dashboard"
-description: "Browser-based administration panel for managing configuration, API keys, MCP servers, messaging pairing, webhooks, the gateway, memory, credentials, sessions, logs, analytics, cron jobs, and skills"
+description: "Browser-based administration panel for managing configuration, API keys, MCP servers, messaging pairing, payment requests, webhooks, the gateway, memory, credentials, sessions, logs, analytics, cron jobs, and skills"
 ---
 
 # Web Dashboard
@@ -228,6 +228,19 @@ Each key shows:
 
 Advanced/rarely-used keys are hidden by default behind a toggle.
 
+### Files
+
+Browse and manage files inside the dashboard without dropping to a shell.
+
+- **Browse directories** — list files under the currently selected path
+- **Navigate** — move up the directory tree or jump directly to another path
+- **Upload** — send local files into the current directory
+- **Create folder** — add directories inline
+- **Download** — fetch any file back to your machine
+- **Delete** — remove files or folders after confirmation
+
+This is the easiest staging surface for invoice PDFs, screenshots, and other payment-request artifacts you want Hermes to review later.
+
 ### Sessions
 
 Browse and inspect all agent sessions. Each row shows the session title, source platform icon (CLI, Telegram, Discord, Slack, cron), model name, message count, tool call count, and how long ago it was active. Live sessions are marked with a pulsing badge.
@@ -273,6 +286,18 @@ Create and manage scheduled cron jobs that run agent prompts on a recurring sche
 - **Edit** — open a pre-filled modal to change a job's prompt, schedule, name, or delivery target
 - **Trigger now** — immediately execute a job outside its normal schedule
 - **Delete** — permanently remove a cron job
+
+### Payments
+
+Review captured invoices and payment requests before paying them manually in your banking app.
+
+- **Sync Gmail** — search Gmail for likely invoices / payment-due messages and import or update queue entries through the existing Google Workspace bridge
+- **Queue** — review vendor, amount, due date, source, confidence, and manual status (`new`, `needs_review`, `ready_to_pay`, `paid`, `ignored`)
+- **Detail view** — inspect the source message summary, warnings, attachments, and a link back to the original Gmail message when available
+- **Copy-ready payment fields** — payee, account holder, account number, sort code, IBAN, SWIFT, routing number, amount, reference, invoice number, due date, and other extracted details
+- **Manual-review only** — the page never initiates transfers; it organizes details for you to copy into your banking app
+
+See [Payments Review](./payments.md) for the full workflow and current limitations.
 
 ### Profiles
 

--- a/website/docs/user-guide/skills/optional/payments/payments-stripe-projects.md
+++ b/website/docs/user-guide/skills/optional/payments/payments-stripe-projects.md
@@ -44,7 +44,7 @@ Trigger phrases:
 - "manage my stack credentials", "rotate this key", "upgrade my plan"
 - "what providers can I add?"
 
-If the user already has a provider account, this skill can still connect it with `stripe projects link &lt;provider>`. If the user wants to use an existing provider resource, such as an existing database or Vercel project, check provider support first; many providers currently support provisioning new resources but not importing existing ones.
+If the user already has a provider account, this skill can still connect it with `stripe projects link <provider>`. If the user wants to use an existing provider resource, such as an existing database or Vercel project, check provider support first; many providers currently support provisioning new resources but not importing existing ones.
 
 ## Prerequisites
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md
@@ -1,0 +1,246 @@
+---
+title: "Vault Para Triage"
+sidebar_label: "Vault Para Triage"
+description: "Capture an Obsidian inbox into a canonical capture event log, stage PARA projections for downstream stores, and learn from Slack feedback"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Vault Para Triage
+
+Capture an Obsidian inbox into a canonical capture event log, stage PARA projections for downstream stores, and learn from Slack feedback.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/productivity/vault-para-triage` |
+| Path | `optional-skills/productivity/vault-para-triage` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `para`, `vault`, `notes`, `cron`, `slack`, `routing`, `frontmatter` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`slack-surfaces`](/docs/user-guide/skills/bundled/productivity/productivity-slack-surfaces) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Vault PARA Triage
+
+Use this optional skill when the user wants Hermes to clean up an Obsidian inbox
+into a PARA-organized note system on a schedule, while keeping a canonical
+capture event log, downstream staged projections, an audit trail, and a review
+loop.
+
+This skill ships a helper script, `scripts/vault_para_triage.py`, backed by the
+shared `hermes_cli.vault_para_triage` module.
+
+## What it does
+
+For each markdown note in the configured inbox folder:
+
+1. ensures YAML frontmatter exists
+2. classifies the note into a canonical PARA target folder
+3. writes canonical markdown content into a capture event log
+4. stages one projected file per enabled downstream store
+5. archives the original inbox note into the capture root
+6. writes immutable audit and status records
+7. marks uncertain routes for review and learns from later feedback
+
+The review loop is designed to pair with the bundled `vault-triage-feedback`
+plugin, which exposes `/para-feedback` inside Slack and other chat surfaces.
+
+## Default paths
+
+- Vault path: `OBSIDIAN_VAULT_PATH`, otherwise `~/Documents/Obsidian Vault`
+- Config file: `<vault>/.hermes/para-triage.yaml`
+- Audit/state root: `<vault>/.hermes/para-triage/`
+- Capture root: `<vault>/.hermes/note-capture/`
+
+The capture root is the canonical handoff point for external sync jobs. Hermes
+does not write directly into the projected vault or second-brain destinations.
+
+## Locate the helper script
+
+```bash
+SCRIPT="$(find ~/.hermes/skills -path '*/vault-para-triage/scripts/vault_para_triage.py' -print -quit)"
+```
+
+If `SCRIPT` is empty, install the skill first.
+
+## Install
+
+```bash
+hermes skills search vault-para-triage
+hermes skills install official/productivity/vault-para-triage
+```
+
+Enable the feedback plugin so `/para-feedback` is available:
+
+```bash
+hermes plugins enable vault-triage-feedback
+```
+
+## Minimal config
+
+Create `<vault>/.hermes/para-triage.yaml`:
+
+```yaml
+inbox_dir: Inbox
+para_roots:
+  projects: Projects
+  areas: Areas
+  resources: Resources
+  archives: Archives
+review_dir: Resources/_Inbox Review
+capture:
+  root: .hermes/note-capture
+  source_archive_dir: source-archive
+projection:
+  stores:
+    vault:
+      enabled: true
+      path_prefix: ""
+    second_brain:
+      enabled: true
+      path_prefix: ""
+routing:
+  min_confidence: 0.72
+  low_confidence_action: review   # one of: review, inbox, auto-file
+  rules:
+    - name: health-notes
+      match_any: ["health", "doctor", "medication"]
+      target: Areas/Health
+      confidence: 0.95
+      reason: Health-related notes belong in Areas/Health.
+    - name: taxes
+      match_any: ["tax", "hmrc", "invoice"]
+      target: Areas/Finance
+      confidence: 0.95
+```
+
+Add more explicit rules as the vault evolves. The helper also stores learned
+examples from reviewer corrections under `.hermes/para-triage/routing_examples.json`.
+
+Projection rules:
+
+- Hermes first decides one canonical logical `target`, such as `Projects/Acme`
+  or `Resources/Content Library`.
+- For each enabled store, Hermes derives the projected relative path as
+  `<path_prefix>/<target>/<filename>`.
+- Hermes stages files under
+  `.hermes/note-capture/staging/<store>/<entry_id>/<projected-relative-path>`.
+- Hermes archives the original note under
+  `.hermes/note-capture/source-archive/<entry_id>/<original-relative-path>`.
+- Hermes records the canonical event under
+  `.hermes/note-capture/events/<entry_id>.json`.
+- External sync outside the Hermes trust boundary is responsible for projecting
+  staged files into the live vault, iCloud, second brain, or other stores.
+
+Low-confidence behavior:
+
+- `review` — stage uncertain notes to `review_dir`
+- `inbox` — keep uncertain notes mapped to their inbox-relative location
+- `auto-file` — still stage uncertain notes to the predicted target, then rely on Slack corrections
+
+## Dry-run and status
+
+Preview the next triage pass:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" run --dry-run
+```
+
+Inspect audit and review state:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" feedback list --limit 20
+```
+
+Inspect canonical capture status:
+
+```bash
+cat "$OBSIDIAN_VAULT_PATH/.hermes/note-capture/status/latest.json"
+```
+
+## Overnight cron job
+
+Use a script-only cron job so the canonical capture logic runs the same way
+every night and the output can be delivered directly to Slack.
+
+First install a cron-safe launcher into `~/.hermes/scripts/`:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper
+```
+
+This prints the generated path, usually:
+
+```text
+~/.hermes/scripts/vault-para-triage-nightly.py
+```
+
+Then schedule that generated wrapper:
+
+```bash
+hermes cron create "0 2 * * *" \
+  --name "Vault PARA triage" \
+  --deliver slack:C0B6MV5RA06 \
+  --script ~/.hermes/scripts/vault-para-triage-nightly.py \
+  --no-agent
+```
+
+For this rollout, `slack:C0B6MV5RA06` is the explicit `#hermes-ops` channel
+target. Using the raw Slack channel ID is safer than relying on name
+resolution.
+
+If the scheduler environment on your machine does not preserve
+`OBSIDIAN_VAULT_PATH`, the generated wrapper already bakes in the absolute vault
+and config path you passed to `install-wrapper`, so cron does not need that env
+var later.
+
+If you want a different filename or output mode:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper \
+  --name para-nightly-review.py \
+  --format slack
+```
+
+## Slack feedback loop
+
+After the nightly run posts to Slack, review uncertain entries with:
+
+```text
+/para-feedback list
+/para-feedback approve <entry_id>
+/para-feedback correct <entry_id> Areas/Health
+/para-feedback ignore <entry_id>
+/para-feedback status
+```
+
+For an on-demand audit summary, use:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+```
+
+`approve` and `correct` both teach future runs. `correct` rewrites the staged
+projection targets for the current capture event to the supplied canonical
+target path.
+
+## Notes
+
+- The helper remembers the vault structure by snapshotting available PARA
+  folders on every run into `.hermes/para-triage/structure.json`.
+- Canonical captures are logged under `.hermes/note-capture/events/`.
+- Projected store health is summarized in `.hermes/note-capture/status/latest.json`.
+- All capture audit rows are logged to `.hermes/para-triage/audit.jsonl`.
+- Reviewer actions are logged separately to `.hermes/para-triage/feedback.jsonl`.
+- This keeps the capability outside Hermes core tools while still making it
+  schedulable and auditable.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -112,6 +112,7 @@ const sidebars: SidebarsConfig = {
           label: 'Management',
           items: [
             'user-guide/features/web-dashboard',
+            'user-guide/features/payments',
             'user-guide/features/extending-the-dashboard',
             'user-guide/features/api-server',
             'user-guide/features/subscription-proxy',


### PR DESCRIPTION
## Summary
- add the payments ops surface across CLI, web UI, and plugins
- add the payments Slack surface helper and payments subcommand wiring
- include related payments tests and supporting runtime changes

## Notes
- split out from the broader local worktree cleanup so payments can review independently