### PR TITLE
fix(agent): enforce honest iteration and patch gates

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1740,9 +1740,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
     summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
+        "The iteration budget is exhausted, so this is a pause caused by the "
+        "system limit, not task completion. Provide a concise status update that "
+        "clearly separates work completed (with evidence) from work still unfinished. "
+        "Do not claim the task is complete while anything remains unfinished. "
+        "Unfinished work remains your responsibility; do not ask the user to perform "
+        "it. Ask the user only to reply 'continue' so you can resume. Do not call any "
+        "more tools."
     )
     messages.append({"role": "user", "content": summary_request})
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3811,6 +3811,28 @@ class TestMcpParallelToolBatch:
 
 
 class TestHandleMaxIterations:
+    def test_summary_request_discloses_budget_pause_and_unfinished_work(self, agent):
+        """The limit summary must report a pause, not counterfeit completion."""
+        agent.client.chat.completions.create.return_value = _mock_response(content="Status")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "finish the migration"}],
+            60,
+        )
+
+        assert result == "Status"
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        summary_request = sent_messages[-1]["content"].lower()
+        assert "iteration budget" in summary_request
+        assert "exhausted" in summary_request
+        assert "completed" in summary_request
+        assert "unfinished" in summary_request
+        assert "remains your responsibility" in summary_request
+        assert "do not claim" in summary_request
+        assert "reply 'continue'" in summary_request
+        assert "do not ask the user to perform" in summary_request
+
     def test_returns_summary(self, agent):
         resp = _mock_response(content="Here is a summary of what I did.")
         agent.client.chat.completions.create.return_value = resp

--- a/tests/tools/test_cross_profile_guard.py
+++ b/tests/tools/test_cross_profile_guard.py
@@ -125,14 +125,18 @@ class TestPatchCrossProfileGuard:
         assert target.read_text() == original
 
     def test_cross_profile_patch_bypass(self, fake_hermes):
-        from tools.file_tools import patch_tool
+        from tools.file_tools import patch_tool, read_file_tool
         target = fake_hermes["root"] / "skills" / "shared-skill" / "SKILL.md"
+        task_id = "cross-profile-patch"
+        read_result = json.loads(read_file_tool(str(target), task_id=task_id))
+        assert not read_result.get("error"), read_result
         result_json = patch_tool(
             mode="replace",
             path=str(target),
             old_string="default copy.",
             new_string="user-directed update.",
             cross_profile=True,
+            task_id=task_id,
         )
         result = json.loads(result_json)
         assert not result.get("error"), f"cross_profile=True bypass: {result}"

--- a/tests/tools/test_file_staleness.py
+++ b/tests/tools/test_file_staleness.py
@@ -221,6 +221,130 @@ class TestPatchStaleness(unittest.TestCase):
             pass
 
     @patch("tools.file_tools._get_file_ops")
