### PR TITLE
fix: keep empty required array instead of removing key in schema sanitizer

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -179,14 +179,14 @@ def test_required_pruned_to_existing_properties():
     assert out[0]["function"]["parameters"]["required"] == ["name"]
 
 
-def test_required_all_missing_is_dropped():
+def test_required_all_missing_set_to_empty_list():
     tools = [_tool("t", {
         "type": "object",
         "properties": {},
         "required": ["x", "y"],
     })]
     out = sanitize_tool_schemas(tools)
-    assert "required" not in out[0]["function"]["parameters"]
+    assert out[0]["function"]["parameters"].get("required") == []
 
 
 def test_well_formed_schema_unchanged():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -347,7 +347,7 @@ def _sanitize_node(node: Any, path: str) -> Any:
         props = out.get("properties") or {}
         valid = [r for r in out["required"] if isinstance(r, str) and r in props]
         if not valid:
-            out.pop("required", None)
+            out["required"] = []
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 


### PR DESCRIPTION
## Summary

The schema sanitizer in `tools/schema_sanitizer.py` removes the `required` key entirely when all entries reference missing properties. Strict OpenAI-compatible API proxies (LiteLLM, corporate gateways, custom providers) default a missing `required` field to `null` internally, which fails JSON-Schema validation with a non-retryable `BadRequestError`: `"null is not of type array"`.

## Changes

- `tools/schema_sanitizer.py:350`: Change `out.pop("required", None)` to `out["required"] = []`
- `tests/tools/test_schema_sanitizer.py`: Update `test_required_all_missing_is_dropped` → `test_required_all_missing_set_to_empty_list` to assert `[]` instead of key absence

## Pattern

When a JSON Schema field has a type constraint (array), removing the key entirely is riskier than setting it to the type's empty equivalent (`[]`). Strict validators may inject defaults that violate the type. This matches the pattern already used for `properties: {}` on the line above (line 341).

## Tests

All 47 tests in `tests/tools/test_schema_sanitizer.py` pass.