### PR TITLE
fix(desktop): drop the stale _assistantOptimisticId field that throws on cancel after the assistant-ui 0.14 upgrade

### DIFF
--- a/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
@@ -1,8 +1,9 @@
 import { fromThreadMessageLike, getAutoStatus, MessageRepository } from '@assistant-ui/core/internal'
-import type { ExportedMessageRepository, ThreadMessage } from '@assistant-ui/react'
+import { ExportedMessageRepository, type ThreadMessage } from '@assistant-ui/react'
+import { act, renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { syncRepositoryIncrementally } from './incremental-external-store-runtime'
+import { syncRepositoryIncrementally, useIncrementalExternalStoreRuntime } from './incremental-external-store-runtime'
 
 const STATUS = getAutoStatus(false, false, false, false, undefined)
 
@@ -140,5 +141,96 @@ describe('syncRepositoryIncrementally', () => {
     })
 
     expect(result.map(item => item.id)).toEqual(['a'])
+  })
+})
+
+const optimisticCreatedAt = new Date('2026-05-01T00:00:00.000Z')
+
+function userMessage(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'do the thing' }],
+    attachments: [],
+    createdAt: optimisticCreatedAt,
+    metadata: { custom: {} }
+  } as unknown as ThreadMessage
+}
+
+// Mirrors chat/index.tsx: incremental runtime driven by a messageRepository,
+// with `isRunning` tracking the gateway's busy flag and onCancel wired up.
+function renderRuntime(onCancel: () => Promise<void>) {
+  const repository = ExportedMessageRepository.fromArray([userMessage()])
+
+  return renderHook(
+    ({ isRunning }: { isRunning: boolean }) =>
+      useIncrementalExternalStoreRuntime<ThreadMessage>({
+        messageRepository: repository,
+        isRunning,
+        setMessages: () => {},
+        onNew: async () => {},
+        onCancel,
+        onReload: async () => {}
+      }),
+    { initialProps: { isRunning: true } }
+  )
+}
+
+// Cancelling a run before the first assistant token must not poison the next
+// adapter sync.
+//
+// The runtime appends an optimistic assistant placeholder while a run is in
+// flight. Core owns that placeholder's lifetime: `cancelRun()` deletes it by
+// looking up the head, and `resetHead` evicts off-branch optimistic messages.
+// Any placeholder id this module holds onto across calls therefore goes stale
+// the moment core removes the message, and re-deleting a stale id throws
+// `MessageRepository(deleteMessage): Message not found`.
+describe('incremental external store runtime — cancel before first token', () => {
+  it('survives the sync that follows a cancelled run', async () => {
+    const onCancel = vi.fn(async () => {})
+    const { result, rerender } = renderRuntime(onCancel)
+
+    // A run is in flight with a trailing user message, so the runtime has
+    // appended an optimistic assistant placeholder.
+    expect(result.current.thread.getState().isRunning).toBe(true)
+
+    // User presses Stop before the first assistant token arrives. Core deletes
+    // the empty placeholder by lookup and clears no state of ours.
+    await act(async () => {
+      result.current.thread.cancelRun()
+    })
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+
+    // The gateway flips busy -> false, which re-syncs the adapter. Before the
+    // fix this re-deleted the now-stale placeholder id and threw.
+    expect(() => {
+      rerender({ isRunning: false })
+    }).not.toThrow()
+  })
+
+  it('still appends a placeholder while a run is in flight', async () => {
+    const { result } = renderRuntime(async () => {})
+
+    // Negative control: the placeholder itself must survive this change --
+    // removing the stale field must not remove the optimistic message.
+    const messages = result.current.thread.getState().messages
+
+    expect(messages.at(-1)?.role).toBe('assistant')
+    expect(messages.at(-1)?.content).toEqual([])
+  })
+
+  it('leaves no placeholder behind once the run ends normally', async () => {
+    const { result, rerender } = renderRuntime(async () => {})
+
+    rerender({ isRunning: false })
+
+    // Negative control: core's own eviction (resetHead ->
+    // evictOffBranchOptimisticMessages) still cleans the placeholder up
+    // without this module tracking its id.
+    const messages = result.current.thread.getState().messages
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.role).toBe('user')
   })
 })

--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -133,7 +133,6 @@ class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRunti
     }
 
     const self = this as unknown as {
-      _assistantOptimisticId: null | string
       _capabilities: object
       _messages: readonly ThreadMessage[]
       _notifyEventSubscribers: (event: string, payload: object) => void
@@ -186,11 +185,6 @@ class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRunti
       return
     }
 
