### PR TITLE
fix(computer-use): empty inventory is not transport failure

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2780,7 +2780,8 @@ class TestSessionLifecycle:
             "data": "", "images": [], "image_mime_types": [],
             "structuredContent": {"windows": []}, "isError": False,
         }
-        backend.capture(mode="ax")
+        with pytest.raises(RuntimeError, match="unhealthy"):
+            backend.capture(mode="ax")
         name, args = backend._session.call_tool.call_args.args
         assert name == "list_windows"
         assert args["session"] == backend._session_id

--- a/tests/tools/test_cua_wrapper_repair.py
+++ b/tests/tools/test_cua_wrapper_repair.py
@@ -1,0 +1,122 @@
+"""Focused regressions for the HARNESS-CUA1 wrapper repair.
+
+These tests mock only the MCP client shim.  They never start or modify the
+privileged ``cua-driver serve`` daemon.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.computer_use.cua_backend import (
+    CuaDriverBackend,
+    _CuaDriverSession,
+    _ingest_windows,
+    _select_app_windows,
+    _window_rank,
+)
+
+
+def test_list_apps_prefers_structured_content():
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+    backend._session.call_tool.return_value = {
+        "structuredContent": {"apps": [{"name": "Safari", "pid": 7}]},
+        "data": "- Wrong (pid 9)",
+    }
+    assert backend.list_apps() == [{"name": "Safari", "pid": 7}]
+
+
+@pytest.mark.parametrize("bullet", ["- ", "* ", "+ ", "1. "])
+def test_list_apps_text_fallback_strips_markdown_bullets(bullet):
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+    backend._session.call_tool.return_value = {
+        "structuredContent": None, "data": f"{bullet}Safari (pid 7)"
+    }
+    assert backend.list_apps() == [{"name": "Safari", "pid": 7}]
+
+
+def _windows():
+    return _ingest_windows([
+        {"app_name": "Safari", "bundle_id": "com.apple.Safari", "pid": 7,
+         "window_id": 1, "width": 800, "height": 600},
+        {"app_name": "Brave Browser", "bundle_id": "com.brave.Browser", "pid": 9,
+         "window_id": 2, "width": 800, "height": 600},
+    ])
+
+
+@pytest.mark.parametrize(("selector", "pid"), [
+    ("Safari", 7), ("Brave Browser", 9), ("com.brave.Browser", 9), ("7", 7),
+])
+def test_selector_accepts_exact_name_bundle_and_pid(selector, pid):
+    assert {w["pid"] for w in _select_app_windows(selector, _windows())} == {pid}
+
+
+def test_selector_rejects_substrings_and_ambiguous_pid():
+    assert _select_app_windows("Brave", _windows()) == []
+    windows = _windows() + _ingest_windows([
+        {"app_name": "Safari Technology Preview", "pid": 7, "window_id": 3}
+    ])
+    with pytest.raises(ValueError, match="Ambiguous"):
+        _select_app_windows("7", windows)
+
+
+def test_window_rank_prefers_contentful_visible_non_minimized_window():
+    candidates = _ingest_windows([
+        {"app_name": "Safari", "pid": 7, "window_id": 1, "z_index": 0,
+         "width": 1200, "height": 0},
+        {"app_name": "Safari", "pid": 7, "window_id": 2, "z_index": 1,
+         "width": 1200, "height": 800},
+        {"app_name": "Safari", "pid": 7, "window_id": 3, "z_index": 2,
+         "width": 1400, "height": 900, "is_minimized": True},
+    ])
+    assert min(candidates, key=_window_rank)["window_id"] == 2
+
+
+def test_reconnect_redeclares_session_before_retry():
+    session = object.__new__(_CuaDriverSession)
+    session._lock = __import__("threading").Lock()
+    session._declared_session_id = "hermes-test"
+    session._started = True
+    session._capabilities = {}
+    session._capability_version = ""
+    session._bridge = MagicMock()
+    session._stop_lifecycle_locked = MagicMock()
+    session._start_lifecycle_locked = MagicMock()
+    session._require_started = lambda: None
+    session._call_tool_async = MagicMock(side_effect=lambda name, args: (name, args))
+    session._bridge.run.side_effect = [BrokenPipeError(), {}, {"data": "ok"}]
+    assert session.call_tool("list_apps", {}) == {"data": "ok"}
+    calls = session._call_tool_async.call_args_list
+    assert calls[1].args == ("start_session", {"session": "hermes-test"})
+    assert calls[2].args == ("list_apps", {})
+
+
+def test_tombstoned_session_is_revived_and_retried_once():
+    session = object.__new__(_CuaDriverSession)
+    session._lock = __import__("threading").Lock()
+    session._declared_session_id = "hermes-test"
+    session._started = True
+    session._bridge = MagicMock()
+    session._require_started = lambda: None
+    session._call_tool_async = MagicMock(side_effect=lambda name, args: (name, args))
+    session._bridge.run.side_effect = [RuntimeError("session tombstoned"), {}, {"ok": True}]
+    assert session.call_tool("click", {}) == {"ok": True}
+    assert session._bridge.run.call_count == 3
+
+
+def test_empty_inventory_is_transport_error_but_no_match_is_typed_result():
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+    backend._session.call_tool.return_value = {"structuredContent": {"windows": []}}
+    backend._session._call_tool_via_cli.return_value = {"structuredContent": {"windows": []}}
+    with pytest.raises(RuntimeError, match="unhealthy"):
+        backend.capture(app="Safari")
+
+    backend._session.call_tool.return_value = {"structuredContent": {"windows": [
+        {"app_name": "Safari", "pid": 7, "window_id": 1}
+    ]}}
+    result = backend.capture(app="Brave Browser")
+    assert result.width == 0
+    assert "no on-screen window matched" in result.window_title

--- a/tests/tools/test_cua_wrapper_repair.py
+++ b/tests/tools/test_cua_wrapper_repair.py
@@ -109,10 +109,19 @@ def test_tombstoned_session_is_revived_and_retried_once():
 def test_empty_inventory_is_transport_error_but_no_match_is_typed_result():
     backend = CuaDriverBackend()
     backend._session = MagicMock()
+    # Successful empty inventory over both transports = legitimate empty desktop.
     backend._session.call_tool.return_value = {"structuredContent": {"windows": []}}
     backend._session._call_tool_via_cli.return_value = {"structuredContent": {"windows": []}}
+    empty = backend.capture(app="Safari")
+    assert empty.width == 0
+    assert "empty window inventory" in empty.window_title
+
+    # Empty MCP + CLI transport failure = unhealthy.
+    backend._session._call_tool_via_cli.side_effect = RuntimeError("cli down")
     with pytest.raises(RuntimeError, match="unhealthy"):
         backend.capture(app="Safari")
+    backend._session._call_tool_via_cli.side_effect = None
+    backend._session._call_tool_via_cli.return_value = {"structuredContent": {"windows": []}}
 
     backend._session.call_tool.return_value = {"structuredContent": {"windows": [
         {"app_name": "Safari", "pid": 7, "window_id": 1}

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -579,6 +579,7 @@ class _CuaDriverSession:
         self._shutdown_event: Optional[asyncio.Event] = None  # created on bridge loop
         self._lifecycle_future = None  # concurrent.futures.Future
         self._setup_error: Optional[BaseException] = None
+        self._declared_session_id: Optional[str] = None
 
     def _require_started(self) -> None:
         if not self._started:
@@ -878,6 +879,22 @@ class _CuaDriverSession:
         self._capability_version = ""
         self._start_lifecycle_locked()
         self._started = True
+        # A daemon restart creates a new MCP child.  Session declarations are
+        # scoped to that child, so restore the run identity before retrying the
+        # interrupted operation.
+        declared_session_id = getattr(self, "_declared_session_id", None)
+        if declared_session_id:
+            self._bridge.run(self._call_tool_async(
+                "start_session", {"session": declared_session_id}
+            ), timeout=30.0)
+
+    @staticmethod
+    def _is_ended_session_error(exc: Exception) -> bool:
+        message = str(exc).casefold()
+        return any(marker in message for marker in (
+            "session ended", "ended session", "session tombstoned",
+            "tombstoned session", "unknown session", "session not found",
+        ))
 
     def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float) -> Dict[str, Any]:
         """Fallback transport: invoke ``cua-driver call <tool> <json>`` as a
