### PR TITLE
fix(anthropic): fall back when OCI emits data-only SSE

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -439,6 +439,17 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     return True  # Any other endpoint is a third-party proxy
 
 
+def _is_oci_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for OCI Generative AI's Anthropic-compatible endpoint."""
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    parsed = urlparse(normalized)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    path = (parsed.path or "").lower().rstrip("/")
+    return host.endswith(".oci.oraclecloud.com") and path.endswith("/anthropic")
+
+
 def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     """Return True for Kimi's /coding endpoint that requires claude-code UA."""
     normalized = _normalize_base_url_text(base_url)
@@ -2749,6 +2760,26 @@ def _is_stream_unavailable_error(exc: Exception) -> bool:
     return False
 
 
+def is_empty_anthropic_stream_assertion(exc: Exception) -> bool:
+    """Return whether the Anthropic SDK received no parseable stream events.
+
+    Some Anthropic-compatible endpoints emit valid SSE ``data:`` frames but
+    omit the accompanying ``event:`` lines. The SDK then reaches
+    ``get_final_message()`` without a message snapshot and raises a blank
+    ``AssertionError``. Keep the check narrow so application assertions are
+    never hidden.
+    """
+    return isinstance(exc, AssertionError) and not str(exc)
+
+
+def _is_empty_anthropic_final_message(message: Any) -> bool:
+    """Return whether a stream produced no usable final-message snapshot."""
+    return message is None or (
+        not getattr(message, "content", None)
+        and getattr(message, "stop_reason", None) is None
+    )
+
+
 def create_anthropic_message(
     client: Any,
     api_kwargs: dict,
@@ -2774,7 +2805,20 @@ def create_anthropic_message(
         stream_kwargs.pop("stream", None)
         try:
             with stream_fn(**stream_kwargs) as stream:
-                return stream.get_final_message()
+                try:
+                    final_message = stream.get_final_message()
+                except Exception as exc:
+                    if not is_empty_anthropic_stream_assertion(exc):
+                        raise
+                else:
+                    if not _is_empty_anthropic_final_message(final_message):
+                        return final_message
+                logger.warning(
+                    "%sAnthropic SDK produced no usable final stream message; "
+                    "retrying this request with messages.create(). The endpoint "
+                    "may emit data-only SSE frames without event names.",
+                    log_prefix,
+                )
         except Exception as exc:
             if not _is_stream_unavailable_error(exc):
                 raise

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2819,6 +2819,30 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
                     _is_empty_stream = isinstance(e, EmptyStreamError)
+                    if (
+                        agent.api_mode == "anthropic_messages"
+                        and _is_empty_stream
+                        and not deltas_were_sent["yes"]
+                    ):
+                        from agent.anthropic_adapter import _is_oci_anthropic_endpoint
+
+                        if _is_oci_anthropic_endpoint(agent.base_url):
+                            agent._disable_streaming = True
+                            agent._safe_print(
+                                "\n⚠  This Anthropic-compatible endpoint returned "
+                                "data-only SSE that the Anthropic SDK could not parse. "
+                                "Switching to non-streaming for this session.\n"
+                            )
+                            logger.warning(
+                                "Anthropic SDK parsed zero events from OCI "
+                                "stream; disabling streaming for this session "
+                                "provider=%s model=%s base_url=%s",
+                                agent.provider,
+                                agent.model,
+                                agent.base_url,
+                            )
+                            result["error"] = e
+                            return
 
                     # If the stream died AFTER some tokens were delivered:
                     # normally we don't retry (the user already saw text,

--- a/tests/agent/test_anthropic_data_only_sse_fallback.py
+++ b/tests/agent/test_anthropic_data_only_sse_fallback.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.anthropic_adapter import create_anthropic_message
+from agent.errors import EmptyStreamError
+
+
+OCI_ANTHROPIC_URL = "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/anthropic"
+
+
+def _empty_snapshot_stream_cm():
+    cm = MagicMock()
+    stream = MagicMock()
+    stream.__iter__ = MagicMock(return_value=iter(()))
+    stream.get_final_message = MagicMock(side_effect=AssertionError())
+    cm.__enter__ = MagicMock(return_value=stream)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+def test_create_message_falls_back_when_sdk_stream_has_no_final_snapshot():
+    client = MagicMock()
+    client.messages.stream.return_value = _empty_snapshot_stream_cm()
+    expected = SimpleNamespace(content=[], stop_reason="end_turn")
+    client.messages.create.return_value = expected
+
+    response = create_anthropic_message(
+        client,
+        {
+            "model": "claude-opus-4-8",
+            "messages": [{"role": "user", "content": "Reply exactly OK"}],
+            "max_tokens": 16,
+        },
+    )
+
+    assert response is expected
+    client.messages.stream.assert_called_once()
+    client.messages.create.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "empty_final",
+    [None, SimpleNamespace(content=[], stop_reason=None)],
+)
+def test_create_message_falls_back_for_empty_final_message_shapes(empty_final):
+    client = MagicMock()
+    cm = _empty_snapshot_stream_cm()
+    get_final_message = cm.__enter__.return_value.get_final_message
+    get_final_message.side_effect = None
+    get_final_message.return_value = empty_final
+    client.messages.stream.return_value = cm
+    expected = SimpleNamespace(content=[], stop_reason="end_turn")
+    client.messages.create.return_value = expected
+
+    response = create_anthropic_message(
+        client,
+        {"model": "claude-opus-4-8", "messages": [], "max_tokens": 16},
+    )
+
+    assert response is expected
+    client.messages.create.assert_called_once()
+
+
+def test_create_message_does_not_hide_nonempty_application_assertions():
+    client = MagicMock()
+    cm = _empty_snapshot_stream_cm()
+    cm.__enter__.return_value.get_final_message.side_effect = AssertionError("bad app state")
+    client.messages.stream.return_value = cm
+
+    with pytest.raises(AssertionError, match="bad app state"):
+        create_anthropic_message(
+            client,
+            {"model": "claude-opus-4-8", "messages": [], "max_tokens": 16},
+        )
+
+    client.messages.create.assert_not_called()
+
+
+def test_create_message_does_not_hide_blank_assertion_before_final_message():
+    client = MagicMock()
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(side_effect=AssertionError())
+    client.messages.stream.return_value = cm
+
+    with pytest.raises(AssertionError):
+        create_anthropic_message(
+            client,
+            {"model": "claude-opus-4-8", "messages": [], "max_tokens": 16},
+        )
+
+    client.messages.create.assert_not_called()
+
+
+def test_oci_empty_stream_disables_streaming_without_retrying(monkeypatch):
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+    agent = AIAgent(
+        api_key="test-key",
+        base_url=OCI_ANTHROPIC_URL,
+        model="claude-opus-4-8",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_client = MagicMock()
+    agent._anthropic_api_key = "test-key"
+    agent._anthropic_client.messages.stream.return_value = _empty_snapshot_stream_cm()
+
+    with pytest.raises(EmptyStreamError):
+        agent._interruptible_streaming_api_call({})
+
+    assert agent._disable_streaming is True
+    agent._anthropic_client.messages.stream.assert_called_once()
+
+
+def test_other_third_party_empty_stream_keeps_transient_retry_behavior(monkeypatch):
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://anthropic-proxy.example.com/v1",
+        model="claude-opus-4-8",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_client = MagicMock()
+    agent._anthropic_api_key = "test-key"
+    agent._rebuild_anthropic_client = MagicMock()
+    agent._anthropic_client.messages.stream.return_value = _empty_snapshot_stream_cm()
+
+    with pytest.raises(EmptyStreamError):
+        agent._interruptible_streaming_api_call({})
+
+    assert getattr(agent, "_disable_streaming", False) is False
+    assert agent._anthropic_client.messages.stream.call_count == 3


### PR DESCRIPTION
## Summary

- Detect OCI Generative AI Anthropic endpoints that return data-only SSE frames the Anthropic SDK cannot parse.
- Disable streaming for the session after the first deterministic OCI empty stream so the existing outer retry uses `messages.create()`.
- Make auxiliary Anthropic aggregation fall back to `messages.create()` for blank SDK assertions and empty final-message shapes while preserving real application assertions.
- Preserve the existing transient empty-stream retry behavior for non-OCI third-party endpoints.

## Root cause

OCI returns valid `data:` SSE frames without the accompanying `event:` lines expected by the Anthropic SDK. The SDK therefore sees no events and raises a blank `AssertionError` from `get_final_message()` even though non-streaming requests succeed.

## Validation

- `scripts/run_tests.sh tests/agent/test_anthropic_data_only_sse_fallback.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py tests/run_agent/test_streaming.py -q` — 59 passed
- Live OCI request: `hermes -z ... -m claude-opus-4-8 --provider custom:oci-claude` — returned exactly `OK`
- Independent Opus review — passed; no security or logic errors

## Risk

Low. The main-turn fallback is restricted to OCI `*.oci.oraclecloud.com/.../anthropic` endpoints and only triggers after a zero-event `EmptyStreamError` before any deltas are delivered. Other third-party endpoints retain the current retry behavior.