### PR TITLE
fix(auxiliary): pass extra_body through to Anthropic-wire auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1337,6 +1337,31 @@ class _AnthropicCompletionsAdapter:
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
 
+        # Pass through caller-supplied extra_body so providers behind
+        # Anthropic-compatible gateways receive their per-vendor request
+        # fields (thinking control, metadata, portal tags, ...). The dict
+        # form is the documented Anthropic SDK passthrough for non-standard
+        # request body keys; merge on top of whatever build_anthropic_kwargs
+        # already produced (e.g. fast-mode ``speed``) so call-time settings
+        # survive. Two exclusions:
+        #   - ``reasoning``: the OpenAI-shaped config dict is TRANSLATED into
+        #     the native ``thinking`` field above (build_anthropic_kwargs);
+        #     forwarding the raw field alongside would double-specify
+        #     reasoning and 400 on strict gateways.
+        #   - ``_``-prefixed keys: private Hermes plumbing (_reasoning_config
+        #     et al.), never wire fields.
+        caller_extra_body = kwargs.get("extra_body")
+        if caller_extra_body and isinstance(caller_extra_body, dict):
+            passthrough = {
+                k: v for k, v in caller_extra_body.items()
+                if k != "reasoning" and not str(k).startswith("_")
+            }
+            if passthrough:
+                existing = anthropic_kwargs.get("extra_body") or {}
+                if not isinstance(existing, dict):
+                    existing = {}
+                anthropic_kwargs["extra_body"] = {**existing, **passthrough}
+
         response = create_anthropic_message(self._client, anthropic_kwargs)
         _transport = get_transport("anthropic_messages")
         _nr = _transport.normalize_response(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -334,6 +334,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "dorokuma@users.noreply.github.com": "dorokuma",
     "liuwei666888@users.noreply.github.com": "liuwei666888",
     "527711370@qq.com": "liuwei666888",
     "217401759+justinschille@users.noreply.github.com": "justinschille",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3380,6 +3380,81 @@ class TestAuxiliaryTaskExtraBody:
         }
         mock_create.assert_called_once()
 
+    def _run_anthropic_adapter(self, *, call_extra_body=None, bak_result=None):
+        """Drive _AnthropicCompletionsAdapter.create() with mocked SDK layers;
+        return the api_kwargs handed to create_anthropic_message."""
+        from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+        adapter = _AnthropicCompletionsAdapter(MagicMock(), "claude-sonnet-4-6", is_oauth=False)
+        bak_result = bak_result or {
+            "model": "claude-sonnet-4-6", "messages": [], "max_tokens": 64,
+        }
+        with patch("agent.anthropic_adapter.build_anthropic_kwargs",
+                   return_value=dict(bak_result)), \
+             patch("agent.anthropic_adapter.create_anthropic_message") as mock_create, \
+             patch("agent.transports.get_transport") as mock_gt:
+            mock_gt.return_value.normalize_response.return_value = MagicMock(
+                content="ok", tool_calls=None, reasoning=None, finish_reason="stop",
+                usage=None, provider_data=None,
+            )
+            kwargs = {
+                "model": "claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 64,
+            }
+            if call_extra_body is not None:
+                kwargs["extra_body"] = call_extra_body
+            adapter.create(**kwargs)
+        return mock_create.call_args.args[1]
+
+    def test_anthropic_aux_extra_body_passthrough(self):
+        """Bug B (#37217): vendor fields in extra_body reach the Anthropic SDK."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={"thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"}},
+        )
+        assert api_kwargs["extra_body"] == {
+            "thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"},
+        }
+
+    def test_anthropic_aux_extra_body_excludes_reasoning_and_private_keys(self):
+        """The OpenAI-shaped reasoning dict is translated (not forwarded), and
+        private _-prefixed plumbing keys never reach the wire."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={
+                "reasoning": {"enabled": True, "effort": "low"},
+                "_internal": "plumbing",
+                "metadata": {"user_id": "u1"},
+            },
+        )
+        assert api_kwargs["extra_body"] == {"metadata": {"user_id": "u1"}}
+
+    def test_anthropic_aux_extra_body_merges_over_existing(self):
+        """Caller extra_body merges on top of what build_anthropic_kwargs
+        already emitted (fast-mode speed) instead of clobbering it."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={"metadata": {"user_id": "u1"}},
+            bak_result={
+                "model": "claude-sonnet-4-6", "messages": [], "max_tokens": 64,
+                "extra_body": {"speed": "fast"},
+            },
+        )
+        assert api_kwargs["extra_body"] == {
+            "speed": "fast", "metadata": {"user_id": "u1"},
+        }
+
+    def test_anthropic_aux_no_extra_body_unchanged(self):
+        """Regression guard: no caller extra_body -> kwargs identical to before."""
+        api_kwargs = self._run_anthropic_adapter(call_extra_body=None)
+        assert "extra_body" not in api_kwargs
+
+    def test_anthropic_aux_reasoning_only_extra_body_adds_nothing(self):
+        """extra_body containing ONLY the reasoning key must not create an
+        empty extra_body dict on the wire."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={"reasoning": {"enabled": False}},
+        )
+        assert "extra_body" not in api_kwargs
+
     def test_no_warning_when_provider_is_custom(self, monkeypatch, caplog):
         """No warning when the provider is 'custom' — OPENAI_BASE_URL is expected."""
         import agent.auxiliary_client as mod