@@ -1005,6 +1022,20 @@ class _CuaDriverSession:
                     "falling back to CLI transport", name, e,
                 )
                 return self._call_tool_via_cli(name, args, timeout)
+            if self._is_ended_session_error(e):
+                # Explicit daemon tombstones require a fresh declaration, not
+                # a transport reconnect.  Revive and retry once under the same
+                # lock so concurrent calls cannot race the declaration.
+                with self._lock:
+                    declared_session_id = getattr(self, "_declared_session_id", None)
+                    if not declared_session_id:
+                        raise
+                    self._bridge.run(self._call_tool_async(
+                        "start_session", {"session": declared_session_id}
+                    ), timeout=timeout)
+                    return self._bridge.run(
+                        self._call_tool_async(name, args), timeout=timeout
+                    )
             if not self._is_closed_session_error(e):
                 raise
             # Daemon restart closes the cached stdio channel. Reconnect once and
@@ -1140,8 +1171,49 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "off_screen": not w.get("is_on_screen", True),
             "title": w.get("title", ""),
             "z_index": w.get("z_index", 0),
+            "bundle_id": w.get("bundle_id") or w.get("bundleId") or "",
+            "is_minimized": bool(w.get("is_minimized", w.get("minimized", False))),
+            "width": w.get("width", (w.get("bounds") or {}).get("width", 0)),
+            "height": w.get("height", (w.get("bounds") or {}).get("height", 0)),
         })
     return windows
