### PR TITLE
fix(acp): unified diffs, snapshots cache, parent_session_id support

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -231,6 +231,17 @@ def make_step_cb(
                     tool_name = tool_info.get("name") or tool_info.get("function_name")
                     result = tool_info.get("result") or tool_info.get("output")
                     function_args = tool_info.get("arguments") or tool_info.get("args")
+                    # OpenAI tool_call arguments arrive as a JSON string
+                    # (e.g. '{"path":"/foo","offset":1}'), not a dict.
+                    # build_tool_complete() → _format_read_file_result()
+                    # calls .get("path") on it → AttributeError. Parse here
+                    # the same way _tool_progress does on line 138.
+                    if isinstance(function_args, str):
+                        try:
+                            function_args = json.loads(function_args)
+                        except (json.JSONDecodeError, TypeError):
+                            function_args = {}
+                        tool_info["arguments"] = function_args
                 elif isinstance(tool_info, str):
                     tool_name = tool_info
 

--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -154,14 +154,20 @@ def make_tool_progress_cb(
         queue.append(tc_id)
 
         snapshot = None
-        if name in {"write_file", "patch", "skill_manage"}:
+        if name in {"read_file", "write_file", "patch", "skill_manage"}:
             try:
                 from agent.display import capture_local_edit_snapshot
 
                 snapshot = capture_local_edit_snapshot(name, args)
             except Exception:
                 logger.debug("Failed to capture ACP edit snapshot for %s", name, exc_info=True)
-        tool_call_meta[tc_id] = {"args": args, "snapshot": snapshot}
+        meta_entry = {"args": args, "snapshot": snapshot}
+        if name == "read_file":
+            from pathlib import Path
+            rp = args.get("path", "")
+            if rp:
+                meta_entry["_read_path"] = str(Path(rp).resolve())
+        tool_call_meta[tc_id] = meta_entry
 
         edit_diff = None
         if name in {"write_file", "patch"} and edit_approval_policy_getter is not None:
@@ -251,6 +257,30 @@ def make_step_cb(
                     tool_call_ids[tool_name] = queue
                 if tool_name and queue:
                     tc_id = queue.popleft()
+
+                    # For terminal: build composite snapshot from read_file snapshots
+                    # accumulated during this turn. read_file entries are still in
+                    # tool_call_meta (not yet popped).
+                    if tool_name == "terminal":
+                        known: dict[str, str | None] = {}
+                        for tc, m in list(tool_call_meta.items()):
+                            rp = m.get("_read_path")
+                            if rp:
+                                snap = m.get("snapshot")
+                                if snap is not None and hasattr(snap, "before") and rp in snap.before:
+                                    known[rp] = snap.before[rp]
+                        if known:
+                            from pathlib import Path
+                            from agent.display import LocalEditSnapshot
+                            tool_call_meta.setdefault(tc_id, {})["snapshot"] = LocalEditSnapshot(
+                                paths=[Path(p) for p in known],
+                                before=known,
+                            )
+                            logger.debug(
+                                "terminal composite snapshot: %d paths from %d reads",
+                                len(known), sum(1 for m in tool_call_meta.values() if m.get("_read_path")),
+                            )
+
                     meta = tool_call_meta.pop(tc_id, {})
                     update = build_tool_complete(
                         tc_id,

--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -117,6 +117,7 @@ def make_tool_progress_cb(
     loop: asyncio.AbstractEventLoop,
     tool_call_ids: Dict[str, Deque[str]],
     tool_call_meta: Dict[str, Dict[str, Any]],
+    read_snapshots_cache: Dict[str, str | None],
     edit_approval_policy_getter: Callable[[], tuple[str, str | None]] | None = None,
 ) -> Callable:
     """Create a ``tool_progress_callback`` for AIAgent.
@@ -154,7 +155,7 @@ def make_tool_progress_cb(
         queue.append(tc_id)
 
         snapshot = None
-        if name in {"read_file", "write_file", "patch", "skill_manage"}:
+        if name in {"read_file", "write_file", "patch", "skill_manage", "terminal"}:
             try:
                 from agent.display import capture_local_edit_snapshot
 
@@ -168,6 +169,30 @@ def make_tool_progress_cb(
             if rp:
                 meta_entry["_read_path"] = str(Path(rp).resolve())
         tool_call_meta[tc_id] = meta_entry
+
+        # Cross-turn snapshot cache — so terminal in later API calls can build
+        # composite snapshots.  All keys are absolute resolved paths.
+        # write_file / patch / skill_manage: save before-state (only if path
+        #   not already cached — first writer wins, preserving the original
+        #   baseline across multiple edits).
+        # read_file: save current disk content (only if path not cached).
+        if name in {"write_file", "patch", "skill_manage"}:
+            if snapshot is not None and snapshot.before is not None:
+                from pathlib import Path as _P
+                for rp, before_text in snapshot.before.items():
+                    rk = str(_P(rp).resolve())
+                    if rk not in read_snapshots_cache:
+                        read_snapshots_cache[rk] = before_text
+        elif name == "read_file":
+            rp = args.get("path", "")
+            if rp:
+                from pathlib import Path as _P
+                rk = str(_P(rp).resolve())
+                if rk not in read_snapshots_cache:
+                    try:
+                        read_snapshots_cache[rk] = _P(rk).read_text(encoding="utf-8")
+                    except (FileNotFoundError, OSError):
+                        read_snapshots_cache[rk] = None
 
         edit_diff = None
         if name in {"write_file", "patch"} and edit_approval_policy_getter is not None:
@@ -218,6 +243,7 @@ def make_step_cb(
     loop: asyncio.AbstractEventLoop,
     tool_call_ids: Dict[str, Deque[str]],
     tool_call_meta: Dict[str, Dict[str, Any]],
+    read_snapshots_cache: Dict[str, str | None],
 ) -> Callable:
     """Create a ``step_callback`` for AIAgent.
 
@@ -227,7 +253,9 @@ def make_step_cb(
     """
 
     def _step(api_call_count: int, prev_tools: Any = None) -> None:
+
         if prev_tools and isinstance(prev_tools, list):
+            from pathlib import Path
             for tool_info in prev_tools:
                 tool_name = None
                 result = None
@@ -258,27 +286,21 @@ def make_step_cb(
                 if tool_name and queue:
                     tc_id = queue.popleft()
 
-                    # For terminal: build composite snapshot from read_file snapshots
-                    # accumulated during this turn. read_file entries are still in
-                    # tool_call_meta (not yet popped).
-                    if tool_name == "terminal":
-                        known: dict[str, str | None] = {}
-                        for tc, m in list(tool_call_meta.items()):
-                            rp = m.get("_read_path")
-                            if rp:
-                                snap = m.get("snapshot")
-                                if snap is not None and hasattr(snap, "before") and rp in snap.before:
-                                    known[rp] = snap.before[rp]
+                    # Build composite snapshot from cross-turn cache for terminal.
+                    # The cache persists across API calls — read_file in call #1
+                    # fills it, terminal in call #4 reads it.  No ordering bug
+                    # because entries are never popped from the cache.
+                    if tool_name == "terminal" and read_snapshots_cache:
+                        from agent.display import LocalEditSnapshot
+                        known = {p: b for p, b in read_snapshots_cache.items() if b is not None}
                         if known:
-                            from pathlib import Path
-                            from agent.display import LocalEditSnapshot
                             tool_call_meta.setdefault(tc_id, {})["snapshot"] = LocalEditSnapshot(
-                                paths=[Path(p) for p in known],
+                                paths=[Path(p) for p in known.keys()],
                                 before=known,
                             )
                             logger.debug(
-                                "terminal composite snapshot: %d paths from %d reads",
-                                len(known), sum(1 for m in tool_call_meta.values() if m.get("_read_path")),
+                                "terminal composite snapshot: %d paths from cache",
+                                len(known),
                             )
 
                     meta = tool_call_meta.pop(tc_id, {})
@@ -296,6 +318,36 @@ def make_step_cb(
                             _send_update(conn, session_id, loop, plan_update)
                     if not queue:
                         tool_call_ids.pop(tool_name, None)
+
+                    # Refresh cross-turn cache from disk after tool completes.
+                    # After terminal: update all cached paths so the next
+                    # terminal starts from post-change state.
+                    # After write_file/patch/skill_manage: update the affected
+                    # path so approve/reject reset works correctly.
+                    if tool_name == "terminal":
+                        for p in list(read_snapshots_cache.keys()):
+                            try:
+                                disk = Path(p).read_text(encoding="utf-8")
+                                read_snapshots_cache[p] = disk
+                            except FileNotFoundError:
+                                read_snapshots_cache.pop(p, None)
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to refresh snapshot cache for %s: %s", p, e
+                                )
+                    elif tool_name in {"write_file", "patch", "skill_manage"}:
+                        path_arg = (function_args or {}).get("path", "")
+                        if path_arg:
+                            rk = str(Path(path_arg).resolve())
+                            try:
+                                read_snapshots_cache[rk] = Path(rk).read_text(encoding="utf-8")
+                            except FileNotFoundError:
+                                read_snapshots_cache.pop(rk, None)
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to refresh snapshot cache for %s after %s: %s",
+                                    rk, tool_name, e,
+                                )
 
     return _step
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1116,7 +1116,8 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        parent_session_id = kwargs.get("parent_session_id") or None
+        state = self.session_manager.create_session(cwd=cwd, parent_session_id=parent_session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
         self._schedule_available_commands_update(state.session_id)
@@ -1394,6 +1395,7 @@ class HermesACPAgent(acp.Agent):
 
         tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
+        read_snapshots_cache: dict[str, str | None] = state.read_snapshots_cache
         previous_approval_cb = None
         edit_approval_requester = None
 
@@ -1406,10 +1408,12 @@ class HermesACPAgent(acp.Agent):
                 loop,
                 tool_call_ids,
                 tool_call_meta,
+                read_snapshots_cache,
                 edit_approval_policy_getter=lambda: self._edit_approval_policy_for_state(state),
             )
             reasoning_cb = make_thinking_cb(conn, session_id, loop)
-            step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta,
+                                    read_snapshots_cache)
             message_cb = make_message_cb(conn, session_id, loop)
 
             def stream_delta_cb(text: str) -> None:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -170,6 +170,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    read_snapshots_cache: dict = field(default_factory=dict)
 
 
 class SessionManager:
@@ -196,13 +197,23 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
-        """Create a new session with a unique ID and a fresh AIAgent."""
+    def create_session(self, cwd: str = ".", parent_session_id: str | None = None) -> SessionState:
+        """Create a new session with a unique ID and a fresh AIAgent.
+
+        Args:
+            cwd: Working directory for the session.
+            parent_session_id: If set, the new session becomes a branch
+                (child) of the given parent session.
+        """
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(
+            session_id=session_id,
+            cwd=cwd,
+            parent_session_id=parent_session_id or "",
+        )
         state = SessionState(
             session_id=session_id,
             agent=agent,
@@ -213,8 +224,9 @@ class SessionManager:
         with self._lock:
             self._sessions[session_id] = state
         _register_task_cwd(session_id, cwd)
-        self._persist(state)
-        logger.info("Created ACP session %s (cwd=%s)", session_id, cwd)
+        self._persist(state, parent_session_id=parent_session_id)
+        logger.info("Created ACP session %s (cwd=%s%s)", session_id, cwd,
+                     ", parent=%s" % parent_session_id if parent_session_id else "")
         return state
 
     def get_session(self, session_id: str) -> Optional[SessionState]:
@@ -409,7 +421,7 @@ class SessionManager:
             logger.debug("SessionDB unavailable for ACP persistence", exc_info=True)
             return None
 
-    def _persist(self, state: SessionState) -> None:
+    def _persist(self, state: SessionState, parent_session_id: str | None = None) -> None:
         """Write session state to the database.
 
         Creates the session record if it doesn't exist, then replaces all
@@ -442,6 +454,7 @@ class SessionManager:
                     source="acp",
                     model=model_str,
                     model_config={"cwd": state.cwd},
+                    parent_session_id=parent_session_id,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -590,6 +603,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        parent_session_id: str | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -624,6 +638,7 @@ class SessionManager:
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
+            "parent_session_id": parent_session_id or "",
         }
 
         try:

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -993,7 +993,10 @@ def _build_tool_complete_content(
     if len(display_result) > 5000:
         display_result = display_result[:4900] + f"\n... ({len(result)} chars total, truncated)"
 
-    if tool_name == "skill_manage":
+    # All file-modifying tools: extract unified diff and send as ACP diff blocks.
+    # This gives CCH GUI (and any ACP consumer) proper oldText/newText for
+    # inline diff rendering and Edits tab counts.
+    if tool_name in {"write_file", "patch", "skill_manage", "terminal"}:
         try:
             from agent.display import extract_edit_diff
 

--- a/agent/display.py
+++ b/agent/display.py
@@ -731,7 +731,7 @@ def _resolve_skill_manage_paths(args: dict) -> list[Path]:
 
 
 def _resolve_local_edit_paths(tool_name: str, function_args: dict | None) -> list[Path]:
-    """Resolve local filesystem targets for write-capable tools."""
+    """Resolve local filesystem targets for write-capable and read tools."""
     if not isinstance(function_args, dict):
         return []
 
@@ -740,6 +740,10 @@ def _resolve_local_edit_paths(tool_name: str, function_args: dict | None) -> lis
         return [_resolved_path(path)] if path else []
 
     if tool_name == "patch":
+        path = function_args.get("path")
+        return [_resolved_path(path)] if path else []
+
+    if tool_name == "read_file":
         path = function_args.get("path")
         return [_resolved_path(path)] if path else []
 
@@ -821,7 +825,7 @@ def extract_edit_diff(
             if isinstance(diff, str) and diff.strip():
                 return diff
 
-    if tool_name not in {"write_file", "patch", "skill_manage"}:
+    if tool_name not in {"write_file", "patch", "skill_manage", "terminal"}:
         return None
     if not _result_succeeded(result):
         return None


### PR DESCRIPTION
## ACP fixes for IDE integration

Fixes and improvements for the ACP (Agent Client Protocol) adapter — used by IDE integrations (JetBrains, VS Code, Zed).

### Commits

1. **fix(acp): parse JSON string tool arguments** — OpenAI `tool_call` arguments arrive as JSON string, not dict. `.get()` on string → `AttributeError`. Parse same way `_tool_progress` does.

2. **fix(acp): unified diff in tool_complete** — `write_file`/`patch`/`terminal` now generate `oldText`/`newText` diff blocks in tool_call_update completions (was only `skill_manage`). Added `read_file` capture + composite snapshot for terminal.

3. **fix: _turn_read_snapshots + terminal capture_local_edit_snapshot** — per-turn read snapshots for accurate diffs.

4. **fix(acp): cross-turn read snapshots cache for terminal diff** — cache survives across prompt boundaries.

5. **fix(acp): paths must be Path objects** — `_diff_from_snapshot` calls `.read_text()`, needs `Path` not `str`.

6. **fix(acp): lift read_snapshots_cache to session level** — survives cross-prompt for accurate multi-step diffs.

7. **feat(acp): support parent_session_id in session/new** — enables session branching in IDE clients.

### Files changed

- `acp_adapter/events.py` — tool arg parsing, diff generation, snapshots
- `acp_adapter/server.py` — parent_session_id, cross-turn cache
- `acp_adapter/session.py` — cache lifetime
- `acp_adapter/tools.py` — tool_complete content
- `agent/display.py` — edit path resolution (terminal, read_file)