-    if (self._assistantOptimisticId) {
-      this.repository.deleteMessage(self._assistantOptimisticId)
-      self._assistantOptimisticId = null
-    }
-
     const messages = syncRepositoryIncrementally(this, store.messageRepository)
 
     if (messages.length > 0) {
@@ -203,18 +197,22 @@ class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRunti
 
     // metadata.isOptimistic keeps this placeholder ephemeral: core evicts
     // off-branch optimistic messages on head moves and omits them from export().
+    // The id stays local to this call -- core owns the placeholder's lifetime
+    // (cancelRun deletes it by lookup, resetHead evicts it on a head move), so
+    // holding it in a field would only let it go stale behind our back.
+    let optimisticId: null | string = null
+
     if (hasUpcomingMessage(isRunning, messages)) {
-      const optimisticId = generateId()
+      optimisticId = generateId()
       this.repository.addOrUpdateMessage(
         messages.at(-1)?.id ?? null,
         fromThreadMessageLike({ role: 'assistant', content: [], metadata: { isOptimistic: true } }, optimisticId, {
           type: 'running'
         })
       )
-      self._assistantOptimisticId = optimisticId
     }
 
-    this.repository.resetHead(self._assistantOptimisticId ?? messages.at(-1)?.id ?? null)
+    this.repository.resetHead(optimisticId ?? messages.at(-1)?.id ?? null)
     self._messages = this.repository.getMessages()
     self._notifySubscribers()
   }


### PR DESCRIPTION
## What does this PR do?

**Symptom:** press **Stop** before the first assistant token arrives, and the next adapter sync throws — the thread is left wedged:

```
Error: MessageRepository(deleteMessage): Message not found.
       This is likely an internal bug in assistant-ui.
```

It isn't an assistant-ui bug. It's a phantom field this module kept across the upgrade.

### Diagnosis

`ddd6ad43f` upgraded assistant-ui core and hand-inlined the removed `appendOptimisticMessage` helper, but kept the old **persistent** `_assistantOptimisticId` field. Upstream had deleted that field from the base class **in the same release** — core 0.2.19 holds the placeholder id in a **local** and lets the repository own its lifetime, evicting off-branch optimistic messages on every head move (`MessageRepository.evictOffBranchOptimisticMessages`).

So the field is now Hermes-private state that **nothing else clears**:

1. `__internal_setAdapter` appends the optimistic placeholder and records its id in `self._assistantOptimisticId` (`:151`).
2. User hits Stop. The **inherited** `cancelRun()` deletes the placeholder **by lookup** — `head.metadata.isOptimistic && head.content.length === 0` — and clears no field of ours. Our id is now dangling.
3. The gateway flips `busy` → `false`, re-syncing the adapter. `:118`'s early-return doesn't apply (`isRunning` changed), so `:124-127` runs and deletes that id **a second time** → the repository throws.

**This is a genuine regression, not a latent bug.** In core 0.1.17 the two were coupled: `cancelRun()` itself did `if (this._assistantOptimisticId) { deleteMessage(...); this._assistantOptimisticId = null }` — the *same* field this module reads through `this`, so it stayed in sync. The upgrade broke that coupling silently.

**Why `tsc` never caught it:** the `as unknown as { _assistantOptimisticId: null | string, ... }` cast at `:70-77` *asserts* a base-class field that no longer exists. `npm run typecheck` reports zero errors both before and after this PR. A grep for `_assistantOptimisticId` across every installed `@assistant-ui` package returns **nothing**.

### Why remove the field instead of guarding the delete

A null/existence guard would silence the throw while leaving this module tracking state whose lifetime it doesn't own — the same drift, just quieter. Removing the field **mirrors upstream's own 0.2.19 design**: keep the id local, let `resetHead` → `evictOffBranchOptimisticMessages` (plus `resetHead`'s `deleteDescendants`) reclaim the placeholder. That is exactly the contract the comment already sitting above that block describes. The field had **no other consumers** (`:71, 124, 125, 126, 151, 154`), so removal is fully contained.

## Related Issue

None — found while reading the desktop runtime after the upgrade; reproduced against the pinned core.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/incremental-external-store-runtime.ts` — drop `_assistantOptimisticId` from the cast; delete the stale-id cleanup block; hold the placeholder id in a local `optimisticId` and pass it to `resetHead`.
- `apps/desktop/src/lib/incremental-external-store-runtime.test.ts` — new regression test for cancel-before-first-token, plus two negative controls.

## How to Test

1. `npm install && npx vitest run --project ui src/lib/incremental-external-store-runtime.test.ts` in `apps/desktop` → **3 passed**.
2. Revert only the `incremental-external-store-runtime.ts` hunk and re-run → **1 failed, 2 passed**, failing with the exact production error:
   ```
   AssertionError: expected [Function] to not throw an error but
   'Error: MessageRepository(deleteMessage): Message not found…' was thrown
   ```
   The 2 that still pass are the negative controls — they're green on both sides and demonstrate the change doesn't remove the placeholder itself, and that core's own eviction still cleans it up when a run ends normally.
3. Manually: send a message, press Stop before the first token, then send another — wedges on `main`, works after.
4. No regressions: `npm run typecheck` clean; full `npx vitest run --project ui` → **164 files, 1284 tests passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suite (`vitest run --project ui`, 1284 tests) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the existing comment already described this contract; extended it to say why the id stays local)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (renderer-side logic, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- **Disjoint from #38470** (@hdd69), the only other open PR touching this file: its change here is the one-line `useEffect` dep array in `useIncrementalExternalStoreRuntime` (~50 lines below, different function, no overlapping hunk), and its test lives in `chat/index.test.tsx` rather than a file for this module. The two should merge in either order.