### PR TITLE
feat(delegation): load optional profile persona

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5805,6 +5805,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            profile=function_args.get("profile"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/tools/test_delegate_profile.py
+++ b/tests/tools/test_delegate_profile.py
@@ -1,0 +1,277 @@
+"""Focused coverage for profile-persona delegation."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import tools.delegate_tool as delegate_module
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_child_system_prompt,
+    _load_profile_soul,
+    delegate_task,
+)
+
+
+@pytest.fixture()
+def profile_home(tmp_path, monkeypatch):
+    """Keep named-profile discovery and HERMES_HOME inside the test temp dir."""
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    def create(name: str, soul: str | None = None) -> Path:
+        profile_dir = default_home / "profiles" / name
+        profile_dir.mkdir(parents=True)
+        if soul is not None:
+            (profile_dir / "SOUL.md").write_text(soul, encoding="utf-8")
+        return profile_dir
+
+    return create
+
+
+def _parent() -> SimpleNamespace:
+    return SimpleNamespace(
+        _delegate_depth=0,
+        _interrupt_requested=False,
+        _memory_manager=None,
+        _active_children=[],
+        _active_children_lock=None,
+        _current_turn_id="",
+        _print_fn=None,
+        session_id="parent-session",
+        session_estimated_cost_usd=0.0,
+        session_cost_source="none",
+        session_cost_status="unknown",
+        tool_progress_callback=None,
+        thinking_callback=None,
+    )
+
+
+@pytest.fixture()
+def isolated_delegate(monkeypatch):
+    """Replace child execution while preserving delegate_task's routing logic."""
+    built: list[dict] = []
+
+    def fake_build_child_agent(**kwargs):
+        built.append(kwargs)
+        return SimpleNamespace(
+            session_id=f"child-{kwargs['task_index']}",
+            _delegate_role=kwargs["role"],
+            _delegate_saved_tool_names=[],
+        )
+
+    def fake_run_single_child(task_index, goal, child, parent_agent):
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": goal,
+            "api_calls": 0,
+            "duration_seconds": 0.0,
+        }
+
+    monkeypatch.setattr(delegate_module, "_build_child_agent", fake_build_child_agent)
+    monkeypatch.setattr(delegate_module, "_run_single_child", fake_run_single_child)
+    monkeypatch.setattr(
+        delegate_module,
+        "_resolve_delegation_credentials",
+        lambda _cfg, _parent: {
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": None,
+        },
+    )
+    monkeypatch.setattr(
+        delegate_module,
+        "_load_config",
+        lambda: {"max_iterations": 50, "max_concurrent_children": 3},
+    )
+    return built
+
+
+def test_load_profile_soul_uses_named_profile_identity(profile_home):
+    profile_home("reviewer", "\nYou are the independent reviewer.\n")
+
+    assert _load_profile_soul(" Reviewer ") == "You are the independent reviewer."
+
+
+def test_load_profile_soul_does_not_switch_or_parse_profile_runtime(profile_home):
+    profile_dir = profile_home("reviewer", "You are the independent reviewer.")
+    (profile_dir / "config.yaml").write_text("not: [valid", encoding="utf-8")
+    (profile_dir / ".env").write_text("PROFILE_ONLY_TOKEN=unused", encoding="utf-8")
+    parent_home = os.environ["HERMES_HOME"]
+
+    assert _load_profile_soul("reviewer") == "You are the independent reviewer."
+    assert os.environ["HERMES_HOME"] == parent_home
+
+
+@pytest.mark.parametrize(
+    ("name", "soul", "message"),
+    [
+        ("missing", None, "Unknown profile"),
+        ("no-soul", None, "has no SOUL.md"),
+        ("empty", "  \n", "empty SOUL.md"),
+    ],
+)
+def test_load_profile_soul_rejects_unusable_profile(profile_home, name, soul, message):
+    if name != "missing":
+        profile_home(name, soul)
+
+    with pytest.raises(ValueError, match=message):
+        _load_profile_soul(name)
+
+
+def test_load_profile_soul_rejects_default_profile(profile_home):
+    with pytest.raises(ValueError, match="non-default"):
+        _load_profile_soul("default")
+
+
+def test_profile_soul_is_first_child_prompt_segment():
+    prompt = _build_child_system_prompt(
+        "Review the patch",
+        profile_soul="You are the independent reviewer.",
+    )
+
+    assert prompt.startswith("You are the independent reviewer.\n")
+    assert "You are a focused subagent" in prompt
+    assert "YOUR TASK:\nReview the patch" in prompt
+
+
+def test_schema_exposes_identity_only_profile_top_level_and_per_task():
+    props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+
+    assert "profile" in props
+    assert "SOUL.md identity prompt" in props["profile"]["description"]
+    task_props = props["tasks"]["items"]["properties"]
+    assert "profile" in task_props
+    assert "SOUL.md identity prompt" in task_props["profile"]["description"]
+
+
+def test_no_profile_keeps_delegate_identity_unset(isolated_delegate, monkeypatch):
+    load_soul = pytest.fail
+    monkeypatch.setattr(delegate_module, "_load_profile_soul", load_soul)
+
+    result = json.loads(delegate_task(goal="plain task", parent_agent=_parent()))
+
+    assert result["results"][0]["status"] == "completed"
+    assert isolated_delegate[0]["profile_soul"] is None
+
+
+def test_top_level_profile_loads_soul_for_child(isolated_delegate, monkeypatch):
+    monkeypatch.setattr(
+        delegate_module,
+        "_load_profile_soul",
+        lambda name: f"identity:{name}",
+    )
+
+    result = json.loads(
+        delegate_task(
+            goal="implement",
+            profile="implementer",
+            parent_agent=_parent(),
+        )
+    )
+
+    assert result["results"][0]["status"] == "completed"
+    assert isolated_delegate[0]["profile_soul"] == "identity:implementer"
+
+
+def test_per_task_profile_overrides_top_level(isolated_delegate, monkeypatch):
+    loaded: list[str] = []
+
+    def fake_load(name):
+        loaded.append(name)
+        return f"identity:{name}"
+
+    monkeypatch.setattr(delegate_module, "_load_profile_soul", fake_load)
+
+    result = json.loads(
+        delegate_task(
+            tasks=[
+                {"goal": "implement"},
+                {"goal": "review", "profile": "reviewer"},
+            ],
+            profile="implementer",
+            parent_agent=_parent(),
+        )
+    )
+
+    assert [entry["status"] for entry in result["results"]] == [
+        "completed",
+        "completed",
+    ]
+    assert loaded == ["implementer", "reviewer"]
+    assert [call["profile_soul"] for call in isolated_delegate] == [
+        "identity:implementer",
+        "identity:reviewer",
+    ]
+
+
+def test_invalid_batch_profile_builds_no_children(isolated_delegate, monkeypatch):
+    def fake_load(name):
+        if name == "missing":
+            raise ValueError("Unknown profile 'missing'")
+        return f"identity:{name}"
+
+    monkeypatch.setattr(delegate_module, "_load_profile_soul", fake_load)
+
+    result = json.loads(
+        delegate_task(
+            tasks=[
+                {"goal": "implement", "profile": "implementer"},
+                {"goal": "review", "profile": "missing"},
+            ],
+            parent_agent=_parent(),
+        )
+    )
+
+    assert "Task 1 profile error" in result["error"]
+    assert isolated_delegate == []
+
+
+def test_live_dispatch_forwards_profile(monkeypatch):
+    import run_agent
+
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    monkeypatch.setattr(delegate_module, "delegate_task", fake_delegate_task)
+
+    run_agent.AIAgent._dispatch_delegate_task(
+        _parent(),
+        {"goal": "review", "profile": "reviewer"},
+    )
+
+    assert captured["profile"] == "reviewer"
+
+
+def test_registry_fallback_forwards_profile(monkeypatch):
+    from tools.registry import registry
+
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    monkeypatch.setattr(delegate_module, "delegate_task", fake_delegate_task)
+
+    entry = registry.get_entry("delegate_task")
+    assert entry is not None
+    entry.handler(
+        {"goal": "review", "profile": "reviewer"},
+        parent_agent=_parent(),
+    )
+
+    assert captured["profile"] == "reviewer"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -351,6 +351,43 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+def _load_profile_soul(profile_name: str) -> str:
+    """Load the identity prompt for a named Hermes profile.
+
+    Delegation intentionally borrows only ``SOUL.md``.  The child keeps the
+    parent's runtime, credentials, and tool isolation; selecting a profile is
+    not the same as starting that profile's independent Hermes instance.
+    """
+    if not isinstance(profile_name, str):
+        raise ValueError("profile must be a string")
+
+    from hermes_cli.profiles import (
+        get_profile_dir,
+        normalize_profile_name,
+        validate_profile_name,
+    )
+
+    canon = normalize_profile_name(profile_name)
+    validate_profile_name(canon)
+    if canon == "default":
+        raise ValueError("profile must name a non-default profile")
+
+    profile_dir = get_profile_dir(canon)
+    if not profile_dir.is_dir():
+        raise ValueError(f"Unknown profile {canon!r}")
+
+    soul_path = profile_dir / "SOUL.md"
+    if not soul_path.is_file():
+        raise ValueError(f"Profile {canon!r} has no SOUL.md")
+    try:
+        soul = soul_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise ValueError(f"Could not read SOUL.md for profile {canon!r}: {exc}") from exc
+    if not soul:
+        raise ValueError(f"Profile {canon!r} has an empty SOUL.md")
+    return soul
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -666,6 +703,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    profile_soul: Optional[str] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -675,11 +713,16 @@ def _build_child_system_prompt(
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
     """
-    parts = [
-        "You are a focused subagent working on a specific delegated task.",
-        "",
-        f"YOUR TASK:\n{goal}",
-    ]
+    parts = []
+    if profile_soul and profile_soul.strip():
+        parts.extend([profile_soul.strip(), ""])
+    parts.extend(
+        [
+            "You are a focused subagent working on a specific delegated task.",
+            "",
+            f"YOUR TASK:\n{goal}",
+        ]
+    )
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -1064,6 +1107,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Optional identity prompt loaded from a named profile's SOUL.md.
+    profile_soul: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1151,6 +1196,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        profile_soul=profile_soul,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -2374,18 +2420,23 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
+    profile: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, role, profile)
+      - Batch:  provide tasks array [{goal, context, role, profile}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The optional 'profile' selects only the named profile's SOUL.md identity
+    prompt. Per-task profile beats the top-level one; runtime configuration,
+    credentials, and tool access remain unchanged.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2473,7 +2524,14 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
+        task_list = [
+            {
+                "goal": goal,
+                "context": context,
+                "role": top_role,
+                "profile": profile,
+            }
+        ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2488,6 +2546,21 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    # Resolve every requested identity before constructing any child. A bad
+    # profile therefore fails the whole batch without partially dispatching it.
+    profile_souls: List[Optional[str]] = []
+    for i, task in enumerate(task_list):
+        profile_name = task.get("profile")
+        if profile_name is None:
+            profile_name = profile
+        if profile_name is None:
+            profile_souls.append(None)
+            continue
+        try:
+            profile_souls.append(_load_profile_soul(profile_name))
+        except ValueError as exc:
+            return tool_error(f"Task {i} profile error: {exc}")
 
     overall_start = time.monotonic()
     results = []
@@ -2532,6 +2605,7 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                profile_soul=profile_souls[i],
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -3436,6 +3510,13 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": (
+                                "Per-task named profile override. Only that "
+                                "profile's SOUL.md identity prompt is loaded."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3448,6 +3529,15 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Optional named Hermes profile (not 'default'). Only its "
+                    "SOUL.md identity prompt is prepended to the subagent; "
+                    "runtime configuration, credentials, and tool access are "
+                    "unchanged. Per-task profile overrides this value."
+                ),
             },
             "background": {
                 "type": "boolean",
@@ -3519,6 +3609,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        profile=args.get("profile"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
     ),


### PR DESCRIPTION
## Problem

delegate_task cannot currently reuse the identity from an existing named Hermes profile without copying SOUL.md into every task context. Starting the selected profile as a separate runtime would also change config, credentials, and tools, while this use case only needs a stable child persona.

## Behavior

- Add an optional profile field in single-task mode and in each batch item; a per-task value overrides the top-level value.
- Normalize and validate a named non-default profile, then read only its SOUL.md. Missing profiles and missing or empty SOUL.md files fail before any child is built.
- Prepend the selected SOUL.md to the child ephemeral system prompt. HERMES_HOME is not changed, and the child keeps the existing parent/delegation runtime, credentials, config, model, and tool-isolation behavior.
- Resolve every requested batch profile before constructing any child, so one invalid item cannot produce a partial fan-out.
- Thread profile through the model dispatch path, registry fallback, static schema, and child builder.

## Related open PRs

- #11169 launches a full profile-backed ACP runtime; this PR deliberately does not switch runtime or HERMES_HOME.
- #43725 adds a separate personas directory and persona parameter; this PR reuses existing Hermes profile SOUL.md files.
- #64970 reads model/provider credentials and config from a selected profile; this PR deliberately keeps those surfaces inherited and reads identity only.

## Tests

- Canonical test runner over 13 delegate, async-delegate, gateway, TUI, and CLI regression files: 261 passed, 0 failed.
- The focused profile suite contributes 14 passing cases, including single and batch routing, per-task precedence, all-before-build validation, default/missing/empty rejection, live and registry dispatch, and unchanged HERMES_HOME with invalid target config present.
- Ruff on run_agent.py, tools/delegate_tool.py, and tests/tools/test_delegate_profile.py: passed.
- git diff --check upstream/main..HEAD: passed.