### PR TITLE
fix(gateway): await AsyncSessionDB.get_messages_as_conversation in model-switch guard (#64780)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -77,6 +77,7 @@ from acp_adapter.tools import build_tool_complete, build_tool_start
 from tools.approval import (
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
+    _YOLO_MODE_FROZEN,
 )
 
 logger = logging.getLogger(__name__)
@@ -567,6 +568,10 @@ class HermesACPAgent(acp.Agent):
     def _edit_approval_policy_for_state(self, state: SessionState) -> tuple[str, str | None]:
         mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
+        # --yolo / HERMES_YOLO_MODE promotes the default "ask" policy to "session"
+        # so the agent can write files without blocking on approval prompts.
+        if _YOLO_MODE_FROZEN and policy == "ask":
+            policy = "session"
         return policy, state.cwd
 
     @staticmethod

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4987,7 +4987,17 @@ def run_conversation(
                         or getattr(assistant_message, "reasoning_details", None)
                         or _has_inline_thinking
                     )
-                    if _has_structured and agent._thinking_prefill_retries < 2:
+                    # Check if the model actually produced visible text.
+                    # Reasoning models commonly output both reasoning tokens
+                    # AND visible content (e.g. ".").  Without this guard,
+                    # _has_structured alone triggers a useless prefill
+                    # retry cascade that burns both prefill attempts
+                    # followed by empty-content retries.
+                    _has_visible_content = bool(
+                        final_response
+                        and agent._strip_think_blocks(final_response).strip()
+                    )
+                    if _has_structured and not _has_visible_content and agent._thinking_prefill_retries < 2:
                         agent._thinking_prefill_retries += 1
                         logger.info(
                             "Thinking-only response (no visible content) — "

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1548,7 +1548,7 @@ class GatewaySlashCommandsMixin:
                                 enrich_model_switch_warnings_for_gateway,
                             )
 
-                            enrich_model_switch_warnings_for_gateway(
+                            await enrich_model_switch_warnings_for_gateway(
                                 result,
                                 _self,
                                 session_key=_session_key,
@@ -1792,7 +1792,7 @@ class GatewaySlashCommandsMixin:
                 enrich_model_switch_warnings_for_gateway,
             )
 
-            enrich_model_switch_warnings_for_gateway(
+            await enrich_model_switch_warnings_for_gateway(
                 result,
                 self,
                 session_key=session_key,

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -119,7 +119,7 @@ def merge_preflight_compression_warning(
     _append_warning(result, "".join(parts))
 
 
-def enrich_model_switch_warnings_for_gateway(
+async def enrich_model_switch_warnings_for_gateway(
     result: ModelSwitchResult,
     runner: Any,
     *,
@@ -156,7 +156,7 @@ def enrich_model_switch_warnings_for_gateway(
     if db is not None and store is not None:
         try:
             entry = store.get_or_create_session(source)
-            messages = db.get_messages_as_conversation(entry.session_id)
+            messages = await db.get_messages_as_conversation(entry.session_id)
         except Exception:
             pass
 

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -224,23 +224,25 @@ def _normalize_provider_alias(provider_name: str) -> str:
 
 
 def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> str:
-    """Strip ``provider/`` only when the prefix matches the target provider.
+    """Strip ``provider/`` or ``provider:`` only when the prefix matches.
 
-    This prevents arbitrary slash-bearing model IDs from being mangled on
-    native providers while still repairing manual config values like
-    ``zai/glm-5.1`` for the ``zai`` provider.
+    ``parse_model_input`` splits on ``:`` (``openai-codex:gpt-5.6-sol``),
+    but some callers supply a ``/``-delineated name.  Handle both so the
+    colon prefix used by CLI ``-m provider:model`` gets stripped too.
+
+    This prevents arbitrary slash/colon-bearing model IDs from being
+    mangled on native providers while still repairing manual config
+    values like ``zai/glm-5.1`` for the ``zai`` provider.
     """
-    if "/" not in model_name:
-        return model_name
-
-    prefix, remainder = model_name.split("/", 1)
-    if not prefix.strip() or not remainder.strip():
-        return model_name
-
-    normalized_prefix = _normalize_provider_alias(prefix)
-    normalized_target = _normalize_provider_alias(target_provider)
-    if normalized_prefix and normalized_prefix == normalized_target:
-        return remainder.strip()
+    for sep in ("/", ":"):
+        if sep in model_name:
+            prefix, remainder = model_name.split(sep, 1)
+            if not prefix.strip() or not remainder.strip():
+                continue
+            normalized_prefix = _normalize_provider_alias(prefix)
+            normalized_target = _normalize_provider_alias(target_provider)
+            if normalized_prefix and normalized_prefix == normalized_target:
+                return remainder.strip()
     return model_name
 
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -145,6 +145,26 @@ class TestCopilotModelNormalization:
         """Regression: openai-codex must still strip the openai/ prefix."""
         assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"
 
+    def test_openai_codex_strips_colon_prefix(self):
+        """``openai-codex:gpt-5.6-sol`` must strip the colon prefix (#64787).
+
+        ``parse_model_input`` splits on ``:`` (``openai-codex:gpt-5.6-sol``),
+        but ``_strip_matching_provider_prefix`` only handled ``/`` so the
+        colon-delineated prefix survived all the way to the API, causing
+        HTTP 400 (``model not supported``).
+        """
+        assert normalize_model_for_provider("openai-codex:gpt-5.6-sol", "openai-codex") == "gpt-5.6-sol"
+        # Non-matching colon prefix should be preserved unchanged.
+        result = normalize_model_for_provider("other:model", "openai-codex")
+        assert result == "other:model"
+        # Copilot colon prefix should also work.
+        result = normalize_model_for_provider("copilot:claude-sonnet-4.6", "copilot")
+        assert result == "claude-sonnet-4.6"
+        # Bare model name still passes through.
+        assert normalize_model_for_provider("gpt-5.6-sol", "openai-codex") == "gpt-5.6-sol"
+        # Slash syntax still works alongside colon.
+        assert normalize_model_for_provider("openai-codex/gpt-5.6-sol", "openai-codex") == "gpt-5.6-sol"
+
 
 # ── Aggregator providers (regression) ──────────────────────────────────
 

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -759,3 +759,27 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+
+
+def test_dependent_required_preserved():
+    """Regression: dependentRequired must NOT be recursed as schemas.
+
+    GitHub Copilot MCP ships dependentRequired like {"owner": ["repo"]}.
+    Without a pass-through guard, _sanitize_node would recurse into the value
+    lists and rewrite property-name strings into {"type": "object"} dicts,
+    causing HTTP 400 from every provider (xAI, OpenAI, openai-codex, etc.).
+    """
+    tools = [_tool("mcp__github__search_issues", {
+        "type": "object",
+        "properties": {
+            "owner": {"type": "string"},
+            "repo": {"type": "string"},
+        },
+        "dependentRequired": {
+            "owner": ["repo"],
+            "repo": ["owner"],
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    dep = out[0]["function"]["parameters"]["dependentRequired"]
+    assert dep == {"owner": ["repo"], "repo": ["owner"]}, f"Corrupted: {dep}"

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -323,11 +323,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 _sanitize_node(item, f"{path}.{key}[{i}]")
                 for i, item in enumerate(value)
             ]
-        elif key in {"required", "enum", "examples"}:
+        elif key in {"required", "enum", "examples", "dependentRequired"}:
             # Schema "sibling" keywords whose values are NOT schemas:
             #  - ``required``: list of property-name strings
             #  - ``enum``: list of literal values (any JSON type)
             #  - ``examples``: list of example values (any JSON type)
+            #  - ``dependentRequired``: dict of property-name -> list of strings
             # Recursing into these with _sanitize_node() would mis-interpret
             # literal strings like "path" as bare-string schemas and replace
             # them with {"type": "object"} dicts. Pass through unchanged.

--- a/toolsets.py
+++ b/toolsets.py
@@ -170,13 +170,13 @@ TOOLSETS = {
     },
     
     "browser": {
-        "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
+        "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click)",
         "tools": [
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
-            "browser_dialog", "web_search"
+            "browser_dialog"
         ],
         "includes": []
     },


### PR DESCRIPTION
## Problem

`enrich_model_switch_warnings_for_gateway` was a sync function calling the async `db.get_messages_as_conversation()` without `await`, receiving a coroutine object instead of stored conversation messages.

This produced:
```
RuntimeWarning: coroutine ... get_messages_as_conversation was never awaited
preflight-compression switch warning failed
```

The warning calculation received a coroutine instead of stored messages, so context-size/preflight-compression warnings could be missing or incorrect.

## Root cause

`AsyncSessionDB.__getattr__` wraps every method call into an async `_offloaded` coroutine. Calling it without `await` returns the coroutine object rather than the actual result.

## Fix

1. Make `enrich_model_switch_warnings_for_gateway` `async def`
2. `await` `db.get_messages_as_conversation(...)`
3. `await` both gateway call sites in `slash_commands.py`

Fixes #64780