### PR TITLE
fix(tui/dashboard): use proportional drain for sticky-follow in xterm.js (#64744)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -844,7 +844,14 @@ function renderNodeToOutput(
           const pastClamp = haveClamp && ((pending < 0 && cur < cMin) || (pending > 0 && cur > cMax))
 
           const eff = pastClamp ? Math.min(4, innerHeight >> 3) : innerHeight
-          cur += isXtermJsHost() ? drainAdaptive(node, pending, eff) : drainProportional(node, pending, eff)
+          // sticky-follow is content-growth tracking, not a user wheel event —
+          // use proportional drain for fast catch-up so streaming text doesn't
+          // fall behind the viewport (xterm.js adaptive drain throttles to 2-3
+          // rows/frame, which can't keep up with LLM output rate).
+          const isStickyFollow = atBottom && pending >= 0
+          cur += isStickyFollow
+            ? drainProportional(node, pending, eff)
+            : (isXtermJsHost() ? drainAdaptive(node, pending, eff) : drainProportional(node, pending, eff))
         } else if (pending === 0) {
           // Opposite scrollBy calls cancelled to zero — clear so we don't
           // schedule an infinite loop of no-op drain frames.


### PR DESCRIPTION
## Problem

In the dashboard's embedded `/chat` tab (xterm.js over `/api/pty`), streaming output text gets visually clipped — the latest lines render below the visible viewport and only become visible after the next user interaction (typing, scrolling, sending).

## Root cause

Per #64744: `drainAdaptive` was designed for xterm.js **wheel scroll events** (sparse, user-initiated) — it throttles to 2-3 rows/frame. But the same drain is also applied to the `stickyScroll` **follow path**, where it should track content growth instead.

LLM streaming content arrives faster than 2-3 rows/frame, so the drain falls behind. The virtual scroll clamp then renders at the clamp edge (not the true bottom), pushing new content below the visible area. The next user interaction triggers a re-render and the hidden lines jump into view.

## Fix

In the sticky-follow branch (`atBottom && pendingScrollDelta >= 0`), use `drainProportional` (75% per frame) for fast catch-up. User wheel scroll (the original xterm.js case) keeps the adaptive drain — the slow, smooth scroll behavior `drainAdaptive` was designed for is preserved for the case it was actually built for.

```ts
const isStickyFollow = atBottom && pending >= 0
cur += isStickyFollow
  ? drainProportional(node, pending, eff)
  : (isXtermJsHost() ? drainAdaptive(node, pending, eff) : drainProportional(node, pending, eff))
```

## Why this is safe

- `sticky-follow` is content-growth tracking, not a user-initiated wheel event — `drainProportional` is the same path native terminals already use for similar growth.
- Wheel scroll on xterm.js still takes the `drainAdaptive` branch (`isStickyFollow` is false when the user is wheeling away from bottom, or when `atBottom` is false).
- Native terminals are unaffected: they always used `drainProportional` and still do.

Fixes #64744