### PR TITLE
fix(desktop): preserve restored zoom state

### DIFF
--- a/apps/desktop/src/store/zoom.test.ts
+++ b/apps/desktop/src/store/zoom.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+type ZoomBridge = NonNullable<Window['hermesDesktop']['zoom']>
+type ZoomPayload = Awaited<ReturnType<ZoomBridge['get']>>
+
+function installZoomBridge(zoom: ZoomBridge): void {
+  desktopWindow.hermesDesktop = { zoom } as unknown as Window['hermesDesktop']
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+describe('zoom state sync', () => {
+  it('uses the initial read when no newer change has arrived', async () => {
+    const zoom: ZoomBridge = {
+      get: vi.fn().mockResolvedValue({ level: 1, percent: 125 }),
+      onChanged: vi.fn(() => vi.fn()),
+      setPercent: vi.fn()
+    }
+
+    installZoomBridge(zoom)
+
+    const { $zoomPercent } = await import('./zoom')
+
+    expect($zoomPercent.get()).toBe(125)
+  })
+
+  it('does not let a stale initial read overwrite a newer zoom event', async () => {
+    const callOrder: string[] = []
+    let emitChanged: ((payload: ZoomPayload) => void) | undefined
+    let resolveInitialRead: ((payload: ZoomPayload) => void) | undefined
+
+    const initialRead = new Promise<ZoomPayload>(resolve => {
+      resolveInitialRead = resolve
+    })
+
+    const zoom: ZoomBridge = {
+      get: vi.fn(() => {
+        callOrder.push('get')
+
+        return initialRead
+      }),
+      onChanged: vi.fn(callback => {
+        callOrder.push('subscribe')
+        emitChanged = callback
+
+        return vi.fn()
+      }),
+      setPercent: vi.fn()
+    }
+
+    installZoomBridge(zoom)
+
+    const { $zoomPercent } = await import('./zoom')
+
+    expect(callOrder).toEqual(['subscribe', 'get'])
+    emitChanged?.({ level: 1, percent: 125 })
+    resolveInitialRead?.({ level: 0, percent: 100 })
+    await initialRead
+    await Promise.resolve()
+
+    expect($zoomPercent.get()).toBe(125)
+  })
+})

--- a/apps/desktop/src/store/zoom.ts
+++ b/apps/desktop/src/store/zoom.ts
@@ -17,6 +17,17 @@ export function setZoomPercent(percent: number): void {
 }
 
 if (typeof window !== 'undefined' && window.hermesDesktop?.zoom) {
-  void window.hermesDesktop.zoom.get().then(({ percent }) => $zoomPercent.set(percent))
-  window.hermesDesktop.zoom.onChanged(({ percent }) => $zoomPercent.set(percent))
+  const zoom = window.hermesDesktop.zoom
+  let receivedZoomChange = false
+
+  zoom.onChanged(({ percent }) => {
+    receivedZoomChange = true
+    $zoomPercent.set(percent)
+  })
+
+  void zoom.get().then(({ percent }) => {
+    if (!receivedZoomChange) {
+      $zoomPercent.set(percent)
+    }
+  })
 }


### PR DESCRIPTION
## What does this PR do?

Keeps the renderer's UI Scale mirror aligned with the latest main-process zoom value during startup.

The zoom change listener is registered before the initial IPC read, and a delayed initial read can no longer overwrite a newer `onChanged` event. The normal no-event startup path still uses the initial read.

## Related Issue

Fixes #64417

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Subscribe to zoom changes before requesting the initial zoom value.
- Ignore a stale initial response after a newer zoom event has been received.
- Add regression coverage for both the normal initial read and the `event(125) -> stale get(100)` ordering.

## How to Test

From `apps/desktop`:

- `npm run test:ui` — 164 files, 1,283 tests passed.
- Store-focused suite — 29 files, 270 tests passed.
- `npm run typecheck` — passed.
- ESLint, Prettier, and `git diff --check` — passed.

The broad jsdom run used `NODE_OPTIONS=--no-experimental-webstorage` because Node's experimental global Web Storage conflicts with jsdom in the current test environment.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for the change
- [ ] I've manually tested the packaged app on macOS

### Documentation & Housekeeping

- [x] Documentation changes are N/A
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact considered; the change only orders renderer IPC state updates
- [x] Tool description/schema changes are N/A
