### PR TITLE
fix(skills): require refresh when loaded content changes

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -4,6 +4,7 @@ Shared between CLI (cli.py) and gateway (gateway/run.py) so both surfaces
 can invoke skills via /skill-name commands.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -22,9 +23,15 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_refresh_fingerprint: Optional[Dict[str, str]] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_SKILL_REFRESH_COMPONENTS = (
+    "enabled_skill_ids",
+    "skill_contents",
+    "tool_schema",
+)
 
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
@@ -405,6 +412,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
+                        "_skill_content_sha256": hashlib.sha256(
+                            content.encode("utf-8")
+                        ).hexdigest(),
                     }
                 except Exception:
                     continue
@@ -420,12 +430,82 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     process serving Telegram and Discord concurrently) so each platform
     sees its own ``skills.platform_disabled`` view (#14536).
     """
+    global _skill_refresh_fingerprint
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
     ):
         scan_skill_commands()
+    if _skill_refresh_fingerprint is None:
+        _skill_refresh_fingerprint = _build_skill_refresh_fingerprint(
+            _skill_commands
+        )
     return _skill_commands
+
+
+def _canonical_tool_schema_json() -> str:
+    """Return the current tool schema as stable canonical JSON."""
+    from model_tools import get_tool_definitions
+
+    schemas = get_tool_definitions(quiet_mode=True)
+    ordered = sorted(
+        schemas,
+        key=lambda schema: (
+            str((schema.get("function") or {}).get("name") or ""),
+            json.dumps(
+                schema,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        ),
+    )
+    return json.dumps(
+        ordered,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _build_skill_refresh_fingerprint(
+    commands: Dict[str, Dict[str, Any]],
+) -> Dict[str, str]:
+    """Hash every prompt-affecting skill/tool component independently."""
+    enabled_skill_ids = sorted(
+        str((info or {}).get("name") or slash_key.lstrip("/"))
+        for slash_key, info in commands.items()
+    )
+    skill_contents = []
+    for slash_key, info in sorted(commands.items()):
+        info = info or {}
+        skill_id = str(info.get("name") or slash_key.lstrip("/"))
+        content_sha256 = str(info.get("_skill_content_sha256") or "")
+        if not content_sha256:
+            try:
+                content_sha256 = hashlib.sha256(
+                    Path(str(info.get("skill_md_path") or "")).read_bytes()
+                ).hexdigest()
+            except OSError:
+                content_sha256 = ""
+        skill_contents.append({"id": skill_id, "sha256": content_sha256})
+
+    def _digest(value: Any) -> str:
+        canonical = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    return {
+        "enabled_skill_ids": _digest(enabled_skill_ids),
+        "skill_contents": _digest(skill_contents),
+        "tool_schema": hashlib.sha256(
+            _canonical_tool_schema_json().encode("utf-8")
+        ).hexdigest(),
+    }
 
 
 def reload_skills() -> Dict[str, Any]:
@@ -441,6 +521,12 @@ def reload_skills() -> Dict[str, Any]:
     Keeping the prompt cache intact preserves prefix caching across the
     reload, so a user invoking ``/reload-skills`` pays no cache-reset cost.
 
+    The refresh fingerprint covers three independently reported components:
+    sorted enabled skill IDs, each enabled skill's complete ``SKILL.md``
+    content, and the canonical JSON tool schema. Content-only and schema-only
+    changes therefore require a fresh session even when the slash-command set
+    is unchanged.
+
     Returns:
         Dict with keys::
 
@@ -450,6 +536,8 @@ def reload_skills() -> Dict[str, Any]:
               "unchanged":  [skill names present before and after],
               "total":      total skill count after rescan,
               "commands":   total /slash-skill count after rescan,
+              "changed":    whether any fingerprint component changed,
+              "changed_components": [changed component names],
             }
 
         ``description`` is the skill's full SKILL.md frontmatter
@@ -467,13 +555,27 @@ def reload_skills() -> Dict[str, Any]:
             out[bare] = (info or {}).get("description") or ""
         return out
 
+    global _skill_refresh_fingerprint
+
     before = _snapshot(_skill_commands)
+    before_fingerprint = (
+        dict(_skill_refresh_fingerprint)
+        if _skill_refresh_fingerprint is not None
+        else _build_skill_refresh_fingerprint(_skill_commands)
+    )
 
     # Rescan the skills dir. ``scan_skill_commands`` resets
     # ``_skill_commands = {}`` internally and repopulates it.
     new_commands = scan_skill_commands()
 
     after = _snapshot(new_commands)
+    after_fingerprint = _build_skill_refresh_fingerprint(new_commands)
+    changed_components = [
+        component
+        for component in _SKILL_REFRESH_COMPONENTS
+        if before_fingerprint.get(component) != after_fingerprint.get(component)
+    ]
+    _skill_refresh_fingerprint = after_fingerprint
 
     added_names = sorted(set(after) - set(before))
     removed_names = sorted(set(before) - set(after))
@@ -490,6 +592,8 @@ def reload_skills() -> Dict[str, Any]:
         "unchanged": unchanged,
         "total": len(after),
         "commands": len(new_commands),
+        "changed": bool(changed_components),
+        "changed_components": changed_components,
     }
 
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4253,19 +4253,13 @@ class GatewaySlashCommandsMixin:
         )
 
     async def _handle_reload_skills_command(self, event: MessageEvent) -> str:
-        """Handle /reload-skills — rescan skills dir, queue a note for next turn.
+        """Handle /reload-skills — rescan skills and report session staleness.
 
-        Skills don't need to be in the system prompt for the model to use
-        them (they're invoked via ``/skill-name``, ``skills_list``, or
-        ``skill_view`` at runtime), so this does NOT clear the prompt cache
-        — prefix caching stays intact.
-
-        If any skills were added or removed, a one-shot note is queued on
-        ``self._pending_skills_reload_notes[session_key]``. The gateway
-        prepends it to the NEXT user message in this session (see the
-        consumer at ~L11025 in ``_run_agent_turn``), then clears it. Nothing
-        is written to the session transcript out-of-band, so message
-        alternation is preserved.
+        Any enabled-skill, SKILL.md-content, or tool-schema change requires a
+        new session because the current session's prompt and schemas are
+        immutable. This handler reports ``SESSION_REFRESH_REQUIRED`` without
+        clearing prompt caches, rebuilding the agent, writing the transcript,
+        or queueing a synthetic note for the next turn.
         """
         loop = asyncio.get_running_loop()
         try:
@@ -4275,6 +4269,7 @@ class GatewaySlashCommandsMixin:
             added = result.get("added", [])      # [{"name", "description"}, ...]
             removed = result.get("removed", [])  # [{"name", "description"}, ...]
             total = result.get("total", 0)
+            changed = bool(result.get("changed", bool(added or removed)))
 
             # Let each connected adapter refresh any platform-side state
             # that cached the skill list at startup. Today that's the
@@ -4299,7 +4294,7 @@ class GatewaySlashCommandsMixin:
                     )
 
             lines = [t("gateway.reload_skills.header")]
