### PR TITLE
fix(lmstudio): clamp max/ultra reasoning effort to LM Studio's ceiling instead of silently dropping to medium

### DIFF
--- a/agent/lmstudio_reasoning.py
+++ b/agent/lmstudio_reasoning.py
@@ -20,6 +20,17 @@ _LM_VALID_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 # Map them onto the OpenAI-compatible request vocabulary.
 _LM_EFFORT_ALIASES = {"off": "none", "on": "medium"}
 
+# Hermes' generic effort ladder grew past LM Studio's vocabulary ("max",
+# "ultra"). Clamp the stronger generic levels onto LM Studio's ceiling: left
+# alone they miss _LM_VALID_EFFORTS, keep the initialized "medium" default and
+# are thereby conflated with unparseable input, so asking for more reasoning
+# yields less than "xhigh". Mirrors the ceiling clamp every other provider
+# applies (see agent/transports/codex.py).
+#
+# Deliberately separate from _LM_EFFORT_ALIASES: that mapping is also applied
+# to the model's published allowed_options, which must not be rewritten.
+_LM_EFFORT_CLAMP = {"max": "xhigh", "ultra": "xhigh"}
+
 
 def resolve_lmstudio_effort(
     reasoning_config: Optional[dict],
@@ -39,6 +50,7 @@ def resolve_lmstudio_effort(
         else:
             raw = (reasoning_config.get("effort") or "").strip().lower()
             raw = _LM_EFFORT_ALIASES.get(raw, raw)
+            raw = _LM_EFFORT_CLAMP.get(raw, raw)
             if raw in _LM_VALID_EFFORTS:
                 effort = raw
     if allowed_options:

--- a/tests/agent/test_lmstudio_reasoning.py
+++ b/tests/agent/test_lmstudio_reasoning.py
@@ -1,0 +1,97 @@
+"""Reasoning-effort resolution for LM Studio.
+
+Covers the contract that Hermes' generic effort ladder must stay monotonic
+once it is mapped onto LM Studio's narrower vocabulary: a stronger requested
+level may resolve to an equal-or-stronger LM Studio level, never a weaker one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from hermes_constants import VALID_REASONING_EFFORTS
+
+# Rank of each value LM Studio accepts, weakest to strongest. Used to assert
+# the resolved ladder never inverts.
+_LM_RANK = {"minimal": 0, "low": 1, "medium": 2, "high": 3, "xhigh": 4}
+
+
+@pytest.mark.parametrize("effort", ["max", "ultra"])
+def test_strong_efforts_clamp_to_lmstudio_ceiling(effort):
+    """"max"/"ultra" exceed LM Studio's vocabulary and clamp to its ceiling.
+
+    Without the clamp they miss the valid set, keep the "medium" default and
+    resolve *below* "xhigh" -- more requested reasoning yielding less.
+    """
+    assert resolve_lmstudio_effort({"enabled": True, "effort": effort}, None) == "xhigh"
+
+
+def test_effort_ladder_is_monotonic():
+    """Resolving Hermes' canonical ladder never produces an inversion."""
+    resolved = [
+        resolve_lmstudio_effort({"enabled": True, "effort": effort}, None)
+        for effort in VALID_REASONING_EFFORTS
+    ]
+    ranks = [_LM_RANK[value] for value in resolved]
+    assert ranks == sorted(ranks), dict(zip(VALID_REASONING_EFFORTS, resolved))
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "minimal"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "xhigh"),
+    ],
+)
+def test_levels_within_lmstudio_vocabulary_are_unchanged(effort, expected):
+    """Negative control: the clamp must not disturb levels LM Studio knows."""
+    assert resolve_lmstudio_effort({"enabled": True, "effort": effort}, None) == expected
+
+
+def test_unparseable_effort_still_falls_back_to_medium():
+    """Negative control: clamping must not change the unrecognized-input path.
+
+    This is the behaviour "max"/"ultra" were previously conflated with.
+    """
+    assert resolve_lmstudio_effort({"enabled": True, "effort": "banana"}, None) == "medium"
+
+
+def test_disabled_reasoning_still_resolves_to_none():
+    """Negative control: the clamp sits after the enabled=False short-circuit."""
+    assert resolve_lmstudio_effort({"enabled": False, "effort": "max"}, None) == "none"
+
+
+@pytest.mark.parametrize("effort", ["max", "ultra"])
+def test_clamped_effort_is_still_checked_against_allowed_options(effort):
+    """A clamped value stays subject to the model's published allowed set.
+
+    "max" resolves to "xhigh"; a model that does not publish "xhigh" gets the
+    field omitted (``None``) so LM Studio applies the model's own default --
+    exactly how a directly-requested "xhigh" already behaves.
+    """
+    assert (
+        resolve_lmstudio_effort(
+            {"enabled": True, "effort": effort}, ["off", "minimal", "low"]
+        )
+        is None
+    )
+    assert (
+        resolve_lmstudio_effort(
+            {"enabled": True, "effort": effort}, ["low", "medium", "high", "xhigh"]
+        )
+        == "xhigh"
+    )
+
+
+def test_clamp_does_not_rewrite_published_allowed_options():
+    """The clamp must not leak into allowed_options normalization.
+
+    A model publishing "max" is not claiming LM Studio's request vocabulary
+    accepts it; allowed_options passes through untouched, so a resolved
+    "xhigh" that the model does not publish is still omitted.
+    """
+    assert resolve_lmstudio_effort({"enabled": True, "effort": "max"}, ["max"]) is None


