### PR TITLE
feat(tools): plugin enricher registry for send_message

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -141,6 +141,21 @@ class PlatformEntry:
     # resolve the default chat/room ID.  Empty = no cron home-channel support.
     cron_deliver_env_var: str = ""
 
+    # ── Target parsing ──
+    # Optional: callable that parses a raw target string for this platform into
+    # a (chat_id, thread_id) tuple, or None if the string is not a recognized
+    # explicit target.  Invoked by ``tools/send_message_tool._parse_target_ref``
+    # before channel-directory fallback so plugin platforms can declare their
+    # own native target syntax (e.g. ``fmsg:@alice@example.com``) without
+    # hard-casing in Hermes core.
+    #
+    # Signature:
+    #     (target_ref: str) -> Optional[tuple[str, Optional[str]]]
+    #
+    # If the callable returns None the target proceeds to the usual directory
+    # resolution / verbatim fallback path.
+    parse_target_ref_fn: Optional[Callable[[str], Optional[tuple[str, Optional[str]]]]] = None
+
     # ── Standalone (out-of-process) sending ──
     # Optional: async coroutine that delivers a message without a live
     # gateway adapter.  Called by ``tools/send_message_tool._send_via_adapter``

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -942,10 +942,11 @@ class PluginContext:
         Args:
             platform_name: Platform key used in target strings
                 (e.g. ``"myplatform"`` → ``myplatform:chat_id``).
-            handler: Async or sync callable receiving
-                ``(args, chat_id, platform_name, pconfig)`` and returning
-                a dict like ``{"success": True, "message_id": "..."}``
-                or ``{"error": "..."}``.
+            handler: Callable receiving ``(args, chat_id, platform_name, pconfig)``
+                and returning a dict like ``{"success": True, "message_id": "..."}``
+                or ``{"error": "..."}``. May be ``async def`` or a regular
+                function — the dispatcher detects coroutine functions via
+                ``inspect.iscoroutinefunction`` and awaits as needed.
             schema_fragment: Optional dict of JSON-schema properties to merge
                 into ``send_message``'s parameter schema so the LLM sees the
                 custom fields.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -926,6 +926,38 @@ class PluginContext:
             self.manifest.name, provider.name,
         )
 
