### PR TITLE
fix(desktop): extend read-aloud request timeout

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,7 +10,8 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  speakText
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -122,6 +123,19 @@ describe('Hermes REST session helpers', () => {
     const call = api.mock.calls[0]?.[0] as { path: string; timeoutMs?: number }
     expect(call.path).toBe('/api/status')
     expect(call.timeoutMs).toBeUndefined()
+  })
+
+  it('keeps natural read-aloud generation alive for long replies', async () => {
+    api.mockResolvedValue({ data_url: 'data:audio/mp3;base64,AA==' })
+
+    await speakText('read this aloud')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/audio/speak',
+      method: 'POST',
+      body: { text: 'read this aloud' },
+      timeoutMs: 300_000
+    })
   })
 
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -71,6 +71,9 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+// Natural TTS providers generate a complete audio response before Desktop can
+// play it. Long replies must not inherit the generic 15s request limit.
+export const AUDIO_SPEAK_REQUEST_TIMEOUT_MS = 300_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -1009,7 +1012,8 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
     path: '/api/audio/speak',
     method: 'POST',
-    body: { text }
+    body: { text },
+    timeoutMs: AUDIO_SPEAK_REQUEST_TIMEOUT_MS
   })
 }
 


### PR DESCRIPTION
## What does this PR do?

Gives Hermes Desktop read-aloud TTS requests a dedicated five-minute timeout instead of the generic 15-second Electron backend timeout.

Natural TTS providers return a complete audio response before Desktop playback begins. Medium and long replies can legitimately exceed 15 seconds, so the current client abandons healthy `/api/audio/speak` work and reports a timeout even though the backend is still generating audio.

This mirrors the per-request timeout pattern already used for other long-running Desktop operations. STT is intentionally out of scope because #46530 owns the open transcription-timeout fix.

## Related Issue

Related: #46530, #46573

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/hermes.ts`: add `AUDIO_SPEAK_REQUEST_TIMEOUT_MS = 300_000` and pass it to `/api/audio/speak`.
- `apps/desktop/src/hermes.test.ts`: assert the read-aloud request carries the dedicated timeout.

## How to Test

1. Run `npm run --workspace apps/desktop test:ui -- src/hermes.test.ts`.
2. Run `npm run --workspace apps/desktop typecheck`.
3. Run `npm run --workspace apps/desktop pack`.
4. Inspect the packaged renderer and confirm `/api/audio/speak` references the minified `3e5` timeout constant.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A; Desktop TypeScript-only change
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior is covered by source comments and tests
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow change
- [x] Cross-platform impact considered; this uses the existing platform-neutral Electron request contract
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

```text
Vitest: 1 file passed, 10 tests passed
TypeScript typecheck: passed
Desktop package: passed
Packaged `/api/audio/speak`: timeout symbol resolves to 300000ms
Static security scan: passed
```
