### PR TITLE
refactor(gateway): extract canonical run registry

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -57,7 +57,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, MutableMapping, MutableSet, Optional
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -84,6 +84,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.run_service import RunRegistry
 from gateway.platforms.base import (
     MEDIA_TAG_CLEANUP_RE,
     BasePlatformAdapter,
@@ -1370,13 +1371,8 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams_created: Dict[str, float] = {}
         # Runs with a connected SSE consumer; their queue is actively draining.
         self._run_stream_subscribers: set[str] = set()
-        # Active run agent/task references for stop support
-        self._active_run_agents: Dict[str, Any] = {}
-        self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
-        # Stop is cooperative: the executor thread may outlive the HTTP request.
-        self._stopping_run_ids: set[str] = set()
-        # Pollable run status for dashboards and external control-plane UIs.
-        self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        # Retained status and stop-control references share one lock-aware owner.
+        self._run_registry = RunRegistry()
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
@@ -1421,7 +1417,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return (
                 int(getattr(self, "_pending_agent_requests", 0))
                 + int(self._inflight_agent_runs)
-                + sum(not task.done() for task in self._active_run_tasks.values())
+                + self._run_registry.active_task_count()
             )
         except Exception:
             return 0
@@ -1465,17 +1461,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _readiness_work_counts(self) -> tuple[int, int, int]:
         """Return bounded work counts from each subsystem's public state."""
-        active_api_runs = sum(
-            1
-            for status in self._run_statuses.values()
-            # "stopping" (set by _handle_stop_run) is not terminal: the run
-            # stays in this state, doing real executor-thread work, until the
-            # agent actually notices the interrupt and the task settles to
-            # "cancelled" — an unbounded window, not the old ~5s hard-timeout
-            # wait. Excluding it here undercounts active_api_runs for the
-            # whole duration of a cooperative stop.
-            if status.get("status") in {"queued", "running", "waiting_for_approval", "stopping"}
-        )
+        active_api_runs = self._run_registry.active_status_count()
         process_depth = 0
         active_delegations = 0
         try:
@@ -6142,27 +6128,50 @@ class APIServerAdapter(BasePlatformAdapter):
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
 
+    # These aliases retain compatibility for existing API code/tests while the
+    # registry remains the sole owner of each authoritative map.
+    @property
+    def _run_statuses(self) -> MutableMapping[str, Dict[str, Any]]:
+        return self._run_registry.statuses
+
+    @_run_statuses.setter
+    def _run_statuses(self, values: Dict[str, Dict[str, Any]]) -> None:
+        self._run_registry.replace_statuses(values)
+
+    @property
+    def _active_run_agents(self) -> MutableMapping[str, Any]:
+        return self._run_registry.agents
+
+    @_active_run_agents.setter
+    def _active_run_agents(self, values: Dict[str, Any]) -> None:
+        self._run_registry.replace_agents(values)
+
+    @property
+    def _active_run_tasks(self) -> MutableMapping[str, "asyncio.Task"]:
+        return self._run_registry.tasks
+
+    @_active_run_tasks.setter
+    def _active_run_tasks(self, values: Dict[str, "asyncio.Task"]) -> None:
+        self._run_registry.replace_tasks(values)
+
+    @property
+    def _stopping_run_ids(self) -> MutableSet[str]:
+        return self._run_registry.stopping_ids
+
+    @_stopping_run_ids.setter
+    def _stopping_run_ids(self, values: set[str]) -> None:
+        self._run_registry.replace_stopping_ids(values)
+
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
-        now = time.time()
-        current = self._run_statuses.get(run_id, {})
-        current.update({
-            "object": "hermes.run",
-            "run_id": run_id,
-            "status": status,
-            "updated_at": now,
-        })
-        current.setdefault("created_at", fields.pop("created_at", now))
-        current.update(fields)
-        self._run_statuses[run_id] = current
-        return current
+        return self._run_registry.set_status(run_id, status, **fields)
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
                 run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
+                self._run_registry.status_value(run_id, "status", "running"),
                 last_event=event.get("event"),
             )
             q = self._run_streams.get(run_id)