### PR DESCRIPTION
## Summary

Caller-supplied `extra_body` now reaches the Anthropic SDK on the auxiliary wire — vendor request fields configured in `auxiliary.<task>.extra_body` (thinking control, metadata, gateway-specific fields) were previously discarded for every aux task routed through Anthropic Messages (anthropic, minimax, zai vision, any `/anthropic` endpoint).

Salvages the Bug B half of PR #37217 by @dorokuma (authorship preserved). Bug A from the same PR (`reasoning_config` hardcoded to `None`) was independently fixed by #64597/#64631.

## Wire safety (the merge-blocking question)

Live probes against the real Anthropic API before writing anything: **the Messages API strictly validates the request body** — unknown keys 400 with "Extra inputs are not permitted". Accepted: `metadata`, `thinking`. Rejected: any unknown key, the OpenAI-shaped `reasoning` dict, vLLM-style `enable_thinking`.

The passthrough is scoped accordingly:
- Forwards only what the user deliberately configured (or a provider profile deliberately emitted for its own endpoint — minimax/zai `thinking` fields are valid on *their* gateways)
- **Excludes `reasoning`** — that key is translated natively into Anthropic `thinking` by `build_anthropic_kwargs`; forwarding it raw would 400 every direct-Anthropic aux call (probe-confirmed)
- **Excludes `_`-prefixed keys** — private Hermes plumbing, never wire fields
- Merges over existing adapter-emitted fields (fast-mode `speed`) instead of clobbering
- Nothing Hermes auto-injects can 400; only a user's own invalid config fails — loudly, instead of today's silent drop

## Changes

- `agent/auxiliary_client.py` (@dorokuma, cherry-picked + conflict-resolved against #64631's `_reasoning_config` plumbing): scoped extra_body merge in `_AnthropicCompletionsAdapter.create()`
- Tests (ours): 5 new — passthrough, reasoning/private-key exclusion, merge-over-existing, no-extra_body regression guard, reasoning-only-adds-nothing
- AUTHOR_MAP entry for dorokuma

## Validation

| Check | Result |
|---|---|
| `tests/agent/test_auxiliary_client.py` | 321/321 pass |
| Live API probes (8 extra_body variants, real api.anthropic.com) | strict-validation matrix documented above |
| Live E2E: real `call_llm(task=...)` → aux Anthropic adapter → real API, config carrying `metadata` + OpenAI-shaped `reasoning` in extra_body | call succeeded; metadata on the wire, reasoning translated + excluded, zero 400s |
| Positive + negative control | same E2E passes pre-patch (fields silently dropped) and post-patch (fields delivered) — no regression either way |

## Infographic

![Anthropic aux extra_body passthrough](https://v3b.fal.media/files/b/0aa2584d/58ffB6MLr5E3_kYdk7vTk_jhZ8p1O4.png)
