### PR TITLE
fix(compressor): unwrap web_extract dict URLs in tool-result summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -686,7 +686,16 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
 
     if tool_name == "web_extract":
         urls = args.get("urls", [])
-        url_desc = urls[0] if isinstance(urls, list) and urls else "?"
+        first = urls[0] if isinstance(urls, list) and urls else "?"
+        # web_search results are dicts ({"url"/"href": ...}) and models often
+        # forward them straight into web_extract. Unwrap to the URL string so
+        # the summary stays readable and the ``+=`` below never hits the
+        # ``dict + str`` TypeError that would abort pre-compression pruning.
+        if isinstance(first, dict):
+            first = first.get("url") or first.get("href") or "?"
+        elif not isinstance(first, str):
+            first = "?"
+        url_desc = first
         if isinstance(urls, list) and len(urls) > 1:
             url_desc += f" (+{len(urls) - 1} more)"
         return f"[web_extract] {url_desc} ({content_len:,} chars)"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,5 +1,6 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+import json
 import pytest
 import time
 from unittest.mock import patch, MagicMock
@@ -9,6 +10,7 @@ from agent.context_compressor import (
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
     COMPRESSED_SUMMARY_METADATA_KEY,
+    _summarize_tool_result,
 )
 from hermes_state import SessionDB
 
@@ -25,6 +27,49 @@ def compressor():
             quiet_mode=True,
         )
         return c
+
+
+class TestSummarizeToolResultWebExtract:
+    """Pre-compression pruning must survive web_extract calls whose ``urls`` are
+    web_search result dicts ({"url"/"href": ...}), which models routinely forward
+    straight into web_extract.
+    """
+
+    CONTENT = "x" * 500  # >200 chars so the pruning pass actually summarizes
+
+    def test_multiple_dict_urls_do_not_crash(self):
+        # Two dict URLs previously hit ``dict + str`` -> TypeError, aborting
+        # _prune_old_tool_results() (and thus compress()).
+        args = json.dumps({
+            "urls": [
+                {"url": "https://example.com/a", "title": "A"},
+                {"url": "https://example.org/b", "title": "B"},
+            ]
+        })
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/a (+1 more) (500 chars)"
+
+    def test_single_dict_url_is_unwrapped_not_stringified(self):
+        args = json.dumps({"urls": [{"url": "https://example.com/a", "title": "A"}]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/a (500 chars)"
+        assert "{" not in summary  # no raw dict repr leaked into the summary
+
+    def test_href_key_is_unwrapped(self):
+        args = json.dumps({"urls": [{"href": "https://example.com/h"}]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/h (500 chars)"
+
+    def test_malformed_dict_falls_back_to_placeholder(self):
+        args = json.dumps({"urls": [{"title": "no url here"}, {"title": "still none"}]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] ? (+1 more) (500 chars)"
+
+    def test_plain_string_urls_unchanged(self):
+        # Regression guard: the normal (already-working) string path is intact.
+        args = json.dumps({"urls": ["https://example.com/a", "https://example.org/b"]})
+        summary = _summarize_tool_result("web_extract", args, self.CONTENT)
+        assert summary == "[web_extract] https://example.com/a (+1 more) (500 chars)"
 
 
 class TestShouldCompress:


### PR DESCRIPTION
## Summary

`web_extract` tool-result summaries stay readable when models forward web_search result dicts (`{"url": ...}` / `{"href": ...}`) as the `urls` argument — the summary unwraps to the URL string instead of degrading. Salvage of @Frowtek's #62561, quality follow-up to #64772.

Context: #64772's never-raises backstop already prevents the crash this PR originally targeted (`dict + str` TypeError in pre-compression pruning) — but the backstop renders the generic `[web_extract] (300 chars result)`, losing the URL. Since the whole point of pruning summaries is to preserve signal, the informative half of the fix is still worth landing: `[web_extract] https://a.com/docs (+1 more) (300 chars)`.

## Changes

- `agent/context_compressor.py` (@Frowtek, cherry-picked): unwrap dict `urls[0]` via `url`/`href` keys; non-string/non-dict shapes degrade to `?`.
- `tests/agent/test_context_compressor.py` (@Frowtek): dict-urls, href-fallback, and malformed-shape regression tests.

## Validation

| Input shape | Summary |
|---|---|
| `["https://plain.com"]` | `[web_extract] https://plain.com (300 chars)` (unchanged) |
| `[{"url": "https://a.com/docs"}, {...}]` | `[web_extract] https://a.com/docs (+1 more) (300 chars)` |
| `[12345]` | `[web_extract] ? (300 chars)` |

Targeted suites: 191/191 (context compressor + type-safety).

## Infographic

![web-extract-summary-unwrap](https://v3b.fal.media/files/b/0aa2580c/Fex_7U7GWHldoCH9lvw2R_4dFDm0U2.png)