+    def test_replace_rejects_existing_file_never_read_by_task(self, mock_ops):
+        fake_ops = MagicMock()
+        fake_ops.patch_replace.return_value = _FakePatchResult()
+        mock_ops.return_value = fake_ops
+
+        result = json.loads(patch_tool(
+            mode="replace", path=self._tmpfile,
+            old_string="original", new_string="patched",
+            task_id="unread-task",
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("read_file", result["error"])
+        fake_ops.patch_replace.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_allows_file_read_by_same_task(self, mock_ops):
+        fake_ops = MagicMock()
+        fake_ops.read_file.side_effect = lambda path, offset=1, limit=500: _FakeReadResult(
+            content="original line\n", total_lines=1, file_size=14,
+        )
+        fake_ops.patch_replace.return_value = _FakePatchResult()
+        mock_ops.return_value = fake_ops
+
+        read_file_tool(self._tmpfile, task_id="reader-task")
+        result = json.loads(patch_tool(
+            mode="replace", path=self._tmpfile,
+            old_string="original", new_string="patched",
+            task_id="reader-task",
+        ))
+
+        self.assertNotIn("error", result)
+        fake_ops.patch_replace.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_allows_new_file_written_by_same_task(self, mock_ops):
+        fake_ops = MagicMock()
+
+        def create_file(path, content):
+            with open(path, "w") as handle:
+                handle.write(content)
+            return _FakeWriteResult()
+
+        fake_ops.write_file.side_effect = create_file
+        fake_ops.patch_replace.return_value = _FakePatchResult()
+        mock_ops.return_value = fake_ops
+        new_path = os.path.join(self._tmpdir, "new_then_patch.txt")
+
+        try:
+            write_result = json.loads(write_file_tool(
+                new_path, "first version\n", task_id="creator-task",
+            ))
+            patch_result = json.loads(patch_tool(
+                mode="replace", path=new_path,
+                old_string="first", new_string="second",
+                task_id="creator-task",
+            ))
+        finally:
+            if os.path.exists(new_path):
+                os.unlink(new_path)
+
+        self.assertNotIn("error", write_result)
+        self.assertNotIn("error", patch_result)
+        fake_ops.patch_replace.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_failed_write_does_not_authorize_replace(self, mock_ops):
+        fake_ops = MagicMock()
+        failed_write = MagicMock()
+        failed_write.to_dict.return_value = {"error": "simulated write failure"}
+        fake_ops.write_file.return_value = failed_write
+        fake_ops.patch_replace.return_value = _FakePatchResult()
+        mock_ops.return_value = fake_ops
+
+        write_result = json.loads(write_file_tool(
+            self._tmpfile, "failed replacement\n", task_id="failed-writer",
+        ))
+        patch_result = json.loads(patch_tool(
+            mode="replace", path=self._tmpfile,
+            old_string="original", new_string="patched",
+            task_id="failed-writer",
+        ))
+
+        self.assertIn("error", write_result)
+        self.assertIn("read_file", patch_result["error"])
+        fake_ops.patch_replace.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_read_permission_is_isolated_by_task(self, mock_ops):
+        fake_ops = MagicMock()
+        fake_ops.read_file.side_effect = lambda path, offset=1, limit=500: _FakeReadResult(
+            content="original line\n", total_lines=1, file_size=14,
+        )
+        fake_ops.patch_replace.return_value = _FakePatchResult()
+        mock_ops.return_value = fake_ops
+
+        read_file_tool(self._tmpfile, task_id="task-a")
+        result = json.loads(patch_tool(
+            mode="replace", path=self._tmpfile,
+            old_string="original", new_string="patched",
+            task_id="task-b",
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("read_file", result["error"])
+        fake_ops.patch_replace.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_read_gate_can_be_disabled(self, mock_ops):
+        fake_ops = MagicMock()
+        fake_ops.patch_replace.return_value = _FakePatchResult()
+        mock_ops.return_value = fake_ops
+
+        with patch.dict(os.environ, {"HERMES_PATCH_REQUIRE_READ": "0"}, clear=False):
+            result = json.loads(patch_tool(
+                mode="replace", path=self._tmpfile,
+                old_string="original", new_string="patched",
+                task_id="unread-but-disabled",
+            ))
+
+        self.assertNotIn("error", result)
+        fake_ops.patch_replace.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
     def test_patch_warns_on_stale_file(self, mock_ops):
         """Patch should warn if the target file changed since last read."""
         mock_ops.return_value = _make_fake_ops("original line\n", 15)

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -368,6 +368,8 @@ def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
     monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": str(workspace))
 
     import json
+    read_result = json.loads(ft.read_file_tool("target.py", task_id="t1"))
+    assert not read_result.get("error"), read_result
     out = json.loads(ft.patch_tool(
         mode="replace", path="target.py",
         old_string="WORKSPACE_ORIGINAL", new_string="WORKSPACE_PATCHED",

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1593,10 +1593,30 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
+        task_data = _read_tracker.setdefault(task_id, {
+            "last_key": None, "consecutive": 0,
+            "read_history": set(), "dedup": {},
+            "dedup_hits": {}, "read_timestamps": {},
+        })
+        task_data.setdefault("read_timestamps", {})[resolved] = current_mtime
+        _cap_read_tracker_data(task_data)
+
+
+def _task_never_read_file(filepath: str, task_id: str) -> bool:
+    """Return True when replace would edit an existing unread file."""
+    if os.getenv("HERMES_PATCH_REQUIRE_READ", "1").strip() == "0":
+        return False
+    try:
+        resolved = str(_resolve_path_for_task(filepath, task_id))
+    except (OSError, ValueError):
+        return False
+    if not os.path.exists(resolved):
+        return False
+    with _read_tracker_lock:
         task_data = _read_tracker.get(task_id)
-        if task_data is not None:
-            task_data.setdefault("read_timestamps", {})[resolved] = current_mtime
-            _cap_read_tracker_data(task_data)
+        if not task_data:
+            return True
+        return resolved not in task_data.get("read_timestamps", {})
 
 
 def _check_file_staleness(filepath: str, task_id: str) -> str | None:
@@ -1706,7 +1726,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
                 _mark_verification_stale(task_id, [path], session_id=session_id)
-            _update_read_timestamp(path, task_id)
+                _update_read_timestamp(path, task_id)
             return json.dumps(result_dict, ensure_ascii=False)
 
         # Serialize the read→modify→write region per-path so concurrent
@@ -1733,10 +1753,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             if not result_dict.get("error"):
                 result_dict["files_modified"] = [_resolved]
                 _mark_verification_stale(task_id, [_resolved], session_id=session_id)
-            # Refresh stamps after the successful write so consecutive
-            # writes by this task don't trigger false staleness warnings.
-            _update_read_timestamp(path, task_id)
-            if not result_dict.get("error"):
+                # Refresh stamps after the successful write so consecutive
+                # writes by this task don't trigger false staleness warnings.
+                _update_read_timestamp(path, task_id)
                 file_state.note_write(task_id, _resolved)
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
@@ -1860,6 +1879,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return tool_error("path required")
                 if old_string is None or new_string is None:
                     return tool_error("old_string and new_string required")
+                if _task_never_read_file(path, task_id):
+                    return tool_error(
+                        f"Refusing to patch existing file '{path}' before this task "
+                        "has read it. Use read_file on the current file, then retry "
+                        "the patch. Set HERMES_PATCH_REQUIRE_READ=0 to disable this gate."
+                    )
                 # Pass the resolved ABSOLUTE path to the shell layer so it
                 # operates on the exact file the tool layer resolved — the
                 # shell's own cwd may differ (worktree-cwd bug), and a relative


### PR DESCRIPTION
## Summary

- Treat max-iteration exhaustion as a system-imposed pause, not task completion; require the status response to separate completed evidence from unfinished work and ask only for a `continue` reply.
- Require a same-task `read_file` before `patch` replace mode edits an existing file. A successful `write_file` establishes the current snapshot; a failed write does not. `HERMES_PATCH_REQUIRE_READ=0` remains an emergency escape hatch.
- Keep task isolation and the existing V4A patch path unchanged.

## Validation

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/tools/test_file_staleness.py tests/tools/test_cross_profile_guard.py tests/tools/test_file_tools_cwd_resolution.py tests/tools/test_file_state_registry.py -q`: **508 passed, 0 failed**.
- `.venv/bin/ruff check` on all six changed files: passed.
- `git diff upstream/main...HEAD --check`: passed.

## Known upstream baseline issue

On macOS, `tests/tools/test_file_tools.py` has three existing path-alias failures: assertions expect `/tmp/...`, while the current resolver intentionally supplies `/private/tmp/...`. The same **49 passed / 3 failed** result reproduces in an independent worktree based on upstream/main `9df5f879b4a5925c0f8f947e7e16ed8e845932c3`, with no changes to `tools/file_tools.py` or that test file. This PR does not alter path-resolution policy to mask those failures.

## Scope

This is source and test work only. It does not deploy, restart, or modify any Hermes runtime.