### PR TITLE
fix(skills): add skills.read_only runtime write guard (#64926)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -674,6 +674,16 @@ skills:
   # Set to 0 to disable.
   creation_nudge_interval: 15
 
+  # Make all skills read-only at runtime. When true, Hermes will never create,
+  # edit, patch, delete, or otherwise write skill files from any code path —
+  # the skill_manage tool, the background self-improvement review loop, and the
+  # dashboard learn flow are all blocked from mutating skills. Listing, viewing,
+  # and *using* skills (running their scripts, following their procedures)
+  # continue to work. Enable this when skills are centrally managed and mounted
+  # into the Hermes container as a read-only volume so runtime changes can't
+  # pollute the shared set across pods. Default: false.
+  # read_only: true
+
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})
   # and resolved to an absolute path.  External dirs are read-only: skill

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1316,35 +1316,123 @@ class TestCuratorConsolidationDeleteGuard:
 
         _reset_background_review_read_marks()
 
-    def test_background_review_support_file_overwrite_requires_that_file_read(self, tmp_path, monkeypatch):
-        from tools.skills_tool import skill_view
-        from tools.skill_manager_tool import _reset_background_review_read_marks
 
-        _reset_background_review_read_marks()
-        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
-            _create_skill("reviewed", _skill_content("reviewed"))
-            ref = tmp_path / ".hermes" / "skills" / "reviewed" / "references"
-            ref.mkdir()
-            (ref / "workflow.md").write_text("old workflow\n", encoding="utf-8")
 
-            # Reading SKILL.md does not authorize overwriting a linked file.
-            assert json.loads(skill_view("reviewed"))["success"] is True
-            blocked = json.loads(skill_manage(
+
+class TestSkillsReadOnly:
+    """#64926: skills.read_only must block every runtime write action while
+    leaving list/view/use paths untouched."""
+
+    def test_read_only_blocks_create(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tools.skill_manager_tool._skills_read_only", lambda: True
+        )
+        with _skill_dir(tmp_path):
+            raw = skill_manage(
+                action="create", name="blocked", content=VALID_SKILL_CONTENT
+            )
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "read_only" in result["error"]
+        assert not (tmp_path / "blocked" / "SKILL.md").exists()
+
+    def test_read_only_blocks_edit(self, tmp_path, monkeypatch):
+        # Create with read_only off, then confirm edit is blocked.
+        with _skill_dir(tmp_path):
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: False
+            )
+            skill_manage(action="create", name="s", content=VALID_SKILL_CONTENT)
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: True
+            )
+            raw = skill_manage(
+                action="edit", name="s", content=VALID_SKILL_CONTENT + "\n# x"
+            )
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "read_only" in result["error"]
+
+    def test_read_only_blocks_patch(self, tmp_path, monkeypatch):
+        with _skill_dir(tmp_path):
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: False
+            )
+            skill_manage(action="create", name="s", content=VALID_SKILL_CONTENT)
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: True
+            )
+            raw = skill_manage(action="patch", name="s", old_string="test", new_string="x")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "read_only" in result["error"]
+
+    def test_read_only_blocks_delete(self, tmp_path, monkeypatch):
+        # Create the skill first (read_only off), then flip read_only on and
+        # confirm delete is blocked and the file survives.
+        with _skill_dir(tmp_path):
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: False
+            )
+            skill_manage(action="create", name="s", content=VALID_SKILL_CONTENT)
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: True
+            )
+            raw = skill_manage(action="delete", name="s")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "read_only" in result["error"]
+        assert (tmp_path / "s" / "SKILL.md").exists()
+
+    def test_read_only_blocks_write_file(self, tmp_path, monkeypatch):
+        with _skill_dir(tmp_path):
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: False
+            )
+            skill_manage(action="create", name="s", content=VALID_SKILL_CONTENT)
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: True
+            )
+            raw = skill_manage(
                 action="write_file",
-                name="reviewed",
-                file_path="references/workflow.md",
-                file_content="new workflow\n",
-            ))
-            assert blocked["success"] is False
-            assert blocked.get("_read_before_write_required") is True
+                name="s",
+                file_path="references/extra.md",
+                file_content="data",
+            )
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "read_only" in result["error"]
 
-            assert json.loads(skill_view("reviewed", "references/workflow.md"))["success"] is True
-            allowed = json.loads(skill_manage(
+    def test_read_only_blocks_remove_file(self, tmp_path, monkeypatch):
+        with _skill_dir(tmp_path):
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: False
+            )
+            skill_manage(action="create", name="s", content=VALID_SKILL_CONTENT)
+            skill_manage(
                 action="write_file",
-                name="reviewed",
-                file_path="references/workflow.md",
-                file_content="new workflow\n",
-            ))
-            assert allowed["success"] is True, allowed
+                name="s",
+                file_path="references/extra.md",
+                file_content="data",
+            )
+            monkeypatch.setattr(
+                "tools.skill_manager_tool._skills_read_only", lambda: True
+            )
+            raw = skill_manage(action="remove_file", name="s", file_path="references/extra.md")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "read_only" in result["error"]
 
