### PR TITLE
fix(gateway): guard internal handoffs and unavailable reply context

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -7,6 +7,7 @@ conversation history.
 
 from __future__ import annotations
 
+import os
 import unicodedata
 from typing import Any
 
@@ -22,6 +23,45 @@ LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "NO_REPLY",
     "NO REPLY",
 })
+
+HANDOFF_GUARD_PREFIXES = ("<analysis>", "<summary>")
+HANDOFF_GUARD_MIN_CHARS = 600
+HANDOFF_GUARD_REPLACEMENT = (
+    "⚠️ Internal context handoff content was withheld. Please retry your request."
+)
+
+
+def _handoff_guard_enabled() -> bool:
+    return os.environ.get("HERMES_HANDOFF_GUARD", "1") != "0"
+
+
+def is_handoff_leak_response(response: Any) -> bool:
+    """Return True for a long internal handoff card at response start."""
+    if not _handoff_guard_enabled() or not isinstance(response, str):
+        return False
+    stripped = response.lstrip()
+    return len(stripped) > HANDOFF_GUARD_MIN_CHARS and stripped.lower().startswith(
+        HANDOFF_GUARD_PREFIXES
+    )
+
+
+def is_partial_handoff_leak_candidate(response: Any) -> bool:
+    """Hold a matching stream prefix until it is short-safe or long-blocked."""
+    if not _handoff_guard_enabled() or not isinstance(response, str):
+        return False
+    stripped = response.lstrip()
+    if not stripped or len(stripped) > HANDOFF_GUARD_MIN_CHARS:
+        return False
+    lowered = stripped.lower()
+    return any(
+        prefix.startswith(lowered) or lowered.startswith(prefix)
+        for prefix in HANDOFF_GUARD_PREFIXES
+    )
+
+
+def guard_handoff_response(response: Any) -> Any:
+    """Replace a detected internal handoff card; preserve every other value."""
+    return HANDOFF_GUARD_REPLACEMENT if is_handoff_leak_response(response) else response
 
 
 def _canonical_silence_candidate(text: str) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -156,6 +156,8 @@ _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
 )
 
+_REPLY_ORIGINAL_UNAVAILABLE = "\x00__HERMES_REPLY_ORIGINAL_UNAVAILABLE__\x00"
+
 
 def _ensure_windows_gateway_venv_imports() -> None:
     """Make detached Windows gateway runs see the Hermes venv packages.
@@ -10712,20 +10714,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
-            # Always inject the reply-to pointer — even when the quoted text
-            # already appears in history. The prefix isn't deduplication, it's
-            # disambiguation: it tells the agent *which* prior message the user
-            # is referencing. History can contain the same or similar text
-            # multiple times, and without an explicit pointer the agent has to
-            # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
-            if getattr(event, "reply_to_is_own_message", False):
-                message_text = (
-                    f'[Replying to your previous message: "{reply_snippet}"]\n\n'
-                    f"{message_text}"
-                )
+            if event.reply_to_text == _REPLY_ORIGINAL_UNAVAILABLE:
+                if history:
+                    reply_context = (
+                        "The user replied to an earlier message, but its text is unavailable. "
+                        "Review the conversation history first. If the target is still unclear, "
+                        "use session_search or ask the user to resend it. Do not guess."
+                    )
+                else:
+                    reply_context = (
+                        "The user replied to an earlier message, but its text is unavailable and "
+                        "this session has no history. Use session_search or ask the user to resend "
+                        "it. Do not guess or act on inferred instructions."
+                    )
+                message_text = f"[Reply context: {reply_context}]\n\n{message_text}"
             else:
-                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+                # Always inject the reply-to pointer — even when the quoted text
+                # already appears in history. The prefix isn't deduplication, it's
+                # disambiguation: it tells the agent *which* prior message the user
+                # is referencing. History can contain the same or similar text
+                # multiple times, and without an explicit pointer the agent has to
+                # guess (or answer for both subjects). Token overhead is minimal.
+                reply_snippet = event.reply_to_text[:500]
+                if getattr(event, "reply_to_is_own_message", False):
+                    message_text = (
+                        f'[Replying to your previous message: "{reply_snippet}"]\n\n'
+                        f"{message_text}"
+                    )
+                else:
+                    message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11810,6 +11810,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             response = agent_result.get("final_response") or ""
             try:
+                from gateway.response_filters import guard_handoff_response
+                _guarded_response = guard_handoff_response(response)
+                if _guarded_response != response:
+                    logger.warning(
+                        "Withheld internal handoff response before delivery (%d chars)",
+                        len(response),
+                    )
+                    response = _guarded_response
+            except Exception:
+                pass
+            try:
                 from gateway.response_filters import is_intentional_silence_agent_result
                 _intentional_silence = is_intentional_silence_agent_result(
                     agent_result, response,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -33,7 +33,10 @@ from gateway.config import (
     DEFAULT_STREAMING_CURSOR as _DEFAULT_STREAMING_CURSOR,
 )
 from gateway.response_filters import (
+    HANDOFF_GUARD_REPLACEMENT as _HANDOFF_GUARD_REPLACEMENT,
+    is_handoff_leak_response as _is_handoff_leak_response,
     is_intentional_silence_response as _is_intentional_silence_response,
+    is_partial_handoff_leak_candidate as _is_partial_handoff_leak_candidate,
     is_partial_silence_marker as _is_partial_silence_marker,
 )
 
@@ -206,6 +209,7 @@ class GatewayStreamConsumer:
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
+        self._handoff_guard_triggered = False
 
         # Native draft-streaming state.  Resolved at the start of run() based
         # on cfg.transport, cfg.chat_type, and the adapter's
@@ -399,6 +403,8 @@ class GatewayStreamConsumer:
         discarded.  Partial tags at buffer boundaries are held back in
         ``_think_buffer`` until enough characters arrive to decide.
         """
