### PR TITLE
fix(skills): resolve the skills root before computing the lock install path

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -737,7 +737,9 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                          bundle.trust_level, "invalid_path", str(exc))
         return
     from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    # install_dir is resolved; resolve the root too so a symlinked HERMES_HOME
+    # doesn't turn a successful install into a ValueError here.
+    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR.resolve())}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
     # Blueprint detection: if the installed skill declares a

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1443,6 +1443,95 @@ class TestInstallPathSafety:
 # ---------------------------------------------------------------------------
 
 
+    def test_install_through_symlinked_home_records_lock_entry(self, tmp_path):
+        """A HERMES_HOME reached through a symlink must still install cleanly.
+
+        _resolve_lock_install_path() returns a RESOLVED path, so comparing it
+        against an unresolved skills root raised ValueError *after* the bundle
+        had already been moved into place — the caller reported "Installation
+        blocked" while the files sat on disk with no lock entry (unlistable,
+        uninstallable). macOS /tmp -> /private/tmp and mounted skills dirs hit
+        this routinely.
+        """
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        link_root = tmp_path / "link"
+        try:
+            link_root.symlink_to(real_root, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        # Reach the skills tree through the symlink, as a symlinked
+        # HERMES_HOME / mounted skills dir does.
+        skills_dir = link_root / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "shop"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: shop\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="shop",
+            files={"SKILL.md": "---\nname: shop\n---\n"},
+            source="official",
+            identifier="official/productivity/shop",
+            trust_level="builtin",
+        )
+        scan_result = ScanResult(
+            skill_name="shop",
+            source="official",
+            trust_level="builtin",
+            verdict="safe",
+        )
+
+        lock_path = real_root / "lock.json"
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch.object(hub.HubLockFile.__init__, "__defaults__", (lock_path,)):
+            install_dir = hub.install_from_quarantine(
+                q_dir, "shop", "productivity", bundle, scan_result,
+            )
+
+        # Content actually landed...
+        assert (install_dir / "SKILL.md").exists()
+        # ...and the lock entry was recorded with a root-relative path, so the
+        # skill is listable / uninstallable rather than an orphan on disk.
+        recorded = json.loads(lock_path.read_text())["installed"]["shop"]
+        assert recorded["install_path"] == "productivity/shop"
+
+    def test_symlinked_home_install_still_rejects_escaping_category(self, tmp_path):
+        """Resolving the root must not weaken the escape check."""
+        import tools.skills_hub as hub
+
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        link_root = tmp_path / "link"
+        try:
+            link_root.symlink_to(real_root, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        skills_dir = link_root / "skills"
+        skills_dir.mkdir(parents=True)
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir):
+            with pytest.raises(ValueError, match="Unsafe install path"):
+                hub._resolve_lock_install_path("../../escape", "escape")
+
+
+# ---------------------------------------------------------------------------
+# parallel_search_sources — overall_timeout must be honoured even when a
+# source blocks for far longer than the budget (regression: the executor used
+# `with ... as pool`, whose __exit__ calls shutdown(wait=True) and blocked the
+# caller on the slow worker, making overall_timeout a no-op).
+# ---------------------------------------------------------------------------
+
+
+
 class _FakeSource(SkillSource):
     def __init__(self, sid: str, sleep: float = 0.0, results=None):
         self._sid = sid

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3823,7 +3823,12 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(_skills_dir())),
+        # Relative to the RESOLVED root: _resolve_lock_install_path() hands back
+        # a resolved install_dir, so comparing it against an unresolved
+        # _skills_dir() raises whenever HERMES_HOME is reached through a symlink
+        # (macOS /tmp -> /private/tmp, a mounted skills dir, a symlinked home).
+        # That fired after the move below, orphaning files outside the lock.
+        install_path=str(install_dir.relative_to(_skills_dir().resolve())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
         scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),


### PR DESCRIPTION
## What does this PR do?

`hermes skills install` reported a false **"Installation blocked"** whenever `HERMES_HOME` was reached through a symlink — while the skill files were *already on disk*. macOS (`/tmp` → `/private/tmp`, `/var` → `/private/var`) and Docker/k8s setups that mount the skills directory hit this routinely.

`_resolve_lock_install_path()` deliberately returns a **resolved** path (it resolves in order to catch symlink-redirect escapes), but `install_from_quarantine()` compared it against an unresolved `_skills_dir()`:

```python
install_path=str(install_dir.relative_to(_skills_dir()))   # tools/skills_hub.py:3644
```

Through a symlink the two roots differ, so `relative_to()` raised `ValueError` — **after** `shutil.move()` had already placed the bundle. `lock.record_install()` never ran, leaving the skill on disk but absent from `lock.json`: invisible to `skills list`, not uninstallable, and reinstalling just repeated the error. The caller's "Installation blocked" message was itself wrong — nothing had been blocked.

The fix compares against the resolved root at both call sites, mirroring what `_resolve_lock_install_path()` already does internally (`skills_root = skills_dir.resolve()`).

**This cannot weaken the escape check.** `_resolve_lock_install_path()` still walks each path component rejecting redirects, and still asserts the resolved target is inside the resolved root and isn't the root itself. The change only stops a legitimate install from failing on its last step — there's a test pinning that an escaping category is still rejected under a symlinked root.

## Related Issue

Fixes #64953

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py`: `install_from_quarantine()` computes `install_path` relative to `_skills_dir().resolve()`.
- `hermes_cli/skills_hub.py`: the `Installed:` line resolves the root too (it had the same unresolved comparison and would have raised next).
- `tests/tools/test_skills_hub.py`: added `test_install_through_symlinked_home_records_lock_entry` (asserts content lands **and** the lock entry is recorded with a root-relative path) and `test_symlinked_home_install_still_rejects_escaping_category` (escape check intact).

## How to Test

```bash
mkdir -p /tmp/real/hermes && ln -s /tmp/real /tmp/link
export HERMES_HOME=/tmp/link/hermes
hermes skills install official/productivity/shop --yes
```

Before: `Installation blocked: '/private/tmp/real/.../shop' is not in the subpath of '/tmp/link/.../skills'`, no `shop` entry in `lock.json`, files orphaned on disk.
After: `Installed: productivity/shop`, lock entry recorded with `install_path: productivity/shop`.

The new regression test fails on `main` with exactly that `ValueError` and passes with the fix.

```
pytest tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py -q   # 188 passed
pytest tests/tools/test_skills_sync.py tests/tools/test_skills_tool.py tests/tools/test_skills_guard.py -q   # 238 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (ARM64)

### Documentation & Housekeeping

- [x] N/A — no user-facing docs affected
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact — `Path.resolve()` also normalizes Windows 8.3/short-name and case differences, so the same class of false failure is fixed there; the escape check is unchanged on every platform.