-            if not added and not removed:
+            if not changed:
                 lines.append(t("gateway.reload_skills.no_new"))
                 lines.append(t("gateway.reload_skills.total", count=total))
                 return "\n".join(lines)
@@ -4319,32 +4314,8 @@ class GatewaySlashCommandsMixin:
                 lines.append(t("gateway.reload_skills.removed_header"))
                 for item in removed:
                     lines.append(_fmt_line(item))
+            lines.append("SESSION_REFRESH_REQUIRED")
             lines.append(t("gateway.reload_skills.total", count=total))
-
-            # Queue the one-shot note for the next user turn in this session.
-            # Format matches how the system prompt renders pre-existing
-            # skills (``    - name: description``) so the model reads the
-            # diff in the same shape as its original skill catalog.
-            sections = ["[USER INITIATED SKILLS RELOAD:"]
-            if added:
-                sections.append("")
-                sections.append("Added Skills:")
-                for item in added:
-                    sections.append(_fmt_line(item))
-            if removed:
-                sections.append("")
-                sections.append("Removed Skills:")
-                for item in removed:
-                    sections.append(_fmt_line(item))
-            sections.append("")
-            sections.append("Use skills_list to see the updated catalog.]")
-            note = "\n".join(sections)
-
-            session_key = self._session_key_for_source(event.source)
-            if not hasattr(self, "_pending_skills_reload_notes"):
-                self._pending_skills_reload_notes = {}
-            if session_key:
-                self._pending_skills_reload_notes[session_key] = note
 
             return "\n".join(lines)
 