### PR DESCRIPTION
## What does this PR do?

Requesting **more** reasoning from an LM Studio model currently gives you **less**. `max` and `ultra` resolve *below* `xhigh` — they land on `medium`, the same value unparseable garbage gets:

| requested | resolved on `main` | resolved after |
|---|---|---|
| `high` | `high` | `high` |
| `xhigh` | `xhigh` | `xhigh` |
| `max` | **`medium`** ⬅ inversion | `xhigh` |
| `ultra` | **`medium`** ⬅ inversion | `xhigh` |
| `banana` (invalid) | `medium` | `medium` |

`_LM_VALID_EFFORTS` (`agent/lmstudio_reasoning.py:17`) omits `max`/`ultra`, so they fail the membership test at `:42`, keep the `effort = "medium"` initializer from `:35`, and are **conflated with unrecognized input**. That also violates the function's own docstring, which promises to "let LM Studio fall back to the model's declared default rather than silently substituting a different effort" — substituting `medium` is exactly what it does.

**This is drift, not a design decision.** When `agent/lmstudio_reasoning.py` was authored (`214ca943a`), `VALID_REASONING_EFFORTS` was exactly `("minimal","low","medium","high","xhigh")` — the set was a complete mirror. Then `f69a33794` added `max` to the ladder, and `7550c594c` (#62650) added `ultra` and swept the copilot, deepseek, ollama-cloud, opencode-zen, zai, codex, chat-completions and anthropic sites — but missed this module. `git log -- agent/lmstudio_reasoning.py` returns exactly one commit: it has never been touched since it was written.

LM Studio is the sole outlier. Every other provider clamps to its **ceiling**, never to `medium` — e.g. `agent/transports/codex.py:172` maps `{xhigh, max, ultra} -> high` for xAI Responses, and `agent/anthropic_adapter.py:70` maps `ultra -> max`.

## Related Issue

None — found while reading the effort-resolution paths; reproduced directly against the module.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/lmstudio_reasoning.py` — add `_LM_EFFORT_CLAMP = {"max": "xhigh", "ultra": "xhigh"}` and apply it to the requested effort after the alias lookup, before the `_LM_VALID_EFFORTS` membership check.
- `tests/agent/test_lmstudio_reasoning.py` — new regression test asserting the clamp plus **monotonicity over the canonical ladder**, with negative controls.

### Why clamp rather than widen `_LM_VALID_EFFORTS`

Adding `max`/`ultra` to the valid set would assert that LM Studio accepts those values **on the wire** — a provider-side claim this repo can't verify, and the stated purpose of that set is "LM Studio accepts these values via its OpenAI-compatible endpoint". Clamping introduces **no new provider claim**: it consumes only the ceiling the file already declares for itself, and matches the idiom used at every other provider site.

### Two details worth flagging for review

- The clamp is **deliberately separate from `_LM_EFFORT_ALIASES`**. That dict is also applied at `:45` to the model's *published* `allowed_options`; folding `max`/`ultra` into it would rewrite what the model advertises. A test pins this.
- A clamped value **remains subject to the `allowed_options` check**: `max` → `xhigh` → if the model doesn't publish `xhigh`, the field is omitted (`None`) and LM Studio applies the model's own default — identical to how a directly-requested `xhigh` already behaves. Also pinned by a test.

## How to Test

1. Reproduce the inversion on `main`:
   ```python
   from agent.lmstudio_reasoning import resolve_lmstudio_effort
   for e in ["high", "xhigh", "max", "ultra"]:
       print(e, "->", resolve_lmstudio_effort({"enabled": True, "effort": e}, None))
   # main:  high -> high | xhigh -> xhigh | max -> medium | ultra -> medium
   # after: high -> high | xhigh -> xhigh | max -> xhigh  | ultra -> xhigh
   ```
2. `pytest tests/agent/test_lmstudio_reasoning.py -v` → 13 passed.
3. Revert only the `agent/lmstudio_reasoning.py` hunk and re-run → **5 failed, 8 passed**. The 5 failures are the clamp/monotonicity assertions; the 8 that still pass are the negative controls, which are green on both sides — they demonstrate the fix doesn't disturb `minimal`/`low`/`medium`/`high`/`xhigh`, the invalid-input fallback, or the `enabled: False` short-circuit.
4. No regression in the consumers: `pytest tests/agent/test_lmstudio_reasoning.py tests/agent/transports/ -q` → 382 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites (`tests/agent/test_lmstudio_reasoning.py`, `tests/agent/transports/`) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior now matches the existing docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure string mapping, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- **Not a duplicate of #32285.** That PR is a test-only coverage sweep that also adds a file at `tests/agent/test_lmstudio_reasoning.py`. It predates the `max`/`ultra` ladder growth, contains no coverage of either value, and makes no production change — so it neither fixes nor asserts this behavior. If both land, the reconcile is a trivial add/add of two disjoint test sets; happy to rebase onto it if it merges first.
- **Complements #62650**, which added `max`/`ultra` and swept the other provider sites. This is the one module that sweep missed.