### PR TITLE
fix(chat_completion_helpers): guard against OverflowError when _stale_timeout is inf in wait notice

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -594,10 +594,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 and getattr(agent, "_codex_stream_last_event_ts", None) is None
             ):
                 _deadline = min(_deadline, _ttfb_timeout)
+            _deadline_text = "no limit" if _deadline == float("inf") else f"{int(_deadline)}s"
             agent._emit_wait_notice(
                 f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
                 f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                f"or overloaded; auto-reconnect at {_deadline_text})"
             )
 
         _elapsed = time.time() - _call_start


### PR DESCRIPTION
## Summary

Guard against `OverflowError` in `_emit_wait_notice` when the non-stream stale timeout is `float('inf')`.

## Problem

`_compute_non_stream_stale_timeout` returns `float('inf')` for local endpoints with implicit default timeouts (line 1313 in run_agent.py). The wait-notice heartbeat in `interruptible_api_call` does `int(_deadline)` to format the auto-reconnect ETA, which crashes with `OverflowError: cannot convert float infinity to integer` when the deadline is infinite. This turns a harmless display-layer heartbeat into an uncaught exception that can break the polling loop.

## Fix

Render `"no limit"` instead of `int(_deadline)` when `_deadline == float("inf")`. Minimal 2-line change — only affects the display string.