### PR TITLE
Fix custom theme rendering before dashboard paint

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -4,15 +4,9 @@ No React, no JavaScript dependency. Listed providers come from the
 registry; clicking a provider sends a GET to
 ``/auth/login?provider=<name>``.
 
-Visual styling mirrors the Nous Research design system (the
-``@nous-research/ui`` package the React dashboard uses): the same
-``Collapse`` / ``Rules Compressed`` typeface, amber-on-dark colour
-tokens (``#170d02`` / ``#ffac02`` / ``#fff``), uppercase + wide-tracking
-brand chrome, and the inset-bevel button shadow. Fonts are served
-out of the SPA's ``/fonts/`` directory which the dashboard-auth gate
-already allowlists pre-auth (see ``_GATE_PUBLIC_PREFIXES`` in
-``middleware.py``), so the page renders without needing the React
-bundle loaded.
+Visual styling uses the active dashboard theme when the caller supplies
+its normalised definition. The page remains self-contained: no React or
+SPA bundle required before authentication.
 
 Test-stable class names: the existing test suite extracts the
 ``class="provider-btn"`` anchor href to walk the OAuth flow. That
@@ -22,6 +16,8 @@ class name MUST NOT change without updating
 from __future__ import annotations
 
 import html
+import re
+from typing import Any, Mapping, Optional
 
 from hermes_cli.dashboard_auth import list_session_providers
 
@@ -34,7 +30,7 @@ from hermes_cli.dashboard_auth import list_session_providers
 # are doubled (``{{`` / ``}}``).
 _LOGIN_HTML_TEMPLATE = """\
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="{theme_name}">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -55,29 +51,30 @@ _LOGIN_HTML_TEMPLATE = """\
     font-display: swap;
     src: url('/fonts/Collapse-Bold.woff2') format('woff2');
   }}