+        if self._handoff_guard_triggered:
+            return
         buf = self._think_buffer + text
         self._think_buffer = ""
 
@@ -597,6 +603,16 @@ class GatewayStreamConsumer:
                     except queue.Empty:
                         break
 
+                _clean_accumulated = self._clean_for_display(self._accumulated)
+                if _is_handoff_leak_response(_clean_accumulated):
+                    logger.warning(
+                        "Withheld internal handoff response from stream (%d chars)",
+                        len(_clean_accumulated),
+                    )
+                    self._accumulated = _HANDOFF_GUARD_REPLACEMENT
+                    self._think_buffer = ""
+                    self._handoff_guard_triggered = True
+
                 # Flush any held-back partial-tag buffer on stream end
                 # so trailing text that was waiting for a potential open
                 # tag is not lost.
@@ -652,8 +668,13 @@ class GatewayStreamConsumer:
                     and not got_done
                     and not got_segment_break
                     and commentary_text is None
-                    and _is_partial_silence_marker(
-                        self._clean_for_display(self._accumulated)
+                    and (
+                        _is_partial_silence_marker(
+                            self._clean_for_display(self._accumulated)
+                        )
+                        or _is_partial_handoff_leak_candidate(
+                            self._clean_for_display(self._accumulated)
+                        )
                     )
                 ):
                     should_edit = False

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -15,6 +15,9 @@ from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
 
+_REPLY_ORIGINAL_UNAVAILABLE = "\x00__HERMES_REPLY_ORIGINAL_UNAVAILABLE__\x00"
+
+
 def _make_runner() -> GatewayRunner:
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
@@ -180,3 +183,50 @@ async def test_reply_snippet_truncated_to_500_chars():
     assert result is not None
     assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
     assert "x" * 501 not in result
+
+
+@pytest.mark.asyncio
+async def test_unavailable_reply_uses_history_without_exposing_marker():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="继续处理这个",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=_REPLY_ORIGINAL_UNAVAILABLE,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[{"role": "assistant", "content": "Earlier context"}],
+    )
+
+    assert "Review the conversation history first" in result
+    assert "Do not guess" in result
+    assert _REPLY_ORIGINAL_UNAVAILABLE not in result
+    assert result.endswith("继续处理这个")
+
+
+@pytest.mark.asyncio
+async def test_unavailable_reply_without_history_requires_search_or_resend():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="继续处理这个",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=_REPLY_ORIGINAL_UNAVAILABLE,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert "this session has no history" in result
+    assert "session_search" in result
+    assert "Do not guess or act" in result
+    assert _REPLY_ORIGINAL_UNAVAILABLE not in result
+    assert result.endswith("继续处理这个")

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -1,4 +1,8 @@
 from gateway.response_filters import (
+    HANDOFF_GUARD_REPLACEMENT,
+    guard_handoff_response,
+    is_handoff_leak_response,
+    is_partial_handoff_leak_candidate,
     is_intentional_silence_agent_result,
     is_intentional_silence_response,
 )
