### PR TITLE
fix(web): scope gateway controls to selected profile

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -104,3 +104,44 @@ describe("api OAuth helpers", () => {
     }
   });
 });
+
+describe("gateway lifecycle profile scoping", () => {
+  it("sends the target profile explicitly for lifecycle mutations", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.startGateway("h");
+    await api.stopGateway("default");
+    await api.restartGateway("h");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/gateway/start?profile=h",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/gateway/stop?profile=default",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/api/gateway/restart?profile=h",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("reads status for the explicit target profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ gateway_running: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getStatus("h");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/status?profile=h",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -306,7 +306,8 @@ function appendProfileParam(url: string, profile?: string): string {
 
 export const api = {
   buildWsUrl,
-  getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getStatus: (profile?: string) =>
+    fetchJSON<StatusResponse>(`/api/status${profileQuery(profile)}`),
   /**
    * Identity probe for the dashboard auth gate (Phase 7).
    *
@@ -900,8 +901,11 @@ export const api = {
     ),
 
   // Gateway / update actions
-  restartGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/restart", { method: "POST" }),
+  restartGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(
+      `/api/gateway/restart${profileQuery(profile)}`,
+      { method: "POST" },
+    ),
   updateHermes: () =>
     fetchJSON<ActionResponse>("/api/hermes/update", { method: "POST" }),
   checkHermesUpdate: (force = false) =>
@@ -1134,10 +1138,16 @@ export const api = {
     }),
 
   // ── Admin: Gateway lifecycle ────────────────────────────────────────
-  startGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/start", { method: "POST" }),
-  stopGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/stop", { method: "POST" }),
+  startGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(
+      `/api/gateway/start${profileQuery(profile)}`,
+      { method: "POST" },
+    ),
+  stopGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(
+      `/api/gateway/stop${profileQuery(profile)}`,
+      { method: "POST" },
+    ),
 
   // ── Admin: Operations ───────────────────────────────────────────────
   runDoctor: () =>

--- a/web/src/lib/gateway-lifecycle.test.ts
+++ b/web/src/lib/gateway-lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  waitForActionCompletion,
+  waitForGatewayState,
+} from "./gateway-lifecycle";
+
+const never = new Promise<never>(() => {});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("waitForGatewayState", () => {
+  it("keeps polling until the selected gateway reaches the expected state", async () => {
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ gateway_running: false })
+      .mockResolvedValueOnce({ gateway_running: true });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const status = await waitForGatewayState(getStatus, true, {
+      intervalMs: 1,
+      timeoutMs: 1_000,
+      sleep,
+    });
+
+    expect(status.gateway_running).toBe(true);
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out when a status request never settles", async () => {
+    vi.useFakeTimers();
+    const result = waitForGatewayState(() => never, true, { timeoutMs: 10 });
+    const rejection = expect(result).rejects.toThrow(
+      "Timed out waiting for gateway state transition",
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    await rejection;
+  });
+
+  it("rejects a matching status that resolves after the deadline", async () => {
+    vi.useFakeTimers();
+    let resolveStatus!: (status: { gateway_running: boolean }) => void;
+    const delayedStatus = new Promise<{ gateway_running: boolean }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const result = waitForGatewayState(() => delayedStatus, true, {
+      timeoutMs: 10,
+    });
+    const rejection = expect(result).rejects.toThrow(
+      "Timed out waiting for gateway state transition",
+    );
+
+    await vi.advanceTimersByTimeAsync(11);
+    resolveStatus({ gateway_running: true });
+    await vi.runAllTimersAsync();
+
+    await rejection;
+  });
+});
+
+describe("waitForActionCompletion", () => {
+  it("accepts a restart already complete before polling the running gateway", async () => {
+    const getActionStatus = vi.fn().mockResolvedValue({
+      running: false,
+      exit_code: 0,
+      pid: 41,
+    });
+    const getStatus = vi.fn().mockResolvedValue({ gateway_running: true });
+
+    await expect(
+      waitForActionCompletion(getActionStatus, 41, { timeoutMs: 1_000 }),
+    ).resolves.toMatchObject({ running: false, exit_code: 0 });
+    await expect(
+      waitForGatewayState(getStatus, true, { timeoutMs: 1_000 }),
+    ).resolves.toMatchObject({ gateway_running: true });
+    expect(getActionStatus).toHaveBeenCalledTimes(1);
+    expect(getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a completed action with an unsuccessful exit", async () => {
+    const getActionStatus = vi.fn().mockResolvedValue({
+      running: false,
+      exit_code: 1,
+      pid: 41,
+    });
+
+    await expect(waitForActionCompletion(getActionStatus, 41)).rejects.toThrow(
+      "Gateway action failed with exit code 1",
+    );
+  });
+
+  it("rejects a shared action slot replaced by a different process", async () => {
+    const getActionStatus = vi.fn().mockResolvedValue({
+      running: false,
+      exit_code: 0,
+      pid: 99,
+    });
+
+    await expect(waitForActionCompletion(getActionStatus, 41)).rejects.toThrow(
+      "Gateway action was replaced by process 99",
+    );
+  });
+
+  it("times out when an action status request never settles", async () => {
+    vi.useFakeTimers();
+    const result = waitForActionCompletion(() => never, 41, { timeoutMs: 10 });
+    const rejection = expect(result).rejects.toThrow(
+      "Timed out waiting for gateway action completion",
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    await rejection;
+  });
+
+  it("rejects a completed action that resolves after the deadline", async () => {
+    vi.useFakeTimers();
+    let resolveStatus!: (status: {
+      running: boolean;
+      exit_code: number | null;
+      pid: number | null;
+    }) => void;
+    const delayedStatus = new Promise<{
+      running: boolean;
+      exit_code: number | null;
+      pid: number | null;
+    }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const result = waitForActionCompletion(() => delayedStatus, 41, {
+      timeoutMs: 10,
+    });
+    const rejection = expect(result).rejects.toThrow(
+      "Timed out waiting for gateway action completion",
+    );
+
+    await vi.advanceTimersByTimeAsync(11);
+    resolveStatus({ running: false, exit_code: 0, pid: 41 });
+    await vi.runAllTimersAsync();
+
+    await rejection;
+  });
+});

--- a/web/src/lib/gateway-lifecycle.ts
+++ b/web/src/lib/gateway-lifecycle.ts
@@ -1,0 +1,95 @@
+export interface GatewayRunningStatus {
+  gateway_running?: boolean;
+}
+
+export interface GatewayActionStatus {
+  running: boolean;
+  exit_code: number | null;
+  pid: number | null;
+}
+
+interface PollOptions {
+  intervalMs?: number;
+  timeoutMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+const defaultSleep = (milliseconds: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+async function beforeDeadline<T>(
+  promise: Promise<T>,
+  deadline: number,
+  timeoutMessage: string,
+): Promise<T> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) throw new Error(timeoutMessage);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(timeoutMessage)), remainingMs);
+      }),
+    ]);
+    if (Date.now() >= deadline) throw new Error(timeoutMessage);
+    return result;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function pollUntil<T>(
+  getValue: () => Promise<T>,
+  isComplete: (value: T) => boolean,
+  timeoutMessage: string,
+  options: PollOptions,
+): Promise<T> {
+  const intervalMs = options.intervalMs ?? 1_000;
+  const deadline = Date.now() + (options.timeoutMs ?? 30_000);
+  const sleep = options.sleep ?? defaultSleep;
+
+  while (true) {
+    const value = await beforeDeadline(getValue(), deadline, timeoutMessage);
+    if (Date.now() >= deadline) throw new Error(timeoutMessage);
+    if (isComplete(value)) return value;
+    await beforeDeadline(sleep(intervalMs), deadline, timeoutMessage);
+  }
+}
+
+export function waitForGatewayState<T extends GatewayRunningStatus>(
+  getStatus: () => Promise<T>,
+  expectedRunning: boolean,
+  options: PollOptions = {},
+): Promise<T> {
+  return pollUntil(
+    getStatus,
+    (status) => status.gateway_running === expectedRunning,
+    "Timed out waiting for gateway state transition",
+    options,
+  );
+}
+
+export async function waitForActionCompletion<T extends GatewayActionStatus>(
+  getActionStatus: () => Promise<T>,
+  expectedPid: number,
+  options: PollOptions = {},
+): Promise<T> {
+  const status = await pollUntil(
+    async () => {
+      const candidate = await getActionStatus();
+      if (candidate.pid !== expectedPid) {
+        throw new Error(`Gateway action was replaced by process ${candidate.pid}`);
+      }
+      return candidate;
+    },
+    (candidate) => !candidate.running,
+    "Timed out waiting for gateway action completion",
+    options,
+  );
+  if (status.exit_code !== 0) {
+    throw new Error(`Gateway action failed with exit code ${status.exit_code}`);
+  }
+  return status;
+}

--- a/web/src/lib/profile-load.test.ts
+++ b/web/src/lib/profile-load.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveProfileStatusLoad } from "./profile-load";
+
+describe("resolveProfileStatusLoad", () => {
+  it("settles a rejected load for the selected profile without stale status", () => {
+    const result = resolveProfileStatusLoad("work", {
+      status: "rejected",
+      reason: new Error("unavailable"),
+    });
+
+    expect(result).toEqual({
+      loadedProfile: "work",
+      status: null,
+      error: "unavailable",
+    });
+  });
+
+  it("clears the selected profile error after a successful retry", () => {
+    const result = resolveProfileStatusLoad("work", {
+      status: "fulfilled",
+      value: { gateway_running: true },
+    });
+
+    expect(result).toEqual({
+      loadedProfile: "work",
+      status: { gateway_running: true },
+      error: null,
+    });
+  });
+});

--- a/web/src/lib/profile-load.ts
+++ b/web/src/lib/profile-load.ts
@@ -1,0 +1,17 @@
+export interface ProfileStatusLoad<T> {
+  loadedProfile: string;
+  status: T | null;
+  error: string | null;
+}
+
+export function resolveProfileStatusLoad<T>(
+  profile: string,
+  result: PromiseSettledResult<T>,
+): ProfileStatusLoad<T> {
+  if (result.status === "fulfilled") {
+    return { loadedProfile: profile, status: result.value, error: null };
+  }
+  const error =
+    result.reason instanceof Error ? result.reason.message : String(result.reason);
+  return { loadedProfile: profile, status: null, error };
+}

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -45,6 +45,12 @@ import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { HermesConsoleModal } from "@/components/HermesConsoleModal";
 import { cn, themedBody } from "@/lib/utils";
 import { api } from "@/lib/api";
+import {
+  waitForActionCompletion,
+  waitForGatewayState,
+} from "@/lib/gateway-lifecycle";
+import { resolveProfileStatusLoad } from "@/lib/profile-load";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import type {
   StatusResponse,
   MemoryStatus,
@@ -191,6 +197,10 @@ const MEMORY_STATUS_TONE: Record<
 
 export default function SystemPage() {
   const { toast, showToast } = useToast();
+  const { profile, currentProfile } = useProfileScope();
+  const targetProfile = profile || currentProfile;
+  const selectedProfileRef = useRef(targetProfile);
+  const loadRequestRef = useRef(0);
 
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [stats, setStats] = useState<SystemStats | null>(null);
@@ -203,6 +213,12 @@ export default function SystemPage() {
   const [curator, setCurator] = useState<CuratorStatus | null>(null);
   const [portal, setPortal] = useState<PortalStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadedProfile, setLoadedProfile] = useState<string | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+
+  useEffect(() => {
+    selectedProfileRef.current = targetProfile;
+  }, [targetProfile]);
 
   const [activeAction, setActiveAction] = useState<string | null>(null);
   const [consoleOpen, setConsoleOpen] = useState(false);
@@ -253,8 +269,9 @@ export default function SystemPage() {
   const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
 
   const loadAll = useCallback(() => {
-    Promise.allSettled([
-      api.getStatus(),
+    const requestId = ++loadRequestRef.current;
+    const requests = [
+      api.getStatus(targetProfile),
       api.getSystemStats(),
       api.getMemory(),
       api.getCredentialPool(),
@@ -265,9 +282,22 @@ export default function SystemPage() {
       // Cached (non-forced) check so the version row shows update status on
       // load without a separate effect / a forced network round-trip.
       api.checkHermesUpdate(false),
-    ])
+    ] as const;
+    return Promise.resolve()
+      .then(() => {
+        if (requestId !== loadRequestRef.current) return;
+        setLoading(true);
+        setStatus(null);
+        setLoadedProfile(null);
+        setStatusError(null);
+      })
+      .then(() => Promise.allSettled(requests))
       .then(([s, st, m, p, c, h, cur, prt, upd]) => {
-        if (s.status === "fulfilled") setStatus(s.value);
+        if (requestId !== loadRequestRef.current) return;
+        const profileLoad = resolveProfileStatusLoad(targetProfile, s);
+        setStatus(profileLoad.status);
+        setLoadedProfile(profileLoad.loadedProfile);
+        setStatusError(profileLoad.error);
         if (st.status === "fulfilled") setStats(st.value);
         if (m.status === "fulfilled") setMemory(m.value);
         if (p.status === "fulfilled") setPool(p.value.providers);
@@ -277,28 +307,52 @@ export default function SystemPage() {
         if (prt.status === "fulfilled") setPortal(prt.value);
         if (upd.status === "fulfilled") setUpdateInfo(upd.value);
       })
-      .finally(() => setLoading(false));
-  }, []);
+      .finally(() => {
+        if (requestId === loadRequestRef.current) setLoading(false);
+      });
+  }, [targetProfile]);
 
   useEffect(() => {
-    loadAll();
+    void loadAll();
   }, [loadAll]);
 
   // ── Gateway lifecycle ──────────────────────────────────────────────
   const runGateway = async (verb: "start" | "stop" | "restart") => {
+    const actionProfile = targetProfile;
     try {
+      let actionName: string;
+      let actionPid: number | null;
       if (verb === "start") {
-        await api.startGateway();
-        setActiveAction("gateway-start");
+        const action = await api.startGateway(actionProfile);
+        actionName = action.name;
+        actionPid = action.pid;
       } else if (verb === "stop") {
-        await api.stopGateway();
-        setActiveAction("gateway-stop");
+        const action = await api.stopGateway(actionProfile);
+        actionName = action.name;
+        actionPid = action.pid;
       } else {
-        await api.restartGateway();
-        setActiveAction("gateway-restart");
+        const action = await api.restartGateway(actionProfile);
+        actionName = action.name;
+        actionPid = action.pid;
       }
+      setActiveAction(actionName);
       showToast(`Gateway ${verb} started`, "success");
-      setTimeout(loadAll, 3000);
+      if (verb === "restart") {
+        if (actionPid === null) {
+          throw new Error("Gateway restart did not return a process ID");
+        }
+        await waitForActionCompletion(
+          () => api.getActionStatus(actionName, 200),
+          actionPid,
+        );
+      }
+      const refreshed = await waitForGatewayState(
+        () => api.getStatus(actionProfile),
+        verb !== "stop",
+      );
+      if (selectedProfileRef.current === actionProfile) {
+        setStatus(refreshed);
+      }
     } catch (e) {
       showToast(`Gateway ${verb} failed: ${e}`, "error");
     }
@@ -628,10 +682,22 @@ export default function SystemPage() {
     ),
   });
 
-  if (loading) {
+  if (loading || loadedProfile !== targetProfile) {
     return (
       <div className="flex items-center justify-center py-24">
         <Spinner className="text-2xl text-primary" />
+      </div>
+    );
+  }
+
+  if (statusError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-24">
+        <Toast toast={toast} />
+        <p className="text-sm text-destructive">
+          Failed to load status for profile {targetProfile}: {statusError}
+        </p>
+        <Button onClick={() => void loadAll()}>Retry</Button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- send the selected profile explicitly for gateway status and lifecycle requests
- reload gateway status safely on profile changes without stale response races
- poll slow start/stop operations and bind restart completion to the returned process PID
- show a recoverable status error instead of stale data or an indefinite spinner

## Tests
- `npm run check` (13 files, 84 tests)
- targeted ESLint on all changed TypeScript files
- `npm run build`
- `git diff --check`
- added regression coverage for explicit profile URLs, delayed lifecycle state, failed/retried profile loads, hard polling deadlines, fast restarts, failed actions, and shared action-slot replacement