### PR TITLE
fix(tui): use proportional drain for xterm.js sticky-follow streaming (#64744)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -844,7 +844,16 @@ function renderNodeToOutput(
           const pastClamp = haveClamp && ((pending < 0 && cur < cMin) || (pending > 0 && cur > cMax))
 
           const eff = pastClamp ? Math.min(4, innerHeight >> 3) : innerHeight
-          cur += isXtermJsHost() ? drainAdaptive(node, pending, eff) : drainProportional(node, pending, eff)
+          // Sticky-follow (content-growth tracking, not a user wheel event)
+          // must use the faster proportional drain so streaming output keeps
+          // up with the LLM's arrival rate. drainAdaptive's small fixed steps
+          // were tuned for sparse xterm.js wheel events and fall behind when
+          // content grows faster than the frame rate, leaving new lines
+          // rendered below the viewport until the next interaction (#64744).
+          const isStickyFollow = atBottom && pending >= 0
+          cur += isStickyFollow
+            ? drainProportional(node, pending, eff)
+            : (isXtermJsHost() ? drainAdaptive(node, pending, eff) : drainProportional(node, pending, eff))
         } else if (pending === 0) {
           // Opposite scrollBy calls cancelled to zero — clear so we don't
           // schedule an infinite loop of no-op drain frames.


### PR DESCRIPTION
## Summary

In the dashboard's embedded xterm.js Chat tab (``hermes dashboard`` → ``/chat``),
streaming output was visually clipped: new lines rendered below the visible
viewport and only appeared after the next user interaction (typing, scrolling,
or sending a message). Reproduces only in the dashboard xterm.js pane, not the
CLI TUI or VS Code's terminal.

## Changes

- ``ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts`` (line ~847)
  - The sticky-follow (content-growth) path reused the xterm.js **adaptive**
    drain (``drainAdaptive``), whose small fixed steps (2-3 rows/frame) were
    tuned for **sparse wheel events** and fall behind when the LLM streams
    faster than the frame rate — leaving new lines painted below the viewport
    until the next scroll/interaction.
  - When stickily following the bottom (``atBottom && pending >= 0``), the
    growth is content tracking, not a user wheel event, so use the faster
    **proportional** drain (``drainProportional``, ~75%/frame) — the same
    strategy native terminals already use.
  - xterm.js **wheel-driven** scrolling keeps ``drainAdaptive``; only the
    sticky-follow catch-up switches to proportional, so the stop-start jitter
    the adaptive drain was designed to fix is preserved for actual wheel input.
  - This is exactly the issue's **Option A**: split the drain by context at the
    selection site.

## Why this is the right boundary

``drainAdaptive`` exists to make xterm.js wheel scrolling smooth (small steps,
no big jumps). Sticky-follow is a different input class — content is arriving
on its own, the viewport must track the tail, and there is no "jump" to smooth.
Forcing the throttled adaptive step there is the mismatch the reporter traced.

## How to Test

Visual (the bug is UI-only, WSL2 / browser dashboard):
1. ``hermes dashboard``, open the ``/chat`` tab in a browser.
2. Send a prompt that streams a long response with tool calls.
3. New lines should now stick to the bottom as they arrive (no hidden/clipped
   content, no need to nudge the terminal).

Type-check / unit note: ``drainAdaptive``/``drainProportional`` are internal to
this module (not exported), so this is covered by the existing ``ui-tui``
``npm run typecheck`` / ``vitest`` suite rather than a new isolated unit test.
The change is type-safe (``atBottom`` is already ``boolean``; ``pending`` is
narrowed to ``number`` by the ``pending !== undefined && pending !== 0`` guard
above the selection). Could not run ``npm install`` in this environment to
exercise the TS build here — CI will cover it.

## Checklist

- [x] Scoped to the single drain-selection site in render-node-to-output.ts
- [x] Cross-platform: dashboard xterm.js (WSL2/browser) fix; CLI TUI and VS Code
      terminal behavior unchanged
- [x] Type-safe change; matches issue's Option A
- [ ] ``npm run typecheck && npm run test`` (CI) — not run locally (no
      node_modules in this sandbox)

## Risk & Impact

**Low.** Only reroutes the sticky-follow catch-up drain for xterm.js hosts from
adaptive to proportional. Wheel scrolling keeps adaptive; native terminals were
already proportional. No change to scroll state, clamp, or sticky flag logic.

Type: Bug fix
Closes: #64744