### PR TITLE
fix: detect llama.cpp runtime context length

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1795,15 +1795,43 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
 
             # Try /v1/models and find the model in the list.
             # Use _model_id_matches to handle "publisher/slug" vs bare "slug".
+            # llama.cpp exposes its runtime window as ``meta.n_ctx`` and uses
+            # the GGUF path as the model id.  A single-model llama.cpp server
+            # therefore cannot match a user-facing configured alias, but its
+            # sole entry is still authoritative for this endpoint.
             resp = client.get(f"{server_url}/v1/models")
             if resp.status_code == 200:
                 data = resp.json()
                 models_list = data.get("data", [])
-                for m in models_list:
-                    if _model_id_matches(m.get("id", ""), model):
-                        ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
-                        if ctx and isinstance(ctx, (int, float)):
-                            return int(ctx)
+                matching_model = next(
+                    (
+                        m for m in models_list
+                        if _model_id_matches(m.get("id", ""), model)
+                    ),
+                    None,
+                )
+                if matching_model is None and len(models_list) == 1:
+                    sole_model = models_list[0]
+                    sole_meta = sole_model.get("meta") if isinstance(sole_model, dict) else None
+                    if isinstance(sole_meta, dict) and (
+                        sole_meta.get("n_ctx") or sole_meta.get("n_ctx_train")
+                    ):
+                        matching_model = sole_model
+                if isinstance(matching_model, dict):
+                    ctx = (
+                        matching_model.get("max_model_len")
+                        or matching_model.get("context_length")
+                        or matching_model.get("max_tokens")
+                    )
+                    if not (ctx and isinstance(ctx, (int, float))):
+                        meta = matching_model.get("meta")
+                        if isinstance(meta, dict):
+                            # ``n_ctx`` is llama.cpp's configured runtime
+                            # window; ``n_ctx_train`` is only the model's
+                            # training limit and may be larger.
+                            ctx = meta.get("n_ctx") or meta.get("n_ctx_train")
+                    if ctx and isinstance(ctx, (int, float)):
+                        return int(ctx)
     except Exception:
         pass
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -1,11 +1,15 @@
 """Tests for _query_local_context_length and the local server fallback in
 get_model_context_length.
 
-All tests use synthetic inputs — no filesystem or live server required.
+Most tests use synthetic inputs. The llama.cpp regression also exercises the
+real HTTP probe path against an in-process server.
 """
 
+import json
 import sys
 import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -256,6 +260,124 @@ class TestQueryLocalContextLengthModelsList:
         with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
              patch("httpx.Client", return_value=client_mock):
             result = _query_local_context_length("omnicoder-9b", "http://localhost:1234")
+
+        assert result is None
+
+    def test_single_llama_cpp_model_uses_runtime_meta_context(self):
+        """A single llama.cpp model is authoritative despite an alias mismatch."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [{
+                "id": "/models/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+                "meta": {"n_ctx": 256000, "n_ctx_train": 262144},
+            }]
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = [detail_resp, list_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "qwen3.6-35b-a3b", "http://localhost:8080/v1"
+            )
+
+        assert result == 256000
+
+    def test_single_llama_cpp_model_uses_meta_context_over_real_http(self):
+        """The live llama.cpp probe resolves a GGUF-path model alias end-to-end."""
+        from agent.model_metadata import _query_local_context_length
+
+        class LlamaCppHandler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802 - stdlib HTTP handler API
+                if self.path == "/v1/props":
+                    status, body = 200, {"default_generation_settings": {}}
+                elif self.path == "/v1/models/qwen3.6-35b-a3b":
+                    status, body = 404, {}
+                elif self.path == "/v1/models":
+                    status, body = 200, {
+                        "data": [{
+                            "id": "/models/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+                            "meta": {"n_ctx": 256000, "n_ctx_train": 262144},
+                        }]
+                    }
+                else:
+                    status, body = 404, {}
+                encoded = json.dumps(body).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            def log_message(self, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), LlamaCppHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            result = _query_local_context_length(
+                "qwen3.6-35b-a3b", f"http://127.0.0.1:{server.server_port}/v1"
+            )
+        finally:
+            server.shutdown()
+            thread.join()
+            server.server_close()
+
+        assert result == 256000
+
+    def test_models_list_prefers_runtime_meta_context_over_training_limit(self):
+        """llama.cpp's configured n_ctx wins over its larger training limit."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [{
+                "id": "qwen3.6-35b-a3b",
+                "meta": {"n_ctx": 128000, "n_ctx_train": 262144},
+            }]
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = [detail_resp, list_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "qwen3.6-35b-a3b", "http://localhost:8080/v1"
+            )
+
+        assert result == 128000
+
+    def test_multiple_unmatched_models_do_not_use_arbitrary_meta_context(self):
+        """Alias fallback stays limited to endpoints with exactly one model."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {"id": "/models/first.gguf", "meta": {"n_ctx": 128000}},
+                {"id": "/models/second.gguf", "meta": {"n_ctx": 256000}},
+            ]
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = [detail_resp, list_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "qwen3.6-35b-a3b", "http://localhost:8080/v1"
+            )
 
         assert result is None
 


### PR DESCRIPTION
## Summary

Fix local llama.cpp context-length detection when a custom model alias does not match the server's GGUF-path model ID.

- Read llama.cpp's runtime `meta.n_ctx` from `/v1/models` responses.
- Prefer `n_ctx` over `n_ctx_train`, since the configured runtime window may be lower than the training limit.
- Treat the sole entry as authoritative only when it exposes llama.cpp metadata; multi-model endpoints remain strict about matching the configured model.

## Root cause

The local `/v1/models` probe only considered top-level context fields and required an ID match. llama.cpp exposes the value under `meta.n_ctx` and commonly returns a GGUF path instead of the configured alias, causing Hermes to fall back to a model-family default.

## Validation

- `scripts/run_tests.sh tests/agent/test_model_metadata_local_ctx.py tests/agent/test_model_metadata.py -q` (159 passed)
- Added a real in-process HTTP regression test for the llama.cpp probe path.
- `ruff check agent/model_metadata.py tests/agent/test_model_metadata_local_ctx.py`

## Notes

Attempting the wider `tests/agent/` suite exposed an independently reproducible baseline failure in `tests/agent/test_credential_pool_oat_authtype.py`; it does not touch the model metadata path changed here.