--- a/tests/agent/test_skill_commands_reload.py
+++ b/tests/agent/test_skill_commands_reload.py
@@ -18,7 +18,12 @@ from pathlib import Path
 import pytest
 
 
-def _write_skill(skills_dir: Path, name: str, description: str = "") -> Path:
+def _write_skill(
+    skills_dir: Path,
+    name: str,
+    description: str = "",
+    body: str = "body",
+) -> Path:
     skill_dir = skills_dir / name
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
@@ -28,7 +33,7 @@ def _write_skill(skills_dir: Path, name: str, description: str = "") -> Path:
             name: {name}
             description: {description or f'{name} skill'}
             ---
-            body
+            {body}
             """
         )
     )
@@ -57,6 +62,8 @@ def hermes_home(monkeypatch):
     monkeypatch.setattr(_st, "SKILLS_DIR", home / "skills", raising=False)
     # Reset the in-process slash-command cache so each test starts from zero.
     monkeypatch.setattr(_sc, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(_sc, "_skill_commands_platform", None, raising=False)
+    monkeypatch.setattr(_sc, "_skill_refresh_fingerprint", None, raising=False)
 
     yield home
 
@@ -70,10 +77,20 @@ class TestReloadSkillsHelper:
         from agent.skill_commands import reload_skills
 
         result = reload_skills()
-        assert set(result) == {"added", "removed", "unchanged", "total", "commands"}
+        assert set(result) == {
+            "added",
+            "removed",
+            "unchanged",
+            "total",
+            "commands",
+            "changed",
+            "changed_components",
+        }
         assert result["total"] == 0
         assert result["added"] == []
         assert result["removed"] == []
+        assert result["changed"] is False
+        assert result["changed_components"] == []
 
     def test_detects_newly_added_skill_with_description(self, hermes_home):
         from agent.skill_commands import reload_skills, get_skill_commands
@@ -88,6 +105,8 @@ class TestReloadSkillsHelper:
         assert result["removed"] == []
         assert result["total"] == 1
         assert result["commands"] == 1
+        assert result["changed"] is True
+        assert "enabled_skill_ids" in result["changed_components"]
 
     def test_detects_removed_skill_carries_description(self, hermes_home):
         from agent.skill_commands import reload_skills
@@ -106,13 +125,15 @@ class TestReloadSkillsHelper:
         assert second["removed"] == [{"name": "demo", "description": "soon to be gone"}]
         assert second["added"] == []
         assert second["total"] == 0
+        assert second["changed"] is True
+        assert "enabled_skill_ids" in second["changed_components"]
 
     def test_description_passes_through_verbatim(self, hermes_home):
         """``description`` must be the full SKILL.md frontmatter string — no
         truncation. The system prompt renders skills as
-        ``    - name: description`` without a length cap, and the reload
-        note mirrors that format, so truncating here would make the diff
-        render differently from the original catalog."""
+        ``    - name: description`` without a length cap, and the gateway
+        reload diff mirrors that value, so truncating here would make the
+        result differ from the original catalog."""
         from agent.skill_commands import reload_skills, get_skill_commands
 
         get_skill_commands()  # prime
@@ -135,6 +156,92 @@ class TestReloadSkillsHelper:
         assert "alpha" in result["unchanged"]
         assert result["added"] == []
         assert result["removed"] == []