@@ -6391,7 +6400,7 @@ class APIServerAdapter(BasePlatformAdapter):
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
-                if run_id in self._stopping_run_ids:
+                if self._run_registry.is_stopping(run_id):
                     _put_event_if_active({
                         "event": "run.cancelled",
                         "run_id": run_id,
@@ -6415,7 +6424,18 @@ class APIServerAdapter(BasePlatformAdapter):
                         model_options=agent_overrides.get("model_options"),
                         route=route,
                     )
-                self._active_run_agents[run_id] = agent
+                if not self._run_registry.register_agent(run_id, agent):
+                    _put_event_if_active({
+                        "event": "run.cancelled",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                    })
+                    self._set_run_status(
+                        run_id,
+                        "cancelled",
+                        last_event="run.cancelled",
+                    )
+                    return
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
                     event = dict(approval_data or {})
@@ -6516,7 +6536,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         return r, u
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
-                if run_id in self._stopping_run_ids:
+                if self._run_registry.is_stopping(run_id):
                     _put_event_if_active({
                         "event": "run.cancelled",
                         "run_id": run_id,
@@ -6634,14 +6654,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     _put_event_if_active(None)
                 except Exception:
                     pass
-                self._active_run_agents.pop(run_id, None)
-                self._active_run_tasks.pop(run_id, None)
+                self._run_registry.remove_control(run_id)
                 self._run_approval_sessions.pop(run_id, None)
-                self._stopping_run_ids.discard(run_id)
 
         self._activate_admitted_request()
         task = asyncio.create_task(_run_and_close())
-        self._active_run_tasks[run_id] = task
+        self._run_registry.register_task(run_id, task)
         try:
             self._background_tasks.add(task)
         except TypeError:
@@ -6665,7 +6683,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
-        status = self._run_statuses.get(run_id)
+        status = self._run_registry.get(run_id)
         if status is None:
             return web.json_response(
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
@@ -6732,8 +6750,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
-        status = self._run_statuses.get(run_id)
-        if status is None:
+        if not self._run_registry.contains(run_id):
             return web.json_response(
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
@@ -6820,30 +6837,32 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
-        agent = self._active_run_agents.get(run_id)
-        task = self._active_run_tasks.get(run_id)
-
-        if agent is None and task is None:
-            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
-
-        self._set_run_status(run_id, "stopping", last_event="run.stopping")
-        self._stopping_run_ids.add(run_id)
-
-        if agent is not None:
-            try:
-                request_hard_interrupt(agent, "Stop requested via API")
-            except Exception:
-                pass
-            # The stopped run is abandoned — reap only the background
-            # processes it created (#76115). Epoch-gated inside, so a
-            # concurrent run sharing the same session_id keeps its own
-            # processes; no-op if the run already finished and cleared
-            # its ownership markers.
-            _reap_disconnected_agent_processes(
-                agent, source="api_server_run_stop"
+        target = self._run_registry.claim_stop_target(run_id)
+        if target is None:
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
             )
+        if target.owns_lease:
+            try:
+                if target.agent is not None:
+                    try:
+                        request_hard_interrupt(target.agent, "Stop requested via API")
+                    except Exception:
+                        pass
+                    # The stopped run is abandoned — reap only the background
+                    # processes it created (#76115). Epoch-gated inside, so a
+                    # concurrent run sharing the same session_id keeps its own
+                    # processes; no-op if the run already finished and cleared
+                    # its ownership markers.
+                    _reap_disconnected_agent_processes(
+                        target.agent, source="api_server_run_stop"
+                    )
+            finally:
+                self._run_registry.release_stop_target(run_id)
 
         return web.json_response({"run_id": run_id, "status": "stopping"})
+
 
     async def _sweep_orphaned_runs(self) -> None:
         """Periodically expire transport buffers and terminal status records."""
@@ -6863,7 +6882,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ]
         for run_id in stale:
             logger.debug("[api_server] sweeping expired run transport %s", run_id)
-            task = self._active_run_tasks.get(run_id)
+            task = self._run_registry.task_for(run_id)
             task_done = task is None or task.done()
             if task_done:
                 try:
@@ -6879,19 +6898,10 @@ class APIServerAdapter(BasePlatformAdapter):
             self._run_streams.pop(run_id, None)
             self._run_streams_created.pop(run_id, None)
             if task_done:
-                self._active_run_agents.pop(run_id, None)
-                self._active_run_tasks.pop(run_id, None)
+                self._run_registry.remove_control(run_id)
                 self._run_approval_sessions.pop(run_id, None)
-                self._stopping_run_ids.discard(run_id)
 
-        stale_statuses = [
-            run_id
-            for run_id, status in list(self._run_statuses.items())
-            if status.get("status") in {"completed", "failed", "cancelled"}
-            and now - float(status.get("updated_at", 0) or 0) > self._RUN_STATUS_TTL
-        ]
-        for run_id in stale_statuses:
-            self._run_statuses.pop(run_id, None)
+        self._run_registry.expire_terminal_statuses(now, self._RUN_STATUS_TTL)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1371,12 +1371,9 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams_created: Dict[str, float] = {}
         # Runs with a connected SSE consumer; their queue is actively draining.
         self._run_stream_subscribers: set[str] = set()
-        # Retained status and stop-control references share one lock-aware owner.
+        # Retained status, stop-control references, and approval-session
+        # ownership share one lock-aware lifecycle owner.
         self._run_registry = RunRegistry()
-        # Active approval session key for each run_id.  The approval core
-        # resolves requests by session key, while API clients address the
-        # in-flight run by run_id.
-        self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Last-known-good resolved model per session (keyed by gateway_session_key
         # ONLY — never session_id, which rotates/is ephemeral for one-off API
@@ -6155,6 +6152,14 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_registry.replace_tasks(values)
 
     @property
+    def _run_approval_sessions(self) -> MutableMapping[str, str]:
+        return self._run_registry.approval_sessions
+
+    @_run_approval_sessions.setter
+    def _run_approval_sessions(self, values: Dict[str, str]) -> None:
+        self._run_registry.replace_approval_sessions(values)
+
+    @property
     def _stopping_run_ids(self) -> MutableSet[str]:
         return self._run_registry.stopping_ids
 
@@ -6360,7 +6365,9 @@ class APIServerAdapter(BasePlatformAdapter):
         created_at = time.time()
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = created_at
-        self._run_approval_sessions[run_id] = approval_session_key
+        self._run_registry.register_approval_session(
+            run_id, approval_session_key
+        )
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
@@ -6655,7 +6662,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
                 self._run_registry.remove_control(run_id)
-                self._run_approval_sessions.pop(run_id, None)
 
         self._activate_admitted_request()
         task = asyncio.create_task(_run_and_close())
@@ -6774,7 +6780,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
-        approval_session_key = self._run_approval_sessions.get(run_id)
+        approval_session_key = self._run_registry.approval_session_for(run_id)
         if not approval_session_key:
             return web.json_response(
                 _openai_error(
@@ -6888,7 +6894,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 try:
                     from tools.approval import unregister_gateway_notify
 
-                    approval_session_key = self._run_approval_sessions.get(run_id)
+                    approval_session_key = (
+                        self._run_registry.approval_session_for(run_id)
+                    )
                     if approval_session_key:
                         unregister_gateway_notify(approval_session_key)
                 except Exception:
@@ -6899,7 +6907,6 @@ class APIServerAdapter(BasePlatformAdapter):
             self._run_streams_created.pop(run_id, None)
             if task_done:
                 self._run_registry.remove_control(run_id)
-                self._run_approval_sessions.pop(run_id, None)
 
         self._run_registry.expire_terminal_statuses(now, self._RUN_STATUS_TTL)
 

--- a/gateway/run_service.py
+++ b/gateway/run_service.py
@@ -199,6 +199,7 @@ class RunRegistry:
         self._statuses: Dict[str, Dict[str, Any]] = {}
         self._agents: Dict[str, Any] = {}
         self._tasks: Dict[str, Any] = {}
+        self._approval_sessions: Dict[str, str] = {}
         self._stopping_ids: set[str] = set()
         self._claimed_stop_ids: set[str] = set()
         self._deferred_control_removals: set[str] = set()
@@ -215,6 +216,11 @@ class RunRegistry:
         )
         self._task_view = _LockedMapping(
             self._tasks,
+            self._lock,
+            mutation_allowed=self._compat_mutation_allowed,
+        )
+        self._approval_session_view = _LockedMapping(
+            self._approval_sessions,
             self._lock,
             mutation_allowed=self._compat_mutation_allowed,
         )
@@ -244,6 +250,11 @@ class RunRegistry:
     def tasks(self) -> MutableMapping:
         """Authoritative task map, exposed only for legacy compatibility."""
         return self._task_view
+
+    @property
+    def approval_sessions(self) -> MutableMapping:
+        """Authoritative approval-session map for legacy adapter compatibility."""
+        return self._approval_session_view
 
     @property
     def stopping_ids(self) -> MutableSet:
@@ -284,6 +295,9 @@ class RunRegistry:
 
     def replace_tasks(self, values: Dict[str, Any]) -> None:
         self._replace_mapping(self._tasks, values)
+
+    def replace_approval_sessions(self, values: Dict[str, str]) -> None:
+        self._replace_mapping(self._approval_sessions, values)
 
     def replace_stopping_ids(self, values: set[str]) -> None:
         if type(values) is not set:
@@ -427,6 +441,20 @@ class RunRegistry:
         with self._lock:
             return self._tasks.get(run_id)
 
+    def register_approval_session(
+        self, run_id: str, approval_session_key: str
+    ) -> bool:
+        """Bind one run to its isolated approval namespace."""
+        with self._lock:
+            if run_id in self._stopping_ids or run_id in self._claimed_stop_ids:
+                return False
+            self._approval_sessions[run_id] = approval_session_key
+            return True
+
+    def approval_session_for(self, run_id: str) -> Optional[str]:
+        with self._lock:
+            return self._approval_sessions.get(run_id)
+
     def active_task_count(self) -> int:
         with self._lock:
             tasks = tuple(self._tasks.values())
@@ -476,5 +504,6 @@ class RunRegistry:
     def _remove_control_locked(self, run_id: str) -> None:
         self._agents.pop(run_id, None)
         self._tasks.pop(run_id, None)
+        self._approval_sessions.pop(run_id, None)
         self._stopping_ids.discard(run_id)
         self._deferred_control_removals.discard(run_id)

--- a/gateway/run_service.py
+++ b/gateway/run_service.py
@@ -1,0 +1,480 @@
+"""Thread-safe retained status and control state for API runs.
+
+This module is deliberately transport-agnostic.  HTTP parsing and response
+translation remain in the API server adapter.
+"""
+
+from collections.abc import MutableMapping, MutableSet
+from dataclasses import dataclass
+import math
+import threading
+import time
+from typing import Any, Callable, Dict, Iterator, Optional
+
+
+PUBLIC_RUN_STATUS_FIELDS = frozenset(
+    {
+        "object",
+        "run_id",
+        "status",
+        "session_id",
+        "model",
+        "created_at",
+        "updated_at",
+        "last_event",
+        "output",
+        "usage",
+        "error",
+    }
+)
+TERMINAL_RUN_STATUSES = frozenset({"completed", "failed", "cancelled"})
+# "stopping" (set by _handle_stop_run) is not terminal: the run stays in this
+# state, doing real executor-thread work, until the agent actually notices the
+# interrupt and the task settles to "cancelled" — an unbounded window, not the
+# old ~5s hard-timeout wait. Excluding it here undercounts active runs for the
+# whole duration of a cooperative stop.
+ACTIVE_RUN_STATUSES = frozenset({"queued", "running", "waiting_for_approval", "stopping"})
+RUN_STATUSES = ACTIVE_RUN_STATUSES | TERMINAL_RUN_STATUSES
+
+
+def _finite_timestamp(value: Any) -> float:
+    try:
+        timestamp = float(value or 0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    return timestamp if math.isfinite(timestamp) else 0.0
+
+
+def _validate_run_status(status: Any) -> None:
+    if type(status) is not str or status not in RUN_STATUSES:
+        raise ValueError(f"unsupported run status: {status!r}")
+
+
+def _snapshot_status_value(value: Any) -> Any:
+    """Copy JSON-shaped status data without invoking user-defined hooks."""
+    value_type = type(value)
+    if value_type is float:
+        if not math.isfinite(value):
+            raise ValueError("run status float values must be finite")
+        return value
+    if value is None or value_type in (bool, int, str):
+        return value
+    if value_type is list:
+        return [_snapshot_status_value(item) for item in value]
+    if value_type is tuple:
+        return tuple(_snapshot_status_value(item) for item in value)
+    if value_type is dict:
+        snapshot = {}
+        for key, item in value.items():
+            if type(key) is not str:
+                raise TypeError("run status mappings must use string keys")
+            snapshot[key] = _snapshot_status_value(item)
+        return snapshot
+    raise TypeError(
+        "run status values must be JSON-compatible builtin data, "
+        f"not {value_type.__name__}"
+    )
+
+
+def _snapshot_status_record(value: Any) -> Dict[str, Any]:
+    if type(value) is not dict:
+        raise TypeError("run status records must be builtin dictionaries")
+    snapshot = {}
+    for key, item in value.items():
+        if type(key) is not str:
+            raise TypeError("run status mappings must use string keys")
+        if key in {"created_at", "updated_at"}:
+            snapshot[key] = _finite_timestamp(item)
+        else:
+            snapshot[key] = _snapshot_status_value(item)
+    _validate_run_status(snapshot.get("status"))
+    return snapshot
+
+
+@dataclass(frozen=True)
+class StopTarget:
+    """Control references claimed for one stop decision."""
+
+    agent: Any
+    task: Any
+    owns_lease: bool = True
+
+
+class _LockedMapping(MutableMapping):
+    """Minimal lock-aware compatibility view over an authoritative dict."""
+
+    def __init__(
+        self,
+        data: Dict[Any, Any],
+        lock: threading.RLock,
+        *,
+        snapshotter: Optional[Callable[[Any], Any]] = None,
+        mutation_allowed: Optional[Callable[[Any], bool]] = None,
+    ):
+        self._data = data
+        self._lock = lock
+        self._snapshotter = snapshotter
+        self._mutation_allowed = mutation_allowed
+
+    def _snapshot(self, value: Any) -> Any:
+        if self._snapshotter is not None:
+            return self._snapshotter(value)
+        return value
+
+    def __getitem__(self, key: Any) -> Any:
+        with self._lock:
+            return self._snapshot(self._data[key])
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        snapshot = self._snapshot(value)
+        with self._lock:
+            self._ensure_mutation_allowed(key)
+            self._data[key] = snapshot
+
+    def __delitem__(self, key: Any) -> None:
+        with self._lock:
+            self._ensure_mutation_allowed(key)
+            del self._data[key]
+
+    def _ensure_mutation_allowed(self, key: Any) -> None:
+        if self._mutation_allowed is not None and not self._mutation_allowed(key):
+            raise RuntimeError("run control mutation rejected while stop is pending")
+
+    def __iter__(self) -> Iterator[Any]:
+        with self._lock:
+            return iter(tuple(self._data))
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+
+class _LockedSet(MutableSet):
+    """Minimal lock-aware compatibility view over an authoritative set."""
+
+    def __init__(
+        self,
+        data: set[Any],
+        lock: threading.RLock,
+        *,
+        mutation_allowed: Optional[Callable[[Any], bool]] = None,
+    ):
+        self._data = data
+        self._lock = lock
+        self._mutation_allowed = mutation_allowed
+
+    def __contains__(self, value: object) -> bool:
+        with self._lock:
+            return value in self._data
+
+    def __iter__(self) -> Iterator[Any]:
+        with self._lock:
+            return iter(tuple(self._data))
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    def add(self, value: Any) -> None:
+        with self._lock:
+            self._ensure_mutation_allowed(value)
+            self._data.add(value)
+
+    def discard(self, value: Any) -> None:
+        with self._lock:
+            self._ensure_mutation_allowed(value)
+            self._data.discard(value)
+
+    def _ensure_mutation_allowed(self, value: Any) -> None:
+        if self._mutation_allowed is not None and not self._mutation_allowed(value):
+            raise RuntimeError("run control mutation rejected while stop is pending")
+
+
+class RunRegistry:
+    """Own retained run statuses and active stop-control references."""
+
+    def __init__(self, *, clock: Callable[[], Any] = time.time):
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._statuses: Dict[str, Dict[str, Any]] = {}
+        self._agents: Dict[str, Any] = {}
+        self._tasks: Dict[str, Any] = {}
+        self._stopping_ids: set[str] = set()
+        self._claimed_stop_ids: set[str] = set()
+        self._deferred_control_removals: set[str] = set()
+        self._status_view = _LockedMapping(
+            self._statuses,
+            self._lock,
+            snapshotter=_snapshot_status_record,
+            mutation_allowed=self._compat_mutation_allowed,
+        )
+        self._agent_view = _LockedMapping(
+            self._agents,
+            self._lock,
+            mutation_allowed=self._compat_mutation_allowed,
+        )
+        self._task_view = _LockedMapping(
+            self._tasks,
+            self._lock,
+            mutation_allowed=self._compat_mutation_allowed,
+        )
+        self._stopping_view = _LockedSet(
+            self._stopping_ids,
+            self._lock,
+            mutation_allowed=self._compat_mutation_allowed,
+        )
+
+    def _compat_mutation_allowed(self, run_id: Any) -> bool:
+        return (
+            run_id not in self._claimed_stop_ids
+            and run_id not in self._stopping_ids
+        )
+
+    @property
+    def statuses(self) -> MutableMapping:
+        """Authoritative status map, exposed only for legacy compatibility."""
+        return self._status_view
+
+    @property
+    def agents(self) -> MutableMapping:
+        """Authoritative agent map, exposed only for legacy compatibility."""
+        return self._agent_view
+
+    @property
+    def tasks(self) -> MutableMapping:
+        """Authoritative task map, exposed only for legacy compatibility."""
+        return self._task_view
+
+    @property
+    def stopping_ids(self) -> MutableSet:
+        """Authoritative stopping set, exposed only for legacy compatibility."""
+        return self._stopping_view
+
+    def _replace_mapping(
+        self,
+        target: Dict[Any, Any],
+        values: Dict[Any, Any],
+        *,
+        snapshotter: Optional[Callable[[Any], Any]] = None,
+    ) -> None:
+        if type(values) is not dict:
+            raise TypeError("run compatibility maps must be builtin dictionaries")
+        replacement = {
+            key: snapshotter(value) if snapshotter is not None else value
+            for key, value in values.items()
+        }
+        with self._lock:
+            for run_id in set(target) | set(replacement):
+                if not self._compat_mutation_allowed(run_id):
+                    raise RuntimeError(
+                        "run control mutation rejected while stop is pending"
+                    )
+            target.clear()
+            target.update(replacement)
+
+    def replace_statuses(self, values: Dict[str, Dict[str, Any]]) -> None:
+        self._replace_mapping(
+            self._statuses,
+            values,
+            snapshotter=_snapshot_status_record,
+        )
+
+    def replace_agents(self, values: Dict[str, Any]) -> None:
+        self._replace_mapping(self._agents, values)
+
+    def replace_tasks(self, values: Dict[str, Any]) -> None:
+        self._replace_mapping(self._tasks, values)
+
+    def replace_stopping_ids(self, values: set[str]) -> None:
+        if type(values) is not set:
+            raise TypeError("run compatibility stopping IDs must be a builtin set")
+        replacement = set(values)
+        with self._lock:
+            for run_id in self._stopping_ids | replacement:
+                if not self._compat_mutation_allowed(run_id):
+                    raise RuntimeError(
+                        "run control mutation rejected while stop is pending"
+                    )
+            self._stopping_ids.clear()
+            self._stopping_ids.update(replacement)
+
+    @staticmethod
+    def finite_timestamp(value: Any) -> float:
+        return _finite_timestamp(value)
+
+    @classmethod
+    def public_status(cls, status: Dict[str, Any]) -> Dict[str, Any]:
+        public = {}
+        for key, value in status.items():
+            if key not in PUBLIC_RUN_STATUS_FIELDS:
+                continue
+            if key in {"created_at", "updated_at"}:
+                public[key] = cls.finite_timestamp(value)
+            else:
+                public[key] = _snapshot_status_value(value)
+        return public
+
+    def _set_status_locked(
+        self,
+        run_id: str,
+        status: str,
+        fields: Dict[str, Any],
+        *,
+        now: float,
+    ) -> Dict[str, Any]:
+        incoming = dict(fields)
+        created_at = incoming.pop("created_at", now)
+        current = self._statuses.get(run_id, {})
+        if (
+            (
+                run_id in self._claimed_stop_ids
+                or run_id in self._stopping_ids
+            )
+            and "session_id" in incoming
+            and incoming["session_id"] != current.get("session_id")
+        ):
+            raise RuntimeError(
+                "run ownership mutation rejected while stop is pending"
+            )
+        candidate = dict(current)
+        candidate.update(
+            {
+                "object": "hermes.run",
+                "run_id": run_id,
+                "status": status,
+                "updated_at": now,
+            }
+        )
+        candidate.setdefault(
+            "created_at",
+            created_at,
+        )
+        candidate.update(incoming)
+        public = self.public_status(candidate)
+        self._statuses[run_id] = candidate
+        return public
+
+    def set_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
+        _validate_run_status(status)
+        now = self.finite_timestamp(self._clock())
+        for field in ("created_at", "updated_at"):
+            if field in fields:
+                fields[field] = self.finite_timestamp(fields[field])
+        incoming = _snapshot_status_value(fields)
+        with self._lock:
+            return self._set_status_locked(
+                run_id,
+                status,
+                incoming,
+                now=now,
+            )
+
+    def get(self, run_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            status = self._statuses.get(run_id)
+            if status is None:
+                return None
+            return self.public_status(status)
+
+    def contains(self, run_id: str) -> bool:
+        with self._lock:
+            return run_id in self._statuses
+
+    def status_value(self, run_id: str, field: str, default: Any = None) -> Any:
+        with self._lock:
+            return _snapshot_status_value(
+                self._statuses.get(run_id, {}).get(field, default)
+            )
+
+
+    def active_status_count(self) -> int:
+        with self._lock:
+            return sum(
+                status.get("status") in ACTIVE_RUN_STATUSES
+                for status in self._statuses.values()
+            )
+
+    def expire_terminal_statuses(self, now: float, ttl: float) -> None:
+        with self._lock:
+            stale = [
+                run_id
+                for run_id, status in self._statuses.items()
+                if status.get("status") in TERMINAL_RUN_STATUSES
+                and now - self.finite_timestamp(status.get("updated_at", 0)) > ttl
+            ]
+            for run_id in stale:
+                self._statuses.pop(run_id, None)
+
+    def register_agent(self, run_id: str, agent: Any) -> bool:
+        with self._lock:
+            if run_id in self._stopping_ids or run_id in self._claimed_stop_ids:
+                return False
+            self._agents[run_id] = agent
+            return True
+
+    def register_task(self, run_id: str, task: Any) -> bool:
+        with self._lock:
+            if run_id in self._stopping_ids or run_id in self._claimed_stop_ids:
+                return False
+            self._tasks[run_id] = task
+            return True
+
+    def agent_for(self, run_id: str) -> Any:
+        with self._lock:
+            return self._agents.get(run_id)
+
+    def task_for(self, run_id: str) -> Any:
+        with self._lock:
+            return self._tasks.get(run_id)
+
+    def active_task_count(self) -> int:
+        with self._lock:
+            tasks = tuple(self._tasks.values())
+        return sum(not task.done() for task in tasks)
+
+    def is_stopping(self, run_id: str) -> bool:
+        with self._lock:
+            return run_id in self._stopping_ids
+
+    def remove_control(self, run_id: str) -> None:
+        with self._lock:
+            if run_id in self._claimed_stop_ids:
+                self._deferred_control_removals.add(run_id)
+                return
+            self._remove_control_locked(run_id)
+
+    def claim_stop_target(self, run_id: str) -> Optional[StopTarget]:
+        """Atomically lease a stop target without running external code locked."""
+        now = self.finite_timestamp(self._clock())
+        with self._lock:
+            agent = self._agents.get(run_id)
+            task = self._tasks.get(run_id)
+            if agent is None and task is None:
+                return None
+
+            if run_id in self._claimed_stop_ids or run_id in self._stopping_ids:
+                return StopTarget(agent=None, task=task, owns_lease=False)
+
+            self._set_status_locked(
+                run_id,
+                "stopping",
+                {"last_event": "run.stopping"},
+                now=now,
+            )
+            self._stopping_ids.add(run_id)
+            self._claimed_stop_ids.add(run_id)
+            return StopTarget(agent=agent, task=task)
+
+    def release_stop_target(self, run_id: str) -> None:
+        """Release a stop lease and apply cleanup deferred during interruption."""
+        with self._lock:
+            self._claimed_stop_ids.discard(run_id)
+            if run_id in self._deferred_control_removals:
+                self._deferred_control_removals.discard(run_id)
+                self._remove_control_locked(run_id)
+
+    def _remove_control_locked(self, run_id: str) -> None:
+        self._agents.pop(run_id, None)
+        self._tasks.pop(run_id, None)
+        self._stopping_ids.discard(run_id)
+        self._deferred_control_removals.discard(run_id)

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -507,6 +507,12 @@ class TestStopRun:
 
                 stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
                 assert stop_resp.status == 200
+                repeated_stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert repeated_stop_resp.status == 200
+                assert (await repeated_stop_resp.json()) == {
+                    "run_id": run_id,
+                    "status": "stopping",
+                }
                 await asyncio.sleep(0.1)
 
                 assert not run_finished.is_set()

--- a/tests/gateway/test_run_service.py
+++ b/tests/gateway/test_run_service.py
@@ -1,0 +1,341 @@
+"""Behavioral tests for the pure, lock-aware run registry."""
+
+import threading
+
+import pytest
+
+from gateway.run_service import RunRegistry
+
+
+PUBLIC_FIELDS = {
+    "object",
+    "run_id",
+    "status",
+    "session_id",
+    "model",
+    "created_at",
+    "updated_at",
+    "last_event",
+    "output",
+    "usage",
+    "error",
+}
+
+
+class MutableTimestamp:
+    def __init__(self, value):
+        self.value = value
+
+    def __float__(self):
+        return float(self.value)
+
+
+class UnsupportedStatusValue:
+    deepcopy_calls = 0
+
+    def __deepcopy__(self, memo):
+        type(self).deepcopy_calls += 1
+        raise AssertionError("custom deepcopy must not run")
+
+
+def test_set_status_retains_creation_time_and_projects_only_public_fields():
+    times = iter((10.0, 20.0))
+    registry = RunRegistry(clock=lambda: next(times))
+
+    registry.set_status(
+        "run_1",
+        "queued",
+        session_id="conversation-a",
+        model="hermes-agent",
+        private_agent="must-not-leak",
+    )
+    registry.set_status(
+        "run_1",
+        "running",
+        created_at=999.0,
+        last_event="run.started",
+    )
+
+    status = registry.get("run_1")
+
+    assert status == {
+        "object": "hermes.run",
+        "run_id": "run_1",
+        "status": "running",
+        "session_id": "conversation-a",
+        "model": "hermes-agent",
+        "created_at": 10.0,
+        "updated_at": 20.0,
+        "last_event": "run.started",
+    }
+    assert set(status) <= PUBLIC_FIELDS
+
+
+def test_set_status_detaches_explicit_creation_time():
+    registry = RunRegistry(clock=lambda: 20.0)
+    created_at = MutableTimestamp(10.0)
+
+    registry.set_status(
+        "run_1",
+        "queued",
+        created_at=created_at,
+        session_id="conversation-a",
+    )
+    created_at.value = 99.0
+
+    status = registry.get("run_1")
+    assert status is not None
+    assert status["created_at"] == 10.0
+
+
+def test_set_status_coerces_and_detaches_clock_value_before_storage():
+    clock_value = MutableTimestamp(10.0)
+    registry = RunRegistry(clock=lambda: clock_value)
+
+    registry.set_status("run_1", "queued", session_id="conversation-a")
+    clock_value.value = 99.0
+
+    status = registry.get("run_1")
+    assert status is not None
+    assert status["created_at"] == 10.0
+    assert status["updated_at"] == 10.0
+
+
+def test_explicit_and_raw_updated_at_values_use_timestamp_fallback():
+    registry = RunRegistry(clock=lambda: 10.0)
+
+    status = registry.set_status(
+        "run_1",
+        "running",
+        session_id="conversation-a",
+        updated_at=float("nan"),
+    )
+    assert status["updated_at"] == 0.0
+    assert RunRegistry.public_status(
+        {
+            "run_id": "run_raw",
+            "status": "running",
+            "updated_at": float("inf"),
+        }
+    )["updated_at"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-number",
+        None,
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        pytest.param(10**10000, id="float-overflow"),
+    ],
+)
+def test_public_status_normalizes_invalid_and_non_finite_timestamps(timestamp):
+    registry = RunRegistry()
+    registry.statuses["run_bad_time"] = {
+        "object": "hermes.run",
+        "run_id": "run_bad_time",
+        "status": "running",
+        "session_id": "conversation-a",
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+
+    status = registry.get("run_bad_time")
+
+    assert status["created_at"] == 0.0
+    assert status["updated_at"] == 0.0
+
+
+def test_status_snapshots_cannot_mutate_authoritative_ownership():
+    registry = RunRegistry()
+    source = {
+        "run_id": "run_owned",
+        "status": "running",
+        "session_id": "conversation-a",
+        "usage": {"input_tokens": 1},
+    }
+    registry.statuses["run_owned"] = source
+
+    source["session_id"] = "conversation-b"
+    source["usage"]["input_tokens"] = 2
+    compatibility_snapshot = registry.statuses["run_owned"]
+    compatibility_snapshot["session_id"] = "conversation-b"
+    compatibility_snapshot["usage"]["input_tokens"] = 3
+    returned = registry.set_status("run_owned", "waiting_for_approval")
+    returned["session_id"] = "conversation-b"
+    returned["usage"]["input_tokens"] = 4
+
+    status = registry.get("run_owned")
+    assert status is not None
+    assert status["session_id"] == "conversation-a"
+    assert status["usage"] == {"input_tokens": 1}
+
+
+def test_unsupported_status_value_fails_before_lock_without_partial_update():
+    times = iter((10.0, 20.0))
+    registry = RunRegistry(clock=lambda: next(times))
+    registry.set_status("run_owned", "running", session_id="conversation-a")
+    before = registry.get("run_owned")
+    UnsupportedStatusValue.deepcopy_calls = 0
+
+    with pytest.raises(TypeError, match="JSON-compatible"):
+        registry.set_status(
+            "run_owned",
+            "waiting_for_approval",
+            usage=UnsupportedStatusValue(),
+        )
+
+    assert UnsupportedStatusValue.deepcopy_calls == 0
+    assert registry.get("run_owned") == before
+
+
+def test_set_status_rejects_unknown_states_and_nonfinite_payload_values():
+    registry = RunRegistry()
+
+    with pytest.raises(ValueError, match="unsupported run status"):
+        registry.set_status("run_1", "runnning", session_id="conversation-a")
+    with pytest.raises(ValueError, match="finite"):
+        registry.set_status(
+            "run_1",
+            "running",
+            session_id="conversation-a",
+            usage={"cost": float("nan")},
+        )
+    with pytest.raises(ValueError, match="unsupported run status"):
+        registry.statuses["run_1"] = {
+            "run_id": "run_1",
+            "status": "runnning",
+            "session_id": "conversation-a",
+        }
+    assert registry.get("run_1") is None
+
+
+def test_active_task_count_calls_done_without_holding_registry_lock():
+    registry = RunRegistry()
+    update_finished = threading.Event()
+
+    class Task:
+        def done(self):
+            def update_registry():
+                registry.set_status(
+                    "run_other",
+                    "running",
+                    session_id="conversation-b",
+                )
+                update_finished.set()
+
+            thread = threading.Thread(target=update_registry)
+            thread.start()
+            thread.join(timeout=1)
+            return update_finished.is_set()
+
+    registry.register_task("run_1", Task())
+
+    assert registry.active_task_count() == 0
+    assert update_finished.is_set()
+
+
+def test_claim_stop_target_atomically_marks_stopping():
+    registry = RunRegistry()
+    agent = object()
+    task = object()
+    registry.set_status("run_owned", "running", session_id="conversation-a")
+    registry.register_agent("run_owned", agent)
+    registry.register_task("run_owned", task)
+
+    assert registry.claim_stop_target("run_missing") is None
+
+    claimed = registry.claim_stop_target("run_owned")
+    assert claimed is not None
+    assert claimed.agent is agent
+    assert claimed.task is task
+    assert registry.is_stopping("run_owned")
+    status = registry.get("run_owned")
+    assert status is not None
+    assert status["status"] == "stopping"
+    assert status["last_event"] == "run.stopping"
+    registry.release_stop_target("run_owned")
+
+
+def test_claim_prevents_control_replacement_without_holding_global_lock():
+    registry = RunRegistry()
+    original_agent = object()
+    replacement_agent = object()
+    original_task = object()
+    replacement_task = object()
+    registry.set_status("run_owned", "running", session_id="conversation-a")
+    registry.register_agent("run_owned", original_agent)
+    registry.register_task("run_owned", original_task)
+
+    claimed = registry.claim_stop_target("run_owned")
+    assert claimed is not None
+    assert claimed.agent is original_agent
+    assert registry.register_agent("run_owned", replacement_agent) is False
+    with pytest.raises(RuntimeError, match="stop is pending"):
+        registry.agents["run_owned"] = replacement_agent
+    with pytest.raises(RuntimeError, match="stop is pending"):
+        registry.tasks["run_owned"] = replacement_task
+    with pytest.raises(RuntimeError, match="stop is pending"):
+        registry.statuses["run_owned"] = {
+            "run_id": "run_owned",
+            "status": "running",
+            "session_id": "conversation-b",
+        }
+    with pytest.raises(RuntimeError, match="stop is pending"):
+        registry.stopping_ids.discard("run_owned")
+    with pytest.raises(RuntimeError, match="ownership mutation"):
+        registry.set_status(
+            "run_owned",
+            "running",
+            session_id="conversation-b",
+        )
+    assert registry.agent_for("run_owned") is original_agent
+    assert registry.task_for("run_owned") is original_task
+    assert registry.get("run_owned") is not None
+
+    unrelated_finished = threading.Event()
+
+    def update_unrelated_run():
+        registry.set_status("run_other", "running", session_id="conversation-b")
+        unrelated_finished.set()
+
+    thread = threading.Thread(target=update_unrelated_run)
+    thread.start()
+    thread.join(timeout=1)
+    assert unrelated_finished.is_set()
+
+    registry.release_stop_target("run_owned")
+    assert registry.register_agent("run_owned", replacement_agent) is False
+    assert registry.register_task("run_owned", replacement_task) is False
+    with pytest.raises(RuntimeError, match="stop is pending"):
+        registry.agents["run_owned"] = replacement_agent
+    with pytest.raises(RuntimeError, match="stop is pending"):
+        registry.tasks["run_owned"] = replacement_task
+    with pytest.raises(RuntimeError, match="ownership mutation"):
+        registry.set_status(
+            "run_owned",
+            "stopping",
+            session_id="conversation-b",
+        )
+    assert registry.agent_for("run_owned") is original_agent
+    assert registry.task_for("run_owned") is original_task
+
+
+def test_claim_defers_control_cleanup_until_release():
+    registry = RunRegistry()
+    agent = object()
+    task = object()
+    registry.set_status("run_owned", "running", session_id="conversation-a")
+    registry.register_agent("run_owned", agent)
+    registry.register_task("run_owned", task)
+
+    assert registry.claim_stop_target("run_owned") is not None
+    registry.remove_control("run_owned")
+    assert registry.agent_for("run_owned") is agent
+    assert registry.task_for("run_owned") is task
+
+    registry.release_stop_target("run_owned")
+    assert registry.agent_for("run_owned") is None
+    assert registry.task_for("run_owned") is None

--- a/tests/gateway/test_run_service.py
+++ b/tests/gateway/test_run_service.py
@@ -330,12 +330,42 @@ def test_claim_defers_control_cleanup_until_release():
     registry.set_status("run_owned", "running", session_id="conversation-a")
     registry.register_agent("run_owned", agent)
     registry.register_task("run_owned", task)
+    registry.register_approval_session("run_owned", "approval-owned")
 
     assert registry.claim_stop_target("run_owned") is not None
     registry.remove_control("run_owned")
     assert registry.agent_for("run_owned") is agent
     assert registry.task_for("run_owned") is task
+    assert registry.approval_session_for("run_owned") == "approval-owned"
 
     registry.release_stop_target("run_owned")
     assert registry.agent_for("run_owned") is None
     assert registry.task_for("run_owned") is None
+    assert registry.approval_session_for("run_owned") is None
+
+
+def test_registry_owns_approval_session_lookup_and_cleanup():
+    registry = RunRegistry()
+
+    registry.register_approval_session("run_owned", "approval-owned")
+
+    assert registry.approval_session_for("run_owned") == "approval-owned"
+    assert registry.approval_session_for("run_missing") is None
+    assert dict(registry.approval_sessions) == {
+        "run_owned": "approval-owned"
+    }
+
+    registry.remove_control("run_owned")
+
+    assert registry.approval_session_for("run_owned") is None
+    assert "run_owned" not in registry.approval_sessions
+
+
+def test_replace_approval_sessions_preserves_legacy_map_compatibility():
+    registry = RunRegistry()
+    registry.replace_approval_sessions(
+        {"run_one": "approval-one", "run_two": "approval-two"}
+    )
+
+    assert registry.approval_session_for("run_one") == "approval-one"
+    assert registry.approval_session_for("run_two") == "approval-two"


### PR DESCRIPTION
## What

This extracts API-server run lifecycle state from `APIServerAdapter` into a canonical `RunRegistry`.

- Centralizes run status, active task and agent references, approval ownership, stop claims, and retained-state cleanup.
- Keeps the existing create, status, events, approval, and stop routes on the same public contract. A run ID remains the bearer capability, with no new listing or session-enumeration surface.
- Adds no model tools, hooks, middleware, behavioral environment variables, or second task store.

## Why this seam

Every transport that needs long-running work should reuse one lifecycle authority instead of creating another run or task store. Keeping state in a host-owned registry makes the API adapter thinner now and gives future voice, desktop, and realtime transports a canonical seam to build on later.

This builds on Mibayy's original `/v1/runs` SSE work. It also follows the one-authority direction in the automated review of Fritz Stapfer Paz's realtime orchestration PR #54462, which asked realtime clients to integrate task state with `/v1/runs` or explicitly scope it as client-owned annotations.

## Testing

- `scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_active_work_drain.py tests/gateway/test_run_service.py tests/gateway/test_api_server_runs.py`
  - 262 passed, 0 failed
  - includes the full API-server and drain regression suites, RunRegistry behavior, and existing Runs API contract
- `scripts/run_tests.sh` completed across the full repository on this macOS host. It reported 27 failures across 15 files plus two files with no completed test run, all outside PR A's four-file diff. This is not presented as a full-suite green claim; the affected 262-test slice above is the scoped green gate.
- Manual changed-path exercise through an isolated real `hermes gateway run` process with a temporary `HERMES_HOME` and local OpenAI-compatible provider:
  - run submission completed with the expected output
  - status returned `completed`; a supplied `session_id` query remained ignored under the existing bearer run-ID contract
  - unscoped SSE replay returned `run.completed` and closed cleanly
  - approval reached `409 approval_not_active`
  - `GET /v1/runs` returned `405`, confirming that no listing surface was introduced
  - bodyless stop returned `200 stopping` and reached `cancelled`
  - a supplied stop-body `session_id` remained ignored under the existing bearer run-ID contract
- `python scripts/check-windows-footguns.py --diff origin/main`
  - no Windows footguns found across the changed files
- `python -m py_compile` passed for all changed Python files.
- `git diff --check origin/main...HEAD` passed.

**Platforms tested:** macOS 26.5.2 (Build 25F84), Apple Silicon arm64, Python 3.11.13. Manual runtime validation was performed on macOS. Windows received the repository's static footgun scan. No manual Linux or Windows runtime claim is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnMCvi2vXqfs996AjVeF2F