-  @font-face {{
-    font-family: 'Rules Compressed';
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    src: url('/fonts/RulesCompressed-Regular.woff2') format('woff2');
-  }}
-  @font-face {{
-    font-family: 'Rules Compressed';
-    font-style: normal;
-    font-weight: 600;
-    font-display: swap;
-    src: url('/fonts/RulesCompressed-Medium.woff2') format('woff2');
-  }}
-
   :root {{
     --background-base: #170d02;
     --background: #170d02;
     --midground: #ffac02;
     --foreground: #ffffff;
-    --hairline: color-mix(in srgb, #ffac02 18%, transparent);
-    --hairline-strong: color-mix(in srgb, #ffac02 35%, transparent);
+    --primary: #ffac02;
+    --primary-foreground: #170d02;
+    --card: color-mix(in srgb, #ffffff 2%, var(--background-base));
+    --card-foreground: #ffffff;
+    --muted-foreground: color-mix(in srgb, #ffffff 65%, transparent);
+    --border: color-mix(in srgb, #ffac02 18%, transparent);
+    --input: color-mix(in srgb, #ffac02 35%, transparent);
+    --ring: #ffac02;
+    --radius: 0;
+    --font-sans: 'Collapse', system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --font-mono: 'Courier New', monospace;
+    --base-size: 16px;
+    --line-height: 1.5;
+    --letter-spacing: 0;
+    --hairline: var(--border);
+    --hairline-strong: var(--input);
   }}
+
+{theme_css}
 
   *, *::before, *::after {{ box-sizing: border-box; }}
 
@@ -86,10 +83,11 @@ _LOGIN_HTML_TEMPLATE = """\
     padding: 0;
     min-height: 100%;
     background: var(--background-base);
-    color: var(--foreground);
-    font-family: 'Collapse', system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    font-size: 16px;
-    line-height: 1.5;
+    color: var(--card-foreground);
+    font-family: var(--font-sans);
+    font-size: var(--base-size);
+    line-height: var(--line-height);
+    letter-spacing: var(--letter-spacing);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }}
@@ -99,11 +97,11 @@ _LOGIN_HTML_TEMPLATE = """\
     background-image:
       radial-gradient(
         ellipse at top,
-        color-mix(in srgb, var(--midground) 6%, transparent) 0%,
+        color-mix(in srgb, var(--primary) 6%, transparent) 0%,
         transparent 55%
       ),
       repeating-conic-gradient(
-        color-mix(in srgb, var(--midground) 4%, transparent) 0% 25%,
+        color-mix(in srgb, var(--primary) 4%, transparent) 0% 25%,
         transparent 0% 50%
       );
     background-size: auto, 3px 3px;
@@ -138,28 +136,20 @@ _LOGIN_HTML_TEMPLATE = """\
   .brand {{
     text-align: center;
     margin-bottom: 1.75rem;
-    font-family: 'Rules Compressed', 'Collapse', sans-serif;
+    font-family: var(--font-sans);
     font-weight: 600;
     font-size: 1.05rem;
     letter-spacing: 0.32em;
     text-transform: uppercase;
-    color: var(--midground);
+    color: var(--primary);
   }}
-  .brand .dot {{
-    display: inline-block;
-    width: 6px;
-    height: 6px;
-    background: var(--midground);
-    margin: 0 0.55em 0.18em;
-    vertical-align: middle;
-    border-radius: 1px;
-  }}
-
   .card {{
     position: relative;
     padding: 2.25rem 2rem 2rem;
-    background: color-mix(in srgb, #ffffff 2%, var(--background-base));
+    background: var(--card);
+    color: var(--card-foreground);
     border: 1px solid var(--hairline);
+    border-radius: var(--radius);
     /* Hairline highlight + bevel shadow — matches DS Button SHADOW_DEFAULT
        (`inset -1px -1px 0 #00000080, inset 1px 1px 0 #ffffff80`) at panel scale. */
     box-shadow:
@@ -170,17 +160,17 @@ _LOGIN_HTML_TEMPLATE = """\
 
   h1 {{
     margin: 0 0 0.4rem;
-    font-family: 'Rules Compressed', 'Collapse', sans-serif;
+    font-family: var(--font-sans);
     font-weight: 600;
     font-size: 1.85rem;
     letter-spacing: 0.05em;
     text-transform: uppercase;
-    color: var(--foreground);
+    color: var(--card-foreground);
   }}
 
   .subtitle {{
     margin: 0 0 1.75rem;
-    color: color-mix(in srgb, var(--foreground) 65%, transparent);
+    color: var(--muted-foreground);
     font-size: 0.95rem;
   }}
 
@@ -189,24 +179,23 @@ _LOGIN_HTML_TEMPLATE = """\
     gap: 0.75rem;
   }}
 
-  /* Provider button — mirrors DS Button (default variant):
-     amber surface, dark text, uppercase + wide tracking, inset bevel. */
+  /* Provider button uses the theme's primary surface and focus ring. */
   .provider-btn {{
     display: block;
     width: 100%;
     box-sizing: border-box;
     padding: 0.95rem 1rem;
     text-align: center;
-    background: var(--midground);
-    color: var(--background-base);
-    font-family: 'Collapse', sans-serif;
+    background: var(--primary);
+    color: var(--primary-foreground);
+    font-family: var(--font-sans);
     font-weight: 700;
     font-size: 0.78rem;
     letter-spacing: 0.2em;
     text-transform: uppercase;
     text-decoration: none;
     border: 0;
-    border-radius: 0;  /* DS Button is squared — no rounded corners. */
+    border-radius: var(--radius);
     cursor: pointer;
     box-shadow:
       inset 1px 1px 0 0 rgba(255, 255, 255, 0.5),
@@ -221,24 +210,23 @@ _LOGIN_HTML_TEMPLATE = """\
     filter: invert(1);
   }}
   .provider-btn:focus-visible {{
-    outline: 2px solid var(--midground);
+    outline: 2px solid var(--ring);
     outline-offset: 3px;
   }}
 
-  /* Password provider form — same visual language as the OAuth buttons:
-     squared inputs, hairline borders, amber focus ring. */
+  /* Password provider form shares themed inputs and focus treatment. */
   .provider-form {{
     display: grid;
     gap: 0.75rem;
     text-align: left;
   }}
   .form-title {{
-    font-family: 'Rules Compressed', 'Collapse', sans-serif;
+    font-family: var(--font-sans);
     font-weight: 600;
     font-size: 0.72rem;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: color-mix(in srgb, var(--foreground) 70%, transparent);
+    color: var(--muted-foreground);
   }}
   .field {{
     display: grid;
@@ -248,23 +236,23 @@ _LOGIN_HTML_TEMPLATE = """\
     font-size: 0.72rem;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: color-mix(in srgb, var(--foreground) 55%, transparent);
+    color: var(--muted-foreground);
   }}
   .field-input {{
     width: 100%;
     box-sizing: border-box;
     padding: 0.7rem 0.8rem;
-    background: color-mix(in srgb, #000000 25%, var(--background-base));
-    color: var(--foreground);
+    background: var(--card);
+    color: var(--card-foreground);
     border: 1px solid var(--hairline-strong);
-    border-radius: 0;
-    font-family: 'Collapse', sans-serif;
+    border-radius: var(--radius);
+    font-family: var(--font-sans);
     font-size: 0.95rem;
   }}
   .field-input:focus-visible {{
     outline: none;
-    border-color: var(--midground);
-    box-shadow: 0 0 0 1px var(--midground);
+    border-color: var(--ring);
+    box-shadow: 0 0 0 1px var(--ring);
   }}
   .form-error {{
     color: #ff6b6b;
@@ -278,7 +266,7 @@ _LOGIN_HTML_TEMPLATE = """\
   footer {{
     margin-top: 1.75rem;
     text-align: center;
-    color: color-mix(in srgb, var(--foreground) 45%, transparent);
+    color: var(--muted-foreground);
     font-size: 0.75rem;
     letter-spacing: 0.1em;
     text-transform: uppercase;
@@ -295,14 +283,14 @@ _LOGIN_HTML_TEMPLATE = """\
 
   /* Selection — DS uses midground bg + background text. */
   ::selection {{
-    background: var(--midground);
-    color: var(--background-base);
+    background: var(--primary);
+    color: var(--primary-foreground);
   }}
 </style>
 </head>
 <body>
 <main>
-  <div class="brand">Nous<span class="dot"></span>Research</div>
+  <div class="brand">{brand_label}</div>
   <div class="card">
     <h1>Sign in</h1>
     <p class="subtitle">Choose a sign-in method to continue to the Hermes Agent dashboard.</p>
@@ -455,7 +443,82 @@ _PASSWORD_FORM_SCRIPT = """\
 """
 
 
-def render_login_html(*, next_path: str = "") -> str:
+def _login_theme_values(
+    theme: Optional[Mapping[str, Any]],
+) -> tuple[str, str, str]:
+    if not theme:
+        return "default", "Nous Research", ""
+
+    palette = theme.get("palette") if isinstance(theme.get("palette"), Mapping) else {}
+    typography = (
+        theme.get("typography") if isinstance(theme.get("typography"), Mapping) else {}
+    )
+    layout = theme.get("layout") if isinstance(theme.get("layout"), Mapping) else {}
+    overrides = (
+        theme.get("colorOverrides")
+        if isinstance(theme.get("colorOverrides"), Mapping)
+        else {}
+    )
+
+    def layer(name: str, fallback: str) -> str:
+        value = palette.get(name)
+        if isinstance(value, Mapping):
+            value = value.get("hex")
+        return value if isinstance(value, str) and value else fallback
+
+    background = layer("background", "#170d02")
+    midground = layer("midground", "#ffac02")
+    foreground = layer("foreground", "#ffffff")
+
+    def value(source: Mapping[str, Any], key: str, fallback: str) -> str:
+        result = source.get(key)
+        return result if isinstance(result, str) and result else fallback
+
+    font_sans = value(typography, "fontSans", "system-ui, sans-serif")
+    font_mono = value(typography, "fontMono", "ui-monospace, monospace")
+    variables = {
+        "--background-base": background,
+        "--background": background,
+        "--midground": midground,
+        "--foreground": foreground,
+        "--primary": value(overrides, "primary", midground),
+        "--primary-foreground": value(overrides, "primaryForeground", background),
+        "--card": value(overrides, "card", background),
+        "--card-foreground": value(overrides, "cardForeground", midground),
+        "--muted-foreground": value(overrides, "mutedForeground", midground),
+        "--border": value(overrides, "border", midground),
+        "--input": value(overrides, "input", midground),
+        "--ring": value(overrides, "ring", value(overrides, "primary", midground)),
+        "--radius": value(layout, "radius", "0"),
+        "--font-sans": font_sans,
+        "--font-mono": font_mono,
+        "--theme-font-sans": font_sans,
+        "--theme-font-mono": font_mono,
+        "--theme-font-display": value(typography, "fontDisplay", font_sans),
+        "--base-size": value(typography, "baseSize", "16px"),
+        "--line-height": value(typography, "lineHeight", "1.5"),
+        "--letter-spacing": value(typography, "letterSpacing", "0"),
+    }
+    css = (
+        "  :root {\n"
+        + "".join(
+            f"    {name}: {css_value};\n" for name, css_value in variables.items()
+        )
+        + "  }"
+    )
+    custom_css = theme.get("customCSS")
+    if isinstance(custom_css, str) and custom_css:
+        css += "\n" + re.sub(r"</style", r"<\\/style", custom_css, flags=re.I)
+    name = value(theme, "name", "default")
+    label = value(theme, "label", name)
+    return name, label, css
+
+
+def render_login_html(
+    *,
+    next_path: str = "",
+    theme: Optional[Mapping[str, Any]] = None,
+) -> str:
     """Return the full HTML for ``GET /login``.
 
     ``next_path`` — when set, the post-login landing path the user
@@ -492,9 +555,13 @@ def render_login_html(*, next_path: str = "") -> str:
                 f'Sign in with {html.escape(p.display_name)}</a>'
             )
     script = _PASSWORD_FORM_SCRIPT if needs_password_script else ""
+    theme_name, brand_label, theme_css = _login_theme_values(theme)
     return _LOGIN_HTML_TEMPLATE.format(
         provider_buttons="\n".join(buttons),
         password_script=script,
+        theme_name=html.escape(theme_name, quote=True),
+        brand_label=html.escape(brand_label),
+        theme_css=theme_css,
     )
 
 

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -138,8 +138,15 @@ async def login_page(request: Request) -> HTMLResponse:
     next_path = _validate_post_login_target(
         request.query_params.get("next", "")
     )
+    # Import at request time to avoid a module cycle: web_server mounts this
+    # router, while owning dashboard theme discovery/normalisation.
+    from hermes_cli.web_server import _dashboard_theme_state
+
     return HTMLResponse(
-        render_login_html(next_path=next_path),
+        render_login_html(
+            next_path=next_path,
+            theme=_dashboard_theme_state()["definition"],
+        ),
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
     )
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15773,7 +15773,12 @@ def mount_spa(application: FastAPI):
             html = html.replace('href="/fonts/', f'href="{prefix}/fonts/')
             html = html.replace('href="/ds-assets/', f'href="{prefix}/ds-assets/')
             html = html.replace('src="/ds-assets/', f'src="{prefix}/ds-assets/')
-        html = html.replace("</head>", f"{bootstrap_script}</head>", 1)
+        theme_script = _dashboard_theme_bootstrap_script(_dashboard_theme_state())
+        html = html.replace(
+            "</head>",
+            f"{theme_script}{bootstrap_script}</head>",
+            1,
+        )
         return HTMLResponse(
             html,
             headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
@@ -16084,6 +16089,116 @@ def _discover_user_themes() -> list:
     return result
 
 
+def _dashboard_theme_state() -> Dict[str, Any]:
+    active = cfg_get(load_config(), "dashboard", "theme", default="default")
+    if not isinstance(active, str) or not active:
+        active = "default"
+    user_themes = _discover_user_themes()
+    seen = set()
+    themes = []
+    for theme in _BUILTIN_DASHBOARD_THEMES:
+        seen.add(theme["name"])
+        themes.append(theme)
+    for theme in user_themes:
+        if theme["name"] in seen:
+            continue
+        themes.append(
+            {
+                "name": theme["name"],
+                "label": theme["label"],
+                "description": theme["description"],
+                "definition": theme,
+            }
+        )
+        seen.add(theme["name"])
+    active_definition = next(
+        (theme for theme in user_themes if theme["name"] == active),
+        None,
+    )
+    return {
+        "themes": themes,
+        "active": active,
+        "definition": active_definition,
+    }
+
+
+def _theme_bootstrap_vars(theme: Dict[str, Any]) -> Dict[str, str]:
+    variables: Dict[str, str] = {}
+    for name in ("background", "midground", "foreground"):
+        layer = theme["palette"][name]
+        percent = round(float(layer["alpha"]) * 100)
+        variables[f"--{name}"] = (
+            f"color-mix(in srgb, {layer['hex']} {percent}%, transparent)"
+        )
+        variables[f"--{name}-base"] = layer["hex"]
+        variables[f"--{name}-alpha"] = str(layer["alpha"])
+
+    typography = theme["typography"]
+    variables.update(
+        {
+            "--theme-font-sans": typography["fontSans"],
+            "--theme-font-mono": typography["fontMono"],
+            "--theme-font-display": typography.get(
+                "fontDisplay", typography["fontSans"]
+            ),
+            "--theme-base-size": typography["baseSize"],
+            "--theme-line-height": typography["lineHeight"],
+            "--theme-letter-spacing": typography["letterSpacing"],
+        }
+    )
+    density = {"compact": "0.85", "comfortable": "1", "spacious": "1.2"}
+    layout = theme["layout"]
+    variables.update(
+        {
+            "--radius": layout["radius"],
+            "--theme-radius": layout["radius"],
+            "--theme-spacing-mul": density.get(layout["density"], "1"),
+            "--theme-density": layout["density"],
+        }
+    )
+    override_vars = {
+        key: f"--color-{re.sub(r'(?<!^)(?=[A-Z])', '-', key).lower()}"
+        for key in _THEME_OVERRIDE_KEYS
+    }
+    for key, value in theme.get("colorOverrides", {}).items():
+        if key in override_vars:
+            variables[override_vars[key]] = value
+    series_vars = {
+        "inputTokenAccent": "--series-input-token",
+        "outputTokenAccent": "--series-output-token",
+    }
+    for key, value in theme.get("seriesColors", {}).items():
+        if key in series_vars:
+            variables[series_vars[key]] = value
+    return variables
+
+
+def _dashboard_theme_bootstrap_script(state: Dict[str, Any]) -> str:
+    definition = state.get("definition")
+    payload = {
+        "active": state["active"],
+        "definition": definition,
+        "vars": _theme_bootstrap_vars(definition) if definition else {},
+        "customCSS": definition.get("customCSS", "") if definition else "",
+    }
+    encoded = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    encoded = (
+        encoded.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+    )
+    return (
+        "<script>"
+        f"window.__HERMES_THEME_BOOTSTRAP__={encoded};"
+        "(function(b){var r=document.documentElement,k;"
+        "for(k in b.vars){r.style.setProperty(k,b.vars[k]);}"
+        "if(b.definition){r.dataset.layoutVariant=b.definition.layoutVariant||'standard';}"
+        "if(b.customCSS){var s=document.createElement('style');"
+        "s.id='hermes-theme-custom-css';s.dataset.hermesThemeCss='true';"
+        "s.textContent=b.customCSS;document.head.appendChild(s);}})"
+        "(window.__HERMES_THEME_BOOTSTRAP__);"
+        "</script>"
+    )
+
+
 @app.get("/api/dashboard/themes")
 async def get_dashboard_themes():
     """Return available themes and the currently active one.
@@ -16094,25 +16209,8 @@ async def get_dashboard_themes():
     normalised definition under `definition`, so the client can apply
     them without a stub.
     """
-    config = load_config()
-    active = cfg_get(config, "dashboard", "theme", default="default")
-    user_themes = _discover_user_themes()
-    seen = set()
-    themes = []
-    for t in _BUILTIN_DASHBOARD_THEMES:
-        seen.add(t["name"])
-        themes.append(t)
-    for t in user_themes:
-        if t["name"] in seen:
-            continue
-        themes.append({
-            "name": t["name"],
-            "label": t["label"],
-            "description": t["description"],
-            "definition": t,
-        })
-        seen.add(t["name"])
-    return {"themes": themes, "active": active}
+    state = _dashboard_theme_state()
+    return {"themes": state["themes"], "active": state["active"]}
 
 
 class ThemeSetBody(BaseModel):

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -133,6 +133,37 @@ def test_gated_login_html_is_public_and_lists_providers(gated_app):
     assert 'href="/auth/login?provider=stub"' in r.text
 
 
+def test_gated_login_uses_active_custom_dashboard_theme(
+    gated_app, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "dashboard:\n  theme: hermes-cloud\n",
+        encoding="utf-8",
+    )
+    themes = tmp_path / "dashboard-themes"
+    themes.mkdir()
+    (themes / "hermes-cloud.yaml").write_text(
+        "name: hermes-cloud\n"
+        "label: Hermes Cloud\n"
+        "palette:\n"
+        "  background: '#f8f8f8'\n"
+        "  midground: '#18181b'\n"
+        "colorOverrides:\n"
+        "  primary: '#ff6700'\n"
+        "  card: '#ffffff'\n",
+        encoding="utf-8",
+    )
+
+    r = gated_app.get("/login")
+
+    assert r.status_code == 200
+    assert '<html lang="en" data-theme="hermes-cloud">' in r.text
+    assert "--background-base: #f8f8f8;" in r.text
+    assert "--primary: #ff6700;" in r.text
+    assert '<div class="brand">Hermes Cloud</div>' in r.text
+
+
 def test_gated_static_asset_path_is_public(gated_app):
     """``/assets/*`` is allowlisted so the SPA's CSS/JS loads pre-login."""
     r = gated_app.get("/assets/_nonexistent.css")

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -418,6 +418,48 @@ class TestRateLimit:
 
 
 class TestLoginPageRender:
+    def test_active_custom_theme_styles_login_page(self):
+        clear_providers()
+        register_provider(PasswordProvider())
+        theme = {
+            "name": "hermes-cloud",
+            "label": "Hermes Cloud",
+            "palette": {
+                "background": {"hex": "#f8f8f8", "alpha": 1},
+                "midground": {"hex": "#18181b", "alpha": 1},
+                "foreground": {"hex": "#18181b", "alpha": 0},
+            },
+            "typography": {
+                "fontSans": "ui-sans-serif, system-ui, sans-serif",
+                "fontMono": "ui-monospace, monospace",
+                "baseSize": "16px",
+                "lineHeight": "1.5",
+                "letterSpacing": "0",
+            },
+            "layout": {"radius": "0.5rem", "density": "comfortable"},
+            "colorOverrides": {
+                "card": "#ffffff",
+                "cardForeground": "#18181b",
+                "primary": "#ff6700",
+                "primaryForeground": "#fff7ed",
+                "mutedForeground": "#71717a",
+                "border": "#e4e4e7",
+                "input": "#d4d4d8",
+                "ring": "#ff6700",
+            },
+        }
+        try:
+            page = render_login_html(theme=theme)
+            assert '<html lang="en" data-theme="hermes-cloud">' in page
+            assert "--background-base: #f8f8f8;" in page
+            assert "--primary: #ff6700;" in page
+            assert "--card: #ffffff;" in page
+            assert "--radius: 0.5rem;" in page
+            assert "--theme-font-sans: ui-sans-serif, system-ui, sans-serif;" in page
+            assert '<div class="brand">Hermes Cloud</div>' in page
+        finally:
+            clear_providers()
+
     def test_password_provider_renders_credential_form_and_script(self):
         clear_providers()
         register_provider(PasswordProvider())

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3082,6 +3082,51 @@ class TestWebServerEndpoints:
 
         assert seen_encodings == {"index": "utf-8", "css": "utf-8"}
 
+    def test_spa_bootstraps_active_custom_theme_before_body(
+        self, monkeypatch, tmp_path
+    ):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text(
+            "dashboard:\n  theme: hermes-cloud\n",
+            encoding="utf-8",
+        )
+        themes = home / "dashboard-themes"
+        themes.mkdir()
+        (themes / "hermes-cloud.yaml").write_text(
+            "name: hermes-cloud\n"
+            "label: Hermes Cloud\n"
+            "palette:\n"
+            "  background: '#f8f8f8'\n"
+            "  midground: '#18181b'\n"
+            "colorOverrides:\n"
+            "  primary: '#ff6700'\n"
+            "customCSS: 'body { background: #f8f8f8; }'\n",
+            encoding="utf-8",
+        )
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            "<html><head></head><body><div id=\"root\"></div></body></html>",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        spa_app = FastAPI()
+        ws.mount_spa(spa_app)
+
+        page = TestClient(spa_app).get("/chat").text
+
+        assert 'window.__HERMES_THEME_BOOTSTRAP__={"active":"hermes-cloud"' in page
+        assert '"--background-base":"#f8f8f8"' in page
+        assert '"--color-primary":"#ff6700"' in page
+        assert "body { background: #f8f8f8; }" in page
+        assert page.index("__HERMES_THEME_BOOTSTRAP__") < page.index("<body>")
+
     def test_headless_serve_disables_spa_even_with_a_dist(self, monkeypatch, tmp_path):
         """`hermes serve` (HERMES_SERVE_HEADLESS) must NOT serve the SPA even
         when a built dist is present — only the API/WS surface is reachable."""

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -39,6 +40,22 @@ const STORAGE_KEY = "hermes-dashboard-theme";
  *  sentinel / absent = "use the active theme's font". Pre-applied before
  *  the React tree mounts (see `main.tsx`) to avoid a font flash. */
 const FONT_STORAGE_KEY = "hermes-dashboard-font";
+
+interface ThemeBootstrap {
+  active: string;
+  definition?: DashboardTheme;
+}
+
+declare global {
+  interface Window {
+    __HERMES_THEME_BOOTSTRAP__?: ThemeBootstrap;
+  }
+}
+
+function themeBootstrap(): ThemeBootstrap | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.__HERMES_THEME_BOOTSTRAP__;
+}
 
 /** Renames of built-in theme keys we've shipped previously. Without this,
  *  users who saved one of the old names in localStorage (or had it
@@ -412,31 +429,47 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   /** Name of the currently active theme (built-in id or user YAML name). */
   const [themeName, setThemeName] = useState<string>(() => {
     if (typeof window === "undefined") return "default";
-    const stored = window.localStorage.getItem(STORAGE_KEY) ?? "default";
+    const bootstrapName = themeBootstrap()?.active;
+    const stored =
+      bootstrapName ?? window.localStorage.getItem(STORAGE_KEY) ?? "default";
     const migrated = migrateThemeName(stored);
-    // Write the migrated name back so future reads converge on the new
-    // key and we eventually retire the alias entry.
-    if (migrated !== stored) {
+    // Server bootstrap is authoritative. Persist it locally so subsequent
+    // development/static loads can still start from the last active theme.
+    if (migrated !== stored || bootstrapName) {
       window.localStorage.setItem(STORAGE_KEY, migrated);
     }
     return migrated;
   });
 
-  /** All selectable themes (shown in the picker). Starts with just the
-   *  built-ins; the API call below merges in user themes. */
-  const [availableThemes, setAvailableThemes] = useState<ThemeListEntry[]>(() =>
-    Object.values(BUILTIN_THEMES).map((t) => ({
-      name: t.name,
-      label: t.label,
-      description: t.description,
-    })),
+  /** All selectable themes (shown in the picker). Starts with built-ins plus
+   *  the server-bootstrapped active custom theme, when present. */
+  const [availableThemes, setAvailableThemes] = useState<ThemeListEntry[]>(
+    () => {
+      const themes = Object.values(BUILTIN_THEMES).map((t) => ({
+        name: t.name,
+        label: t.label,
+        description: t.description,
+      }));
+      const definition = themeBootstrap()?.definition;
+      if (definition && !BUILTIN_THEMES[definition.name]) {
+        themes.push({
+          name: definition.name,
+          label: definition.label,
+          description: definition.description,
+        });
+      }
+      return themes;
+    },
   );
 
-  /** Full definitions for user themes keyed by name — the API provides
-   *  these so custom YAMLs apply without a client-side stub. */
+  /** Full definitions for user themes keyed by name — seeded by the HTML
+   *  bootstrap so the active custom theme exists before first paint. */
   const [userThemeDefs, setUserThemeDefs] = useState<
     Record<string, DashboardTheme>
-  >({});
+  >(() => {
+    const definition = themeBootstrap()?.definition;
+    return definition ? { [definition.name]: definition } : {};
+  });
 
   /** Active font-override id (independent of theme). `THEME_DEFAULT_FONT_ID`
    *  = no override. Seeded from localStorage so it's applied flash-free. */
@@ -465,7 +498,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // whenever the theme, the resolver, OR the font override changes. Folding
   // font into the same effect means clearing the override re-runs applyTheme,
   // which restores the theme's own font; setting it re-asserts the override.
-  useEffect(() => {
+  useLayoutEffect(() => {
     _ACTIVE_FONT_OVERRIDE = fontId;
     applyTheme(resolveTheme(themeName));
   }, [themeName, resolveTheme, fontId]);


### PR DESCRIPTION
## Summary
- render dashboard login from active server-side theme
- inject active theme bootstrap before first paint
- initialize React theme context from bootstrap while preserving user overrides

## Validation
- 56 auth/login tests
- 36 theme/SPA tests
- 67 frontend tests
- frontend typecheck and build
- Playwright login/reload theme smoke