+        assert result["changed"] is False
+        assert result["changed_components"] == []
+
+    def test_detects_skill_content_only_change(self, hermes_home):
+        from agent.skill_commands import reload_skills, get_skill_commands
+
+        skill_dir = _write_skill(hermes_home / "skills", "alpha", body="before")
+        get_skill_commands()
+        _write_skill(hermes_home / "skills", "alpha", body="after")
+
+        result = reload_skills()
+
+        assert result["added"] == []
+        assert result["removed"] == []
+        assert result["changed"] is True
+        assert result["changed_components"] == ["skill_contents"]
+        assert skill_dir.exists()
+
+    def test_detects_tool_schema_only_change(self, hermes_home, monkeypatch):
+        import agent.skill_commands as skill_commands
+
+        schema = {"value": "before"}
+        monkeypatch.setattr(
+            skill_commands,
+            "_canonical_tool_schema_json",
+            lambda: schema["value"],
+        )
+        _write_skill(hermes_home / "skills", "alpha")
+        skill_commands.get_skill_commands()
+        schema["value"] = "after"
+
+        result = skill_commands.reload_skills()
+
+        assert result["added"] == []
+        assert result["removed"] == []
+        assert result["changed"] is True
+        assert result["changed_components"] == ["tool_schema"]
+
+    def test_canonical_tool_schema_ignores_tool_and_key_order(
+        self, monkeypatch
+    ):
+        import agent.skill_commands as skill_commands
+        import model_tools
+
+        schemas = {
+            "value": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "beta",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "function": {
+                        "parameters": {"properties": {}, "type": "object"},
+                        "name": "alpha",
+                    },
+                    "type": "function",
+                },
+            ]
+        }
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda quiet_mode=True: schemas["value"],
+        )
+        before = skill_commands._canonical_tool_schema_json()
+        schemas["value"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "alpha",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "function": {
+                    "parameters": {"properties": {}, "type": "object"},
+                    "name": "beta",
+                },
+                "type": "function",
+            },
+        ]
+
+        assert skill_commands._canonical_tool_schema_json() == before
 
     def test_does_not_invalidate_prompt_cache_snapshot(self, hermes_home):
         """reload_skills must NOT delete the skills prompt-cache snapshot.

--- a/tests/gateway/test_reload_skills_command.py
+++ b/tests/gateway/test_reload_skills_command.py
@@ -5,10 +5,10 @@ Verifies:
   * the underscored alias ``/reload_skills`` is not flagged as unknown
   * the handler invokes ``agent.skill_commands.reload_skills`` and renders a
     human-readable diff
-  * when any skills changed, a one-shot note is queued on
-    ``runner._pending_skills_reload_notes[session_key]`` (the agent loop
-    consumes and clears it on the next user turn — see ``gateway/run.py``
-    near the ``_has_fresh_tool_tail`` block)
+  * when any fingerprint component changed, the response contains the exact
+    marker ``SESSION_REFRESH_REQUIRED``
+  * changed reloads do not clear the current agent cache or queue a next-turn
+    reload note
   * the handler does NOT append to the session transcript out-of-band —
     message alternation must not be broken by a phantom user turn
 """
@@ -70,6 +70,7 @@ def _make_runner():
     runner.session_store.append_to_transcript = MagicMock()
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
+    runner._agent_cache = {"sentinel": object()}
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
@@ -89,8 +90,8 @@ def _make_runner():
 
 
 @pytest.mark.asyncio