@@ -25,3 +29,28 @@ def test_blank_and_prose_mentions_are_not_silence():
 def test_failed_agent_result_never_counts_as_intentional_silence():
     assert is_intentional_silence_agent_result({"failed": False}, "NO_REPLY")
     assert not is_intentional_silence_agent_result({"failed": True}, "NO_REPLY")
+
+
+def test_long_internal_handoff_is_replaced():
+    raw = "<analysis>" + ("internal state " * 50)
+    assert is_handoff_leak_response(raw)
+    assert guard_handoff_response(raw) == HANDOFF_GUARD_REPLACEMENT
+
+
+def test_handoff_guard_keeps_short_or_ordinary_text():
+    short = "<summary>brief user-facing summary</summary>"
+    ordinary = "Here is how the <analysis> tag works. " + ("x" * 700)
+    assert guard_handoff_response(short) == short
+    assert guard_handoff_response(ordinary) == ordinary
+
+
+def test_handoff_stream_prefix_is_held_until_decided():
+    assert is_partial_handoff_leak_candidate("<ana")
+    assert is_partial_handoff_leak_candidate("<analysis>" + ("x" * 500))
+    assert not is_partial_handoff_leak_candidate("<analysis>" + ("x" * 601))
+
+
+def test_handoff_guard_escape_hatch(monkeypatch):
+    raw = "<summary>" + ("internal state " * 50)
+    monkeypatch.setenv("HERMES_HANDOFF_GUARD", "0")
+    assert guard_handoff_response(raw) == raw

--- a/tests/gateway/test_stream_consumer_silence.py
+++ b/tests/gateway/test_stream_consumer_silence.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.response_filters import (
+    HANDOFF_GUARD_REPLACEMENT,
     is_intentional_silence_response,
     is_partial_silence_marker,
 )
@@ -122,6 +123,24 @@ def _sent_and_edited(adapter):
 
 
 class TestStreamedSilenceSuppression:
+    @pytest.mark.asyncio
+    async def test_long_handoff_stream_is_replaced_before_delivery(self):
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+        )
+        consumer.on_delta("<analysis>" + ("internal state " * 50))
+        consumer.on_delta("secret tail that must also be dropped")
+        consumer.finish()
+        await consumer.run()
+
+        delivered = "".join(_sent_and_edited(adapter))
+        assert HANDOFF_GUARD_REPLACEMENT in delivered
+        assert "<analysis>" not in delivered
+        assert "internal state" not in delivered
+        assert "secret tail" not in delivered
+
     @pytest.mark.asyncio
     async def test_no_reply_only_stream_is_fully_suppressed(self):
         """A stream whose entire content is NO_REPLY sends nothing visible."""


### PR DESCRIPTION
## Problem

- A long internal context handoff card that starts with <analysis> or <summary> can reach a messaging gateway as user-visible output. The streaming path can expose it before the completed response is available for filtering.
- Some platform adapters know that a user replied to an earlier message but cannot retrieve the original text. Passing the opaque unavailable-text sentinel through as a quote encourages the model to infer the target instead of asking for evidence.

## Behavior

- Add a focused filter in gateway/response_filters.py for start-tagged handoff cards longer than 600 characters. Apply it to completed gateway responses and to streaming delivery; the streaming path holds the matching prefix until it is either safe or replaced. HERMES_HANDOFF_GUARD=0 remains an emergency opt-out.
- Recognize the existing unavailable-reply sentinel before quote injection. The prompt now tells the agent to inspect history first, then use session_search or ask the user to resend the target instead of guessing. The sentinel itself is never exposed to the model.
- Ordinary prose, short summaries, and normal reply quotes keep their existing behavior.

## Tests

- scripts/run_tests.sh tests/gateway/test_response_filters.py tests/gateway/test_stream_consumer_silence.py tests/gateway/test_reply_to_injection.py -q — 47 passed.
- Ruff on all six changed Python files — passed.
- git diff --check upstream/main..HEAD — passed.