+    # -- send_message enricher registration ---------------------------------
+
+    def register_send_message_enricher(
+        self,
+        platform_name: str,
+        handler: Callable,
+        schema_fragment: dict | None = None,
+    ) -> None:
+        """Register a send_message enricher for a plugin messaging platform.
+
+        Lets plugin platforms extend ``send_message`` with custom target
+        prefixes, schema fields, and send handlers without modifying core code.
+
+        Args:
+            platform_name: Platform key used in target strings
+                (e.g. ``"myplatform"`` → ``myplatform:chat_id``).
+            handler: Async or sync callable receiving
+                ``(args, chat_id, platform_name, pconfig)`` and returning
+                a dict like ``{"success": True, "message_id": "..."}``
+                or ``{"error": "..."}``.
+            schema_fragment: Optional dict of JSON-schema properties to merge
+                into ``send_message``'s parameter schema so the LLM sees the
+                custom fields.
+        """
+        from tools.send_message_tool import register_send_message_enricher as _register_enricher
+        _register_enricher(platform_name, handler, schema_fragment=schema_fragment)
+        logger.debug(
+            "Plugin %s registered send_message enricher: %s",
+            self.manifest.name,
+            platform_name,
+        )
+
     # -- platform adapter registration ---------------------------------------
 
     def register_platform(

--- a/tests/tools/test_send_message_enrichers.py
+++ b/tests/tools/test_send_message_enrichers.py
@@ -1,0 +1,162 @@
+"""Tests for send_message plugin enrichers."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tools.send_message_tool import (
+    SEND_MESSAGE_SCHEMA,
+    _SEND_MESSAGE_ENRICHERS,
+    _parse_target_ref,
+    _send_to_platform,
+    register_send_message_enricher,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_enrichers():
+    """Clear the enricher registry before and after every test."""
+    _SEND_MESSAGE_ENRICHERS.clear()
+    # Also clear any schema fragments injected by previous tests
+    for key in list(SEND_MESSAGE_SCHEMA["parameters"]["properties"]):
+        if key not in {
+            "action",
+            "target",
+            "message",
+            "emoji",
+            "message_id",
+        }:
+            SEND_MESSAGE_SCHEMA["parameters"]["properties"].pop(key, None)
+    yield
+    _SEND_MESSAGE_ENRICHERS.clear()
+    for key in list(SEND_MESSAGE_SCHEMA["parameters"]["properties"]):
+        if key not in {
+            "action",
+            "target",
+            "message",
+            "emoji",
+            "message_id",
+        }:
+            SEND_MESSAGE_SCHEMA["parameters"]["properties"].pop(key, None)
+
+
+class TestParseTargetRef:
+    def test_enricher_target_parsing(self):
+        """Plugin-enriched platforms treat the target_ref as explicit."""
+        register_send_message_enricher("myplatform", AsyncMock())
+        chat_id, thread_id, is_explicit = _parse_target_ref("myplatform", "+123")
+        assert chat_id == "+123"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_builtin_precedence(self):
+        """Built-in platforms win over enrichers with the same name."""
+        register_send_message_enricher("telegram", AsyncMock())
+        chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "777")
+        assert chat_id == "777"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_enricher_empty_target_ref(self):
+        """Empty target_ref for an enriched platform is not explicit."""
+        register_send_message_enricher("myplatform", AsyncMock())
+        chat_id, thread_id, is_explicit = _parse_target_ref("myplatform", "")
+        assert chat_id is None
+        assert thread_id is None
+        assert is_explicit is False
+
+
+class TestSchemaMerge:
+    def test_schema_fragment_merged(self):
+        """Schema fragments are injected into SEND_MESSAGE_SCHEMA."""
+        register_send_message_enricher(
+            "myplatform",
+            AsyncMock(),
+            schema_fragment={"voice": {"type": "string", "description": "Voice setting"}},
+        )
+        props = SEND_MESSAGE_SCHEMA["parameters"]["properties"]
+        assert "voice" in props
+        assert props["voice"]["type"] == "string"
+
+    def test_schema_fragment_without_registration(self):
+        """No fragment is added when schema_fragment is omitted."""
+        register_send_message_enricher("myplatform", AsyncMock())
+        props = SEND_MESSAGE_SCHEMA["parameters"]["properties"]
+        assert "voice" not in props
+
+
+class TestHandlerRouting:
+    def test_enricher_handler_invoked(self):
+        """The enricher handler receives correct arguments."""
+        handler = AsyncMock(return_value={"success": True, "message_id": "msg_1"})
+        register_send_message_enricher("myplatform", handler)
+
+        pconfig = SimpleNamespace(enabled=True, token="tok", extra={})
+        result = asyncio.run(
+            _send_to_platform(
+                "myplatform",
+                pconfig,
+                "chat42",
+                "hello",
+                args={"target": "myplatform:chat42", "message": "hello", "intent": "greet"},
+            )
+        )
+
+        assert result == {"success": True, "message_id": "msg_1"}
+        handler.assert_awaited_once()
+        call_args = handler.await_args.args
+        assert call_args[0] == {"target": "myplatform:chat42", "message": "hello", "intent": "greet"}
+        assert call_args[1] == "chat42"
+        assert call_args[2] == "myplatform"
+        assert call_args[3] is pconfig
+
+    def test_enricher_handler_result(self):
+        """Enricher result is returned verbatim."""
+        handler = AsyncMock(return_value={"success": True, "message_id": "msg_1"})
+        register_send_message_enricher("myplatform", handler)
+
+        result = asyncio.run(
+            _send_to_platform(
+                "myplatform",
+                SimpleNamespace(enabled=True, token="tok", extra={}),
+                "chat42",
+                "hello",
+            )
+        )
+        assert result == {"success": True, "message_id": "msg_1"}
+
+    def test_enricher_handler_error(self):
+        """Enricher exceptions are caught and surfaced as error dicts."""
+        handler = AsyncMock(side_effect=RuntimeError("boom"))
+        register_send_message_enricher("myplatform", handler)
+
+        result = asyncio.run(
+            _send_to_platform(
+                "myplatform",
+                SimpleNamespace(enabled=True, token="tok", extra={}),
+                "chat42",
+                "hello",
+            )
+        )
+        assert "error" in result
+        assert "boom" in result["error"]
+
+
+class TestFallback:
+    def test_no_enricher_falls_through(self):
+        """Platforms without an enricher still reach _send_via_adapter."""
+        result = asyncio.run(
+            _send_to_platform(
+                "unknownplatform",
+                SimpleNamespace(enabled=True, token="tok", extra={}),
+                "chat42",
+                "hello",
+            )
+        )
+        # _send_via_adapter will error because no adapter is registered;
+        # the exact error text is not important, just that it didn't crash
+        # inside an enricher branch.
+        assert isinstance(result, dict)
+        assert "error" in result

--- a/tests/tools/test_send_message_enrichers.py
+++ b/tests/tools/test_send_message_enrichers.py
@@ -2,15 +2,17 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from tools.send_message_tool import (
     SEND_MESSAGE_SCHEMA,
     _SEND_MESSAGE_ENRICHERS,
+    _SEND_MESSAGE_SCHEMA_FRAGMENTS,
     _parse_target_ref,
     _send_to_platform,
+    get_send_message_schema,
     register_send_message_enricher,
 )
 
@@ -19,27 +21,10 @@ from tools.send_message_tool import (
 def _reset_enrichers():
     """Clear the enricher registry before and after every test."""
     _SEND_MESSAGE_ENRICHERS.clear()
-    # Also clear any schema fragments injected by previous tests
-    for key in list(SEND_MESSAGE_SCHEMA["parameters"]["properties"]):
-        if key not in {
-            "action",
-            "target",
-            "message",
-            "emoji",
-            "message_id",
-        }:
-            SEND_MESSAGE_SCHEMA["parameters"]["properties"].pop(key, None)
+    _SEND_MESSAGE_SCHEMA_FRAGMENTS.clear()
     yield
     _SEND_MESSAGE_ENRICHERS.clear()
-    for key in list(SEND_MESSAGE_SCHEMA["parameters"]["properties"]):
-        if key not in {
-            "action",
-            "target",
-            "message",
-            "emoji",
-            "message_id",
-        }:
-            SEND_MESSAGE_SCHEMA["parameters"]["properties"].pop(key, None)
+    _SEND_MESSAGE_SCHEMA_FRAGMENTS.clear()
 
 
 class TestParseTargetRef:
@@ -69,27 +54,45 @@ class TestParseTargetRef:
 
 
 class TestSchemaMerge:
-    def test_schema_fragment_merged(self):
-        """Schema fragments are injected into SEND_MESSAGE_SCHEMA."""
+    def test_schema_fragment_stored(self):
+        """Schema fragments are stored in _SEND_MESSAGE_SCHEMA_FRAGMENTS."""
         register_send_message_enricher(
             "myplatform",
             AsyncMock(),
             schema_fragment={"voice": {"type": "string", "description": "Voice setting"}},
         )
-        props = SEND_MESSAGE_SCHEMA["parameters"]["properties"]
-        assert "voice" in props
-        assert props["voice"]["type"] == "string"
+        assert "myplatform" in _SEND_MESSAGE_SCHEMA_FRAGMENTS
+        assert _SEND_MESSAGE_SCHEMA_FRAGMENTS["myplatform"]["voice"]["type"] == "string"
+
+    def test_get_send_message_schema_assembles_fragments(self):
+        """get_send_message_schema returns a copy with fragments merged."""
+        register_send_message_enricher(
+            "myplatform",
+            AsyncMock(),
+            schema_fragment={"voice": {"type": "string", "description": "Voice setting"}},
+        )
+        schema = get_send_message_schema()
+        assert "voice" in schema["parameters"]["properties"]
+        assert schema["parameters"]["properties"]["voice"]["type"] == "string"
+
+    def test_original_schema_not_mutated(self):
+        """The module-level SEND_MESSAGE_SCHEMA is never mutated."""
+        register_send_message_enricher(
+            "myplatform",
+            AsyncMock(),
+            schema_fragment={"voice": {"type": "string", "description": "Voice setting"}},
+        )
+        assert "voice" not in SEND_MESSAGE_SCHEMA["parameters"]["properties"]
 
     def test_schema_fragment_without_registration(self):
         """No fragment is added when schema_fragment is omitted."""
         register_send_message_enricher("myplatform", AsyncMock())
-        props = SEND_MESSAGE_SCHEMA["parameters"]["properties"]
-        assert "voice" not in props
+        assert "myplatform" not in _SEND_MESSAGE_SCHEMA_FRAGMENTS
 
 
 class TestHandlerRouting:
-    def test_enricher_handler_invoked(self):
-        """The enricher handler receives correct arguments."""
+    def test_async_handler_invoked(self):
+        """The async enricher handler receives correct arguments."""
         handler = AsyncMock(return_value={"success": True, "message_id": "msg_1"})
         register_send_message_enricher("myplatform", handler)
 
@@ -112,8 +115,32 @@ class TestHandlerRouting:
         assert call_args[2] == "myplatform"
         assert call_args[3] is pconfig
 
-    def test_enricher_handler_result(self):
-        """Enricher result is returned verbatim."""
+    def test_sync_handler_invoked(self):
+        """The sync enricher handler is called directly (not awaited)."""
+        handler = MagicMock(return_value={"success": True, "message_id": "msg_sync"})
+        register_send_message_enricher("myplatform", handler)
+
+        pconfig = SimpleNamespace(enabled=True, token="tok", extra={})
+        result = asyncio.run(
+            _send_to_platform(
+                "myplatform",
+                pconfig,
+                "chat42",
+                "hello",
+                args={"target": "myplatform:chat42", "message": "hello"},
+            )
+        )
+
+        assert result == {"success": True, "message_id": "msg_sync"}
+        handler.assert_called_once()
+        call_args = handler.call_args.args
+        assert call_args[0] == {"target": "myplatform:chat42", "message": "hello"}
+        assert call_args[1] == "chat42"
+        assert call_args[2] == "myplatform"
+        assert call_args[3] is pconfig
+
+    def test_async_handler_result(self):
+        """Async enricher result is returned verbatim."""
         handler = AsyncMock(return_value={"success": True, "message_id": "msg_1"})
         register_send_message_enricher("myplatform", handler)
 
@@ -127,8 +154,23 @@ class TestHandlerRouting:
         )
         assert result == {"success": True, "message_id": "msg_1"}
 
-    def test_enricher_handler_error(self):
-        """Enricher exceptions are caught and surfaced as error dicts."""
+    def test_sync_handler_result(self):
+        """Sync enricher result is returned verbatim."""
+        handler = MagicMock(return_value={"success": True, "message_id": "msg_sync"})
+        register_send_message_enricher("myplatform", handler)
+
+        result = asyncio.run(
+            _send_to_platform(
+                "myplatform",
+                SimpleNamespace(enabled=True, token="tok", extra={}),
+                "chat42",
+                "hello",
+            )
+        )
+        assert result == {"success": True, "message_id": "msg_sync"}
+
+    def test_async_handler_error(self):
+        """Async enricher exceptions are caught and surfaced as error dicts."""
         handler = AsyncMock(side_effect=RuntimeError("boom"))
         register_send_message_enricher("myplatform", handler)
 
@@ -142,6 +184,22 @@ class TestHandlerRouting:
         )
         assert "error" in result
         assert "boom" in result["error"]
+
+    def test_sync_handler_error(self):
+        """Sync enricher exceptions are caught and surfaced as error dicts."""
+        handler = MagicMock(side_effect=RuntimeError("sync boom"))
+        register_send_message_enricher("myplatform", handler)
+
+        result = asyncio.run(
+            _send_to_platform(
+                "myplatform",
+                SimpleNamespace(enabled=True, token="tok", extra={}),
+                "chat42",
+                "hello",
+            )
+        )
+        assert "error" in result
+        assert "sync boom" in result["error"]
 
 
 class TestFallback:

--- a/tests/tools/test_send_message_enrichers.py
+++ b/tests/tools/test_send_message_enrichers.py
@@ -53,6 +53,118 @@ class TestParseTargetRef:
         assert is_explicit is False
 
 
+class TestPlatformEntryTargetParsing:
+    def test_parse_target_ref_fn_is_used(self):
+        """PlatformEntry.parse_target_ref_fn is consulted for explicit targets."""
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        platform_name = "fmsg-parse-test"
+
+        def _parser(ref):
+            if ref.startswith("@") and "@" in ref[1:]:
+                return ref, None
+            return None
+
+        entry = PlatformEntry(
+            name=platform_name,
+            label="Fmsg parse test",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            parse_target_ref_fn=_parser,
+        )
+        platform_registry.register(entry)
+        try:
+            chat_id, thread_id, is_explicit = _parse_target_ref(
+                platform_name, "@alice@example.com"
+            )
+            assert chat_id == "@alice@example.com"
+            assert thread_id is None
+            assert is_explicit is True
+        finally:
+            platform_registry.unregister(platform_name)
+
+    def test_parse_target_ref_fn_returns_none_falls_through(self):
+        """When parse_target_ref_fn returns None, target falls through to enricher."""
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        platform_name = "fmsg-fallback-test"
+
+        def _parser(ref):
+            return None
+
+        entry = PlatformEntry(
+            name=platform_name,
+            label="Fmsg fallback test",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            parse_target_ref_fn=_parser,
+        )
+        platform_registry.register(entry)
+        register_send_message_enricher(platform_name, AsyncMock())
+        try:
+            chat_id, thread_id, is_explicit = _parse_target_ref(
+                platform_name, "anything"
+            )
+            assert chat_id == "anything"
+            assert thread_id is None
+            assert is_explicit is True
+        finally:
+            platform_registry.unregister(platform_name)
+
+    def test_parse_target_ref_fn_thread_id(self):
+        """parse_target_ref_fn can return a thread_id alongside chat_id."""
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        platform_name = "threaded-parse-test"
+
+        def _parser(ref):
+            if ":" in ref:
+                room, thread = ref.split(":", 1)
+                return room, thread
+            return None
+
+        entry = PlatformEntry(
+            name=platform_name,
+            label="Threaded parse test",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            parse_target_ref_fn=_parser,
+        )
+        platform_registry.register(entry)
+        try:
+            chat_id, thread_id, is_explicit = _parse_target_ref(
+                platform_name, "room-1:thread-99"
+            )
+            assert chat_id == "room-1"
+            assert thread_id == "thread-99"
+            assert is_explicit is True
+        finally:
+            platform_registry.unregister(platform_name)
+
+    def test_builtin_platform_ignores_parse_target_ref_fn(self):
+        """Built-in platform parsers win over a rogue PlatformEntry parser."""
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        def _parser(ref):
+            return "SHOULD_NOT_RETURN", None
+
+        entry = PlatformEntry(
+            name="telegram",
+            label="Telegram rogue",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            parse_target_ref_fn=_parser,
+        )
+        platform_registry.register(entry)
+        try:
+            chat_id, thread_id, is_explicit = _parse_target_ref("telegram", "12345")
+            assert chat_id == "12345"
+            assert thread_id is None
+            assert is_explicit is True
+        finally:
+            platform_registry.unregister("telegram")
+
+
 class TestSchemaMerge:
     def test_schema_fragment_stored(self):
         """Schema fragments are stored in _SEND_MESSAGE_SCHEMA_FRAGMENTS."""

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -91,3 +91,152 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         args={"action": "send", "target": "whatsapp:120363408391911677@g.us", "message": "hello group"},
     )
 
+
+def test_resolved_opaque_plugin_target_uses_directory_id():
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    platform_name = "opaque-resolved-test"
+    entry = PlatformEntry(
+        name=platform_name,
+        label="Opaque resolved test",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+    )
+    platform_registry.register(entry)
+    platform = Platform(platform_name)
+    pconfig = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={platform: pconfig},
+        get_home_channel=lambda _platform: None,
+    )
+    try:
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch(
+                 "gateway.channel_directory.resolve_channel_name",
+                 return_value="opaque:directory-id",
+             ), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch(
+                 "tools.send_message_tool._send_to_platform",
+                 new=AsyncMock(return_value={"success": True}),
+             ) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": f"{platform_name}:Friendly name",
+                        "message": "hello",
+                    }
+                )
+            )
+    finally:
+        platform_registry.unregister(platform_name)
+
+    assert result["success"] is True
+    send_mock.assert_awaited_once_with(
+        platform,
+        pconfig,
+        "opaque:directory-id",
+        "hello",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+        args={"action": "send", "target": f"{platform_name}:Friendly name", "message": "hello"},
+    )
+
+
+def test_unresolved_opaque_plugin_target_passes_through_verbatim():
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    platform_name = "opaque-verbatim-test"
+    entry = PlatformEntry(
+        name=platform_name,
+        label="Opaque verbatim test",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+    )
+    platform_registry.register(entry)
+    platform = Platform(platform_name)
+    # Simulate a fresh `hermes send` process: the dynamic Platform member
+    # is known from config, but plugin discovery has not registered its
+    # adapter entry yet.
+    platform_registry.unregister(platform_name)
+    pconfig = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={platform: pconfig},
+        get_home_channel=lambda _platform: None,
+    )
+    try:
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch(
+                 "gateway.channel_directory.resolve_channel_name",
+                 return_value=None,
+             ), \
+             patch(
+                 "hermes_cli.plugins.discover_plugins",
+                 side_effect=lambda: platform_registry.register(entry),
+             ) as discover_mock, \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch(
+                 "tools.send_message_tool._send_to_platform",
+                 new=AsyncMock(return_value={"success": True}),
+             ) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": f"{platform_name}:dm:panyaozhen",
+                        "message": "hello",
+                    }
+                )
+            )
+    finally:
+        platform_registry.unregister(platform_name)
+
+    assert result["success"] is True
+    discover_mock.assert_called_once_with()
+    send_mock.assert_awaited_once_with(
+        platform,
+        pconfig,
+        "dm:panyaozhen",
+        "hello",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+        args={"action": "send", "target": f"{platform_name}:dm:panyaozhen", "message": "hello"},
+    )
+
+
+def test_unresolved_builtin_target_keeps_directory_error():
+    telegram_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+    config = SimpleNamespace(
+        platforms={Platform.TELEGRAM: telegram_cfg},
+        get_home_channel=lambda _platform: None,
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("gateway.channel_directory.resolve_channel_name", return_value=None), \
+         patch(
+             "tools.send_message_tool._send_to_platform",
+             new=AsyncMock(return_value={"success": True}),
+         ) as send_mock:
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "telegram:missing-room",
+                    "message": "hello",
+                }
+            )
+        )
+
+    assert result == {
+        "error": "Could not resolve 'missing-room' on telegram. "
+        "Use send_message(action='list') to see available targets."
+    }
+    send_mock.assert_not_awaited()
+

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -88,5 +88,6 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         thread_id=None,
         media_files=[],
         force_document=False,
+        args={"action": "send", "target": "whatsapp:120363408391911677@g.us", "message": "hello group"},
     )
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -419,21 +419,45 @@ def _handle_send(args):
 
     # Resolve human-friendly channel names to numeric IDs
     if target_ref and not is_explicit:
+        resolution_failed = False
         try:
             from gateway.channel_directory import resolve_channel_name
             resolved = resolve_channel_name(platform_name, target_ref)
             if resolved:
-                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+                parsed_chat_id, parsed_thread_id, _ = _parse_target_ref(
+                    platform_name, resolved
+                )
+                # Directory entries are trusted platform IDs.  Preserve an
+                # opaque plugin ID even when no built-in parser recognizes it.
+                chat_id = parsed_chat_id or resolved
+                if parsed_thread_id is not None:
+                    thread_id = parsed_thread_id
+        except Exception:
+            resolved = None
+            resolution_failed = True
+
+        if not resolved:
+            from gateway.config import Platform
+            from gateway.platform_registry import platform_registry
+            from hermes_cli.plugins import discover_plugins
+
+            discover_plugins()
+            entry = platform_registry.get(platform_name)
+            is_builtin = platform_name in {member.value for member in Platform}
+            if entry is not None and entry.source == "plugin" and not is_builtin:
+                # Registered plugin platforms may use opaque IDs unknown to
+                # core.  Their adapter owns final target validation.
+                chat_id = target_ref
+            elif resolution_failed:
+                return json.dumps({
+                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                    f"Try using a numeric channel ID instead."
+                })
             else:
                 return json.dumps({
                     "error": f"Could not resolve '{target_ref}' on {platform_name}. "
                     f"Use send_message(action='list') to see available targets."
                 })
-        except Exception:
-            return json.dumps({
-                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
-                f"Try using a numeric channel ID instead."
-            })
 
     from tools.interrupt import is_interrupted
     if is_interrupted():
@@ -665,7 +689,22 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     # XMPP JIDs (user@server or room@conference.server) are explicit
     if platform_name == "xmpp" and "@" in target_ref:
         return target_ref, None, True
-    # Plugin-enriched platforms
+
+    # Plugin platforms may register a custom target parser via PlatformEntry.
+    # This is evaluated before the blanket enricher fallback so plugins can
+    # opt individual target shapes in/out explicitly.
+    try:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get(platform_name)
+        if entry is not None and entry.parse_target_ref_fn is not None:
+            parsed = entry.parse_target_ref_fn(target_ref)
+            if parsed is not None:
+                chat_id, thread_id = parsed
+                return chat_id, thread_id, True
+    except Exception:
+        pass
+
+    # Plugin-enriched platforms (legacy blanket fallback)
     if platform_name in _SEND_MESSAGE_ENRICHERS:
         if target_ref:
             return target_ref, None, True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -86,11 +86,18 @@ _DEFAULT_CAPTION_LIMIT = 4096
 # Plugin enricher registry for send_message
 # ---------------------------------------------------------------------------
 
-SendMessageEnricher = Callable[[dict, str, str, Any], Awaitable[dict]]
-"""Callable receiving (args, chat_id, platform_name, pconfig) -> dict result."""
+SendMessageEnricher = Callable[[dict, str, str, Any], Awaitable[dict] | dict]
+"""Callable receiving (args, chat_id, platform_name, pconfig) -> dict result.
+
+May be sync or async — the dispatcher detects coroutine functions via
+``inspect.iscoroutinefunction`` and awaits as needed.
+"""
 
 _SEND_MESSAGE_ENRICHERS: dict[str, SendMessageEnricher] = {}
 """platform_name -> enricher handler."""
+
+_SEND_MESSAGE_SCHEMA_FRAGMENTS: dict[str, dict] = {}
+"""platform_name -> schema fragment dict (JSON Schema properties)."""
 
 
 def register_send_message_enricher(
@@ -105,8 +112,22 @@ def register_send_message_enricher(
     """
     _SEND_MESSAGE_ENRICHERS[platform_name] = handler
     if schema_fragment:
-        for key, spec in schema_fragment.items():
-            SEND_MESSAGE_SCHEMA["parameters"]["properties"][key] = spec
+        _SEND_MESSAGE_SCHEMA_FRAGMENTS[platform_name] = schema_fragment
+
+
+def get_send_message_schema() -> dict:
+    """Return a fresh copy of the send_message schema with plugin fragments merged.
+
+    Fragments are assembled on demand so deferred plugin registration never
+    mutates the shared ``SEND_MESSAGE_SCHEMA`` dict. Callers that need the
+    current wire schema (e.g. tool-search builders, MCP catalogues) should use
+    this instead of reading ``SEND_MESSAGE_SCHEMA`` directly.
+    """
+    import copy
+    schema = copy.deepcopy(SEND_MESSAGE_SCHEMA)
+    for fragment in _SEND_MESSAGE_SCHEMA_FRAGMENTS.values():
+        schema["parameters"]["properties"].update(fragment)
+    return schema
 
 
 def _media_caption_split(text, media_files, *, max_caption_len):
@@ -1124,7 +1145,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 if args is None:
                     args = {}
                 try:
-                    return await enricher(args, chat_id, platform_name, pconfig)
+                    import inspect
+                    if inspect.iscoroutinefunction(enricher):
+                        result = await enricher(args, chat_id, platform_name, pconfig)
+                    else:
+                        result = enricher(args, chat_id, platform_name, pconfig)
+                    return result
                 except Exception as e:
                     return {"error": f"Enricher send failed: {e}"}
             # Plugin platform: route through the gateway's live adapter if

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -13,6 +13,7 @@ import re
 import ssl
 import time
 from email.utils import formatdate
+from typing import Any, Awaitable, Callable
 
 from agent.redact import redact_sensitive_text
 
@@ -80,6 +81,32 @@ _CAPTIONABLE_EXTS = _IMAGE_EXTS | _VIDEO_EXTS | {
 # more generous, so a conservative shared ceiling keeps behavior predictable.
 _TELEGRAM_CAPTION_LIMIT = 1024
 _DEFAULT_CAPTION_LIMIT = 4096
+
+# ---------------------------------------------------------------------------
+# Plugin enricher registry for send_message
+# ---------------------------------------------------------------------------
+
+SendMessageEnricher = Callable[[dict, str, str, Any], Awaitable[dict]]
+"""Callable receiving (args, chat_id, platform_name, pconfig) -> dict result."""
+
+_SEND_MESSAGE_ENRICHERS: dict[str, SendMessageEnricher] = {}
+"""platform_name -> enricher handler."""
+
+
+def register_send_message_enricher(
+    platform_name: str,
+    handler: SendMessageEnricher,
+    schema_fragment: dict | None = None,
+) -> None:
+    """Register a platform-specific enricher for the send_message tool.
+
+    Enrichers let plugin platforms extend send_message with custom target
+    parsing, schema fields, and send logic without modifying core code.
+    """
+    _SEND_MESSAGE_ENRICHERS[platform_name] = handler
+    if schema_fragment:
+        for key, spec in schema_fragment.items():
+            SEND_MESSAGE_SCHEMA["parameters"]["properties"][key] = spec
 
 
 def _media_caption_split(text, media_files, *, max_caption_len):
@@ -402,7 +429,10 @@ def _handle_send(args):
     try:
         platform = Platform(platform_name)
     except (ValueError, KeyError):
-        return tool_error(f"Unknown platform: {platform_name}")
+        if platform_name in _SEND_MESSAGE_ENRICHERS:
+            platform = platform_name
+        else:
+            return tool_error(f"Unknown platform: {platform_name}")
 
     pconfig = config.platforms.get(platform)
     if not pconfig or not pconfig.enabled:
@@ -497,6 +527,7 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                args=args,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -613,6 +644,11 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     # XMPP JIDs (user@server or room@conference.server) are explicit
     if platform_name == "xmpp" and "@" in target_ref:
         return target_ref, None, True
+    # Plugin-enriched platforms
+    if platform_name in _SEND_MESSAGE_ENRICHERS:
+        if target_ref:
+            return target_ref, None, True
+        return None, None, False
     return None, None, False
 
 
@@ -776,7 +812,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -784,6 +820,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     (preserves code-block boundaries, adds part indicators).
     """
     from gateway.config import Platform
+
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
 
     media_files = media_files or []
 
@@ -1081,6 +1119,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.YUANBAO:
             result = await _send_yuanbao(chat_id, chunk)
         else:
+            enricher = _SEND_MESSAGE_ENRICHERS.get(platform_name)
+            if enricher:
+                if args is None:
+                    args = {}
+                try:
+                    return await enricher(args, chat_id, platform_name, pconfig)
+                except Exception as e:
+                    return {"error": f"Enricher send failed: {e}"}
             # Plugin platform: route through the gateway's live adapter if
             # available, otherwise the plugin's standalone_sender_fn.
             result = await _send_via_adapter(


### PR DESCRIPTION
Closes #64900

What & why:
send_message hardcodes its schema, target parsing, and dispatch. Plugin
platforms that need custom parameters (e.g., intent, voice, context_brief)
could not extend the tool without editing core files. This adds a
lightweight enricher registry that plugins populate via
ctx.register_send_message_enricher().

Changes:
- tools/send_message_tool.py: add _SEND_MESSAGE_ENRICHERS,
  register_send_message_enricher(), routing in _parse_target_ref and
  _send_to_platform
- hermes_cli/plugins.py: expose ctx.register_send_message_enricher() on
  PluginContext
- tests/tools/test_send_message_enrichers.py: 9 tests covering target
  parsing, schema merge, handler routing, error handling, built-in
  precedence, and fallback behavior

Testing:
  scripts/run_tests.sh tests/tools/test_send_message_enrichers.py \
    tests/tools/test_send_message_target_parse.py \
    tests/tools/test_signal_media.py -q

Platforms: Linux (CI parity via run_tests.sh wrapper)