-async def test_reload_skills_handler_queues_note_on_diff(monkeypatch):
-    """Diff non-empty → handler queues a one-shot note and does NOT touch transcript."""
+async def test_reload_skills_handler_requires_new_session_on_diff(monkeypatch):
+    """Diff non-empty → require /new without touching cache or transcript."""
     fake_result = {
         "added": [
             {"name": "alpha", "description": "Run alpha to do xyz"},
@@ -102,12 +103,15 @@ async def test_reload_skills_handler_queues_note_on_diff(monkeypatch):
         "unchanged": ["delta"],
         "total": 3,
         "commands": 3,
+        "changed": True,
+        "changed_components": ["enabled_skill_ids", "skill_contents"],
     }
 
     import agent.skill_commands as skill_commands_mod
     monkeypatch.setattr(skill_commands_mod, "reload_skills", lambda: fake_result)
 
     runner = _make_runner()
+    agent_cache = runner._agent_cache
     event = _make_event("/reload-skills")
     out = await runner._handle_reload_skills_command(event)
 
@@ -119,23 +123,45 @@ async def test_reload_skills_handler_queues_note_on_diff(monkeypatch):
     assert "Removed Skills:" in out
     assert "- gamma: Old removed skill" in out
     assert "3 skill(s) available" in out
+    assert "SESSION_REFRESH_REQUIRED" in out
 
     # MUST NOT write to the session transcript — that would break alternation.
     runner.session_store.append_to_transcript.assert_not_called()
 
-    # MUST have queued a one-shot note keyed on the session.
+    # MUST NOT queue a synthetic next-turn note or clear the current agent cache.
     pending = getattr(runner, "_pending_skills_reload_notes", None)
-    assert pending is not None
-    session_key = runner._session_key_for_source(event.source)
-    assert session_key in pending
-    note = pending[session_key]
-    assert note.startswith("[USER INITIATED SKILLS RELOAD:")
-    assert note.endswith("Use skills_list to see the updated catalog.]")
-    assert "Added Skills:" in note
-    assert "    - alpha: Run alpha to do xyz" in note
-    assert "    - beta: Run beta to do abc" in note
-    assert "Removed Skills:" in note
-    assert "    - gamma: Old removed skill" in note
+    assert not pending
+    assert runner._agent_cache is agent_cache
+
+
+@pytest.mark.asyncio
+async def test_reload_skills_handler_marks_content_only_change(monkeypatch):
+    """Content/schema-only changes still require a new session."""
+    import agent.skill_commands as skill_commands_mod
+
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "reload_skills",
+        lambda: {
+            "added": [],
+            "removed": [],
+            "unchanged": ["alpha"],
+            "total": 1,
+            "commands": 1,
+            "changed": True,
+            "changed_components": ["skill_contents"],
+        },
+    )
+
+    runner = _make_runner()
+    out = await runner._handle_reload_skills_command(
+        _make_event("/reload-skills")
+    )
+
+    assert "SESSION_REFRESH_REQUIRED" in out
+    assert "No new skills detected" not in out
+    assert not getattr(runner, "_pending_skills_reload_notes", None)
+    runner.session_store.append_to_transcript.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -152,6 +178,8 @@ async def test_reload_skills_handler_reports_no_changes(monkeypatch):
             "unchanged": ["alpha"],
             "total": 1,
             "commands": 1,
+            "changed": False,
+            "changed_components": [],
         },
     )
 
@@ -160,6 +188,7 @@ async def test_reload_skills_handler_reports_no_changes(monkeypatch):
 
     assert "No new skills detected" in out
     assert "1 skill(s) available" in out
+    assert "SESSION_REFRESH_REQUIRED" not in out
     runner.session_store.append_to_transcript.assert_not_called()
     # No queued note when nothing changed.
     pending = getattr(runner, "_pending_skills_reload_notes", None)


### PR DESCRIPTION
## Summary

`/reload-skills` currently detects only added or removed slash-skill commands. Editing an enabled `SKILL.md` body or changing the normalized tool schema can therefore report no change even though the active session still carries stale prompt or schema state.

This change keeps the refresh contract narrow:

- fingerprint sorted enabled skill IDs
- hash each enabled skill complete `SKILL.md` content
- canonicalize and hash the active tool schema so key and tool order do not create false changes
- return `SESSION_REFRESH_REQUIRED` only when one of those components changed
- preserve the current agent cache and transcript; do not queue a synthetic next-turn note

No new framework or runtime reload path is introduced.

## Tests

- `scripts/run_tests.sh tests/agent/test_skill_commands.py tests/agent/test_skill_commands_reload.py tests/gateway/test_reload_skills_command.py tests/gateway/test_reload_skills_discord_resync.py -q` — 78 passed
- `ruff check` on the four changed files — passed
- `git diff upstream/main...HEAD --check` — passed