+
+
+def _select_app_windows(app: str, windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Resolve an exact app name, bundle id, or PID without fuzzy targeting."""
+    selector = app.strip().casefold()
+    by_name = [w for w in windows if str(w.get("app_name", "")).casefold() == selector]
+    if by_name:
+        return by_name
+    by_bundle = [w for w in windows if
+                 str(w.get("bundle_id", "")).strip().casefold() == selector]
+    if by_bundle:
+        names = {str(w.get("app_name", "")).casefold() for w in by_bundle}
+        if len(names) == 1:
+            return by_bundle
+    else:
+        by_bundle = []
+    by_pid = [w for w in windows if str(w["pid"]) == selector]
+    matched = by_bundle or by_pid
+    names = {str(w.get("app_name", "")).casefold() for w in matched}
+    if len(names) > 1:
+        names_text = ", ".join(sorted(names))
+        raise ValueError(f"Ambiguous app selector {app!r}; matched: {names_text}")
+    return matched
+
+
+def _window_rank(window: Dict[str, Any]) -> Tuple[int, int, int, int]:
+    """Prefer usable content windows, then preserve driver z-order."""
+    try:
+        area = max(0, int(window.get("width") or 0)) * max(0, int(window.get("height") or 0))
+    except (TypeError, ValueError):
+        area = 0
+    return (
+        1 if window.get("off_screen") else 0,
+        1 if window.get("is_minimized") else 0,
+        1 if area == 0 else 0,
+        int(window.get("z_index") or 0),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1214,7 +1286,10 @@ class CuaDriverBackend(ComputerUseBackend):
         # accept anonymous calls (the cursor just won't render),
         # so we degrade rather than abort.
         try:
+            # Keep call_tool as the compatibility surface for test doubles and
+            # older session wrappers, then remember the id for reconnects.
             self._session.call_tool("start_session", {"session": self._session_id})
+            self._session._declared_session_id = self._session_id
         except Exception as e:
             logger.debug("cua-driver start_session failed (continuing anonymous): %s", e)
 
@@ -1291,15 +1366,18 @@ class CuaDriverBackend(ComputerUseBackend):
                 logger.error("cua-driver CLI re-fetch for list_windows failed: %s", cli_exc)
 
         if not windows:
-            return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
-                                 elements=[], app="", window_title="", png_bytes_len=0)
+            raise RuntimeError(
+                "cua-driver unhealthy: list_windows returned an empty inventory "
+                "over both MCP and CLI transports"
+            )
 
-        # Filter by app name (case-insensitive substring) if requested.
+        # Filter by exact canonical app name or an advertised bundle/PID alias.
         # When the filter matches nothing, surface that explicitly instead of
         # silently capturing the frontmost window — on macOS the `app_name`
         # returned by list_windows is the localized name (e.g. "計算機"), so
         # `app="Calculator"` legitimately matches no windows on a non-English
         # system and the caller needs to retry with the localized name.
+        desktop_target: Optional[Dict[str, Any]] = None
         if app and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS:
             # Whole-screen / desktop request. cua-driver has no virtual-desktop
             # capture tool, so resolve to the OS shell/desktop window (the
@@ -1336,9 +1414,9 @@ class CuaDriverBackend(ComputerUseBackend):
                     for n in ("progman", "workerw", "program manager", "finder", "desktop")
                 ) else 1,
             )
+            desktop_target = windows[0]
         elif app:
-            app_lower = app.lower()
-            filtered = [w for w in windows if app_lower in w["app_name"].lower()]
+            filtered = _select_app_windows(app, windows)
             if not filtered:
                 return CaptureResult(
                     mode=mode, width=0, height=0, png_b64=None,
@@ -1354,7 +1432,7 @@ class CuaDriverBackend(ComputerUseBackend):
             windows = filtered
 
         # Pick first on-screen window (sorted by z_index / z-order above).
-        target = next((w for w in windows if not w["off_screen"]), windows[0])
+        target = desktop_target or min(windows, key=_window_rank)
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
         app_name = target["app_name"]
@@ -1720,6 +1798,9 @@ class CuaDriverBackend(ComputerUseBackend):
     # ── Introspection ──────────────────────────────────────────────
     def list_apps(self) -> List[Dict[str, Any]]:
         out = self._session.call_tool("list_apps", {"session": self._session_id})
+        structured_apps = (out.get("structuredContent") or {}).get("apps")
+        if isinstance(structured_apps, list):
+            return structured_apps
         data = out["data"]
         if isinstance(data, list):
             return data
@@ -1731,7 +1812,9 @@ class CuaDriverBackend(ComputerUseBackend):
             for line in data.splitlines():
                 m = re.search(r'(.+?)\s+\(pid\s+(\d+)\)', line)
                 if m:
-                    apps.append({"name": m.group(1).strip(), "pid": int(m.group(2))})
+                    name = re.sub(r'^\s*(?:[-*+]\s+|\d+[.)]\s+)', '', m.group(1))
+                    name = re.sub(r'^[`*_]+|[`*_]+$', '', name.strip()).strip()
+                    apps.append({"name": name, "pid": int(m.group(2))})
             return apps
         return []
 
@@ -1756,13 +1839,12 @@ class CuaDriverBackend(ComputerUseBackend):
         windows = _ingest_windows(raw_windows)
         windows.sort(key=lambda w: w["z_index"])
 
-        app_lower = app.lower()
-        matched = [w for w in windows if app_lower in w["app_name"].lower()]
+        matched = _select_app_windows(app, windows)
         # Don't silently fall back to the frontmost window when the filter
         # matches nothing — that hides the real failure (often a localized
         # macOS app name mismatch, e.g. caller passed "Calculator" but
         # list_windows returns "計算機").
-        target = matched[0] if matched else None
+        target = min(matched, key=_window_rank) if matched else None
         if target:
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1355,6 +1355,7 @@ class CuaDriverBackend(ComputerUseBackend):
                 "cua-driver list_windows returned no windows over MCP; "
                 "re-fetching via CLI transport",
             )
+            cli_inventory_failed = False
             try:
                 cli_lw = self._session._call_tool_via_cli(
                     "list_windows",
@@ -1363,12 +1364,31 @@ class CuaDriverBackend(ComputerUseBackend):
                 )
                 windows = _windows_from(cli_lw)
             except Exception as cli_exc:
+                cli_inventory_failed = True
                 logger.error("cua-driver CLI re-fetch for list_windows failed: %s", cli_exc)
 
         if not windows:
-            raise RuntimeError(
-                "cua-driver unhealthy: list_windows returned an empty inventory "
-                "over both MCP and CLI transports"
+            # Successful empty inventory (MCP+CLI both returned empty) is
+            # legitimate on locked/headless/empty desktops — return a typed
+            # empty CaptureResult. Only treat as transport-unhealthy when the
+            # CLI path failed after an empty MCP inventory.
+            if cli_inventory_failed:
+                raise RuntimeError(
+                    "cua-driver unhealthy: list_windows empty over MCP and CLI "
+                    "inventory transport failed"
+                )
+            return CaptureResult(
+                mode=mode,
+                width=0,
+                height=0,
+                png_b64=None,
+                elements=[],
+                app=(app or "").strip(),
+                window_title=(
+                    "<empty window inventory: no on-screen windows "
+                    "(locked/headless/empty desktop); not a transport failure>"
+                ),
+                png_bytes_len=0,
             )
 
         # Filter by exact canonical app name or an advertised bundle/PID alias.


### PR DESCRIPTION
## Summary
Successful empty `list_windows` over MCP+CLI is legitimate (locked/headless/empty desktop). Return a typed empty `CaptureResult` instead of raising unhealthy. Only raise when MCP inventory is empty **and** CLI re-fetch fails.

Addresses REQUEST CHANGES on CUA wrapper repair @ 7dde9637.

## Tests
`pytest tests/tools/test_cua_wrapper_repair.py` — 14 passed

## Ops
Local host installs may copy `tools/computer_use/cua_backend.py` from this tip after review.