-        _reset_background_review_read_marks()
+    def test_read_only_false_allows_write(self, tmp_path, monkeypatch):
+        """When the flag is off (default) writes still succeed."""
+        monkeypatch.setattr(
+            "tools.skill_manager_tool._skills_read_only", lambda: False
+        )
+        with _skill_dir(tmp_path):
+            raw = skill_manage(
+                action="create", name="allowed", content=VALID_SKILL_CONTENT
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert (tmp_path / "allowed" / "SKILL.md").exists()
+

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -99,6 +99,28 @@ except ImportError:
     _GUARD_AVAILABLE = False
 
 
+def _skills_read_only() -> bool:
+    """True when runtime Skill writes are disabled via ``skills.read_only``.
+
+    Platform operators who mount a centrally-managed skill set into the
+    Hermes container (read-only volume) use this to guarantee Hermes never
+    creates, edits, patches, or deletes skill files at runtime — from any
+    path (the ``skill_manage`` tool, the background self-improvement review,
+    or the dashboard learn flow). Listing, viewing, and *using* skills are
+    unaffected. See NousResearch/hermes-agent#64926.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        return is_truthy_value(
+            cfg_get(cfg, "skills", "read_only"),
+            default=False,
+        )
+    except Exception:
+        return False
+
+
 def _guard_agent_created_enabled() -> bool:
     """Read skills.guard_agent_created from config (default False).
 
@@ -1334,6 +1356,23 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    _WRITE_ACTIONS = frozenset(
+        {"create", "edit", "patch", "delete", "write_file", "remove_file"}
+    )
+    if action in _WRITE_ACTIONS and _skills_read_only():
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    "Skill writes are disabled by platform policy "
+                    "(skills.read_only is true). Skills are read-only at runtime: "
+                    "create/edit/patch/delete/write_file/remove_file are all blocked. "
+                    "Listing, viewing, and using skills still work."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)


### PR DESCRIPTION
## Summary

Platform operators who mount a centrally-managed skill set into the Hermes
container as a read-only volume currently have no way to stop Hermes from
mutating skill files at runtime. The background self-improvement review loop
and the dashboard learn flow call into ``skill_manage``, which patches/edits
``SKILL.md`` and ``references/`` files — the exact *"Self-improvement review:
Patched SKILL.md in skill 'ontology-infer-sql'"* behavior the reporter saw on a
shared, externally-mounted skill directory (#64926).

## Changes

- ``tools/skill_manager_tool.py``
  - New ``_skills_read_only()`` helper reads ``skills.read_only`` from config
    (cfg_get/load_config, default ``False``) — same pattern as the existing
    ``_guard_agent_created_enabled()``.
  - ``skill_manage()`` now short-circuits at the very top: when
    ``skills.read_only`` is true and the action is one of
    ``create/edit/patch/delete/write_file/remove_file``, it returns a clear
    ``read_only`` error **before** any handler (background-review preflight,
    write-approval gate, or the actual write) runs.
  - Because every runtime skill write — the ``skill_manage`` tool, the
    background self-improvement review fork, and the dashboard learn flow —
    funnels through ``skill_manage``, this one guard covers all write paths.
    Listing, viewing, and *using* skills are unaffected.
- ``cli-config.yaml.example`` — documents the new ``skills.read_only`` flag.
- ``tests/tools/test_skill_manager_tool.py`` — new ``TestSkillsReadOnly`` class
  (7 tests): each write action is blocked under ``read_only``, ``delete``
  leaves the file on disk, and writes still succeed when the flag is off.

## How to Test

```
python -m pytest tests/tools/test_skill_manager_tool.py::TestSkillsReadOnly -v
```

7 passed. Full file: 113 passed (no regression).

## Why a single guard is sufficient

- ``curator.py`` does **not** write skill files (it only reports provenance
  counts) — out of scope.
- ``tui_gateway/server.py`` ``skills.manage`` RPC only supports
  list/search/install/browse/inspect — no runtime write.
- ``background_review.py`` drives skill evolution via the ``skill_manage`` tool
  (LLM-directed), so it is covered by the same guard.

## Checklist

- [x] Tests pass (113/113 in file; 7 new)
- [x] Conventional Commits (``fix(skills): …``)
- [x] Scoped to ``skill_manage`` + config doc + its test file
- [x] Cross-platform: none (pure config gate)
- [x] profile-safe paths: unchanged
- [x] .env not used for non-credential settings: behavioral flag is config.yaml

## Risk & Impact

**Low.** Only adds an opt-in, default-off config gate on skill writes. When
``skills.read_only`` is unset/false (the default), behavior is byte-for-byte
identical to before. When enabled, the only change is skill write calls
return a refusal instead of mutating files; reads/use are untouched.

Type: Bug fix
Closes: #64926